### PR TITLE
feat: cli serve do not write dist file

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -56,6 +56,7 @@ pub struct RawBuiltins {
   pub progress: Option<RawProgressPluginConfig>,
   pub react: Option<RawReactOptions>,
   pub decorator: Option<RawDecoratorOptions>,
+  pub no_emit_assets: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -74,6 +75,7 @@ pub struct RawBuiltins {
   pub progress: Option<RawProgressPluginConfig>,
   pub react: Option<RawReactOptions>,
   pub decorator: Option<RawDecoratorOptions>,
+  pub no_emit_assets: Option<bool>,
 }
 
 pub(super) fn normalize_builtin(
@@ -137,6 +139,7 @@ pub(super) fn normalize_builtin(
     side_effects: builtins.side_effects.unwrap_or_default(),
     react: RawOption::raw_to_compiler_option(builtins.react, options)?,
     decorator: transform_to_decorator_options(builtins.decorator),
+    no_emit_assets: builtins.no_emit_assets.unwrap_or(false),
   };
   Ok(ret)
 }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -141,7 +141,10 @@ impl Compiler {
       .compilation
       .push_batch_diagnostic(plugin_driver_diagnostics);
 
-    self.emit_assets(&self.compilation)?;
+    if !self.compilation.options.builtins.no_emit_assets {
+      self.emit_assets(&self.compilation)?;
+    }
+
     self.compilation.done(self.plugin_driver.clone()).await?;
 
     Ok(())

--- a/crates/rspack_core/src/options/builtins.rs
+++ b/crates/rspack_core/src/options/builtins.rs
@@ -37,6 +37,7 @@ pub struct Builtins {
   pub side_effects: bool,
   pub react: ReactOptions,
   pub decorator: Option<DecoratorOptions>,
+  pub no_emit_assets: bool,
 }
 
 #[derive(Debug, Clone, Default, Copy)]

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -107,6 +107,11 @@ export class RspackCLI {
 			minify: item.builtins?.minify ?? isEnvProduction
 		};
 
+		// no emit assets when run dev server, it will use node_binding api get file content
+		if (typeof item.builtins.noEmitAssets === "undefined") {
+			item.builtins.noEmitAssets = isEnvDevelopment;
+		}
+
 		// Tells webpack to set process.env.NODE_ENV to a given string value.
 		// optimization.nodeEnv uses DefinePlugin unless set to false.
 		// optimization.nodeEnv defaults to mode if set, else falls back to 'production'.

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -11,7 +11,11 @@
   "dependencies": {
     "@rspack/core": "workspace:*",
     "express": "4.18.1",
-    "webpack-dev-middleware": "6.0.0"
+    "webpack-dev-middleware": "6.0.0",
+    "mime-types": "2.1.35"
+  },
+  "devDependencies": {
+    "@types/mime-types": "2.1.1"
   },
   "keywords": [],
   "author": "",

--- a/packages/rspack-dev-middleware/src/index.ts
+++ b/packages/rspack-dev-middleware/src/index.ts
@@ -17,3 +17,4 @@ const rdm: typeof wdm = (compiler, options) => {
 };
 
 export default rdm;
+export * from "./middleware";

--- a/packages/rspack-dev-middleware/src/middleware.ts
+++ b/packages/rspack-dev-middleware/src/middleware.ts
@@ -1,0 +1,23 @@
+import { extname } from "path";
+import type { Compiler } from "@rspack/core";
+import type { RequestHandler } from "express";
+import { lookup } from "mime-types";
+
+export function getRspackMemoryAssets(compiler: Compiler): RequestHandler {
+	return function (req, res, next) {
+		const { method, path } = req;
+		if (method !== "GET") {
+			return next();
+		}
+
+		// asset name is not start with /, so path need to slice 1
+		let buffer = compiler.getAsset(path.slice(1));
+		if (!buffer) {
+			return next();
+		}
+
+		let contentType = lookup(extname(path)) || "text/plain";
+		res.setHeader("Content-Type", contentType);
+		res.send(buffer);
+	};
+}

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -8,7 +8,7 @@ import type {
 	RequestHandler as ExpressRequestHandler,
 	ErrorRequestHandler as ExpressErrorRequestHandler
 } from "express";
-import type { DevMiddleware } from "@rspack/dev-middleware";
+import { DevMiddleware, getRspackMemoryAssets } from "@rspack/dev-middleware";
 import type { Server } from "http";
 import type { ResolvedDev } from "./config";
 import fs from "fs";
@@ -400,6 +400,11 @@ export class RspackDevServer {
 			this.compiler.options.output.publicPath === "auto"
 				? ""
 				: this.compiler.options.output.publicPath;
+		middlewares.push({
+			name: "rspack-memory-assets",
+			path: publicPath,
+			middleware: getRspackMemoryAssets(this.compiler)
+		});
 		middlewares.push({
 			name: "express-static",
 			path: publicPath,

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -210,7 +210,11 @@ export class Compilation {
 	 * @internal
 	 */
 	__internal__getAssetSource(filename: string): Source | null {
-		return createSourceFromRaw(this.#inner.getAssetSource(filename));
+		const rawSource = this.#inner.getAssetSource(filename);
+		if (!rawSource) {
+			return null;
+		}
+		return createSourceFromRaw(rawSource);
 	}
 
 	/**

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -379,6 +379,14 @@ class Compiler {
 			}
 		);
 	}
+
+	getAsset(name: string) {
+		let source = this.compilation.__internal__getAssetSource(name);
+		if (!source) {
+			return null;
+		}
+		return source.buffer();
+	}
 }
 
 export { Compiler };

--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -5,7 +5,6 @@ import type {
 	Minification
 } from "@rspack/binding";
 import { loadConfig } from "browserslist";
-import { Dev } from "./devServer";
 
 export type BuiltinsHtmlPluginConfig = Omit<RawHtmlPluginConfig, "meta"> & {
 	meta?: Record<string, string | Record<string, string>>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,12 +419,17 @@ importers:
   packages/rspack-dev-middleware:
     specifiers:
       '@rspack/core': workspace:*
+      '@types/mime-types': 2.1.1
       express: 4.18.1
+      mime-types: 2.1.35
       webpack-dev-middleware: 6.0.0
     dependencies:
       '@rspack/core': link:../rspack
       express: 4.18.1
+      mime-types: 2.1.35
       webpack-dev-middleware: 6.0.0
+    devDependencies:
+      '@types/mime-types': 2.1.1
 
   packages/rspack-dev-server:
     specifiers:
@@ -4648,6 +4653,10 @@ packages:
 
   /@types/lodash/4.14.189:
     resolution: {integrity: sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==}
+    dev: true
+
+  /@types/mime-types/2.1.1:
+    resolution: {integrity: sha512-vXOTGVSLR2jMw440moWTC7H19iUyLtP3Z1YTj7cSsubOICinjMxFeb/V57v9QdyyPGbbWolUFSSmSiRSn94tFw==}
     dev: true
 
   /@types/mime/3.0.1:


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
1. add `builtins.no_emit_assets` options to control dist file write in rust side
2. dev server add a middleware to read assets info from rust directly

before
![image](https://user-images.githubusercontent.com/9291503/207867905-c9e6d407-ec62-44fa-8b05-7d18f6af970a.png)

after
![image](https://user-images.githubusercontent.com/9291503/207865898-f900d2a7-db72-4374-a60a-2c571c3421f4.png)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
