### PR TITLE
feat: deleteAsset for InlineChunkHtmlPlugin

### DIFF
--- a/crates/node_binding/src/js_values/compilation.rs
+++ b/crates/node_binding/src/js_values/compilation.rs
@@ -121,6 +121,18 @@ impl JsCompilation {
     Ok(())
   }
 
+  #[napi]
+  pub fn delete_asset(&mut self, filename: String) {
+    // Safety: It is safe as modify for the asset will never move Compilation.
+    unsafe {
+      self
+        .inner
+        .as_mut()
+        .get_unchecked_mut()
+        .delete_asset(&filename);
+    };
+  }
+
   #[napi(getter)]
   pub fn assets(&self) -> Result<HashMap<String, JsCompatSource>> {
     let assets = self.inner.assets();

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -159,6 +159,17 @@ impl Compilation {
     }
   }
 
+  pub fn delete_asset(&mut self, filename: &str) {
+    if let Some(asset) = self.assets.remove(filename) {
+      if let Some(source_map) = asset.info.related.source_map {
+        self.delete_asset(&source_map);
+      }
+      self.chunk_by_ukey.iter_mut().for_each(|(_, chunk)| {
+        chunk.files.remove(filename);
+      });
+    }
+  }
+
   pub fn assets(&self) -> &CompilationAssets {
     &self.assets
   }

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -123,6 +123,10 @@ export class Compilation {
 		this.#inner.emitAsset(filename, createRawFromSource(source), assetInfo);
 	}
 
+	deleteAsset(filename: string) {
+		this.#inner.deleteAsset(filename);
+	}
+
 	/**
 	 * Get an array of Asset
 	 *


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

fixes #1005 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
