### PR TITLE
test: sass '~' should resolve to node_modules

### DIFF
--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/.gitignore
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/.gitignore
@@ -1,0 +1,1 @@
+!/node_modules

--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/index.js
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/index.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+
+it('should work when "@import" at-rules from scoped npm packages', () => {
+	require("./index.scss");
+	const css = fs.readFileSync(path.resolve(__dirname, "main.css"), "utf-8");
+	expect(css.includes(".org-pkg") && css.includes(".scoped-npm-pkg-foo")).toBe(
+		true
+	);
+});

--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/index.scss
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/index.scss
@@ -1,0 +1,6 @@
+@import "~@org/pkg";
+@import "~@org/bar/foo";
+
+.foo {
+  background: #000;
+}

--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/node_modules/@org/bar/_foo.scss
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/node_modules/@org/bar/_foo.scss
@@ -1,0 +1,3 @@
+.scoped-npm-pkg-foo {
+    background: black;
+}

--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/node_modules/@org/pkg/index.scss
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/node_modules/@org/pkg/index.scss
@@ -1,0 +1,3 @@
+.org-pkg {
+    background: white;
+}

--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/node_modules/@org/pkg/package.json
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/node_modules/@org/pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@org/pkg",
+  "main": "./index.scss"
+}

--- a/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/webpack.config.js
+++ b/packages/rspack/tests/configCases/sass/import-from-npm-org-pkg/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: "\\.s[ac]ss$",
+				uses: [{ builtinLoader: "sass-loader" }],
+				type: "css"
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

test for #1109 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
