### PR TITLE
chore: fix cargo.lock

### DIFF
--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2248,7 +2248,6 @@ dependencies = [
  "sugar_path",
  "swc_core",
  "tracing",
- "ustr",
  "xxhash-rust",
 ]
 
@@ -2310,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc84f60d35bf76c332b42a00eb2d85ad5a3b76598d150cfa7f7c7734222174"
+checksum = "1d93e958d22fd1b2cdc3df462b416464f8fb18bb9183ab47c8ab9ef5411195f9"
 dependencies = [
  "dashmap",
  "dyn-clone",


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
