### PR TITLE
refactor(config): add "browser" in mainFileds

### DIFF
--- a/packages/rspack/src/config/index.ts
+++ b/packages/rspack/src/config/index.ts
@@ -80,7 +80,7 @@ export function getNormalizedRspackOptions(
 	const externalsType = config.externalsType ?? "";
 	const plugins = config.plugins ?? [];
 	const builtins = resolveBuiltinsOptions(config.builtins || {}, context);
-	const resolve = resolveResolveOptions(config.resolve);
+	const resolve = resolveResolveOptions(config.resolve, { target });
 	const devtool = resolveDevtoolOptions(config.devtool);
 	const module = resolveModuleOptions(config.module, { devtool, context });
 	const stats = resolveStatsOptions(config.stats);

--- a/packages/rspack/src/config/resolve.ts
+++ b/packages/rspack/src/config/resolve.ts
@@ -1,3 +1,5 @@
+import type { ResolvedTarget } from "./target";
+
 export type Resolve = {
 	preferRelative?: boolean;
 	extensions?: string[];
@@ -20,7 +22,14 @@ export type ResolvedResolve = {
 	tsConfigPath: string;
 };
 
-export function resolveResolveOptions(resolve: Resolve = {}): ResolvedResolve {
+interface ResolveContext {
+	target: ResolvedTarget;
+}
+
+export function resolveResolveOptions(
+	resolve: Resolve = {},
+	{ target }: ResolveContext
+): ResolvedResolve {
 	const preferRelative = resolve.preferRelative ?? false;
 	const extensions = resolve.extensions ?? [
 		".tsx",
@@ -30,7 +39,11 @@ export function resolveResolveOptions(resolve: Resolve = {}): ResolvedResolve {
 		".json",
 		".d.ts"
 	];
-	const mainFields = resolve.mainFields ?? ["module", "main"];
+	const defaultMainFields = ["module", "main"];
+	if (target.includes("web")) {
+		defaultMainFields.unshift("browser");
+	}
+	const mainFields = resolve.mainFields ?? defaultMainFields;
 	const mainFiles = resolve.mainFiles ?? ["index"];
 	const browserField = resolve.browserField ?? true;
 	const alias = resolve.alias ?? {};

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -72,66 +72,67 @@ describe("snapshots", () => {
 
 	it("should have the correct base config", () => {
 		expect(baseConfig).toMatchInlineSnapshot(`
-{
-  "builtins": {
-    "browserslist": [],
-    "decorator": {
-      "emitMetadata": true,
-      "legacy": true,
-      "useDefineForClassFields": true,
-    },
-    "html": [],
-  },
-  "context": "<cwd>",
-  "devServer": undefined,
-  "devtool": "",
-  "entry": {
-    "main": [
-      "<cwd>/src/index.js",
-    ],
-  },
-  "externals": {},
-  "externalsType": "",
-  "infrastructureLogging": {},
-  "mode": "none",
-  "module": {
-    "rules": [],
-  },
-  "output": {},
-  "plugins": [],
-  "resolve": {
-    "alias": {},
-    "browserField": true,
-    "conditionNames": [
-      "module",
-      "import",
-    ],
-    "extensions": [
-      ".tsx",
-      ".jsx",
-      ".ts",
-      ".js",
-      ".json",
-      ".d.ts",
-    ],
-    "mainFields": [
-      "module",
-      "main",
-    ],
-    "mainFiles": [
-      "index",
-    ],
-    "preferRelative": false,
-    "tsConfigPath": "",
-  },
-  "stats": {
-    "colors": false,
-  },
-  "target": [
-    "web",
-  ],
-}
-`);
+		{
+		  "builtins": {
+		    "browserslist": [],
+		    "decorator": {
+		      "emitMetadata": true,
+		      "legacy": true,
+		      "useDefineForClassFields": true,
+		    },
+		    "html": [],
+		  },
+		  "context": "<cwd>",
+		  "devServer": undefined,
+		  "devtool": "",
+		  "entry": {
+		    "main": [
+		      "<cwd>/src/index.js",
+		    ],
+		  },
+		  "externals": {},
+		  "externalsType": "",
+		  "infrastructureLogging": {},
+		  "mode": "none",
+		  "module": {
+		    "rules": [],
+		  },
+		  "output": {},
+		  "plugins": [],
+		  "resolve": {
+		    "alias": {},
+		    "browserField": true,
+		    "conditionNames": [
+		      "module",
+		      "import",
+		    ],
+		    "extensions": [
+		      ".tsx",
+		      ".jsx",
+		      ".ts",
+		      ".js",
+		      ".json",
+		      ".d.ts",
+		    ],
+		    "mainFields": [
+		      "browser",
+		      "module",
+		      "main",
+		    ],
+		    "mainFiles": [
+		      "index",
+		    ],
+		    "preferRelative": false,
+		    "tsConfigPath": "",
+		  },
+		  "stats": {
+		    "colors": false,
+		  },
+		  "target": [
+		    "web",
+		  ],
+		}
+	`);
 	});
 
 	const test = (name, options, fn, before, after) => {
@@ -406,6 +407,8 @@ describe("snapshots", () => {
 		+ Received
 
 		@@ ... @@
+		-       "browser",
+		@@ ... @@
 		-     "web",
 		+     "node",
 	`)
@@ -415,6 +418,8 @@ describe("snapshots", () => {
 		- Expected
 		+ Received
 
+		@@ ... @@
+		-       "browser",
 		@@ ... @@
 		-     "web",
 		+     "webworker",
@@ -426,6 +431,8 @@ describe("snapshots", () => {
 		+ Received
 
 		@@ ... @@
+		-       "browser",
+		@@ ... @@
 		-     "web",
 		+     "electron-main",
 	`)
@@ -435,6 +442,8 @@ describe("snapshots", () => {
 		- Expected
 		+ Received
 
+		@@ ... @@
+		-       "browser",
 		@@ ... @@
 		-     "web",
 		+     "electron-preload",


### PR DESCRIPTION
the default value of `resolve.mainfileds` is `["browser", "module", "main"]` when target includes `web` in webpack, align it.

reference https://webpack.js.org/configuration/resolve/#resolvemainfields