### PR TITLE
feature: dynamic ensure in node

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -62,7 +62,7 @@ impl Chunk {
       .collect::<Vec<_>>();
 
     if let ChunkKind::Entry { .. } = &self.kind {
-      let code = rspack_runtime(&options.runtime);
+      let code = rspack_runtime(&options.runtime, options);
       if code.trim() != "" {
         let runtime = Box::new(RawSource::new(&code));
         concattables.push(runtime);

--- a/crates/rspack_core/src/runtime/mod.rs
+++ b/crates/rspack_core/src/runtime/mod.rs
@@ -1,3 +1,5 @@
+use crate::{BundleOptions, Platform};
+
 #[derive(Default, Debug)]
 pub struct RuntimeOptions {
   pub hmr: bool,
@@ -13,13 +15,17 @@ impl RuntimeOptions {
   }
 }
 
-pub fn rspack_runtime(options: &RuntimeOptions) -> String {
+pub fn rspack_runtime(options: &RuntimeOptions, bundle_options: &BundleOptions) -> String {
   let mut runtime = "".to_string();
   if options.hmr {
     runtime += include_str!("hmr.js");
   }
   if options.module {
-    runtime += include_str!("module.js");
+    let module_code = match bundle_options.platform {
+      Platform::Browser => include_str!("module_in_browser.js"),
+      Platform::Node => include_str!("module_in_node.js"),
+    };
+    runtime += module_code;
   }
   runtime
 }

--- a/crates/rspack_core/src/runtime/module_in_browser.js
+++ b/crates/rspack_core/src/runtime/module_in_browser.js
@@ -1,0 +1,118 @@
+(function () {
+  let __rspack_modules__ = {};
+  class Hot {
+    constructor(id) {
+      this.id = id;
+      this.accepts = [];
+    }
+    accept(ids, callback) {
+      if (ids === undefined) {
+        this.accepts.push({
+          ids: this.id,
+          accept: undefined,
+        });
+      } else if (typeof ids === 'function') {
+        this.accepts.push({
+          ids: this.id,
+          accept: ids,
+        });
+      } else {
+        this.accepts.push({
+          ids,
+          accept: callback,
+        });
+      }
+    }
+    dispose(callback) {
+      this.accepts.push({
+        id: this.id,
+        dispose: callback,
+      });
+    }
+  }
+  class Module {
+    constructor(options) {
+      this.id = options.id;
+      this.factory = options.factory;
+      this.loaded = options.loaded;
+      this.exports = options.exports;
+      this.children = new Set(); // children module
+      this.parents = new Set(); //  parent module
+    }
+  }
+  function __rspack_define__(id, factory) {
+    const mod = __rspack_modules__[id];
+    if (!mod) {
+      __rspack_modules__[id] = new Module({
+        factory: factory,
+        loaded: false,
+        exports: {},
+        id,
+      });
+    } else {
+      console.debug('repeated define for', id);
+      // mod.loaded = false;
+      // mod.exports = {};
+      // mod.factory = factory;
+    }
+  }
+  async function __rspack_dynamic_require__(module_id, chunk_id) {
+    await ensure(chunk_id);
+    return __rspack_require__(module_id);
+  }
+  function __rspack_require__(id) {
+    const self = this;
+    let mod = __rspack_modules__[id];
+    if (!mod) {
+      throw new Error(id + ' not exits');
+    }
+    if (mod.loaded) {
+      return mod.exports;
+    }
+    if (self instanceof Module) {
+      this.children.add(mod);
+      mod.parents.add(this);
+    }
+    mod.hot = new Hot(id);
+    mod.loaded = true;
+    mod.factory(__rspack_require__.bind(mod), mod, mod.exports);
+    return mod.exports;
+  }
+  function loadStyles(url) {
+    return new Promise((rsl, rej) => {
+      var link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.type = 'text/css';
+      link.href = url;
+      link.onload = rsl;
+      link.onerror = rej;
+      var head = document.getElementsByTagName('head')[0];
+      head.appendChild(link);
+    });
+  }
+  const ensurers = {
+    async js(chunk_id) {
+      await import('http://127.0.01:4444/' + chunk_id + '.js');
+    },
+    async css(chunk_id) {
+      try {
+        await loadStyles('http://127.0.01:4444/' + chunk_id + '.css');
+      } catch (err) {
+        console.log('css load fail', err);
+      }
+    },
+  };
+  function ensure(chunkId) {
+    return Promise.all(
+      Object.keys(ensurers).map((ensurerName) => {
+        return ensurers[ensurerName](chunkId);
+      })
+    );
+  }
+  globalThis.rs = {
+    define: __rspack_define__,
+    require: __rspack_require__,
+    dynamic_require: __rspack_dynamic_require__,
+    m: __rspack_modules__,
+  };
+})();

--- a/crates/rspack_core/src/runtime/module_in_node.js
+++ b/crates/rspack_core/src/runtime/module_in_node.js
@@ -57,9 +57,8 @@
     }
   }
   async function __rspack_dynamic_require__(module_id, chunk_id) {
-    await ensure(chunk_id);
-    const result = __rspack_require__(module_id);
-    return result;
+    await ensure(`./${chunk_id}`);
+    return __rspack_require__(module_id);
   }
   function __rspack_require__(id) {
     const self = this;
@@ -79,30 +78,12 @@
     mod.factory(__rspack_require__.bind(mod), mod, mod.exports);
     return mod.exports;
   }
-  function loadStyles(url){
-    return new Promise((rsl, rej) => {
-      var link = document.createElement('link');
-      link.rel = 'stylesheet';
-      link.type = 'text/css';
-      link.href = url;
-      link.onload = rsl;
-      link.onerror = rej;
-      var head = document.getElementsByTagName('head')[0];
-      head.appendChild(link);
-    })
-  }
   const ensurers = {
     async js(chunk_id) {
-      await import('http://127.0.01:4444/' + chunk_id + '.js');
+      require(chunk_id);
     },
-    async css(chunk_id) {
-      try {
-        await loadStyles('http://127.0.01:4444/' + chunk_id + '.css');
-      } catch (err) {
-        console.log('css load fail', err);
-      }
-    }
-  }
+  };
+
   function ensure(chunkId) {
     return Promise.all(
       Object.keys(ensurers).map((ensurerName) => {

--- a/crates/testground/fixtures/asset-emitted/index.js
+++ b/crates/testground/fixtures/asset-emitted/index.js
@@ -1,0 +1,5 @@
+import { equal } from 'assert';
+
+import("./module").then((res) => {
+  equal(res, "module");
+})

--- a/crates/testground/fixtures/asset-emitted/module.js
+++ b/crates/testground/fixtures/asset-emitted/module.js
@@ -1,0 +1,1 @@
+module.exports = "module"

--- a/crates/testground/fixtures/asset-emitted/rspack.config.json
+++ b/crates/testground/fixtures/asset-emitted/rspack.config.json
@@ -1,0 +1,7 @@
+{
+  "mode": "development",
+  "entries": {
+    "main": "./index.js"
+  },
+  "platform": "node"
+}

--- a/crates/testground/tests/common/mod.rs
+++ b/crates/testground/tests/common/mod.rs
@@ -74,10 +74,28 @@ pub fn run_js_asset_in_node(js_asset: &Asset) {
   let filename = &js_asset.filename;
   let source = &js_asset.source;
   // TODO: should optimized
-  match std::process::Command::new("node")
+  // WARNING: `node eval` do not had module context.
+  let command_result = std::process::Command::new("node")
     .args(["-e", source])
-    .output()
-  {
+    .output();
+  deal_node_command_output(&command_result, filename);
+}
+
+pub fn run_js_output_in_node(js_asset: &Asset, options: &BundleOptions) {
+  let filename = &js_asset.filename;
+  let output_file = Path::new(&options.outdir)
+    .join(filename)
+    .display()
+    .to_string();
+  // TODO: should optimized
+  let command_result = std::process::Command::new("node")
+    .args([output_file])
+    .output();
+  deal_node_command_output(&command_result, filename);
+}
+
+fn deal_node_command_output(output: &std::io::Result<std::process::Output>, filename: &str) {
+  match output {
     Ok(result) => {
       if !result.stderr.is_empty() {
         panic!(

--- a/crates/testground/tests/fixtures/assets.rs
+++ b/crates/testground/tests/fixtures/assets.rs
@@ -1,0 +1,26 @@
+use crate::common::{compile_fixture, run_js_output_in_node};
+use std::collections::HashMap;
+
+#[tokio::test]
+async fn asset_emitted() {
+  let bundler = compile_fixture("asset-emitted").await;
+  let assets = bundler.bundle.context.assets.lock().unwrap();
+  let map: HashMap<String, rspack_core::Asset> = assets
+    .iter()
+    .map(|asset| {
+      (
+        asset.filename.to_string(),
+        rspack_core::Asset {
+          filename: asset.filename.to_string(),
+          source: asset.source.to_string(),
+        },
+      )
+    })
+    .collect();
+
+  assert_eq!(map.len(), 2);
+  assert!(map.contains_key("main.js"));
+  assert!(map.contains_key("module_js.js"));
+  let main_asset = map.get("main.js").unwrap();
+  run_js_output_in_node(main_asset, &bundler.options);
+}

--- a/crates/testground/tests/fixtures/mod.rs
+++ b/crates/testground/tests/fixtures/mod.rs
@@ -1,3 +1,4 @@
+mod assets;
 mod code_splitting;
 mod constant_folding;
 mod contenthash;


### PR DESCRIPTION
This PR had following changes:

1. dynamic `ensure` in node env.
2. test for js asset emitted.