### PR TITLE
fix: 🐛 fallback to internal error when path is not found

### DIFF
--- a/crates/rspack_error/src/diagnostic.rs
+++ b/crates/rspack_error/src/diagnostic.rs
@@ -99,18 +99,29 @@ impl From<Error> for Vec<Diagnostic> {
         ..
       }) => {
         let source = if let Some(source) = source {
-          source
+          Some(source)
         } else {
-          std::fs::read_to_string(&path).unwrap()
+          std::fs::read_to_string(&path).ok()
         };
-        Diagnostic {
-          message: error_message,
-          source_info: Some(DiagnosticSourceInfo { source, path }),
-          start,
-          end,
-          title,
-          kind,
-          severity,
+        match source {
+          Some(source) => Diagnostic {
+            message: error_message,
+            source_info: Some(DiagnosticSourceInfo { source, path }),
+            start,
+            end,
+            title,
+            kind,
+            severity,
+          },
+          // Fallback to internal diagnostic
+          None => Diagnostic {
+            message: error_message,
+            source_info: None,
+            start: 0,
+            end: 0,
+            severity,
+            ..Default::default()
+          },
         }
       }
       Error::Io { source } => Diagnostic {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
