### PR TITLE
fix: fix null exception when not set devServer

### DIFF
--- a/packages/rspack/src/config/module.ts
+++ b/packages/rspack/src/config/module.ts
@@ -304,7 +304,7 @@ function composeJsUse(
 					resourceFragment: data.resourceFragment || "",
 					loaderIndex,
 					mode: compiler.options.mode,
-					hot: compiler.options.devServer.hot,
+					hot: compiler.options.devServer?.hot,
 					getOptions(schema) {
 						let { options } = use;
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
