### PR TITLE
perf(rspack_core): use FxHasher in DashMap

### DIFF
--- a/crates/rspack_core/src/cache/snapshot/manager.rs
+++ b/crates/rspack_core/src/cache/snapshot/manager.rs
@@ -1,11 +1,12 @@
 use std::{
+  hash::BuildHasherDefault,
   path::{Path, PathBuf},
   time::SystemTime,
 };
 
 use dashmap::DashMap;
 use rspack_error::Result;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHasher};
 
 use super::Snapshot;
 use crate::{calc_hash, SnapshotOptions, SnapshotStrategy};
@@ -19,9 +20,9 @@ pub struct SnapshotManager {
   /// global snapshot options
   options: SnapshotOptions,
   /// cache file update time
-  update_time_cache: DashMap<PathBuf, SystemTime>,
+  update_time_cache: DashMap<PathBuf, SystemTime, BuildHasherDefault<FxHasher>>,
   /// cache file hash
-  hash_cache: DashMap<PathBuf, u64>,
+  hash_cache: DashMap<PathBuf, u64, BuildHasherDefault<FxHasher>>,
 }
 
 impl SnapshotManager {

--- a/crates/rspack_core/src/cache/storage/memory.rs
+++ b/crates/rspack_core/src/cache/storage/memory.rs
@@ -1,17 +1,19 @@
+use std::hash::BuildHasherDefault;
+
 use dashmap::DashMap;
 
 use super::Storage;
-use crate::Identifier;
+use crate::{Identifier, IdentifierHasher};
 
 #[derive(Debug)]
 pub struct MemoryStorage<Item> {
-  data: DashMap<Identifier, Item>,
+  data: DashMap<Identifier, Item, BuildHasherDefault<IdentifierHasher>>,
 }
 
 impl<Item> MemoryStorage<Item> {
   pub fn new() -> Self {
     Self {
-      data: DashMap::new(),
+      data: DashMap::default(),
     }
   }
 }

--- a/crates/rspack_core/src/compiler/resolver.rs
+++ b/crates/rspack_core/src/compiler/resolver.rs
@@ -1,7 +1,11 @@
-use std::path::Path;
-use std::path::PathBuf;
-use std::sync::Arc;
+use std::{
+  hash::BuildHasherDefault,
+  path::{Path, PathBuf},
+  sync::Arc,
+};
 
+use dashmap::DashMap;
+use rustc_hash::FxHasher;
 use tracing::instrument;
 
 use crate::Resolve;
@@ -29,7 +33,7 @@ impl ResolveInfo {
 pub struct ResolverFactory {
   cache: Arc<nodejs_resolver::Cache>,
   base_options: Resolve,
-  resolvers: dashmap::DashMap<Resolve, Arc<Resolver>>,
+  resolvers: DashMap<Resolve, Arc<Resolver>, BuildHasherDefault<FxHasher>>,
 }
 
 impl Default for ResolverFactory {

--- a/crates/rspack_core/src/identifier.rs
+++ b/crates/rspack_core/src/identifier.rs
@@ -3,21 +3,24 @@ use std::hash::BuildHasherDefault;
 use std::{convert::From, fmt, ops::Deref};
 
 use hashlink::{LinkedHashMap, LinkedHashSet};
-use ustr::{IdentityHasher, Ustr};
+use ustr::Ustr;
 
 pub trait Identifiable {
   fn identifier(&self) -> Identifier;
 }
 
+pub type IdentifierHasher = ustr::IdentityHasher;
+
 /// A standard `HashMap` using `Ustr` as the key type with a custom `Hasher` that
 /// just uses the precomputed hash for speed instead of calculating it
-pub type IdentifierMap<V> = HashMap<Identifier, V, BuildHasherDefault<IdentityHasher>>;
-pub type IdentifierLinkedMap<V> = LinkedHashMap<Identifier, V, BuildHasherDefault<IdentityHasher>>;
+pub type IdentifierMap<V> = HashMap<Identifier, V, BuildHasherDefault<IdentifierHasher>>;
+pub type IdentifierLinkedMap<V> =
+  LinkedHashMap<Identifier, V, BuildHasherDefault<IdentifierHasher>>;
 
 /// A standard `HashSet` using `Ustr` as the key type with a custom `Hasher` that
 /// just uses the precomputed hash for speed instead of calculating it
-pub type IdentifierSet = HashSet<Identifier, BuildHasherDefault<IdentityHasher>>;
-pub type IdentifierLinkedSet = LinkedHashSet<Identifier, BuildHasherDefault<IdentityHasher>>;
+pub type IdentifierSet = HashSet<Identifier, BuildHasherDefault<IdentifierHasher>>;
+pub type IdentifierLinkedSet = LinkedHashSet<Identifier, BuildHasherDefault<IdentifierHasher>>;
 
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Identifier(Ustr);

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -1,6 +1,7 @@
 use std::{
   borrow::Cow,
   fmt::Debug,
+  hash::BuildHasherDefault,
   hash::Hash,
   path::PathBuf,
   sync::{
@@ -21,7 +22,7 @@ use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawSource, Source, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
 };
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use serde_json::json;
 
 use crate::{
@@ -323,7 +324,7 @@ pub struct NormalModule {
   options: Arc<CompilerOptions>,
   #[allow(unused)]
   debug_id: usize,
-  cached_source_sizes: DashMap<SourceType, f64>,
+  cached_source_sizes: DashMap<SourceType, f64, BuildHasherDefault<FxHasher>>,
 
   code_generation_dependencies: Option<Vec<Box<dyn ModuleDependency>>>,
 
@@ -382,7 +383,7 @@ impl NormalModule {
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
 
       options,
-      cached_source_sizes: DashMap::new(),
+      cached_source_sizes: DashMap::default(),
       code_generation_dependencies: None,
       build_info: Default::default(),
     }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
