### PR TITLE
feat: add module issuer

### DIFF
--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -78,6 +78,8 @@ pub struct JsStatsModule {
   pub id: String,
   pub chunks: Vec<String>,
   pub size: f64,
+  pub issuer: Option<String>,
+  pub issuer_name: Option<String>,
 }
 
 impl From<rspack_core::StatsModule> for JsStatsModule {
@@ -90,6 +92,8 @@ impl From<rspack_core::StatsModule> for JsStatsModule {
       module_type: stats.module_type.to_string(),
       identifier: stats.identifier,
       id: stats.id,
+      issuer: stats.issuer,
+      issuer_name: stats.issuer_name,
     }
   }
 }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -358,8 +358,14 @@ impl Compilation {
         match rx.try_recv() {
           Ok(item) => match item {
             Msg::ModuleCreated(module_with_diagnostic) => {
-              let (mgm, module, original_module_identifier, dependency_id, dependency, is_entry) =
-                *module_with_diagnostic.inner;
+              let (
+                mut mgm,
+                module,
+                original_module_identifier,
+                dependency_id,
+                dependency,
+                is_entry,
+              ) = *module_with_diagnostic.inner;
 
               let module_identifier = module.identifier();
 
@@ -384,6 +390,8 @@ impl Compilation {
               if is_entry {
                 self.entry_module_identifiers.insert(module_identifier);
               }
+
+              mgm.set_issuer_if_unset(original_module_identifier);
 
               self.handle_module_build_and_dependencies(
                 original_module_identifier,

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -95,6 +95,7 @@ impl<'compilation> Stats<'compilation> {
           .module_graph
           .module_graph_module_by_identifier(&identifier)
           .unwrap();
+        let issuer = mgm.get_issuer();
         let mut chunks: Vec<String> = self
           .compilation
           .chunk_graph
@@ -114,6 +115,13 @@ impl<'compilation> Stats<'compilation> {
           id: mgm.id(&self.compilation.chunk_graph).to_string(),
           chunks,
           size: module.size(&SourceType::JavaScript),
+          issuer: issuer.identifier().map(|i| i.to_string()),
+          issuer_name: issuer
+            .readable_identifier(
+              &self.compilation.module_graph,
+              &self.compilation.options.context,
+            )
+            .map(|i| i.to_string()),
         }
       })
       .collect();
@@ -288,6 +296,8 @@ pub struct StatsModule {
   pub id: String,
   pub chunks: Vec<String>,
   pub size: f64,
+  pub issuer: Option<String>,
+  pub issuer_name: Option<String>,
 }
 
 #[derive(Debug)]

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -131,6 +131,8 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       ],
       "id": "426",
       "identifier": "<PROJECT_ROOT>/tests/statsCases/filename/dynamic.js",
+      "issuer": "<PROJECT_ROOT>/tests/statsCases/filename/index.js",
+      "issuerName": "./index.js",
       "moduleType": "js",
       "name": "./dynamic.js",
       "size": 32,


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

closes #1477 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
