### PR TITLE
rename build_end hook to done hook

### DIFF
--- a/crates/node_binding/src/adapter/common.rs
+++ b/crates/node_binding/src/adapter/common.rs
@@ -7,5 +7,5 @@ use tokio::sync::oneshot::Sender;
 
 pub type ThreadsafeRspackCallback = ThreadsafeFunction<String, ErrorStrategy::CalleeHandled>;
 
-pub static REGISTERED_BUILD_END_SENDERS: Lazy<Arc<DashMap<usize, Sender<()>>>> =
+pub static REGISTERED_DONE_SENDERS: Lazy<Arc<DashMap<usize, Sender<()>>>> =
   Lazy::new(Default::default);

--- a/crates/node_binding/src/adapter/utils.rs
+++ b/crates/node_binding/src/adapter/utils.rs
@@ -4,7 +4,7 @@ use napi::{
   Env,
 };
 
-use super::common::REGISTERED_BUILD_END_SENDERS;
+use super::common::REGISTERED_DONE_SENDERS;
 use crate::PluginCallbacks;
 
 pub fn create_node_adapter_from_plugin_callbacks(
@@ -12,51 +12,51 @@ pub fn create_node_adapter_from_plugin_callbacks(
   plugin_callbacks: Option<PluginCallbacks>,
 ) -> Result<Option<super::RspackPluginNodeAdapter>> {
   plugin_callbacks
-    .map(|PluginCallbacks { build_end_callback }| {
-      let mut build_end_tsfn: ThreadsafeFunction<String, ErrorStrategy::CalleeHandled> =
-        build_end_callback.create_threadsafe_function(
-          0,
-          |ctx| ctx.env.create_string_from_std(ctx.value).map(|v| vec![v]),
-          |ctx: ThreadSafeResultContext<Promise<String>>| {
-            let return_value = ctx.return_value;
+    .map(|PluginCallbacks { done_callback }| {
+      let mut done_tsfn: ThreadsafeFunction<String, ErrorStrategy::CalleeHandled> = done_callback
+        .create_threadsafe_function(
+        0,
+        |ctx| ctx.env.create_string_from_std(ctx.value).map(|v| vec![v]),
+        |ctx: ThreadSafeResultContext<Promise<String>>| {
+          let return_value = ctx.return_value;
 
-            ctx
-              .env
-              .execute_tokio_future(
-                async move {
-                  let result = return_value.await?;
+          ctx
+            .env
+            .execute_tokio_future(
+              async move {
+                let result = return_value.await?;
 
-                  let result: super::RspackThreadsafeResult<()> =
-                    serde_json::from_str(&result).expect("failed to evaluate build_end result");
+                let result: super::RspackThreadsafeResult<()> =
+                  serde_json::from_str(&result).expect("failed to evaluate done result");
 
-                  tracing::debug!("build end result {:?}", result);
+                tracing::debug!("build end result {:?}", result);
 
-                  let sender = REGISTERED_BUILD_END_SENDERS.remove(&result.get_call_id());
+                let sender = REGISTERED_DONE_SENDERS.remove(&result.get_call_id());
 
-                  if let Some((_, sender)) = sender {
-                    sender.send(()).map_err(|m| {
-                      Error::new(
-                        napi::Status::GenericFailure,
-                        format!("failed to send result {:#?}", m),
-                      )
-                    })?;
-                  } else {
-                    return Err(Error::new(
+                if let Some((_, sender)) = sender {
+                  sender.send(()).map_err(|m| {
+                    Error::new(
                       napi::Status::GenericFailure,
-                      "failed to get sender for plugin".to_owned(),
-                    ));
-                  }
+                      format!("failed to send result {:#?}", m),
+                    )
+                  })?;
+                } else {
+                  return Err(Error::new(
+                    napi::Status::GenericFailure,
+                    "failed to get sender for plugin".to_owned(),
+                  ));
+                }
 
-                  Ok(())
-                },
-                |_, ret| Ok(ret),
-              )
-              .expect("failed to execute tokio future");
-          },
-        )?;
-      build_end_tsfn.unref(env)?;
+                Ok(())
+              },
+              |_, ret| Ok(ret),
+            )
+            .expect("failed to execute tokio future");
+        },
+      )?;
+      done_tsfn.unref(env)?;
 
-      Ok(super::RspackPluginNodeAdapter { build_end_tsfn })
+      Ok(super::RspackPluginNodeAdapter { done_tsfn })
     })
     .transpose()
 }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -30,12 +30,12 @@ pub type Rspack = Arc<Mutex<rspack::Compiler>>;
 #[napi(object)]
 
 pub struct PluginCallbacks {
-  pub build_end_callback: JsFunction,
+  pub done_callback: JsFunction,
 }
 impl Debug for PluginCallbacks {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("PluginCallbacks")
-      .field("build_end_callback", &"build_end_adapter")
+      .field("done_callback", &"done_adapter")
       .finish()
   }
 }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -119,8 +119,8 @@ impl Compilation {
       })
       .ok();
   }
-  pub async fn build_end(&mut self, plugin_driver: Arc<PluginDriver>) -> Result<()> {
-    plugin_driver.build_end().await?;
+  pub async fn done(&mut self, plugin_driver: Arc<PluginDriver>) -> Result<()> {
+    plugin_driver.done().await?;
     Ok(())
   }
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -156,10 +156,7 @@ impl Compiler {
     // self.compilation.calc_exec_order();
 
     self.compilation.seal(self.plugin_driver.clone())?;
-    self
-      .compilation
-      .build_end(self.plugin_driver.clone())
-      .await?;
+    self.compilation.done(self.plugin_driver.clone()).await?;
 
     // Consume plugin driver diagnostic
     let mut plugin_driver_diagnostics = self.plugin_driver.take_diagnostic();

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -42,7 +42,7 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
-  async fn build_end(&self) -> PluginBuildEndHookOutput {
+  async fn done(&self) -> PluginBuildEndHookOutput {
     Ok(())
   }
 

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -166,9 +166,9 @@ impl PluginDriver {
     Ok(())
   }
   #[instrument(skip_all)]
-  pub async fn build_end(&self) -> PluginBuildEndHookOutput {
+  pub async fn done(&self) -> PluginBuildEndHookOutput {
     for plugin in &self.plugins {
-      plugin.build_end().await?;
+      plugin.done().await?;
     }
     Ok(())
   }

--- a/packages/rspack/src/config.ts
+++ b/packages/rspack/src/config.ts
@@ -5,7 +5,7 @@ import { createRawModuleRuleUses } from ".";
 
 export type Plugin = {
 	name: string;
-	buildEnd?: () => void | Promise<void>;
+	done?: () => void | Promise<void>;
 };
 
 export interface RspackOptions {

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -226,13 +226,13 @@ class Rspack {
 		this.#plugins = options.plugins ?? [];
 
 		this.#instance = binding.newRspack(nativeConfig, {
-			buildEndCallback: this.#buildEnd.bind(this)
+			doneCallback: this.#done.bind(this)
 		});
 	}
-	async #buildEnd(err: Error, value: string) {
+	async #done(err: Error, value: string) {
 		const context: RspackThreadsafeContext<void> = JSON.parse(value);
 		for (const plugin of this.#plugins) {
-			await plugin.buildEnd?.();
+			await plugin.done?.();
 		}
 		return createDummyResult(context.id);
 	}


### PR DESCRIPTION
## Summary
in order to align with webpack's api , we change build_end hook to done hook(https://webpack.js.org/api/compiler-hooks/#done), more parameters will add in later mr
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
