### PR TITLE
fix(packages/rspack-cli): fix define override

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -6,7 +6,6 @@ const path = require('path');
  * @type {import('webpack').Configuration}
  */
 module.exports = {
-  mode: 'production',
   context: __dirname,
   entry: { main: './src/index.tsx' },
   devServer: {
@@ -18,7 +17,6 @@ module.exports = {
       template: './index.html',
       publicPath: '/'
     }],
-    define: { 'process.env.NODE_ENV': JSON.stringify('production') },
     react: {
       development: true,
       refresh: true,

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -101,11 +101,24 @@ export class RspackCLI {
 		console.log("after", item);
 		item.builtins = {
 			...item.builtins,
-			define: item.builtins.define ?? {
-				"process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV)
-			},
 			minify: item.builtins?.minify ?? isEnvProduction
 		};
+
+		// Tells webpack to set process.env.NODE_ENV to a given string value.
+		// optimization.nodeEnv uses DefinePlugin unless set to false.
+		// optimization.nodeEnv defaults to mode if set, else falls back to 'production'.
+		// See doc: https://webpack.js.org/configuration/optimization/#optimizationnodeenv
+		// See source: https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/WebpackOptionsApply.js#L563
+
+		// When mode is set to 'none', optimization.nodeEnv defaults to false.
+		if (item.mode !== "none") {
+			item.builtins.define = {
+				// User defined `process.env.NODE_ENV` always has highest priority than default define
+				"process.env.NODE_ENV": JSON.stringify(item.mode),
+				...item.builtins.define
+			};
+		}
+
 		item.output = {
 			...item.output,
 			publicPath: item.output?.path ?? "/"


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

React fast refresh is not intended to work with `production` mode. Remove the force override to make it working for serving

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
