### PR TITLE
fix: rspack memory assets middleware not work

### DIFF
--- a/packages/rspack-dev-middleware/src/index.ts
+++ b/packages/rspack-dev-middleware/src/index.ts
@@ -12,7 +12,6 @@ const rdm: typeof wdm = (compiler, options) => {
 		options = {};
 	}
 	options.writeToDisk = false;
-	options.outputFileSystem = require("fs");
 	return wdm(compiler, options);
 };
 

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf lib/ && tsc",
+    "build": "rm -rf dist/ && tsc",
     "dev": "tsc -w",
     "test": "rm -rf .test-temp && jest --verbose"
   },


### PR DESCRIPTION
## Summary

The webpack-dev-middleware will handle requests when access output files, but we have other middleware to handle it.
This PR will make webpack-dev-middleware use memory-fs to skip processing file requests

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
