### PR TITLE
feat(node-binding): plugin context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,21 +1175,6 @@ dependencies = [
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69503316831c3d1d51f019faa68724282be054e8b0d6d48a5741599b2b812bcc"
-dependencies = [
- "daachorse",
- "dashmap",
- "indexmap",
- "once_cell",
- "phf",
- "serde_json",
- "smol_str",
-]
-
-[[package]]
-name = "nodejs-resolver"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee96654396109ae794f3e5a9ff6baa9d31d166727445b9fef8328e1c656c61a"
@@ -1784,7 +1769,7 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "nodejs-resolver 0.0.11",
+ "nodejs-resolver 0.0.12",
  "once_cell",
  "rspack",
  "rspack_core",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1"
 rspack = { path = "../rspack" }
 rspack_core = { path = "../rspack_core" }
 futures = "0.3"
-nodejs-resolver = "0.0.11"
+nodejs-resolver = "0.0.12"
 once_cell = "1"
 async-trait = "0.1.53"
 dashmap = "5.0.0"

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -5,84 +5,96 @@
 
 export class ExternalObject<T> {
   readonly '': {
-    readonly '': unique symbol
-    [K: symbol]: T
-  }
+    readonly '': unique symbol;
+    [K: symbol]: T;
+  };
 }
 export interface OnLoadContext {
-  id: string
+  id: string;
 }
 export interface OnLoadResult {
-  content?: string
-  loader?: "dataURI" | "json" | "text" | "css" | "less" | "scss" | "sass" | "js" | "jsx" | "ts" | "tsx" | "null"
+  content?: string;
+  loader?: 'dataURI' | 'json' | 'text' | 'css' | 'less' | 'scss' | 'sass' | 'js' | 'jsx' | 'ts' | 'tsx' | 'null';
 }
 export interface OnResolveContext {
-  importer?: string
-  importee: string
+  importer?: string;
+  importee: string;
 }
 export interface OnResolveResult {
-  uri: string
-  external: boolean
+  uri: string;
+  external: boolean;
 }
 export interface RawEnhancedOptions {
-  svgr?: boolean
-  progress?: boolean
-  lazyCompilation?: boolean
-  react?: RawReactOptions
-  inlineStyle?: boolean
-  globals?: Record<string, string>
-  define?: Record<string, string>
+  svgr?: boolean;
+  progress?: boolean;
+  lazyCompilation?: boolean;
+  react?: RawReactOptions;
+  inlineStyle?: boolean;
+  globals?: Record<string, string>;
+  define?: Record<string, string>;
 }
 export interface RawOptimizationOptions {
-  splitChunks?: RawSplitChunksOptions
-  minify?: boolean
-  removeEmptyChunks?: boolean
-  chunkIdAlgo?: string
-  moduleIdAlgo?: string
+  splitChunks?: RawSplitChunksOptions;
+  minify?: boolean;
+  removeEmptyChunks?: boolean;
+  chunkIdAlgo?: string;
+  moduleIdAlgo?: string;
 }
 export interface RawOutputOptions {
-  outdir?: string
-  entryFilename?: string
-  sourceMap?: "linked" | "external" | "inline" | "none"
+  outdir?: string;
+  entryFilename?: string;
+  sourceMap?: 'linked' | 'external' | 'inline' | 'none';
 }
 export interface RawReactOptions {
-  fastFresh?: boolean
+  fastFresh?: boolean;
 }
 export interface RawResolveOptions {
-  alias?: Record<string, string>
-  conditionNames?: Array<string>
-  aliasFields?: string
+  alias?: Record<string, string>;
+  conditionNames?: Array<string>;
+  aliasField?: string;
 }
 export interface RawSplitChunksOptions {
-  codeSplitting?: boolean
-  reuseExstingChunk?: boolean
+  codeSplitting?: boolean;
+  reuseExstingChunk?: boolean;
 }
 export interface RawOptions {
-  entries: Record<string, string>
-  mode?: "development" | "production" | "none"
-  root?: string
-  loader?: Record<string, string>
-  enhanced?: RawEnhancedOptions
-  optimization?: RawOptimizationOptions
-  output?: RawOutputOptions
-  resolve?: RawResolveOptions
-  chunkFilename?: string
+  entries: Record<string, string>;
+  mode?: 'development' | 'production' | 'none';
+  root?: string;
+  loader?: Record<string, string>;
+  enhanced?: RawEnhancedOptions;
+  optimization?: RawOptimizationOptions;
+  output?: RawOutputOptions;
+  resolve?: RawResolveOptions;
+  chunkFilename?: string;
 }
-export function initCustomTraceSubscriber(): void
+export function initCustomTraceSubscriber(): void;
 export interface PluginCallbacks {
-  buildStartCallback: (...args: any[]) => any
-  loadCallback: (...args: any[]) => any
-  resolveCallback: (...args: any[]) => any
-  buildEndCallback: (...args: any[]) => any
+  buildStartCallback: (...args: any[]) => any;
+  loadCallback: (...args: any[]) => any;
+  resolveCallback: (...args: any[]) => any;
+  buildEndCallback: (...args: any[]) => any;
 }
-export function newRspack(optionJson: string, pluginCallbacks?: PluginCallbacks | undefined | null): ExternalObject<RspackInternal>
-export function build(rspack: ExternalObject<RspackInternal>): Promise<Record<string, string>>
-export function rebuild(rspack: ExternalObject<RspackInternal>, changedFile: string[]): Promise<[diff: Record<string, string>, map: Record<string, string>]>
-export interface ResolveRet {
-  status: boolean
-  result?: string
+export function newRspack(
+  optionJson: string,
+  pluginCallbacks?: PluginCallbacks | undefined | null
+): ExternalObject<RspackInternal>;
+export function build(rspack: ExternalObject<RspackInternal>): Promise<Record<string, string>>;
+export function rebuild(
+  rspack: ExternalObject<RspackInternal>,
+  changedFile: string[]
+): Promise<[diff: Record<string, string>, map: Record<string, string>]>;
+export function resolve(
+  rspack: ExternalObject<RspackInternal>,
+  source: string,
+  resolveOptions: ResolveOptions
+): ResolveResult;
+export interface ResolveOptions {
+  resolveDir: string;
 }
-export function resolveFile(baseDir: string, importPath: string): string
-export interface RspackInternal {
-  
+export interface ResolveResult {
+  status: boolean;
+  path?: string;
 }
+export function resolveFile(baseDir: string, importPath: string): string;
+export interface RspackInternal {}

--- a/packages/rspack/src/node/core.ts
+++ b/packages/rspack/src/node/core.ts
@@ -3,10 +3,9 @@ import path from 'path';
 import { DevServer } from './server';
 import chokidar from 'chokidar';
 import { RawOptions } from '@rspack/binding';
-import { Rspack } from './rspack';
+import { Rspack, RspackRawOptions } from './rspack';
 import { LessPlugin } from './rspack/plugins/less';
 import log from 'why-is-node-running';
-import type { UserRspackConfig } from './cli';
 
 type Defer = { resolve: any; reject: any; promise: any };
 const Defer = (): Defer => {
@@ -31,7 +30,7 @@ export type BundlerOptions = Partial<RawOptions> & {
   command: 'dev' | 'build';
 };
 
-export async function run(options: UserRspackConfig, command: 'dev' | 'build') {
+export async function run(options: RspackRawOptions, command: 'dev' | 'build') {
   console.time('build');
   const root = options.root;
   const outdir = path.resolve(options.root, 'dist');

--- a/packages/rspack/src/node/rspack/plugins/index.ts
+++ b/packages/rspack/src/node/rspack/plugins/index.ts
@@ -1,9 +1,148 @@
-import type { OnLoadResult, OnResolveResult } from '@rspack/binding';
+import type {
+  ExternalObject,
+  OnLoadContext,
+  OnLoadResult,
+  OnResolveContext,
+  OnResolveResult,
+  RspackInternal,
+  ResolveOptions,
+  ResolveResult,
+} from '@rspack/binding';
+import * as binding from '@rspack/binding';
+
+import { debugNapi } from '..';
 
 export interface RspackPlugin {
   name: string;
-  buildStart?(): Promise<void>;
-  load?(id: string): Promise<OnLoadResult | void>;
-  resolve?(source: string, importer: string | undefined): Promise<OnResolveResult | void>;
-  buildEnd?(): Promise<void>;
+  buildStart?(this: RspackPluginContext): Promise<void>;
+  load?(this: RspackPluginContext, id: string): Promise<OnLoadResult | void>;
+  resolve?(this: RspackPluginContext, source: string, importer: string | undefined): Promise<OnResolveResult | void>;
+  buildEnd?(this: RspackPluginContext): Promise<void>;
+}
+
+interface RspackThreadsafeContext<T> {
+  readonly id: number;
+  readonly inner: T;
+}
+
+interface RspackThreadsafeResult<T> {
+  readonly id: number;
+  readonly inner: T;
+}
+
+const createDummyResult = (id: number): string => {
+  const result: RspackThreadsafeResult<null> = {
+    id,
+    inner: null,
+  };
+  return JSON.stringify(result);
+};
+
+const isNil = (value: unknown): value is null | undefined => {
+  return value === null || value === undefined;
+};
+
+class RspackPluginContext {
+  constructor(private factory: RspackPluginFactory) {}
+
+  resolve(source: string, resolveOptions: ResolveOptions): ResolveResult {
+    console.log(source, resolveOptions);
+    return binding.resolve(this.factory._rspack, source, resolveOptions);
+  }
+}
+
+export class RspackPluginFactory {
+  _rspack: ExternalObject<RspackInternal>;
+
+  private pluginContext: RspackPluginContext;
+
+  constructor(public plugins: RspackPlugin[]) {
+    this.pluginContext = new RspackPluginContext(this);
+
+    this.buildStart = this.buildStart.bind(this);
+    this.buildEnd = this.buildEnd.bind(this);
+    this.load = this.load.bind(this);
+    this.resolve = this.resolve.bind(this);
+  }
+
+  setRspackInstance(rspack: ExternalObject<RspackInternal>) {
+    this._rspack = rspack;
+  }
+
+  async buildStart(err: Error, value: string): Promise<string> {
+    if (err) {
+      throw err;
+    }
+
+    const context: RspackThreadsafeContext<void> = JSON.parse(value);
+
+    await Promise.all(this.plugins.map((plugin) => plugin.buildStart?.bind(this.pluginContext)?.()));
+
+    return createDummyResult(context.id);
+  }
+
+  async buildEnd(err: Error, value: string): Promise<string> {
+    if (err) {
+      throw err;
+    }
+
+    const context: RspackThreadsafeContext<void> = JSON.parse(value);
+
+    await Promise.all(this.plugins.map((plugin) => plugin.buildEnd?.bind(this.pluginContext)?.()));
+
+    return createDummyResult(context.id);
+  }
+
+  async load(err: Error, value: string): Promise<string> {
+    if (err) {
+      throw err;
+    }
+
+    const context: RspackThreadsafeContext<OnLoadContext> = JSON.parse(value);
+
+    for (const plugin of this.plugins) {
+      const { id } = context.inner;
+      const result = await plugin.load?.(id);
+      debugNapi('onLoadResult', result, 'context', context);
+
+      if (isNil(result)) {
+        continue;
+      }
+
+      return JSON.stringify({
+        id: context.id,
+        inner: result,
+      });
+    }
+
+    debugNapi('onLoadResult', null, 'context', context);
+
+    return createDummyResult(context.id);
+  }
+
+  async resolve(err: Error, value: string): Promise<string> {
+    if (err) {
+      throw err;
+    }
+
+    const context: RspackThreadsafeContext<OnResolveContext> = JSON.parse(value);
+
+    for (const plugin of this.plugins) {
+      const { importer, importee } = context.inner;
+      const result = await plugin.resolve?.bind(this.pluginContext)?.(importee, importer);
+      debugNapi('onResolveResult', result, 'context', context);
+
+      if (isNil(result)) {
+        continue;
+      }
+
+      return JSON.stringify({
+        id: context.id,
+        inner: result,
+      });
+    }
+
+    debugNapi('onResolveResult', null, 'context', context);
+    return createDummyResult(context.id);
+  }
 }

--- a/packages/rspack/tests/fixtures/basic/foo.js
+++ b/packages/rspack/tests/fixtures/basic/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/packages/rspack/tests/fixtures/basic/index.js
+++ b/packages/rspack/tests/fixtures/basic/index.js
@@ -1,0 +1,2 @@
+import { foo } from './foo';
+console.log(foo);

--- a/packages/rspack/tests/fixtures/plugin/foo.js
+++ b/packages/rspack/tests/fixtures/plugin/foo.js
@@ -1,0 +1,1 @@
+console.log("foo");

--- a/packages/rspack/tests/fixtures/plugin/index.js
+++ b/packages/rspack/tests/fixtures/plugin/index.js
@@ -1,0 +1,2 @@
+import 'foo';
+console.log('rspack-binding');

--- a/packages/rspack/tests/rspack.spec.ts
+++ b/packages/rspack/tests/rspack.spec.ts
@@ -1,0 +1,150 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import assert from 'assert';
+
+import { expect } from '@rspack/test-toolkit';
+
+import { Rspack, RspackPlugin } from '../src/node/rspack';
+
+const fixtureRoot = path.resolve(__dirname, './fixtures');
+
+describe('rspack:node-plugin', () => {
+  it('should work with plugins', async () => {
+    const fixture = path.join(fixtureRoot, 'plugin');
+
+    const plugin: RspackPlugin = {
+      async load(id) {
+        if (id.endsWith('foo.js')) {
+          return {
+            content: `${await fs.readFile(id, 'utf-8')};console.log("fooo");`,
+            loader: 'js',
+          };
+        }
+      },
+      async resolve(source, importer) {
+        console.log('resolveing');
+
+        if (source === 'foo') {
+          const nativeResult = this.resolve('./foo', {
+            resolveDir: path.dirname(importer),
+          });
+          console.log('nativeResult', nativeResult);
+
+          return {
+            uri: nativeResult.path,
+            external: false,
+          };
+        }
+      },
+    };
+
+    const rspack = new Rspack({
+      entries: { index: path.join(fixture, 'index.js') },
+      plugins: [plugin],
+      output: {
+        outdir: path.join(fixture, 'dist'),
+        sourceMap: 'none',
+      },
+    });
+
+    await rspack.build();
+  });
+
+  it('should keep the correct order', async () => {
+    const fixture = path.join(fixtureRoot, 'basic');
+
+    const order = {
+      buildStart: [],
+      resolve: [],
+      load: [],
+      buildEnd: [],
+    };
+
+    let resolveRound = 1;
+    let loadRound = 1;
+
+    const rspack = new Rspack({
+      entries: { index: path.join(fixture, 'index.js') },
+      output: {
+        outdir: path.join(fixture, 'dist'),
+      },
+      plugins: [
+        {
+          name: 'plugin-1',
+          async buildStart() {
+            return new Promise((res) => {
+              setTimeout(() => {
+                order.buildStart.push(1);
+                res();
+              });
+            });
+          },
+          async load() {
+            expect(order.buildStart.length).to.eq(2);
+            expect(order.buildStart).to.deep.equal([2, 1]);
+
+            if (loadRound === 1) {
+              expect(order.load.length).to.eq(0);
+            }
+
+            if (loadRound === 2) {
+              expect(order.load.length).to.eq(2);
+            }
+
+            order.load.push(1);
+            loadRound += 1;
+          },
+          async resolve() {
+            if (resolveRound === 1) {
+              expect(order.load.length).to.eq(0);
+            }
+
+            if (resolveRound === 2) {
+              expect(order.load.length).to.eq(2);
+            }
+            resolveRound += 1;
+          },
+          async buildEnd() {
+            order.buildEnd.push(1);
+          },
+        },
+        {
+          name: 'plugin-2',
+          async buildStart() {
+            order.buildStart.push(2);
+          },
+          async load() {
+            order.load.push(2);
+
+            if (loadRound === 1) {
+              expect(order.load.length).to.eq(1);
+              expect(order.load[0]).to.eq(1);
+            }
+
+            if (loadRound === 2) {
+              expect(order.load.length).to.eq(2);
+              expect(order.load[0]).to.eq(1);
+            }
+          },
+          async resolve() {
+            if (resolveRound === 1) {
+              expect(order.resolve.length).to.eq(1);
+            }
+          },
+          async buildEnd() {
+            return new Promise((res) => {
+              setTimeout(() => {
+                order.buildEnd.push(2);
+                res();
+              });
+            });
+          },
+        },
+      ],
+    });
+
+    await rspack.build();
+
+    expect(order.buildEnd).to.deep.equal([1, 2]);
+  });
+});


### PR DESCRIPTION
Add `resolve` to plugin context, users can use `this.resolve` to get internal resolver implementation from node side.