### PR TITLE
fix(resolve): fix bug when self had included in node_modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,9 +1587,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.52"
+version = "0.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf4e0403ba71076b75c8473d80bacb55d2a3d9db3063e2e5d0a66b9976ff8b0"
+checksum = "ef426dbc66a8895868183fde785d7a913d2ecf5249331098aea108f900e89ac9"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1327,9 +1327,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.52"
+version = "0.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adf4e0403ba71076b75c8473d80bacb55d2a3d9db3063e2e5d0a66b9976ff8b0"
+checksum = "ef426dbc66a8895868183fde785d7a913d2ecf5249331098aea108f900e89ac9"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.21"
 hashbrown = { version = "0.12.1", features = ["rayon", "serde", "ahash"] }
 hashlink = "0.8.1"
 indexmap = "1.9.1"
-nodejs-resolver = "0.0.52"
+nodejs-resolver = "0.0.54"
 once_cell = "1"
 paste = "1.0"
 petgraph = "0.6.0"


### PR DESCRIPTION
fix the bug when a library point to itself.

```
/ lib                        <---- |
/--- node_modules                  |
/------    lib                ---- |  created by `ln -s`
/--------     index.js
/--------     package.json
/---  index.js
/---  package.json
```


test case: https://github.com/speedy-js/nodejs_resolver/pull/99/files#diff-24975acf43b4bc39c4c8b57246e4bfbdc0c76428c86ed68f1db0e1b10a6db277R2771