### PR TITLE
perf: optimize stats type

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -167,7 +167,7 @@ impl Compiler {
         }
       })?;
 
-    Ok(Stats::new(assets))
+    Ok(Stats::new(assets.into_boxed_slice()))
   }
 
   #[instrument(skip_all)]

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -2,11 +2,11 @@ use crate::Asset;
 
 #[derive(Debug)]
 pub struct Stats {
-  assets: Vec<Asset>,
+  assets: Box<[Asset]>,
 }
 
 impl Stats {
-  pub fn new(assets: Vec<Asset>) -> Self {
+  pub fn new(assets: Box<[Asset]>) -> Self {
     Self { assets }
   }
 }


### PR DESCRIPTION
1. Make `assets` in `Stats` immutable, which is more expressive to describe the immutability
2. Avoid unnecessary cap allocation.