### PR TITLE
chore: change critcmp branch next to baseline

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -78,7 +78,7 @@ jobs:
           ref: next
 
       - name: Run Bench on Next Branch
-        run: cargo bench --bench main -- --save-baseline next
+        run: cargo bench --bench main -- --save-baseline baseline
 
       - name: Compare Bench Results
         id: bench_comparison


### PR DESCRIPTION
## Summary
1. `next` and `pr` both have the meaning of `new` which may lead the benchmark comparison a little ambiguous, 
use `baseline` instead of `next` sort of reducing the ambiguity.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
