### PR TITLE
fix(resolve): path names hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1581,9 +1581,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.54"
+version = "0.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef426dbc66a8895868183fde785d7a913d2ecf5249331098aea108f900e89ac9"
+checksum = "6458c4443bcecaaac66c84fc20c02a0609078c8d8593983a8cb65b24302e9883"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1327,9 +1327,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.54"
+version = "0.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef426dbc66a8895868183fde785d7a913d2ecf5249331098aea108f900e89ac9"
+checksum = "6458c4443bcecaaac66c84fc20c02a0609078c8d8593983a8cb65b24302e9883"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -13,7 +13,7 @@ futures = "0.3.21"
 hashbrown = { version = "0.12.1", features = ["rayon", "serde", "ahash"] }
 hashlink = "0.8.1"
 indexmap = "1.9.1"
-nodejs-resolver = "0.0.54"
+nodejs-resolver = "0.0.55"
 once_cell = "1"
 paste = "1.0"
 petgraph = "0.6.0"

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -36,7 +36,6 @@ pub async fn resolve(
       _ => {
         if let Some(importer) = args.importer {
           let span = args.span.unwrap_or_default();
-
           let message = if let nodejs_resolver::Error::Overflow = error {
             format!(
               "Can't resolve {:?} in {importer} , maybe it had cycle alias",

--- a/packages/rspack/tests/cases/resolve/path-with-symbol/#/@@iterator/index.js
+++ b/packages/rspack/tests/cases/resolve/path-with-symbol/#/@@iterator/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+	s: "@@iterator",
+	g: require("../../g")
+};

--- a/packages/rspack/tests/cases/resolve/path-with-symbol/#/index.js
+++ b/packages/rspack/tests/cases/resolve/path-with-symbol/#/index.js
@@ -1,0 +1,7 @@
+const value = require("./@@iterator");
+module.exports = {
+	"@@iterator": value.s,
+	g: value.g,
+	a: require("../_a-b-c"),
+	d: require("../d-e_f")
+};

--- a/packages/rspack/tests/cases/resolve/path-with-symbol/_a-b-c.js
+++ b/packages/rspack/tests/cases/resolve/path-with-symbol/_a-b-c.js
@@ -1,0 +1,1 @@
+module.exports = "_a-b-c";

--- a/packages/rspack/tests/cases/resolve/path-with-symbol/d-e_f.js
+++ b/packages/rspack/tests/cases/resolve/path-with-symbol/d-e_f.js
@@ -1,0 +1,1 @@
+module.exports = "d-e_f";

--- a/packages/rspack/tests/cases/resolve/path-with-symbol/g.js
+++ b/packages/rspack/tests/cases/resolve/path-with-symbol/g.js
@@ -1,0 +1,1 @@
+module.exports = "g";

--- a/packages/rspack/tests/cases/resolve/path-with-symbol/index.js
+++ b/packages/rspack/tests/cases/resolve/path-with-symbol/index.js
@@ -1,0 +1,8 @@
+import x from "./#";
+
+it("resolver should work when path with symbol", () => {
+	expect(x["@@iterator"]).toBe("@@iterator");
+	expect(x.g).toBe("g");
+	expect(x.a).toBe("_a-b-c");
+	expect(x.d).toBe("d-e_f");
+});


### PR DESCRIPTION
This PR brings the following changes:

1. upgrade `nodejs_resolver` to fix error when resolve path which contains `#`.
2. rename `calculate_module_type_by_uri` to `calculate_module_type_by_resource`, because of the unexpected behavior of `url.path()`, which will return `/a/b/` when encounter `/a/b/#/`.