### PR TITLE
chore: add defalut value for cacheable api

### DIFF
--- a/packages/rspack/src/config/module.ts
+++ b/packages/rspack/src/config/module.ts
@@ -91,7 +91,7 @@ export interface LoaderContext
 		sourceMap?: string | SourceMap,
 		additionalData?: AdditionalData
 	): void;
-	cacheable(cacheable: boolean): void;
+	cacheable(cacheable?: boolean): void;
 	sourceMap: boolean;
 	rootContext: string;
 	context: string;
@@ -389,7 +389,7 @@ function composeJsUse(
 							[name, data.resource].filter(Boolean).join("|")
 						);
 					},
-					cacheable(value) {
+					cacheable(value = true) {
 						cacheable = value;
 					},
 					async() {


### PR DESCRIPTION
## Summary

fix error when use some webpack loader.
add defalut value for cacheable api. consistent with webpack.


![c0abcff2-2c1d-43f3-9ab3-d73c29156020](https://user-images.githubusercontent.com/22373761/210528007-0374b37a-6db8-4f89-a12b-ee47fea6d029.jpeg)

<img width="437" alt="image" src="https://user-images.githubusercontent.com/22373761/210528917-0d6e1ff7-8655-44d2-9183-21a5799f110a.png">


#### In webpack
https://webpack.js.org/api/loaders/#thiscacheable

<img width="766" alt="image" src="https://user-images.githubusercontent.com/22373761/210529065-7b7e4049-0f1f-404c-82f1-23c2378cba58.png">

