### PR TITLE
chore: add esbuild_perf command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ crates/node_binding/binding.d.ts
 
 # profile
 profile.json
+
+# esbuild trace
+esbuild.trace

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,8 @@ bench_three: | copy/three
 	@hyperfine --warmup 3 './node_modules/esbuild/bin/esbuild --bundle --global-name=THREE  benchcases/three/src/entry.js --outfile=benchcases/three/esbuild/entry.esbuild.js --timing'
 	@echo "webpack"
 	@hyperfine --warmup 3 './node_modules/webpack-cli/bin/cli.js  -c ./benchcases/three/webpack.config.js'
+
+
+esbuild_perf:
+	./node_modules/esbuild/bin/esbuild --bundle benchcases/three/src/entry.js --outfile=/dev/null --trace=esbuild.trace
+	go tool trace esbuild.trace


### PR DESCRIPTION
## Summary
 To simplify the comparison between esbuild and rspack, we add perf command for esbuild
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
