### PR TITLE
feat: support transform_include

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags-ignore:
-      - "**"
+      - '**'
   pull_request:
 
 jobs:
@@ -29,7 +29,5 @@ jobs:
 
       - name: Cargo fmt
         run: cargo fmt -- --check
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- --deny warnings
+      - uses: Cargo clippy
+        run: cargo clippy --all-features -- --deny warnings

--- a/crates/rspack/fixtures/svgr/app.tsx
+++ b/crates/rspack/fixtures/svgr/app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import LogoUrl from './logo.svg?raw';
+import LogoUrl from './logo.svg';
 import Logo from './logo.svg';
 
 console.log('LogoUrl', LogoUrl);

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(clippy::all)]
 #![feature(box_patterns)]
 #![feature(iter_intersperse)]
-
 mod bundle;
 mod bundle_context;
 mod chunk;

--- a/crates/rspack_core/src/plugin/mod.rs
+++ b/crates/rspack_core/src/plugin/mod.rs
@@ -45,7 +45,10 @@ pub type PluginTapGeneratedChunkHookOutput = Result<()>;
 #[async_trait]
 pub trait Plugin: Sync + Send + Debug {
   fn name(&self) -> &'static str;
-
+  #[inline]
+  fn transform_include(&self, _: &str) -> bool {
+    true
+  }
   #[inline]
   fn need_build_start(&self) -> bool {
     true

--- a/crates/rspack_core/src/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin_driver.rs
@@ -142,7 +142,11 @@ impl PluginDriver {
       .transform_hints
       .iter()
       .fold(Ok(raw), |transformed_raw, i| {
-        self.plugins[*i].transform(&self.plugin_context(), uri, loader, transformed_raw?)
+        if self.plugins[*i].transform_include(uri) {
+          self.plugins[*i].transform(&self.plugin_context(), uri, loader, transformed_raw?)
+        } else {
+          transformed_raw
+        }
       })
   }
   #[instrument(skip_all)]
@@ -151,7 +155,11 @@ impl PluginDriver {
       .transform_ast_hints
       .iter()
       .fold(Ok(ast), |transformed_ast, i| {
-        self.plugins[*i].transform_ast(&self.plugin_context(), path, transformed_ast?)
+        if self.plugins[*i].transform_include(path) {
+          self.plugins[*i].transform_ast(&self.plugin_context(), path, transformed_ast?)
+        } else {
+          transformed_ast
+        }
       })
   }
   #[instrument(skip_all)]

--- a/examples/react/src/app.jsx
+++ b/examples/react/src/app.jsx
@@ -1,7 +1,7 @@
 import './base.css';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import LogoUrl from './logo.svg?raw';
+import LogoUrl from './logo.svg';
 import Logo from './logo.svg';
 import Light from './light.svg';
 import Dark from './dark.svg';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prepare": "husky install",
     "format:rs": "cargo fmt",
     "format:js": "prettier --write \"packages/**/*.{ts,js}\"",
-    "lint:rs": "cargo clippy",
+    "lint:rs": "cargo clippy --all-features -- --deny warnings",
     "build:core": "yarn workspace @rspack/binding run build ",
     "release:core": "yarn workspace @rspack/binding run build:release ",
     "setup": "yarn install && yarn build:core",


### PR DESCRIPTION
support transform_include, so that we could the filter logic out of transform logic
since specify loader by query is deprecated in webpack, we may not support it now
think a better pattern 