### PR TITLE
fix: add html-rspack-plugin name for types

### DIFF
--- a/packages/rspack-plugin-html/src/index.ts
+++ b/packages/rspack-plugin-html/src/index.ts
@@ -1,4 +1,4 @@
-import type { Compiler, Compilation } from "@rspack/core";
+import type { Compiler, Compilation, Plugin } from "@rspack/core";
 import type { Options as MinifyOptions } from "html-minifier-terser";
 import assert from "assert";
 import path from "path";
@@ -240,7 +240,9 @@ export interface TemplateParameter {
 	webpackConfig: any;
 }
 
-export default class HtmlRspackPlugin {
+export default class HtmlRspackPlugin implements Plugin {
+	name = "HtmlRspackPlugin";
+
 	userOptions: Options;
 	options: ProcessedOptions;
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
