### PR TITLE
fix: 🐛 clean up vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,19 +20,13 @@
   "eslint.enable": false,
   "cSpell.allowCompoundWords": true,
   "cSpell.caseSensitive": true,
-  "rust-analyzer.checkOnSave.command": "clippy",
-  "rust-analyzer.checkOnSave.extraArgs": [
-    "--all-features"
-  ],
   // "rust-analyzer.checkOnSave.features": [
   //   // We use this to make IDE faster
   //   "rust-analyzer"
   // ]
   "json.schemas": [
     {
-      "fileMatch": [
-        "rspack.config.json"
-      ],
+      "fileMatch": ["rspack.config.json"],
       // Point to the options schema of rspack.
       "url": "./packages/rspack/src/node/rspack/options/schema.json"
     }


### PR DESCRIPTION
1. This pr remove custom `rust-analyzer.checkOnSave.command` which increase burden of cpu, you could put this settings under your global vscode `settings.json` if you like.