### PR TITLE
fix: avoid extra strict mode(close: #1463)

### DIFF
--- a/crates/rspack/tests/fixtures/code-splitting/expected/a_js.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/a_js.js
@@ -1,6 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["a_js"], {
 "./a.js": function (module, exports, __webpack_require__) {
-"use strict";
 console.log('a');
 },
 

--- a/crates/rspack/tests/fixtures/code-splitting/expected/b_js.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/b_js.js
@@ -1,6 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["b_js"], {
 "./b.js": function (module, exports, __webpack_require__) {
-"use strict";
 console.log('b');
 },
 

--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -1,6 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
 console.log('hello, world');
 __webpack_require__.e("a_js").then(__webpack_require__.bind(__webpack_require__, "./a.js"));
 __webpack_require__.e("b_js").then(__webpack_require__.bind(__webpack_require__, "./b.js"));

--- a/crates/rspack/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack/tests/fixtures/simple/expected/main.js
@@ -1,6 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
 console.log('hello, world');
 },
 

--- a/crates/rspack/tests/fixtures/static-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/static-import/expected/main.js
@@ -8,7 +8,6 @@ __webpack_require__("./b.js");
 console.log('a');
 },
 "./b.js": function (module, exports, __webpack_require__) {
-"use strict";
 console.log('b');
 },
 "./index.js": function (module, exports, __webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
@@ -15,11 +15,9 @@ const a = "a";
 exports.test = 30;
 },
 "./b.js": function (module, exports, __webpack_require__) {
-"use strict";
 module.exports = a = "b";
 },
 "./foo.js": function (module, exports, __webpack_require__) {
-"use strict";
 if (process.env.NODE_ENV !== "production") {
     const res = __webpack_require__("./a.js");
     module.exports = res;

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/expected/main.js
@@ -1,6 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
 it("should be able to load package without side effects where modules are unused", ()=>{
     __webpack_require__("./module.js");
 });

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
@@ -9,7 +9,6 @@ expect(_module.ok).toBe(true);
 expect(_module.ok2).toBe(true);
 },
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
 it("should not threat globals as pure", ()=>{
     __webpack_require__("./import-module.js");
 });

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -284,6 +284,11 @@ impl From<BoxSource> for AstOrSource {
   }
 }
 
+#[derive(Debug, Default)]
+pub struct BuildInfo {
+  pub strict: bool,
+}
+
 #[derive(Debug)]
 pub struct NormalModule {
   /// Request with loaders from config
@@ -312,6 +317,8 @@ pub struct NormalModule {
   cached_source_sizes: DashMap<SourceType, f64>,
 
   code_generation_dependencies: Option<Vec<Dependency>>,
+
+  pub build_info: BuildInfo,
 }
 
 #[derive(Debug)]
@@ -368,6 +375,7 @@ impl NormalModule {
       options,
       cached_source_sizes: DashMap::new(),
       code_generation_dependencies: None,
+      build_info: Default::default(),
     }
   }
 
@@ -482,6 +490,7 @@ impl Module for NormalModule {
         compiler_options: build_context.compiler_options,
         additional_data: loader_result.additional_data,
         code_generation_dependencies: &mut code_generation_dependencies,
+        build_info: &mut self.build_info,
       })?
       .split_into_parts();
     diagnostics.extend(ds);

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -7,8 +7,8 @@ use rspack_loader_runner::ResourceData;
 use rspack_sources::Source;
 
 use crate::{
-  AstOrSource, CodeGenerationResults, Compilation, CompilerOptions, GenerationResult, Module,
-  ModuleDependency, ModuleType, SourceType,
+  AstOrSource, BuildInfo, CodeGenerationResults, Compilation, CompilerOptions, GenerationResult,
+  Module, ModuleDependency, ModuleType, SourceType,
 };
 
 #[derive(Debug)]
@@ -19,6 +19,7 @@ pub struct ParseContext<'a> {
   pub compiler_options: &'a CompilerOptions,
   pub additional_data: Option<String>,
   pub code_generation_dependencies: &'a mut Vec<ModuleDependency>,
+  pub build_info: &'a mut BuildInfo,
 }
 
 #[derive(Debug)]

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -206,8 +206,10 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     &mut self,
     parse_context: rspack_core::ParseContext,
   ) -> Result<rspack_error::TWithDiagnosticArray<rspack_core::ParseResult>> {
-    let ParseContext { source, .. } = parse_context;
-
+    let ParseContext {
+      source, build_info, ..
+    } = parse_context;
+    build_info.strict = true;
     let size = source.size();
 
     self.parsed_asset_config = match &self.data_url {

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -367,8 +367,9 @@ impl ParserAndGenerator for CssParserAndGenerator {
       resource_data,
       compiler_options,
       code_generation_dependencies,
+      build_info,
     } = parse_context;
-
+    build_info.strict = true;
     let cm: Arc<swc_core::common::SourceMap> = Default::default();
     let content = source.source().to_string();
     let css_modules = matches!(module_type, ModuleType::CssModule);

--- a/crates/rspack_plugin_devtool/tests/fixtures/simple/expected/main.js.map
+++ b/crates/rspack_plugin_devtool/tests/fixtures/simple/expected/main.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"main.js","sources":["index.jsx"],"sourcesContent":["console.log(<div>?</div>);"],"names":[],"mappings":";;;;AAAA,QAAQ,GAAG,CAAC,oBAAC,aAAI"}
+{"version":3,"file":"main.js","sources":["index.jsx"],"sourcesContent":["console.log(<div>?</div>);"],"names":[],"mappings":";;;AAAA,QAAQ,GAAG,CAAC,oBAAC,aAAI"}

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -230,7 +230,13 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       ),
     };
 
-    run_before_pass(resource_data, &mut ast, compiler_options, syntax)?;
+    run_before_pass(
+      resource_data,
+      &mut ast,
+      compiler_options,
+      syntax,
+      parse_context.build_info,
+    )?;
 
     let dep_scanner = ast.visit(|program, context| {
       let mut dep_scanner = DependencyScanner::new(context.unresolved_mark);

--- a/crates/rspack_plugin_javascript/src/utils.rs
+++ b/crates/rspack_plugin_javascript/src/utils.rs
@@ -1,8 +1,8 @@
 use pathdiff::diff_paths;
 use rspack_core::rspack_sources::{
-  BoxSource, CachedSource, ConcatSource, MapOptions, RawSource, Source, SourceExt,
+  BoxSource, CachedSource, MapOptions, RawSource, Source, SourceExt,
 };
-use rspack_core::{runtime_globals, Compilation, ErrorSpan, ModuleType};
+use rspack_core::{Compilation, ErrorSpan, ModuleType};
 use rspack_error::{internal_error, DiagnosticKind, Error};
 use serde_json::json;
 use std::path::Path;
@@ -123,29 +123,6 @@ pub fn is_dynamic_import_literal_expr(e: &CallExpr) -> bool {
   } else {
     false
   }
-}
-
-pub fn wrap_module_function(source: BoxSource, module_id: &str) -> BoxSource {
-  /***
-   * generate wrapper module:
-   * {module_id}: function(module, exports, __rspack_require__, __rspack_dynamic_require__) {
-   * "use strict";
-   * {source}
-   * },
-   */
-  CachedSource::new(ConcatSource::new([
-    RawSource::from("\"").boxed(),
-    RawSource::from(module_id.to_string()).boxed(),
-    RawSource::from("\": ").boxed(),
-    RawSource::from(format!(
-      "function (module, exports, {}) {{\n",
-      runtime_globals::REQUIRE
-    ))
-    .boxed(),
-    source,
-    RawSource::from("},\n").boxed(),
-  ]))
-  .boxed()
 }
 
 pub fn ecma_parse_error_to_rspack_error(

--- a/crates/rspack_plugin_javascript/src/visitors/strict.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/strict.rs
@@ -1,0 +1,29 @@
+use rspack_core::ast::javascript::Context;
+use rspack_core::BuildInfo;
+use swc_core::ecma::ast::{Expr, ExprStmt, Lit, ModuleItem, Stmt, Str};
+use swc_core::ecma::visit::{as_folder, noop_visit_mut_type, Fold, VisitMut};
+
+pub fn strict_mode<'a>(build_info: &'a mut BuildInfo, context: &'a Context) -> impl Fold + 'a {
+  if context.is_esm {
+    build_info.strict = true;
+  }
+  as_folder(StrictModeVisitor { build_info })
+}
+
+struct StrictModeVisitor<'a> {
+  build_info: &'a mut BuildInfo,
+}
+
+impl<'a> VisitMut for StrictModeVisitor<'a> {
+  noop_visit_mut_type!();
+
+  fn visit_mut_module_item(&mut self, module_item: &mut ModuleItem) {
+    if let ModuleItem::Stmt(Stmt::Expr(ExprStmt { expr, .. })) = module_item {
+      if let Expr::Lit(Lit::Str(Str { ref value, .. })) = **expr {
+        if value == "use strict" {
+          self.build_info.strict = true;
+        }
+      }
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/constant_folding/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/constant_folding/expected/main.js
@@ -1,9 +1,7 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./development.js": function (module, exports, __webpack_require__) {
-"use strict";
 },
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
 __webpack_require__("./development.js");
 },
 

--- a/crates/rspack_plugin_javascript/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/simple/expected/main.js
@@ -1,6 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
 console.log('hello, world');
 },
 

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -31,8 +31,10 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     let rspack_core::ParseContext {
       source: box_source,
       resource_data,
+      build_info,
       ..
     } = parse_context;
+    build_info.strict = true;
     let source = box_source.source();
 
     json::parse(&source).map_err(|e| {

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -34,7 +34,7 @@ describe("Stats", () => {
 		        "hotModuleReplacement": false,
 		      },
 		      "name": "main.js",
-		      "size": 12163,
+		      "size": 12150,
 		      "type": "asset",
 		    },
 		  ],
@@ -58,10 +58,10 @@ describe("Stats", () => {
 		      "assets": [
 		        {
 		          "name": "main.js",
-		          "size": 12163,
+		          "size": 12150,
 		        },
 		      ],
-		      "assetsSize": 12163,
+		      "assetsSize": 12150,
 		      "chunks": [
 		        "main",
 		      ],

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -47,7 +47,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
         "hotModuleReplacement": false,
       },
       "name": "main.xxxx.js",
-      "size": 9320,
+      "size": 9307,
       "type": "asset",
     },
     {
@@ -100,10 +100,10 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       "assets": [
         {
           "name": "main.xxxx.js",
-          "size": 9320,
+          "size": 9307,
         },
       ],
-      "assetsSize": 9320,
+      "assetsSize": 9307,
       "chunks": [
         "main",
       ],
@@ -147,7 +147,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
 exports[`StatsTestCases should print correct stats for filename 2`] = `
 "Hash: 8c0a3e20ea6b5e7a
              Asset       Size      Chunks             Chunk Names
-      main.xxxx.js    9.1 KiB        main  [emitted]  main
+      main.xxxx.js   9.09 KiB        main  [emitted]  main
 dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]  dynamic_js
 Entrypoint main = main.xxxx.js
 chunk {dynamic_js} dynamic_js.xxxx.js (dynamic_js) 32 bytes
@@ -172,7 +172,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
         "hotModuleReplacement": false,
       },
       "name": "bundle.js",
-      "size": 8912,
+      "size": 8899,
       "type": "asset",
     },
   ],
@@ -196,10 +196,10 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
       "assets": [
         {
           "name": "bundle.js",
-          "size": 8912,
+          "size": 8899,
         },
       ],
-      "assetsSize": 8912,
+      "assetsSize": 8899,
       "chunks": [
         "main",
       ],
@@ -229,8 +229,8 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
 
 exports[`StatsTestCases should print correct stats for hot+production 2`] = `
 "Hash: 1a7c8fd0bc8ded89
-    Asset     Size  Chunks             Chunk Names
-bundle.js  8.7 KiB    main  [emitted]  main
+    Asset      Size  Chunks             Chunk Names
+bundle.js  8.69 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 25 bytes [entry]
 [10] ./index.js 25 bytes {main}"

--- a/packages/rspack/tests/configCases/errors/module-build-error/index.js
+++ b/packages/rspack/tests/configCases/errors/module-build-error/index.js
@@ -9,7 +9,7 @@ it("build error module should have 'throw error'", () => {
 	}
 		
 	const output = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
-	let scssCode = /".\/index.scss":.*\n\"use strict\";\n(.*)/.exec(
+	let scssCode = /".\/index.scss":.*\n(.*)/.exec(
 		output
 	)[1];
 	expect(scssCode.includes("throw new Error")).toBe(true);

--- a/packages/rspack/tests/configCases/errors/module-parse-error/index.js
+++ b/packages/rspack/tests/configCases/errors/module-parse-error/index.js
@@ -10,10 +10,10 @@ it("parse error module should have 'throw error'", () => {
 	}
 
 	const output = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
-	let nonRecCode = /".\/non-recoverable.js":.*\n\"use strict\";\n(.*)/.exec(
+	let nonRecCode = /".\/non-recoverable.js":.*\n(.*)/.exec(
 		output
 	)[1];
-	let recCode = /".\/recoverable.js":.*\n\"use strict\";\n(.*)/.exec(output)[1];
+	let recCode = /".\/recoverable.js":.*\n(.*)/.exec(output)[1];
 	expect(nonRecCode.includes("throw new Error")).toBe(true);
 	expect(recCode.includes("throw new Error")).toBe(true);
 });


### PR DESCRIPTION
## Summary

only use strict mode for esm module.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

#1463 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
