### PR TITLE
perf: use short name for interop funtion

### DIFF
--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -1,8 +1,8 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
 console.log('hello, world');
-__webpack_require__.e("a_js").then(__webpack_require__.bind(__webpack_require__, "./a.js")).then(__webpack_require__.interopRequire);
-__webpack_require__.e("b_js").then(__webpack_require__.bind(__webpack_require__, "./b.js")).then(__webpack_require__.interopRequire);
+__webpack_require__.e("a_js").then(__webpack_require__.bind(__webpack_require__, "./a.js")).then(__webpack_require__.ir);
+__webpack_require__.e("b_js").then(__webpack_require__.bind(__webpack_require__, "./b.js")).then(__webpack_require__.ir);
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/fixtures/hash/expected/main.js
+++ b/crates/rspack/tests/fixtures/hash/expected/main.js
@@ -1,6 +1,6 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
-__webpack_require__.e("common_js").then(__webpack_require__.bind(__webpack_require__, "./common.js")).then(__webpack_require__.interopRequire);
+__webpack_require__.e("common_js").then(__webpack_require__.bind(__webpack_require__, "./common.js")).then(__webpack_require__.ir);
 console.log('index.js');
 },
 

--- a/crates/rspack/tests/fixtures/hash/expected/runtime.js
+++ b/crates/rspack/tests/fixtures/hash/expected/runtime.js
@@ -76,7 +76,7 @@ __webpack_require__.O = function (result, chunkIds, fn, priority) {
 };
 
 })();
-// rspack/runtime/interopRequire
+// rspack/runtime/ir
 (function() {
 (function () {
 	function _getRequireCache(nodeInterop) {
@@ -89,7 +89,7 @@ __webpack_require__.O = function (result, chunkIds, fn, priority) {
 		})(nodeInterop);
 	}
 
-	__webpack_require__.interopRequire = function (obj, nodeInterop) {
+	__webpack_require__.ir = function (obj, nodeInterop) {
 		if (!nodeInterop && obj && obj.__esModule) {
 			return obj;
 		}

--- a/crates/rspack/tests/tree-shaking/basic/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/basic/expected/main.js
@@ -28,7 +28,7 @@ if (module.hot?.accept) module.hot.accept((module1)=>{
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _appJs = __webpack_require__.interopRequire(__webpack_require__("./app.js"));
+const _appJs = __webpack_require__.ir(__webpack_require__("./app.js"));
 },
 "./lib.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/expected/main.js
@@ -18,8 +18,8 @@ const b = 'foo';
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/default_export/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/default_export/expected/main.js
@@ -34,7 +34,7 @@ function result() {}
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _appJs = __webpack_require__.interopRequire(__webpack_require__("./app.js"));
+const _appJs = __webpack_require__.ir(__webpack_require__("./app.js"));
 (0, _appJs.render)(_appJs.default);
 },
 "./lib.js": function (module, exports, __webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/expected/main.js
@@ -11,7 +11,7 @@ Object.defineProperty(exports, "a", {
     enumerable: true,
     get: ()=>a
 });
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
 const a = 'foo';
 },
 "./index.js": function (module, exports, __webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/expected/main.js
@@ -23,7 +23,7 @@ Object.defineProperty(exports, "a", {
     get: ()=>_bazJs.a
 });
 const _bazJs = __webpack_require__("./baz.js");
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/export-star-chain/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export-star-chain/expected/main.js
@@ -4,7 +4,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./something/index.js"), exports);
+__webpack_require__.es(__webpack_require__("./something/index.js"), exports);
 },
 "./colors/a.js": function (module, exports, __webpack_require__) {
 "use strict";
@@ -33,16 +33,16 @@ const blue = 'blue';
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./colors/result.js"), exports);
+__webpack_require__.es(__webpack_require__("./colors/result.js"), exports);
 },
 "./colors/index.js": function (module, exports, __webpack_require__) {
 "use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./colors/a.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./colors/b.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./colors/c.js"), exports);
+__webpack_require__.es(__webpack_require__("./colors/a.js"), exports);
+__webpack_require__.es(__webpack_require__("./colors/b.js"), exports);
+__webpack_require__.es(__webpack_require__("./colors/c.js"), exports);
 },
 "./colors/result.js": function (module, exports, __webpack_require__) {
 "use strict";
@@ -60,7 +60,7 @@ const result = 'ssss';
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./Layout.js"), exports);
+__webpack_require__.es(__webpack_require__("./Layout.js"), exports);
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";
@@ -92,8 +92,8 @@ Object.defineProperty(exports, "Colors", {
     enumerable: true,
     get: ()=>_indexJs
 });
-const _indexJs = __webpack_require__.interopRequire(__webpack_require__("./colors/index.js"));
-__webpack_require__.exportStar(__webpack_require__("./something/Something.js"), exports);
+const _indexJs = __webpack_require__.ir(__webpack_require__("./colors/index.js"));
+__webpack_require__.es(__webpack_require__("./something/Something.js"), exports);
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/export_star/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star/expected/main.js
@@ -14,8 +14,8 @@ _export(exports, {
     b: ()=>b,
     bar: ()=>_fooJs
 });
-const _fooJs = __webpack_require__.interopRequire(__webpack_require__("./foo.js"));
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+const _fooJs = __webpack_require__.ir(__webpack_require__("./foo.js"));
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 function b() {}
 },
 "./foo.js": function (module, exports, __webpack_require__) {
@@ -33,8 +33,8 @@ _export(exports, {
     a: ()=>a,
     foo: ()=>foo
 });
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 const a = 3;
 const foo = 3;
 },
@@ -56,8 +56,8 @@ Object.defineProperty(exports, "c", {
     enumerable: true,
     get: ()=>c
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
 const c = 103330;
 },
 

--- a/crates/rspack/tests/tree-shaking/export_star2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star2/expected/main.js
@@ -8,8 +8,8 @@ Object.defineProperty(exports, "b", {
     enumerable: true,
     get: ()=>b
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 function b() {}
 },
 "./foo.js": function (module, exports, __webpack_require__) {
@@ -21,8 +21,8 @@ Object.defineProperty(exports, "a", {
     enumerable: true,
     get: ()=>a
 });
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 const a = 3;
 },
 "./index.js": function (module, exports, __webpack_require__) {
@@ -30,9 +30,9 @@ const a = 3;
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 },
 "./result.js": function (module, exports, __webpack_require__) {
 "use strict";
@@ -43,8 +43,8 @@ Object.defineProperty(exports, "c", {
     enumerable: true,
     get: ()=>c
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
 const c = 103330;
 },
 

--- a/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/expected/main.js
@@ -8,8 +8,8 @@ Object.defineProperty(exports, "b", {
     enumerable: true,
     get: ()=>b
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 function b() {}
 },
 "./foo.js": function (module, exports, __webpack_require__) {
@@ -17,8 +17,8 @@ function b() {}
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./result.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./result.js"), exports);
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";
@@ -33,8 +33,8 @@ const _barJs = __webpack_require__("./bar.js");
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./foo.js"), exports);
-__webpack_require__.exportStar(__webpack_require__("./bar.js"), exports);
+__webpack_require__.es(__webpack_require__("./foo.js"), exports);
+__webpack_require__.es(__webpack_require__("./bar.js"), exports);
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/expected/main.js
@@ -20,7 +20,7 @@ Object.defineProperty(exports, "Sider", {
     enumerable: true,
     get: ()=>_somethingJs.default
 });
-const _somethingJs = __webpack_require__.interopRequire(__webpack_require__("./Something.js"));
+const _somethingJs = __webpack_require__.ir(__webpack_require__("./Something.js"));
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/expected/main.js
@@ -41,7 +41,7 @@ Object.defineProperty(exports, "cccc", {
     enumerable: true,
     get: ()=>_cJs.cccc
 });
-const _layoutJs = __webpack_require__.interopRequire(__webpack_require__("./Layout.js"));
+const _layoutJs = __webpack_require__.ir(__webpack_require__("./Layout.js"));
 const _somethingJs = __webpack_require__("./Something.js");
 const _cJs = __webpack_require__("./c.js");
 var L = _layoutJs.default;

--- a/crates/rspack/tests/tree-shaking/named_export_alias/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/named_export_alias/expected/main.js
@@ -29,7 +29,7 @@ var a = function test() {
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _exportJs = __webpack_require__.interopRequire(__webpack_require__("./export.js"));
+const _exportJs = __webpack_require__.ir(__webpack_require__("./export.js"));
 _exportJs.default;
 },
 

--- a/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
@@ -8,14 +8,14 @@ Object.defineProperty(exports, "Provider", {
     enumerable: true,
     get: ()=>_libJs.default
 });
-const _libJs = __webpack_require__.interopRequire(__webpack_require__("./lib.js"));
+const _libJs = __webpack_require__.ir(__webpack_require__("./lib.js"));
 },
 "./foo.js": function (module, exports, __webpack_require__) {
 "use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./app.js"), exports);
+__webpack_require__.es(__webpack_require__("./app.js"), exports);
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/reexport_default_as/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/reexport_default_as/expected/main.js
@@ -19,7 +19,7 @@ Object.defineProperty(exports, "Select", {
     enumerable: true,
     get: ()=>_barJs.default
 });
-const _barJs = __webpack_require__.interopRequire(__webpack_require__("./bar.js"));
+const _barJs = __webpack_require__.ir(__webpack_require__("./bar.js"));
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/expected/main.js
@@ -27,7 +27,7 @@ function bar() {
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _fooJs = __webpack_require__.interopRequire(__webpack_require__("./foo.js"));
+const _fooJs = __webpack_require__.ir(__webpack_require__("./foo.js"));
 var answer = (0, _fooJs.default)();
 (0, _fooJs.bar)();
 console.log(answer);

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/expected/main.js
@@ -24,7 +24,7 @@ Foo.prototype = {
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _fooJs = __webpack_require__.interopRequire(__webpack_require__("./foo.js"));
+const _fooJs = __webpack_require__.ir(__webpack_require__("./foo.js"));
 new _fooJs.default();
 },
 

--- a/crates/rspack/tests/tree-shaking/rollup-unused-called-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-called-import/expected/main.js
@@ -11,7 +11,7 @@ Object.defineProperty(exports, "default", {
     enumerable: true,
     get: ()=>_default
 });
-const _deadJs = __webpack_require__.interopRequire(__webpack_require__("./dead.js"));
+const _deadJs = __webpack_require__.ir(__webpack_require__("./dead.js"));
 function _default() {
     return "foo";
 }
@@ -21,7 +21,7 @@ function _default() {
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _fooJs = __webpack_require__.interopRequire(__webpack_require__("./foo.js"));
+const _fooJs = __webpack_require__.ir(__webpack_require__("./foo.js"));
 assert.equal((0, _fooJs.default)(), "foo");
 },
 

--- a/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
@@ -4,7 +4,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-__webpack_require__.exportStar(__webpack_require__("./lib.js"), exports);
+__webpack_require__.es(__webpack_require__("./lib.js"), exports);
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "something", {
     enumerable: true,
     get: ()=>_libJs.default
 });
-const _libJs = __webpack_require__.interopRequire(__webpack_require__("./lib.js"));
+const _libJs = __webpack_require__.ir(__webpack_require__("./lib.js"));
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
@@ -4,7 +4,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _mathsJs = __webpack_require__.interopRequire(__webpack_require__("./maths.js"));
+const _mathsJs = __webpack_require__.ir(__webpack_require__("./maths.js"));
 console.log(_mathsJs.xxx.test);
 console.log(_mathsJs['square']);
 },
@@ -23,7 +23,7 @@ _export(exports, {
     square: ()=>square,
     xxx: ()=>_testJs
 });
-const _testJs = __webpack_require__.interopRequire(__webpack_require__("./test.js"));
+const _testJs = __webpack_require__.ir(__webpack_require__("./test.js"));
 function square(x) {
     return x * x;
 }

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "a", {
     enumerable: true,
     get: ()=>a
 });
-__webpack_require__.e("bar_js").then(__webpack_require__.bind(__webpack_require__, "./bar.js")).then(__webpack_require__.interopRequire).then((mod)=>{
+__webpack_require__.e("bar_js").then(__webpack_require__.bind(__webpack_require__, "./bar.js")).then(__webpack_require__.ir).then((mod)=>{
     console.log(mod);
 });
 const a = "a";
@@ -31,7 +31,7 @@ if (process.env.NODE_ENV !== "production") {
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _fooJs = __webpack_require__.interopRequire(__webpack_require__("./foo.js"));
+const _fooJs = __webpack_require__.ir(__webpack_require__("./foo.js"));
 (0, _fooJs.default)();
 },
 

--- a/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/lib_js.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/lib_js.js
@@ -8,7 +8,7 @@ Object.defineProperty(exports, "default", {
     enumerable: true,
     get: ()=>_default
 });
-const _testJs = __webpack_require__.interopRequire(__webpack_require__("./test.js"));
+const _testJs = __webpack_require__.ir(__webpack_require__("./test.js"));
 function myanswer() {
     _testJs.default;
 }

--- a/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/main.js
@@ -16,7 +16,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 const _appJs = __webpack_require__("./app.js");
-const a = test(()=>__webpack_require__.e("lib_js").then(__webpack_require__.bind(__webpack_require__, "./lib.js")).then(__webpack_require__.interopRequire));
+const a = test(()=>__webpack_require__.e("lib_js").then(__webpack_require__.bind(__webpack_require__, "./lib.js")).then(__webpack_require__.ir));
 (0, _appJs.answer)();
 a;
 },

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
@@ -11,7 +11,7 @@ it("export should be unused when only unused functions use it", ()=>{
     expect(_innerJs.exportAUsed).toBe(true);
     expect(_innerJs.exportBUsed).toBe(true);
     if (process.env.NODE_ENV === "production") expect(_innerJs.exportCUsed).toBe(false);
-    return __webpack_require__.e("chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js")).then(__webpack_require__.interopRequire);
+    return __webpack_require__.e("chunk_js").then(__webpack_require__.bind(__webpack_require__, "./chunk.js")).then(__webpack_require__.ir);
 });
 },
 "./inner.js": function (module, exports, __webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
@@ -61,7 +61,7 @@ _export(exports, {
     z: ()=>_bJs.z,
     default: ()=>_default
 });
-__webpack_require__.exportStar(__webpack_require__("../node_modules/pmodule/a.js"), exports);
+__webpack_require__.es(__webpack_require__("../node_modules/pmodule/a.js"), exports);
 const _bJs = __webpack_require__("../node_modules/pmodule/b.js");
 const _trackerJs = __webpack_require__("../node_modules/pmodule/tracker.js");
 (0, _trackerJs.track)("index.js");
@@ -94,7 +94,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 const _trackerJs = __webpack_require__("../node_modules/pmodule/tracker.js");
-const _indexJs = __webpack_require__.interopRequire(__webpack_require__("../node_modules/pmodule/index.js"));
+const _indexJs = __webpack_require__.ir(__webpack_require__("../node_modules/pmodule/index.js"));
 _indexJs.default.should.be.eql("def");
 _indexJs.a.should.be.eql("a");
 _indexJs.x.should.be.eql("x");

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
@@ -80,7 +80,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 const _trackerJs = __webpack_require__("../node_modules/pmodule/tracker.js");
-const _indexJs = __webpack_require__.interopRequire(__webpack_require__("../node_modules/pmodule/index.js"));
+const _indexJs = __webpack_require__.ir(__webpack_require__("../node_modules/pmodule/index.js"));
 _indexJs.default.should.be.eql("def");
 _indexJs.x.should.be.eql("x");
 _indexJs.z.should.be.eql("z");

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -1,5 +1,5 @@
-pub const INTEROP_REQUIRE: &str = "interopRequire";
-pub const EXPORT_STAR: &str = "exportStar";
+pub const INTEROP_REQUIRE: &str = "ir";
+pub const EXPORT_STAR: &str = "es";
 
 // port from webpack RuntimeGlobals
 

--- a/crates/rspack_plugin_asset/fixtures/rspack/asset-source/expected/main.js
+++ b/crates/rspack_plugin_asset/fixtures/rspack/asset-source/expected/main.js
@@ -7,7 +7,7 @@ module.exports = "- Isn't Rspack a gamechanging bundler?\n  - Hella yeah!";},
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _dataTxt = __webpack_require__.interopRequire(__webpack_require__("./data.txt"));
+const _dataTxt = __webpack_require__.ir(__webpack_require__("./data.txt"));
 console.log(_dataTxt.default);
 },
 

--- a/crates/rspack_plugin_asset/fixtures/webpack/asset-advanced/expected/main.js
+++ b/crates/rspack_plugin_asset/fixtures/webpack/asset-advanced/expected/main.js
@@ -7,7 +7,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5v
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _fileSvg = __webpack_require__.interopRequire(__webpack_require__("./images/file.svg"));
+const _fileSvg = __webpack_require__.ir(__webpack_require__("./images/file.svg"));
 const container = document.createElement("div");
 Object.assign(container.style, {
     display: "flex",

--- a/crates/rspack_plugin_asset/fixtures/webpack/asset-simple/expected/main.js
+++ b/crates/rspack_plugin_asset/fixtures/webpack/asset-simple/expected/main.js
@@ -13,9 +13,9 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5v
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _filePng = __webpack_require__.interopRequire(__webpack_require__("./images/file.png"));
-const _fileJpg = __webpack_require__.interopRequire(__webpack_require__("./images/file.jpg"));
-const _fileSvg = __webpack_require__.interopRequire(__webpack_require__("./images/file.svg"));
+const _filePng = __webpack_require__.ir(__webpack_require__("./images/file.png"));
+const _fileJpg = __webpack_require__.ir(__webpack_require__("./images/file.jpg"));
+const _fileSvg = __webpack_require__.ir(__webpack_require__("./images/file.svg"));
 const container = document.createElement("div");
 Object.assign(container.style, {
     display: "flex",

--- a/crates/rspack_plugin_javascript/src/visitors/format.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/format.rs
@@ -212,7 +212,10 @@ impl<'a> RspackModuleFormatTransformer<'a> {
               runtime_globals::REQUIRE.into(),
               DUMMY_SP,
             ))),
-            prop: MemberProp::Ident(Ident::new("interopRequire".into(), DUMMY_SP)),
+            prop: MemberProp::Ident(Ident::new(
+              runtime_globals::INTEROP_REQUIRE.into(),
+              DUMMY_SP,
+            )),
           }
           .as_arg()];
         } else {
@@ -270,7 +273,10 @@ impl<'a> RspackModuleFormatTransformer<'a> {
                         runtime_globals::REQUIRE.into(),
                         DUMMY_SP,
                       ))),
-                      prop: MemberProp::Ident(Ident::new("interopRequire".into(), DUMMY_SP)),
+                      prop: MemberProp::Ident(Ident::new(
+                        runtime_globals::INTEROP_REQUIRE.into(),
+                        DUMMY_SP,
+                      )),
                     }
                     .as_arg()],
                     type_args: None,

--- a/crates/rspack_plugin_javascript/src/visitors/inject_runtime_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/inject_runtime_helper.rs
@@ -73,7 +73,10 @@ impl<'a> VisitMut for InjectRuntimeHelper<'a> {
             runtime_globals::REQUIRE.into(),
             DUMMY_SP,
           ))),
-          prop: MemberProp::Ident(Ident::new("interopRequire".into(), DUMMY_SP)),
+          prop: MemberProp::Ident(Ident::new(
+            runtime_globals::INTEROP_REQUIRE.into(),
+            DUMMY_SP,
+          )),
         }
         .as_callee();
         n.args.visit_mut_children_with(self);
@@ -91,7 +94,7 @@ impl<'a> VisitMut for InjectRuntimeHelper<'a> {
             runtime_globals::REQUIRE.into(),
             DUMMY_SP,
           ))),
-          prop: MemberProp::Ident(Ident::new("exportStar".into(), DUMMY_SP)),
+          prop: MemberProp::Ident(Ident::new(runtime_globals::EXPORT_STAR.into(), DUMMY_SP)),
         }
         .as_callee();
         n.args.visit_mut_children_with(self);

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/expected/main.js
@@ -4,7 +4,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _libJs = __webpack_require__.interopRequire(__webpack_require__("./lib.js"));
+const _libJs = __webpack_require__.ir(__webpack_require__("./lib.js"));
 const lib = __webpack_require__("./lib.js");
 const { DO_NOT_CONVERTED9  } = __webpack_require__("./lib.js");
 equal(true, true);

--- a/crates/rspack_plugin_javascript/tests/fixtures/duplicate-generated-default-import-name-esm-to-commonjs/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/duplicate-generated-default-import-name-esm-to-commonjs/expected/main.js
@@ -37,9 +37,9 @@ const _default = 'cart-c';
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _cartJs = __webpack_require__.interopRequire(__webpack_require__("./a/cart.js"));
-const _cartJs1 = __webpack_require__.interopRequire(__webpack_require__("./b/cart.js"));
-const _cartJs2 = __webpack_require__.interopRequire(__webpack_require__("./c/cart.js"));
+const _cartJs = __webpack_require__.ir(__webpack_require__("./a/cart.js"));
+const _cartJs1 = __webpack_require__.ir(__webpack_require__("./b/cart.js"));
+const _cartJs2 = __webpack_require__.ir(__webpack_require__("./c/cart.js"));
 console.log(_cartJs.default, _cartJs1.default, _cartJs2.default);
 },
 

--- a/crates/rspack_plugin_json/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack_plugin_json/tests/fixtures/simple/expected/main.js
@@ -4,7 +4,7 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _jsonJson = __webpack_require__.interopRequire(__webpack_require__("./json.json"));
+const _jsonJson = __webpack_require__.ir(__webpack_require__("./json.json"));
 console.log(_jsonJson.default);
 },
 "./json.json": function (module, exports, __webpack_require__) {

--- a/crates/rspack_plugin_runtime/src/runtime/common/_export_star.js
+++ b/crates/rspack_plugin_runtime/src/runtime/common/_export_star.js
@@ -1,5 +1,5 @@
 (function () {
-	__webpack_require__.exportStar = function (from, to) {
+	__webpack_require__.es = function (from, to) {
 		Object.keys(from).forEach(function (k) {
 			if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k))
 				Object.defineProperty(to, k, {

--- a/crates/rspack_plugin_runtime/src/runtime/common/_interop_require.js
+++ b/crates/rspack_plugin_runtime/src/runtime/common/_interop_require.js
@@ -9,7 +9,7 @@
 		})(nodeInterop);
 	}
 
-	__webpack_require__.interopRequire = function (obj, nodeInterop) {
+	__webpack_require__.ir = function (obj, nodeInterop) {
 		if (!nodeInterop && obj && obj.__esModule) {
 			return obj;
 		}

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -47,7 +47,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
         "hotModuleReplacement": false,
       },
       "name": "main.xxxx.js",
-      "size": 1321,
+      "size": 1297,
       "type": "asset",
     },
     {
@@ -96,10 +96,10 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       "assets": [
         {
           "name": "main.xxxx.js",
-          "size": 1321,
+          "size": 1297,
         },
       ],
-      "assetsSize": 1321,
+      "assetsSize": 1297,
       "chunks": [
         "main",
       ],
@@ -108,7 +108,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
-  "hash": "43657cde39b00269",
+  "hash": "44611678b7aac9ae",
   "modules": [
     {
       "chunks": [
@@ -160,9 +160,9 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for filename 2`] = `
-"Hash: 43657cde39b00269
+"Hash: 44611678b7aac9ae
              Asset       Size      Chunks             Chunk Names
-      main.xxxx.js   1.29 KiB        main  [emitted]  main
+      main.xxxx.js   1.27 KiB        main  [emitted]  main
 dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]  
 Entrypoint main = main.xxxx.js
 chunk {dynamic_js} dynamic_js.xxxx.js 32 bytes
@@ -489,7 +489,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
         "hotModuleReplacement": false,
       },
       "name": "bundle.js",
-      "size": 889,
+      "size": 865,
       "type": "asset",
     },
   ],
@@ -513,10 +513,10 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
       "assets": [
         {
           "name": "bundle.js",
-          "size": 889,
+          "size": 865,
         },
       ],
-      "assetsSize": 889,
+      "assetsSize": 865,
       "chunks": [
         "main",
       ],
@@ -531,7 +531,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
     },
   ],
   "errorsCount": 1,
-  "hash": "1d99a30a4839d630",
+  "hash": "4130679ddcefbaa3",
   "modules": [
     {
       "chunks": [
@@ -555,9 +555,9 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-unexpected-exports-in-pkg 2`] = `
-"Hash: 1d99a30a4839d630
+"Hash: 4130679ddcefbaa3
     Asset       Size  Chunks             Chunk Names
-bundle.js  889 bytes    main  [emitted]  main
+bundle.js  865 bytes    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 39 bytes [entry]
 [10] ./index.js 39 bytes {main}

--- a/packages/rspack/tests/cases/interop/multiple/index.js
+++ b/packages/rspack/tests/cases/interop/multiple/index.js
@@ -13,6 +13,6 @@ it("should have interop", function () {
 
 it("should interop helper inject once", function () {
 	const content = fs.readFileSync(__filename, "utf-8");
-	const keyStr = content.match(/__webpack_require__\.interopRequire/);
+	const keyStr = content.match(/__webpack_require__\.ir/);
 	expect(keyStr && keyStr.length).toBe(1);
 });


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
