### PR TITLE
feat: prettify plugin loader result

### DIFF
--- a/crates/rspack_plugin_loader/src/lib.rs
+++ b/crates/rspack_plugin_loader/src/lib.rs
@@ -39,40 +39,24 @@ impl Plugin for LoaderInterpreterPlugin {
           let format = "base64";
           let data_uri = format!("data:{};{},{}", mime_type, format, base64::encode(&raw));
           format!(
-            "
-            var img = \"{}\";
-            export default img;
-            ",
-            data_uri
+            "var img = \"{data_uri}\";
+export default img;",
           )
           .trim()
           .to_string()
         }
         Loader::Json => {
           *loader = Loader::Js;
-          format!(
-            "
-            export default {}
-            ",
-            raw
-          )
+          format!("export default {raw};")
         }
         Loader::Text => {
           *loader = Loader::Js;
           let data = serde_json::to_string(&raw).unwrap();
-          format!(
-            "
-            export default {}
-            ",
-            data
-          )
+          format!("export default {data};")
         }
         Loader::Null => {
           *loader = Loader::Js;
-          r#"
-          export default {}
-          "#
-          .to_string()
+          r#"export default {};"#.to_string()
         }
         _ => raw,
       }


### PR DESCRIPTION
In format, line breaking and any other breaking would be generated to code, which results unnecessary sourcemap token generation.