### PR TITLE
chore: debugger ci hash

### DIFF
--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -46,8 +46,8 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
         "development": false,
         "hotModuleReplacement": false,
       },
-      "name": "main.xxxx.js",
-      "size": 1321,
+      "name": "main.549f05.js",
+      "size": 1323,
       "type": "asset",
     },
     {
@@ -60,7 +60,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
         "development": false,
         "hotModuleReplacement": false,
       },
-      "name": "dynamic_js.xxxx.js",
+      "name": "dynamic_js.fb77ce.js",
       "size": 218,
       "type": "asset",
     },
@@ -69,7 +69,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
     {
       "entry": false,
       "files": [
-        "dynamic_js.xxxx.js",
+        "dynamic_js.fb77ce.js",
       ],
       "id": "dynamic_js",
       "initial": false,
@@ -80,7 +80,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
     {
       "entry": true,
       "files": [
-        "main.xxxx.js",
+        "main.549f05.js",
       ],
       "id": "main",
       "initial": true,
@@ -95,11 +95,11 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
     "main": {
       "assets": [
         {
-          "name": "main.xxxx.js",
-          "size": 1321,
+          "name": "main.549f05.js",
+          "size": 1323,
         },
       ],
-      "assetsSize": 1321,
+      "assetsSize": 1323,
       "chunks": [
         "main",
       ],
@@ -108,7 +108,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
-  "hash": "43657cde39b00269",
+  "hash": "ac2020b3324ec09d",
   "modules": [
     {
       "chunks": [
@@ -160,13 +160,13 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for filename 2`] = `
-"Hash: 43657cde39b00269
-             Asset       Size      Chunks             Chunk Names
-      main.xxxx.js   1.29 KiB        main  [emitted]  main
-dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]  
-Entrypoint main = main.xxxx.js
-chunk {dynamic_js} dynamic_js.xxxx.js 32 bytes
-chunk {main} main.xxxx.js (main) 38 bytes [entry]
+"Hash: ac2020b3324ec09d
+               Asset       Size      Chunks             Chunk Names
+      main.549f05.js   1.29 KiB        main  [emitted]  main
+dynamic_js.fb77ce.js  218 bytes  dynamic_js  [emitted]  
+Entrypoint main = main.549f05.js
+chunk {dynamic_js} dynamic_js.fb77ce.js 32 bytes
+chunk {main} main.549f05.js (main) 38 bytes [entry]
 [10] ./index.js 38 bytes {main}
     
 [426] ./dynamic.js 32 bytes {dynamic_js}

--- a/packages/rspack/tests/statsCases/filename/webpack.config.js
+++ b/packages/rspack/tests/statsCases/filename/webpack.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	output: {
-		filename: "[id].xxxx.js",
-		chunkFilename: "[id].xxxx.js"
+		filename: "[id].[hash].js",
+		chunkFilename: "[id].[hash].js"
 	}
 };


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
