### PR TITLE
chore: add build info to progress

### DIFF
--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -77,6 +77,9 @@ impl Plugin for ProgressPlugin {
     self
       .progress_bar
       .set_position((10.0 + 55.0 * percent) as u64);
+    self
+      .progress_bar
+      .set_message(format!("building {}", _module.raw_request()));
     Ok(())
   }
 


### PR DESCRIPTION
## Summary
closes #1136 

https://user-images.githubusercontent.com/8898718/201703051-b105d72f-f605-446c-8067-b5139c874ebc.mov




## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
