### PR TITLE
chore: remove unnecessary logs

### DIFF
--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -94,11 +94,9 @@ export class RspackCLI {
 		}
 
 		// false is also a valid value for sourcemap, so don't override it
-		console.log(item);
 		if (typeof item.devtool === "undefined") {
 			item.devtool = isEnvProduction ? "source-map" : "cheap-module-source-map";
 		}
-		console.log("after", item);
 		item.builtins = {
 			...item.builtins,
 			minify: item.builtins?.minify ?? isEnvProduction

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -308,8 +308,6 @@ class Compiler {
 
 		let stats = new Stats(rawStats, this.compilation);
 		await this.hooks.done.promise(stats);
-		// TODO: log stats string should move to cli
-		console.log(stats.toString(this.options.stats));
 		console.log("build success, time cost", Date.now() - begin, "ms");
 
 		let pendingChangedFilepaths = new Set<string>();
@@ -338,8 +336,6 @@ class Compiler {
 				const begin = Date.now();
 				this.rebuild(changedFilepath, (error: any, rawStats) => {
 					let stats = new Stats(rawStats, this.compilation);
-					// TODO: log stats string should move to cli
-					console.log(stats.toString(this.options.stats));
 					isBuildFinished = true;
 
 					const hasPending = Boolean(pendingChangedFilepaths.size);


### PR DESCRIPTION
## Summary
rspack serve will repeatedly print stats logs which is annoying.
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
