### PR TITLE
fix: generate fixed hash

### DIFF
--- a/crates/rspack_core/src/chunk_graph.rs
+++ b/crates/rspack_core/src/chunk_graph.rs
@@ -190,6 +190,16 @@ impl ChunkGraph {
       .collect()
   }
 
+  pub fn get_ordered_chunk_modules<'module>(
+    &self,
+    chunk: &ChunkUkey,
+    module_graph: &'module ModuleGraph,
+  ) -> Vec<&'module ModuleGraphModule> {
+    let mut modules = self.get_chunk_modules(chunk, module_graph);
+    modules.sort_by_key(|m| m.module_identifier.to_string());
+    modules
+  }
+
   pub fn get_chunk_modules_by_source_type<'module>(
     &self,
     chunk: &ChunkUkey,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1120,10 +1120,12 @@ impl Compilation {
 
   #[instrument(skip_all)]
   pub fn create_hash(&mut self) {
-    for (chunk_ukey, chunk) in self.chunk_by_ukey.iter_mut() {
+    let mut chunks = self.chunk_by_ukey.values_mut().collect::<Vec<_>>();
+    chunks.sort_by_key(|chunk| chunk.ukey);
+    for chunk in chunks.iter_mut() {
       for mgm in self
         .chunk_graph
-        .get_chunk_modules(chunk_ukey, &self.module_graph)
+        .get_ordered_chunk_modules(&chunk.ukey, &self.module_graph)
       {
         if let Some(module) = self
           .module_graph


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
