### PR TITLE
chore: 🤖 fix benchmark history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ copy/three:
 	echo > benchcases/three/src/entry.js
 	for i in 1 2 3 4 5 6 7 8 9 10; do test -d "benchcases/three/src/copy$$i" || cp -r examples/.three/src "benchcases/three/src/copy$$i"; done
 	for i in 1 2 3 4 5 6 7 8 9 10; do echo "import * as copy$$i from './copy$$i/Three.js'; export {copy$$i}" >> benchcases/three/src/entry.js; done
-	echo "module.exports = {mode: 'development',entry: {index: ['./src/entry.js']}};" > benchcases/three/test.config.js
+	echo "module.exports = {mode: 'development',entry: {index: {import: ['./src/entry.js']}}};" > benchcases/three/test.config.js
 	echo "module.exports = {mode: 'development',entry: {index: ['./benchcases/three/src/entry.js']},devtool: 'eval',cache: {type: 'filesystem'}}" > benchcases/three/webpack.config.js
 
 flamegraph:

--- a/benchcases/css-heavy/test.config.js
+++ b/benchcases/css-heavy/test.config.js
@@ -1,7 +1,9 @@
 module.exports = {
 	mode: "development",
 	entry: {
-		index: ["./index.js"]
+		index: {
+			import: ["./index.js"]
+		}
 	},
 	enhanced: {},
 	builtins: {

--- a/benchcases/lodash-with-simple-css/test.config.js
+++ b/benchcases/lodash-with-simple-css/test.config.js
@@ -1,7 +1,9 @@
 module.exports = {
 	mode: "development",
 	entry: {
-		index: ["./src/index.js"]
+		index: {
+			import: ["./src/index.js"]
+		}
 	},
 	enhanced: {},
 	builtins: {

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -14,7 +14,7 @@ async fn main() {
   let guard = enable_tracing_by_env_with_chrome_layer();
   let manifest_dir = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
   // let bundle_dir = manifest_dir.join("tests/fixtures/postcss/pxtorem");
-  let bundle_dir: PathBuf = manifest_dir.join("examples/basic");
+  let bundle_dir: PathBuf = manifest_dir.join("benchcases/three");
   println!("{:?}", bundle_dir);
   let mut options = read_test_config_and_normalize(&bundle_dir);
   options.__emit_error = true;


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
