### PR TITLE
fix: use defined fields in class

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_decorator.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_decorator.rs
@@ -10,7 +10,6 @@ use serde::{Deserialize, Serialize};
 pub struct RawDecoratorOptions {
   pub legacy: bool,
   pub emit_metadata: bool,
-  pub use_define_for_class_fields: bool,
 }
 
 #[derive(Deserialize, Debug, Serialize, Default, Clone)]
@@ -19,7 +18,6 @@ pub struct RawDecoratorOptions {
 pub struct RawDecoratorOptions {
   pub legacy: bool,
   pub emit_metadata: bool,
-  pub use_define_for_class_fields: bool,
 }
 
 pub fn transform_to_decorator_options(
@@ -29,12 +27,10 @@ pub fn transform_to_decorator_options(
     let RawDecoratorOptions {
       legacy,
       emit_metadata,
-      use_define_for_class_fields,
     } = inner;
     DecoratorOptions {
       legacy,
       emit_metadata,
-      use_define_for_class_fields,
     }
   })
 }

--- a/crates/rspack_core/src/options/builtins.rs
+++ b/crates/rspack_core/src/options/builtins.rs
@@ -23,8 +23,6 @@ pub struct DecoratorOptions {
   pub legacy: bool,
   // https://swc.rs/docs/configuration/compilation#jsctransformdecoratormetadata
   pub emit_metadata: bool,
-  // https://babeljs.io/docs/en/assumptions#setpublicclassfields
-  pub use_define_for_class_fields: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/compat.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/compat.rs
@@ -140,17 +140,12 @@ fn compat_by_es_version(
 pub fn compat(
   browser_config: Option<BrowserConfig>,
   es_version: Option<EsVersion>,
+  assumptions: Assumptions,
   top_level_mark: Mark,
   unresolved_mark: Mark,
   comments: Option<&SingleThreadedComments>,
   is_typescript: bool,
 ) -> impl Fold + '_ {
-  let mut assumptions = Assumptions::default();
-  if is_typescript {
-    assumptions.set_class_methods = true;
-    assumptions.set_public_class_fields = true;
-  };
-
   chain!(
     compat_by_browser_list(browser_config, top_level_mark, assumptions, comments),
     compat_by_es_version(

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/decorator.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/decorator.rs
@@ -1,19 +1,18 @@
+use either::Either;
 use rspack_core::DecoratorOptions;
+use swc_core::ecma::transforms::base::pass::noop;
+use swc_core::ecma::transforms::base::Assumptions;
 use swc_core::ecma::transforms::proposal::decorators;
 use swc_core::ecma::visit::Fold;
 
-pub fn decorator(option: &Option<DecoratorOptions>) -> impl Fold {
-  let config = match option {
-    Some(DecoratorOptions {
-      legacy,
-      emit_metadata,
-      use_define_for_class_fields,
-    }) => decorators::Config {
-      legacy: *legacy,
-      emit_metadata: *emit_metadata,
-      use_define_for_class_fields: *use_define_for_class_fields,
-    },
-    None => Default::default(),
-  };
-  decorators(config)
+pub fn decorator(assumptions: Assumptions, option: &Option<DecoratorOptions>) -> impl Fold {
+  if let Some(option) = option {
+    Either::Left(decorators(decorators::Config {
+      legacy: option.legacy,
+      emit_metadata: option.emit_metadata,
+      use_define_for_class_fields: !assumptions.set_public_class_fields,
+    }))
+  } else {
+    Either::Right(noop())
+  }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/typescript.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/typescript.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 use swc_core::common::{comments::SingleThreadedComments, Mark, SourceMap};
+use swc_core::ecma::transforms::base::Assumptions;
 use swc_core::ecma::transforms::{
   react::{default_pragma, default_pragma_frag},
   typescript::{self, TsEnumConfig, TsImportExportAssignConfig},
@@ -7,6 +8,7 @@ use swc_core::ecma::transforms::{
 use swc_core::ecma::visit::Fold;
 
 pub fn typescript<'a>(
+  assumptions: Assumptions,
   top_level_mark: Mark,
   comments: Option<&'a SingleThreadedComments>,
   cm: &Arc<SourceMap>,
@@ -28,9 +30,9 @@ pub fn typescript<'a>(
       pragma_frag: Some(default_pragma_frag()),
       ts_enum_config: TsEnumConfig {
         treat_const_enum_as_enum: false,
-        ts_enum_is_readonly: false,
+        ts_enum_is_readonly: assumptions.ts_enum_is_readonly,
       },
-      use_define_for_class_fields: true,
+      use_define_for_class_fields: !assumptions.set_public_class_fields,
       import_export_assign_config: TsImportExportAssignConfig::Classic,
       ..Default::default()
     },

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -52,7 +52,6 @@ exports[`normalize options snapshot react.development and react.refresh should b
     "decorator": {
       "emitMetadata": true,
       "legacy": true,
-      "useDefineForClassFields": true,
     },
     "define": {},
     "html": [],

--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -63,8 +63,7 @@ function resolveDecorator(
 	return Object.assign(
 		{
 			legacy: true,
-			emitMetadata: true,
-			useDefineForClassFields: true
+			emitMetadata: true
 		},
 		decorator
 	);

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -78,7 +78,6 @@ describe("snapshots", () => {
 		    "decorator": {
 		      "emitMetadata": true,
 		      "legacy": true,
-		      "useDefineForClassFields": true,
 		    },
 		    "define": {},
 		    "html": [],

--- a/packages/rspack/tests/case.template.ts
+++ b/packages/rspack/tests/case.template.ts
@@ -31,10 +31,9 @@ export function describeCases(config: { name: string; casePath: string }) {
 				const outputPath = path.resolve(testRoot, `./dist`);
 				const bundlePath = path.resolve(outputPath, "main.js");
 				if (
-					!(
-						fs.existsSync(path.resolve(testRoot, "index.js")) ||
-						fs.existsSync(path.resolve(testRoot, "index.jsx"))
-					)
+					[".js", ".jsx", ".ts", ".tsx"].every(ext => {
+						return !fs.existsSync(path.resolve(testRoot, "index" + ext));
+					})
 				) {
 					continue;
 				}

--- a/packages/rspack/tests/configCases/builtins/use-defined-field/index.ts
+++ b/packages/rspack/tests/configCases/builtins/use-defined-field/index.ts
@@ -1,0 +1,14 @@
+class Parent {
+	time: undefined | number = new Date().valueOf();
+}
+
+class Child extends Parent {
+	time: undefined | number;
+}
+
+it("should class use defined field", () => {
+	const parent = new Parent();
+	const child = new Child();
+	expect(typeof parent.time).toBe("number");
+	expect(typeof child.time).toBe("number");
+});

--- a/packages/rspack/tests/configCases/builtins/use-defined-field/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/use-defined-field/webpack.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	target: ["node", "es2022"],
+	builtins: {}
+};


### PR DESCRIPTION
## Summary

1. remove `builtins.decorator.useDefineForClassFields` config
2. use_defined_fields behaves the same as swc

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
