### PR TITLE
chore: add explicit feature for example

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -13,6 +13,15 @@ crate-type = ["lib", "cdylib"]
 default = []
 test = ["napi-derive/noop"]
 
+[[example]]
+name = "basic"
+required-features = ["test"]
+
+[[example]]
+name = "serve"
+required-features = ["test"]
+
+
 [dependencies]
 anyhow = {version = "1", features = ["backtrace"]}
 async-trait = "0.1.53"


### PR DESCRIPTION
## Summary

Temporarily fix the issue with examples by adding an explicit warning for the user end when trying to invoke an example from command-line 
```
error: target `serve` in package `rspack_node` requires the features: `test`
Consider enabling them by passing, e.g., `--features="test"`
```

Rust analyzer understands `required-features` and it will append features to the running command, so basically it is ok for our daily use basis.

For the long-term speaking, it's not a good idea to place configuration in node binding which arouse a mix-up with `lib`
 and `cdylib`. We will resolve this in the future.

## Further reading
https://github.com/rust-lang/cargo/issues/4663
https://github.com/rust-lang/rfcs/pull/2887


