### PR TITLE
adding args to trace 

### DIFF
--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -28,6 +28,7 @@ use sass_embedded::{
 use serde::Deserialize;
 use str_indices::utf16;
 use tokio::sync::Mutex;
+use tracing::instrument;
 
 static IS_SPECIAL_MODULE_IMPORT: Lazy<Regex> = Lazy::new(|| Regex::new(r"^~[^/]+$").unwrap());
 static IS_NATIVE_WIN32_PATH: Lazy<Regex> =
@@ -457,7 +458,7 @@ impl Loader<CompilerContext, CompilationContext> for SassLoader {
   fn name(&self) -> &'static str {
     "sass-loader"
   }
-
+  #[instrument("sass-loader", skip_self)]
   async fn run(
     &self,
     loader_context: &LoaderContext<'_, '_, CompilerContext, CompilationContext>,

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -197,7 +197,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     module.original_source().map_or(0, |source| source.size()) as f64
   }
 
-  #[instrument(name = "js:parse", skip_all)]
+  #[instrument(name = "js:parse", fields(name = &parse_context.resource_data.resource_path),skip_all)]
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>> {
     let ParseContext {
       source,

--- a/crates/rspack_tracing/src/lib.rs
+++ b/crates/rspack_tracing/src/lib.rs
@@ -56,7 +56,7 @@ pub fn enable_tracing_by_env_with_chrome_layer() -> Option<FlushGuard> {
     use tracing_chrome::ChromeLayerBuilder;
     use tracing_subscriber::{prelude::*, EnvFilter};
 
-    let (chrome_layer, guard) = ChromeLayerBuilder::new().build();
+    let (chrome_layer, guard) = ChromeLayerBuilder::new().include_args(true).build();
     // If we don't do this. chrome_layer will collect nothing.
     // std::mem::forget(guard);
     tracing_subscriber::registry()


### PR DESCRIPTION
## Summary
args is very helpful for debugging performance problem
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
