### PR TITLE
Fix: 🤖 fix bash escape issue on mac

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -90,9 +90,9 @@ jobs:
           echo "\`\`\`" >> output
           cat output
           comment="$(cat output)"
-          # comment="${comment//'%'/'%25'}"
-          # comment="${comment//$'\n'/'%0A'}"
-          # comment="${comment//$'\r'/'%0D'}"
+          comment="${comment//'%'/%25}"
+          comment="${comment//$'\n'/%0A}"
+          comment="${comment//$'\r'/%0D}"
           echo "::set-output name=comment::$comment"
       - name: Write a new comment
         uses: peter-evans/create-or-update-comment@v1.4.5


### PR DESCRIPTION
## Summary
1. Fix issues when github write a benchmark result comment. 
The issue is mainly caused by Macos and Linux having different behavior when handling bash substitution.

Assume you have such `output.txt`
 ~~~
### Benchmark Results
```
group                  baseline                                pr
-----                  --------                                --
css_heavy              1.55     43.6±1.83ms        ? ?/sec     1.00     28.2±0.69ms        ? ?/sec
lodash                 1.36     74.5±5.05ms        ? ?/sec     1.00     54.6±6.38ms        ? ?/sec
ten_copy_of_threejs    1.93  1452.0±207.89ms        ? ?/sec    1.00   753.1±49.48ms        ? ?/seca
```
~~~

try such test.sh
```bash
#! /bin/bash

cat output
comment="$(cat output)"
comment="${comment//'%'/'%25'}"
comment="${comment//$'\n'/'%0A'}"
comment="${comment//$'\r'/'%0D'}"

echo "::set-output name=comment::$comment"
```

The result on Linux is:
~~~
```::set-output name=comment::### Benchmark Results%0A```%0Agroup                  baseline                                pr%0A-----                  --------                                --%0Acss_heavy              1.55     43.6±1.83ms        ? ?/sec     1.00     28.2±0.69ms        ? ?/sec%0Alodash                 1.36     74.5±5.05ms        ? ?/sec     1.00     54.6±6.38ms        ? ?/sec%0Aten_copy_of_threejs    1.93  1452.0±207.89ms        ? ?/sec    1.00   753.1±49.48ms        ? ?/seca%0A```
~~~

The result on mac is:
~~~
```::set-output name=comment::### Benchmark Results'%0A'```'%0A'group                  baseline                                pr'%0A'-----                  --------                                --'%0A'css_heavy              1.55     43.6±1.83ms        ? ?/sec     1.00     28.2±0.69ms        ? ?/sec'%0A'lodash                 1.36     74.5±5.05ms        ? ?/sec     1.00     54.6±6.38ms        ? ?/sec'%0A'ten_copy_of_threejs    1.93  1452.0±207.89ms        ? ?/sec    1.00   753.1±49.48ms        ? ?/seca'%0A'```
~~~

Notice Mac will not remove `'`, single quote

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
