### PR TITLE
type(packages/rspack): add cssFilename for Output option

### DIFF
--- a/packages/rspack/src/config/output.ts
+++ b/packages/rspack/src/config/output.ts
@@ -6,8 +6,8 @@ export interface Output {
 	chunkFilename?: string;
 	uniqueName?: string;
 	hashFunction?: string;
-	cssFilename?: string,
-	cssChunkFilename?: string,
+	cssFilename?: string;
+	cssChunkFilename?: string;
 }
 
 // TODO: removed optional
@@ -22,8 +22,8 @@ export interface ResolvedOutput {
 	hashDigestLength?: string;
 	hashDigest?: string;
 	hashSalt?: string;
-	cssFilename?: string,
-	cssChunkFilename?: string,
+	cssFilename?: string;
+	cssChunkFilename?: string;
 }
 
 export function resolveOutputOptions(output: Output = {}): ResolvedOutput {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
