### PR TITLE
refactor: use module in generator

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -194,7 +194,7 @@ impl Compiler {
                 None
               } else if item.module_type.is_js_like() {
                 // TODO: it soo slowly, should use cache to instead.
-                let code = module.code_generation(item, s.compilation).unwrap();
+                let code = module.code_generation(s.compilation).unwrap();
                 let code = if let Some(code) = code.get(JavaScript) {
                   code.ast_or_source.as_source().unwrap().source().to_string()
                 } else {
@@ -204,7 +204,7 @@ impl Compiler {
                 Some((item.module_identifier.clone(), code))
               } else if item.module_type.is_css() {
                 // TODO: it soo slowly, should use cache to instead.
-                let code = module.code_generation(item, s.compilation).unwrap();
+                let code = module.code_generation(s.compilation).unwrap();
                 let code = if let Some(code) = code.get(Css) {
                   // only used for compare between two build
                   code.ast_or_source.as_source().unwrap().source().to_string()

--- a/crates/rspack_core/src/external.rs
+++ b/crates/rspack_core/src/external.rs
@@ -66,7 +66,7 @@ impl ParserAndGenerator for ExternalParserAndGenerator {
     &self,
     _requested_source_type: crate::SourceType,
     ast_or_source: &crate::AstOrSource,
-    _module: &crate::ModuleGraphModule,
+    _module: &crate::NormalModule,
     _compilation: &crate::Compilation,
   ) -> rspack_error::Result<crate::GenerationResult> {
     Ok(crate::GenerationResult {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -275,7 +275,7 @@ pub trait ParserAndGenerator: Send + Sync + Debug {
     &self,
     requested_source_type: SourceType,
     ast_or_source: &AstOrSource,
-    module: &ModuleGraphModule,
+    module: &NormalModule,
     compilation: &Compilation,
   ) -> Result<GenerationResult>;
 }
@@ -530,21 +530,15 @@ impl NormalModule {
     Ok(BuildResult { dependencies }.with_diagnostic(diagnostics))
   }
 
-  pub fn code_generation(
-    &self,
-    module_graph_module: &ModuleGraphModule,
-    compilation: &Compilation,
-  ) -> Result<CodeGenerationResult> {
+  pub fn code_generation(&self, compilation: &Compilation) -> Result<CodeGenerationResult> {
     if let NormalModuleAstOrSource::BuiltSucceed(ast_or_source) = self.ast_or_source() {
       let mut code_generation_result = CodeGenerationResult::default();
 
       for source_type in self.source_types() {
-        let generation_result = self.parser_and_generator.generate(
-          *source_type,
-          ast_or_source,
-          module_graph_module,
-          compilation,
-        )?;
+        let generation_result =
+          self
+            .parser_and_generator
+            .generate(*source_type, ast_or_source, self, compilation)?;
 
         code_generation_result.add(*source_type, generation_result);
       }

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -192,14 +192,10 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     &self,
     requested_source_type: SourceType,
     ast_or_source: &rspack_core::AstOrSource,
-    mgm: &rspack_core::ModuleGraphModule,
+    module: &rspack_core::NormalModule,
     compilation: &rspack_core::Compilation,
   ) -> Result<rspack_core::GenerationResult> {
     let parsed_asset_config = self.parsed_asset_config.as_ref().unwrap();
-    let module = compilation
-      .module_graph
-      .module_by_identifier(&mgm.module_identifier)
-      .ok_or_else(|| Error::InternalError("Failed to get module".to_owned()))?;
 
     let result = match requested_source_type {
       SourceType::JavaScript => Ok(GenerationResult {
@@ -377,7 +373,7 @@ impl Plugin for AssetPlugin {
 
         Ok(
           module
-            .code_generation(mgm, compilation)
+            .code_generation(compilation)
             .map(|source| {
               source
                 .inner()

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -130,16 +130,9 @@ impl ParserAndGenerator for CssParserAndGenerator {
     &self,
     requested_source_type: SourceType,
     ast_or_source: &rspack_core::AstOrSource,
-    mgm: &rspack_core::ModuleGraphModule,
+    module: &rspack_core::NormalModule,
     compilation: &rspack_core::Compilation,
   ) -> Result<rspack_core::GenerationResult> {
-    // Safety: OriginalSource exists in code generation, and CSS AST is also available from parse.
-
-    let module = compilation
-      .module_graph
-      .module_by_identifier(&mgm.module_identifier)
-      .ok_or_else(|| Error::InternalError("Failed to get module".to_owned()))?;
-
     let result = match requested_source_type {
       SourceType::Css => {
         let (code, source_map) = SWC_COMPILER.codegen(
@@ -351,7 +344,7 @@ impl Plugin for CssPlugin {
           // FIXME: use result
           .expect("Failed to get module");
 
-        module.code_generation(mgm, compilation).map(|source| {
+        module.code_generation(compilation).map(|source| {
           // TODO: this logic is definitely not performant, move to compilation afterwards
           source
             .inner()

--- a/crates/rspack_plugin_javascript/src/visitors/finalize.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/finalize.rs
@@ -1,12 +1,12 @@
 // use super::hmr::HmrModuleIdReWriter;
 use crate::visitors::RspackModuleFinalizer;
-use rspack_core::{Compilation, ModuleGraphModule};
+use rspack_core::{Compilation, NormalModule};
 use swc_common::{Mark, DUMMY_SP, GLOBALS};
 use swc_ecma_utils::quote_ident;
 use swc_ecma_visit::Fold;
 
 pub fn finalize<'a>(
-  module: &'a ModuleGraphModule,
+  module: &'a NormalModule,
   compilation: &'a Compilation,
   unresolved_mark: Mark,
 ) -> impl Fold + 'a {

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -91,7 +91,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     &self,
     requested_source_type: SourceType,
     ast_or_source: &rspack_core::AstOrSource,
-    _module: &rspack_core::ModuleGraphModule,
+    _module: &rspack_core::NormalModule,
     _compilation: &rspack_core::Compilation,
   ) -> Result<rspack_core::GenerationResult> {
     match requested_source_type {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [X] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
