### PR TITLE
chore: re-organize CodeSplitter to help of tracing

### DIFF
--- a/crates/rspack_core/src/chunk_spliter/split_chunks.rs
+++ b/crates/rspack_core/src/chunk_spliter/split_chunks.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
+use hashbrown::HashMap;
 use hashbrown::HashSet;
 use rspack_error::Result;
-use std::collections::HashMap;
 use tracing::instrument;
 
 use crate::{ChunkGroup, ChunkGroupKind, ChunkGroupUkey, ChunkUkey, Compilation, ModuleIdentifier};


### PR DESCRIPTION
## Summary

With changes, we should be able to see how code splitting affects performance clearly.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
