### PR TITLE
fix(packages/rspack): fix node api

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -87,17 +87,17 @@ class Compiler {
 			this._instance ||
 			// @ts-ignored
 			new binding.Rspack(this.options, {
-				doneCallback: this.#done.bind(this),
-				processAssetsCallback: this.#processAssets.bind(this),
+				done: this.#done.bind(this),
+				processAssets: this.#processAssets.bind(this),
 				// `Compilation` should be created with hook `thisCompilation`, and here is the reason:
 				// We know that the hook `thisCompilation` will not be called from a child compiler(it doesn't matter whether the child compiler is created on the Rust or the Node side).
 				// See webpack's API: https://webpack.js.org/api/compiler-hooks/#thiscompilation
 				// So it is safe to create a new compilation here.
-				thisCompilationCallback: this.#newCompilation.bind(this),
+				thisCompilation: this.#newCompilation.bind(this),
 				// The hook `Compilation` should be called whenever it's a call from the child compiler or normal compiler and
 				// still it does not matter where the child compiler is created(Rust or Node) as calling the hook `compilation` is a required task.
 				// No matter how it will be implemented, it will be copied to the child compiler.
-				compilationCallback: this.#compilation.bind(this)
+				compilation: this.#compilation.bind(this)
 			});
 		// @ts-ignored
 		return this._instance;


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
