### PR TITLE
fix: examples/arco-pro less config

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -30,15 +30,14 @@ module.exports = {
     rules:
       [
         {
-          test: 'module.less$',
+          test: '.less$',
           uses:
             [
+              { loader: postcssLoader, options: { modules: true } },
               { loader: lessLoader },
-              { loader: postcssLoader, options: { modules: true } }
             ],
           type: 'css'
         },
-        { test: '.less$', uses: [{ loader: lessLoader }], type: 'css' },
         { test: '.svg$', uses: [{ loader: './svg-loader.js' }], type: 'jsx' }
       ]
   },
@@ -49,5 +48,4 @@ module.exports = {
   infrastructureLogging: {
     debug: false
   },
-
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
