### PR TITLE
chore(rspack): export `Configuration`

### DIFF
--- a/packages/rspack-cli/src/types.ts
+++ b/packages/rspack-cli/src/types.ts
@@ -1,6 +1,7 @@
 import { Colorette } from "colorette";
 import { RspackCLI } from "./rspack-cli";
 import { WebpackOptionsNormalized } from "webpack";
+export type { Configuration } from "@rspack/core";
 import { Configuration as DevServerConfig } from "webpack-dev-server";
 export interface IRspackCLI {
 	runRspack(): Promise<void>;

--- a/packages/rspack/src/config/index.ts
+++ b/packages/rspack/src/config/index.ts
@@ -28,6 +28,7 @@ import {
 	StatsOptions
 } from "./stats";
 
+export type Configuration = RspackOptions;
 export interface RspackOptions {
 	name?: string;
 	entry?: Entry;


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Align with Webpack's `Configuration`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
