### PR TITLE
test(packages/rspack): add loader async error tests

### DIFF
--- a/crates/rspack_binding_options/src/threadsafe_function.rs
+++ b/crates/rspack_binding_options/src/threadsafe_function.rs
@@ -141,12 +141,9 @@ impl<R: 'static + Send> ThreadSafeResolver<R> {
                 rspack_error::Error::InternalError("Failed to convert error to UTF-8".to_owned())
               })?;
 
-              Err(rspack_error::Error::InternalError(format!(
-                "Error: {}",
-                message
-              )))
+              Err(rspack_error::Error::InternalError(message))
             }))
-            .map_err(|_| napi::Error::from_reason(format!("Failed to send resolved value")))
+            .map_err(|_| napi::Error::from_reason("Failed to send resolved value".to_owned()))
         },
       )?;
 

--- a/packages/rspack/tests/configCases/errors/loader-error-async/async.js
+++ b/packages/rspack/tests/configCases/errors/loader-error-async/async.js
@@ -1,0 +1,6 @@
+module.exports = function (content) {
+  const callback = this.async();
+  setTimeout(() => {
+    callback(new Error("Failed to load (async)"))
+  }, 100);
+};

--- a/packages/rspack/tests/configCases/errors/loader-error-async/callback.js
+++ b/packages/rspack/tests/configCases/errors/loader-error-async/callback.js
@@ -1,0 +1,3 @@
+module.exports = function (content) {
+  this.callback(new Error("Failed to load (callback)"))
+};

--- a/packages/rspack/tests/configCases/errors/loader-error-async/index.js
+++ b/packages/rspack/tests/configCases/errors/loader-error-async/index.js
@@ -1,0 +1,22 @@
+it("should report error (async)", () => {
+  let errored = false;
+	try {
+		require("./lib?async");
+	} catch (e) {
+    errored = true;
+		expect(e.message).toContain("Failed to load (async)");
+	}
+  expect(errored).toBeTruthy()
+});
+
+it("should report error (callback)", () => {
+  let errored = false;
+	try {
+		require("./lib?callback");
+	} catch (e) {
+    errored = true;
+		expect(e.message).toContain("Failed to load (callback)");
+	}
+  expect(errored).toBeTruthy()
+});
+

--- a/packages/rspack/tests/configCases/errors/loader-error-async/lib.js
+++ b/packages/rspack/tests/configCases/errors/loader-error-async/lib.js
@@ -1,0 +1,1 @@
+export const lib = "lib";

--- a/packages/rspack/tests/configCases/errors/loader-error-async/webpack.config.js
+++ b/packages/rspack/tests/configCases/errors/loader-error-async/webpack.config.js
@@ -1,0 +1,31 @@
+const path = require("path")
+const file =  path.resolve(__dirname, "lib.js")
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: file,
+        resourceQuery: /async/,
+				use: [
+					{
+						loader: "./async.js"
+					}
+				]
+			},
+      {
+				test: file,
+        resourceQuery: /callback/,
+				use: [
+					{
+						loader: "./callback.js"
+					}
+				]
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add test for `async` loader API for errors:

- `this.async`
- `this.callback`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [X] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
