### PR TITLE
feat: add stats hash

### DIFF
--- a/crates/node_binding/src/js_values/compilation.rs
+++ b/crates/node_binding/src/js_values/compilation.rs
@@ -191,6 +191,11 @@ impl JsCompilation {
       })
       .collect()
   }
+
+  #[napi(getter)]
+  pub fn hash(&self) -> String {
+    self.inner.hash.to_string()
+  }
 }
 
 impl JsCompilation {

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -8,7 +8,6 @@ import {
 	JsAsset
 } from "@rspack/binding";
 
-import { createHash } from "./utils/createHash";
 import { RspackOptionsNormalized } from "./config";
 import { createRawFromSource, createSourceFromRaw } from "./utils/createSource";
 import { ResolvedOutput } from "./config/output";
@@ -24,8 +23,6 @@ export class Compilation {
 	hooks: {
 		processAssets: tapable.AsyncSeriesHook<Record<string, Source>>;
 	};
-	fullHash: string;
-	hash: string;
 	options: RspackOptionsNormalized;
 	outputOptions: ResolvedOutput;
 	compiler: Compiler;
@@ -39,10 +36,15 @@ export class Compilation {
 		this.compiler = compiler;
 		this.options = compiler.options;
 		this.outputOptions = compiler.options.output;
-		const hash = createHash(this.options.output.hashFunction);
-		this.fullHash = hash.digest(this.options.output.hashDigest);
-		this.hash = this.fullHash.slice(0, hashDigestLength);
 		this.#inner = inner;
+	}
+
+	get hash() {
+		return this.#inner.hash;
+	}
+
+	get fullHash() {
+		return this.#inner.hash;
 	}
 
 	/**

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -26,6 +26,10 @@ export class Stats {
 		this.compilation = compilation;
 	}
 
+	get hash() {
+		return this.compilation.hash;
+	}
+
 	hasErrors() {
 		return this.#statsJson.errorsCount > 0;
 	}

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -17,6 +17,7 @@ describe("Stats", () => {
 			}
 		});
 		const statsOptions = { all: true };
+		expect(typeof stats.hash).toBe("string");
 		expect(stats.toJson(statsOptions)).toMatchInlineSnapshot(`
 		{
 		  "assets": [


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
