### PR TITLE
fix: 🐛 ci js snapshot release

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -15,7 +15,7 @@
     "build:debug": "napi build --platform --js false --dts binding.d.ts --config napirs.rc.json",
     "build:debug:x64": "napi build --platform --js false --dts binding.d.ts --config napirs.rc.json --target x86_64-apple-darwin",
     "build:release:all": "run-p build:release build:release:x64 build:release:linux && pnpm move-binding",
-    "build:release": "napi build --release --platform --js false --dts binding.d.ts --config napirs.rc.json",
+    "build:release": "napi build --release --platform --js false --dts binding.d.ts --config napirs.rc.json && pnpm move-binding",
     "build:release:x64": "napi build --release --platform --js false --dts binding.d.ts --config napirs.rc.json --target x86_64-apple-darwin",
     "build:release:linux": "napi build --release --platform --js false --dts binding.d.ts --config napirs.rc.json --zig --target x86_64-unknown-linux-gnu --zig-abi-suffix=2.17",
     "move-binding": "node scripts/move-binding"


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
