### PR TITLE
chore: take crossbuild from snapshot

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -46,7 +46,7 @@ jobs:
         id: release
         run: |
           pnpm version:snapshot $(git rev-parse --short HEAD)
-          ./x build js-release-all
+          ./x build js-release
           pnpm release:snapshot
           comment=$(./x pkg-version)
           echo "::set-output name=comment::$comment"


### PR DESCRIPTION
## Summary
before setting up crossbuild environment we takedown crossbuild temporarily
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
