### PR TITLE
chore: ensure JS hook call ordering

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -87,13 +87,15 @@ impl Compiler {
       .plugin_driver
       .write()
       .await
-      .this_compilation(&mut self.compilation)?;
+      .this_compilation(&mut self.compilation)
+      .await?;
 
     self
       .plugin_driver
       .write()
       .await
-      .compilation(&mut self.compilation)?;
+      .compilation(&mut self.compilation)
+      .await?;
 
     let deps = self.compilation.entry_dependencies();
     self.compile(deps).await?;

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -46,11 +46,14 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
-  fn compilation(&mut self, _args: CompilationArgs) -> PluginCompilationHookOutput {
+  async fn compilation(&mut self, _args: CompilationArgs<'_>) -> PluginCompilationHookOutput {
     Ok(())
   }
 
-  fn this_compilation(&mut self, _args: ThisCompilationArgs) -> PluginThisCompilationHookOutput {
+  async fn this_compilation(
+    &mut self,
+    _args: ThisCompilationArgs<'_>,
+  ) -> PluginThisCompilationHookOutput {
     Ok(())
   }
 

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -133,14 +133,13 @@ impl PluginDriver {
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#compilation
   #[instrument(name = "plugin:compilation", skip_all)]
-  pub fn compilation(&mut self, compilation: &mut Compilation) -> PluginCompilationHookOutput {
-    self
-      .plugins
-      .iter_mut()
-      .try_for_each(|plugin| -> Result<()> {
-        plugin.compilation(CompilationArgs { compilation })?;
-        Ok(())
-      })?;
+  pub async fn compilation(
+    &mut self,
+    compilation: &mut Compilation,
+  ) -> PluginCompilationHookOutput {
+    for plugin in &mut self.plugins {
+      plugin.compilation(CompilationArgs { compilation }).await?;
+    }
 
     Ok(())
   }
@@ -149,19 +148,17 @@ impl PluginDriver {
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#thiscompilation
   #[instrument(name = "plugin:this_compilation", skip_all)]
-  pub fn this_compilation(
+  pub async fn this_compilation(
     &mut self,
     compilation: &mut Compilation,
   ) -> PluginThisCompilationHookOutput {
-    self
-      .plugins
-      .iter_mut()
-      .try_for_each(|plugin| -> Result<()> {
-        plugin.this_compilation(ThisCompilationArgs {
+    for plugin in &mut self.plugins {
+      plugin
+        .this_compilation(ThisCompilationArgs {
           this_compilation: compilation,
-        })?;
-        Ok(())
-      })?;
+        })
+        .await?;
+    }
 
     Ok(())
   }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Ensure the ordering of call-into-js operation.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
