### PR TITLE
chore: add more panic info

### DIFF
--- a/crates/rspack_core/src/chunk_spliter/split_chunks.rs
+++ b/crates/rspack_core/src/chunk_spliter/split_chunks.rs
@@ -108,7 +108,7 @@ impl<'me> CodeSplitter<'me> {
       for dep in dependencies.iter() {
         let module = module_graph
           .module_by_dependency(dep)
-          .ok_or_else(|| anyhow::format_err!("no module found"))?;
+          .ok_or_else(|| anyhow::format_err!("no module found: {:?}", &dep))?;
         compilation.chunk_graph.add_module(module.module_identifier);
 
         input_entrypoints_and_modules
@@ -322,7 +322,7 @@ impl<'me> CodeSplitter<'me> {
         .compilation
         .module_graph
         .module_graph_module_by_identifier_mut(&item.module_identifier)
-        .expect("No module found");
+        .unwrap_or_else(|| panic!("No module found {:?}", &item.module_identifier));
 
       if module.pre_order_index.is_none() {
         module.pre_order_index = Some(self.next_free_module_pre_order_index);
@@ -360,7 +360,7 @@ impl<'me> CodeSplitter<'me> {
       .compilation
       .module_graph
       .module_graph_module_by_identifier_mut(&item.module_identifier)
-      .expect("no module found");
+      .unwrap_or_else(|| panic!("no module found: {:?}", &item.module_identifier));
 
     if module.post_order_index.is_none() {
       module.post_order_index = Some(self.next_free_module_post_order_index);
@@ -374,7 +374,7 @@ impl<'me> CodeSplitter<'me> {
       .compilation
       .module_graph
       .module_graph_module_by_identifier(&item.module_identifier)
-      .expect("no module found");
+      .unwrap_or_else(|| panic!("no module found: {:?}", &item.module_identifier));
 
     for dep_mgm in mgm
       .depended_modules(&self.compilation.module_graph)


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
