### PR TITLE
chore: fix localhost not accessible

### DIFF
--- a/packages/rspack-dev-server/src/config.ts
+++ b/packages/rspack-dev-server/src/config.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import { resolveWatchOption } from "@rspack/core";
 
 export interface ResolvedDev {
+	host: string;
 	port: number;
 	static: {
 		directory: string;
@@ -52,6 +53,7 @@ export function resolveDevOptions(
 	}
 
 	return {
+		host: devConfig.host,
 		port: devConfig.port ? Number(devConfig.port) : undefined,
 		static: {
 			directory,

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -107,7 +107,7 @@ export class RspackDevServer {
 		return WebpackDevServer.internalIPSync(family);
 	}
 
-	static async getHostname(hostname: Host): Promise<string> {
+	static async getHostname(hostname?: Host): Promise<string> {
 		return WebpackDevServer.getHostname(hostname);
 	}
 
@@ -173,7 +173,7 @@ export class RspackDevServer {
 		this.createWebsocketServer();
 		this.setupDevMiddleware();
 		this.setupMiddlewares();
-		const host = await RspackDevServer.getHostname("local-ip");
+		const host = await RspackDevServer.getHostname(this.options.host);
 		const port = await RspackDevServer.getFreePort(this.options.port, host);
 		await new Promise(resolve =>
 			this.server.listen(
@@ -182,8 +182,11 @@ export class RspackDevServer {
 					host
 				},
 				() => {
-					this.logger.info(`Loopback: http:localhost:${port}`);
-					this.logger.info(`Your Network (IPV4) http://${host}:${port}`);
+					this.logger.info(`Loopback: http://localhost:${port}`);
+					let internalIPv4 = WebpackDevServer.internalIPSync("v4");
+					this.logger.info(
+						`Your Network (IPV4) http://${internalIPv4}:${port}`
+					);
 					resolve({});
 				}
 			)

--- a/packages/rspack/src/config/devServer.ts
+++ b/packages/rspack/src/config/devServer.ts
@@ -9,6 +9,7 @@ export interface WebSocketServerOptions {
 }
 
 export interface Dev {
+	host?: string;
 	port?: number | string;
 	// TODO: static maybe `boolean`, `string`, `object`, `array`
 	static?: {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
