### PR TITLE
feat: add module_parsed hook

### DIFF
--- a/crates/rspack_core/src/plugin/mod.rs
+++ b/crates/rspack_core/src/plugin/mod.rs
@@ -102,6 +102,10 @@ pub trait Plugin: Sync + Send + Debug {
     false
   }
   #[inline]
+  fn module_parsed(&self, _ctx: &PluginContext, _uri: &str) -> Result<()> {
+    Ok(())
+  }
+  #[inline]
   fn need_build_start(&self) -> bool {
     true
   }

--- a/crates/rspack_core/src/task.rs
+++ b/crates/rspack_core/src/task.rs
@@ -110,7 +110,7 @@ impl Task {
     };
 
     let mut ast = plugin_hook::optimize_ast(module_id, raw_ast, loader, &self.plugin_driver)?;
-
+    self.plugin_driver.module_parsed(module_id)?;
     self
       .pre_analyze_imported_module(&uri_resolver, &ast)
       .await?;

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -188,22 +188,21 @@ impl Plugin for ProgressPlugin {
 
     Ok(())
   }
-  // take down progress temporary
-  // fn transform(&self, _ctx: &PluginContext, args: TransformArgs) -> PluginTransformHookOutput {
-  //   let done = self
-  //     .progress
-  //     .done
-  //     .lock()
-  //     .map_err(|_| anyhow::anyhow!("failed to acquire lock of done"))?;
-  //   if *done {
-  //     return Ok(args.into());
-  //   }
-  //   // if matches!(_ctx.options.mode, BundleMode::Dev) {
-  //   //   return None;
-  //   // }
-  //   self.progress.update("RsPack", &args.uri, 1)?;
-  //   Ok(args.into())
-  // }
+  fn module_parsed(&self, _ctx: &PluginContext, uri: &str) -> Result<()> {
+    let done = self
+      .progress
+      .done
+      .lock()
+      .map_err(|_| anyhow::anyhow!("failed to acquire lock of done"))?;
+    if *done {
+      return Ok(());
+    }
+    // if matches!(_ctx.options.mode, BundleMode::Dev) {
+    //   return None;
+    // }
+    self.progress.update("RsPack", uri, 1)?;
+    Ok(())
+  }
   async fn build_end(&self, _ctx: &PluginContext) -> PluginBuildEndHookOutput {
     let mut done = self.progress.done.lock().unwrap();
     if *done {


### PR DESCRIPTION
progress plugin need an hook to trace module graph build progress and transform hook is not suitable,
so we add another hook module_parsed for it(name borrow from rollup).