### PR TITLE
feat: remove query in importer

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -144,6 +144,7 @@ impl NormalModuleFactory {
 
   #[instrument(name = "normal_module_factory:factory_normal_module", skip_all)]
   pub async fn factorize_normal_module(&mut self) -> Result<Option<(String, BoxModule, u32)>> {
+    // TODO: `importer` should use `NormalModule::context || options.context`;
     let importer = self.dependency.parent_module_identifier.as_deref();
     let specifier = self.dependency.detail.specifier.as_str();
     let kind = self.dependency.detail.kind;

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -11,9 +11,16 @@ pub async fn resolve(
 ) -> Result<ResolveResult> {
   let plugin_driver = plugin_driver.read().await;
   let base_dir = if let Some(importer) = args.importer {
-    Path::new(importer)
-      .parent()
-      .ok_or_else(|| anyhow::format_err!("parent() failed for {:?}", importer))?
+    {
+      // TODO: delete this fn after use `normalModule.context` rather than `importer`
+      if let Some(index) = importer.find('?') {
+        Path::new(&importer[0..index])
+      } else {
+        Path::new(importer)
+      }
+    }
+    .parent()
+    .ok_or_else(|| anyhow::format_err!("parent() failed for {:?}", importer))?
   } else {
     &plugin_driver.options.context
   };

--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -25,7 +25,6 @@
   "exports": {
     ".": "./dist/index.js",
     "./devServer": "./dist/devServer.js",
-    "./react-refresh": "./dist/reactRefresh.js",
-    "./css": "./dist/css.js"
+    "./react-refresh": "./dist/reactRefresh.js"
   }
 }

--- a/packages/rspack/tests/cases/resolve/query/file.js
+++ b/packages/rspack/tests/cases/resolve/query/file.js
@@ -1,0 +1,1 @@
+module.exports = require("./file2");

--- a/packages/rspack/tests/cases/resolve/query/file2.js
+++ b/packages/rspack/tests/cases/resolve/query/file2.js
@@ -1,0 +1,1 @@
+module.exports = "file2";

--- a/packages/rspack/tests/cases/resolve/query/index.js
+++ b/packages/rspack/tests/cases/resolve/query/index.js
@@ -1,4 +1,7 @@
 it("should make different modules for query", function () {
+	var d = require("./file?path=/t");
+	expect(d).toBe("file2");
+
 	var a = require("./empty");
 	var b = require("./empty?1");
 	var c = require("./empty?2");


### PR DESCRIPTION
this PR brings two changes:

1. remove `./css` exports in dev-client.
2. remove query when importer has `?` symbol, but the better way is use `NomralModule::context` rather than `ModuleIdentifier`.