### PR TITLE
chore: bump rspack-sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,8 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.1.13"
-source = "git+https://github.com/speedy-js/rspack-sources?branch=chore/iter2#5cd7f1051b74286de552614bce5c0ac0fad44b6e"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdc84f60d35bf76c332b42a00eb2d85ad5a3b76598d150cfa7f7c7734222174"
 dependencies = [
  "dashmap",
  "dyn-clone",

--- a/crates/loader_runner/Cargo.toml
+++ b/crates/loader_runner/Cargo.toml
@@ -23,6 +23,6 @@ tokio = { version = "1.21.0", features = [
 ] }
 
 rspack_error       = { path = "../rspack_error" }
-rspack_sources     = { version = "0.1.13", git = "https://github.com/speedy-js/rspack-sources", branch = "chore/iter2" }
+rspack_sources     = { version = "0.1.14" }
 tracing            = "0.1.34"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2310,8 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.1.13"
-source = "git+https://github.com/speedy-js/rspack-sources?branch=chore/iter2#c8af55f69cba26ee45b2fdfcba8ddd74859426ae"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdc84f60d35bf76c332b42a00eb2d85ad5a3b76598d150cfa7f7c7734222174"
 dependencies = [
  "dashmap",
  "dyn-clone",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -25,7 +25,7 @@ regex = "1.6.0"
 rspack_error = { path = "../rspack_error" }
 rspack_loader_runner = { path = "../loader_runner" }
 rspack_regex = { path = "../rspack_regex" }
-rspack_sources = { version = "0.1.13", git = "https://github.com/speedy-js/rspack-sources", branch = "chore/iter2" }
+rspack_sources = { version = "0.1.14" }
 rspack_symbol = { path = "../rspack_symbol" }
 rspack_tracing = { path = "../rspack_tracing" }
 serde = "1"


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
