### PR TITLE
feat: more postcss modules options for postcss-loader

### DIFF
--- a/packages/rspack-plugin-postcss/src/index.js
+++ b/packages/rspack-plugin-postcss/src/index.js
@@ -45,7 +45,9 @@ module.exports = async function loader(loaderContext) {
 
 		if (modulesOptions) {
 			let auto =
-				typeof modulesOptions === "boolean" ? true : modulesOptions.auto;
+				typeof modulesOptions === "boolean"
+					? true
+					: modulesOptions.auto ?? true;
 			let isModules;
 			if (typeof auto === "boolean") {
 				isModules = auto && IS_MODULES.test(loaderContext.resourcePath);

--- a/packages/rspack/tests/configCases/postcss/modules-config/auto-false.module.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/auto-false.module.css
@@ -1,0 +1,3 @@
+.auto-false {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/auto-function.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/auto-function.css
@@ -1,0 +1,3 @@
+.auto-function {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/auto-regex.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/auto-regex.css
@@ -1,0 +1,3 @@
+.auto-regex {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/auto-true.module.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/auto-true.module.css
@@ -1,0 +1,3 @@
+.auto-true {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/generateScopedName.module.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/generateScopedName.module.css
@@ -1,0 +1,3 @@
+.generate-scoped-name {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/index.js
+++ b/packages/rspack/tests/configCases/postcss/modules-config/index.js
@@ -1,0 +1,45 @@
+it("modules-true should use css modules", () => {
+	const css = require("./modules-true.module.css");
+	expect(css).toEqual({ "module-true": "_module-true_3vgpi_1" });
+});
+
+it("modules-false should not use css modules", () => {
+	const css = require("./modules-false.module.css");
+	expect(css).toEqual({});
+});
+
+it("auto-true should use css modules", () => {
+	const css = require("./auto-true.module.css");
+	expect(css).toEqual({ "auto-true": "_auto-true_mtxdv_1" });
+});
+
+it("auto-false should not use css modules", () => {
+	const css = require("./auto-false.module.css");
+	expect(css).toEqual({});
+});
+
+it("auto-regex should use css modules", () => {
+	const css = require("./auto-regex.css");
+	expect(css).toEqual({ "auto-regex": "_auto-regex_1j4lx_1" });
+});
+
+it("auto-function should use css modules", () => {
+	const css = require("./auto-function.css");
+	expect(css).toEqual({ "auto-function": "_auto-function_b0amx_1" });
+});
+
+it("generateScopedName should use right name for css modules", () => {
+	const css = require("./generateScopedName.module.css");
+	expect(css).toEqual({
+		"generate-scoped-name":
+			"generateScopedName-module__generate-scoped-name___xw790"
+	});
+});
+
+it("localsConvention should use right convention for css modules", () => {
+	const css = require("./localsConvention.module.css");
+	expect(css).toEqual({
+		"locals-convention": "_locals-convention_1eiju_1",
+		localsConvention: "_locals-convention_1eiju_1"
+	});
+});

--- a/packages/rspack/tests/configCases/postcss/modules-config/localsConvention.module.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/localsConvention.module.css
@@ -1,0 +1,3 @@
+.locals-convention {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/modules-false.module.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/modules-false.module.css
@@ -1,0 +1,3 @@
+.module-false {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/modules-true.module.css
+++ b/packages/rspack/tests/configCases/postcss/modules-config/modules-true.module.css
@@ -1,0 +1,3 @@
+.module-true {
+	color: powderblue;
+}

--- a/packages/rspack/tests/configCases/postcss/modules-config/webpack.config.js
+++ b/packages/rspack/tests/configCases/postcss/modules-config/webpack.config.js
@@ -1,0 +1,109 @@
+const postcssLoader = require("@rspack/plugin-postcss");
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: "modules-true.module.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: true
+						}
+					}
+				]
+			},
+			{
+				test: "modules-false.module.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: false
+						}
+					}
+				]
+			},
+			{
+				test: "auto-true.module.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: {
+								auto: true
+							}
+						}
+					}
+				]
+			},
+			{
+				test: "auto-false.module.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: {
+								auto: false
+							}
+						}
+					}
+				]
+			},
+			{
+				test: "auto-regex.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: {
+								auto: /auto-regex.css$/
+							}
+						}
+					}
+				]
+			},
+			{
+				test: "auto-function.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: {
+								auto(p) {
+									return p.endsWith("auto-function.css");
+								}
+							}
+						}
+					}
+				]
+			},
+			{
+				test: "generateScopedName.module.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: {
+								generateScopedName: "[name]__[local]___[hash:base64:5]"
+							}
+						}
+					}
+				]
+			},
+			{
+				test: "localsConvention.module.css$",
+				uses: [
+					{
+						loader: postcssLoader,
+						options: {
+							modules: {
+								localsConvention: "camelCase"
+							}
+						}
+					}
+				]
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

fixes #1169 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
