### PR TITLE
chore(packages/rspack): narrow ts-ignore

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -24,6 +24,8 @@ class HotModuleReplacementPlugin {
 }
 type CompilationParams = Record<string, any>;
 class Compiler {
+	#_instance: binding.Rspack;
+
 	webpack: any;
 	compilation: Compilation;
 	infrastructureLogger: any;
@@ -81,12 +83,12 @@ class Compiler {
 	 * Lazy initialize instance so it could access the changed options
 	 */
 	get #instance() {
-		// @ts-ignored
-		this._instance =
-			// @ts-ignored
-			this._instance ||
-			// @ts-ignored
-			new binding.Rspack(this.options, {
+		// @ts-ignore TODO: fix this
+		const options: binding.RawOptions = this.options;
+
+		this.#_instance =
+			this.#_instance ||
+			new binding.Rspack(options, {
 				done: this.#done.bind(this),
 				processAssets: this.#processAssets.bind(this),
 				// `Compilation` should be created with hook `thisCompilation`, and here is the reason:
@@ -99,8 +101,8 @@ class Compiler {
 				// No matter how it will be implemented, it will be copied to the child compiler.
 				compilation: this.#compilation.bind(this)
 			});
-		// @ts-ignored
-		return this._instance;
+
+		return this.#_instance;
 	}
 	getInfrastructureLogger(name: string | Function) {
 		if (!name) {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
