### PR TITLE
chore: 🤖 remove dist before test

### DIFF
--- a/crates/rspack_test/src/rspack_only.rs
+++ b/crates/rspack_test/src/rspack_only.rs
@@ -11,6 +11,11 @@ use rspack::Compiler;
 #[tokio::main]
 pub async fn test_fixture(fixture_path: &Path) -> Compiler {
   enable_tracing_by_env();
+  //avoid interference from previous testing
+  let dist_dir = fixture_path.join("dist");
+  if dist_dir.exists() {
+    std::fs::remove_dir_all(dist_dir.clone()).unwrap();
+  }
   let options: CompilerOptions = RawOptions::from_fixture(fixture_path).to_compiler_options();
   let output_path = options.output.path.clone();
   let mut compiler = rspack::rspack(options, Default::default());


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
