### PR TITLE
fix: rerun sass-embedded build script

### DIFF
--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1.53"
 tokio = { version = "1.17.0", features = ["full"] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
-sass-embedded = { version = "0.5", features = ["legacy", "serde"] }
+sass-embedded = { version = "0.5.1", features = ["legacy", "serde"] }
 regex = "1"
 once_cell = "1"
 itertools = "0.10"


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`sass-embedded-0.5.0` causes rerun its build script after `cargo check` everytimes, and leads rust-analyzer a bad experience, `sass-embedded-0.5.1` fixes it.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
