### PR TITLE
feat: compiler new compilation use fast_set

### DIFF
--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -5,7 +5,7 @@ use rspack_error::Result;
 use rspack_sources::{RawSource, SourceExt};
 
 use crate::{
-  AssetInfo, Chunk, ChunkKind, Compilation, CompilationAsset, Compiler, ModuleIdentifier,
+  fast_set, AssetInfo, Chunk, ChunkKind, Compilation, CompilationAsset, Compiler, ModuleIdentifier,
   RenderManifestArgs, RuntimeSpec, Stats,
 };
 
@@ -120,15 +120,18 @@ impl Compiler {
       self.cache.end_idle().await;
       self.plugin_driver.read().await.resolver.clear();
 
-      self.compilation = Compilation::new(
-        // TODO: use Arc<T> instead
-        self.options.clone(),
-        self.options.entry.clone(),
-        Default::default(),
-        Default::default(),
-        self.plugin_driver.clone(),
-        self.loader_runner_runner.clone(),
-        self.cache.clone(),
+      fast_set(
+        &mut self.compilation,
+        Compilation::new(
+          // TODO: use Arc<T> instead
+          self.options.clone(),
+          self.options.entry.clone(),
+          Default::default(),
+          Default::default(),
+          self.plugin_driver.clone(),
+          self.loader_runner_runner.clone(),
+          self.cache.clone(),
+        ),
       );
       self.compilation.lazy_visit_modules = changed_files.clone();
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -14,8 +14,8 @@ use tokio::sync::RwLock;
 use tracing::instrument;
 
 use crate::{
-  cache::Cache, BoxModule, CompilerOptions, Dependency, LoaderRunnerRunner, ModuleGraphModule,
-  ModuleIdentifier, Plugin, PluginDriver, SharedPluginDriver, Stats,
+  cache::Cache, fast_set, BoxModule, CompilerOptions, Dependency, LoaderRunnerRunner,
+  ModuleGraphModule, ModuleIdentifier, Plugin, PluginDriver, SharedPluginDriver, Stats,
 };
 
 #[derive(Debug)]
@@ -75,15 +75,18 @@ impl Compiler {
     // TODO: maybe it's better to use external entries.
     self.plugin_driver.read().await.resolver.clear();
 
-    self.compilation = Compilation::new(
-      // TODO: use Arc<T> instead
-      self.options.clone(),
-      self.options.entry.clone(),
-      Default::default(),
-      Default::default(),
-      self.plugin_driver.clone(),
-      self.loader_runner_runner.clone(),
-      self.cache.clone(),
+    fast_set(
+      &mut self.compilation,
+      Compilation::new(
+        // TODO: use Arc<T> instead
+        self.options.clone(),
+        self.options.entry.clone(),
+        Default::default(),
+        Default::default(),
+        self.plugin_driver.clone(),
+        self.loader_runner_runner.clone(),
+        self.cache.clone(),
+      ),
     );
 
     // Fake this compilation as *currently* rebuilding does not create a new compilation

--- a/crates/rspack_core/src/utils/fast_set.rs
+++ b/crates/rspack_core/src/utils/fast_set.rs
@@ -1,0 +1,14 @@
+use std::{mem, thread};
+
+/// Fast set `src` into the referenced `dest`, and drop the old value in other thread
+///
+/// This method is used when the dropping time is long
+pub fn fast_set<T>(dest: &mut T, src: T)
+where
+  T: Send + 'static,
+{
+  let old = mem::replace(dest, src);
+  thread::spawn(move || {
+    mem::drop(old);
+  });
+}

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -22,6 +22,9 @@ pub use hash::*;
 mod module_rules;
 pub use module_rules::*;
 
+mod fast_set;
+pub use fast_set::*;
+
 pub static PATH_START_BYTE_POS_MAP: Lazy<Arc<DashMap<String, u32>>> =
   Lazy::new(|| Arc::new(DashMap::new()));
 


### PR DESCRIPTION
## Summary

new compilation with drop old compilation in other thread
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

![image](https://user-images.githubusercontent.com/9291503/207538486-1a3323a5-c91a-4bf0-9d70-a0f4ddc25030.png)

![image](https://user-images.githubusercontent.com/9291503/207540119-84dd6a64-0d2c-4c3c-a69c-b6ef63ada11b.png)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
