### PR TITLE
Hyf split chunks default options temp mod

### DIFF
--- a/crates/rspack_core/src/chunk_graph.rs
+++ b/crates/rspack_core/src/chunk_graph.rs
@@ -179,17 +179,19 @@ impl ChunkGraph {
     modules
   }
 
-  pub fn get_chunk_modules_iterable_by_source_type<'module, 'me: 'module>(
-    &'me self,
+  pub fn get_chunk_modules_iterable_by_source_type<'module>(
+    &self,
     chunk: &ChunkUkey,
     source_type: SourceType,
     module_graph: &'module ModuleGraph,
-  ) -> impl Iterator<Item = &'module dyn Module> + 'module {
-    let chunk_graph_chunk = self.get_chunk_graph_chunk(chunk);
-    chunk_graph_chunk
+  ) -> impl Iterator<Item = &'module dyn Module> {
+    self
+      .get_chunk_graph_chunk(chunk)
       .modules
       .iter()
       .filter_map(|uri| module_graph.module_by_identifier(uri))
+      .collect::<Vec<_>>()
+      .into_iter()
       .filter(move |module| module.source_types().contains(&source_type))
       .map(|m| m.as_ref())
   }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -142,15 +142,15 @@ impl Module for Box<dyn Module> {
   }
 }
 
-impl PartialEq for dyn Module {
+impl PartialEq for dyn Module + '_ {
   fn eq(&self, other: &Self) -> bool {
     self.dyn_eq(other.as_any())
   }
 }
 
-impl Eq for dyn Module {}
+impl Eq for dyn Module + '_ {}
 
-impl Hash for dyn Module {
+impl Hash for dyn Module + '_ {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
     self.dyn_hash(state)
   }

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -109,14 +109,14 @@ impl CssParserAndGenerator {
 
   pub(crate) fn get_modules_in_order<'module>(
     chunk: &Chunk,
-    modules: Vec<&'module (dyn Module + 'module)>,
+    modules: Vec<&'module dyn Module>,
     compilation: &Compilation,
   ) -> Vec<&'module (dyn Module + 'module)> {
     if modules.is_empty() {
       return modules;
     };
 
-    let modules_list = modules;
+    // let modules_list = modules;
 
     // Get ordered list of modules per chunk group
     // Lists are in reverse order to allow to use Array.pop()
@@ -126,7 +126,7 @@ impl CssParserAndGenerator {
       .iter()
       .filter_map(|ukey| compilation.chunk_group_by_ukey.get(ukey))
       .map(|chunk_group| {
-        let sorted_modules = modules_list
+        let sorted_modules = modules
           .clone()
           .into_iter()
           .map(|module| {
@@ -135,6 +135,8 @@ impl CssParserAndGenerator {
               chunk_group.module_post_order_index(&module.identifier()),
             )
           })
+          .collect::<Vec<_>>()
+          .into_iter()
           .sorted_by(|a, b| {
             // TODO: Align with .sort((a, b) => b.index - a.index)
             if b.1 > a.1 {
@@ -150,7 +152,7 @@ impl CssParserAndGenerator {
         let mut list = Vec::with_capacity(sorted_modules.len());
         let mut set = HashSet::with_capacity(sorted_modules.len());
         for item in sorted_modules {
-          list.push(item.0.clone());
+          list.push(item.0);
           set.insert(item.0);
         }
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
