### PR TITLE
chore: 🤖 remove eprintln trace

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1308,10 +1308,10 @@ fn mark_symbol(
       let module_result = match analyze_map.get(&indirect_symbol.uri) {
         Some(module_result) => module_result,
         None => {
-          eprintln!(
-            "Can't get optimize dep result for module {}",
-            indirect_symbol.uri,
-          );
+          // eprintln!(
+          //   "Can't get optimize dep result for module {}",
+          //   indirect_symbol.uri,
+          // );
           return;
         }
       };


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
