### PR TITLE
perf: reduce atomic lock contention

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -17,7 +17,6 @@ use std::{
   marker::PhantomPinned,
   path::PathBuf,
   pin::Pin,
-  sync::atomic::{AtomicU32, Ordering},
   sync::Arc,
 };
 use swc_core::ecma::atoms::JsWord;
@@ -333,7 +332,7 @@ impl Compilation {
       self.push_batch_diagnostic(e.into());
     }
 
-    let mut active_task_count = 0 as usize;
+    let mut active_task_count = 0usize;
     let (result_tx, mut result_rx) = tokio::sync::mpsc::unbounded_channel::<Result<TaskResult>>();
     let mut factorize_queue = FactorizeQueue::new();
     let mut add_queue = AddQueue::new();


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
