### PR TITLE
chore: change to less-loader

### DIFF
--- a/examples/arco-pro/package.json
+++ b/examples/arco-pro/package.json
@@ -52,6 +52,7 @@
     "css-loader": "^6.7.1",
     "html-webpack-plugin": "^5.5.0",
     "less-loader": "^11.1.0",
+    "postcss-loader": "7.0.2",
     "mini-css-extract-plugin": "^2.6.1",
     "style-loader": "^3.3.1",
     "swc-loader": "^0.2.3",

--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -1,5 +1,3 @@
-const lessLoader = require('@rspack/less-loader');
-const postcssLoader = require('@rspack/postcss-loader');
 const path = require('path');
 
 /**
@@ -33,10 +31,17 @@ module.exports = {
           test: /\.less$/,
           use:
             [
-              { loader: postcssLoader, options: { modules: true } },
-              { loader: lessLoader },
+              { loader: 'less-loader' },
             ],
           type: 'css'
+        },
+        {
+          test: /\.module\.less$/,
+          use:
+            [
+              { loader: 'less-loader' },
+            ],
+          type: 'css/module'
         },
         { test: /\.svg$/, use: [{ loader: './svg-loader.js' }], type: 'jsx' }
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,7 @@ importers:
       mini-css-extract-plugin: ^2.6.1
       mockjs: ^1.1.0
       nprogress: ^0.2.0
+      postcss-loader: 7.0.2
       query-string: ^6.14.1
       react: ^17.0.2
       react-color: ^2.19.3
@@ -137,6 +138,7 @@ importers:
       html-webpack-plugin: 5.5.0_webpack@5.74.0
       less-loader: 11.1.0_webpack@5.74.0
       mini-css-extract-plugin: 2.7.2_webpack@5.74.0
+      postcss-loader: 7.0.2_webpack@5.74.0
       serve: 14.1.2
       style-loader: 3.3.1_webpack@5.74.0
       swc-loader: 0.2.3_hzeag5wohmlrlexhcbrhkqzb4q
@@ -10623,6 +10625,19 @@ packages:
       cosmiconfig: 7.1.0
       klona: 2.0.5
       semver: 7.3.8
+    dev: true
+
+  /postcss-loader/7.0.2_webpack@5.74.0:
+    resolution: {integrity: sha512-fUJzV/QH7NXUAqV8dWJ9Lg4aTkDCezpTS5HgJ2DvqznexTbSTxgi/dTECvTZ15BwKTtk8G/bqI/QTu2HPd3ZCg==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      postcss: ^7.0.0 || ^8.0.1
+      webpack: ^5.0.0
+    dependencies:
+      cosmiconfig: 7.1.0
+      klona: 2.0.5
+      semver: 7.3.8
+      webpack: 5.74.0_id63hl4ti3a2o54kosxu7nkk2i
     dev: true
 
   /postcss-modules-extract-imports/3.0.0_postcss@8.4.16:


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
