### PR TITLE
chore: rebuild binding options for node binding

### DIFF
--- a/crates/rspack_binding_options/build.rs
+++ b/crates/rspack_binding_options/build.rs
@@ -1,0 +1,8 @@
+use std::env;
+
+fn main() {
+  // Rebuild binding options if and only if it's built for crate `node_binding`
+  if env::var("OUT_DIR").unwrap().contains("node_binding") {
+    println!("cargo:rerun-if-changed=../node_binding");
+  }
+}


### PR DESCRIPTION
## Summary

Rebuild binding options if and only if it's built for crate `node_binding` for stabilizing dts generation.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
