### PR TITLE
feat: sass-loader on rust side

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -48,6 +48,11 @@ jobs:
           script: |
             const response = await github.request(context.payload.issue.pull_request.url);
             return response.data.head.sha;
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout PR Branch
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,6 +47,10 @@ jobs:
         if: ${{ always() }}
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install toolchain
         run: rustup show
       #- name: Cache
@@ -67,7 +71,12 @@ jobs:
       - name: Cleanup workspace
         uses: TooMuch4U/actions-clean@v2.1
         if: ${{ always() }}
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install toolchain
         run: rustup show
       #- name: Cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1405,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
 name = "multipart"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,6 +1899,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,6 +2101,7 @@ dependencies = [
  "rspack_binding_options",
  "rspack_core",
  "rspack_error",
+ "rspack_loader_sass",
  "rspack_plugin_asset",
  "rspack_plugin_css",
  "rspack_plugin_html",
@@ -2073,6 +2133,7 @@ dependencies = [
  "regex",
  "rspack_core",
  "rspack_error",
+ "rspack_loader_sass",
  "rspack_plugin_css",
  "rspack_plugin_html",
  "serde",
@@ -2130,6 +2191,24 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+]
+
+[[package]]
+name = "rspack_loader_sass"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "itertools",
+ "once_cell",
+ "regex",
+ "rspack_core",
+ "rspack_error",
+ "rspack_loader_runner",
+ "rspack_test",
+ "sass-embedded",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2310,6 +2389,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sass-embedded"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f4bb13e7ebead354cd7c07ab25490a27444a35a45c27aabc9975e834782f6e"
+dependencies = [
+ "atty",
+ "crossbeam-channel",
+ "dashmap",
+ "parking_lot",
+ "prost",
+ "prost-build",
+ "regex",
+ "rustc-hash",
+ "serde_json",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -4290,6 +4388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,6 +4554,17 @@ checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -713,6 +713,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1166,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multipart"
@@ -1616,6 +1628,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools",
+ "lazy_static",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost",
+ "prost-types",
+ "regex",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+dependencies = [
+ "bytes",
+ "prost",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +1818,7 @@ dependencies = [
  "once_cell",
  "rspack_core",
  "rspack_error",
+ "rspack_loader_sass",
  "rspack_plugin_asset",
  "rspack_plugin_css",
  "rspack_plugin_html",
@@ -1832,6 +1898,22 @@ dependencies = [
  "anyhow",
  "async-trait",
  "rspack_error",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "rspack_loader_sass"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "regex",
+ "rspack_core",
+ "rspack_error",
+ "rspack_loader_runner",
+ "sass-embedded",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2000,6 +2082,25 @@ name = "safemem"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
+
+[[package]]
+name = "sass-embedded"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ebad66d9bb96a9221c66db18dc981491ab036988e084c3c4b4eafe1f4c8d0a"
+dependencies = [
+ "atty",
+ "crossbeam-channel",
+ "dashmap",
+ "parking_lot",
+ "prost",
+ "prost-build",
+ "regex",
+ "rustc-hash",
+ "serde_json",
+ "url",
+ "urlencoding",
+]
 
 [[package]]
 name = "scoped-tls"
@@ -3924,6 +4025,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4054,6 +4161,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+
+[[package]]
+name = "which"
+version = "4.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -23,6 +23,7 @@ rspack_plugin_html = { path = "../rspack_plugin_html" }
 rspack_plugin_javascript = { path = "../rspack_plugin_javascript" }
 rspack_plugin_json = { path = "../rspack_plugin_json" }
 rspack_plugin_runtime = { path = "../rspack_plugin_runtime" }
+rspack_loader_sass = { path = "../rspack_loader_sass" }
 # futures = "0.3.21"
 anyhow = "1"
 async-trait = "0.1.53"

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 rspack_core = { path = "../rspack_core" }
 rspack_plugin_html = { path = "../rspack_plugin_html" }
 rspack_plugin_css = { path = "../rspack_plugin_css" }
+rspack_loader_sass = { path = "../rspack_loader_sass" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1.53"

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -91,6 +91,8 @@ impl TryFrom<&str> for ModuleType {
       "jpg" => Ok(Self::Asset),
       "svg" => Ok(Self::Asset),
       "txt" => Ok(Self::AssetSource),
+      // TODO: get module_type from module
+      "scss" | "sass" => Ok(Self::Css),
       _ => Err(()),
     }
   }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -172,7 +172,7 @@ impl NormalModuleFactory {
       resource_fragment: url.fragment().map(|f| f.to_owned()),
     };
 
-    let runner_result = if uri.starts_with("UnReachable:") || uri.contains(".scss") {
+    let runner_result = if uri.starts_with("UnReachable:") {
       LoaderResult {
         content: Content::Buffer("module.exports = {}".to_string().as_bytes().to_vec()),
       }

--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition = "2021"
+name = "rspack_loader_sass"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rspack_core = { path = "../rspack_core" }
+rspack_error = { path = "../rspack_error" }
+rspack_loader_runner = { path = "../loader_runner" }
+async-trait = "0.1.53"
+tokio = { version = "1.17.0", features = ["full"] }
+tracing = "0.1.34"
+tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+sass-embedded = { version = "0.4", features = ["legacy"] }
+regex = "1"
+once_cell = "1"
+itertools = "0.10"
+
+[dev_dependencies]
+rspack_test = { path = "../rspack_test" }

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -1,0 +1,424 @@
+use std::{
+  collections::HashSet,
+  env,
+  iter::Peekable,
+  path::{Path, PathBuf},
+};
+
+use itertools::Itertools;
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rspack_core::{Resolve, ResolveResult, Resolver, ResolverFactory};
+use rspack_error::{Error, Result, TraceableError};
+use rspack_loader_runner::{Loader, LoaderContext, LoaderResult};
+use sass_embedded::{
+  legacy::{
+    IndentType, LegacyImporter, LegacyImporterResult, LegacyImporterThis, LegacyOptions,
+    LegacyOptionsBuilder, LineFeed, OutputStyle,
+  },
+  Exception, Sass, Url,
+};
+use tokio::sync::Mutex;
+
+static IS_SPECIAL_MODULE_IMPORT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^~[^/]+$").unwrap());
+static IS_NATIVE_WIN32_PATH: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"(?i)^[a-z]:[/\\]|^\\\\").unwrap());
+static MODULE_REQUEST: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[^?]*~").unwrap());
+static IS_MODULE_IMPORT: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^~([^/]+|[^/]+/|@[^/]+[/][^/]+|@[^/]+/?|@[^/]+[/][^/]+/)$").unwrap());
+
+#[derive(Debug)]
+pub struct SassLoaderOptions {
+  sass_options: SassOptions,
+  // `None` means open or close source map depends on whether in production mode.
+  source_map: Option<bool>,
+  additional_data: Option<String>,
+  rspack_importer: bool,
+}
+
+impl Default for SassLoaderOptions {
+  fn default() -> Self {
+    Self {
+      rspack_importer: true,
+      source_map: Default::default(),
+      additional_data: Default::default(),
+      sass_options: Default::default(),
+    }
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct SassOptions {
+  indented_syntax: Option<bool>,
+  include_paths: Vec<PathBuf>,
+  charset: Option<bool>,
+  indent_type: Option<IndentType>,
+  indent_width: Option<usize>,
+  linefeed: Option<LineFeed>,
+  output_style: Option<OutputStyle>,
+  quiet_deps: Option<bool>,
+  verbose: Option<bool>,
+}
+
+#[derive(Debug)]
+struct RspackImporter {
+  include_paths: Vec<PathBuf>,
+  sass_module_resolve: Resolver,
+  sass_import_resolve: Resolver,
+  rspack_module_resolve: Resolver,
+  rspack_import_resolve: Resolver,
+}
+
+impl RspackImporter {
+  pub fn new(include_paths: Vec<PathBuf>) -> Self {
+    // TODO: use `loader_context.getResolve` for factory to support inherit
+    // alias and modules from compiler options.
+    let factory = ResolverFactory::default();
+    let sass_module_resolve = factory.get(Resolve {
+      extensions: vec![".sass".to_owned(), ".scss".to_owned(), ".css".to_owned()],
+      alias: Vec::new(),
+      prefer_relative: true,
+      main_files: vec!["_index".to_owned(), "index".to_owned()],
+      main_fields: Vec::new(),
+      // TODO: add restrictions field when resolver supports it.
+      ..Default::default()
+    });
+    let sass_import_resolve = factory.get(Resolve {
+      extensions: vec![".sass".to_owned(), ".scss".to_owned(), ".css".to_owned()],
+      alias: Vec::new(),
+      prefer_relative: true,
+      main_files: vec![
+        "_index.import".to_owned(),
+        "_index".to_owned(),
+        "index.import".to_owned(),
+        "index".to_owned(),
+      ],
+      main_fields: Vec::new(),
+      ..Default::default()
+    });
+    let rspack_module_resolve = factory.get(Resolve {
+      // TODO: add dependencyType.
+      condition_names: HashSet::from_iter(["sass".to_owned(), "style".to_owned()]),
+      // TODO: ["sass", "style", "main", "..."] support `"..."`.
+      main_fields: vec!["sass".to_owned(), "style".to_owned(), "main".to_owned()],
+      // TODO: ["_index", "index", "..."] support `"..."`.
+      main_files: vec!["_index".to_owned(), "index".to_owned()],
+      extensions: vec![".sass".to_owned(), ".scss".to_owned(), ".css".to_owned()],
+      prefer_relative: true,
+      ..Default::default()
+    });
+    let rspack_import_resolve = factory.get(Resolve {
+      condition_names: HashSet::from_iter(["sass".to_owned(), "style".to_owned()]),
+      main_fields: vec!["sass".to_owned(), "style".to_owned(), "main".to_owned()],
+      main_files: vec![
+        "_index.import".to_owned(),
+        "_index".to_owned(),
+        "index.import".to_owned(),
+        "index".to_owned(),
+      ],
+      extensions: vec![".sass".to_owned(), ".scss".to_owned(), ".css".to_owned()],
+      prefer_relative: true,
+      ..Default::default()
+    });
+    Self {
+      include_paths,
+      sass_import_resolve,
+      sass_module_resolve,
+      rspack_import_resolve,
+      rspack_module_resolve,
+    }
+  }
+}
+
+fn get_possible_requests(
+  url: &str,
+  for_rspack_resolver: bool,
+  from_import: bool,
+) -> std::result::Result<Vec<String>, Exception> {
+  let mut request = url.to_string();
+  if for_rspack_resolver {
+    if MODULE_REQUEST.is_match(url) {
+      request = MODULE_REQUEST.replace(&request, "").to_string();
+    }
+    if IS_MODULE_IMPORT.is_match(url) {
+      if !request.ends_with('/') {
+        request.push('/');
+      }
+      if request == url {
+        return Ok(vec![request]);
+      }
+      return Ok(vec![request, url.to_string()]);
+    }
+  }
+
+  let request_path = Path::new(&request);
+  let ext = match request_path.extension() {
+    Some(ext) if ext.to_string_lossy() == "css" => return Ok(Vec::new()),
+    Some(ext) => format!(".{}", ext.to_string_lossy()),
+    None => "".to_owned(),
+  };
+
+  let dirname = request_path.parent();
+  let dirname = if matches!(dirname, None)
+    || matches!(
+      dirname,
+      Some(p) if p == Path::new("") || p == Path::new(".")
+    ) {
+    "".to_owned()
+  } else {
+    // SAFETY: `unwrap` is ok since `None` is checked in if branch.
+    format!("{}/", dirname.unwrap().display())
+  };
+  let basename = request_path
+    .file_name()
+    .ok_or_else(|| Exception::new("The path of sass's dependency should have file name"))?
+    .to_string_lossy();
+  // SAFETY: `unwrap` is ok since `request_path` has file name is checked before.
+  let basename_without_ext = request_path.file_stem().unwrap().to_string_lossy();
+
+  let mut requests = Vec::new();
+  if from_import {
+    requests.push(format!("{dirname}_{basename_without_ext}.import{ext}"));
+    requests.push(format!("{dirname}{basename_without_ext}.import{ext}"));
+  }
+  requests.push(format!("{dirname}_{basename}"));
+  requests.push(format!("{dirname}{basename}"));
+  if for_rspack_resolver {
+    requests.push(url.to_string());
+  }
+  Ok(requests.into_iter().unique().collect())
+}
+
+#[derive(Debug)]
+struct Resolution<'r, 'c, I: Iterator<Item = String>> {
+  resolve: &'r Resolver,
+  context: &'c Path,
+  possible_requests: I,
+}
+
+fn start_resolving<'r, 'c, I: Iterator<Item = String>>(
+  mut resolutions: Peekable<impl Iterator<Item = Resolution<'r, 'c, I>>>,
+) -> Option<PathBuf> {
+  let resolution = resolutions.peek_mut()?;
+  if let Some(possible_request) = resolution.possible_requests.next() {
+    if let Ok(ResolveResult::Info(info)) = resolution
+      .resolve
+      .resolve(resolution.context, &possible_request)
+    {
+      Some(info.path)
+    } else {
+      start_resolving(resolutions)
+    }
+  } else {
+    resolutions.next();
+    start_resolving(resolutions)
+  }
+}
+
+impl LegacyImporter for RspackImporter {
+  fn call(
+    &self,
+    options: &LegacyImporterThis,
+    request: &str,
+    context: &str,
+  ) -> sass_embedded::Result<Option<LegacyImporterResult>> {
+    let from_importer = options.from_import;
+    let need_emulate_sass_resolver = !IS_SPECIAL_MODULE_IMPORT.is_match(request)
+      && !request.starts_with('/')
+      && !IS_NATIVE_WIN32_PATH.is_match(request);
+
+    let mut resolutions = Vec::new();
+    if !self.include_paths.is_empty() && need_emulate_sass_resolver {
+      let sass_possible_requests = get_possible_requests(request, false, from_importer)?;
+      resolutions.extend(self.include_paths.iter().map(|context| Resolution {
+        resolve: if from_importer {
+          &self.sass_import_resolve
+        } else {
+          &self.sass_module_resolve
+        },
+        context,
+        possible_requests: sass_possible_requests.clone().into_iter(),
+      }));
+    }
+
+    let rspack_possible_requests = get_possible_requests(request, true, from_importer)?;
+    resolutions.push(Resolution {
+      resolve: if from_importer {
+        &self.rspack_import_resolve
+      } else {
+        &self.rspack_module_resolve
+      },
+      context: Path::new(context)
+        .parent()
+        .ok_or_else(|| Exception::new(format!("dirname of {context} is `None`")))?,
+      possible_requests: rspack_possible_requests.into_iter(),
+    });
+
+    Ok(start_resolving(resolutions.into_iter().peekable()).map(LegacyImporterResult::file))
+  }
+}
+
+#[derive(Debug)]
+pub struct SassLoader {
+  compiler: Mutex<Sass>,
+  options: SassLoaderOptions,
+}
+
+fn exe_path() -> PathBuf {
+  let os = match env::consts::OS {
+    "linux" => "linux",
+    "macos" => "darwin",
+    "windows" => "win32",
+    os => panic!("dart-sass-embedded is not supported for {os}"),
+  };
+  let arch = match env::consts::ARCH {
+    "x86" => "ia32",
+    "x86_64" => "x64",
+    "aarch64" => "arm64",
+    arch => panic!("dart-sass-embedded is not supported for {arch}"),
+  };
+  PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR")))
+    .join(format!("../../node_modules/@tmp-sass-embedded/{os}-{arch}"))
+    .join("dart-sass-embedded/dart-sass-embedded")
+}
+
+impl SassLoader {
+  pub fn new(path: Option<PathBuf>, options: SassLoaderOptions) -> Self {
+    Self {
+      // js side should ensure exe_path is a correct dart-sass-embedded path.
+      compiler: Mutex::new(Sass::new(path.unwrap_or_else(exe_path)).unwrap()),
+      options,
+    }
+  }
+
+  fn get_sass_options<'a>(
+    &self,
+    loader_context: &LoaderContext<'a>,
+    content: String,
+    source_map: bool,
+  ) -> LegacyOptions {
+    let mut builder = LegacyOptionsBuilder::default()
+      .data(
+        if let Some(additional_data) = &self.options.additional_data {
+          format!("{additional_data}\n{content}")
+        } else {
+          content
+        },
+      )
+      // TODO: switch to loader_context.get_logger("sass-loader") after rspack
+      // logging implemented (https://webpack.js.org/api/loaders/#logging).
+      // .logger(arg)
+      .file(loader_context.resource_path)
+      .source_map(source_map)
+      // TODO: use OutputStyle::Compressed when loader_context.mode is production.
+      .output_style(
+        self
+          .options
+          .sass_options
+          .output_style
+          .unwrap_or(OutputStyle::Expanded),
+      )
+      .indented_syntax(
+        self
+          .options
+          .sass_options
+          .indented_syntax
+          .unwrap_or_else(|| {
+            Path::new(loader_context.resource_path)
+              .extension()
+              .map(|ext| ext == "sass")
+              .unwrap_or_default()
+          }),
+      );
+
+    let mut include_paths = vec![env::current_dir().unwrap()];
+    include_paths.extend(self.options.sass_options.include_paths.iter().map(|path| {
+      if path.is_absolute() {
+        path.to_owned()
+      } else {
+        env::current_dir().unwrap().join(path)
+      }
+    }));
+    builder = builder.include_paths(&include_paths);
+
+    if self.options.rspack_importer {
+      builder = builder.importer(RspackImporter::new(include_paths));
+    }
+
+    if let Some(charset) = &self.options.sass_options.charset {
+      builder = builder.charset(*charset);
+    }
+    if let Some(indent_type) = &self.options.sass_options.indent_type {
+      builder = builder.indent_type(indent_type.to_owned());
+    }
+    if let Some(linefeed) = &self.options.sass_options.linefeed {
+      builder = builder.linefeed(linefeed.to_owned());
+    }
+    if let Some(indent_width) = &self.options.sass_options.indent_width {
+      builder = builder.indent_width(*indent_width);
+    }
+    if let Some(quiet_deps) = &self.options.sass_options.quiet_deps {
+      builder = builder.quiet_deps(*quiet_deps);
+    }
+    if let Some(verbose) = &self.options.sass_options.verbose {
+      builder = builder.verbose(*verbose);
+    }
+
+    builder.build()
+  }
+}
+
+#[async_trait::async_trait]
+impl Loader for SassLoader {
+  fn name(&self) -> &'static str {
+    "sass-loader"
+  }
+
+  async fn run(&self, loader_context: &LoaderContext<'_>) -> Result<Option<LoaderResult>> {
+    let source = loader_context.source.to_owned();
+    let source_map = self.options.source_map.unwrap_or({
+      // TODO: change to loader_context.options.source_map
+      false
+    });
+    let sass_options = self.get_sass_options(loader_context, source.try_into_string()?, source_map);
+    let result = self
+      .compiler
+      .lock()
+      .await
+      .render(sass_options)
+      .map_err(sass_exception_to_error)?;
+    Ok(Some(LoaderResult {
+      content: result.css.into(),
+    }))
+  }
+
+  fn as_any(&self) -> &dyn std::any::Any {
+    self
+  }
+
+  fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+    self
+  }
+}
+
+fn sass_exception_to_error(e: Exception) -> Error {
+  if let Some(span) = e.span()
+    && let Some(start) = &span.start
+    && let Some(end) = &span.end
+    && let Some(message) = e.sass_message() {
+    Error::TraceableError(TraceableError::from_path(
+      Url::parse(&span.url)
+        .unwrap()
+        .to_file_path()
+        .unwrap()
+        .to_string_lossy()
+        .to_string(),
+      start.offset.try_into().unwrap(),
+      end.offset.try_into().unwrap(),
+      "Sass Error".to_string(),
+      message.to_string(),
+    ))
+  } else {
+    Error::InternalError(e.message().to_string())
+  }
+}

--- a/crates/rspack_loader_sass/tests/expected/rspack_importer.css
+++ b/crates/rspack_loader_sass/tests/expected/rspack_importer.css
@@ -1,0 +1,35 @@
+@charset "UTF-8";
+@import "./file.css";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+
+.foo:before {
+  content: "\e0c6";
+}
+
+.bar:before {
+  content: "∑";
+}

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -1,0 +1,45 @@
+use std::{
+  env, fs,
+  path::{Path, PathBuf},
+};
+
+use rspack_core::{Loader, LoaderRunner, ResourceData};
+use rspack_loader_sass::{SassLoader, SassLoaderOptions};
+use rspack_test::{fixture, test_fixture};
+use sass_embedded::Url;
+
+// UPDATE_SASS_LOADER_TEST=1 cargo test --package rspack_loader_sass test_fn_name -- --exact --nocapture
+async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
+  let tests_path = PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"))).join("tests");
+  let expected_path = tests_path.join(expected);
+  let actual_path = tests_path.join(actual);
+
+  let url = Url::from_file_path(&actual_path.to_string_lossy().to_string()).unwrap();
+  let result = LoaderRunner::new(ResourceData {
+    resource: actual_path.to_string_lossy().to_string(),
+    resource_path: url.path().to_owned(),
+    resource_query: url.query().map(|q| q.to_owned()),
+    resource_fragment: url.fragment().map(|f| f.to_owned()),
+  })
+  .run([&SassLoader::new(None, SassLoaderOptions::default()) as &dyn Loader])
+  .await
+  .unwrap();
+  let result = result.content.try_into_string().unwrap();
+
+  if env::var("UPDATE_SASS_LOADER_TEST").is_ok() {
+    fs::write(expected_path, result).unwrap();
+  } else {
+    let expected = fs::read_to_string(expected_path).unwrap();
+    assert_eq!(result, expected);
+  }
+}
+
+#[tokio::test]
+async fn rspack_importer() {
+  loader_test("scss/language.scss", "expected/rspack_importer.css").await;
+}
+
+#[fixture("tests/fixtures/*")]
+fn sass(fixture_path: PathBuf) {
+  test_fixture(&fixture_path);
+}

--- a/crates/rspack_loader_sass/tests/fixtures/rspack_importer/expected/main.css
+++ b/crates/rspack_loader_sass/tests/fixtures/rspack_importer/expected/main.css
@@ -1,0 +1,36 @@
+
+
+.color-red {
+  color: red;
+}
+
+@charset "UTF-8";
+body {
+  font: 100% Helvetica, sans-serif;
+  color: #333;
+}
+nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+nav li {
+  display: inline-block;
+}
+nav a {
+  display: block;
+  padding: 6px 12px;
+  text-decoration: none;
+}
+.box {
+  -webkit-border-radius: 10px;
+  -moz-border-radius: 10px;
+  -ms-border-radius: 10px;
+  border-radius: 10px;
+}
+.foo:before {
+  content: "\e0c6";
+}
+.bar:before {
+  content: "∑";
+}

--- a/crates/rspack_loader_sass/tests/fixtures/rspack_importer/index.js
+++ b/crates/rspack_loader_sass/tests/fixtures/rspack_importer/index.js
@@ -1,0 +1,1 @@
+import '../../scss/language.scss';

--- a/crates/rspack_loader_sass/tests/fixtures/rspack_importer/test.config.json
+++ b/crates/rspack_loader_sass/tests/fixtures/rspack_importer/test.config.json
@@ -1,0 +1,5 @@
+{
+  "entry": {
+    "main": "./index.js"
+  }
+}

--- a/crates/rspack_loader_sass/tests/scss/another/_variables.scss
+++ b/crates/rspack_loader_sass/tests/scss/another/_variables.scss
@@ -1,0 +1,1 @@
+$n-ary-summation: '\2211'

--- a/crates/rspack_loader_sass/tests/scss/file.css
+++ b/crates/rspack_loader_sass/tests/scss/file.css
@@ -1,0 +1,3 @@
+.color-red {
+    color: red;
+}

--- a/crates/rspack_loader_sass/tests/scss/language.scss
+++ b/crates/rspack_loader_sass/tests/scss/language.scss
@@ -1,0 +1,48 @@
+@import "another/variables";
+@import "./file.css";
+
+$font-stack:    Helvetica, sans-serif;
+$primary-color: #333;
+$pi:            '\e0C6';
+
+body {
+  font: 100% $font-stack;
+  color: $primary-color;
+}
+
+nav {
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li { display: inline-block; }
+
+  a {
+    display: block;
+    padding: 6px 12px;
+    text-decoration: none;
+  }
+}
+
+@mixin border-radius($radius) {
+  -webkit-border-radius: $radius;
+     -moz-border-radius: $radius;
+      -ms-border-radius: $radius;
+          border-radius: $radius;
+}
+
+.box { @include border-radius(10px); }
+
+.foo {
+  &:before {
+    content: $pi;
+  }
+}
+
+.bar {
+  &:before {
+    content: $n-ary-summation;
+  }
+}

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -18,5 +18,14 @@
     "@rspack/binding": "workspace:*",
     "commander": "^9.4.0",
     "rspack-dev-server": "workspace:^"
+  },
+  "optionalDependencies": {
+    "@tmp-sass-embedded/darwin-arm64": "1.54.4",
+    "@tmp-sass-embedded/darwin-x64": "1.54.4",
+    "@tmp-sass-embedded/linux-arm64": "1.54.4",
+    "@tmp-sass-embedded/linux-ia32": "1.54.4",
+    "@tmp-sass-embedded/linux-x64": "1.54.4",
+    "@tmp-sass-embedded/win32-ia32": "1.54.4",
+    "@tmp-sass-embedded/win32-x64": "1.54.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 importers:
 
@@ -55,8 +55,8 @@ importers:
     dependencies:
       '@antv/data-set': 0.11.8
       '@arco-design/color': 0.4.0
-      '@arco-design/web-react': 2.29.2_sfoxds7t5ydpegc3knd667wn6m
-      '@arco-themes/react-arco-pro': 0.0.7_ukqlr2dsvgygpqtt7k6pq4rpp4
+      '@arco-design/web-react': 2.29.2_react-dom@17.0.2+react@17.0.2
+      '@arco-themes/react-arco-pro': 0.0.7_@arco-design+web-react@2.29.2
       '@loadable/component': 5.15.2_react@17.0.2
       '@turf/turf': 6.5.0
       arco-design-pro: 2.7.0
@@ -72,7 +72,7 @@ importers:
       react: 17.0.2
       react-color: 2.19.3_react@17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-redux: 7.2.8_sfoxds7t5ydpegc3knd667wn6m
+      react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
       react-router: 5.3.3_react@17.0.2
       react-router-dom: 5.3.3_react@17.0.2
       redux: 4.2.0
@@ -130,6 +130,13 @@ importers:
   packages/rspack:
     specifiers:
       '@rspack/binding': workspace:*
+      '@tmp-sass-embedded/darwin-arm64': 1.54.4
+      '@tmp-sass-embedded/darwin-x64': 1.54.4
+      '@tmp-sass-embedded/linux-arm64': 1.54.4
+      '@tmp-sass-embedded/linux-ia32': 1.54.4
+      '@tmp-sass-embedded/linux-x64': 1.54.4
+      '@tmp-sass-embedded/win32-ia32': 1.54.4
+      '@tmp-sass-embedded/win32-x64': 1.54.4
       '@types/node': ^18.6.3
       commander: ^9.4.0
       rspack-dev-server: workspace:^
@@ -139,6 +146,14 @@ importers:
       '@rspack/binding': link:../../crates/node_binding
       commander: 9.4.0
       rspack-dev-server: link:../rspack-dev-server
+    optionalDependencies:
+      '@tmp-sass-embedded/darwin-arm64': 1.54.4
+      '@tmp-sass-embedded/darwin-x64': 1.54.4
+      '@tmp-sass-embedded/linux-arm64': 1.54.4
+      '@tmp-sass-embedded/linux-ia32': 1.54.4
+      '@tmp-sass-embedded/linux-x64': 1.54.4
+      '@tmp-sass-embedded/win32-ia32': 1.54.4
+      '@tmp-sass-embedded/win32-x64': 1.54.4
     devDependencies:
       '@types/node': 18.7.9
       tsm: 2.2.2
@@ -367,7 +382,7 @@ packages:
       color: 3.2.1
     dev: false
 
-  /@arco-design/web-react/2.29.2_sfoxds7t5ydpegc3knd667wn6m:
+  /@arco-design/web-react/2.29.2_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-nDMIWfuvYKlxc8lFBtaLPPDURtAJLmXu77r0KCH0Y6GB3S8mUQb7hs0hCC/K+1Pp5yzuVr05ESrEYovM8O5AvQ==}
     peerDependencies:
       react: '>=16'
@@ -384,7 +399,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-focus-lock: 2.9.1_react@17.0.2
-      react-transition-group: 4.4.5_sfoxds7t5ydpegc3knd667wn6m
+      react-transition-group: 4.4.5_react-dom@17.0.2+react@17.0.2
       resize-observer-polyfill: 1.5.1
       scroll-into-view-if-needed: 2.2.20
       shallowequal: 1.1.0
@@ -392,12 +407,12 @@ packages:
       - '@types/react'
     dev: false
 
-  /@arco-themes/react-arco-pro/0.0.7_ukqlr2dsvgygpqtt7k6pq4rpp4:
+  /@arco-themes/react-arco-pro/0.0.7_@arco-design+web-react@2.29.2:
     resolution: {integrity: sha512-ymLuKbfwdYha9noATRQXe5qQH4THjqlEkZTWtAysq4GssYeemNObof51NnuJSMyQtdTS8KC7r//+zHjZrk4dcA==}
     peerDependencies:
       '@arco-design/web-react': ^2.25.1
     dependencies:
-      '@arco-design/web-react': 2.29.2_sfoxds7t5ydpegc3knd667wn6m
+      '@arco-design/web-react': 2.29.2_react-dom@17.0.2+react@17.0.2
     dev: false
 
   /@babel/code-frame/7.18.6:
@@ -683,6 +698,69 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
     dev: true
+
+  /@tmp-sass-embedded/darwin-arm64/1.54.4:
+    resolution: {integrity: sha512-arr7kUSfrUevXigecwAxVf48/ay+iUzMCPxBCxKVmW74dYI9IGNsEp4v/rijhI8oDKBCR1neWTZEZi4MqO5BBQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@tmp-sass-embedded/darwin-x64/1.54.4:
+    resolution: {integrity: sha512-D8X8DeEZfdHPPI/gsZMILYOKwrM/dJLtsejcWOOHgTZYCYNntSBeevzEGUwmx6GNbSzEWVqejn21ecLBrbjsfA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@tmp-sass-embedded/linux-arm64/1.54.4:
+    resolution: {integrity: sha512-Mq09afThDvCqLLOZPBzIZGNsYyv9QW6uhQ7YHB+IqJubStLVRsilM+31AafNASEutQxDItty1Ak5OSy2WsptOA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@tmp-sass-embedded/linux-ia32/1.54.4:
+    resolution: {integrity: sha512-wtjHk75fZTpQvMoGpnN+yZeabzTbmaQXCT/brvTz07xCzxNsLFi0poToG7w5jmLqbAmtQyIoQ5SL+/B4/apiDw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@tmp-sass-embedded/linux-x64/1.54.4:
+    resolution: {integrity: sha512-7MuDVETnAmjLyrYnf7OF0Zbs+gO+qvfgdHQ0q4KSiSMusE8kV/XrB6vQ93rHQzUQKtJL9LE+wCrCftF8WtJaCg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@tmp-sass-embedded/win32-ia32/1.54.4:
+    resolution: {integrity: sha512-7gyRYdjOnkDLkiRTUKfHQ4tB79aCBAfuVGOGtCcuBxCJuvP4lvNufk50a8EzN26zgf2ToRVp1RHt6hKFgbbvPw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@tmp-sass-embedded/win32-x64/1.54.4:
+    resolution: {integrity: sha512-N0SVUapliSJ9739WJv8bXJkkAjtIFxwAYBFsK5mIpm2Pe1F1hH3t7UosgilN4gwviTgvggFobT7KUBoBEooLYg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@turf/along/6.5.0:
     resolution: {integrity: sha512-LLyWQ0AARqJCmMcIEAXF4GEu8usmd4Kbz3qk1Oy5HoRNpZX47+i5exQtmIWKdqJ1MMhW26fCTXgpsEs5zgJ5gw==}
@@ -3619,7 +3697,7 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /mini-create-react-context/0.4.1_at7mkepldmzoo6silmqc5bca74:
+  /mini-create-react-context/0.4.1_prop-types@15.8.1+react@17.0.2:
     resolution: {integrity: sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==}
     peerDependencies:
       prop-types: ^15.0.0
@@ -4054,7 +4132,7 @@ packages:
       scheduler: 0.19.1
     dev: false
 
-  /react-redux/7.2.8_sfoxds7t5ydpegc3knd667wn6m:
+  /react-redux/7.2.8_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==}
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18
@@ -4105,7 +4183,7 @@ packages:
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
-      mini-create-react-context: 0.4.1_at7mkepldmzoo6silmqc5bca74
+      mini-create-react-context: 0.4.1_prop-types@15.8.1+react@17.0.2
       path-to-regexp: 1.8.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -4114,7 +4192,7 @@ packages:
       tiny-warning: 1.0.3
     dev: false
 
-  /react-transition-group/4.4.5_sfoxds7t5ydpegc3knd667wn6m:
+  /react-transition-group/4.4.5_react-dom@17.0.2+react@17.0.2:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
       react: '>=16.6.0'


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Needs to install the [Protocol Buffer Compiler](https://grpc.io/docs/protoc-installation/) since the sass-embedded-host-rust is using protobuf to communicate with the dart-sass-embedded.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

#536 

## Further reading

<!-- Reference that may help understand this pull request -->
