### PR TITLE
Fix binding lsp

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,11 +22,17 @@
   "cSpell.caseSensitive": true,
   "json.schemas": [
     {
-      "fileMatch": ["test.config.json"],
+      "fileMatch": [
+        "test.config.json"
+      ],
       // Point to the options schema of rspack.
       "url": "./crates/temp_test_utils/test.config.scheme.json"
     }
   ],
   "rust-analyzer.procMacro.enable": true,
-  "rust-analyzer.procMacro.attributes.enable": true
+  "rust-analyzer.procMacro.attributes.enable": true,
+  "rust-analyzer.linkedProjects": [
+    "Cargo.toml",
+    "crates/node_binding/Cargo.toml"
+  ]
 }


### PR DESCRIPTION
## Summary

node_binding lsp is broken due to exclude from workspace, so we add it back to RA and not affects build behavior
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
