### PR TITLE
fix: cjs transformed as esm bug

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -144,7 +144,7 @@ pub fn run_after_pass(ast: &mut Ast, module: &dyn Module, generate_context: &mut
         Some(ModuleConfig::CommonJs(CommonjsConfig {
           ignore_dynamic: true,
           strict_mode: false,
-          no_interop: false,
+          no_interop: !context.is_esm,
           ..Default::default()
         })),
         comments,

--- a/packages/rspack/tests/configCases/target/mix-cjs-esm/cjs.js
+++ b/packages/rspack/tests/configCases/target/mix-cjs-esm/cjs.js
@@ -1,0 +1,8 @@
+const cjs = require("./lib/cjs");
+const esm = require("./lib/esm");
+
+exports.getFilePath = async function () {
+	const cjsLib = await cjs.getFilePath();
+	const esmLib = await esm.getFilePath();
+	return ["cjs.js", cjsLib, esmLib].join("|");
+};

--- a/packages/rspack/tests/configCases/target/mix-cjs-esm/esm.js
+++ b/packages/rspack/tests/configCases/target/mix-cjs-esm/esm.js
@@ -1,0 +1,8 @@
+import cjs from "./lib/cjs";
+import { getFilePath as esmGetFilePath } from "./lib/esm";
+
+export async function getFilePath() {
+	const cjsLib = await cjs.getFilePath();
+	const esmLib = await esmGetFilePath();
+	return ["esm.js", cjsLib, esmLib].join("|");
+}

--- a/packages/rspack/tests/configCases/target/mix-cjs-esm/index.js
+++ b/packages/rspack/tests/configCases/target/mix-cjs-esm/index.js
@@ -1,0 +1,7 @@
+const cjs = require("./cjs");
+const esm = require("./esm");
+
+it("should mix cjs and esm works", async () => {
+	expect(await cjs.getFilePath()).toBe("cjs.js|lib/cjs.js|lib/esm.js");
+	expect(await esm.getFilePath()).toBe("esm.js|lib/cjs.js|lib/esm.js");
+});

--- a/packages/rspack/tests/configCases/target/mix-cjs-esm/lib/cjs.js
+++ b/packages/rspack/tests/configCases/target/mix-cjs-esm/lib/cjs.js
@@ -1,0 +1,3 @@
+exports.getFilePath = async function () {
+	return "lib/cjs.js";
+};

--- a/packages/rspack/tests/configCases/target/mix-cjs-esm/lib/esm.js
+++ b/packages/rspack/tests/configCases/target/mix-cjs-esm/lib/esm.js
@@ -1,0 +1,3 @@
+export async function getFilePath() {
+	return "lib/esm.js";
+}

--- a/packages/rspack/tests/configCases/target/mix-cjs-esm/webpack.config.js
+++ b/packages/rspack/tests/configCases/target/mix-cjs-esm/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	target: ["node", "es5"]
+};


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
1. fix cjs transformed as esm when target is es[x] or browserslist.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
