### PR TITLE
chore: skip husky prepare in ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release": "changeset publish --no-git-checks",
     "bump": "changeset version",
     "changeset": "changeset",
-    "prepare": "husky install"
+    "prepare": "is-ci || husky install"
   },
   "repository": {
     "type": "git",
@@ -54,7 +54,8 @@
     "typescript": "4.8.3",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0",
-    "why-is-node-running": "2.2.1"
+    "why-is-node-running": "2.2.1",
+    "is-ci": "3.0.1"
   },
   "packageManager": "pnpm@7.3.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ importers:
       commander: 9.4.0
       esbuild: ^0.15.9
       husky: ^7.0.4
+      is-ci: 3.0.1
       jest: 29.0.3
       lint-staged: ^12.5.0
       prettier: 2.5.1
@@ -24,6 +25,7 @@ importers:
       commander: 9.4.0
       esbuild: 0.15.9
       husky: 7.0.4
+      is-ci: 3.0.1
       jest: 29.0.3
       lint-staged: 12.5.0
       prettier: 2.5.1


### PR DESCRIPTION
## Summary
husky prepared in ci enviroment, so we need to skip husky install in ci
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## Further reading

<!-- Reference that may help understand this pull request -->
