### PR TITLE
feat: add environment, afterEnvironment, afterPlugins, and afterResolvers compiler hooks

### DIFF
--- a/.changeset/chilly-glasses-taste.md
+++ b/.changeset/chilly-glasses-taste.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+feat: environment, afterEnvironment, afterPlugins, and afterResolvers hooks

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -55,6 +55,7 @@ export class Compilation {
 	outputOptions: ResolvedOutput;
 	compiler: Compiler;
 	resolverFactory: ResolverFactory;
+	inputFileSystem: any;
 	logging: Map<string, LogEntry[]>;
 	name: string;
 
@@ -65,6 +66,8 @@ export class Compilation {
 			log: new tapable.SyncBailHook(["origin", "logEntry"])
 		};
 		this.compiler = compiler;
+		this.resolverFactory = compiler.resolverFactory;
+		this.inputFileSystem = compiler.inputFileSystem;
 		this.options = compiler.options;
 		this.outputOptions = compiler.options.output;
 		this.logging = new Map();

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -61,6 +61,10 @@ class Compiler {
 		failed: tapable.SyncHook<[Error]>;
 		watchRun: tapable.AsyncSeriesHook<[Compiler]>;
 		watchClose: tapable.SyncHook<[]>;
+		environment: tapable.SyncHook<[]>;
+		afterEnvironment: tapable.SyncHook<[]>;
+		afterPlugins: tapable.SyncHook<[Compiler]>;
+		afterResolvers: tapable.SyncHook<[Compiler]>;
 	};
 	options: RspackOptionsNormalized;
 
@@ -104,7 +108,11 @@ class Compiler {
 			infrastructureLog: new SyncBailHook(["origin", "type", "args"]),
 			failed: new SyncHook(["error"]),
 			watchRun: new tapable.AsyncSeriesHook(["compiler"]),
-			watchClose: new tapable.SyncHook([])
+			watchClose: new tapable.SyncHook([]),
+			environment: new tapable.SyncHook([]),
+			afterEnvironment: new tapable.SyncHook([]),
+			afterPlugins: new tapable.SyncHook(["compiler"]),
+			afterResolvers: new tapable.SyncHook(["compiler"])
 		};
 		this.modifiedFiles = undefined;
 		this.removedFiles = undefined;

--- a/packages/rspack/src/config/plugin.ts
+++ b/packages/rspack/src/config/plugin.ts
@@ -1,6 +1,6 @@
 import { Compiler } from "..";
 
 export interface PluginInstance {
-	name: string;
+	name?: string;
 	apply(compiler: Compiler): void;
 }

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -71,6 +71,8 @@ function createCompiler(userOptions: RspackOptions): Compiler {
 		"NormalizedOptions:",
 		util.inspect(compiler.options, { colors: true, depth: null })
 	);
+	compiler.hooks.environment.call();
+	compiler.hooks.afterEnvironment.call();
 	new RspackOptionsApply().process(compiler.options, compiler);
 	compiler.hooks.initialize.call();
 	return compiler;

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -25,6 +25,7 @@ export class RspackOptionsApply {
 		}
 		new ResolveSwcPlugin().apply(compiler);
 
+		compiler.hooks.afterPlugins.call(compiler);
 		if (!compiler.inputFileSystem) {
 			throw new Error("No input filesystem provided");
 		}
@@ -43,5 +44,6 @@ export class RspackOptionsApply {
 				resolveOptions.resolveToContext = true;
 				return resolveOptions;
 			});
+		compiler.hooks.afterResolvers.call(compiler);
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
