### PR TITLE
feat(core): auto publicPath and do not resolve url started by `data:`

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -145,6 +145,9 @@ impl NormalModuleFactory {
     let importer = self.dependency.parent_module_identifier.as_deref();
     let specifier = self.dependency.detail.specifier.as_str();
     let kind = self.dependency.detail.kind;
+    if should_skip_resolve(specifier) {
+      return Ok(None);
+    }
     let resolve_args = ResolveArgs {
       importer,
       specifier,
@@ -397,6 +400,10 @@ impl NormalModuleFactory {
   //     normal_module_factory.create().await;
   //   });
   // }
+}
+
+pub fn should_skip_resolve(s: &str) -> bool {
+  s.starts_with("data:") || s.starts_with("http://") || s.starts_with("https://")
 }
 
 pub fn resolve_module_type_by_uri<T: AsRef<Path>>(uri: T) -> Option<ModuleType> {

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -17,8 +17,7 @@ impl RuntimeModule for PublicPathRuntimeModule {
         include_str!("runtime/public_path.js").replace("__PUBLIC_PATH_PLACEHOLDER__", str),
       )
       .boxed(),
-      // TODO
-      PublicPath::Auto => RawSource::from("".to_string()).boxed(),
+      PublicPath::Auto => RawSource::from(include_str!("runtime/public_path_auto.js")).boxed(),
     }
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/public_path_auto.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/public_path_auto.js
@@ -1,0 +1,26 @@
+var scriptUrl;
+// TODO: should use `__webpack_require__.g`
+// if (__webpack_require__.g.importScripts) {
+//   scriptUrl = __webpack_require__.g.location + ""
+// };
+// var document = __webpack_require__.g.document;
+if (self.importScripts) {
+	scriptUrl = self.location + "";
+}
+var document = self.document;
+if (!scriptUrl && document) {
+	if (document.currentScript) scriptUrl = document.currentScript.src;
+	if (!scriptUrl) {
+		var scripts = document.getElementsByTagName("script");
+		if (scripts.length) scriptUrl = scripts[scripts.length - 1].src;
+	}
+}
+// When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration
+// or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.
+if (!scriptUrl)
+	throw new Error("Automatic publicPath is not supported in this browser");
+scriptUrl = scriptUrl
+	.replace(/#.*$/, "")
+	.replace(/\?.*$/, "")
+	.replace(/\/[^\/]+$/, "/");
+__webpack_require__.p = scriptUrl;

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -34,7 +34,7 @@ describe("Stats", () => {
 		        "hotModuleReplacement": false,
 		      },
 		      "name": "main.js",
-		      "size": 11808,
+		      "size": 12163,
 		      "type": "asset",
 		    },
 		  ],
@@ -58,10 +58,10 @@ describe("Stats", () => {
 		      "assets": [
 		        {
 		          "name": "main.js",
-		          "size": 11808,
+		          "size": 12163,
 		        },
 		      ],
-		      "assetsSize": 11808,
+		      "assetsSize": 12163,
 		      "chunks": [
 		        "main",
 		      ],
@@ -89,7 +89,7 @@ describe("Stats", () => {
 	`);
 		expect(stats.toString(statsOptions)).toMatchInlineSnapshot(`
 		"  Asset      Size  Chunks             Chunk Names
-		main.js  11.5 KiB    main  [emitted]  main
+		main.js  11.9 KiB    main  [emitted]  main
 		Entrypoint main = main.js
 		chunk {main} main.js (main) 55 bytes [entry]
 		[876] ./fixtures/a.js 55 bytes {main}"

--- a/packages/rspack/tests/cases/css/rewrite-url/index.css
+++ b/packages/rspack/tests/cases/css/rewrite-url/index.css
@@ -1,3 +1,6 @@
 body {
-  background-image: url('./logo.png');
+	background-image: url("./logo.png");
+}
+p {
+	background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAOCAYAAAAbvf3sAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAEWSURBVHgBjZFRSsNAEIb/3fQAOUK9gfpe6YIovjU3UE+gJ2g8gTcw3sC+itUFrW+BeAN7ATFSKAjbHWcSC+mSlszLDrvfzvzzj0LHmNpZBtBQd4Gf7fuYgHPPueoCe1DK1UsHd7Dzw+P0daQj/SC5h09OzdGktw221vZXUBlVMN0ILPd6O9yzBBXX8CBdv6kWOGa4YLivQJNjM0ia73oTLsBwJjCB5gu4i7CgbsIey5ThEcOfKziTGFOGHypJeZ7jZ/Gbst4x2/fN9h2eGTNvgk92VrDEWLNmfJXLpIYrRy5b4Fs+9v2/pL0oUncI7FuHLI6PK5lJZGoe8qXNvrry27DesoRLpLPmNkTw9yEcxPWJMR+S/AFbfpAZqxwUNQAAAABJRU5ErkJggg==");
 }


### PR DESCRIPTION
This PR brings these changes:

1. use `scriptUrl` to reassign the value of `__webpack_require__.p`. Fixed #1474 
2. skip resolve asset which url begins with `data:` or `https?:`