### PR TITLE
ci:  add benchmark back

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   benchmarks:
     name: Benchmarks
-    # if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench')
     runs-on: [self-hosted, rspack-bench]
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
1. Benchmark will not triggered by every commits, instead you could trigger it by left a comment that contains `!bench` under your pull request