### PR TITLE
chore: takedown bundle stats temporarily

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -118,43 +118,43 @@ jobs:
           pnpm --filter @rspack/dev-server run test
           pnpm run build:webpack
 
-  bundle-stats:
-    name: Bundle stats compare
-    runs-on: [self-hosted, rspack-common, ARM64]
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          architecture: "arm64"
-      - name: Install dependencies && and build lib
-        run: |
-          node -e "console.log(process.arch)"  
-          pnpm install
-          pnpm run build:cli
-      - name: Create rspack stats
-        run: pnpm --filter example-arco-design-pro bundle-stats
-      - name: Send rspack stats to RelativeCI
-        uses: relative-ci/agent-action@v2
-        with:
-          webpackStatsFile: ./examples/arco-pro/rspack-stats.json
-          key: ${{ secrets.RELATIVE_CI_KEY }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+  # bundle-stats:
+  #   name: Bundle stats compare
+  #   runs-on: [self-hosted, rspack-common, ARM64]
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: "16"
+  #         architecture: "arm64"
+  #     - name: Install dependencies && and build lib
+  #       run: |
+  #         node -e "console.log(process.arch)"
+  #         pnpm install
+  #         pnpm run build:cli
+  #     - name: Create rspack stats
+  #       run: pnpm --filter example-arco-design-pro bundle-stats
+  #     - name: Send rspack stats to RelativeCI
+  #       uses: relative-ci/agent-action@v2
+  #       with:
+  #         webpackStatsFile: ./examples/arco-pro/rspack-stats.json
+  #         key: ${{ secrets.RELATIVE_CI_KEY }}
+  #         token: ${{ secrets.GITHUB_TOKEN }}
 
-      #- name: Cache
-      #uses: speedy-js/rust-cache-self-hosted@v1
-      # - name: Install yarn
-      #   run: npm install -g yarn
-      # - name: yarn install --no-immutable
-      #   run: npm run init
-      # - name: Configure cache
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/bin/
-      #       ~/.cargo/registry/index/
-      #       ~/.cargo/registry/cache/
-      #       ~/.cargo/git/db/
-      #       target/
-      #     key: test-${{ runner.os }}-cargo-gcc-${{ matrix.gcc }}-clang-${{ matrix.clang }}-${{ hashFiles('**/Cargo.lock') }}
+  #- name: Cache
+  #uses: speedy-js/rust-cache-self-hosted@v1
+  # - name: Install yarn
+  #   run: npm install -g yarn
+  # - name: yarn install --no-immutable
+  #   run: npm run init
+  # - name: Configure cache
+  #   uses: actions/cache@v2
+  #   with:
+  #     path: |
+  #       ~/.cargo/bin/
+  #       ~/.cargo/registry/index/
+  #       ~/.cargo/registry/cache/
+  #       ~/.cargo/git/db/
+  #       target/
+  #     key: test-${{ runner.os }}-cargo-gcc-${{ matrix.gcc }}-clang-${{ matrix.clang }}-${{ hashFiles('**/Cargo.lock') }}


### PR DESCRIPTION
## Summary
currently build arco-pro has performance regression, so we disable it for saving ci resource
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
