### PR TITLE
(WIP) feat: use module type in identifier

### DIFF
--- a/crates/rspack_core/src/cache/occasion/resolve_module.rs
+++ b/crates/rspack_core/src/cache/occasion/resolve_module.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use futures::Future;
 use rspack_error::Result;
-use std::sync::Arc;
+use std::{path::Path, sync::Arc};
 
 type Storage = dyn storage::Storage<(Snapshot, ResolveResult)>;
 
@@ -38,7 +38,11 @@ impl ResolveModuleOccasion {
       None => return generator(args).await,
     };
 
-    let id = format!("{}|{}", args.importer.unwrap_or(""), args.specifier);
+    let id = format!(
+      "{}|{}",
+      args.context.unwrap_or(&Path::new("")).display(),
+      args.specifier
+    );
     {
       // read
       if let Some((snapshot, data)) = storage.get(&id) {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -1,4 +1,5 @@
 use std::hash::Hash;
+use std::path::Path;
 use std::{any::Any, borrow::Cow, fmt::Debug};
 
 use async_trait::async_trait;
@@ -77,6 +78,10 @@ pub trait Module: Debug + Send + Sync + AsAny + DynHash + DynEq + Identifiable {
   fn readable_identifier(&self, _context: &Context) -> Cow<str>;
 
   fn size(&self, _source_type: &SourceType) -> f64;
+
+  fn context(&self) -> Option<&Path> {
+    None
+  }
 
   async fn build(
     &mut self,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -2,6 +2,7 @@ use std::{
   borrow::Cow,
   fmt::Debug,
   hash::Hash,
+  path::Path,
   sync::{
     atomic::{AtomicU32, Ordering},
     Arc,
@@ -430,6 +431,10 @@ impl Module for NormalModule {
 
   fn readable_identifier(&self, context: &Context) -> Cow<str> {
     Cow::Owned(context.shorten(&self.user_request))
+  }
+
+  fn context(&self) -> Option<&Path> {
+    Path::new(&self.resource_resolved_data().resource_path).parent()
   }
 
   fn size(&self, source_type: &SourceType) -> f64 {

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -19,8 +19,9 @@ pub type PluginMakeHookOutput = Result<()>;
 pub type PluginBuildEndHookOutput = Result<()>;
 pub type PluginProcessAssetsHookOutput = Result<()>;
 pub type PluginReadResourceOutput = Result<Option<Content>>;
-// FIXME: factorize should only return `BoxModule`, the first string currently is used to generate `id`(moduleIds)
-pub type PluginFactorizeHookOutput = Result<Option<(String, BoxModule)>>;
+pub type PluginLoadHookOutput = Result<Option<Content>>;
+// pub type PluginTransformOutput = Result<TransformResult>;
+pub type PluginFactorizeHookOutput = Result<Option<BoxModule>>;
 pub type PluginModuleHookOutput = Result<Option<BoxModule>>;
 pub type PluginRenderManifestHookOutput = Result<Vec<RenderManifestEntry>>;
 pub type PluginRenderChunkHookOutput = Result<Option<BoxSource>>;

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -7,6 +7,9 @@ use crate::{
 use hashbrown::HashSet;
 use rspack_error::{internal_error, Error, Result};
 use std::fmt::Debug;
+use std::path::Path;
+use swc_core::ecma::ast::Program as SwcProgram;
+use swc_css::ast::Stylesheet;
 
 // #[derive(Debug)]
 // pub struct ParseModuleArgs<'a> {
@@ -53,6 +56,7 @@ pub struct ModuleArgs {
 
 #[derive(Debug, Clone)]
 pub struct ResolveArgs<'a> {
+  pub context: Option<&'a Path>,
   pub importer: Option<&'a str>,
   pub specifier: &'a str,
   pub kind: ResolveKind,

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -10,23 +10,10 @@ pub async fn resolve(
   //  _job_context: &mut NormalModuleFactoryContext,
 ) -> Result<ResolveResult> {
   let plugin_driver = plugin_driver.read().await;
-  let base_dir = if let Some(importer) = args.importer {
-    {
-      // TODO: delete this fn after use `normalModule.context` rather than `importer`
-      if let Some(index) = importer.find('?') {
-        Path::new(&importer[0..index])
-      } else {
-        Path::new(importer)
-      }
-    }
-    .parent()
-    .ok_or_else(|| anyhow::format_err!("parent() failed for {:?}", importer))?
-  } else {
-    &plugin_driver.options.context
-  };
+  let base_dir = args.context.unwrap_or(&plugin_driver.options.context);
   tracing::trace!(
-    "resolved importer:{:?},specifier:{:?}",
-    args.importer,
+    "resolved context:{:?},specifier:{:?}",
+    args.context,
     args.specifier
   );
   let resolver = args

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -39,7 +39,7 @@ impl Plugin for ExternalPlugin {
               target.to_owned(),
               args.dependency.detail.specifier.clone(),
             );
-            return Ok(Some((specifier.to_owned(), external_module.boxed())));
+            return Ok(Some(external_module.boxed()));
           }
         }
         _ => {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
