### PR TITLE
fix: generate fixed chunk content hash

### DIFF
--- a/crates/rspack/tests/fixtures/hash/common.css
+++ b/crates/rspack/tests/fixtures/hash/common.css
@@ -1,0 +1,3 @@
+body {
+    color: red;
+}

--- a/crates/rspack/tests/fixtures/hash/common.js
+++ b/crates/rspack/tests/fixtures/hash/common.js
@@ -1,0 +1,3 @@
+import './common.css';
+
+console.log('common.js')

--- a/crates/rspack/tests/fixtures/hash/expected/common_js.84c38289cfb90.css
+++ b/crates/rspack/tests/fixtures/hash/expected/common_js.84c38289cfb90.css
@@ -1,0 +1,5 @@
+
+
+body {
+  color: red;
+}

--- a/crates/rspack/tests/fixtures/hash/expected/common_js.d37fbb532b5fd.js
+++ b/crates/rspack/tests/fixtures/hash/expected/common_js.d37fbb532b5fd.js
@@ -1,0 +1,14 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["common_js"], {
+"./common.css": function (module, exports, __webpack_require__) {
+"use strict";
+},
+"./common.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+__webpack_require__("./common.css");
+console.log('common.js');
+},
+
+}]);

--- a/crates/rspack/tests/fixtures/hash/expected/main.js
+++ b/crates/rspack/tests/fixtures/hash/expected/main.js
@@ -1,0 +1,10 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
+"./index.js": function (module, exports, __webpack_require__) {
+__webpack_require__.e("common_js").then(__webpack_require__.bind(__webpack_require__, "./common.js")).then(__webpack_require__.interopRequire);
+console.log('index.js');
+},
+
+},function(__webpack_require__) {
+__webpack_require__("./index.js");
+}
+]);

--- a/crates/rspack/tests/fixtures/hash/expected/runtime.js
+++ b/crates/rspack/tests/fixtures/hash/expected/runtime.js
@@ -1,0 +1,432 @@
+(function() {
+var __webpack_modules__ = {
+
+}
+// The module cache
+ var __webpack_module_cache__ = {};
+function __webpack_require__(moduleId) {
+// Check if module is in cache
+        var cachedModule = __webpack_module_cache__[moduleId];
+        if (cachedModule !== undefined) {
+      return cachedModule.exports;
+      }
+      // Create a new module (and put it into the cache)
+      var module = (__webpack_module_cache__[moduleId] = {
+      // no module.loaded needed
+          exports: {}
+        });
+        // Execute the module function
+      __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+// Return the exports of the module
+ return module.exports;
+
+}
+// expose the modules object (__webpack_modules__)
+ __webpack_require__.m = __webpack_modules__;
+// webpack/runtime/ensure_chunk
+(function() {
+__webpack_require__.f = {};
+// This file contains only the entry chunk.
+// The chunk loading function for additional chunks
+__webpack_require__.e = function (chunkId) {
+	return Promise.all(
+		Object.keys(__webpack_require__.f).reduce(function (promises, key) {
+			__webpack_require__.f[key](chunkId, promises);
+			return promises;
+		}, [])
+	);
+};
+
+})();
+// webpack/runtime/on_chunk_loaded
+(function() {
+var deferred = [];
+__webpack_require__.O = function (result, chunkIds, fn, priority) {
+	if (chunkIds) {
+		priority = priority || 0;
+		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)
+			deferred[i] = deferred[i - 1];
+		deferred[i] = [chunkIds, fn, priority];
+		return;
+	}
+	var notFulfilled = Infinity;
+	for (var i = 0; i < deferred.length; i++) {
+		var [chunkIds, fn, priority] = deferred[i];
+		var fulfilled = true;
+		for (var j = 0; j < chunkIds.length; j++) {
+			if (
+				(priority & (1 === 0) || notFulfilled >= priority) &&
+				Object.keys(__webpack_require__.O).every(function (key) {
+					__webpack_require__.O[key](chunkIds[j]);
+				})
+			) {
+				chunkIds.splice(j--, 1);
+			} else {
+				fulfilled = false;
+				if (priority < notFulfilled) notFulfilled = priority;
+			}
+		}
+		if (fulfilled) {
+			deferred.splice(i--, 1);
+			var r = fn();
+			if (r !== undefined) result = r;
+		}
+	}
+	return result;
+};
+
+})();
+// rspack/runtime/interopRequire
+(function() {
+(function () {
+	function _getRequireCache(nodeInterop) {
+		if (typeof WeakMap !== "function") return null;
+
+		var cacheBabelInterop = new WeakMap();
+		var cacheNodeInterop = new WeakMap();
+		return (_getRequireCache = function (nodeInterop) {
+			return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+		})(nodeInterop);
+	}
+
+	__webpack_require__.interopRequire = function (obj, nodeInterop) {
+		if (!nodeInterop && obj && obj.__esModule) {
+			return obj;
+		}
+
+		if (
+			obj === null ||
+			(typeof obj !== "object" && typeof obj !== "function")
+		) {
+			return { default: obj };
+		}
+
+		var cache = _getRequireCache(nodeInterop);
+		if (cache && cache.has(obj)) {
+			return cache.get(obj);
+		}
+
+		var newObj = {};
+		var hasPropertyDescriptor =
+			Object.defineProperty && Object.getOwnPropertyDescriptor;
+		for (var key in obj) {
+			if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+				var desc = hasPropertyDescriptor
+					? Object.getOwnPropertyDescriptor(obj, key)
+					: null;
+				if (desc && (desc.get || desc.set)) {
+					Object.defineProperty(newObj, key, desc);
+				} else {
+					newObj[key] = obj[key];
+				}
+			}
+		}
+		newObj.default = obj;
+		if (cache) {
+			cache.set(obj, newObj);
+		}
+		return newObj;
+	};
+})();
+
+})();
+// webpack/runtime/get_chunk_filename/__webpack_require__.k
+(function() {
+// This function allow to reference chunks
+        __webpack_require__.k = function (chunkId) {
+          // return url for filenames based on template
+          return {"common_js": "common_js.84c38289cfb90.css",}[chunkId];
+        };
+      
+})();
+// webpack/runtime/load_script
+(function() {
+var inProgress = {};
+// var dataWebpackPrefix = "webpack:";
+// loadScript function to load a script via script tag
+__webpack_require__.l = function loadScript(url, done, key, chunkId) {
+	// TODO add this after hash
+	// if (inProgress[url]) {
+	// 	inProgress[url].push(done);
+	// 	return;
+	// }
+	var script, needAttach;
+	if (key !== undefined) {
+		var scripts = document.getElementsByTagName("script");
+		for (var i = 0; i < scripts.length; i++) {
+			var s = scripts[i];
+			if (
+				s.getAttribute("src") == url
+				// || s.getAttribute("data-webpack") == dataWebpackPrefix + key
+			) {
+				script = s;
+				break;
+			}
+		}
+	}
+	if (!script) {
+		needAttach = true;
+		script = document.createElement("script");
+
+		script.charset = "utf-8";
+		script.timeout = 120;
+		// script.setAttribute("data-webpack", dataWebpackPrefix + key);
+		script.src = url;
+	}
+	inProgress[url] = [done];
+	var onScriptComplete = function (prev, event) {
+		script.onerror = script.onload = null;
+		clearTimeout(timeout);
+		var doneFns = inProgress[url];
+		delete inProgress[url];
+		script.parentNode && script.parentNode.removeChild(script);
+		doneFns &&
+			doneFns.forEach(function (fn) {
+				return fn(event);
+			});
+		if (prev) return prev(event);
+	};
+	var timeout = setTimeout(
+		onScriptComplete.bind(null, undefined, {
+			type: "timeout",
+			target: script
+		}),
+		120000
+	);
+	script.onerror = onScriptComplete.bind(null, script.onerror);
+	script.onload = onScriptComplete.bind(null, script.onload);
+	needAttach && document.head.appendChild(script);
+};
+
+})();
+// webpack/runtime/has_own_property
+(function() {
+__webpack_require__.o = function (obj, prop) {
+	return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+})();
+// webpack/runtime/public_path
+(function() {
+__webpack_require__.p = "/";
+
+})();
+// webpack/runtime/get_chunk_filename/__webpack_require__.u
+(function() {
+// This function allow to reference chunks
+        __webpack_require__.u = function (chunkId) {
+          // return url for filenames based on template
+          return {"common_js": "common_js.d37fbb532b5fd.js",}[chunkId];
+        };
+      
+})();
+// webpack/runtime/css_loading
+(function() {
+var installedChunks = {};
+var uniqueName = "webpack";
+// loadCssChunkData is unnecessary
+var loadingAttribute = "data-webpack-loading";
+var loadStylesheet = (chunkId, url, done, hmr) => {
+	var link,
+		needAttach,
+		key = "chunk-" + chunkId;
+	if (!hmr) {
+		var links = document.getElementsByTagName("link");
+		for (var i = 0; i < links.length; i++) {
+			var l = links[i];
+			if (
+				l.rel == "stylesheet" &&
+				(l.href.startsWith(url) ||
+					l.getAttribute("href").startsWith(url) ||
+					l.getAttribute("data-webpack") == uniqueName + ":" + key)
+			) {
+				link = l;
+				break;
+			}
+		}
+		if (!done) return link;
+	}
+	if (!link) {
+		needAttach = true;
+		link = document.createElement("link");
+		link.setAttribute("data-webpack", uniqueName + ":" + key);
+		link.setAttribute(loadingAttribute, 1);
+		link.rel = "stylesheet";
+		link.href = url;
+	}
+	var onLinkComplete = (prev, event) => {
+		link.onerror = link.onload = null;
+		link.removeAttribute(loadingAttribute);
+		clearTimeout(timeout);
+		if (event && event.type != "load") link.parentNode.removeChild(link);
+		done(event);
+		if (prev) return prev(event);
+	};
+	if (link.getAttribute(loadingAttribute)) {
+		var timeout = setTimeout(
+			onLinkComplete.bind(null, undefined, { type: "timeout", target: link }),
+			120000
+		);
+		link.onerror = onLinkComplete.bind(null, link.onerror);
+		link.onload = onLinkComplete.bind(null, link.onload);
+	} else onLinkComplete(undefined, { type: "load", target: link });
+	hmr
+		? document.head.insertBefore(link, hmr)
+		: needAttach && document.head.appendChild(link);
+	return link;
+};
+__webpack_require__.f.css = function (chunkId, promises) {
+	// css chunk loading
+	var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
+		? installedChunks[chunkId]
+		: undefined;
+	if (installedChunkData !== 0) {
+		// 0 means "already installed".
+
+		// a Promise means "currently loading".
+		if (installedChunkData) {
+			promises.push(installedChunkData[2]);
+		} else {
+			if (["common_js",].indexOf(chunkId) > -1) {
+				// setup Promise in chunk cache
+				var promise = new Promise(function (resolve, reject) {
+					installedChunkData = installedChunks[chunkId] = [resolve, reject];
+				});
+				promises.push((installedChunkData[2] = promise));
+
+				// start chunk loading
+				var url = __webpack_require__.p + __webpack_require__.k(chunkId);
+				// create error before stack unwound to get useful stacktrace later
+				var error = new Error();
+				var loadingEnded = function (event) {
+					if (__webpack_require__.o(installedChunks, chunkId)) {
+						installedChunkData = installedChunks[chunkId];
+						if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+						if (installedChunkData) {
+							if (event.type !== "load") {
+								var errorType = event && event.type;
+								var realSrc = event && event.target && event.target.src;
+								error.message =
+									"Loading css chunk " +
+									chunkId +
+									" failed.\n(" +
+									errorType +
+									": " +
+									realSrc +
+									")";
+								error.name = "ChunkLoadError";
+								error.type = errorType;
+								error.request = realSrc;
+								installedChunkData[1](error);
+							} else {
+								// loadCssChunkData(__webpack_require__.m, link, chunkId);
+								installedChunkData[0]();
+							}
+						}
+					}
+				};
+				var link = loadStylesheet(chunkId, url, loadingEnded);
+			} else installedChunks[chunkId] = 0;
+		}
+	}
+};
+
+})();
+// webpack/runtime/jsonp_chunk_loading
+(function() {
+var installedChunks = {"runtime": 0,};
+__webpack_require__.f.j = function (chunkId, promises) {
+	// JSONP chunk loading for javascript
+	var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
+		? installedChunks[chunkId]
+		: undefined;
+	if (installedChunkData !== 0) {
+		// 0 means "already installed".
+
+		// a Promise means "currently loading".
+		if (installedChunkData) {
+			promises.push(installedChunkData[2]);
+		} else {
+			if (chunkId) {
+				// setup Promise in chunk cache
+				var promise = new Promise(function (resolve, reject) {
+					installedChunkData = installedChunks[chunkId] = [resolve, reject];
+				});
+				promises.push((installedChunkData[2] = promise));
+
+				// start chunk loading
+				var url = __webpack_require__.p + __webpack_require__.u(chunkId);
+				// create error before stack unwound to get useful stacktrace later
+				var error = new Error();
+				var loadingEnded = function (event) {
+					if (__webpack_require__.o(installedChunks, chunkId)) {
+						installedChunkData = installedChunks[chunkId];
+						if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+						if (installedChunkData) {
+							var errorType =
+								event && (event.type === "load" ? "missing" : event.type);
+							var realSrc = event && event.target && event.target.src;
+							error.message =
+								"Loading chunk " +
+								chunkId +
+								" failed.\n(" +
+								errorType +
+								": " +
+								realSrc +
+								")";
+							error.name = "ChunkLoadError";
+							error.type = errorType;
+							error.request = realSrc;
+							installedChunkData[1](error);
+						}
+					}
+				};
+				__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
+			} else installedChunks[chunkId] = 0;
+		}
+	}
+};
+__webpack_require__.O.j = function (chunkId) {
+	installedChunks[chunkId] === 0;
+};
+// install a JSONP callback for chunk loading
+var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
+	var [chunkIds, moreModules, runtime] = data;
+	// add "moreModules" to the modules object,
+	// then flag all "chunkIds" as loaded and fire callback
+	var moduleId,
+		chunkId,
+		i = 0;
+	if (chunkIds.some(id => installedChunks[id] !== 0)) {
+		for (moduleId in moreModules) {
+			if (__webpack_require__.o(moreModules, moduleId)) {
+				__webpack_require__.m[moduleId] = moreModules[moduleId];
+			}
+		}
+		if (runtime) var result = runtime(__webpack_require__);
+	}
+	if (parentChunkLoadingFunction) parentChunkLoadingFunction(data);
+	for (; i < chunkIds.length; i++) {
+		chunkId = chunkIds[i];
+		if (
+			__webpack_require__.o(installedChunks, chunkId) &&
+			installedChunks[chunkId]
+		) {
+			installedChunks[chunkId][0]();
+		}
+		installedChunks[chunkId] = 0;
+	}
+	return __webpack_require__.O(result);
+};
+
+var chunkLoadingGlobal = (self["webpackChunkwebpack"] =
+	self["webpackChunkwebpack"] || []);
+chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
+chunkLoadingGlobal.push = webpackJsonpCallback.bind(
+	null,
+	chunkLoadingGlobal.push.bind(chunkLoadingGlobal)
+);
+
+})();
+
+})();

--- a/crates/rspack/tests/fixtures/hash/index.js
+++ b/crates/rspack/tests/fixtures/hash/index.js
@@ -1,0 +1,3 @@
+import('./common.js')
+
+console.log('index.js')

--- a/crates/rspack/tests/fixtures/hash/test.config.js
+++ b/crates/rspack/tests/fixtures/hash/test.config.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('webpack').Configuration}
+ */
+module.exports = {
+	mode: "development",
+	entry: {
+		main: {
+			import: ["./index.js"]
+		}
+	},
+	output: {
+		chunkFilename: "[name].[contenthash][ext]",
+	}
+};

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -391,11 +391,12 @@ impl Plugin for JsPlugin {
 
     let mut hasher = Xxh3::default();
 
-    let ordered_modules = compilation.chunk_graph.get_chunk_modules_by_source_type(
+    let mut ordered_modules = compilation.chunk_graph.get_chunk_modules_by_source_type(
       &args.chunk_ukey,
       SourceType::JavaScript,
       &compilation.module_graph,
     );
+    ordered_modules.sort_by_key(|m| &m.module_identifier);
     for mgm in ordered_modules {
       if let Some(module) = compilation
         .module_graph


### PR DESCRIPTION
## Summary

- generate fixed chunk content hash
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
