### PR TITLE
feat(crates/plugin_asset): supports placeholder [name] for assetModuleFilename

### DIFF
--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -252,7 +252,10 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     let hash = hash_value_to_string(self.hash_for_ast_or_source(ast_or_source));
 
     let asset_filename = asset_filename_template.render(FilenameRenderOptions {
-      filename: None,
+      filename: module.as_normal_module().and_then(|m| {
+        let p = Path::new(&m.resource_resolved_data().resource_path);
+        p.file_stem().map(|s| s.to_string_lossy().to_string())
+      }),
       path: module.as_normal_module().map(|m| {
         Path::new(&m.resource_resolved_data().resource_path)
           .relative(&generate_context.compilation.options.context)


### PR DESCRIPTION

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
