### PR TITLE
refactor: 💡 Better method naming and doc comments with `CompilerOptionsBuilder`

### DIFF
--- a/crates/node_binding/src/options/mod.rs
+++ b/crates/node_binding/src/options/mod.rs
@@ -92,7 +92,7 @@ pub struct RawOptions {
 
 pub fn normalize_bundle_options(raw_options: RawOptions) -> anyhow::Result<CompilerOptions> {
   // normalize_options should ensuring orderliness.
-  let compier_options = CompilerOptionsBuilder::default()
+  let compiler_options = CompilerOptionsBuilder::default()
     .then(|mut options| {
       let context = RawOption::raw_to_compiler_option(raw_options.context, &options)?;
       options.context = Some(context);
@@ -140,9 +140,9 @@ pub fn normalize_bundle_options(raw_options: RawOptions) -> anyhow::Result<Compi
       options.module = module_options;
       Ok(options)
     })?
-    .unwrap();
+    .finish();
 
-  Ok(compier_options)
+  Ok(compiler_options)
 }
 
 // pub fn parse_raw_alias(

--- a/crates/rspack_core/src/options/mod.rs
+++ b/crates/rspack_core/src/options/mod.rs
@@ -35,7 +35,10 @@ pub struct CompilerOptionsBuilder {
 }
 
 impl CompilerOptionsBuilder {
-  pub fn unwrap(self) -> CompilerOptions {
+  /// ## Warning
+  /// Caller should ensure that all fields of [CompilerOptionsBuilder] are not `None`.
+  /// Otherwise, this function will panic during the runtime
+  pub fn finish(self) -> CompilerOptions {
     CompilerOptions {
       entry: self.entry.unwrap(),
       context: self.context.unwrap(),


### PR DESCRIPTION
## Summary
1. Better method naming,  `unwrap` maybe conflict with convention. Mostly, it is used with `Option<T>` or `Result<T>`
2. Fixing typo.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Future reading

<!-- Reference that may help understand this pull request -->