### PR TITLE
chore: control tracing layer by env

### DIFF
--- a/crates/node_binding/src/utils.rs
+++ b/crates/node_binding/src/utils.rs
@@ -80,7 +80,15 @@ pub fn init_custom_trace_subscriber(
   // trace_out_file_path: Option<String>,
 ) -> Result<()> {
   CUSTOM_TRACE_SUBSCRIBER.get_or_init(|| {
-    let guard = rspack_tracing::enable_tracing_by_env_with_chrome_layer();
+    let layer = std::env::var("layer").unwrap_or("logger".to_string());
+    let guard = match layer.as_str() {
+      "chrome" => rspack_tracing::enable_tracing_by_env_with_chrome_layer(),
+      "logger" => {
+        rspack_tracing::enable_tracing_by_env();
+        None
+      }
+      _ => panic!("not supported layer type:{}", layer),
+    };
     if let Some(guard) = guard {
       env
         .add_env_cleanup_hook(guard, |flush_guard| {

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -7,6 +7,7 @@ module.exports = (env) => {
   return {
     context: __dirname,
     builtins: {
+      noEmitAssets:false,
       html: [{
         template: './index.html'
       }],
@@ -23,10 +24,7 @@ module.exports = (env) => {
       "process.env.NODE_ENV": "'development'",
     },
     infrastructureLogging: {
-      debug: false
-    },
-    builtins: {
-      minify: false
+      debug: true
     },
     output: {
       path: path.resolve(__dirname, 'dist')


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
