### PR TITLE
chore: 🤖 disable toml lint in ci

### DIFF
--- a/.github/workflows/check-js.yaml
+++ b/.github/workflows/check-js.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           node -e "console.log(process.arch)"  
           pnpm install
-          pnpm run format-ci:toml
+          # pnpm run format-ci:toml
           pnpm run lint:js
           pnpm run build:cli:release
           pnpm --filter @rspack/plugin-html run build


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
