### PR TITLE
chore: fix windows compat

### DIFF
--- a/crates/rspack_plugin_css/src/pxtorem/tests/cases/fixtures.hrx
+++ b/crates/rspack_plugin_css/src/pxtorem/tests/cases/fixtures.hrx
@@ -22,7 +22,7 @@ h1 { margin: 0 0 20px; font-size: 2rem; line-height: 1.2; letter-spacing: 0.0625
 <===> .expected
 :root { --rem-14px: 0.875rem; } .rule { font-size: var(--rem-14px); }
 
-<===> should handle < 1 values and values without a leading 0.css
+<===> should handle values and values without a leading 0.css
 .rule { margin: 0.5rem .5px -0.2px -.2em }
 <===> .config
 {

--- a/crates/rspack_plugin_css/src/pxtorem/tests/cases/should_handle_values_and_values_without_a_leading_0.css.snap
+++ b/crates/rspack_plugin_css/src/pxtorem/tests/cases/should_handle_values_and_values_without_a_leading_0.css.snap
@@ -1,7 +1,6 @@
 ---
 source: crates/rspack_plugin_css/src/pxtorem/tests/mod.rs
-assertion_line: 29
-expression: should_handle_<_1_values_and_values_without_a_leading_0.css
+expression: should_handle_values_and_values_without_a_leading_0.css
 ---
 # Input
 .rule { margin: 0.5rem .5px -0.2px -.2em }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
