### PR TITLE
chore: bump version, add more panic info

### DIFF
--- a/crates/node_binding/CHANGELOG.md
+++ b/crates/node_binding/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/binding
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Node binding for rspack",
   "main": "binding.js",
   "types": "binding.d.ts",

--- a/npm/darwin-arm64/CHANGELOG.md
+++ b/npm/darwin-arm64/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/binding-darwin-arm64
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",
   "publishConfig": {

--- a/npm/darwin-x64/CHANGELOG.md
+++ b/npm/darwin-x64/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/binding-darwin-x64
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",
   "publishConfig": {

--- a/npm/linux-x64-gnu/CHANGELOG.md
+++ b/npm/linux-x64-gnu/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/binding-linux-x64-gnu
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",
   "publishConfig": {

--- a/packages/create-rspack/CHANGELOG.md
+++ b/packages/create-rspack/CHANGELOG.md
@@ -1,5 +1,11 @@
 # create-rspack
 
+## 0.0.14
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.13
 
 ### Patch Changes

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "",
   "main": "index.js",
   "bin": {

--- a/packages/less-loader/CHANGELOG.md
+++ b/packages/less-loader/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/plugin-less
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/less-loader/package.json
+++ b/packages/less-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/less-loader",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "less plugin for rspack",
   "author": "wangzhenzhuo",
   "main": "dist/index.js",

--- a/packages/postcss-loader/CHANGELOG.md
+++ b/packages/postcss-loader/CHANGELOG.md
@@ -1,5 +1,13 @@
 # rspack-plugin-postcss
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/binding@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/postcss-loader/package.json
+++ b/packages/postcss-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/postcss-loader",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/packages/rspack-cli/CHANGELOG.md
+++ b/packages/rspack-cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rspack/cli
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/core@0.0.18
+  - @rspack/dev-server@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "bin": {
     "rspack": "./bin/rspack"
   },

--- a/packages/rspack-dev-client/CHANGELOG.md
+++ b/packages/rspack-dev-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rspack/dev-client
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/core@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rspack/dev-client",
   "description": "",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",

--- a/packages/rspack-dev-middleware/CHANGELOG.md
+++ b/packages/rspack-dev-middleware/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rspack/dev-middleware
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/core@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/dev-middleware",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rspack-dev-server/CHANGELOG.md
+++ b/packages/rspack-dev-server/CHANGELOG.md
@@ -1,5 +1,16 @@
 # rspack-dev-server
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/core@0.0.18
+  - @rspack/dev-client@0.0.18
+  - @rspack/dev-middleware@0.0.18
+  - @rspack/dev-server@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rspack/dev-server",
   "description": "",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {

--- a/packages/rspack-plugin-html/CHANGELOG.md
+++ b/packages/rspack-plugin-html/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @rspack/plugin-html
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/core@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-html",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "html plugin for rspack",
   "author": "",
   "main": "dist/index.js",

--- a/packages/rspack-plugin-minify/CHANGELOG.md
+++ b/packages/rspack-plugin-minify/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/plugin-minify
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-plugin-minify/package.json
+++ b/packages/rspack-plugin-minify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-minify",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "src/index.js",
   "scripts": {},

--- a/packages/rspack-plugin-node-polyfill/CHANGELOG.md
+++ b/packages/rspack-plugin-node-polyfill/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @rspack/plugin-node-polyfill
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack-plugin-node-polyfill/package.json
+++ b/packages/rspack-plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/plugin-node-polyfill",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/packages/rspack/CHANGELOG.md
+++ b/packages/rspack/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @rspack/core
 
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+- Updated dependencies
+  - @rspack/binding@0.0.18
+  - @rspack/dev-client@0.0.18
+
 ## 0.0.17
 
 ### Patch Changes

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
