### PR TITLE
feat: support buffer and string result for loadings and transformations

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -11,8 +11,9 @@ use sugar_path::PathSugar;
 use tokio::sync::mpsc::UnboundedSender;
 
 use crate::{
-  load, parse_to_url, resolve, LoadArgs, ModuleGraphModule, ModuleType, Msg, ParseModuleArgs,
-  PluginDriver, ResolveArgs, TransformArgs, TransformResult, VisitedModuleIdentity,
+  load, parse_to_url, resolve, Content, LoadArgs, ModuleGraphModule, ModuleType, Msg,
+  ParseModuleArgs, PluginDriver, ResolveArgs, TransformArgs, TransformResult,
+  VisitedModuleIdentity,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -131,17 +132,13 @@ impl NormalModuleFactory {
       &mut self.context,
     )
     .await?;
-    tracing::trace!(
-      "load ({:?}) source {:?}",
-      self.context.module_type,
-      &source[0..usize::min(source.len(), 20)]
-    );
+    tracing::trace!("load ({:?}) source {:?}", self.context.module_type, source);
 
     // TODO: transform
     let transform_result = self.plugin_driver.transform(
       TransformArgs {
         uri: &uri,
-        code: Some(source),
+        content: Some(source),
         ast: None,
       },
       &mut self.context,
@@ -150,7 +147,7 @@ impl NormalModuleFactory {
     let mut module = self.plugin_driver.parse(
       ParseModuleArgs {
         uri: uri.as_str(),
-        source: transform_result.code,
+        source: transform_result.content,
         ast: transform_result.ast,
       },
       &mut self.context,

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -1,23 +1,23 @@
 use std::fmt::Debug;
 
-use crate::TransformArgs;
 use crate::{
   BoxModule, LoadArgs, ModuleType, NormalModuleFactoryContext, ParseModuleArgs, PluginContext,
   RenderManifestArgs, ResolveArgs, RspackAst, TransformResult,
 };
+use crate::{Content, TransformArgs};
 
 use anyhow::Context;
 use anyhow::Result;
 use hashbrown::HashMap;
 pub type PluginBuildStartHookOutput = Result<()>;
 pub type PluginBuildEndHookOutput = Result<()>;
-pub type PluginLoadHookOutput = Result<Option<String>>;
+pub type PluginLoadHookOutput = Result<Option<Content>>;
 pub type PluginTransformOutput = Result<TransformResult>;
 pub type PluginRenderManifestHookOutput = Result<Vec<Asset>>;
 pub type PluginParseModuleHookOutput = Result<BoxModule>;
 pub type PluginResolveHookOutput = Result<Option<String>>;
 pub type PluginParseOutput = Result<RspackAst>;
-pub type PluginGenerateOutput = Result<String>;
+pub type PluginGenerateOutput = Result<Content>;
 // pub type PluginTransformAstHookOutput = Result<ast::Module>;
 
 // pub type PluginTransformHookOutput = Result<TransformResult>;
@@ -66,7 +66,7 @@ pub trait Plugin: Debug + Send + Sync {
       RspackAst::Css(_ast) => Err(anyhow::anyhow!("css ast codegen not supported yet ")),
     }
   }
-  fn parse(&self, uri: &str, code: &str) -> PluginParseOutput {
+  fn parse(&self, uri: &str, content: &Content) -> PluginParseOutput {
     unreachable!()
   }
   fn transform(
@@ -75,7 +75,7 @@ pub trait Plugin: Debug + Send + Sync {
     args: TransformArgs,
   ) -> PluginTransformOutput {
     let result = TransformResult {
-      code: args.code,
+      content: args.content,
       ast: args.ast,
     };
     Ok(result)

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -1,11 +1,12 @@
 use crate::{Compilation, ResolveKind};
+use std::fmt::Debug;
 use swc_css::ast::Stylesheet;
 use swc_ecma_ast as ast;
 
 #[derive(Debug)]
 pub struct ParseModuleArgs<'a> {
   pub uri: &'a str,
-  pub source: Option<String>,
+  pub source: Option<Content>,
   pub ast: Option<RspackAst>,
 }
 
@@ -32,15 +33,34 @@ pub enum RspackAst {
   Css(Stylesheet), // I'm not sure what the final ast is, so just take placehold
 }
 
+#[derive(Clone)]
+pub enum Content {
+  String(String),
+  Buffer(Vec<u8>),
+}
+
+impl Debug for Content {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut content = f.debug_struct("Content");
+
+    match self {
+      Self::String(s) => content
+        .field("String", &s[0..usize::min(s.len(), 20)].to_owned())
+        .finish(),
+      Self::Buffer(_) => content.field("Buffer", &{ .. }).finish(),
+    }
+  }
+}
+
 #[derive(Clone, Default, Debug)]
 pub struct TransformArgs<'a> {
   pub uri: &'a str,
-  pub code: Option<String>,
+  pub content: Option<Content>,
   pub ast: Option<RspackAst>,
 }
 
 #[derive(Clone, Default, Debug)]
 pub struct TransformResult {
-  pub code: Option<String>,
+  pub content: Option<Content>,
   pub ast: Option<RspackAst>,
 }

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -1,5 +1,6 @@
 use crate::{
-  parse_to_url, LoadArgs, NormalModuleFactoryContext, PluginDriver, ResolveArgs, TransformArgs,
+  parse_to_url, Content, LoadArgs, NormalModuleFactoryContext, PluginDriver, ResolveArgs,
+  TransformArgs,
 };
 use nodejs_resolver::ResolveResult;
 use std::path::Path;
@@ -8,15 +9,17 @@ pub async fn load(
   plugin_driver: &PluginDriver,
   args: LoadArgs<'_>,
   job_ctx: &mut NormalModuleFactoryContext,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<Content> {
   let plugin_output = plugin_driver.load(args.clone(), job_ctx).await?;
 
   if let Some(output) = plugin_output {
     Ok(output)
   } else {
     let url = parse_to_url(args.uri);
-    assert_eq!(url.scheme(), "specifier");
-    Ok(tokio::fs::read_to_string(url.path()).await?)
+    debug_assert_eq!(url.scheme(), "specifier");
+    Ok(Content::String(
+      tokio::fs::read_to_string(url.path()).await?,
+    ))
   }
 }
 

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -7,8 +7,8 @@ use mime_guess::MimeGuess;
 use rayon::prelude::*;
 
 use rspack_core::{
-  Asset, AssetContent, BoxModule, Filename, LoadArgs, Module, ModuleRenderResult, ModuleType,
-  NormalModuleFactoryContext, OutputAssetModuleFilename, Parser, Plugin, PluginContext,
+  Asset, AssetContent, BoxModule, Content, Filename, LoadArgs, Module, ModuleRenderResult,
+  ModuleType, NormalModuleFactoryContext, OutputAssetModuleFilename, Parser, Plugin, PluginContext,
   PluginLoadHookOutput, PluginRenderManifestHookOutput, RenderManifestArgs, SourceType,
 };
 
@@ -17,6 +17,10 @@ pub struct AssetPlugin {}
 
 #[async_trait]
 impl Plugin for AssetPlugin {
+  fn name(&self) -> &'static str {
+    "asset"
+  }
+
   fn apply(
     &mut self,
     ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
@@ -46,7 +50,7 @@ impl Plugin for AssetPlugin {
       ctx.context.module_type,
       Some(ModuleType::Asset) | Some(ModuleType::AssetInline) | Some(ModuleType::AssetResource)
     ) {
-      Ok(Some("".to_owned()))
+      Ok(Some(Content::String("".to_owned())))
     } else {
       Ok(None)
     }

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -3,8 +3,9 @@ use crate::visitors::ClearMark;
 use crate::{module::JsModule, utils::get_swc_compiler};
 use rayon::prelude::*;
 use rspack_core::{
-  Asset, AssetContent, Filename, ModuleRenderResult, ModuleType, OutputFilename, ParseModuleArgs,
-  Parser, Plugin, PluginContext, PluginRenderManifestHookOutput, RspackAst, SourceType,
+  Asset, AssetContent, Content, Filename, ModuleRenderResult, ModuleType, OutputFilename,
+  ParseModuleArgs, Parser, Plugin, PluginContext, PluginRenderManifestHookOutput, RspackAst,
+  SourceType,
 };
 use rspack_sources::{RawSource, Source};
 
@@ -119,10 +120,14 @@ impl Parser for JsParser {
       match args.ast {
         Some(RspackAst::JavaScript(_ast)) => Ok::<_, anyhow::Error>(_ast),
         None => {
-          if let Some(source) = args.source {
+          if let Some(Content::String(source)) = args.source {
             Ok(parse_file(source, args.uri, &module_type))
           } else {
-            anyhow::bail!("ast and source is both empty for {}", args.uri)
+            anyhow::bail!(
+              "ast and source is both empty for {}, or content type does not match {:?}",
+              args.uri,
+              args.source
+            )
           }
         }
         _ => anyhow::bail!("not supported ast {:?} for js parser", args.ast),


### PR DESCRIPTION
## What does this PR do?

1. Change `code` in a few options to `content` for naming compatibility to different module types
2. Content now supports both `Buffer` and `String`.