### PR TITLE
feat(crates/rspack_core): add module graph util

### DIFF
--- a/crates/rspack_core/src/module_graph.rs
+++ b/crates/rspack_core/src/module_graph.rs
@@ -271,7 +271,12 @@ impl ModuleGraph {
     self.connection_id_to_connection.get(&connection_id)
   }
 
-  pub fn remove_connection_by_dependency(&mut self, dep: &BoxModuleDependency) {
+  pub fn remove_connection_by_dependency(
+    &mut self,
+    dep: &BoxModuleDependency,
+  ) -> Option<ModuleGraphConnection> {
+    let mut removed = None;
+
     if let Some(id) = self.dependency_to_dependency_id.get(dep).copied() {
       if let Some(conn) = self.dependency_id_to_connection_id.remove(&id) {
         self.connection_id_to_dependency_id.remove(&conn);
@@ -290,12 +295,16 @@ impl ModuleGraph {
           if let Some(mgm) = self.module_graph_module_by_identifier_mut(&conn.module_identifier) {
             mgm.incoming_connections.remove(&conn.id);
           }
+
+          removed = Some(conn);
         }
       }
       self.dependency_id_to_module_identifier.remove(&id);
       self.dependency_id_to_dependency.remove(&id);
       self.dependency_to_dependency_id.remove(dep);
     }
+
+    removed
   }
 
   pub fn get_pre_order_index(&self, module_identifier: &ModuleIdentifier) -> Option<usize> {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
