### PR TITLE
fix(plugin-javascript): _export_star undefined when use export all and import at same time

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/inject_runtime_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/inject_runtime_helper.rs
@@ -3,7 +3,7 @@ use swc_common::{Mark, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms::helpers::HELPERS;
 use swc_ecma_utils::ExprFactory;
-use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut};
+use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
 pub fn inject_runtime_helper() -> impl Fold {
   let helper_mark = HELPERS.with(|helper| helper.mark());
@@ -36,6 +36,7 @@ impl VisitMut for InjectRuntimeHelper {
           prop: MemberProp::Ident(Ident::new("interopRequire".into(), DUMMY_SP)),
         }
         .as_callee();
+        n.args.visit_mut_children_with(self);
         return;
       }
 
@@ -47,6 +48,7 @@ impl VisitMut for InjectRuntimeHelper {
           prop: MemberProp::Ident(Ident::new("exportStar".into(), DUMMY_SP)),
         }
         .as_callee();
+        n.args.visit_mut_children_with(self);
         return;
       }
 

--- a/packages/rspack/tests/cases/esm/export-star-and-import/a.js
+++ b/packages/rspack/tests/cases/esm/export-star-and-import/a.js
@@ -1,0 +1,3 @@
+export default 1;
+export let a = "a";
+export let b = "b";

--- a/packages/rspack/tests/cases/esm/export-star-and-import/index.js
+++ b/packages/rspack/tests/cases/esm/export-star-and-import/index.js
@@ -1,0 +1,6 @@
+import a from "./a";
+export * from "./a";
+
+it("should work well when use export star and import at same time", function () {
+	expect(a).toBe(1);
+});


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When use export all and import together, swc will generate code like this `_interopRequireDefault(_exportStar(require("./a"), exports));`, which leads to '_export_start is undefined' error.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
