### PR TITLE
chore: sync napi dep version with `speedy-release`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "napi"
 version = "2.4.3"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "ctor",
  "lazy_static",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "napi-derive"
 version = "2.4.1"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "1.0.32"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "2.2.2"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "libloading",
 ]

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 [[package]]
 name = "napi"
 version = "2.4.3"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "ctor",
  "lazy_static",
@@ -1207,14 +1207,13 @@ dependencies = [
 
 [[package]]
 name = "napi-build"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
+version = "2.0.0"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 
 [[package]]
 name = "napi-derive"
 version = "2.4.1"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -1226,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "1.0.32"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -1239,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "2.2.2"
-source = "git+https://github.com/speedy-js/napi-rs?branch=speedy#628b2c500476cd9f70100158236fbdde6c256f7c"
+source = "git+https://github.com/speedy-js/napi-rs?branch=speedy-release#628b2c500476cd9f70100158236fbdde6c256f7c"
 dependencies = [
  "libloading",
 ]

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -15,13 +15,13 @@ async-trait = "0.1.53"
 backtrace = "0.3"
 dashmap = "5.0.0"
 futures = "0.3"
-napi = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy", default-features = false, features = [
+napi = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy-release", default-features = false, features = [
   "async",
   "tokio_rt",
   "serde-json",
 ]}
-napi-derive = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy"}
-napi-sys = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy"}
+napi-derive = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy-release"}
+napi-sys = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy-release"}
 once_cell = "1"
 regex = "1.6.0"
 rspack = {path = "../rspack"}
@@ -38,7 +38,7 @@ tracing = "0.1.34"
 mimalloc-rust = {version = "0.1"}
 
 [build-dependencies]
-napi-build = "1"
+napi-build = {git = "https://github.com/speedy-js/napi-rs", branch = "speedy-release"}
 
 [dev-dependencies]
 testing_macros = {version = "0.2.5"}

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -26,11 +26,11 @@ cfg-if = "1.0.0"
 rspack_error = { path = "../rspack_error" }
 [dependencies.napi]
 git = "https://github.com/speedy-js/napi-rs"
-branch = "speedy"
+branch = "speedy-release"
 features = ["async", "tokio_rt", "serde-json"]
 optional = true
 
 [dependencies.napi-derive]
 git = "https://github.com/speedy-js/napi-rs"
-branch = "speedy"
+branch = "speedy-release"
 optional = true


### PR DESCRIPTION
## Summary

The branch `speedy` of the forked `napi-rs` could sometimes unstable, in this PR, rspack switches napi related packages to `speedy-release` to make it stable.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
