### PR TITLE
chore: disable dbg macro in CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,4 +10,5 @@ xtask = "run --package xtask --"
 [target.'cfg(all())']
 rustflags = [
   "-Dclippy::unwrap_in_result", # https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_in_result
+  "-Wclippy::dbg_macro",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+allow-dbg-in-tests = true

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,7 @@
 mod copy_three;
 use std::env::args;
 
+#[allow(clippy::dbg_macro)]
 fn main() {
   let args = args().into_iter().skip(1).collect::<Vec<_>>();
   // dbg!(&args);


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
