### PR TITLE
chore: add @rspack/plugin-minify

### DIFF
--- a/packages/rspack-plugin-minify/package.json
+++ b/packages/rspack-plugin-minify/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@rspack/plugin-minify",
+  "version": "0.0.1",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "esbuild": "0.16.3",
+    "terser": "5.16.1",
+    "jest-worker": "29.3.1",
+    "webpack-sources": "3.2.3"
+  }
+}

--- a/packages/rspack-plugin-minify/src/index.js
+++ b/packages/rspack-plugin-minify/src/index.js
@@ -1,0 +1,90 @@
+const isJsFile = /\.[cm]?js(?:\?.*)?$/i;
+const esbuild = require("esbuild");
+const terser = require("terser");
+const { RawSource, SourceMapSource } = require("webpack-sources");
+module.exports = class RspackMinifyPlugin {
+	/**
+	 *
+	 * @param {{minifier: 'esbuild' | 'terser'}} options
+	 */
+	constructor(options) {
+		this.options = options || {
+			minifier: "esbuild",
+			target: "es6"
+		};
+	}
+	async transform(code, { sourcemap, sourcefile }) {
+		if (this.options.minifier === "esbuild") {
+			return await esbuild.transform(code, {
+				target: this.options.target,
+				sourcefile,
+				sourcemap,
+				minify: true,
+				minifyIdentifiers: true,
+				minifySyntax: true,
+				minifyWhitespace: true
+			});
+		} else if (this.options.minifier === "terser") {
+			const result = await terser.minify(
+				{
+					[sourcefile]: code
+				},
+				{
+					sourceMap: sourcemap,
+					ecma: this.options.target,
+					compress: {
+						passes: 2
+					}
+				}
+			);
+			console.log("result:", result);
+			return result;
+		}
+	}
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("RspackMinifyPlugin", compilation => {
+			compilation.hooks.processAssets.tapPromise(
+				{
+					name: "RspackMinifyPlugin"
+				},
+				async _ => {
+					const {
+						options: { devtool }
+					} = compilation.compiler;
+					const sourcemap = !!devtool;
+					const assets = compilation.getAssets().filter(asset => {
+						return isJsFile.test(asset.name);
+					});
+
+					await Promise.all(
+						assets.map(async asset => {
+							const { source, map } = asset.source.sourceAndMap();
+							const sourceAsString = source.toString();
+							const result = await this.transform(sourceAsString, {
+								sourcemap,
+								sourcefile: asset.name
+							});
+							compilation.updateAsset(
+								asset.name,
+								sourcemap
+									? new SourceMapSource(
+											result.code,
+											asset.name,
+											result.map,
+											sourceAsString,
+											map,
+											true
+									  )
+									: new RawSource(result.code),
+								{
+									...asset.info,
+									minimized: true
+								}
+							);
+						})
+					);
+				}
+			);
+		});
+	}
+};

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -31,6 +31,7 @@
     "@rspack/less-loader": "workspace:^",
     "@rspack/postcss-loader": "workspace:^",
     "@rspack/plugin-node-polyfill": "workspace:^",
+    "@rspack/plugin-minify": "workspace:^",
     "rimraf": "3.0.2",
     "@types/rimraf": "3.0.2"
   },

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -2,6 +2,8 @@ import { RspackOptions, RspackOptionsNormalized } from "..";
 import path from "path";
 import { getDefaultTarget } from "./target";
 import { ResolvedOutput } from "./output";
+const NODE_MODULES_REGEXP = /[\\/]node_modules[\\/]/i;
+
 const D = <T, P extends keyof T>(obj: T, prop: P, value: T[P]) => {
 	if (obj[prop] === undefined) {
 		obj[prop] = value;
@@ -10,6 +12,36 @@ const D = <T, P extends keyof T>(obj: T, prop: P, value: T[P]) => {
 const F = <T, P extends keyof T>(obj: T, prop: P, factory: () => T[P]) => {
 	if (obj[prop] === undefined) {
 		obj[prop] = factory();
+	}
+};
+
+const A = <T, P extends keyof T>(
+	obj: T,
+	prop: P,
+	factory: () => T[P]
+): void => {
+	const value = obj[prop];
+	if (value === undefined) {
+		obj[prop] = factory();
+	} else if (Array.isArray(value)) {
+		let newArray = undefined;
+		for (let i = 0; i < value.length; i++) {
+			const item = value[i];
+			if (item === "...") {
+				if (newArray === undefined) {
+					newArray = value.slice(0, i);
+					obj[prop] = newArray;
+				}
+				const items = factory();
+				if (items !== undefined) {
+					for (const item of items as any) {
+						newArray.push(item);
+					}
+				}
+			} else if (newArray !== undefined) {
+				newArray.push(item);
+			}
+		}
 	}
 };
 export function applyRspackOptionsBaseDefaults(
@@ -33,11 +65,77 @@ const applyInfrastructureLoggingDefaults = infrastructureLogging => {
 	D(infrastructureLogging, "colors", tty);
 	D(infrastructureLogging, "appendOnly", !tty);
 };
-const applyOutputDefaults = (output: ResolvedOutput) => {
+const applyOutputDefaults = (output: ResolvedOutput, context) => {
 	D(output, "hashFunction", "xxhash64");
-	F(output, "path", () => path.resolve(process.cwd(), "dist"));
+	F(output, "path", () => path.resolve(context, "dist"));
 	D(output, "publicPath", "auto");
 	return output;
+};
+const applyOptimizationDefaults = (
+	optimization,
+	{ production, development, css, records }
+) => {
+	D(optimization, "removeAvailableModules", false);
+	D(optimization, "removeEmptyChunks", true);
+	D(optimization, "mergeDuplicateChunks", true);
+	D(optimization, "flagIncludedChunks", production);
+	F(optimization, "moduleIds", () => {
+		if (production) return "deterministic";
+		if (development) return "named";
+		return "natural";
+	});
+	F(optimization, "chunkIds", () => {
+		if (production) return "deterministic";
+		if (development) return "named";
+		return "natural";
+	});
+	F(optimization, "sideEffects", () => (production ? true : "flag"));
+	D(optimization, "providedExports", true);
+	D(optimization, "usedExports", production);
+	D(optimization, "innerGraph", production);
+	D(optimization, "mangleExports", production);
+	D(optimization, "concatenateModules", production);
+	D(optimization, "runtimeChunk", false);
+	D(optimization, "emitOnErrors", !production);
+	D(optimization, "checkWasmTypes", production);
+	D(optimization, "mangleWasmImports", false);
+	D(optimization, "portableRecords", records);
+	D(optimization, "realContentHash", production);
+	D(optimization, "minimize", production);
+	F(optimization, "nodeEnv", () => {
+		if (production) return "production";
+		if (development) return "development";
+		return false;
+	});
+	const { splitChunks } = optimization;
+	if (splitChunks) {
+		A(splitChunks, "defaultSizeTypes", () =>
+			css ? ["javascript", "css", "unknown"] : ["javascript", "unknown"]
+		);
+		D(splitChunks, "hidePathInfo", production);
+		D(splitChunks, "chunks", "async");
+		D(splitChunks, "usedExports", optimization.usedExports === true);
+		D(splitChunks, "minChunks", 1);
+		F(splitChunks, "minSize", () => (production ? 20000 : 10000));
+		F(splitChunks, "minRemainingSize", () => (development ? 0 : undefined));
+		F(splitChunks, "enforceSizeThreshold", () => (production ? 50000 : 30000));
+		F(splitChunks, "maxAsyncRequests", () => (production ? 30 : Infinity));
+		F(splitChunks, "maxInitialRequests", () => (production ? 30 : Infinity));
+		D(splitChunks, "automaticNameDelimiter", "-");
+		const { cacheGroups } = splitChunks;
+		F(cacheGroups, "default", () => ({
+			idHint: "",
+			reuseExistingChunk: true,
+			minChunks: 2,
+			priority: -20
+		}));
+		F(cacheGroups, "defaultVendors", () => ({
+			idHint: "vendors",
+			reuseExistingChunk: true,
+			test: NODE_MODULES_REGEXP,
+			priority: -10
+		}));
+	}
 };
 export function applyRspackOptionsDefaults(options: RspackOptionsNormalized) {
 	F(options, "context", () => process.cwd());
@@ -49,5 +147,11 @@ export function applyRspackOptionsDefaults(options: RspackOptionsNormalized) {
 	const development = mode === "development";
 	const production = mode === "production" || !mode;
 	F(options, "devtool", () => (development ? "eval" : ""));
-	applyOutputDefaults(options.output);
+	applyOutputDefaults(options.output, context);
+	applyOptimizationDefaults(options.optimization, {
+		development,
+		production,
+		css: false, // todo
+		records: false
+	});
 }

--- a/packages/rspack/src/config/index.ts
+++ b/packages/rspack/src/config/index.ts
@@ -16,7 +16,7 @@ import type {
 	Loader,
 	SourceMap
 } from "./module";
-import type { Plugin } from "./plugin";
+import type { PluginInstance } from "./plugin";
 import type { ResolvedTarget, Target } from "./target";
 import type { Output, ResolvedOutput } from "./output";
 import type { Resolve, ResolvedResolve } from "./resolve";
@@ -50,7 +50,7 @@ export interface RspackOptions {
 	name?: string;
 	entry?: Entry;
 	context?: Context;
-	plugins?: Plugin[];
+	plugins?: PluginInstance[];
 	devServer?: Dev;
 	module?: Module;
 	target?: Target;
@@ -72,7 +72,7 @@ export interface RspackOptionsNormalized {
 	name?: string;
 	entry: ResolvedEntry;
 	context: ResolvedContext;
-	plugins: Plugin[];
+	plugins: PluginInstance[];
 	devServer?: Dev;
 	module: ResolvedModule;
 	target: ResolvedTarget;
@@ -150,7 +150,7 @@ export function getNormalizedRspackOptions(
 function cloneObject(value: Record<string, any> | undefined) {
 	return { ...value };
 }
-export type { Plugin, LoaderContext, Loader, SourceMap };
+export type { PluginInstance as Plugin, LoaderContext, Loader, SourceMap };
 export type { WebSocketServerOptions, Dev } from "./devServer";
 export { resolveWatchOption } from "./watch";
 export type { StatsOptions } from "./stats";

--- a/packages/rspack/src/config/optimization.ts
+++ b/packages/rspack/src/config/optimization.ts
@@ -1,16 +1,24 @@
+import { PluginInstance } from "./plugin";
+
 export interface Optimization {
 	moduleIds?: "named" | "deterministic";
+	minimize?: boolean;
+	minimizer?: ("..." | PluginInstance)[];
 }
 
 export interface ResolvedOptimization {
 	moduleIds: "named" | "deterministic";
+	minimize?: boolean;
+	minimizer?: ("..." | PluginInstance)[];
 }
-
 export function resolveOptimizationOptions(
 	op: Optimization,
 	mode: string
 ): ResolvedOptimization {
 	return {
-		moduleIds: op.moduleIds ?? mode === "production" ? "deterministic" : "named"
+		moduleIds:
+			op.moduleIds ?? mode === "production" ? "deterministic" : "named",
+		minimize: op.minimize,
+		minimizer: op.minimizer
 	};
 }

--- a/packages/rspack/src/config/plugin.ts
+++ b/packages/rspack/src/config/plugin.ts
@@ -1,6 +1,6 @@
 import { Compiler } from "..";
 
-export interface Plugin {
+export interface PluginInstance {
 	name: string;
 	apply(compiler: Compiler): void;
 }

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -12,6 +12,16 @@ export class RspackOptionsApply {
 		if (compiler.options.target.includes("node")) {
 			new NodeTargetPlugin().apply(compiler);
 		}
+		// after we migrate minify to minimze, we could remove it
+		if (options.optimization.minimize || options.builtins.minify) {
+			if (options.optimization.minimizer) {
+				for (const minimizer of options.optimization.minimizer) {
+					if (minimizer !== "...") {
+						minimizer.apply(compiler);
+					}
+				}
+			}
+		}
 		new ResolveSwcPlugin().apply(compiler);
 	}
 }

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -121,6 +121,8 @@ describe("snapshots", () => {
 		    "rules": [],
 		  },
 		  "optimization": {
+		    "minimize": undefined,
+		    "minimizer": undefined,
 		    "moduleIds": "named",
 		  },
 		  "output": {},

--- a/packages/rspack/tests/configCases/plugins/minify-esbuild/index.js
+++ b/packages/rspack/tests/configCases/plugins/minify-esbuild/index.js
@@ -1,0 +1,5 @@
+const lib = require("./lib");
+it("minify-plugin", () => {
+	console.log("lib:", lib);
+	expect(lib.answer).toEqual(42);
+});

--- a/packages/rspack/tests/configCases/plugins/minify-esbuild/lib.js
+++ b/packages/rspack/tests/configCases/plugins/minify-esbuild/lib.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/rspack/tests/configCases/plugins/minify-esbuild/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-esbuild/webpack.config.js
@@ -1,0 +1,15 @@
+const minifyPlugin = require("@rspack/plugin-minify");
+module.exports = {
+	context: __dirname,
+	target: "node",
+	builtins: {
+		minify: false
+	},
+	entry: {
+		main: "./index.js"
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [new minifyPlugin()]
+	}
+};

--- a/packages/rspack/tests/configCases/plugins/minify-terser/index.js
+++ b/packages/rspack/tests/configCases/plugins/minify-terser/index.js
@@ -1,0 +1,5 @@
+const lib = require("./lib");
+it("minify-plugin", () => {
+	console.log("lib:", lib);
+	expect(lib.answer).toEqual(42);
+});

--- a/packages/rspack/tests/configCases/plugins/minify-terser/lib.js
+++ b/packages/rspack/tests/configCases/plugins/minify-terser/lib.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/rspack/tests/configCases/plugins/minify-terser/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-terser/webpack.config.js
@@ -1,0 +1,19 @@
+const minifyPlugin = require("@rspack/plugin-minify");
+module.exports = {
+	context: __dirname,
+	target: "node",
+	builtins: {
+		minify: false
+	},
+	entry: {
+		main: "./index.js"
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new minifyPlugin({
+				minifier: "terser"
+			})
+		]
+	}
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,7 @@ importers:
       '@rspack/core': workspace:*
       '@rspack/dev-client': workspace:*
       '@rspack/less-loader': workspace:^
+      '@rspack/plugin-minify': workspace:^
       '@rspack/plugin-node-polyfill': workspace:^
       '@rspack/postcss-loader': workspace:^
       '@swc/helpers': 0.4.13
@@ -310,6 +311,7 @@ importers:
     devDependencies:
       '@rspack/core': 'link:'
       '@rspack/less-loader': link:../less-loader
+      '@rspack/plugin-minify': link:../rspack-plugin-minify
       '@rspack/plugin-node-polyfill': link:../rspack-plugin-node-polyfill
       '@rspack/postcss-loader': link:../postcss-loader
       '@types/jest': 29.0.2
@@ -449,6 +451,18 @@ importers:
       jest: 29.0.3
       loader-runner: 4.3.0
       pug: 3.0.2
+
+  packages/rspack-plugin-minify:
+    specifiers:
+      esbuild: 0.16.3
+      jest-worker: 29.3.1
+      terser: 5.16.1
+      webpack-sources: 3.2.3
+    dependencies:
+      esbuild: 0.16.3
+      jest-worker: 29.3.1
+      terser: 5.16.1
+      webpack-sources: 3.2.3
 
   packages/rspack-plugin-node-polyfill:
     specifiers:
@@ -2436,6 +2450,96 @@ packages:
     dev: true
     optional: true
 
+  /@esbuild/android-arm/0.16.3:
+    resolution: {integrity: sha512-mueuEoh+s1eRbSJqq9KNBQwI4QhQV6sRXIfTyLXSHGMpyew61rOK4qY21uKbXl1iBoMb0AdL1deWFCQVlN2qHA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-arm64/0.16.3:
+    resolution: {integrity: sha512-RolFVeinkeraDvN/OoRf1F/lP0KUfGNb5jxy/vkIMeRRChkrX/HTYN6TYZosRJs3a1+8wqpxAo5PI5hFmxyPRg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-x64/0.16.3:
+    resolution: {integrity: sha512-SFpTUcIT1bIJuCCBMCQWq1bL2gPTjWoLZdjmIhjdcQHaUfV41OQfho6Ici5uvvkMmZRXIUGpM3GxysP/EU7ifQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-arm64/0.16.3:
+    resolution: {integrity: sha512-DO8WykMyB+N9mIDfI/Hug70Dk1KipavlGAecxS3jDUwAbTpDXj0Lcwzw9svkhxfpCagDmpaTMgxWK8/C/XcXvw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-x64/0.16.3:
+    resolution: {integrity: sha512-uEqZQ2omc6BvWqdCiyZ5+XmxuHEi1SPzpVxXCSSV2+Sh7sbXbpeNhHIeFrIpRjAs0lI1FmA1iIOxFozKBhKgRQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.16.3:
+    resolution: {integrity: sha512-nJansp3sSXakNkOD5i5mIz2Is/HjzIhFs49b1tjrPrpCmwgBmH9SSzhC/Z1UqlkivqMYkhfPwMw1dGFUuwmXhw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-x64/0.16.3:
+    resolution: {integrity: sha512-TfoDzLw+QHfc4a8aKtGSQ96Wa+6eimljjkq9HKR0rHlU83vw8aldMOUSJTUDxbcUdcgnJzPaX8/vGWm7vyV7ug==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm/0.16.3:
+    resolution: {integrity: sha512-VwswmSYwVAAq6LysV59Fyqk3UIjbhuc6wb3vEcJ7HEJUtFuLK9uXWuFoH1lulEbE4+5GjtHi3MHX+w1gNHdOWQ==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm64/0.16.3:
+    resolution: {integrity: sha512-7I3RlsnxEFCHVZNBLb2w7unamgZ5sVwO0/ikE2GaYvYuUQs9Qte/w7TqWcXHtCwxvZx/2+F97ndiUQAWs47ZfQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ia32/0.16.3:
+    resolution: {integrity: sha512-X8FDDxM9cqda2rJE+iblQhIMYY49LfvW4kaEjoFbTTQ4Go8G96Smj2w3BRTwA8IHGoi9dPOPGAX63dhuv19UqA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
   /@esbuild/linux-loong64/0.14.54:
     resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
     engines: {node: '>=12'}
@@ -2452,6 +2556,114 @@ packages:
     os: [linux]
     requiresBuild: true
     dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.16.3:
+    resolution: {integrity: sha512-hIbeejCOyO0X9ujfIIOKjBjNAs9XD/YdJ9JXAy1lHA+8UXuOqbFe4ErMCqMr8dhlMGBuvcQYGF7+kO7waj2KHw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-mips64el/0.16.3:
+    resolution: {integrity: sha512-znFRzICT/V8VZQMt6rjb21MtAVJv/3dmKRMlohlShrbVXdBuOdDrGb+C2cZGQAR8RFyRe7HS6klmHq103WpmVw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ppc64/0.16.3:
+    resolution: {integrity: sha512-EV7LuEybxhXrVTDpbqWF2yehYRNz5e5p+u3oQUS2+ZFpknyi1NXxr8URk4ykR8Efm7iu04//4sBg249yNOwy5Q==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-riscv64/0.16.3:
+    resolution: {integrity: sha512-uDxqFOcLzFIJ+r/pkTTSE9lsCEaV/Y6rMlQjUI9BkzASEChYL/aSQjZjchtEmdnVxDKETnUAmsaZ4pqK1eE5BQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-s390x/0.16.3:
+    resolution: {integrity: sha512-NbeREhzSxYwFhnCAQOQZmajsPYtX71Ufej3IQ8W2Gxskfz9DK58ENEju4SbpIj48VenktRASC52N5Fhyf/aliQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-x64/0.16.3:
+    resolution: {integrity: sha512-SDiG0nCixYO9JgpehoKgScwic7vXXndfasjnD5DLbp1xltANzqZ425l7LSdHynt19UWOcDjG9wJJzSElsPvk0w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/netbsd-x64/0.16.3:
+    resolution: {integrity: sha512-AzbsJqiHEq1I/tUvOfAzCY15h4/7Ivp3ff/o1GpP16n48JMNAtbW0qui2WCgoIZArEHD0SUQ95gvR0oSO7ZbdA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/openbsd-x64/0.16.3:
+    resolution: {integrity: sha512-gSABi8qHl8k3Cbi/4toAzHiykuBuWLZs43JomTcXkjMZVkp0gj3gg9mO+9HJW/8GB5H89RX/V0QP4JGL7YEEVg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/sunos-x64/0.16.3:
+    resolution: {integrity: sha512-SF9Kch5Ete4reovvRO6yNjMxrvlfT0F0Flm+NPoUw5Z4Q3r1d23LFTgaLwm3Cp0iGbrU/MoUI+ZqwCv5XJijCw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-arm64/0.16.3:
+    resolution: {integrity: sha512-u5aBonZIyGopAZyOnoPAA6fGsDeHByZ9CnEzyML9NqntK6D/xl5jteZUKm/p6nD09+v3pTM6TuUIqSPcChk5gg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-ia32/0.16.3:
+    resolution: {integrity: sha512-GlgVq1WpvOEhNioh74TKelwla9KDuAaLZrdxuuUgsP2vayxeLgVc+rbpIv0IYF4+tlIzq2vRhofV+KGLD+37EQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-x64/0.16.3:
+    resolution: {integrity: sha512-5/JuTd8OWW8UzEtyf19fbrtMJENza+C9JoPIkvItgTBQ1FO2ZLvjbPO6Xs54vk0s5JB5QsfieUEshRQfu7ZHow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
     optional: true
 
   /@icons/material/0.2.4_react@17.0.2:
@@ -2482,11 +2694,11 @@ packages:
     resolution: {integrity: sha512-cGg0r+klVHSYnfE977S9wmpuQ9L+iYuYgL+5bPXiUlUynLLYunRxswEmhBzvrSKGof5AKiHuTTmUKAqRcDY9dg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       chalk: 4.1.2
       jest-message-util: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       slash: 3.0.0
     dev: true
 
@@ -2503,7 +2715,7 @@ packages:
       '@jest/reporters': 29.0.3
       '@jest/test-result': 29.0.3
       '@jest/transform': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -2520,7 +2732,7 @@ packages:
       jest-runner: 29.0.3
       jest-runtime: 29.0.3
       jest-snapshot: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       jest-validate: 29.0.3
       jest-watcher: 29.0.3
       micromatch: 4.0.5
@@ -2537,7 +2749,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/fake-timers': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       jest-mock: 29.0.3
     dev: true
@@ -2563,12 +2775,12 @@ packages:
     resolution: {integrity: sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@sinonjs/fake-timers': 9.1.2
       '@types/node': 18.7.9
       jest-message-util: 29.0.3
       jest-mock: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
     dev: true
 
   /@jest/globals/29.0.3:
@@ -2577,7 +2789,7 @@ packages:
     dependencies:
       '@jest/environment': 29.0.3
       '@jest/expect': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       jest-mock: 29.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2596,7 +2808,7 @@ packages:
       '@jest/console': 29.0.3
       '@jest/test-result': 29.0.3
       '@jest/transform': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@jridgewell/trace-mapping': 0.3.15
       '@types/node': 18.7.9
       chalk: 4.1.2
@@ -2610,8 +2822,8 @@ packages:
       istanbul-lib-source-maps: 4.0.1
       istanbul-reports: 3.1.5
       jest-message-util: 29.0.3
-      jest-util: 29.0.3
-      jest-worker: 29.0.3
+      jest-util: 29.3.1
+      jest-worker: 29.3.1
       slash: 3.0.0
       string-length: 4.0.2
       strip-ansi: 6.0.1
@@ -2626,7 +2838,6 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@sinclair/typebox': 0.24.41
-    dev: true
 
   /@jest/source-map/29.0.0:
     resolution: {integrity: sha512-nOr+0EM8GiHf34mq2GcJyz/gYFyLQ2INDhAylrZJ9mMWoW21mLBfZa0BUVPPMxVYrLjeiRe2Z7kWXOGnS0TFhQ==}
@@ -2642,7 +2853,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/console': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/istanbul-lib-coverage': 2.0.4
       collect-v8-coverage: 1.0.1
     dev: true
@@ -2662,7 +2873,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.19.6
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@jridgewell/trace-mapping': 0.3.15
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
@@ -2671,7 +2882,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.0.3
       jest-regex-util: 29.0.0
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       micromatch: 4.0.5
       pirates: 4.0.5
       slash: 3.0.0
@@ -2691,6 +2902,17 @@ packages:
       '@types/yargs': 17.0.12
       chalk: 4.1.2
     dev: true
+
+  /@jest/types/29.3.1:
+    resolution: {integrity: sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.0.0
+      '@types/istanbul-lib-coverage': 2.0.4
+      '@types/istanbul-reports': 3.0.1
+      '@types/node': 18.7.9
+      '@types/yargs': 17.0.12
+      chalk: 4.1.2
 
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
@@ -2849,7 +3071,6 @@ packages:
 
   /@sinclair/typebox/0.24.41:
     resolution: {integrity: sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA==}
-    dev: true
 
   /@sindresorhus/is/0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
@@ -4405,19 +4626,16 @@ packages:
 
   /@types/istanbul-lib-coverage/2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==}
-    dev: true
 
   /@types/istanbul-lib-report/3.0.0:
     resolution: {integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==}
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.4
-    dev: true
 
   /@types/istanbul-reports/3.0.1:
     resolution: {integrity: sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==}
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
-    dev: true
 
   /@types/jest/27.5.2:
     resolution: {integrity: sha512-mpT8LJJ4CMeeahobofYWIjFo0xonRS/HfxnVEPMPFSQdGUt1uHCnoPT7Zhb+sjDU2wz0oKV0OLUR0WzrHNgfeA==}
@@ -4610,13 +4828,11 @@ packages:
 
   /@types/yargs-parser/21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
-    dev: true
 
   /@types/yargs/17.0.12:
     resolution: {integrity: sha512-Nz4MPhecOFArtm81gFQvQqdV7XYCrWKx5uUt6GNHredFHn1i2mtWqXTON7EPXMtNi1qjtjEM/VCHDhcHsAMLXQ==}
     dependencies:
       '@types/yargs-parser': 21.0.0
-    dev: true
 
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
@@ -5636,7 +5852,6 @@ packages:
 
   /ci-info/3.3.2:
     resolution: {integrity: sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==}
-    dev: true
 
   /cipher-base/1.0.4:
     resolution: {integrity: sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==}
@@ -7218,6 +7433,36 @@ packages:
       esbuild-windows-arm64: 0.15.9
     dev: true
 
+  /esbuild/0.16.3:
+    resolution: {integrity: sha512-71f7EjPWTiSguen8X/kxEpkAS7BFHwtQKisCDDV3Y4GLGWBaoSCyD5uXkaUew6JDzA9FEN1W23mdnSwW9kqCeg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.16.3
+      '@esbuild/android-arm64': 0.16.3
+      '@esbuild/android-x64': 0.16.3
+      '@esbuild/darwin-arm64': 0.16.3
+      '@esbuild/darwin-x64': 0.16.3
+      '@esbuild/freebsd-arm64': 0.16.3
+      '@esbuild/freebsd-x64': 0.16.3
+      '@esbuild/linux-arm': 0.16.3
+      '@esbuild/linux-arm64': 0.16.3
+      '@esbuild/linux-ia32': 0.16.3
+      '@esbuild/linux-loong64': 0.16.3
+      '@esbuild/linux-mips64el': 0.16.3
+      '@esbuild/linux-ppc64': 0.16.3
+      '@esbuild/linux-riscv64': 0.16.3
+      '@esbuild/linux-s390x': 0.16.3
+      '@esbuild/linux-x64': 0.16.3
+      '@esbuild/netbsd-x64': 0.16.3
+      '@esbuild/openbsd-x64': 0.16.3
+      '@esbuild/sunos-x64': 0.16.3
+      '@esbuild/win32-arm64': 0.16.3
+      '@esbuild/win32-ia32': 0.16.3
+      '@esbuild/win32-x64': 0.16.3
+    dev: false
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -7324,7 +7569,7 @@ packages:
       jest-get-type: 29.0.0
       jest-matcher-utils: 29.0.3
       jest-message-util: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
     dev: true
 
   /express/4.18.1:
@@ -7899,7 +8144,7 @@ packages:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.15.0
+      terser: 5.16.1
     dev: true
 
   /html-minifier-terser/7.0.0:
@@ -7913,7 +8158,7 @@ packages:
       entities: 4.4.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.15.0
+      terser: 5.16.1
 
   /html-webpack-plugin/5.5.0_webpack@5.74.0:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
@@ -8517,7 +8762,7 @@ packages:
       '@jest/environment': 29.0.3
       '@jest/expect': 29.0.3
       '@jest/test-result': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       chalk: 4.1.2
       co: 4.6.0
@@ -8528,7 +8773,7 @@ packages:
       jest-message-util: 29.0.3
       jest-runtime: 29.0.3
       jest-snapshot: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       p-limit: 3.1.0
       pretty-format: 29.0.3
       slash: 3.0.0
@@ -8549,13 +8794,13 @@ packages:
     dependencies:
       '@jest/core': 29.0.3
       '@jest/test-result': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       jest-validate: 29.0.3
       prompts: 2.4.2
       yargs: 17.6.2
@@ -8579,7 +8824,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       babel-jest: 29.0.3_@babel+core@7.19.6
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -8592,7 +8837,7 @@ packages:
       jest-regex-util: 29.0.0
       jest-resolve: 29.0.3
       jest-runner: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       jest-validate: 29.0.3
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -8617,7 +8862,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@jest/test-sequencer': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       babel-jest: 29.0.3_@babel+core@7.19.6
       chalk: 4.1.2
@@ -8631,7 +8876,7 @@ packages:
       jest-regex-util: 29.0.0
       jest-resolve: 29.0.3
       jest-runner: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       jest-validate: 29.0.3
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -8673,10 +8918,10 @@ packages:
     resolution: {integrity: sha512-wILhZfESURHHBNvPMJ0lZlYZrvOQJxAo3wNHi+ycr90V7M+uGR9Gh4+4a/BmaZF0XTyZsk4OiYEf3GJN7Ltqzg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       chalk: 4.1.2
       jest-get-type: 29.0.0
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       pretty-format: 29.0.3
     dev: true
 
@@ -8686,10 +8931,10 @@ packages:
     dependencies:
       '@jest/environment': 29.0.3
       '@jest/fake-timers': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       jest-mock: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
     dev: true
 
   /jest-get-type/27.5.1:
@@ -8706,15 +8951,15 @@ packages:
     resolution: {integrity: sha512-uMqR99+GuBHo0RjRhOE4iA6LmsxEwRdgiIAQgMU/wdT2XebsLDz5obIwLZm/Psj+GwSEQhw9AfAVKGYbh2G55A==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/graceful-fs': 4.1.5
       '@types/node': 18.7.9
       anymatch: 3.1.2
       fb-watchman: 2.0.1
       graceful-fs: 4.2.10
       jest-regex-util: 29.0.0
-      jest-util: 29.0.3
-      jest-worker: 29.0.3
+      jest-util: 29.3.1
+      jest-worker: 29.3.1
       micromatch: 4.0.5
       walker: 1.0.8
     optionalDependencies:
@@ -8754,7 +8999,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.10
@@ -8768,7 +9013,7 @@ packages:
     resolution: {integrity: sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
     dev: true
 
@@ -8807,7 +9052,7 @@ packages:
       graceful-fs: 4.2.10
       jest-haste-map: 29.0.3
       jest-pnp-resolver: 1.2.2_jest-resolve@29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       jest-validate: 29.0.3
       resolve: 1.22.1
       resolve.exports: 1.1.0
@@ -8822,7 +9067,7 @@ packages:
       '@jest/environment': 29.0.3
       '@jest/test-result': 29.0.3
       '@jest/transform': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       chalk: 4.1.2
       emittery: 0.10.2
@@ -8834,9 +9079,9 @@ packages:
       jest-message-util: 29.0.3
       jest-resolve: 29.0.3
       jest-runtime: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       jest-watcher: 29.0.3
-      jest-worker: 29.0.3
+      jest-worker: 29.3.1
       p-limit: 3.1.0
       source-map-support: 0.5.13
     transitivePeerDependencies:
@@ -8853,7 +9098,7 @@ packages:
       '@jest/source-map': 29.0.0
       '@jest/test-result': 29.0.3
       '@jest/transform': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
@@ -8866,7 +9111,7 @@ packages:
       jest-regex-util: 29.0.0
       jest-resolve: 29.0.3
       jest-snapshot: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -8894,7 +9139,7 @@ packages:
       '@babel/types': 7.20.2
       '@jest/expect-utils': 29.0.3
       '@jest/transform': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/babel__traverse': 7.18.1
       '@types/prettier': 2.7.0
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.6
@@ -8906,7 +9151,7 @@ packages:
       jest-haste-map: 29.0.3
       jest-matcher-utils: 29.0.3
       jest-message-util: 29.0.3
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       natural-compare: 1.4.0
       pretty-format: 29.0.3
       semver: 7.3.7
@@ -8918,7 +9163,7 @@ packages:
     resolution: {integrity: sha512-Q0xaG3YRG8QiTC4R6fHjHQPaPpz9pJBEi0AeOE4mQh/FuWOijFjGXMMOfQEaU9i3z76cNR7FobZZUQnL6IyfdQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -8926,11 +9171,22 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /jest-util/29.3.1:
+    resolution: {integrity: sha512-7YOVZaiX7RJLv76ZfHt4nbNEzzTRiMW/IiOG7ZOKmTXmoGBxUDefgMAxQubu6WPVqP5zSzAdZG0FfLcC7HOIFQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/types': 29.3.1
+      '@types/node': 18.7.9
+      chalk: 4.1.2
+      ci-info: 3.3.2
+      graceful-fs: 4.2.10
+      picomatch: 2.3.1
+
   /jest-validate/29.0.3:
     resolution: {integrity: sha512-OebiqqT6lK8cbMPtrSoS3aZP4juID762lZvpf1u+smZnwTEBCBInan0GAIIhv36MxGaJvmq5uJm7dl5gVt+Zrw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       camelcase: 6.3.0
       chalk: 4.1.2
       jest-get-type: 29.0.0
@@ -8943,12 +9199,12 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.0.3
-      '@jest/types': 29.0.3
+      '@jest/types': 29.3.1
       '@types/node': 18.7.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.10.2
-      jest-util: 29.0.3
+      jest-util: 29.3.1
       string-length: 4.0.2
     dev: true
 
@@ -8960,14 +9216,14 @@ packages:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  /jest-worker/29.0.3:
-    resolution: {integrity: sha512-Tl/YWUugQOjoTYwjKdfJWkSOfhufJHO5LhXTSZC3TRoQKO+fuXnZAdoXXBlpLXKGODBL3OvdUasfDD4PcMe6ng==}
+  /jest-worker/29.3.1:
+    resolution: {integrity: sha512-lY4AnnmsEWeiXirAIA0c9SDPbuCBq8IYuDVL8PMm0MZ2PEs2yPvRA/J64QBXuZp7CYKrDM/rmNrc9/i3KJQncw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@types/node': 18.7.9
+      jest-util: 29.3.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
 
   /jest/29.0.3:
     resolution: {integrity: sha512-ElgUtJBLgXM1E8L6K1RW1T96R897YY/3lRYqq9uVcPWtP2AAl/nQ16IYDh/FzQOOQ12VEuLdcPU83mbhG2C3PQ==}
@@ -12036,7 +12292,7 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
-      terser: 5.15.0
+      terser: 5.16.1
       webpack: 5.74.0_s76zm2l7l4ywgel5skomka3v5u
     dev: true
 
@@ -12061,7 +12317,7 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
-      terser: 5.15.0
+      terser: 5.16.1
       webpack: 5.74.0_3gcbx63bynl6ohasvvqkdbe3aq
     dev: true
 
@@ -12085,11 +12341,11 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
-      terser: 5.15.0
+      terser: 5.16.1
       webpack: 5.74.0
 
-  /terser/5.15.0:
-    resolution: {integrity: sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==}
+  /terser/5.16.1:
+    resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:


### PR DESCRIPTION
## Summary
This PR adds a js minify plugin to support minfy in js side because
* swc minify is not stable and not performs well right now, we may need to use other minify plugin for our internal projects.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
