### PR TITLE
chore: 🤖 disable strip=true in node-binding

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -55,5 +55,6 @@ napi-build = "2"
 testing_macros = { version = "0.2.5" }
 
 [profile.release]
-strip = true # Automatically strip symbols from the binary.
+# strip = true
+# Automatically strip symbols from the binary.
 # lto = true   # disabled by now, because it will significantly increase our compile time.


### PR DESCRIPTION
## Summary
1. Recently, we focus on BP which don't care too much package size, on the other hand, disable strip would give us better 
DX.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
