### PR TITLE
feat: add hash for runtime modules

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -1,9 +1,13 @@
-use hashbrown::HashSet;
-
 use crate::{
   ChunkGraph, ChunkGroupByUkey, ChunkGroupKind, ChunkGroupUkey, ChunkUkey, ModuleGraph,
   RuntimeSpec, SourceType,
 };
+use hashbrown::HashSet;
+use std::{
+  fmt::{Debug, Formatter, Result},
+  hash::Hasher,
+};
+use xxhash_rust::xxh3::Xxh3;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum ChunkKind {
@@ -11,7 +15,6 @@ pub enum ChunkKind {
   Normal,
 }
 
-#[derive(Debug)]
 pub struct Chunk {
   pub name: Option<String>,
   pub ukey: ChunkUkey,
@@ -20,7 +23,21 @@ pub struct Chunk {
   pub groups: HashSet<ChunkGroupUkey>,
   pub runtime: RuntimeSpec,
   pub kind: ChunkKind,
-  pub hash: String,
+  pub hash: Xxh3,
+}
+
+impl Debug for Chunk {
+  fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+    f.debug_struct("Chunk")
+      .field("name", &self.name)
+      .field("ukey", &self.ukey)
+      .field("id", &self.id)
+      .field("files", &self.files)
+      .field("groups", &self.groups)
+      .field("runtime", &self.runtime)
+      .field("kind", &self.kind)
+      .finish()
+  }
 }
 
 impl Chunk {
@@ -216,6 +233,10 @@ impl Chunk {
     }
 
     chunks
+  }
+
+  pub fn get_render_hash(&self) -> String {
+    format!("{:x}", self.hash.finish())
   }
 }
 

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -1,8 +1,7 @@
+use crate::{ChunkUkey, Compilation};
 use hashbrown::{HashMap, HashSet};
 use rspack_sources::{BoxSource, CachedSource, RawSource, SourceExt};
-use std::fmt::Debug;
-
-use crate::{ChunkUkey, Compilation};
+use std::{fmt::Debug, hash::Hash};
 
 pub type RuntimeSpec = HashSet<String>;
 pub type RuntimeKey = String;
@@ -144,6 +143,10 @@ pub trait RuntimeModule: Debug + Send + Sync {
   fn identifier(&self) -> &str;
   fn generate(&self, compilation: &Compilation) -> BoxSource;
   fn attach(&mut self, _chunk: ChunkUkey) {}
+  fn hash(&self, compilation: &Compilation, mut state: &mut dyn std::hash::Hasher) {
+    self.identifier().hash(&mut state);
+    self.generate(compilation).source().hash(&mut state);
+  }
 }
 
 pub trait RuntimeModuleExt {
@@ -179,6 +182,4 @@ impl RuntimeModule for NormalRuntimeModule {
   fn generate(&self, _compilation: &Compilation) -> BoxSource {
     CachedSource::new(self.sources.clone()).boxed()
   }
-
-  fn attach(&mut self, _chunk: ChunkUkey) {}
 }

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -484,6 +484,7 @@ impl Plugin for CssPlugin {
     // let hash = None;
     // let chunkhash = None;
     // let contenthash = Some(chunk.hash.clone());
+    let hash = Some(chunk.get_render_hash());
     if source.source().is_empty() {
       Ok(Default::default())
     } else {
@@ -496,9 +497,9 @@ impl Plugin for CssPlugin {
             filename: chunk.name.clone(),
             extension: Some(".css".to_owned()),
             id: Some(chunk.id.to_owned()),
-            contenthash: Some(chunk.hash.clone()),
-            chunkhash: Some(chunk.hash.clone()),
-            hash: Some(chunk.hash.clone()),
+            contenthash: hash.clone(),
+            chunkhash: hash.clone(),
+            hash,
           })
       } else {
         compilation
@@ -509,9 +510,9 @@ impl Plugin for CssPlugin {
             filename: chunk.name.clone(),
             extension: Some(".css".to_owned()),
             id: Some(chunk.id.to_owned()),
-            contenthash: Some(chunk.hash.clone()),
-            chunkhash: Some(chunk.hash.clone()),
-            hash: Some(chunk.hash.clone()),
+            contenthash: hash.clone(),
+            chunkhash: hash.clone(),
+            hash,
           })
       };
       Ok(vec![RenderManifestEntry::new(source.boxed(), output_path)])

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -421,6 +421,7 @@ impl Plugin for JsPlugin {
     // let chunkhash = Some(get_chunkhash(compilation, &args.chunk_ukey, module_graph).to_string());
     // let chunkhash = None;
     // let contenthash = Some(chunk.hash.clone());
+    let hash = Some(chunk.get_render_hash());
 
     let output_path = if chunk.is_only_initial(&args.compilation.chunk_group_by_ukey) {
       compilation
@@ -431,9 +432,9 @@ impl Plugin for JsPlugin {
           filename: chunk.name.clone(),
           extension: Some(".js".to_owned()),
           id: Some(chunk.id.to_string()),
-          contenthash: Some(chunk.hash.clone()),
-          chunkhash: Some(chunk.hash.clone()),
-          hash: Some(chunk.hash.clone()),
+          contenthash: hash.clone(),
+          chunkhash: hash.clone(),
+          hash,
         })
     } else {
       compilation
@@ -444,9 +445,9 @@ impl Plugin for JsPlugin {
           filename: chunk.name.clone(),
           extension: Some(".js".to_owned()),
           id: Some(chunk.id.to_owned()),
-          contenthash: Some(chunk.hash.clone()),
-          chunkhash: Some(chunk.hash.clone()),
-          hash: Some(chunk.hash.clone()),
+          contenthash: hash.clone(),
+          chunkhash: hash.clone(),
+          hash,
         })
     };
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -33,6 +33,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
           let mut async_chunks_map = HashMap::new();
           for async_chunk in async_chunks.iter() {
             if let Some(chunk) = compilation.chunk_by_ukey.get(async_chunk) {
+              let hash = Some(chunk.get_render_hash());
               async_chunks_map.insert(
                 chunk.id.clone(),
                 compilation
@@ -43,9 +44,9 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                     filename: chunk.name.clone(),
                     extension: Some(format!(".{}", self.content_type)),
                     id: Some(chunk.id.clone()),
-                    contenthash: Some(chunk.hash.clone()),
-                    chunkhash: Some(chunk.hash.clone()),
-                    hash: Some(chunk.hash.clone()),
+                    contenthash: hash.clone(),
+                    chunkhash: hash.clone(),
+                    hash,
                   }),
               );
             }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

#1220 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
