### PR TITLE
fix: loading dynamic css chunk(close: #1053)

### DIFF
--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -15,9 +15,9 @@ pub fn rspack(mut options: CompilerOptions, mut plugins: Vec<Box<dyn Plugin>>) -
   plugins.push(Box::new(
     rspack_plugin_runtime::ArrayPushCallbackChunkFormatPlugin {},
   ));
-
   match &options.target.platform {
     TargetPlatform::Web => {
+      plugins.push(Box::new(rspack_plugin_runtime::CssModulesPlugin {}));
       plugins.push(Box::new(rspack_plugin_runtime::JsonPChunkLoadingPlugin {}));
     }
     TargetPlatform::Node(_) => {

--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -1120,6 +1120,13 @@ __webpack_require__.chunkId = 'main'})();
 	};
 })();
 (function () {
+        // This function allow to reference async chunks
+        __webpack_require__.k = function (chunkId) {
+          // return url for filenames based on template
+          return {}[chunkId];
+        };
+      })();
+(function () {
 	var inProgress = {};
 	var dataWebpackPrefix = "webpack:";
 	// loadScript function to load a script via script tag
@@ -1186,10 +1193,10 @@ __webpack_require__.chunkId = 'main'})();
 	__webpack_require__.p = "/";
 })();
 (function () {
-	// This function allow to reference async chunks
-	__webpack_require__.u = function (chunkId) {
-		// return url for filenames based on template
-		return {"a_js": "a_js.js","b_js": "b_js.js",}[chunkId];
-	};
-})();
+        // This function allow to reference async chunks
+        __webpack_require__.u = function (chunkId) {
+          // return url for filenames based on template
+          return {"a_js": "a_js.js","b_js": "b_js.js",}[chunkId];
+        };
+      })();
 __webpack_require__("./index.js");})()

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1048,16 +1048,14 @@ impl Compilation {
 
   pub fn add_runtime_module(&mut self, chunk_ukey: &ChunkUkey, mut module: Box<dyn RuntimeModule>) {
     module.attach(*chunk_ukey);
-    self.chunk_graph.add_module(module.identifier().to_string());
+    self.chunk_graph.add_module(module.identifier());
     self
       .chunk_graph
-      .connect_chunk_and_module(*chunk_ukey, module.identifier().to_string());
+      .connect_chunk_and_module(*chunk_ukey, module.identifier());
     self
       .chunk_graph
-      .connect_chunk_and_runtime_module(*chunk_ukey, module.identifier().to_string());
-    self
-      .runtime_modules
-      .insert(module.identifier().to_string(), module);
+      .connect_chunk_and_runtime_module(*chunk_ukey, module.identifier());
+    self.runtime_modules.insert(module.identifier(), module);
   }
 }
 

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -140,7 +140,7 @@ impl RuntimeSpecSet {
 }
 
 pub trait RuntimeModule: Debug + Send + Sync {
-  fn identifier(&self) -> &str;
+  fn identifier(&self) -> String;
   fn generate(&self, compilation: &Compilation) -> BoxSource;
   fn attach(&mut self, _chunk: ChunkUkey) {}
   fn hash(&self, compilation: &Compilation, mut state: &mut dyn std::hash::Hasher) {
@@ -175,8 +175,8 @@ impl NormalRuntimeModule {
 }
 
 impl RuntimeModule for NormalRuntimeModule {
-  fn identifier(&self) -> &str {
-    &self.identifier
+  fn identifier(&self) -> String {
+    self.identifier.clone()
   }
 
   fn generate(&self, _compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/css_modules.rs
+++ b/crates/rspack_plugin_runtime/src/css_modules.rs
@@ -1,0 +1,44 @@
+use crate::runtime_module::CssLoadingRuntimeModule;
+use async_trait::async_trait;
+use rspack_core::{
+  runtime_globals, AdditionalChunkRuntimeRequirementsArgs, Plugin,
+  PluginAdditionalChunkRuntimeRequirementsOutput, PluginContext, RuntimeModuleExt,
+};
+use rspack_error::Result;
+
+#[derive(Debug)]
+pub struct CssModulesPlugin {}
+
+#[async_trait]
+impl Plugin for CssModulesPlugin {
+  fn name(&self) -> &'static str {
+    "CssModulesPlugin"
+  }
+
+  fn apply(
+    &mut self,
+    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
+  ) -> Result<()> {
+    Ok(())
+  }
+
+  fn runtime_requirements_in_tree(
+    &self,
+    _ctx: PluginContext,
+    args: &mut AdditionalChunkRuntimeRequirementsArgs,
+  ) -> PluginAdditionalChunkRuntimeRequirementsOutput {
+    let compilation = &mut args.compilation;
+    let chunk = args.chunk;
+    let runtime_requirements = &mut args.runtime_requirements;
+
+    if runtime_requirements.contains(runtime_globals::ENSURE_CHUNK_HANDLERS) {
+      runtime_requirements.insert(runtime_globals::PUBLIC_PATH.to_string());
+      runtime_requirements.insert(runtime_globals::GET_CHUNK_CSS_FILENAME.to_string());
+      runtime_requirements.insert(runtime_globals::HAS_OWN_PROPERTY.to_string());
+      runtime_requirements.insert(runtime_globals::MODULE_FACTORIES_ADD_ONLY.to_string());
+      compilation.add_runtime_module(chunk, CssLoadingRuntimeModule::default().boxed());
+    }
+
+    Ok(())
+  }
+}

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -6,11 +6,14 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use rspack_core::{
   runtime_globals, AdditionalChunkRuntimeRequirementsArgs, NormalRuntimeModule, Plugin,
-  PluginAdditionalChunkRuntimeRequirementsOutput, PluginContext, RuntimeModuleExt, TargetPlatform,
+  PluginAdditionalChunkRuntimeRequirementsOutput, PluginContext, RuntimeModuleExt, SourceType,
+  TargetPlatform,
 };
 use rspack_error::Result;
 use web::*;
 
+mod css_modules;
+pub use css_modules::CssModulesPlugin;
 mod array_push_callback_chunk_format;
 pub use array_push_callback_chunk_format::ArrayPushCallbackChunkFormatPlugin;
 mod common_js_chunk_loading;
@@ -177,7 +180,21 @@ impl Plugin for RuntimePlugin {
         }
         runtime_globals::GET_CHUNK_SCRIPT_FILENAME => compilation.add_runtime_module(
           chunk,
-          GetChunkFilenameRuntimeModule::new("js".to_string()).boxed(),
+          GetChunkFilenameRuntimeModule::new(
+            "js".to_string(),
+            SourceType::JavaScript,
+            runtime_globals::GET_CHUNK_SCRIPT_FILENAME.to_string(),
+          )
+          .boxed(),
+        ),
+        runtime_globals::GET_CHUNK_CSS_FILENAME => compilation.add_runtime_module(
+          chunk,
+          GetChunkFilenameRuntimeModule::new(
+            "css".to_string(),
+            SourceType::Css,
+            runtime_globals::GET_CHUNK_CSS_FILENAME.to_string(),
+          )
+          .boxed(),
         ),
         runtime_globals::LOAD_SCRIPT => {
           compilation.add_runtime_module(chunk, LoadScriptRuntimeModule::default().boxed())

--- a/crates/rspack_plugin_runtime/src/runtime_module/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/common_js_chunk_loading.rs
@@ -10,8 +10,8 @@ pub struct CommonJsChunkLoadingRuntimeModule {
 }
 
 impl RuntimeModule for CommonJsChunkLoadingRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/common_js_chunk_loading"
+  fn identifier(&self) -> String {
+    "webpack/runtime/common_js_chunk_loading".to_string()
   }
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
@@ -1,17 +1,74 @@
+use hashbrown::HashSet;
 use rspack_core::{
   rspack_sources::{BoxSource, RawSource, SourceExt},
-  Compilation, RuntimeModule,
+  ChunkUkey, Compilation, RuntimeModule, SourceType,
 };
 
+use super::utils::stringify_chunks;
+
 #[derive(Debug, Default)]
-pub struct CssLoadingRuntimeModule {}
+pub struct CssLoadingRuntimeModule {
+  chunk: Option<ChunkUkey>,
+}
+
+impl CssLoadingRuntimeModule {
+  pub fn chunk_has_css(chunk: &ChunkUkey, compilation: &Compilation) -> bool {
+    !compilation
+      .chunk_graph
+      .get_chunk_modules_by_source_type(chunk, SourceType::Css, &compilation.module_graph)
+      .is_empty()
+  }
+}
 
 impl RuntimeModule for CssLoadingRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/css_loading"
+  fn identifier(&self) -> String {
+    "webpack/runtime/css_loading".to_string()
   }
 
-  fn generate(&self, _compilation: &Compilation) -> BoxSource {
-    RawSource::from(include_str!("runtime/css_loading.js").to_string()).boxed()
+  fn generate(&self, compilation: &Compilation) -> BoxSource {
+    if let Some(chunk_ukey) = self.chunk {
+      let chunk = compilation
+        .chunk_by_ukey
+        .get(&chunk_ukey)
+        .expect("Chunk not found");
+
+      let all_async_chunks = chunk.get_all_async_chunks(&compilation.chunk_group_by_ukey);
+
+      if all_async_chunks
+        .iter()
+        .all(|chunk_ukey| !Self::chunk_has_css(chunk_ukey, compilation))
+      {
+        return RawSource::from("".to_string()).boxed();
+      }
+
+      let mut initial_chunk_ids_with_css = HashSet::new();
+
+      for chunk_ukey in chunk.get_all_initial_chunks(&compilation.chunk_group_by_ukey) {
+        if Self::chunk_has_css(&chunk_ukey, compilation) {
+          let chunk = compilation
+            .chunk_by_ukey
+            .get(&chunk_ukey)
+            .expect("Chunk not found");
+          initial_chunk_ids_with_css.insert(chunk.id.clone());
+        }
+      }
+      RawSource::from(
+        include_str!("runtime/css_loading.js")
+          .to_string()
+          .replace(
+            "INSTALLED_CHUNKS_WITH_CSS",
+            &stringify_chunks(&initial_chunk_ids_with_css, 0),
+          )
+          // TODO
+          .replace("CSS_MATCHER", "chunkId"),
+      )
+      .boxed()
+    } else {
+      unreachable!("should attach chunk for css_loading")
+    }
+  }
+
+  fn attach(&mut self, chunk: ChunkUkey) {
+    self.chunk = Some(chunk);
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
@@ -17,8 +17,8 @@ impl EnsureChunkRuntimeModule {
 }
 
 impl RuntimeModule for EnsureChunkRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/ensure_chunk"
+  fn identifier(&self) -> String {
+    "webpack/runtime/ensure_chunk".to_string()
   }
 
   fn generate(&self, _compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use rspack_core::{
   rspack_sources::{BoxSource, RawSource, SourceExt},
-  ChunkUkey, Compilation, FilenameRenderOptions, RuntimeModule,
+  ChunkUkey, Compilation, FilenameRenderOptions, RuntimeModule, SourceType,
 };
 use std::collections::HashMap;
 
@@ -9,27 +9,44 @@ use std::collections::HashMap;
 pub struct GetChunkFilenameRuntimeModule {
   chunk: Option<ChunkUkey>,
   content_type: String,
+  source_type: SourceType,
+  global: String,
 }
 
 impl GetChunkFilenameRuntimeModule {
-  pub fn new(content_type: String) -> Self {
+  pub fn new(content_type: String, source_type: SourceType, global: String) -> Self {
     Self {
       chunk: None,
       content_type,
+      source_type,
+      global,
     }
   }
 }
 
 impl RuntimeModule for GetChunkFilenameRuntimeModule {
-  fn identifier(&self) -> &str {
-    "rspack/runtime/get_chunk_filename"
+  fn identifier(&self) -> String {
+    format!("webpack/runtime/get_chunk_filename/{}", self.content_type)
   }
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let url = match self.chunk {
       Some(chunk) => match compilation.chunk_by_ukey.get(&chunk) {
         Some(chunk) => {
-          let async_chunks = chunk.get_all_async_chunks(&compilation.chunk_group_by_ukey);
+          let all_async_chunks = chunk.get_all_async_chunks(&compilation.chunk_group_by_ukey);
+          let async_chunks = all_async_chunks
+            .iter()
+            .filter(|chunk_ukey| {
+              !compilation
+                .chunk_graph
+                .get_chunk_modules_by_source_type(
+                  chunk_ukey,
+                  self.source_type,
+                  &compilation.module_graph,
+                )
+                .is_empty()
+            })
+            .collect::<Vec<_>>();
           let mut async_chunks_map = HashMap::new();
           for async_chunk in async_chunks.iter() {
             if let Some(chunk) = compilation.chunk_by_ukey.get(async_chunk) {
@@ -57,16 +74,18 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
       },
       None => None,
     };
-    RawSource::from(
-      include_str!("runtime/get_chunk_filename.js")
-        .to_string()
-        .replace(
-          "URL",
-          url
-            .unwrap_or_else(|| format!("'' + chunkId + '.{}'", self.content_type))
-            .as_str(),
-        ),
-    )
+
+    RawSource::from(format!(
+      "(function () {{
+        // This function allow to reference async chunks
+        {} = function (chunkId) {{
+          // return url for filenames based on template
+          return {};
+        }};
+      }})();\n",
+      self.global,
+      url.unwrap_or_else(|| format!("'' + chunkId + '.{}'", self.content_type))
+    ))
     .boxed()
   }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/has_own_property.rs
@@ -7,8 +7,8 @@ use rspack_core::{
 pub struct HasOwnPropertyRuntimeModule {}
 
 impl RuntimeModule for HasOwnPropertyRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/has_own_property"
+  fn identifier(&self) -> String {
+    "webpack/runtime/has_own_property".to_string()
   }
 
   fn generate(&self, _compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -21,8 +21,8 @@ impl JsonpChunkLoadingRuntimeModule {
 }
 
 impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/jsonp_chunk_loading"
+  fn identifier(&self) -> String {
+    "webpack/runtime/jsonp_chunk_loading".to_string()
   }
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -7,8 +7,8 @@ use rspack_core::{
 pub struct LoadScriptRuntimeModule {}
 
 impl RuntimeModule for LoadScriptRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/load_script"
+  fn identifier(&self) -> String {
+    "webpack/runtime/load_script".to_string()
   }
 
   fn generate(&self, _compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/on_chunk_loaded.rs
@@ -7,8 +7,8 @@ use rspack_core::{
 pub struct OnChunkLoadedRuntimeModule {}
 
 impl RuntimeModule for OnChunkLoadedRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/on_chunk_loaded"
+  fn identifier(&self) -> String {
+    "webpack/runtime/on_chunk_loaded".to_string()
   }
 
   fn generate(&self, _compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -7,8 +7,8 @@ use rspack_core::{
 pub struct PublicPathRuntimeModule {}
 
 impl RuntimeModule for PublicPathRuntimeModule {
-  fn identifier(&self) -> &str {
-    "webpack/runtime/public_path"
+  fn identifier(&self) -> String {
+    "webpack/runtime/public_path".to_string()
   }
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading.js
@@ -2,62 +2,10 @@
 	// object to store loaded and loading chunks
 	// undefined = chunk not loaded, null = chunk preloaded/prefetched
 	// [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-	var installedChunks = { "runtime~index": 0, index: 0 };
+	var installedChunks = INSTALLED_CHUNKS_WITH_CSS;
 
 	var uniqueName = "webpack";
-	var loadCssChunkData = function (target, link, chunkId) {
-		var data,
-			token = "",
-			token2,
-			exports = {},
-			exportsWithId = [],
-			exportsWithDashes = [],
-			i = 0,
-			cc = 1;
-		try {
-			if (!link) link = loadStylesheet(chunkId);
-			data = link.sheet.cssRules;
-			data = data[data.length - 1].style;
-		} catch (e) {
-			data = getComputedStyle(document.head);
-		}
-		data = data.getPropertyValue("--webpack-" + uniqueName + "-" + chunkId);
-		if (!data) return [];
-		for (; cc; i++) {
-			cc = data.charCodeAt(i);
-			if (cc == 40) {
-				token2 = token;
-				token = "";
-			} else if (cc == 41) {
-				exports[token2.replace(/^_/, "")] = token.replace(/^_/, "");
-				token = "";
-			} else if (cc == 47 || cc == 37) {
-				token = token.replace(/^_/, "");
-				exports[token] = token;
-				exportsWithId.push(token);
-				if (cc == 37) exportsWithDashes.push(token);
-				token = "";
-			} else if (!cc || cc == 44) {
-				token = token.replace(/^_/, "");
-				exportsWithId.forEach(
-					x => (exports[x] = uniqueName + "-" + token + "-" + exports[x])
-				);
-				exportsWithDashes.forEach(x => (exports[x] = "--" + exports[x]));
-				__webpack_require__.r(exports);
-				target[token] = ((exports, module) => {
-					module.exports = exports;
-				}).bind(null, exports);
-				token = "";
-				exports = {};
-				exportsWithId.length = 0;
-			} else if (cc == 92) {
-				token += data[++i];
-			} else {
-				token += data[i];
-			}
-		}
-		installedChunks[chunkId] = 0;
-	};
+	// loadCssChunkData is unnecessary
 	var loadingAttribute = "data-webpack-loading";
 	var loadStylesheet = function (chunkId, url, done) {
 		var link,
@@ -121,7 +69,7 @@
 			if (installedChunkData) {
 				promises.push(installedChunkData[2]);
 			} else {
-				if ("demo_b_js" == chunkId) {
+				if (CSS_MATCHER) {
 					// setup Promise in chunk cache
 					var promise = new Promise(function (resolve, reject) {
 						installedChunkData = installedChunks[chunkId] = [resolve, reject];
@@ -154,7 +102,7 @@
 									error.request = realSrc;
 									installedChunkData[1](error);
 								} else {
-									loadCssChunkData(__webpack_require__.m, link, chunkId);
+									// loadCssChunkData(__webpack_require__.m, link, chunkId);
 									installedChunkData[0]();
 								}
 							}

--- a/packages/rspack/tests/HotTestCasesWeb.test.ts
+++ b/packages/rspack/tests/HotTestCasesWeb.test.ts
@@ -4,6 +4,7 @@ describe("HotTestCases", () => {
 	describeCases({
 		name: "web",
 		target: "web",
-		casesPath: "hotCases"
+		casesPath: "hotCases",
+		hot: true
 	});
 });

--- a/packages/rspack/tests/RuntimeCases.test.ts
+++ b/packages/rspack/tests/RuntimeCases.test.ts
@@ -5,7 +5,8 @@ describe("RuntimeTestCases", () => {
 	describeCasesForJsonp({
 		name: "RuntimeTestCases jsonp",
 		target: "web",
-		casesPath: "runtimeCases"
+		casesPath: "runtimeCases",
+		hot: false
 	});
 
 	describeCasesForNode({

--- a/packages/rspack/tests/case.template.ts
+++ b/packages/rspack/tests/case.template.ts
@@ -82,6 +82,7 @@ export function describeCases(config: { name: string; casePath: string }) {
 										`${statsJson.errors!.map(x => x.message).join("\n")}`
 									);
 								}
+								console.log(statsJson.errors);
 								assert(statsJson.errors!.length === 0);
 							}
 						});

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/dynamic.css
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/dynamic.css
@@ -1,0 +1,3 @@
+#dynamic {
+    background: red;
+}

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/dynamic.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/dynamic.js
@@ -1,1 +1,3 @@
+import "./dynamic.css";
+
 export const value = "dynamic";

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/index.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/index.js
@@ -1,5 +1,10 @@
-it("load dynamic chunk", function () {
+it("load dynamic chunk with hash", function (done) {
 	import("./dynamic").then(module => {
 		expect(module.value).toBe("dynamic");
+		// test is only for css loading
+		if (__webpack_require__.f.css) {
+			expect(document.getElementsByTagName("link").length).toBe(1);
+		}
+		done();
 	});
 });

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/webpack.config.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk-with-hash/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
 	output: {
-		chunkFilename: "[id].[hash].js"
+		chunkFilename: "[id].[hash][ext]"
 	}
 };

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk/dynamic.css
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk/dynamic.css
@@ -1,0 +1,3 @@
+#dynamic {
+    background: red;
+}

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk/dynamic.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk/dynamic.js
@@ -1,1 +1,3 @@
+import "./dynamic.css";
+
 export const value = "dynamic";

--- a/packages/rspack/tests/runtimeCases/runtime/split-chunk/index.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-chunk/index.js
@@ -1,5 +1,10 @@
-it("load dynamic chunk", function () {
+it("load dynamic chunk", function (done) {
 	import("./dynamic").then(module => {
 		expect(module.value).toBe("dynamic");
+		// test is only for css loading
+		if (__webpack_require__.f.css) {
+			expect(document.getElementsByTagName("link").length).toBe(1);
+		}
+		done();
 	});
 });


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

#1053 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
