### PR TITLE
fix: lock rebuild to avoid undefined behaviors

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -279,7 +279,6 @@ class Compiler {
 		watcher.on("change", async changedFilepath => {
 			// TODO: only build because we lack the snapshot info of file.
 			// TODO: it means there a lot of things to do....
-			const begin = Date.now();
 
 			// store the changed file path, it may or may not be consumed right now
 			pendingChangedFilepaths.add(changedFilepath);
@@ -297,6 +296,7 @@ class Compiler {
 				isBuildFinished = false;
 				console.log("hit change and start to build");
 
+				const begin = Date.now();
 				this.unsafe_rebuild(changedFilepath, (error: any, diffStats) => {
 					isBuildFinished = true;
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix a bug where `rebuild` is called multiple times from watcher which results in undefined behaviors with `unsafe_rebuild`. The fix is pretty simple: if a rebuilding task is running, changed files will be cached, and the compiler will rerun the rebuild if the previous task is released.


Behind the curtain: Calling `unsafe_rebuild` initiates a `rebuild` task for the tokio worker and the method itself directly returns and unlocks the global lock, which let Node be able to call another `unsafe_build`. If the tokio worker has not finished the current task, it will cause data races and leads to undefined behavior.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

closes https://github.com/speedy-js/rspack/issues/936

## Further reading

<!-- Reference that may help understand this pull request -->
