### PR TITLE
chore: 🤖 disable lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [workspace]
-members = ["crates/*"]
 exclude = [
   "crates/node_binding",
 ] # Avoid including node binding, since feature unification will cause an linking issue. See: https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
+members = ["crates/*"]
 
 [profile.dev]
+debug       = 2
 incremental = true
-debug = 2
 
 [profile.release]
 codegen-units = 1
-debug = false
-lto = true
-opt-level = 3
-incremental = true
+debug         = false
+incremental   = true
+lto           = false
+opt-level     = 3

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "format:rs": "./x format rs",
     "format:js": "./x format js",
     "format-ci:toml": "./x format toml",
-    "format:toml": "npx @taplo/cli format '.cargo/*.toml' './crates/**/Cargo.toml'",
+    "format:toml": "npx @taplo/cli format '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "lint:js": "./x lint js",
     "lint:rs": "./x lint rs",
     "release:binding": "pnpm --filter @rspack/binding run build:release",

--- a/scripts/cmd.js
+++ b/scripts/cmd.js
@@ -133,7 +133,7 @@ function createCLI() {
 					break;
 				case "toml":
 					command =
-						"npx @taplo/cli format --check '.cargo/*.toml' './crates/**/Cargo.toml'";
+						"npx @taplo/cli format --check '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'";
 					break;
 				default:
 					log.error(


### PR DESCRIPTION
## Summary
1. enable `lto` seems does not have positive improvement for our bundler, on  the other hand It increase a lot of compile time.
So disable it in the release
**Benchmark Result**
![SAgyohsy40](https://user-images.githubusercontent.com/17974631/195524078-149fd7a3-79db-4c03-b976-f0c361043785.jpg)
**Compile time with lto enable**
![tlQT0JMVhS](https://user-images.githubusercontent.com/17974631/195524185-9ca2af9c-f275-4e21-8803-714316434733.jpg)
You could see It increased 2m of compile time compared to lto disable 
2. Adding `Cargo.toml` into toml format path list.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
