### PR TITLE
fix: fix resolve logic when deal with empty importer

### DIFF
--- a/crates/rspack/examples/arco_pro.rs
+++ b/crates/rspack/examples/arco_pro.rs
@@ -57,7 +57,7 @@ async fn main() {
               + "/",
           ),
         )]),
-        ..Default::default()
+        ..ResolveOption::from(BundleMode::Dev)
       },
       source_map: false.into(),
       ..Default::default()


### PR DESCRIPTION
we should call node_resolver even when importer is empty(to handle bare module resolve), also fix wrong default value for rust's side.

we should leave most of the normalizeOptions to rust side other than nodejs side 