### PR TITLE
fix resolve error under pnpm stucture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,9 +1576,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.50"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dfdcbed39e502919660f04d804df1030dd971c17628d7704b4855533c98d10"
+checksum = "adf4e0403ba71076b75c8473d80bacb55d2a3d9db3063e2e5d0a66b9976ff8b0"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1316,9 +1316,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.50"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dfdcbed39e502919660f04d804df1030dd971c17628d7704b4855533c98d10"
+checksum = "adf4e0403ba71076b75c8473d80bacb55d2a3d9db3063e2e5d0a66b9976ff8b0"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.21"
 hashbrown = { version = "0.12.1", features = ["rayon", "serde", "ahash"] }
 hashlink = "0.8.1"
 indexmap = "1.9.1"
-nodejs-resolver = "0.0.50"
+nodejs-resolver = "0.0.52"
 once_cell = "1"
 paste = "1.0"
 petgraph = "0.6.0"


### PR DESCRIPTION
There is a logical problem with resolve when the following directory structure is present.

```
|- node_modules
|--    a
|----    node_modules
|----    a1
|------   node_modules
|------   index.js
|------   package.json
|----    a2
|------   node_modules
|------   index.js
|------   package.json
```

error code: `resolve('a/node_modules/a1/index', 'a2')`

This PR solves the error reported in this case, and more tests can be found at https://github.com/speedy-js/nodejs_resolver/commit/7cba4af0f137d8cdfe114c55c468c169c28ecc1c#diff-24975acf43b4bc39c4c8b57246e4bfbdc0c76428c86ed68f1db0e1b10a6db277R882