### PR TITLE
(WIP) test: add back error message test

### DIFF
--- a/crates/rspack_binding_options/src/threadsafe_function.rs
+++ b/crates/rspack_binding_options/src/threadsafe_function.rs
@@ -99,7 +99,7 @@ impl<R: 'static + Send> ThreadSafeResolver<R> {
                     &mut value_ptr,
                   )
                 },
-                "failed to get the error message"
+                "failed to get the named property of the underlying error message"
               )?;
 
               let mut str_len = 0;
@@ -113,7 +113,7 @@ impl<R: 'static + Send> ThreadSafeResolver<R> {
                     &mut str_len,
                   )
                 },
-                "failed to get the error message"
+                "failed to get the length of the underlying error message"
               )?;
 
               str_len += 1;
@@ -130,7 +130,7 @@ impl<R: 'static + Send> ThreadSafeResolver<R> {
                     &mut copied_len,
                   )
                 },
-                "failed to get the error message"
+                "failed to get the value of the underlying error message"
               )?;
 
               let mut buf = std::mem::ManuallyDrop::new(buf);

--- a/packages/rspack/tests/configCases/errors/asset-module-build-failed/index.js
+++ b/packages/rspack/tests/configCases/errors/asset-module-build-failed/index.js
@@ -4,7 +4,7 @@ it("should throw if a module is failed to build", () => {
     require("./logo.svg");
   } catch(err) {
     errored = true
-    // expect(err.message).toContain("Failed to load")
+    expect(err.message).toContain("Failed to load")
   }
   expect(errored).toBeTruthy()
 });

--- a/packages/rspack/tests/configCases/errors/loader-error-async/index.js
+++ b/packages/rspack/tests/configCases/errors/loader-error-async/index.js
@@ -4,7 +4,7 @@ it("should report error (async)", () => {
 		require("./lib?async");
 	} catch (e) {
     errored = true;
-		// expect(e.message).toContain("Failed to load (async)");
+		expect(e.message).toContain("Failed to load (async)");
 	}
   expect(errored).toBeTruthy()
 });
@@ -15,7 +15,7 @@ it("should report error (callback)", () => {
 		require("./lib?callback");
 	} catch (e) {
     errored = true;
-		// expect(e.message).toContain("Failed to load (callback)");
+		expect(e.message).toContain("Failed to load (callback)");
 	}
   expect(errored).toBeTruthy()
 });

--- a/packages/rspack/tests/configCases/errors/loader-syntax-error/index.js
+++ b/packages/rspack/tests/configCases/errors/loader-syntax-error/index.js
@@ -4,7 +4,7 @@ it("should report syntax error", () => {
 		require("./lib");
 	} catch (e) {
     errored = true;
-		// expect(e.message).toContain("SyntaxError");
+		expect(e.message).toContain("SyntaxError");
 	}
   expect(errored).toBeTruthy()
 });

--- a/packages/rspack/tests/configCases/errors/loader-throw-error/index.js
+++ b/packages/rspack/tests/configCases/errors/loader-throw-error/index.js
@@ -4,7 +4,7 @@ it("should include loader thrown error", () => {
 		require("./lib");
 	} catch (e) {
     errored = true;
-		// expect(e.message).toContain("Failed to load");
+		expect(e.message).toContain("Failed to load");
 	}
   expect(errored).toBeTruthy()
 });


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
