### PR TITLE
ci: 🎡 only generate rspack.stat.json

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -134,7 +134,7 @@ jobs:
           pnpm install
           pnpm run build:cli
       - name: Create rspack stats
-        run: pnpm --filter example-arco-design-pro compare-bundle-stats
+        run: pnpm --filter example-arco-design-pro bundle-stats
       - name: Send rspack stats to RelativeCI
         uses: relative-ci/agent-action@v2
         with:


### PR DESCRIPTION
## Summary
1. We only send `rspack-stats.json` to relative-ci, so I don't think it is necessary to generate webpack-stats.json every time.
2.  I don't expect this would save amount of time, IIRC webpack only cost about 20+s to bundle arco-pro
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
