### PR TITLE
fix: __webpack_require__.O.j is not defined

### DIFF
--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -1119,6 +1119,11 @@ __webpack_require__.chunkId = 'main'})();
 	);
 })();
 (function () {
+	__webpack_require__.O.j = function (chunkId) {
+		installedChunks[chunkId] === 0;
+	};
+})();
+(function () {
 	var inProgress = {};
 	var dataWebpackPrefix = "webpack:";
 	// loadScript function to load a script via script tag

--- a/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
@@ -37,7 +37,10 @@ impl Plugin for JsonPChunkLoadingPlugin {
       runtime_requirements.insert(runtime_globals::PUBLIC_PATH.to_string());
       runtime_requirements.insert(runtime_globals::LOAD_SCRIPT.to_string());
       runtime_requirements.insert(runtime_globals::GET_CHUNK_SCRIPT_FILENAME.to_string());
-      compilation.add_runtime_module(chunk, JsonpChunkLoadingRuntimeModule::default().boxed());
+      compilation.add_runtime_module(
+        chunk,
+        JsonpChunkLoadingRuntimeModule::new(runtime_requirements.clone()).boxed(),
+      );
     }
 
     Ok(())

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -1,12 +1,23 @@
 use crate::runtime_module::utils::{get_initial_chunk_ids, stringify_chunks};
+use hashbrown::HashSet;
 use rspack_core::{
-  rspack_sources::{BoxSource, RawSource, SourceExt},
-  ChunkUkey, Compilation, RuntimeModule,
+  rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt},
+  runtime_globals, ChunkUkey, Compilation, RuntimeModule,
 };
 
 #[derive(Debug, Default)]
 pub struct JsonpChunkLoadingRuntimeModule {
   chunk: Option<ChunkUkey>,
+  runtime_requirements: HashSet<String>,
+}
+
+impl JsonpChunkLoadingRuntimeModule {
+  pub fn new(runtime_requirements: HashSet<String>) -> Self {
+    Self {
+      chunk: None,
+      runtime_requirements,
+    }
+  }
 }
 
 impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
@@ -23,14 +34,25 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
     //   chunk_hash_js,
     // );
     let initial_chunks = get_initial_chunk_ids(self.chunk, compilation);
-    RawSource::from(
+    let mut source = ConcatSource::default();
+    source.add(RawSource::from(
       include_str!("runtime/jsonp_chunk_loading.js")
         .to_string()
         .replace("INSTALLED_CHUNKS", &stringify_chunks(&initial_chunks, 0))
         // TODO
         .replace("JS_MATCHER", "chunkId"),
-    )
-    .boxed()
+    ));
+
+    if self
+      .runtime_requirements
+      .contains(runtime_globals::ON_CHUNKS_LOADED)
+    {
+      source.add(RawSource::from(
+        include_str!("runtime/jsonp_chunk_loading_with_on_chunk_load.js").to_string(),
+      ));
+    }
+
+    source.boxed()
   }
 
   fn attach(&mut self, chunk: ChunkUkey) {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_on_chunk_load.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_on_chunk_load.js
@@ -1,0 +1,5 @@
+(function () {
+	__webpack_require__.O.j = function (chunkId) {
+		installedChunks[chunkId] === 0;
+	};
+})();


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->


## Related issue (if exists)

#1219 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
