### PR TITLE
test(packages/rspack): ensure loader content with `loader.raw`

### DIFF
--- a/packages/rspack/src/config/module.ts
+++ b/packages/rspack/src/config/module.ts
@@ -211,7 +211,7 @@ function composeJsUse(
 					undefined;
 				try {
 					result = use.loader.apply(loaderContext, [
-						use.loader.raw ? content : content.toString("utf-8"),
+						use.loader.raw ? Buffer.from(content) : content.toString("utf-8"),
 						sourceMap,
 						additionalData
 					]);

--- a/packages/rspack/tests/configCases/loader/loader-raw-string/index.js
+++ b/packages/rspack/tests/configCases/loader/loader-raw-string/index.js
@@ -1,0 +1,4 @@
+it("should ensure the combination for `raw` and `string` content", () => {
+	expect(require("./lib?case-1")).toEqual([true, false, true]);
+	expect(require("./lib?case-2")).toEqual([false, true, false]);
+});

--- a/packages/rspack/tests/configCases/loader/loader-raw-string/lib.js
+++ b/packages/rspack/tests/configCases/loader/loader-raw-string/lib.js
@@ -1,0 +1,1 @@
+export const lib = "lib";

--- a/packages/rspack/tests/configCases/loader/loader-raw-string/loader-util.js
+++ b/packages/rspack/tests/configCases/loader/loader-raw-string/loader-util.js
@@ -1,0 +1,11 @@
+exports.ensureObject = o => {
+	if (o === undefined) {
+		return {};
+	}
+
+	if (o && typeof o === "object") {
+		return o;
+	}
+
+	return JSON.parse(o);
+};

--- a/packages/rspack/tests/configCases/loader/loader-raw-string/raw.js
+++ b/packages/rspack/tests/configCases/loader/loader-raw-string/raw.js
@@ -1,0 +1,14 @@
+function loader(content, sourceMap, meta) {
+	const { ensureObject } = require("./loader-util");
+	meta = ensureObject(meta);
+	(meta.data = meta.data || []).push(Buffer.isBuffer(content));
+
+	if (meta.data.length === 3) {
+		return `module.exports = ${JSON.stringify(meta.data)};`;
+	}
+
+	this.callback(null, content, null, meta);
+}
+loader.raw = true;
+
+module.exports = loader;

--- a/packages/rspack/tests/configCases/loader/loader-raw-string/string.js
+++ b/packages/rspack/tests/configCases/loader/loader-raw-string/string.js
@@ -1,0 +1,13 @@
+function loader(content, sourceMap, meta) {
+	const { ensureObject } = require("./loader-util");
+	meta = ensureObject(meta);
+	(meta.data = meta.data || []).push(Buffer.isBuffer(content));
+
+	if (meta.data.length === 3) {
+		return `module.exports = ${JSON.stringify(meta.data)};`;
+	}
+
+	this.callback(null, content, null, meta);
+}
+
+module.exports = loader;

--- a/packages/rspack/tests/configCases/loader/loader-raw-string/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/loader-raw-string/webpack.config.js
@@ -1,0 +1,20 @@
+const path = require("path");
+const file = path.resolve(__dirname, "lib.js");
+const createUse = loaders => loaders.map(l => ({ loader: l }));
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: file,
+				resourceQuery: /case-1/,
+				use: createUse(["./raw", "./string", "./raw"])
+			},
+			{
+				test: file,
+				resourceQuery: /case-2/,
+				use: createUse(["./string", "./raw", "./string"])
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`content` of a loader should be passed with `string` if `raw` is not specified, and should be passed with `buffer` if `raw` is sat to `true`

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [X] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
