### PR TITLE
Revert "chore: snapshot with debuginfo"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,3 @@ debug         = false
 incremental   = true
 lto           = false
 opt-level     = 3
-
-[profile.release-debuginfo]
-inherits  = "release"
-opt-level = 3

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -57,7 +57,3 @@ testing_macros = { version = "0.2.5" }
 [profile.release]
 strip = true # Automatically strip symbols from the binary.
 # lto = true   # disabled by now, because it will significantly increase our compile time.
-
-[profile.release-debuginfo]
-debug    = true
-inherits = "release"

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -14,8 +14,7 @@
   ],
   "scripts": {
     "build": "napi build --platform --js false --dts binding.d.ts --config napirs.rc.json",
-    "build:release": "napi build --release --platform --js false --dts binding.d.ts --config napirs.rc.json",
-    "build:release-debuginfo": "napi build --platform --js false --dts binding.d.ts --config napirs.rc.json --cargo-flags='--profile release-debuginfo'"
+    "build:release": "napi build --release --platform --js false --dts binding.d.ts --config napirs.rc.json"
   },
   "keywords": [],
   "author": "",

--- a/scripts/cmd.js
+++ b/scripts/cmd.js
@@ -93,7 +93,7 @@ function createCLI() {
 					command = `pnpm --filter "@rspack/*" build`;
 					break;
 				case "js-release":
-					command = `pnpm --filter "@rspack/*" build && pnpm --filter @rspack/binding build:release-debuginfo`;
+					command = `pnpm --filter "@rspack/*" build && pnpm --filter @rspack/binding build --release`;
 					break;
 				case "binding":
 					command = "pnpm --filter @rspack/binding build";


### PR DESCRIPTION
Reverts speedy-js/rspack#1059, for huge performance regression for project _shadow_