### PR TITLE
feat(node-binding): add panic handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1768,6 +1768,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backtrace",
  "dashmap",
  "futures",
  "mimalloc-rust",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -28,6 +28,7 @@ async-trait = "0.1.53"
 dashmap = "5.0.0"
 tokio = { version = "1.17.0", features = ["full"] }
 tracing = "0.1.34"
+backtrace = "0.3"
 
 [target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 mimalloc-rust = { version = "0.1" }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -180,6 +180,18 @@ pub fn resolve_file(base_dir: String, import_path: String) -> Result<String> {
   }
 }
 
+#[napi::module_init]
+fn init() {
+  use backtrace::Backtrace;
+  use std::panic::set_hook;
+
+  set_hook(Box::new(|panic_info| {
+    let backtrace = Backtrace::new();
+    println!("Panic: {:?}\nBacktrace: {:?}", panic_info, backtrace);
+    std::process::exit(1)
+  }));
+}
+
 // for dts generation only
 #[napi(object)]
 pub struct RspackInternal {}


### PR DESCRIPTION
## Dos and donts

1. Handle errors for node binding
2. Rust panics should be handled by rust developers that uses this lib

## Next step

1. Prettify errors