### PR TITLE
chore: on-demand compile tokio, reduce compile time.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3941,6 +3941,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 
 # [target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]

--- a/crates/cargo-rst/Cargo.toml
+++ b/crates/cargo-rst/Cargo.toml
@@ -22,4 +22,5 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }

--- a/crates/loader_runner/Cargo.toml
+++ b/crates/loader_runner/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 
 tracing = "0.1.34"

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -3506,6 +3506,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 tracing = "0.1.34"
 

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -35,6 +35,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 tracing = "0.1.34"
 warp = "0.3"

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 cfg-if = "1.0.0"
 rspack_error = { path = "../rspack_error" }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 tracing = "0.1.34"
 rspack_sources = "0.1.7"

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -23,6 +23,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 rspack_binding_options = { path = "../rspack_binding_options" }
 rspack_core = { path = "../rspack_core" }

--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 tracing = "0.1.34"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/crates/rspack_plugin_asset/Cargo.toml
+++ b/crates/rspack_plugin_asset/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 base64 = "0.13.0"
 mime_guess = "2.0.4"

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 dashmap = "5.0.0"
 sugar_path = "0.0.5"

--- a/crates/rspack_test/Cargo.toml
+++ b/crates/rspack_test/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1.21.0", features = [
   "rt-multi-thread",
   "macros",
   "test-util",
+  "parking_lot",
 ] }
 rspack_binding_options = { path = "../rspack_binding_options" }
 glob = "0.3.0"


### PR DESCRIPTION
## Summary
1. Using `features` to enable on-demand compile `tokio`, reduce some crates and compile time.
2. Bump `tokio` version, and update lock file.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
