### PR TITLE
fix: support use export in d.ts

### DIFF
--- a/crates/rspack_plugin_javascript/src/ast/parse.rs
+++ b/crates/rspack_plugin_javascript/src/ast/parse.rs
@@ -54,6 +54,13 @@ pub fn parse(
   filename: &str,
   module_type: &ModuleType,
 ) -> Result<Ast, Error> {
+  let source_code = if syntax.dts() {
+    // dts build result must be empty
+    "".to_string()
+  } else {
+    source_code
+  };
+
   let compiler = get_swc_compiler();
   let fm = compiler
     .cm

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -266,7 +266,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     }
 
     let syntax = syntax_by_module_type(
-      &source.source(),
+      &resource_data.resource_path,
       module_type,
       compiler_options.builtins.decorator.is_some(),
     );

--- a/crates/rspack_plugin_javascript/src/utils.rs
+++ b/crates/rspack_plugin_javascript/src/utils.rs
@@ -27,11 +27,16 @@ pub fn get_swc_compiler() -> Arc<SwcCompiler> {
   SWC_COMPILER.clone()
 }
 
-fn syntax_by_ext(ext: &str, enable_decorators: bool) -> Syntax {
+fn syntax_by_ext(filename: &str, enable_decorators: bool) -> Syntax {
+  let ext = Path::new(filename)
+    .extension()
+    .and_then(|ext| ext.to_str())
+    .unwrap_or("js");
   match ext == "ts" || ext == "tsx" {
     true => Syntax::Typescript(TsConfig {
       decorators: enable_decorators,
       tsx: ext == "tsx",
+      dts: filename.ends_with(".d.ts") || filename.ends_with(".d.tsx"),
       ..Default::default()
     }),
     false => Syntax::Es(EsConfig {
@@ -68,15 +73,10 @@ pub fn syntax_by_module_type(
     ModuleType::Ts | ModuleType::Tsx => Syntax::Typescript(TsConfig {
       decorators: enable_decorators,
       tsx: matches!(module_type, ModuleType::Tsx),
+      dts: filename.ends_with(".d.ts") || filename.ends_with(".d.tsx"),
       ..Default::default()
     }),
-    _ => {
-      let ext = Path::new(filename)
-        .extension()
-        .and_then(|ext| ext.to_str())
-        .unwrap_or("js");
-      syntax_by_ext(ext, enable_decorators)
-    }
+    _ => syntax_by_ext(filename, enable_decorators),
   }
 }
 

--- a/packages/rspack/tests/cases/resolve/dts/index.js
+++ b/packages/rspack/tests/cases/resolve/dts/index.js
@@ -1,0 +1,8 @@
+import { a, b, c, d } from "./test.d.ts";
+
+it("should can import d.ts", function () {
+	expect(a).toBeUndefined();
+	expect(b).toBeUndefined();
+	expect(c).toBeUndefined();
+	expect(d).toBeUndefined();
+});

--- a/packages/rspack/tests/cases/resolve/dts/test.d.ts
+++ b/packages/rspack/tests/cases/resolve/dts/test.d.ts
@@ -1,0 +1,4 @@
+declare const a: number = 1;
+export const b: number = 2;
+const c: number = 3;
+export const d: number;


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
1. support use export in d.ts

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
