### PR TITLE
ci: cleanup workspace

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -37,6 +37,9 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Cleanup workspace
+        uses: TooMuch4U/actions-clean@v2.1
+        if: ${{ always() }}
       - name: Get PR SHA
         id: sha
         uses: actions/github-script@v6
@@ -95,10 +98,3 @@ jobs:
             ${{ steps.bench_comparison.outputs.comment }}
       - name: Remove Criterion Artifact
         run: rm -rf ./target/criterion
-
-      # - name: Clean working directory
-      #   shell: bash
-      #   run: |
-      #     cd $RUNNER_WORKSPACE
-      #     cd ..
-      #     rm -r *

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,6 +17,9 @@ jobs:
     name: Format Rust Files
     runs-on: [self-hosted, common]
     steps:
+      - name: Cleanup workspace
+        uses: TooMuch4U/actions-clean@v2.1
+        if: ${{ always() }}
       - name: Checkout PR Branch
         uses: actions/checkout@v3
         with:
@@ -39,6 +42,9 @@ jobs:
     name: Lint Rust Files
     runs-on: [self-hosted, common]
     steps:
+      - name: Cleanup workspace
+        uses: TooMuch4U/actions-clean@v2.1
+        if: ${{ always() }}
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Install toolchain
@@ -58,6 +64,9 @@ jobs:
     runs-on: [self-hosted, common]
     timeout-minutes: 30
     steps:
+      - name: Cleanup workspace
+        uses: TooMuch4U/actions-clean@v2.1
+        if: ${{ always() }}
       - uses: actions/checkout@v2
       - name: Install toolchain
         run: rustup show


### PR DESCRIPTION
## Summary

Cleanup workspace as soon as CI Job finishes

## Further reading
Use a post-entrypoint to do the cleanup https://github.com/TooMuch4U/actions-clean, which runs after the cache was uploaded