### PR TITLE
fix: performance issue of scanner

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -270,7 +270,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     let dep_scanner = ast.visit(|program, _context| {
       let mut dep_scanner = DependencyScanner::default();
-      program.visit_all_with(&mut dep_scanner);
+      program.visit_with(&mut dep_scanner);
       dep_scanner
     });
 

--- a/packages/rspack-dev-client/src/css.ts
+++ b/packages/rspack-dev-client/src/css.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import cssReload from "mini-css-extract-plugin/dist/hmr/hotModuleReplacement.js";
 
 var id = "/css-hmr";


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix the buggy scanner, the `VisitAll` with recursive calls costs `O(n*n)`(`n` stands for the number of nodes). Changing it to the `Visit` costs `O(n)`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

fixes https://github.com/speedy-js/rspack/issues/1137

Setting target to `es5` will convert template literals with `expressions` into `...concat(...)`, which cause so much revisits of `call_expr` in dependency scanner.

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
