### PR TITLE
chore: use env_logger replace debug log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fasteval"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +742,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ident_case"
@@ -1697,8 +1716,10 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "ena",
+ "env_logger",
  "futures",
  "linked-hash-map",
+ "log",
  "md4",
  "nodejs-resolver 0.0.14",
  "num_cpus",
@@ -1744,6 +1765,7 @@ dependencies = [
  "hashbrown 0.12.1",
  "indicatif",
  "linked-hash-map",
+ "log",
  "nodejs-resolver 0.0.14",
  "once_cell",
  "petgraph",

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -43,6 +43,8 @@ serde_json = "1.0.59"
 nodejs-resolver = "0.0.14"
 rspack_style = "0.1"
 md4 = "0.10.1"
+env_logger = "0.9.0"
+log = "0.4.17"
 
 [dev-dependencies]
 swc_ecma_transforms_testing = "0.80.0"

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -30,6 +30,6 @@ strum = "0.24.0"
 strum_macros = "0.24"
 hashbrown = { version = "0.12.1", features = ["rayon"]}
 better_scoped_tls = "0.1.0"
-
+log = "0.4.17"
 [dev-dependencies]
 serde_json = "1.0.81"

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -103,7 +103,7 @@ impl Chunk {
 
         HELPERS.set(&bundle.context.helpers, || {
           HELPERS.with(|helpers| {
-            println!("{:#?}", helpers);
+            log::debug!("{:#?}", helpers);
           })
         });
 


### PR DESCRIPTION
The log is quite annoying and only helps for debug, so it shouldn't be printed by default.