### PR TITLE
chore: 🤖 reduce bench sample size

### DIFF
--- a/crates/rspack/benches/main.rs
+++ b/crates/rspack/benches/main.rs
@@ -42,7 +42,7 @@ fn criterion_benchmark(c: &mut Criterion) {
   // High cost benchmark
   // sample count reduce to 50
   let mut group = c.benchmark_group("high_cost_benchmark");
-  group.sample_size(50);
+  group.sample_size(30);
   let sh = Shell::new().unwrap();
   println!("{:?}", sh.current_dir());
   sh.change_dir(PathBuf::from(env!("CARGO_WORKSPACE_DIR")));


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
