### PR TITLE
feat: resolve swc-helpers to internal path

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -43,7 +43,8 @@
     "webpack-sources": "3.2.3",
     "graceful-fs": "4.2.10",
     "neo-async": "2.6.2",
-    "react-refresh": "0.14.0"
+    "react-refresh": "0.14.0",
+    "@swc/helpers": "0.4.13"
   },
   "optionalDependencies": {
     "@tmp-sass-embedded/darwin-arm64": "1.54.4",

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -2,6 +2,7 @@ import { RspackOptionsNormalized, Compiler } from ".";
 import fs from "graceful-fs";
 
 import { NodeTargetPlugin } from "./node/NodeTargetPlugin";
+import { ResolveSwcPlugin } from "./web/ResolveSwcPlugin";
 export class RspackOptionsApply {
 	constructor() {}
 	process(options: RspackOptionsNormalized, compiler: Compiler) {
@@ -11,5 +12,6 @@ export class RspackOptionsApply {
 		if (compiler.options.target.includes("node")) {
 			new NodeTargetPlugin().apply(compiler);
 		}
+		new ResolveSwcPlugin().apply(compiler);
 	}
 }

--- a/packages/rspack/src/web/ResolveSwcPlugin.ts
+++ b/packages/rspack/src/web/ResolveSwcPlugin.ts
@@ -1,0 +1,14 @@
+import { Compiler } from "../compiler";
+import path from "path";
+export class ResolveSwcPlugin {
+	apply(compiler: Compiler) {
+		const swcPath = path.dirname(require.resolve("@swc/helpers/package.json"));
+		const refreshPath = path.dirname(require.resolve("react-refresh"));
+		// redirect @swc/helpers to rspack, so user don't have to manual install it
+		compiler.options.resolve.alias = {
+			"@swc/helpers": swcPath,
+			"react-refresh": refreshPath,
+			...compiler.options.resolve.alias
+		};
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,7 +223,7 @@ importers:
       '@rspack/plugin-less': workspace:^
       '@rspack/plugin-node-polyfill': workspace:^
       '@rspack/plugin-postcss': workspace:^
-      '@swc/helpers': ^0.4.12
+      '@swc/helpers': 0.4.13
       '@tmp-sass-embedded/darwin-arm64': 1.54.4
       '@tmp-sass-embedded/darwin-x64': 1.54.4
       '@tmp-sass-embedded/linux-arm64': 1.54.4
@@ -256,6 +256,7 @@ importers:
     dependencies:
       '@rspack/binding': link:../../crates/node_binding
       '@rspack/dev-client': link:../rspack-dev-client
+      '@swc/helpers': 0.4.13
       browserslist: 4.21.3
       chokidar: 3.5.3
       graceful-fs: 4.2.10
@@ -276,7 +277,6 @@ importers:
       '@rspack/plugin-less': link:../rspack-plugin-less
       '@rspack/plugin-node-polyfill': link:../rspack-plugin-node-polyfill
       '@rspack/plugin-postcss': link:../rspack-plugin-postcss
-      '@swc/helpers': 0.4.12
       '@types/jest': 29.0.2
       '@types/node': 18.7.9
       '@types/rimraf': 3.0.2
@@ -3324,11 +3324,11 @@ packages:
       '@swc/core-win32-x64-msvc': 1.3.14
     dev: true
 
-  /@swc/helpers/0.4.12:
-    resolution: {integrity: sha512-R6RmwS9Dld5lNvwKlPn62+piU+WDG1sMfsnfJioXCciyko/gZ0DQ4Mqglhq1iGU1nQ/RcGkAwfMH+elMSkJH3Q==}
+  /@swc/helpers/0.4.13:
+    resolution: {integrity: sha512-WOoZMSqpmUgL72xOeaWcU9IG7C6t5Wh1e8NGpSyBvmN5BSCXleK4/PLS6Oko1i/Lvn/yGYOv62bxlfsDvmRurg==}
     dependencies:
       tslib: 2.4.0
-    dev: true
+    dev: false
 
   /@szmarczak/http-timer/1.1.2:
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
