### PR TITLE
test(packages/rspack): module type override

### DIFF
--- a/packages/rspack/tests/configCases/errors/mismatched-module-type/app.js
+++ b/packages/rspack/tests/configCases/errors/mismatched-module-type/app.js
@@ -1,0 +1,4 @@
+const React = {
+	createElement() {}
+};
+export const App = () => <div></div>;

--- a/packages/rspack/tests/configCases/errors/mismatched-module-type/app.jsx
+++ b/packages/rspack/tests/configCases/errors/mismatched-module-type/app.jsx
@@ -1,0 +1,4 @@
+const React = {
+	createElement() {}
+};
+export const App = () => <div></div>;

--- a/packages/rspack/tests/configCases/errors/mismatched-module-type/app.ts
+++ b/packages/rspack/tests/configCases/errors/mismatched-module-type/app.ts
@@ -1,0 +1,7 @@
+const React = {
+	createElement(elm: any) {}
+};
+function Component<T>() {
+  return <div></div>
+}
+export const App = () => <Component<any>></Component>;

--- a/packages/rspack/tests/configCases/errors/mismatched-module-type/app.tsx
+++ b/packages/rspack/tests/configCases/errors/mismatched-module-type/app.tsx
@@ -1,0 +1,7 @@
+const React = {
+	createElement(elm: any) {}
+};
+function Component<T>() {
+	return <div></div>;
+}
+export const App = () => <Component<any>></Component>;

--- a/packages/rspack/tests/configCases/errors/mismatched-module-type/index.js
+++ b/packages/rspack/tests/configCases/errors/mismatched-module-type/index.js
@@ -1,0 +1,39 @@
+it("should throw if `jsx` is used in `js`", () => {
+  let errored = false
+  try {
+	  require("./app.js");
+  } catch(err) {
+    errored = true
+  }
+  expect(errored).toBeTruthy()
+});
+
+it("should throw if `tsx` is used in `ts`", () => {
+  let errored = false
+  try {
+	  require("./app.ts");
+  } catch(err) {
+    errored = true
+  }
+  expect(errored).toBeTruthy()
+});
+
+it("should throw if `jsx` is sat to type `js`", () => {
+  let errored = false
+  try {
+	  require("./app.jsx");
+  } catch(err) {
+    errored = true
+  }
+  expect(errored).toBeTruthy()
+})
+
+it("should throw if `tsx` is sat to type `ts`", () => {
+  let errored = false
+  try {
+	  require("./app.tsx");
+  } catch(err) {
+    errored = true
+  }
+  expect(errored).toBeTruthy()
+})

--- a/packages/rspack/tests/configCases/errors/mismatched-module-type/webpack.config.js
+++ b/packages/rspack/tests/configCases/errors/mismatched-module-type/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require("path");
+const resolve = filename => path.resolve(__dirname, filename);
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+      {
+        test: resolve("app.jsx"),
+        type: "js"
+      },
+      {
+        test: resolve("app.tsx"), 
+        type: "ts"
+      },
+		]
+	}
+};

--- a/packages/rspack/tests/configCases/rule-set/module-type/app.js
+++ b/packages/rspack/tests/configCases/rule-set/module-type/app.js
@@ -1,0 +1,4 @@
+const React = {
+	createElement() {}
+};
+export const App = () => <div></div>;

--- a/packages/rspack/tests/configCases/rule-set/module-type/app.jsx
+++ b/packages/rspack/tests/configCases/rule-set/module-type/app.jsx
@@ -1,0 +1,4 @@
+const React = {
+	createElement() {}
+};
+export const App = () => <div></div>;

--- a/packages/rspack/tests/configCases/rule-set/module-type/app.ts
+++ b/packages/rspack/tests/configCases/rule-set/module-type/app.ts
@@ -1,0 +1,4 @@
+const React = {
+	createElement(elm: any) {}
+};
+export const App = () => <div></div>;

--- a/packages/rspack/tests/configCases/rule-set/module-type/app.tsx
+++ b/packages/rspack/tests/configCases/rule-set/module-type/app.tsx
@@ -1,0 +1,7 @@
+const React = {
+	createElement(elm: any) {}
+};
+function Component<T>() {
+	return <div></div>;
+}
+export const App = () => <Component<any>></Component>;

--- a/packages/rspack/tests/configCases/rule-set/module-type/index.js
+++ b/packages/rspack/tests/configCases/rule-set/module-type/index.js
@@ -1,0 +1,11 @@
+it("should finalize (j|t)sx-in-(j|t)s with internal module type `(j|t)sx`", () => {
+	require("./app.js");
+	require("./app.ts");
+});
+
+it("should work with auto module type finalizations", () => {
+	require("./app.tsx");
+	require("./app.jsx");
+	require("./lib.ts");
+	require("./lib.js");
+});

--- a/packages/rspack/tests/configCases/rule-set/module-type/lib.js
+++ b/packages/rspack/tests/configCases/rule-set/module-type/lib.js
@@ -1,0 +1,1 @@
+export const lib = "lib";

--- a/packages/rspack/tests/configCases/rule-set/module-type/lib.ts
+++ b/packages/rspack/tests/configCases/rule-set/module-type/lib.ts
@@ -1,0 +1,1 @@
+export const lib: string = "lib";

--- a/packages/rspack/tests/configCases/rule-set/module-type/webpack.config.js
+++ b/packages/rspack/tests/configCases/rule-set/module-type/webpack.config.js
@@ -1,0 +1,21 @@
+const path = require("path");
+const resolve = filename => path.resolve(__dirname, filename);
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: resolve("app.js"),
+				type: "jsx"
+			},
+			{
+				test: resolve("app.ts"),
+				type: "tsx"
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add a test for shitty usage and some other test to avoid shitty things from happening

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
