### PR TITLE
chore: fix return empty string are overrided in previous loader

### DIFF
--- a/packages/rspack/src/config/module.ts
+++ b/packages/rspack/src/config/module.ts
@@ -276,10 +276,10 @@ function composeJsUse(
 				additionalData =
 					(typeof loaderResult.additionalData === "string"
 						? JSON.parse(loaderResult.additionalData)
-						: loaderResult.additionalData) || additionalData;
-				content = loaderResult.content || content;
-				sourceMap = loaderResult.sourceMap || sourceMap;
-				cacheable = loaderResult.cacheable || cacheable;
+						: loaderResult.additionalData) ?? additionalData;
+				content = loaderResult.content ?? content;
+				sourceMap = loaderResult.sourceMap ?? sourceMap;
+				cacheable = loaderResult.cacheable ?? cacheable;
 			}
 		}
 


### PR DESCRIPTION
## Summary
currently if we return empty string from previous loader it will be override by source which is not what webpack doing
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
