### PR TITLE
chore: fix wss url

### DIFF
--- a/packages/rspack-dev-client/src/index.ts
+++ b/packages/rspack-dev-client/src/index.ts
@@ -3,7 +3,6 @@ import createSocketURL from "./createSocketURL";
 import parseURL from "./parseURL.js";
 import type { Handler } from "./socket";
 import reloadApp from "./utils/reloadApp";
-// const parsedResourceQuery = parseURL(document.location.toString());
 
 const status = {
 	currentHash: ""
@@ -30,6 +29,7 @@ const onSocketMessage: Handler = {
 	}
 };
 
-// const socketURL = createSocketURL(parsedResourceQuery as any);
+const parsedResourceQuery = parseURL(location.search);
+const socketURL = createSocketURL(parsedResourceQuery as any);
 
-socket(`ws://${location.host}/ws`, onSocketMessage);
+socket(socketURL, onSocketMessage);

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -14,6 +14,7 @@ exports[`normalize options snapshot additional entires should added 1`] = `
 exports[`normalize options snapshot no options 1`] = `
 {
   "devMiddleware": {},
+  "host": undefined,
   "hot": true,
   "liveReload": true,
   "open": true,
@@ -29,6 +30,7 @@ exports[`normalize options snapshot no options 1`] = `
 exports[`normalize options snapshot port string 1`] = `
 {
   "devMiddleware": {},
+  "host": undefined,
   "hot": true,
   "liveReload": true,
   "open": true,

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -298,6 +298,7 @@ class Compiler {
 		let rawStats = await util.promisify(this.build.bind(this))();
 
 		let stats = new Stats(rawStats);
+		await this.hooks.done.promise(stats);
 		// TODO: log stats string should move to cli
 		console.log(stats.toString(this.options.stats));
 		console.log("build success, time cost", Date.now() - begin, "ms");
@@ -350,6 +351,11 @@ class Compiler {
 							client.send(JSON.stringify({ type: "ok" }));
 						}
 					}
+					this.hooks.done.callAsync(stats, err => {
+						if (err) {
+							throw err;
+						}
+					});
 					console.log("rebuild success, time cost", Date.now() - begin, "ms");
 				});
 			};


### PR DESCRIPTION
## Summary
* fix wrong websocket url when loaded in https 
* add done hooks to watch to support copy-plugin
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
