### PR TITLE
chore: set default value for dev&build

### DIFF
--- a/examples/basic/test.config.js
+++ b/examples/basic/test.config.js
@@ -1,3 +1,4 @@
+const path = require('path');
 /**
  * @type {import('webpack').Configuration}
  */
@@ -6,7 +7,6 @@ module.exports = {
     html: [{
       template: './index.html'
     }],
-    minify: false
   },
   context: __dirname,
   entry: {
@@ -19,5 +19,8 @@ module.exports = {
   },
   infrastructureLogging: {
     debug: false
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist')
   }
 };

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -78,7 +78,7 @@ export class BuildCommand implements RspackCommand {
 					}
 				};
 				console.time("build");
-				const compiler = await cli.createCompiler(options);
+				const compiler = await cli.createCompiler(options, "production");
 				compiler.run((err, Stats) => {
 					callback(err, Stats);
 					console.timeEnd("build");

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -10,7 +10,7 @@ export class ServeCommand implements RspackCommand {
 			"run the rspack dev server.",
 			commonOptions,
 			async options => {
-				const compiler = await cli.createCompiler(options);
+				const compiler = await cli.createCompiler(options, "development");
 				const server = new RspackDevServer(compiler);
 				await server.start();
 			}


### PR DESCRIPTION
## Summary
rspack-cli is hard to use compared tools like vite | create-react-app because we need too much uncessary configuration for user to kickoff a real world application.
* before
we need repeat these configuration for nearly every projects
```ts
const isProd = process.env.NODE_ENV === 'production';
module.exports = {
   mode: isProd ? 'production': 'development',
   devtools: isProd ? 'source-map' : 'cheap-module-source-map',
   builtins: {
      define: { 
         "process.env.NODE_ENV: JSON.stringify(process.env.NODE_ENV)
      },
     minify: isProd
   },
  output: {
    publicPath: '/'
  }
}
```
* after
```
module.exports = {
}
```
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [x] No
we choose not stick to webpack-cli implementation since it's hard to use, and nearly none of our internal projects use webpack-cli directly(most of them use webpack node api or use internal build framework)

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
