### PR TITLE
refactor: rename transform_ast to optimize_ast && remove transform & …

### DIFF
--- a/crates/rspack_core/src/plugin/mod.rs
+++ b/crates/rspack_core/src/plugin/mod.rs
@@ -120,16 +120,6 @@ pub trait Plugin: Sync + Send + Debug {
   fn need_load(&self) -> bool {
     true
   }
-
-  #[inline]
-  fn need_transform(&self) -> bool {
-    true
-  }
-
-  #[inline]
-  fn need_transform_ast(&self) -> bool {
-    true
-  }
   #[inline]
   fn reuse_ast(&self) -> bool {
     true
@@ -189,7 +179,7 @@ pub trait Plugin: Sync + Send + Debug {
   }
 
   #[inline]
-  fn transform_ast(
+  fn optimize_ast(
     &self,
     _ctx: &PluginContext,
     _uri: &str,

--- a/crates/rspack_core/src/task.rs
+++ b/crates/rspack_core/src/task.rs
@@ -109,7 +109,7 @@ impl Task {
       parse_file(&transformed_result.code, module_id, loader).expect_module()
     };
 
-    let mut ast = plugin_hook::transform_ast(module_id, raw_ast, loader, &self.plugin_driver)?;
+    let mut ast = plugin_hook::optimize_ast(module_id, raw_ast, loader, &self.plugin_driver)?;
 
     self
       .pre_analyze_imported_module(&uri_resolver, &ast)

--- a/crates/rspack_core/src/utils/plugin_hook/transform.rs
+++ b/crates/rspack_core/src/utils/plugin_hook/transform.rs
@@ -9,13 +9,13 @@ use crate::{
 
 #[instrument(skip(ast, plugin_driver))]
 #[inline]
-pub fn transform_ast(
+pub fn optimize_ast(
   path: &str,
   ast: ast::Module,
   loader: &Loader,
   plugin_driver: &PluginDriver,
 ) -> PluginTransformAstHookOutput {
-  plugin_driver.transform_ast(path, ast, loader)
+  plugin_driver.optimize_ast(path, ast, loader)
 }
 
 #[instrument(skip_all)]

--- a/crates/rspack_plugin_ast_optimization/src/lib.rs
+++ b/crates/rspack_plugin_ast_optimization/src/lib.rs
@@ -52,16 +52,11 @@ impl Plugin for OptimizationPlugin {
   fn need_load(&self) -> bool {
     false
   }
-
-  #[inline]
-  fn need_transform(&self) -> bool {
-    false
-  }
   #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }
-  fn transform_ast(
+  fn optimize_ast(
     &self,
     ctx: &PluginContext,
     _path: &str,

--- a/crates/rspack_plugin_define/src/lib.rs
+++ b/crates/rspack_plugin_define/src/lib.rs
@@ -37,16 +37,11 @@ impl Plugin for DefinePlugin {
   }
 
   #[inline]
-  fn need_transform(&self) -> bool {
-    false
-  }
-
-  #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }
 
-  fn transform_ast(
+  fn optimize_ast(
     &self,
     ctx: &PluginContext,
     _path: &str,

--- a/crates/rspack_plugin_globals/src/lib.rs
+++ b/crates/rspack_plugin_globals/src/lib.rs
@@ -26,17 +26,6 @@ impl Plugin for GlobalsPlugin {
   fn need_build_end(&self) -> bool {
     false
   }
-
-  #[inline]
-  fn need_transform(&self) -> bool {
-    false
-  }
-
-  #[inline]
-  fn need_transform_ast(&self) -> bool {
-    false
-  }
-
   #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false

--- a/crates/rspack_plugin_lazy_compilation/src/lib.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/lib.rs
@@ -44,16 +44,6 @@ impl Plugin for LazyCompilationPlugin {
   }
 
   #[inline]
-  fn need_transform(&self) -> bool {
-    false
-  }
-
-  #[inline]
-  fn need_transform_ast(&self) -> bool {
-    false
-  }
-
-  #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }

--- a/crates/rspack_plugin_loader/src/lib.rs
+++ b/crates/rspack_plugin_loader/src/lib.rs
@@ -37,16 +37,6 @@ impl Plugin for LoaderInterpreterPlugin {
   }
 
   #[inline]
-  fn need_load(&self) -> bool {
-    false
-  }
-
-  #[inline]
-  fn need_transform_ast(&self) -> bool {
-    false
-  }
-
-  #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }

--- a/crates/rspack_plugin_node_built_in/src/lib.rs
+++ b/crates/rspack_plugin_node_built_in/src/lib.rs
@@ -31,16 +31,6 @@ impl Plugin for NodeBuiltInPlugin {
   }
 
   #[inline]
-  fn need_transform(&self) -> bool {
-    false
-  }
-
-  #[inline]
-  fn need_transform_ast(&self) -> bool {
-    false
-  }
-
-  #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -167,11 +167,6 @@ impl Plugin for ProgressPlugin {
   }
 
   #[inline]
-  fn need_transform_ast(&self) -> bool {
-    false
-  }
-
-  #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }

--- a/crates/rspack_plugin_react/src/lib.rs
+++ b/crates/rspack_plugin_react/src/lib.rs
@@ -45,11 +45,6 @@ impl Plugin for ReactPlugin {
   }
 
   #[inline]
-  fn need_transform(&self) -> bool {
-    false
-  }
-
-  #[inline]
   fn need_tap_generated_chunk(&self) -> bool {
     false
   }

--- a/crates/rspack_plugin_stylesource/src/plugin.rs
+++ b/crates/rspack_plugin_stylesource/src/plugin.rs
@@ -149,11 +149,6 @@ impl Plugin for StyleSourcePlugin {
   fn need_load(&self) -> bool {
     false
   }
-
-  #[inline]
-  fn need_transform_ast(&self) -> bool {
-    false
-  }
   #[inline]
   fn transform_include(
     &self,

--- a/crates/testground/tests/fixtures/plugin_hook.rs
+++ b/crates/testground/tests/fixtures/plugin_hook.rs
@@ -14,7 +14,7 @@ struct Record {
   call_resolve: Arc<AtomicBool>,
   call_load: Arc<AtomicBool>,
   call_transform: Arc<AtomicBool>,
-  call_transform_ast: Arc<AtomicBool>,
+  call_optimize_ast: Arc<AtomicBool>,
   call_tap_generated_chunk: Arc<AtomicBool>,
 }
 
@@ -45,7 +45,7 @@ impl Plugin for PluginHookTester {
     Ok(None)
   }
 
-  fn transform_ast(
+  fn optimize_ast(
     &self,
     _ctx: &PluginContext,
     _path: &str,
@@ -53,7 +53,7 @@ impl Plugin for PluginHookTester {
   ) -> PluginTransformAstHookOutput {
     self
       .record
-      .call_transform_ast
+      .call_optimize_ast
       .store(true, std::sync::atomic::Ordering::SeqCst);
     Ok(ast)
   }
@@ -93,7 +93,7 @@ async fn plugin_test() {
     .call_transform
     .load(std::sync::atomic::Ordering::SeqCst));
   assert!(!record
-    .call_transform_ast
+    .call_optimize_ast
     .load(std::sync::atomic::Ordering::SeqCst));
   assert!(!record
     .call_tap_generated_chunk
@@ -107,7 +107,7 @@ async fn plugin_test() {
     .call_resolve
     .load(std::sync::atomic::Ordering::SeqCst));
   assert!(record
-    .call_transform_ast
+    .call_optimize_ast
     .load(std::sync::atomic::Ordering::SeqCst));
   assert!(record
     .call_tap_generated_chunk


### PR DESCRIPTION
since transform hook already supports ast, transform_ast is confusing and it shuold be used as an optimize stage other than 
transform stage. 
and since we support transform_include and i think transform_ast hint is not necessary.
let's  see if remove this hint will cause  performance regression.