### PR TITLE
feat: support resolve ignored

### DIFF
--- a/crates/node_binding/src/options/mod.rs
+++ b/crates/node_binding/src/options/mod.rs
@@ -295,11 +295,27 @@ pub fn parse_entries(raw_entry: HashMap<String, String>) -> HashMap<String, Entr
     .collect()
 }
 
-pub fn parse_raw_alias(alias: HashMap<String, String>) -> Vec<(String, Option<String>)> {
-  alias
-    .into_iter()
-    .map(|(s1, s2)| (s1, Some(s2)))
-    .collect::<Vec<_>>()
+pub fn parse_raw_alias(
+  alias: HashMap<String, ResolveAliasValue>,
+) -> HashMap<String, Option<String>> {
+  HashMap::from_iter(
+    alias
+      .into_iter()
+      .map(|(key, value)| {
+        let value = match value {
+          ResolveAliasValue::False(b) => {
+            if b {
+              panic!("alias should not be true");
+            } else {
+              None
+            }
+          }
+          ResolveAliasValue::Target(s) => Some(s),
+        };
+        (key, value)
+      })
+      .collect::<Vec<_>>(),
+  )
 }
 
 pub fn parse_raw_condition_names(condition_names: Vec<String>) -> HashSet<String> {

--- a/crates/node_binding/src/options/resolve.rs
+++ b/crates/node_binding/src/options/resolve.rs
@@ -1,14 +1,77 @@
 use std::collections::HashMap;
 
+#[cfg(not(feature = "test"))]
 use napi_derive::napi;
+
 use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+#[serde(untagged)]
+pub enum ResolveAliasValue {
+  // `bool` just for derserialize
+  False(bool),
+  Target(String),
+}
+
+impl napi::bindgen_prelude::ToNapiValue for ResolveAliasValue {
+  unsafe fn to_napi_value(
+    env: napi::sys::napi_env,
+    val: Self,
+  ) -> napi::Result<napi::sys::napi_value> {
+    match val {
+      ResolveAliasValue::False(b) => bool::to_napi_value(env, b),
+      ResolveAliasValue::Target(s) => String::to_napi_value(env, s),
+    }
+  }
+}
+
+impl napi::bindgen_prelude::FromNapiValue for ResolveAliasValue {
+  unsafe fn from_napi_value(
+    env: napi::sys::napi_env,
+    napi_val: napi::sys::napi_value,
+  ) -> napi::Result<Self> {
+    let mut val_type = 0;
+
+    napi::check_status!(
+      napi::sys::napi_typeof(env, napi_val, &mut val_type),
+      "Failed to convert napi value into rust type `ResolveAliasValue`",
+    )?;
+
+    match val_type {
+      napi::sys::ValueType::napi_boolean => Ok(ResolveAliasValue::False(bool::from_napi_value(
+        env, napi_val,
+      )?)),
+      _ => Ok(ResolveAliasValue::Target(String::from_napi_value(
+        env, napi_val,
+      )?)),
+    }
+  }
+}
+
+impl Default for ResolveAliasValue {
+  fn default() -> Self {
+    ResolveAliasValue::False(false)
+  }
+}
 
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
+#[cfg(not(feature = "test"))]
 pub struct RawResolveOptions {
   pub extensions: Option<Vec<String>>,
-  pub alias: Option<HashMap<String, String>>,
+  #[napi(ts_type = "{ [key: string]: false | string }")]
+  pub alias: Option<HashMap<String, ResolveAliasValue>>,
+  pub condition_names: Option<Vec<String>>,
+  pub alias_field: Option<String>,
+}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+#[cfg(feature = "test")]
+pub struct RawResolveOptions {
+  pub extensions: Option<Vec<String>>,
+  pub alias: Option<HashMap<String, ResolveAliasValue>>,
   pub condition_names: Option<Vec<String>>,
   pub alias_field: Option<String>,
 }

--- a/crates/rspack/examples/arco_pro.rs
+++ b/crates/rspack/examples/arco_pro.rs
@@ -47,7 +47,7 @@ async fn main() {
         ("svg".to_string(), Loader::DataURI),
       ]),
       resolve: ResolveOption {
-        alias: vec![(
+        alias: HashMap::from_iter([(
           "@/".to_string(),
           Some(
             Path::new("./examples/arco-pro/src/")
@@ -56,7 +56,7 @@ async fn main() {
               .to_string()
               + "/",
           ),
-        )],
+        )]),
         ..Default::default()
       },
       source_map: false.into(),

--- a/crates/rspack/tests/alias.rs
+++ b/crates/rspack/tests/alias.rs
@@ -1,5 +1,7 @@
 mod utils;
 
+use std::collections::HashMap;
+
 use rspack::bundler::BundleOptions;
 use rspack_core::ResolveOption;
 use utils::compile_with_options;
@@ -10,10 +12,10 @@ fn alias() {
     "alias",
     BundleOptions {
       resolve: ResolveOption {
-        alias: vec![
+        alias: HashMap::from_iter([
           ("./wrong".to_string(), Some("./ok".to_string())),
           ("@/".to_string(), Some("./src/".to_string())),
-        ],
+        ]),
         ..Default::default()
       },
       ..Default::default()

--- a/crates/rspack_core/src/bundle.rs
+++ b/crates/rspack_core/src/bundle.rs
@@ -71,6 +71,7 @@ impl Bundle {
           uri: rd,
           kind: ImportKind::Import,
           external: false,
+          ignored: false,
         });
       });
     }

--- a/crates/rspack_core/src/js_module.rs
+++ b/crates/rspack_core/src/js_module.rs
@@ -176,6 +176,7 @@ pub enum JsModuleKind {
   UserEntry { name: String },
   Normal,
   External,
+  Ignored,
 }
 
 impl JsModuleKind {

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -39,14 +39,16 @@ pub struct ResolvedURI {
   pub uri: String,
   pub kind: ImportKind,
   pub external: bool,
+  pub ignored: bool,
 }
 
 impl ResolvedURI {
-  pub fn new<T: Into<String>>(path: T, external: bool, kind: ImportKind) -> Self {
+  pub fn new<T: Into<String>>(path: T, external: bool, kind: ImportKind, ignored: bool) -> Self {
     Self {
       uri: path.into(),
       external,
       kind, // module_side_effects: false,
+      ignored,
     }
   }
 }

--- a/crates/rspack_core/src/options/resolve.rs
+++ b/crates/rspack_core/src/options/resolve.rs
@@ -1,11 +1,10 @@
-use std::collections::HashSet;
-
 use crate::BundleMode;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
 pub struct ResolveOption {
   pub extensions: Vec<String>,
-  pub alias: Vec<(String, Option<String>)>,
+  pub alias: HashMap<String, Option<String>>,
   pub condition_names: HashSet<String>,
   pub symlinks: bool,
   pub alias_field: String,
@@ -18,7 +17,7 @@ impl Default for ResolveOption {
         .into_iter()
         .map(|s| s.to_string())
         .collect(),
-      alias: vec![],
+      alias: Default::default(),
       condition_names: Default::default(),
       symlinks: true,
       alias_field: String::from("browser"),

--- a/crates/rspack_core/src/utils/plugin_hook/load.rs
+++ b/crates/rspack_core/src/utils/plugin_hook/load.rs
@@ -30,10 +30,10 @@ pub async fn load(
 }
 
 fn guess_loader_by_id(id: &str, options: &LoaderOptions) -> Option<Loader> {
-  let ext = if let Some(ext) = Path::new(id).extension() {
-    ext.to_str()?
+  let loader = if let Some(ext) = Path::new(id).extension() {
+    *options.get(ext.to_str()?)?
   } else {
-    "js"
+    Loader::Js
   };
-  Some(*options.get(ext)?)
+  Some(loader)
 }

--- a/crates/testground/fixtures/resolve-alias-ignore/index.js
+++ b/crates/testground/fixtures/resolve-alias-ignore/index.js
@@ -1,0 +1,3 @@
+import ignoreModule from 'ignore-module';
+
+require('assert').deepStrictEqual(ignoreModule, {});

--- a/crates/testground/fixtures/resolve-alias-ignore/rspack.config.json
+++ b/crates/testground/fixtures/resolve-alias-ignore/rspack.config.json
@@ -1,0 +1,12 @@
+{
+  "mode": "development",
+  "entries": {
+    "main": "./index.js"
+  },
+  "platform": "node",
+  "resolve": {
+    "alias": {
+      "ignore-module": false
+    }
+  }
+}

--- a/crates/testground/tests/common/mod.rs
+++ b/crates/testground/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, path::Path};
 
-use node_binding::{normalize_bundle_options, RawOptions};
+use node_binding::{normalize_bundle_options, RawOptions, RawOutputOptions};
 use rspack::bundler::Bundler;
 use rspack_core::{Asset, BundleOptions, Plugin};
 
@@ -40,10 +40,17 @@ impl RawOptionsTestExt for RawOptions {
     let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     let fixtures_dir = dir.join("fixtures").join(fixture_path);
     let pkg_path = fixtures_dir.join("rspack.config.json");
+    let outdir = fixtures_dir.join("dist").to_str().unwrap().to_string();
     let mut options = {
       if pkg_path.exists() {
         let pkg_content = std::fs::read_to_string(pkg_path).unwrap();
-        let options: RawOptions = serde_json::from_str(&pkg_content).unwrap();
+        let mut options: RawOptions = serde_json::from_str(&pkg_content).unwrap();
+        if options.output.is_none() {
+          options.output = Some(RawOutputOptions {
+            outdir: Some(outdir),
+            ..Default::default()
+          });
+        }
         options
       } else {
         RawOptions {
@@ -51,6 +58,10 @@ impl RawOptionsTestExt for RawOptions {
             "main".to_string(),
             fixtures_dir.join("index.js").to_str().unwrap().to_string(),
           )]),
+          output: Some(RawOutputOptions {
+            outdir: Some(outdir),
+            ..Default::default()
+          }),
           ..Default::default()
         }
       }

--- a/crates/testground/tests/fixtures/resolve.rs
+++ b/crates/testground/tests/fixtures/resolve.rs
@@ -8,3 +8,11 @@ async fn resolve_extensions_order() {
 
   run_js_asset_in_node(js_asset);
 }
+
+#[tokio::test]
+async fn alias_ignore() {
+  let bundler = compile_fixture("resolve-alias-ignore").await;
+  let assets = bundler.bundle.context.assets.lock().unwrap();
+  let js_asset = assets.get(0).unwrap();
+  run_js_asset_in_node(js_asset);
+}

--- a/packages/rspack/src/node/rspack/options/schema.json
+++ b/packages/rspack/src/node/rspack/options/schema.json
@@ -55,7 +55,16 @@
           "additionalProperties": false,
           "patternProperties": {
             ".*": {
-              "type": "string"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "enum": [
+                    false
+                  ]
+                }
+              ]
             }
           }
         },


### PR DESCRIPTION
This PR had following changed:

1. support `ResolvedResult::Ignored`, when user set the value is `false` in `alias` or `aliasField`, it will not bundle this module.
2. enhanced napi binding for `resolve.alias`, change its value  from `Option<String>` to `enum` and the ts type become `{ [key: string]: {false | string}`.
3. in testground, if user do not set the `outdir`, the default value changed from `testground/dist` to `testground/<cases>/dist`
4. resolve ignore test case