### PR TITLE
perf: reduce snapshot lock contention

### DIFF
--- a/crates/rspack_core/src/cache/snapshot/manager.rs
+++ b/crates/rspack_core/src/cache/snapshot/manager.rs
@@ -17,7 +17,6 @@ pub struct SnapshotManager {
   update_time_cache: DashMap<String, SystemTime>,
   /// cache file hash
   hash_cache: DashMap<String, u64>,
-  // update_time_and_hash_cache: DashMap<String, (Option<SystemTime>, Option<u64>)>,
 }
 
 impl SnapshotManager {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Benchmarking with the HMR case:

Before:
<img width="574" alt="image" src="https://user-images.githubusercontent.com/10465670/207653230-75994a63-4bba-40e2-bd4d-d420fb913295.png">

After:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/10465670/207653268-c366727f-37fb-48b0-9d2a-13e063150be6.png">


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
