### PR TITLE
chore: support loader as string

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -1,22 +1,7 @@
 const lessLoader = require('@rspack/plugin-less').default;
 const postcssLoader = require('@rspack/plugin-postcss');
 const path = require('path');
-const { transform } = require('@svgr/core');
-async function svgLoader(loaderContext){
-  const svgCode = loaderContext.source.getCode();
-  const filePath = loaderContext.resourcePath;
-  const componentCode = await transform(svgCode, {}, {
-    filePath,
-    caller: {
-      previousExport: null
-    }
-  })
-  return {
-    content: componentCode,
-    meta: "",
-    map: undefined
-  }
-}
+
 /**
  * @type {import('webpack').Configuration}
  */
@@ -52,7 +37,7 @@ module.exports = {
         type : 'css'
       },
       {test : '.less$', uses : [{loader : lessLoader}], type : 'css'},
-      {test : '.svg$', uses : [{loader : svgLoader}], type : 'jsx'}
+      {test : '.svg$', uses : [{loader : './svg-loader.js'}], type : 'jsx'}
     ]
   },
   resolve : {alias : {'@' : path.resolve(__dirname, 'src')}},

--- a/examples/arco-pro/svg-loader.js
+++ b/examples/arco-pro/svg-loader.js
@@ -1,0 +1,16 @@
+const { transform } = require('@svgr/core');
+module.exports = async function svgLoader(loaderContext){
+  const svgCode = loaderContext.source.getCode();
+  const filePath = loaderContext.resourcePath;
+  const componentCode = await transform(svgCode, {}, {
+    filePath,
+    caller: {
+      previousExport: null
+    }
+  })
+  return {
+    content: componentCode,
+    meta: "",
+    map: undefined
+  }
+}

--- a/packages/rspack/src/config/module.ts
+++ b/packages/rspack/src/config/module.ts
@@ -128,6 +128,15 @@ function composeJsUse(
 		// Loader is executed from right to left
 		for (const use of uses) {
 			assert("loader" in use);
+			/**
+			 * support loader as string
+			 */
+			if (typeof use.loader === "string") {
+				let loaderPath = require.resolve(use.loader, {
+					paths: [options.context]
+				});
+				use.loader = require(loaderPath);
+			}
 			const loaderContext = {
 				...loaderContextInternal,
 				source: {
@@ -145,7 +154,6 @@ function composeJsUse(
 				rootContext: options.context,
 				context: path.dirname(loaderContextInternal.resourcePath)
 			};
-
 			let loaderResult: LoaderResult;
 			if (
 				(loaderResult = await Promise.resolve().then(() =>

--- a/packages/rspack/tests/configCases/loader/loader-string/index.js
+++ b/packages/rspack/tests/configCases/loader/loader-string/index.js
@@ -1,0 +1,4 @@
+import { lib } from "./lib";
+it("loader-as-string", () => {
+	expect(lib).toEqual(43);
+});

--- a/packages/rspack/tests/configCases/loader/loader-string/lib.js
+++ b/packages/rspack/tests/configCases/loader/loader-string/lib.js
@@ -1,0 +1,1 @@
+export const lib = 42;

--- a/packages/rspack/tests/configCases/loader/loader-string/my-loader.js
+++ b/packages/rspack/tests/configCases/loader/loader-string/my-loader.js
@@ -1,0 +1,7 @@
+module.exports = function (context) {
+	return {
+		content: context.source.getCode().replace("42", "43"),
+		map: undefined,
+		meta: ""
+	};
+};

--- a/packages/rspack/tests/configCases/loader/loader-string/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/loader-string/webpack.config.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: "lib.js",
+				uses: [
+					{
+						loader: "./my-loader.js"
+					}
+				]
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary
webpack support pass loader as string, we should align to it 
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
