### PR TITLE
Refactor node_binding_options

### DIFF
--- a/crates/node_binding/src/options/mod.rs
+++ b/crates/node_binding/src/options/mod.rs
@@ -32,31 +32,14 @@ pub use output::*;
 // pub use resolve::*;
 // pub use split_chunks::*;
 
-#[cfg(not(feature = "test"))]
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-#[napi(object)]
+#[cfg_attr(not(feature = "test"), napi(object))]
 pub struct RawOptions {
   pub entry: HashMap<String, String>,
   // #[napi(ts_type = "\"development\" | \"production\" | \"none\"")]
   // pub mode: Option<String>,
   // #[napi(ts_type = "\"browser\" | \"node\"")]
-  // pub platform: Option<String>,
-  pub context: Option<String>,
-  // pub loader: Option<HashMap<String, String>>,
-  // pub enhanced: Option<RawEnhancedOptions>,
-  // pub optimization: Option<RawOptimizationOptions>,
-  pub output: Option<RawOutputOptions>,
-  // pub resolve: Option<RawResolveOptions>,
-  // pub chunk_filename: Option<String>,
-}
-
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
-#[cfg(feature = "test")]
-pub struct RawOptions {
-  pub entry: HashMap<String, String>,
-  // pub mode: Option<String>,
   // pub platform: Option<String>,
   pub context: Option<String>,
   // pub loader: Option<HashMap<String, String>>,

--- a/crates/node_binding/src/options/output.rs
+++ b/crates/node_binding/src/options/output.rs
@@ -5,19 +5,7 @@ use napi_derive::napi;
 
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
-#[napi(object)]
-#[cfg(not(feature = "test"))]
-pub struct RawOutputOptions {
-  pub path: Option<String>,
-  pub asset_module_filename: Option<String>,
-  // pub entry_filename: Option<String>,
-  // #[napi(ts_type = "\"linked\" | \"external\" | \"inline\" | \"none\"")]
-  // pub source_map: Option<String>,
-}
-
-#[derive(Deserialize, Debug, Default)]
-#[serde(rename_all = "camelCase")]
-#[cfg(feature = "test")]
+#[cfg_attr(not(feature = "test"), napi(object))]
 pub struct RawOutputOptions {
   pub path: Option<String>,
   pub asset_module_filename: Option<String>,


### PR DESCRIPTION
## Summary
1. using `#[cfg_attr(not(feature = "test"), napi(object))]` to avoid maintain two separate config struct, 
this is especially helpful when you have some document comments on your config.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan
1. The CI should pass.

## Related issue (if exists)

## Future reading

<!-- Reference that may help understand this pull request -->