### PR TITLE
chore:use exact version

### DIFF
--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -29,8 +29,8 @@
     "npm-run-all": "4.1.5"
   },
   "optionalDependencies": {
-    "@rspack/binding-darwin-arm64": "workspace:^",
-    "@rspack/binding-linux-x64-gnu": "workspace:^",
-    "@rspack/binding-darwin-x64": "workspace:^"
+    "@rspack/binding-darwin-arm64": "workspace:*",
+    "@rspack/binding-linux-x64-gnu": "workspace:*",
+    "@rspack/binding-darwin-x64": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,9 +39,9 @@ importers:
   crates/node_binding:
     specifiers:
       '@napi-rs/cli': ^2.6.2
-      '@rspack/binding-darwin-arm64': workspace:^
-      '@rspack/binding-darwin-x64': workspace:^
-      '@rspack/binding-linux-x64-gnu': workspace:^
+      '@rspack/binding-darwin-arm64': workspace:*
+      '@rspack/binding-darwin-x64': workspace:*
+      '@rspack/binding-linux-x64-gnu': workspace:*
       npm-run-all: 4.1.5
       why-is-node-running: 2.2.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
