### PR TITLE
chore: release 0.10.0

### DIFF
--- a/.changeset/pretty-lemons-yawn.md
+++ b/.changeset/pretty-lemons-yawn.md
@@ -1,5 +1,0 @@
----
-"@rspack/core": patch
----
-
-fix parse url failed

--- a/crates/node_binding/CHANGELOG.md
+++ b/crates/node_binding/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @rspack/binding
 
+## 0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Node binding for rspack",
   "main": "binding.js",
   "types": "binding.d.ts",

--- a/packages/rspack-cli/CHANGELOG.md
+++ b/packages/rspack-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rspack/cli
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [062e692d]
+  - @rspack/core@0.0.10
+  - @rspack/dev-server@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "bin": {
     "rspack": "./bin/rspack"
   },

--- a/packages/rspack-dev-client/CHANGELOG.md
+++ b/packages/rspack-dev-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @rspack/dev-client
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [062e692d]
+  - @rspack/core@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rspack/dev-client",
   "description": "",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",

--- a/packages/rspack-dev-middleware/CHANGELOG.md
+++ b/packages/rspack-dev-middleware/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @rspack/dev-middleware
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [062e692d]
+  - @rspack/core@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/dev-middleware",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rspack-dev-server/CHANGELOG.md
+++ b/packages/rspack-dev-server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # rspack-dev-server
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [062e692d]
+  - @rspack/core@0.0.10
+  - @rspack/dev-middleware@0.0.10
+  - @rspack/dev-server@0.0.10
+  - @rspack/dev-client@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rspack/dev-server",
   "description": "",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/rspack-plugin-html/CHANGELOG.md
+++ b/packages/rspack-plugin-html/CHANGELOG.md
@@ -1,1 +1,8 @@
 # @rspack/plugin-html
+
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [062e692d]
+  - @rspack/core@0.0.10

--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-html",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "html plugin for rspack",
   "author": "",
   "main": "dist/index.js",

--- a/packages/rspack-plugin-less/CHANGELOG.md
+++ b/packages/rspack-plugin-less/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @rspack/plugin-less
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies [062e692d]
+  - @rspack/core@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack-plugin-less/package.json
+++ b/packages/rspack-plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-less",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "less plugin for rspack",
   "author": "wangzhenzhuo",
   "main": "dist/index.js",

--- a/packages/rspack-plugin-node-polyfill/CHANGELOG.md
+++ b/packages/rspack-plugin-node-polyfill/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @rspack/plugin-node-polyfill
+
+## 0.0.10

--- a/packages/rspack-plugin-node-polyfill/package.json
+++ b/packages/rspack-plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-node-polyfill",
-  "version": "0.0.1",
+  "version": "0.0.10",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/packages/rspack-plugin-postcss/CHANGELOG.md
+++ b/packages/rspack-plugin-postcss/CHANGELOG.md
@@ -1,5 +1,11 @@
 # rspack-plugin-postcss
 
+## 0.0.10
+
+### Patch Changes
+
+- @rspack/binding@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack-plugin-postcss/package.json
+++ b/packages/rspack-plugin-postcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-postcss",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rspack/core
 
+## 0.0.10
+
+### Patch Changes
+
+- 062e692d: fix parse url failed
+  - @rspack/binding@0.0.10
+  - @rspack/dev-client@0.0.10
+
 ## 0.0.9
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary
This release adds x64 supports
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
