### PR TITLE
chore: support local-ip

### DIFF
--- a/packages/rspack-dev-server/src/config.ts
+++ b/packages/rspack-dev-server/src/config.ts
@@ -24,8 +24,6 @@ export function resolveDevOptions(
 	devConfig: Dev,
 	compilerOptions: RspackOptionsNormalized
 ): ResolvedDev {
-	const port = Number(devConfig.port ?? 8080);
-
 	const open = true;
 	const hot = devConfig.hot ?? true;
 	// --- static
@@ -54,7 +52,7 @@ export function resolveDevOptions(
 	}
 
 	return {
-		port,
+		port: devConfig.port ? Number(devConfig.port) : undefined,
 		static: {
 			directory,
 			watch

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -9,7 +9,7 @@ import type {
 	RequestHandler as ExpressRequestHandler,
 	ErrorRequestHandler as ExpressErrorRequestHandler
 } from "express";
-import type { Server } from "http";
+import { Server } from "http";
 import type { ResolvedDev } from "./config";
 
 import chokidar from "chokidar";
@@ -166,7 +166,6 @@ export class RspackDevServer {
 			this.middleware.invalidate(callback);
 		}
 	}
-
 	async start(): Promise<void> {
 		this.setupApp();
 		this.createServer();
@@ -174,14 +173,17 @@ export class RspackDevServer {
 		this.createWebsocketServer();
 		this.setupDevMiddleware();
 		this.setupMiddlewares();
+		const host = await RspackDevServer.getHostname("local-ip");
+		const port = await RspackDevServer.getFreePort(this.options.port, host);
 		await new Promise(resolve =>
 			this.server.listen(
 				{
-					port: this.options.port,
-					host: "localhost"
+					port,
+					host
 				},
 				() => {
-					console.log(`begin server at http://localhost:${this.options.port}`);
+					this.logger.info(`Loopback: http:localhost:${port}`);
+					this.logger.info(`Your Network (IPV4) http://${host}:${port}`);
 					resolve({});
 				}
 			)

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -17,7 +17,7 @@ exports[`normalize options snapshot no options 1`] = `
   "hot": true,
   "liveReload": true,
   "open": true,
-  "port": 8080,
+  "port": undefined,
   "static": {
     "directory": "<PROJECT_ROOT>/dist",
     "watch": {},


### PR DESCRIPTION
## Summary
closes #1172
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
