### PR TITLE
 fix:add more panic info about dependency resolve

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/tree_shaking.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/tree_shaking.rs
@@ -79,7 +79,20 @@ impl<'a> Fold for TreeShaker<'a> {
         ModuleDecl::Import(ref import) => {
           let module_identifier = self
             .resolve_module_identifier(import.src.value.to_string(), ResolveKind::Import)
-            .unwrap();
+            .unwrap_or_else(|| {
+              // FIXME: This is just a hack because of an unstable bug panic here.
+              panic!(
+                "Failed to resolve {:?},",
+                Dependency {
+                  detail: ModuleDependency {
+                    specifier: import.src.value.to_string(),
+                    kind: ResolveKind::Import,
+                    span: None,
+                  },
+                  parent_module_identifier: Some(self.module_identifier),
+                }
+              )
+            });
           let mgm = self
             .module_graph
             .module_graph_module_by_identifier(&module_identifier)


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
