### PR TITLE
refactor: hmr api expr matcher

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -284,11 +284,10 @@ fn test_dependency_scanner() {
   // )
 }
 
-fn match_member_expr(expr: &Expr, value: &str) -> bool {
+fn match_member_expr(mut expr: &Expr, value: &str) -> bool {
   let mut parts: Vec<&str> = value.split('.').collect();
   parts.reverse();
   let last = parts.pop().expect("should have a last str");
-  let mut expr = expr;
   for part in parts {
     if let Expr::Member(member_expr) = expr {
       if let MemberProp::Ident(ident) = &member_expr.prop {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
