### PR TITLE
bench: bundle three benchcase in production mode with sourcemap and minify

### DIFF
--- a/xtask/src/copy_three.rs
+++ b/xtask/src/copy_three.rs
@@ -43,11 +43,7 @@ pub fn copy_three(num: usize) {
   // test.config.js
   let test_config_file = r#"
 module.exports = {
-    mode: 'production',
-    devtool: 'source-map', 
-    builtins: {
-      minify: true
-    },
+    mode: 'development',
     entry: {
         index: {
             import: ['./src/entry.js']
@@ -73,4 +69,26 @@ module.exports = {
   let webpack_config_path = root_dir.join("benchcases/three/webpack.config.js");
   let mut file = File::create(webpack_config_path).unwrap();
   file.write_all(webpack_config_file.as_bytes()).unwrap();
+}
+
+pub fn three_production_config() {
+  let root_dir = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
+  // test.config.js
+  let test_config_file = r#"
+module.exports = {
+    mode: 'production',
+    devtool: 'source-map', 
+    builtins: {
+      minify: true
+    },
+    entry: {
+        index: {
+            import: ['./src/entry.js']
+        }
+    }
+};
+  "#;
+  let test_config_path = root_dir.join("benchcases/three/test.config.js");
+  let mut file = File::create(test_config_path).unwrap();
+  file.write_all(test_config_file.as_bytes()).unwrap();
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,11 +5,17 @@ fn main() {
   let args = args().into_iter().skip(1).collect::<Vec<_>>();
   dbg!(&args);
   let command = &args[0];
-  if let "copy_three" = command.as_ref() {
-    let num = args
-      .get(1)
-      .and_then(|num| num.parse::<usize>().ok())
-      .unwrap_or(10);
-    copy_three::copy_three(num);
+  match command.as_ref() {
+    "copy_three" => {
+      let num = args
+        .get(1)
+        .and_then(|num| num.parse::<usize>().ok())
+        .unwrap_or(10);
+      copy_three::copy_three(num);
+    }
+    "three_production_config" => {
+      copy_three::three_production_config();
+    }
+    _ => (),
   }
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
