### PR TITLE
chore(crates/node_binding): make mimalloc verbose

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -311,6 +311,16 @@ fn init() {
   use backtrace::Backtrace;
   use std::panic::set_hook;
 
+  #[cfg(debug_assertions)]
+  {
+    use mimalloc_rust::raw::runtime_options::*;
+
+    unsafe {
+      mi_option_enable(mi_option_show_stats);
+      mi_option_enable(mi_option_verbose);
+    }
+  }
+
   set_hook(Box::new(|panic_info| {
     let backtrace = Backtrace::new();
     println!("Panic: {:?}\nBacktrace: \n{:?}", panic_info, backtrace);


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

See more for the runtime options: https://microsoft.github.io/mimalloc/group__options.html#gafebf7ed116adb38ae5218bc3ce06884c

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
