### PR TITLE
fix: change processAssets params to Source

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -94,11 +94,13 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install dependencies and run test
+      - name: Install dependencies && and build lib
         run: |
           pnpm install
           pnpm run format:js
           pnpm run build:cli
+      - name: binding test
+        run: |
           pnpm run build:webpack
           pnpm --filter @rspack/core run example
           pnpm --filter @rspack/core run test

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_loader_runner::{Content, ResourceData};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 // use anyhow::{Context, Result};
 use hashbrown::HashMap;
@@ -131,7 +131,8 @@ pub trait Plugin: Debug + Send + Sync {
   }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum AssetContent {
   Buffer(Vec<u8>),
   String(String),

--- a/packages/rspack/example/basic.ts
+++ b/packages/rspack/example/basic.ts
@@ -21,6 +21,9 @@ const rspack = new Rspack({
 					compilation.hooks.processAssets.tapPromise(
 						"processAssets1",
 						async assets => {
+							for (const value of Object.values(assets)) {
+								console.log("value:", value.buffer(), value.source());
+							}
 							compilation.emitAsset("test.js", {
 								source: "hello world"
 							});

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -20,7 +20,8 @@
     "@types/ws": "8.5.3",
     "@types/connect": "3.4.35",
     "uvu": "0.5.6",
-    "@rspack/core": "workspace:*"
+    "@rspack/core": "workspace:*",
+    "@types/webpack-sources": "3.2.0"
   },
   "dependencies": {
     "@rspack/binding": "workspace:*",
@@ -33,7 +34,8 @@
     "@rspack/dev-server": "workspace:^",
     "sirv": "2.0.2",
     "@rspack/plugin-postcss": "workspace:^",
-    "tapable": "2.2.1"
+    "tapable": "2.2.1",
+    "webpack-sources": "3.2.3"
   },
   "optionalDependencies": {
     "@tmp-sass-embedded/darwin-arm64": "1.54.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,7 @@ importers:
       '@tmp-sass-embedded/win32-x64': 1.54.4
       '@types/connect': 3.4.35
       '@types/node': ^18.6.3
+      '@types/webpack-sources': 3.2.0
       '@types/ws': 8.5.3
       chokidar: 3.5.3
       clipanion: 3.2.0-rc.11
@@ -174,6 +175,7 @@ importers:
       tsm: ^2.2.2
       typescript: 4.7.3
       uvu: 0.5.6
+      webpack-sources: 3.2.3
       ws: 8.8.1
     dependencies:
       '@rspack/binding': link:../../crates/node_binding
@@ -186,6 +188,7 @@ importers:
       open: 8.4.0
       sirv: 2.0.2
       tapable: 2.2.1
+      webpack-sources: 3.2.3
       ws: 8.8.1
     optionalDependencies:
       '@tmp-sass-embedded/darwin-arm64': 1.54.4
@@ -199,6 +202,7 @@ importers:
       '@rspack/core': 'link:'
       '@types/connect': 3.4.35
       '@types/node': 18.7.9
+      '@types/webpack-sources': 3.2.0
       '@types/ws': 8.5.3
       ts-node: 10.9.1_iqqktkndlpjcw7xba3ta44d6ve
       tsm: 2.2.2
@@ -2221,6 +2225,18 @@ packages:
       '@types/mime': 3.0.1
       '@types/node': 18.7.9
     dev: false
+
+  /@types/source-list-map/0.1.2:
+    resolution: {integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==}
+    dev: true
+
+  /@types/webpack-sources/3.2.0:
+    resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==}
+    dependencies:
+      '@types/node': 18.7.9
+      '@types/source-list-map': 0.1.2
+      source-map: 0.7.4
+    dev: true
 
   /@types/ws/8.5.3:
     resolution: {integrity: sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==}
@@ -5668,6 +5684,11 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /source-map/0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /spawndamnit/2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
     dependencies:
@@ -6210,6 +6231,11 @@ packages:
     dependencies:
       defaults: 1.0.3
     dev: true
+
+  /webpack-sources/3.2.3:
+    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
+    engines: {node: '>=10.13.0'}
+    dev: false
 
   /which-boxed-primitive/1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}


### PR DESCRIPTION
## Summary
webpack pass Source to processAssets hook, we need to do the same to be compatible with it.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
