### PR TITLE
chore: 🤖 revert wrong make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,12 @@
 # github/three:
 # 	mkdir -p github
 # 	git clone --depth 1 --branch r108 https://github.com/mrdoob/three.js.git github/three
-copy_num = 10
 copy/three:
 
 	mkdir -p benchcases/three/src
 	echo > benchcases/three/src/entry.js
-	for i in {1..$(copy_num)}; do test -d "benchcases/three/src/copy$$i" || cp -r examples/.three/src "benchcases/three/src/copy$$i"; done
-	for i in {1..$(copy_num)}; do echo "import * as copy$$i from './copy$$i/Three.js'; export {copy$$i}" >> benchcases/three/src/entry.js; done
+	for i in 1 2 3 4 5 6 7 8 9 10; do test -d "benchcases/three/src/copy$$i" || cp -r examples/.three/src "benchcases/three/src/copy$$i"; done
+	for i in 1 2 3 4 5 6 7 8 9 10; do echo "import * as copy$$i from './copy$$i/Three.js'; export {copy$$i}" >> benchcases/three/src/entry.js; done
 	echo "module.exports = {mode: 'development',entry: {index: './src/entry.js'}};" > benchcases/three/test.config.js
 	echo "module.exports = {mode: 'development',entry: {index: './benchcases/three/src/entry.js'},devtool: 'eval',cache: {type: 'filesystem'}}" > benchcases/three/webpack.config.js
 


### PR DESCRIPTION
## Summary
1. Revert wrong make optimization, the Makefile shell seems not work as we expected.
only generate one copy of three.js, that's why this pull request improves so significantly performance.
https://speedy-js.github.io/metrics/dev/bench/
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
