### PR TITLE
feat: add size of normal module

### DIFF
--- a/crates/rspack_core/src/external.rs
+++ b/crates/rspack_core/src/external.rs
@@ -22,7 +22,7 @@ impl ParserAndGenerator for ExternalParserAndGenerator {
     &[SourceType::JavaScript]
   }
 
-  fn size(&self, _module: &NormalModule, _source_type: &SourceType) -> f32 {
+  fn size(&self, _module: &NormalModule, _source_type: &SourceType) -> f64 {
     // copied from webpack `ExternalModule`
     // roughly for url
     42.0

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -191,7 +191,7 @@ pub struct ParseResult {
 pub trait ParserAndGenerator: Send + Sync + Debug {
   fn source_types(&self) -> &[SourceType];
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>>;
-  fn size(&self, module: &NormalModule, source_type: &SourceType) -> f32;
+  fn size(&self, module: &NormalModule, source_type: &SourceType) -> f64;
   fn generate(
     &self,
     requested_source_type: SourceType,
@@ -214,7 +214,7 @@ pub struct NormalModule {
   ast_or_source: Option<AstOrSource>,
 
   options: Arc<CompilerOptions>,
-  cached_source_sizes: DashMap<SourceType, f32>,
+  cached_source_sizes: DashMap<SourceType, f64>,
 
   // FIXME: dirty workaround to support external module
   skip_build: bool,
@@ -335,11 +335,11 @@ impl NormalModule {
     self.ast_or_source.as_ref()
   }
 
-  pub fn size(&self, source_type: &SourceType) -> f32 {
+  pub fn size(&self, source_type: &SourceType) -> f64 {
     if let Some(size_ref) = self.cached_source_sizes.get(source_type) {
       *size_ref
     } else {
-      let size = f32::max(1.0, self.parser_and_generator.size(self, source_type));
+      let size = f64::max(1.0, self.parser_and_generator.size(self, source_type));
       self.cached_source_sizes.insert(*source_type, size);
       size
     }

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -115,8 +115,8 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     }
   }
 
-  fn size(&self, module: &NormalModule, source_type: &SourceType) -> f32 {
-    let original_source_size = module.original_source().map_or(0, |source| source.size()) as f32;
+  fn size(&self, module: &NormalModule, source_type: &SourceType) -> f64 {
+    let original_source_size = module.original_source().map_or(0, |source| source.size()) as f64;
     match source_type {
       SourceType::Asset => original_source_size,
       SourceType::JavaScript => {

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -75,17 +75,17 @@ impl ParserAndGenerator for CssParserAndGenerator {
     CSS_MODULE_SOURCE_TYPE_LIST
   }
 
-  fn size(&self, module: &NormalModule, source_type: &SourceType) -> f32 {
+  fn size(&self, module: &NormalModule, source_type: &SourceType) -> f64 {
     match source_type {
       SourceType::JavaScript => {
         // meta + `module.exports = ...`
         self
           .meta
           .as_ref()
-          .map(|item| item.len() as f32 + 17.0)
+          .map(|item| item.len() as f64 + 17.0)
           .unwrap_or(0.0)
       }
-      SourceType::Css => module.original_source().map_or(0, |source| source.size()) as f32,
+      SourceType::Css => module.original_source().map_or(0, |source| source.size()) as f64,
       _ => unreachable!(),
     }
   }

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -67,8 +67,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     SOURCE_TYPES
   }
 
-  fn size(&self, module: &NormalModule, _source_type: &SourceType) -> f32 {
-    module.original_source().map_or(0, |source| source.size()) as f32
+  fn size(&self, module: &NormalModule, _source_type: &SourceType) -> f64 {
+    module.original_source().map_or(0, |source| source.size()) as f64
   }
 
   #[instrument(name = "js:parse")]

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -20,8 +20,8 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     &[SourceType::JavaScript]
   }
 
-  fn size(&self, module: &NormalModule, _source_type: &SourceType) -> f32 {
-    module.original_source().map_or(0, |source| source.size()) as f32
+  fn size(&self, module: &NormalModule, _source_type: &SourceType) -> f64 {
+    module.original_source().map_or(0, |source| source.size()) as f64
   }
 
   fn parse(


### PR DESCRIPTION
## Summary

Aligns the `size` implementation with webpack.
1. Bring down `size` to generator for each _SourceType_
2. Support `size` for _NormalModule_

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
