### PR TITLE
chore(ci): add cache to check-rs workflow

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -83,3 +83,6 @@ jobs:
 
       - name: Remove Criterion Artifact
         run: rm -rf ./target/criterion
+
+      - name: Clean cache
+        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache

--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -52,6 +52,9 @@ jobs:
           command: fmt
           args: --all --verbose -- --check
 
+      - name: Clean cache
+        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache
+
   lint:
     name: Lint Rust Files
     runs-on: [self-hosted, rspack-common]
@@ -79,6 +82,9 @@ jobs:
       - name: Check Dependencies
         run: |
           node ./scripts/check_rust_dependency.js
+
+      - name: Clean cache
+        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache
 
   test-rs:
     name: Rust test
@@ -111,3 +117,6 @@ jobs:
           npm i -g pnpm
           pnpm i
           cargo test --all -- --nocapture
+
+      - name: Clean cache
+        run: cargo install cargo-cache --no-default-features --features ci-autoclean && cargo-cache


### PR DESCRIPTION
## Summary

Our current ci runs for too long, let's add some cache to speed it up.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
