### PR TITLE
chore: only prints error info for dev

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -57,6 +57,6 @@ module.exports = {
     publicPath: '/'
   },
   infrastructureLogging: {
-    debug:true
+    debug:false
   }
 }

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -92,7 +92,6 @@ export class RspackCLI {
 		if (!item.mode) {
 			item.mode = "production";
 		}
-		console.log("mode:", options.mode, item.mode);
 		return item;
 	}
 	async loadConfig(options: RspackCLIOptions): Promise<RspackOptions> {

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -299,9 +299,19 @@ class Compiler {
 		);
 		const begin = Date.now();
 		let rawStats = await util.promisify(this.build.bind(this))();
+
 		let stats = new Stats(rawStats);
+		if (stats.hasErrors()) {
+			console.log(
+				stats.toString({
+					all: false,
+					warnings: true,
+					errors: true,
+					...this.options.stats
+				})
+			);
+		}
 		// TODO: log stats string should move to cli
-		console.log(stats.toString(this.options.stats));
 		console.log("build success, time cost", Date.now() - begin, "ms");
 
 		let pendingChangedFilepaths = new Set<string>();
@@ -333,7 +343,16 @@ class Compiler {
 					(error: any, { diff, stats: rawStats }) => {
 						let stats = new Stats(rawStats);
 						// TODO: log stats string should move to cli
-						console.log(stats.toString(this.options.stats));
+						if (stats.hasErrors()) {
+							console.log(
+								stats.toString({
+									all: false,
+									warnings: true,
+									errors: true,
+									...this.options.stats
+								})
+							);
+						}
 						isBuildFinished = true;
 
 						const hasPending = Boolean(pendingChangedFilepaths.size);

--- a/packages/rspack/src/config/stats.ts
+++ b/packages/rspack/src/config/stats.ts
@@ -4,6 +4,9 @@ export type ResolvedStatsOptions = binding.RawStatsOptions;
 
 export interface StatsOptions {
 	colors?: boolean;
+	all?: boolean;
+	warnings?: boolean;
+	errors?: boolean;
 }
 
 export function resolveStatsOptions(


### PR DESCRIPTION
## Summary
Print all stats info is not friendly to developer especially it will creates lots of noises for HMR info, 
so we only print warning and error info for dev
warning、all、errors filters is not implemented in stats yet, it is left to another PR
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
