### PR TITLE
fix: fix minify default value

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "dev": "rspack serve -c test.config.js",
-    "build": "rspack build -c test.config.js"
+    "dev": "rspack serve -c ./rspack.config.js",
+    "build": "rspack build -c ./rspack.config.js"
   },
   "keywords": [],
   "author": "",

--- a/examples/react/rspack.config.js
+++ b/examples/react/rspack.config.js
@@ -1,0 +1,47 @@
+module.exports = {
+  mode : 'development',
+  entry : {
+    main: {
+      import: ["./src/index.js"],
+    }
+  },
+  output : {
+    publicPath : '/',
+    // filename: '[name].[contenthash:8][ext]',
+  },
+  devServer: {
+    webSocketServer: true,
+    hot: true,
+  },
+  module : {
+    rules : [
+      {
+        test : /\.less$/,
+        type : 'css'
+      }, 
+    ],
+    parser : {
+      asset : {
+        dataUrlCondition : {
+          maxSize : 1,
+        },
+      },
+    },
+  },
+  infrastructureLogging:{
+    debug:true,
+  },
+  builtins : {
+    html : [{
+      template: './index.html'
+    }],
+    define : {
+      'process.env.NODE_ENV' : "'development'"
+    },
+    progress: {},
+    react: {
+      development: true,
+      refresh: true,
+    }
+  },
+};

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -104,7 +104,7 @@ export class RspackCLI {
 		}
 		item.builtins = {
 			...item.builtins,
-			minify: item.builtins?.minify ?? isEnvProduction
+			minify: item.builtins?.minify ?? item.mode === "production"
 		};
 
 		// no emit assets when run dev server, it will use node_binding api get file content


### PR DESCRIPTION
## Summary
minify default value should be controlled by mode other than command directly
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
