### PR TITLE
fix(html): default template compatible with html-plugin

### DIFF
--- a/crates/node_binding/examples/basic.rs
+++ b/crates/node_binding/examples/basic.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
-
 use rspack::rspack;
 use rspack_core::log;
 use rspack_node::{normalize_bundle_options, RawOptions, RawOutputOptions};
+use serde_json::json;
+use std::collections::HashMap;
 
 #[tokio::main]
 async fn main() {
@@ -25,6 +25,7 @@ async fn main() {
         public_path: Some(String::from("http://localhost:3000/")),
         ..RawOutputOptions::default()
       }),
+      plugins: Some(json!(["html"])),
       ..Default::default()
     })
     .unwrap(),

--- a/crates/node_binding/src/options/raw_plugins.rs
+++ b/crates/node_binding/src/options/raw_plugins.rs
@@ -30,7 +30,6 @@ impl RawOption<Result<Plugins>> for RawPlugins {
             "`config.plugins[{i}]`: structure is not recognized."
           )));
         };
-
         match target.as_deref() {
           Some("html") => {
             let config: HtmlPluginConfig = match config {

--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -9,7 +9,6 @@ pub fn rspack(mut options: CompilerOptions, mut plugins: Vec<Box<dyn Plugin>>) -
   plugins.push(Box::new(rspack_plugin_asset::AssetPlugin {}));
   plugins.push(Box::new(rspack_plugin_json::JsonPlugin {}));
   plugins.push(Box::new(rspack_plugin_runtime::RuntimePlugin {}));
-
   plugins.append(&mut options.plugins);
   Compiler::new(options, plugins)
 }

--- a/crates/rspack_plugin_html/fixtures/basic/test.config.json
+++ b/crates/rspack_plugin_html/fixtures/basic/test.config.json
@@ -3,6 +3,11 @@
     "index": "./index.js"
   },
   "plugins": [
-    "html"
+    [
+      "html",
+      {
+        "template": "index.html"
+      }
+    ]
   ]
 }

--- a/crates/rspack_plugin_html/fixtures/chunks/test.config.json
+++ b/crates/rspack_plugin_html/fixtures/chunks/test.config.json
@@ -8,6 +8,7 @@
     [
       "html",
       {
+        "template": "index.html",
         "chunks": [
           "chunk1",
           "chunk2"

--- a/crates/rspack_plugin_html/fixtures/mpa/test.config.json
+++ b/crates/rspack_plugin_html/fixtures/mpa/test.config.json
@@ -8,6 +8,7 @@
     [
       "html",
       {
+        "template": "index.html",
         "sri": "sha384",
         "filename": "chunk1.html",
         "chunks": [
@@ -18,6 +19,7 @@
     [
       "html",
       {
+        "template": "index.html",
         "sri": "sha256",
         "filename": "chunk2.html",
         "chunks": [
@@ -28,6 +30,7 @@
     [
       "html",
       {
+        "template": "index.html",
         "sri": "sha512",
         "filename": "chunk3.html",
         "chunks": [

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -23,8 +23,7 @@ pub struct HtmlPluginConfig {
   #[serde(default = "default_filename")]
   pub filename: String,
   /// template html file
-  #[serde(default = "default_template")]
-  pub template: String,
+  pub template: Option<String>,
   /// `head`, `body` or None
   pub inject: Option<HtmlPluginConfigInject>,
   /// path or `auto`
@@ -58,7 +57,7 @@ impl Default for HtmlPluginConfig {
   fn default() -> HtmlPluginConfig {
     HtmlPluginConfig {
       filename: default_filename(),
-      template: default_template(),
+      template: None,
       inject: None,
       public_path: None,
       script_loading: default_script_loading(),

--- a/examples/react/test.config.json
+++ b/examples/react/test.config.json
@@ -8,5 +8,8 @@
       "fastRefresh": false
     },
     "svgr": true
-  }
+  },
+  "plugins": [
+    "html"
+  ]
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
enable html-plugin and make html-plugin options more compatible with webpack-html-plugin, since plugin options is not ready yet, I just enable html-plugin by default.
It seems html-plugin not handle js chunk order correctly, leave it to another pr

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Future reading

<!-- Reference that may help understand this pull request -->