### PR TITLE
chore: add release-snapshot bot

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
 jobs:
   release:
-    name: Create Release Pull Request
+    name: release-snapshot
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '!snapshot')
     runs-on: macos-latest
     steps:
       - name: Checkout Repo
@@ -35,6 +36,4 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: release snapshot
         run: |
-          npm run build
-          npm run version:snapshot
-          npm run release:snapshot
+          make release-snapshot

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ sync_bnpm:
 	@bnpm sync @rspack/plugin-less
 	@bnpm sync @rspack/plugin-postcss
 	@bnpm sync @rspack/cli
-release:
+release-snapshot:
 	@pnpm version:snapshot
 	@./x build js-release
 	@pnpm release:snapshot


### PR DESCRIPTION
## Summary
This PR adds release-snapshot bot, when you comment `!snapshot` on mr, it will automatically trigger a snapshot-release
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
