### PR TITLE
feature(dev-server): tips when react are not enabled

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -73,6 +73,10 @@ export class RspackDevServer {
 		if (this.options.hot) {
 			this.compiler.options.builtins.react.refresh =
 				this.compiler.options.builtins.react.refresh ?? true;
+		} else if (this.compiler.options.builtins.react.refresh) {
+			this.logger.warn(
+				"[Builtins] react.refresh need react.development and devServer.hot enabled."
+			);
 		}
 	}
 

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -391,6 +391,7 @@ class Compiler {
 			}
 		};
 	}
+
 	purgeInputFileSystem() {
 		if (this.inputFileSystem && this.inputFileSystem.purge) {
 			this.inputFileSystem.purge();


### PR DESCRIPTION
This PR brings the following changes:

1. warning when `react.refresh` enabled but `dev.Server` is false.
2. some debug log in e2e/hot because it encounter unexpected error after merged main branch.