### PR TITLE
chore: 🤖 wrong ci runs-on

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   format:
     name: Format Rust Files
-    runs-on: [self-hosted, rspack-common, rspack-bench]
+    runs-on: [self-hosted, rspack-common]
     steps:
       # - name: Cleanup workspace
       #   uses: TooMuch4U/actions-clean@v2.1
@@ -39,7 +39,7 @@ jobs:
 
   lint:
     name: Lint Rust Files
-    runs-on: [self-hosted, rspack-common, rspack-bench]
+    runs-on: [self-hosted, rspack-common]
     steps:
       # - name: Cleanup workspace
       #   uses: TooMuch4U/actions-clean@v2.1
@@ -67,7 +67,7 @@ jobs:
     name: Rust test
     strategy:
       fail-fast: true
-    runs-on: [self-hosted, rspack-common, rspack-bench]
+    runs-on: [self-hosted, rspack-common]
     timeout-minutes: 30
     steps:
       # - name: Cleanup workspace


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
