### PR TITLE
chore: 🤖 move all swc dependencies in workspace dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,23 @@ debug         = false
 incremental   = true
 lto           = false
 opt-level     = 3
+
+
+[workspace.dependencies]
+swc                 = "0.232.112"
+swc_atoms           = "0.4.23"
+swc_common          = { version = "0.29.16", features = ["concurrent"] }
+swc_css             = "0.137.7"
+swc_css_prefixer    = "0.135.6"
+swc_ecma_ast        = "0.94.14"
+swc_ecma_codegen    = "0.127.24"
+swc_ecma_transforms = { version = "0.198.27", features = [] }
+swc_ecma_visit      = "0.80.14"
+swc_html            = "0.93.15"
+swc_html_minifier   = "0.90.15"
+
+swc_ecma_lints      = "0.66.33"
+swc_ecma_minifier   = "0.159.63"
+swc_ecma_parser     = "0.122.30"
+swc_ecma_preset_env = "0.174.27"
+swc_ecma_utils      = "0.105.25"

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -31,7 +31,7 @@ rspack_plugin_progress = { path = "../rspack_plugin_progress" }
 rspack_plugin_split_chunks = { path = "../rspack_plugin_split_chunks" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-swc_ecma_transforms = { version = "0.198.27", features = [
+swc_ecma_transforms = { workspace = true, features = [
   "swc_ecma_transforms_react",
 ] }
 tokio = { version = "1.21.0", features = [

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -27,17 +27,17 @@ rspack_tracing = { path = "../rspack_tracing" }
 serde = "1"
 serde_json = "1"
 sugar_path = "0.0.8"
-swc = "0.232.112"
-swc_atoms = "0.4.23"
-swc_common = { version = "0.29.16", features = ["concurrent", "tty-emitter"] }
-swc_css = "0.137.7"
-swc_ecma_ast = "0.94.14"
-swc_ecma_codegen = "0.127.24"
-swc_ecma_transforms = { version = "0.198.27", features = [
+swc = { workspace = true }
+swc_atoms = { workspace = true }
+swc_common = { workspace = true, features = ["concurrent", "tty-emitter"] }
+swc_css = { workspace = true }
+swc_ecma_ast = { workspace = true }
+swc_ecma_codegen = { workspace = true }
+swc_ecma_transforms = { workspace = true, features = [
   "swc_ecma_transforms_module",
   "swc_ecma_transforms_react",
 ] }
-swc_ecma_visit = "0.80.14"
+swc_ecma_visit = { workspace = true }
 tokio = { version = "1.21.0", features = [
   "rt",
   "rt-multi-thread",

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -25,10 +25,10 @@ rspack_core = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 serde = "1.0.144"
 serde_json = "1.0.85"
-swc_atoms = "0.4.23"
-swc_common = { version = "0.29.16", features = ["concurrent"] }
-swc_css = { version = "0.137.7", features = ["swc_css_minifier"] }
-swc_css_prefixer = "0.135.6"
+swc_atoms = { workspace = true }
+swc_common = { workspace = true, features = ["concurrent"] }
+swc_css = { workspace = true, features = ["swc_css_minifier"] }
+swc_css_prefixer = { workspace = true }
 tokio = { version = "1.21.0", features = [
   "rt",
   "rt-multi-thread",

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -21,7 +21,7 @@ serde             = { version = "1", features = ["derive"] }
 serde_json        = "1"
 sha2              = "0.10.2"
 sugar_path        = "0.0.8"
-swc_atoms         = "0.4.23"
-swc_common        = { version = "0.29.16", features = ["concurrent"] }
-swc_html          = "0.93.15"
-swc_html_minifier = "0.90.15"
+swc_atoms         = { workspace = true }
+swc_common        = { workspace = true, features = ["concurrent"] }
+swc_html          = { workspace = true }
+swc_html_minifier = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -27,19 +27,19 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sourcemap = "6.2.0"
 sugar_path = "0.0.8"
-swc = "0.232.112"
-swc_atoms = "0.4.23"
-swc_common = { version = "0.29.16", features = ["concurrent"] }
-swc_ecma_ast = "0.94.14"
-swc_ecma_lints = "0.66.33"
-swc_ecma_minifier = "0.159.63"
-swc_ecma_parser = "0.122.30"
-swc_ecma_preset_env = "0.174.27"
-swc_ecma_transforms = { version = "0.198.27", features = [
+swc = { workspace = true }
+swc_atoms = { workspace = true }
+swc_common = { workspace = true, features = ["concurrent"] }
+swc_ecma_ast = { workspace = true }
+swc_ecma_lints = { workspace = true }
+swc_ecma_minifier = { workspace = true }
+swc_ecma_parser = { workspace = true }
+swc_ecma_preset_env = { workspace = true }
+swc_ecma_transforms = { workspace = true, features = [
   "swc_ecma_transforms_module",
   "swc_ecma_transforms_react",
 ] }
-swc_ecma_utils = "0.105.25"
-swc_ecma_visit = "0.80.14"
+swc_ecma_utils = { workspace = true }
+swc_ecma_visit = { workspace = true }
 tracing = "0.1.34"
 ustr = "0.9.0"

--- a/crates/rspack_symbol/Cargo.toml
+++ b/crates/rspack_symbol/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 bitflags     = "1.3.2"
-swc_atoms    = "0.4.23"
-swc_common   = { version = "0.29.16", features = ["concurrent", "tty-emitter"] }
-swc_ecma_ast = "0.94.14"
+swc_atoms    = { workspace = true }
+swc_common   = { workspace = true, features = ["concurrent", "tty-emitter"] }
+swc_ecma_ast = { workspace = true }
 ustr         = "0.9.0"


### PR DESCRIPTION
## Summary
1. Moving all  swc related dependencies into `workspace.depdencies`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
