### PR TITLE
chore: revert example change

### DIFF
--- a/examples/basic/test.config.js
+++ b/examples/basic/test.config.js
@@ -1,4 +1,3 @@
-const path = require('path');
 /**
  * @type {import('webpack').Configuration}
  */
@@ -7,6 +6,7 @@ module.exports = {
     html: [{
       template: './index.html'
     }],
+    minify: false
   },
   context: __dirname,
   entry: {
@@ -19,8 +19,5 @@ module.exports = {
   },
   infrastructureLogging: {
     debug: false
-  },
-  output: {
-    path: path.resolve(__dirname, 'dist')
   }
 };


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
