### PR TITLE
chore: add esbuild cpuprofile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,9 @@ profile.json
 # esbuild trace
 esbuild.trace
 
+# esbuild cpuprofile
+esbuild.cpuprofile
+
 
 # this node_modules is used for tree-shaking snapshot
 !crates/rspack/tests/tree-shaking/node_modules

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ esbuild_trace:
 	./node_modules/esbuild/bin/esbuild --bundle benchcases/three/src/entry.js --outfile=/dev/null --trace=esbuild.trace
 	go tool trace esbuild.trace
 
+esbuild_cpuprofile:
+	./node_modules/esbuild/bin/esbuild --bundle benchcases/three/src/entry.js --outfile=/dev/null --cpuprofile=esbuild.cpuprofile
+	go tool pprof -http=:1234 esbuild.cpuprofile
+
 rspack_trace:
 	TRACE=TRACE cargo run -F tracing --release --bin bench
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

For performance diagnosis

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
