### PR TITLE
fix: 🤖 update snapshot

### DIFF
--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -417,7 +417,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
         "development": false,
       },
       "name": "bundle.js",
-      "size": 1685,
+      "size": 879,
       "type": "asset",
     },
   ],
@@ -441,10 +441,10 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
       "assets": [
         {
           "name": "bundle.js",
-          "size": 1685,
+          "size": 879,
         },
       ],
-      "assetsSize": 1685,
+      "assetsSize": 879,
       "chunks": [
         "main",
       ],
@@ -483,8 +483,8 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-overflow 2`] = `
-"    Asset      Size  Chunks  Chunk Names
-bundle.js  1.65 KiB    main  main
+"    Asset       Size  Chunks  Chunk Names
+bundle.js  879 bytes    main  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 51 bytes [entry]
 [./index.js] 51 bytes {main}
@@ -512,7 +512,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
         "development": false,
       },
       "name": "bundle.js",
-      "size": 1701,
+      "size": 1498,
       "type": "asset",
     },
   ],
@@ -536,10 +536,10 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
       "assets": [
         {
           "name": "bundle.js",
-          "size": 1701,
+          "size": 1498,
         },
       ],
-      "assetsSize": 1701,
+      "assetsSize": 1498,
       "chunks": [
         "main",
       ],
@@ -578,7 +578,7 @@ disabled backtrace",
 
 exports[`StatsTestCases should print correct stats for resolve-unexpected-exports-in-pkg 2`] = `
 "    Asset      Size  Chunks  Chunk Names
-bundle.js  1.66 KiB    main  main
+bundle.js  1.46 KiB    main  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 39 bytes [entry]
 [./index.js] 39 bytes {main}


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
