### PR TITLE
perf: use relaxed memory ordering

### DIFF
--- a/crates/node_binding/src/adapter/mod.rs
+++ b/crates/node_binding/src/adapter/mod.rs
@@ -9,7 +9,7 @@ use rspack_core::{
 use anyhow::Context;
 use async_trait::async_trait;
 use napi::threadsafe_function::ThreadsafeFunctionCallMode;
-use napi::{CallContext, Error, JsString, JsUndefined};
+use napi::{CallContext, Error, JsUndefined};
 use napi_derive::napi;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -44,7 +44,7 @@ pub struct RspackThreadsafeContext<T: Debug> {
 impl<T: Debug> RspackThreadsafeContext<T> {
   pub fn new(payload: T) -> Self {
     Self {
-      id: CALL_ID.fetch_add(1, Ordering::SeqCst),
+      id: CALL_ID.fetch_add(1, Ordering::Relaxed),
       inner: payload,
     }
   }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use napi::bindgen_prelude::*;
 use napi::{Env, Result};
 use napi_derive::napi;
-use rspack_core::CompilationAsset;
 // use nodejs_resolver::Resolver;
 use tokio::sync::Mutex;
 mod adapter;

--- a/crates/rspack_binding_options/src/options/raw_module.rs
+++ b/crates/rspack_binding_options/src/options/raw_module.rs
@@ -245,7 +245,7 @@ impl rspack_core::Loader<rspack_core::CompilerContext, rspack_core::CompilationC
       resource_query: loader_context.resource_query.map(|r| r.to_owned()),
     };
 
-    let current_id = LOADER_CALL_ID.fetch_add(1, Ordering::SeqCst);
+    let current_id = LOADER_CALL_ID.fetch_add(1, Ordering::Relaxed);
 
     let loader_tsfn_context = LoaderThreadsafeContext {
       p: loader_context,

--- a/crates/rspack_core/src/ukey.rs
+++ b/crates/rspack_core/src/ukey.rs
@@ -19,7 +19,7 @@ impl Default for Ukey {
 
 impl Ukey {
   fn gen_ukey() -> usize {
-    NEXT_UNIQUE_KEY.fetch_add(1, Ordering::SeqCst)
+    NEXT_UNIQUE_KEY.fetch_add(1, Ordering::Relaxed)
   }
 
   pub fn new() -> Self {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Since ids are only being used as a counter, which means no other guarantees(orderings and synchronizations) other than atomicity are required for these kinds of operations. We can change orderings from `SeqCst` to `Relaxed` which leads to better performance.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->



## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
