### PR TITLE
chore: remove format on save for rust

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,9 +9,6 @@
     "**/target": true,
     "**/.yarn": true
   },
-  "[rust]": {
-    "editor.formatOnSave": true
-  },
   "[typescript]": {
     "editor.formatOnSave": true
   },


### PR DESCRIPTION
## Summary
format on save for rust is very laggy, so let the user decide whether to enable it
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
