### PR TITLE
chore: fix jsx not transform in node_modules

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -38,8 +38,7 @@ pub fn run_before_pass(
 ) -> Result<()> {
   let cm = ast.get_context().source_map.clone();
   // TODO: should use react-loader to get exclude/include
-  let out_of_node_modules = !resource_data.resource.contains("node_modules");
-  let should_transform_by_react = out_of_node_modules && module_type.is_jsx_like();
+  let should_transform_by_react = module_type.is_jsx_like();
   ast.transform_with_handler(cm.clone(), |handler, program, context| {
     let top_level_mark = context.top_level_mark;
     let unresolved_mark = context.unresolved_mark;


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
