### PR TITLE
chore: add more comments to module graph impl

### DIFF
--- a/crates/rspack_core/src/chunk_graph.rs
+++ b/crates/rspack_core/src/chunk_graph.rs
@@ -145,7 +145,7 @@ impl ChunkGraph {
     chunk_graph_chunk
       .modules
       .iter()
-      .filter_map(|uri| module_graph.module_by_uri(uri))
+      .filter_map(|uri| module_graph.module_graph_module_by_identifier(uri))
       .collect()
   }
 
@@ -159,7 +159,7 @@ impl ChunkGraph {
     let modules = chunk_graph_chunk
       .modules
       .iter()
-      .filter_map(|uri| module_graph.module_by_uri(uri))
+      .filter_map(|uri| module_graph.module_graph_module_by_identifier(uri))
       .filter(|mgm| {
         module_graph
           .module_by_identifier(&mgm.module_identifier)

--- a/crates/rspack_core/src/chunk_spliter/split_chunks.rs
+++ b/crates/rspack_core/src/chunk_spliter/split_chunks.rs
@@ -280,7 +280,7 @@ impl<'me> CodeSplitter<'me> {
       let mut module = self
         .compilation
         .module_graph
-        .module_by_uri_mut(&item.module_identifier)
+        .module_graph_module_by_identifier_mut(&item.module_identifier)
         .expect("No module found");
 
       if module.pre_order_index.is_none() {
@@ -319,7 +319,7 @@ impl<'me> CodeSplitter<'me> {
     let mut module = self
       .compilation
       .module_graph
-      .module_by_uri_mut(&item.module_identifier)
+      .module_graph_module_by_identifier_mut(&item.module_identifier)
       .expect("no module found");
 
     if module.post_order_index.is_none() {
@@ -333,7 +333,7 @@ impl<'me> CodeSplitter<'me> {
     let mgm = self
       .compilation
       .module_graph
-      .module_by_uri(&item.module_identifier)
+      .module_graph_module_by_identifier(&item.module_identifier)
       .expect("no module found");
 
     for dep_mgm in mgm

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -122,7 +122,7 @@ impl Compilation {
       .filter_map(|entry_module_identifier| {
         self
           .module_graph
-          .module_by_uri(entry_module_identifier)
+          .module_graph_module_by_identifier(entry_module_identifier)
           .map(|module| &module.id)
       })
       .collect::<Vec<_>>();

--- a/crates/rspack_core/src/module_graph.rs
+++ b/crates/rspack_core/src/module_graph.rs
@@ -12,10 +12,14 @@ pub(crate) static DEPENDENCY_ID: AtomicU32 = AtomicU32::new(1);
 
 #[derive(Debug, Clone, Eq)]
 pub struct ModuleGraphConnection {
+  /// The referencing module identifier
   pub original_module_identifier: Option<ModuleIdentifier>,
+  /// The referenced module identifier
   pub module_identifier: ModuleIdentifier,
+  /// The referencing dependency id
   pub dependency_id: u32,
 
+  /// The unique id of this connection
   pub id: u32,
 }
 
@@ -55,13 +59,16 @@ impl ModuleGraphConnection {
 pub struct ModuleGraph {
   dependency_id_to_module_identifier: HashMap<u32, String>,
 
+  /// Module identifier to its module
   pub module_identifier_to_module: HashMap<ModuleIdentifier, NormalModule>,
+  /// Module identifier to its module graph module
   pub module_identifier_to_module_graph_module: HashMap<ModuleIdentifier, ModuleGraphModule>,
 
   dependency_id_to_connection_id: HashMap<u32, u32>,
   dependency_id_to_dependency: HashMap<u32, Dependency>,
   dependency_to_dependency_id: HashMap<Dependency, u32>,
 
+  /// The module graph connections
   pub connections: HashSet<ModuleGraphConnection>,
   connection_id_to_connection: HashMap<u32, ModuleGraphConnection>,
 }
@@ -95,6 +102,7 @@ impl ModuleGraph {
       .insert(dependency_id, resolved_uri);
   }
 
+  /// Uniquely identify a module by its dependency
   pub fn module_by_dependency(&self, dep: &Dependency) -> Option<&ModuleGraphModule> {
     self
       .dependency_to_dependency_id
@@ -107,18 +115,22 @@ impl ModuleGraph {
       })
   }
 
+  /// Get the dependency id of a dependency
   pub fn dependency_id_by_dependency(&self, dep: &Dependency) -> Option<u32> {
     self.dependency_to_dependency_id.get(dep).cloned()
   }
 
+  /// Return an unordered iterator of module graph modules
   pub fn module_graph_modules(&self) -> impl Iterator<Item = &ModuleGraphModule> {
     self.module_identifier_to_module_graph_module.values()
   }
 
+  /// Return an unordered iterator of modules
   pub fn modules(&self) -> impl Iterator<Item = &NormalModule> {
     self.module_identifier_to_module.values()
   }
 
+  /// Add a connection between two module graph modules, if a connection exists, then it will be reused.
   pub fn set_resolved_module(
     &mut self,
     original_module_identifier: Option<ModuleIdentifier>,
@@ -165,21 +177,19 @@ impl ModuleGraph {
     Ok(())
   }
 
-  #[inline]
-  pub fn module_by_uri(&self, uri: &str) -> Option<&ModuleGraphModule> {
-    self.module_identifier_to_module_graph_module.get(uri)
-  }
-
+  /// Uniquely identify a module by its identifier and return the aliased reference
   #[inline]
   pub fn module_by_identifier(&self, identifier: &str) -> Option<&NormalModule> {
     self.module_identifier_to_module.get(identifier)
   }
 
+  /// Uniquely identify a module by its identifier and return the exclusive reference
   #[inline]
   pub fn module_by_identifier_mut(&mut self, identifier: &str) -> Option<&mut NormalModule> {
     self.module_identifier_to_module.get_mut(identifier)
   }
 
+  /// Uniquely identify a module graph module by its module's identifier and return the aliased reference
   #[inline]
   pub fn module_graph_module_by_identifier(&self, identifier: &str) -> Option<&ModuleGraphModule> {
     self
@@ -187,6 +197,7 @@ impl ModuleGraph {
       .get(identifier)
   }
 
+  /// Uniquely identify a module graph module by its module's identifier and return the exclusive reference
   #[inline]
   pub fn module_graph_module_by_identifier_mut(
     &mut self,
@@ -197,11 +208,7 @@ impl ModuleGraph {
       .get_mut(identifier)
   }
 
-  #[inline]
-  pub fn module_by_uri_mut(&mut self, uri: &str) -> Option<&mut ModuleGraphModule> {
-    self.module_identifier_to_module_graph_module.get_mut(uri)
-  }
-
+  /// Uniquely identify a connection by a given dependency
   pub fn connection_by_dependency(&self, dep: &Dependency) -> Option<&ModuleGraphConnection> {
     self
       .dependency_to_dependency_id

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -256,9 +256,13 @@ pub struct ParseResult {
 }
 
 pub trait ParserAndGenerator: Send + Sync + Debug {
+  /// The source types that the generator can generate (the source types you can make requests for)
   fn source_types(&self) -> &[SourceType];
+  /// Parse the source and return the dependencies and the ast or source
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>>;
+  /// Size of the original source
   fn size(&self, module: &NormalModule, source_type: &SourceType) -> f64;
+  /// Generate source or AST based on the built source or AST
   fn generate(
     &self,
     requested_source_type: SourceType,
@@ -270,14 +274,22 @@ pub trait ParserAndGenerator: Send + Sync + Debug {
 
 #[derive(Debug)]
 pub struct NormalModule {
+  /// Request with loaders from config
   request: String,
+  /// Request intended by user (without loaders from config)
   user_request: String,
+  /// Request without resolving
   raw_request: String,
+  /// The resolved module type of a module
   module_type: ModuleType,
+  /// Affiliated parser and generator to the module type
   parser_and_generator: Box<dyn ParserAndGenerator>,
+  /// Resource data (path, url, etc.)
   resource_data: ResourceData,
 
+  /// Original content of this module, will be available after module build
   original_source: Option<Box<dyn Source>>,
+  /// Built AST or source of this module (passed with loaders)
   ast_or_source: NormalModuleAstOrSource,
 
   options: Arc<CompilerOptions>,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -21,19 +21,10 @@ use crate::{
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct Dependency {
+  /// Parent module identifier (Can be used to locate its parent module in module graph)
   pub parent_module_identifier: Option<ModuleIdentifier>,
   pub detail: ModuleDependency,
 }
-
-// impl Dependency {
-//   pub fn new(importer: Option<String>, specifier: String, kind: ResolveKind) -> Self {
-//     Self {
-//       importer,
-//       specifier,
-//       kind,
-//     }
-//   }
-// }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 pub enum ResolveKind {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add more comments to the module graph implementation and some small refactoring to used APIs.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [X] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
