### PR TITLE
chore: use self-hosted rust-cache

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install toolchain
         run: rustup show
       - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: speedy-js/rust-cache-self-hosted@v1
       - name: Run rustfmt
         uses: actions-rs/cargo@v1
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Install toolchain
         run: rustup show
       - name: Cache
-        uses: Swatinem/rust-cache@v1
+        uses: speedy-js/rust-cache-self-hosted@v1
       - name: Run cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -66,6 +66,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install toolchain
         run: rustup show
+      - name: Cache
+        uses: speedy-js/rust-cache-self-hosted@v1
       # - name: Install yarn
       #   run: npm install -g yarn
       # - name: yarn install --no-immutable


### PR DESCRIPTION
Use a forked version of rust-cache, in which `.cargo/bin` cache is removed due to https://github.com/Swatinem/rust-cache/issues/16

The forked version: https://github.com/speedy-js/rust-cache-self-hosted
Changes of the forked version: https://github.com/speedy-js/rust-cache-self-hosted/commit/c93c18a4b108cf02cf33a17e6a8085d28f69d255