### PR TITLE
perf(rspack_core): cache module identifier for NormalModule

### DIFF
--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -265,7 +265,7 @@ impl Compiler {
           .filter_map(|module| {
             updated_runtime_modules
               .contains(module)
-              .then_some(ModuleIdentifier::from(module.as_str()))
+              .then(|| ModuleIdentifier::from(module.as_str()))
           })
           .collect::<Vec<_>>();
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -301,6 +301,7 @@ pub struct BuildInfo {
 
 #[derive(Debug)]
 pub struct NormalModule {
+  id: ModuleIdentifier,
   /// Request with loaders from config
   request: String,
   /// Request intended by user (without loaders from config)
@@ -377,6 +378,7 @@ impl NormalModule {
     options: Arc<CompilerOptions>,
   ) -> Self {
     Self {
+      id: ModuleIdentifier::from(request.as_ref()),
       request,
       user_request,
       raw_request,
@@ -437,7 +439,7 @@ impl NormalModule {
 
 impl Identifiable for NormalModule {
   fn identifier(&self) -> ModuleIdentifier {
-    ModuleIdentifier::from(self.request.as_str())
+    self.id
   }
 }
 


### PR DESCRIPTION
## Summary

ModuleIdentifier::from currently runs Ustr::from,
which has a performance overhead by a hash + (conditional) mutex lock.


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
