### PR TITLE
chore: fix examples cli build

### DIFF
--- a/examples/bundle-splitting/package.json
+++ b/examples/bundle-splitting/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack"
+    "dev": "rspack serve -c test.config.js",
+    "build": "rspack build -c test.config.js"
   },
   "devDependencies": {
-    "@rspack/core": "workspace:*"
+    "@rspack/cli": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/code-splitting/package.json
+++ b/examples/code-splitting/package.json
@@ -5,12 +5,13 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack"
+    "dev": "rspack serve -c test.config.js",
+    "build": "rspack build -c test.config.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@rspack/core": "workspace:*"
+    "@rspack/cli": "workspace:*"
   }
 }

--- a/examples/multi-entry/package.json
+++ b/examples/multi-entry/package.json
@@ -5,18 +5,13 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack"
+    "dev": "rspack serve -c test.config.js",
+    "build": "rspack build -c test.config.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@rspack/core": "workspace:*"
-  },
-  "rspack": {
-    "entry": {
-      "main": "./index.js",
-      "other": "./second.js"
-    }
+    "@rspack/cli": "workspace:*"
   }
 }

--- a/examples/postcss/package.json
+++ b/examples/postcss/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack"
+    "dev": "rspack serve -c test.config.js",
+    "build": "rspack build -c test.config.js"
   },
   "devDependencies": {
-    "@rspack/core": "workspace:*"
+    "@rspack/cli": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/react-refresh/package.json
+++ b/examples/react-refresh/package.json
@@ -5,22 +5,14 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack"
+    "dev": "rspack serve -c test.config.js",
+    "build": "rspack build -c test.config.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "rspack": {
-    "entry": {
-      "index": "./src/index.tsx"
-    },
-    "react": {
-      "refresh": true
-    },
-    "lazyCompilation": true
-  },
   "dependencies": {
-    "@rspack/core": "workspace:*",
+    "@rspack/cli": "workspace:*",
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-refresh": "0.13.0"

--- a/examples/react-with-less/package.json
+++ b/examples/react-with-less/package.json
@@ -4,12 +4,15 @@
   "description": "",
   "main": "index.js",
   "private": true,
-  "scripts": {},
+  "scripts": {
+    "build": "rspack build",
+    "dev": "rspack serve"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@rspack/core": "workspace:*",
+    "@rspack/cli": "workspace:*",
     "@rspack/plugin-less": "workspace:^",
     "react": "17.0.0",
     "react-dom": "17.0.0"

--- a/examples/react-with-less/rspack.config.js
+++ b/examples/react-with-less/rspack.config.js
@@ -1,0 +1,16 @@
+const lessLoader = require('@rspack/plugin-less').default;
+module.exports = {
+  mode : 'development',
+  entry : {
+    main : ['./src/index.jsx'],
+  },
+  define : {
+    'process.env.NODE_ENV' : '\'development\'',
+  },
+  builtins : {
+    html : [{}],
+  },
+  module : {
+    rules : [{test : '.less$', uses : [{loader : lessLoader}], type : 'css'}]
+  }
+};

--- a/examples/react-with-sass/package.json
+++ b/examples/react-with-sass/package.json
@@ -4,12 +4,16 @@
   "description": "",
   "main": "index.js",
   "private": true,
+  "build": {
+    "build": "rspack build -c test.config.js",
+    "dev": "rspack serve -c test.config.js"
+  },
   "scripts": {},
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@rspack/core": "workspace:*",
+    "@rspack/cli": "workspace:*",
     "react": "17.0.0",
     "react-dom": "17.0.0"
   }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -5,21 +5,16 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack"
+    "dev": "rspack serve -c test.config.js",
+    "build": "rspack build -c test.config.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@rspack/core": "workspace:*",
+    "@rspack/cli": "workspace:*",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
-  },
-  "rspack": {
-    "entry": {
-      "index": "src/index.js"
-    },
-    "react": {},
-    "svgr": true
+    "react-dom": "18.2.0",
+    "react-refresh": "0.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,69 +115,71 @@ importers:
 
   examples/bundle-splitting:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
     devDependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
 
   examples/code-splitting:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
     devDependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
 
   examples/multi-entry:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
     devDependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
 
   examples/postcss:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
     devDependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
 
   examples/react:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
       react: 18.2.0
       react-dom: 18.2.0
+      react-refresh: 0.14.0
     dependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+      react-refresh: 0.14.0
 
   examples/react-refresh:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
       react: 18.0.0
       react-dom: 18.0.0
       react-refresh: 0.13.0
     dependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
       react: 18.0.0
       react-dom: 18.0.0_react@18.0.0
       react-refresh: 0.13.0
 
   examples/react-with-less:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
       '@rspack/plugin-less': workspace:^
       react: 17.0.0
       react-dom: 17.0.0
     dependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
       '@rspack/plugin-less': link:../../packages/rspack-plugin-less
       react: 17.0.0
       react-dom: 17.0.0_react@17.0.0
 
   examples/react-with-sass:
     specifiers:
-      '@rspack/core': workspace:*
+      '@rspack/cli': workspace:*
       react: 17.0.0
       react-dom: 17.0.0
     dependencies:
-      '@rspack/core': link:../../packages/rspack
+      '@rspack/cli': link:../../packages/rspack-cli
       react: 17.0.0
       react-dom: 17.0.0_react@17.0.0
 

--- a/scripts/cmd.js
+++ b/scripts/cmd.js
@@ -86,6 +86,7 @@ function createCLI() {
 		.option("bundle", "build example directory in rust side")
 		.option("webpack", "build webpack-example directory")
 		.option("js", "build all js library")
+		.option("examples", "build all rspack examples")
 		.action(args => {
 			let command;
 			switch (args) {
@@ -107,6 +108,9 @@ function createCLI() {
 					break;
 				case "webpack":
 					command = "cd webpack-examples && node buildAll.js && cd -";
+					break;
+				case "examples":
+					command = 'pnpm --filter "example-*" build';
 					break;
 				default:
 					log.error("invalid args, see `./x build -h` to get more information");


### PR DESCRIPTION
## Summary
ensure all rspack examples build successfully in ci
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
