### PR TITLE
fix: 🐛 tree-shaking dev with concurrent minifier

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -133,7 +133,7 @@ pub fn run_before_pass(
 pub fn run_after_pass(ast: &mut Ast, module: &dyn Module, generate_context: &mut GenerateContext) {
   let cm = ast.get_context().source_map.clone();
 
-  ast.transform(|program, context| {
+  _ = ast.transform_with_handler(cm.clone(), |_, program, context| {
     let unresolved_mark = context.unresolved_mark;
     let top_level_mark = context.top_level_mark;
     let tree_shaking = generate_context.compilation.options.builtins.tree_shaking;
@@ -210,5 +210,6 @@ pub fn run_after_pass(ast: &mut Ast, module: &dyn Module, generate_context: &mut
     );
 
     program.fold_with(&mut pass);
+    Ok(())
   });
 }


### PR DESCRIPTION
## Summary
1. try `examples/arco-pro` with this branch `rspack-cli`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
