### PR TITLE
refactor: napi-derive with noop

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -22,7 +22,7 @@ once_cell = "1"
 regex = "1.6.0"
 rspack = { path = "../rspack" }
 rspack_binding_macros = { path = "../rspack_binding_macros" }
-rspack_binding_options = { path = "../rspack_binding_options", features = [
+rspack_binding_options = { path = "../rspack_binding_options", default-features = false, features = [
   "node-api",
 ] }
 rspack_core = { path = "../rspack_core" }

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -4,13 +4,8 @@ name    = "rspack_binding_options"
 version = "0.1.0"
 
 [features]
-default = []
-node-api = [
-  "dep:napi-derive",
-  "dep:napi",
-  "dep:napi-sys",
-  "dep:rspack_binding_macros",
-]
+default  = ["napi-derive/noop"]
+node-api = []
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
@@ -22,12 +17,12 @@ napi = { workspace = true, features = [
   "tokio_rt",
   "serde-json",
   "anyhow",
-], optional = true }
-napi-derive = { workspace = true, optional = true, version = "2" }
-napi-sys = { workspace = true, optional = true, version = "2" }
+] }
+napi-derive = { workspace = true, version = "2" }
+napi-sys = { workspace = true, version = "2" }
 once_cell = "1"
 regex = "1.6.0"
-rspack_binding_macros = { path = "../rspack_binding_macros", optional = true }
+rspack_binding_macros = { path = "../rspack_binding_macros" }
 rspack_core = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error", features = ["napi"] }
 rspack_loader_sass = { path = "../rspack_loader_sass" }

--- a/crates/rspack_binding_options/src/options/raw_module.rs
+++ b/crates/rspack_binding_options/src/options/raw_module.rs
@@ -1,24 +1,18 @@
 use std::fmt::Debug;
 
-#[cfg(feature = "node-api")]
 use napi::{bindgen_prelude::*, JsFunction, NapiRaw};
-#[cfg(feature = "node-api")]
 use napi_derive::napi;
-#[cfg(feature = "node-api")]
 use rspack_binding_macros::call_js_function_with_napi_objects;
 use rspack_core::{
   AssetGeneratorOptions, AssetParserDataUrlOption, AssetParserOptions, BoxedLoader,
-  CompilerOptionsBuilder, ModuleOptions, ModuleRule, ParserOptions,
+  CompilerOptionsBuilder, Loader, ModuleOptions, ModuleRule, ParserOptions,
 };
-#[cfg(feature = "node-api")]
 use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use serde::Deserialize;
 
-#[cfg(feature = "node-api")]
 use crate::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use crate::{RawOption, RawResolveOptions};
 
-#[cfg(feature = "node-api")]
 type JsLoader<R> = ThreadsafeFunction<JsLoaderContext, R>;
 // type ModuleRuleFunc = ThreadsafeFunction<Vec<u8>, ErrorStrategy::CalleeHandled>;
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
