### PR TITLE
chore: fix watch swallen error info

### DIFF
--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use napi::bindgen_prelude::*;
 
 #[napi]
@@ -19,10 +21,16 @@ impl From<u8> for DiffStatKind {
 }
 
 // TODO: remove it after hash
-#[napi]
+#[napi(object)]
 pub struct DiffStat {
   pub content: String,
   pub kind: DiffStatKind,
+}
+
+#[napi(object)]
+pub struct RebuildResult {
+  pub diff: HashMap<String, DiffStat>,
+  pub stats: StatsCompilation,
 }
 
 #[napi(object)]

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -226,7 +226,7 @@ impl Rspack {
       };
 
       callbackify(env, f, async move {
-        let diff = compiler
+        let (diff, stats) = compiler
           .rebuild(
             HashSet::from_iter(changed_files.into_iter()),
             HashSet::from_iter(removed_files.into_iter()),
@@ -234,7 +234,7 @@ impl Rspack {
           .await
           .map_err(|e| Error::new(napi::Status::GenericFailure, format!("{:?}", e)))?;
 
-        let stats: HashMap<String, DiffStat> = diff
+        let diff_stats: HashMap<String, DiffStat> = diff
           .into_iter()
           .map(|(uri, stats)| {
             (
@@ -246,10 +246,14 @@ impl Rspack {
             )
           })
           .collect();
+        let stats: StatsCompilation = stats.to_description().into();
         // let stats: Stats = _rspack_stats.into();
-
+        let rebuild_result = RebuildResult {
+          diff: diff_stats,
+          stats: stats,
+        };
         tracing::info!("rebuild success");
-        Ok(stats)
+        Ok(rebuild_result)
       })
     };
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -158,7 +158,7 @@ impl Compiler {
     &mut self,
     changed_files: std::collections::HashSet<String>,
     removed_files: std::collections::HashSet<String>,
-  ) -> Result<std::collections::HashMap<String, (u8, String)>> {
+  ) -> Result<(std::collections::HashMap<String, (u8, String)>, Stats)> {
     fn collect_modules_from_stats(
       s: &Stats<'_>,
       changed_files: &std::collections::HashSet<String>,
@@ -213,8 +213,8 @@ impl Compiler {
     let old = self.stats()?;
     let old = collect_modules_from_stats(&old, &changed_files, &removed_files);
 
-    let new = self.build().await?;
-    let new = collect_modules_from_stats(&new, &changed_files, &removed_files);
+    let new_stats = self.build().await?;
+    let new = collect_modules_from_stats(&new_stats, &changed_files, &removed_files);
 
     let mut diff = std::collections::HashMap::new();
 
@@ -239,7 +239,7 @@ impl Compiler {
     }
     // return all diff modules is not a good idea,
     // maybe a connection between browser client and local server is a better choice.
-    Ok(diff)
+    Ok((diff, new_stats))
   }
 }
 


### PR DESCRIPTION
## Summary
currently rebuild missing return stats (which contains error info) cause rebuild will not print error when met build error, closes #972 
The print error logic is very naive now ,  pretty print error should be implement in Stats.toString(), which left to another PR, related to https://github.com/speedy-js/rspack/issues/966
currently rebuild and build returns different data structure which is not friendly to error handler, which should be fixed in #981
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)


## Further reading

<!-- Reference that may help understand this pull request -->
