### PR TITLE
fix: avoid hmrF overwrite(close: #1247)

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/common_js_chunk_loading.rs
@@ -18,7 +18,6 @@ impl RuntimeModule for CommonJsChunkLoadingRuntimeModule {
     let initial_chunks = get_initial_chunk_ids(self.chunk, compilation);
     RawSource::from(
       include_str!("runtime/common_js_chunk_loading.js")
-        .to_string()
         .replace("INSTALLED_CHUNKS", &stringify_chunks(&initial_chunks, 1))
         // TODO
         .replace("JS_MATCHER", "chunkId"),

--- a/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
@@ -54,7 +54,6 @@ impl RuntimeModule for CssLoadingRuntimeModule {
       }
       RawSource::from(
         include_str!("runtime/css_loading.js")
-          .to_string()
           .replace(
             "INSTALLED_CHUNKS_WITH_CSS",
             &stringify_chunks(&initial_chunk_ids_with_css, 0),

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -25,8 +25,7 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
         .expect("Chunk not found");
       RawSource::from(
         include_str!("runtime/get_update_manifest_filename.js")
-          .to_string()
-          .replace("$CHUNK_ID$", &stringify_runtime(chunk.runtime.clone())),
+          .replace("$CHUNK_ID$", &stringify_runtime(&chunk.runtime)),
       )
       .boxed()
     } else {
@@ -40,6 +39,6 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
 }
 
 #[inline]
-fn stringify_runtime(runtime: RuntimeSpec) -> String {
-  Vec::from_iter(runtime.into_iter()).join("_")
+fn stringify_runtime(runtime: &RuntimeSpec) -> String {
+  Vec::from_iter(runtime.iter().map(|s| s.as_str())).join("_")
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -51,7 +51,6 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
     {
       source.add(RawSource::from(
         include_str!("runtime/jsonp_chunk_loading.js")
-          .to_string()
           // TODO
           .replace("JS_MATCHER", "chunkId"),
       ));
@@ -65,9 +64,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
         include_str!("runtime/jsonp_chunk_loading_with_hmr.js").to_string(),
       ));
       source.add(RawSource::from(
-        include_str!("runtime/javascript_hot_module_replacement.js")
-          .to_string()
-          .replace("$key$", "jsonp"),
+        include_str!("runtime/javascript_hot_module_replacement.js").replace("$key$", "jsonp"),
       ));
     }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -14,9 +14,7 @@ impl RuntimeModule for PublicPathRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     match &compilation.options.output.public_path {
       PublicPath::String(str) => RawSource::from(
-        include_str!("runtime/public_path.js")
-          .to_string()
-          .replace("__PUBLIC_PATH_PLACEHOLDER__", str),
+        include_str!("runtime/public_path.js").replace("__PUBLIC_PATH_PLACEHOLDER__", str),
       )
       .boxed(),
       // TODO


### PR DESCRIPTION
## Summary

because rspack store runtimeModules at compilation, but webpack store reference of it, webpack has't runtime modules overwrite problem.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

#1247 
## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
