### PR TITLE
perf: remove create_chunk_assets_occasion cache

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -648,18 +648,12 @@ impl Compilation {
       .chunk_by_ukey
       .values()
       .map(|chunk| async {
-        let manifest = self
-          .cache
-          .create_chunk_assets_occasion
-          .use_cache(self, chunk, || async {
-            plugin_driver
-              .read()
-              .await
-              .render_manifest(RenderManifestArgs {
-                chunk_ukey: chunk.ukey,
-                compilation: self,
-              })
-              .await
+        let manifest = plugin_driver
+          .read()
+          .await
+          .render_manifest(RenderManifestArgs {
+            chunk_ukey: chunk.ukey,
+            compilation: self,
           })
           .await;
 


### PR DESCRIPTION
## Summary

create_chunk_assets_occasion will copy and store the render_manifest result, which will be more time-consuming than using render_manifest directly.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
