### PR TITLE
feat(error): support napi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,6 +2208,7 @@ dependencies = [
  "dashmap",
  "insta",
  "json",
+ "napi",
  "rspack",
  "rspack_binding_options",
  "rspack_core",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "codespan-reporting",
  "dashmap",
  "json",
+ "napi",
  "sugar_path",
  "termcolor",
  "thiserror",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -31,7 +31,7 @@ rspack_binding_options = { path = "../rspack_binding_options", features = [
   "node-api",
 ] }
 rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
+rspack_error = { path = "../rspack_error", features = ["napi"] }
 rspack_plugin_html = { path = "../rspack_plugin_html" }
 rspack_tracing = { path = "../rspack_tracing" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/node_binding/src/adapter/mod.rs
+++ b/crates/node_binding/src/adapter/mod.rs
@@ -89,7 +89,7 @@ impl Plugin for RspackPluginNodeAdapter {
           (value, Box::new(emit_asset) as BoxedClosure),
           crate::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
         )
-        .map_err(|err| rspack_error::Error::InternalError(format!("{:?}", err)))?
+        .map_err(rspack_error::Error::from)?
     };
 
     rx.await
@@ -104,7 +104,7 @@ impl Plugin for RspackPluginNodeAdapter {
         (),
         crate::threadsafe_function::ThreadsafeFunctionCallMode::Blocking,
       )
-      .map_err(|err| rspack_error::Error::InternalError(format!("{:?}", err)))?
+      .map_err(rspack_error::Error::from)?
       .await
       .map_err(|err| rspack_error::Error::InternalError(format!("{:?}", err)))?;
 

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -17,7 +17,7 @@ dashmap = "5.0.0"
 once_cell = "1"
 regex = "1.6.0"
 rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
+rspack_error = { path = "../rspack_error", features = ["napi"] }
 rspack_loader_sass = { path = "../rspack_loader_sass" }
 rspack_plugin_css = { path = "../rspack_plugin_css" }
 rspack_plugin_html = { path = "../rspack_plugin_html" }

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -5,6 +5,9 @@ version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+napi = ["dep:napi"]
+
 [dependencies]
 anyhow             = "1.0.61"
 codespan-reporting = "0.11.1"
@@ -13,6 +16,11 @@ json               = "0.12.4"
 sugar_path         = { version = "0.0.5" }
 termcolor          = "1.1"
 thiserror          = "1.0.32"
+
+  [dependencies.napi]
+  default-features = false
+  optional         = true
+  version          = "2"
 
 [dev-dependencies]
 insta = "1.19.0"

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -130,3 +130,10 @@ impl std::fmt::Display for DiagnosticKind {
     }
   }
 }
+
+#[cfg(feature = "napi")]
+impl From<napi::Error> for Error {
+  fn from(err: napi::Error) -> Self {
+    Error::InternalError(err.to_string())
+  }
+}


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds a feature `napi` for `rspack_error`, which enables us to derive errors from `napi::Error` to `rspack_error::Error`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
