### PR TITLE
fix: reuse module by module identifier

### DIFF
--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -108,10 +108,7 @@ impl AddTask {
   pub fn run(self, compilation: &mut Compilation) -> Result<TaskResult> {
     let module_identifier = self.module.identifier();
 
-    if compilation
-      .visited_module_id
-      .contains(&(module_identifier, self.dependencies[0].detail.clone()))
-    {
+    if compilation.visited_module_id.contains(&module_identifier) {
       Self::set_resolved_module(
         &mut compilation.module_graph,
         self.original_module_identifier,
@@ -122,9 +119,7 @@ impl AddTask {
       return Ok(TaskResult::Add(AddTaskResult::ModuleReused(self.module)));
     }
 
-    compilation
-      .visited_module_id
-      .insert((module_identifier, self.dependencies[0].detail.clone()));
+    compilation.visited_module_id.insert(module_identifier);
 
     compilation
       .module_graph

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -188,7 +188,7 @@ impl TryFrom<&str> for ModuleType {
   }
 }
 
-pub(crate) type VisitedModuleIdentity = HashSet<(ModuleIdentifier, ModuleDependency)>;
+pub(crate) type VisitedModuleIdentity = HashSet<ModuleIdentifier>;
 
 pub(crate) type ChunkByUkey = HashMap<ChunkUkey, Chunk>;
 pub type ChunkGroupByUkey = HashMap<ChunkGroupUkey, ChunkGroup>;


### PR DESCRIPTION
## Summary

1. reuse module only check module identifier

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
