### PR TITLE
fix(close: #1661): avoid additional entry depend on __webpack_require__.m

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -68,7 +68,8 @@ impl Visit for FoundReactRefreshVisitor {
   }
 }
 
-static HMR_HEADER: &str = r#"var RefreshRuntime = __webpack_require__('/react-refresh');
+// __webpack_require__.$ReactRefreshRuntime$ is injected by the react-refresh additional entry
+static HMR_HEADER: &str = r#"var RefreshRuntime = __webpack_require__.$ReactRefreshRuntime$;
 var prevRefreshReg;
 var prevRefreshSig;
 prevRefreshReg = globalThis.$RefreshReg$;
@@ -78,7 +79,7 @@ globalThis.$RefreshReg$ = (type, id) => {
 };
 globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;"#;
 
-static HMR_FOOTER: &str = r#"var RefreshRuntime = __webpack_require__('/react-refresh');
+static HMR_FOOTER: &str = r#"var RefreshRuntime = __webpack_require__.$ReactRefreshRuntime$;
 globalThis.$RefreshReg$ = prevRefreshReg;
 globalThis.$RefreshSig$ = prevRefreshSig;
 module.hot.accept();

--- a/packages/rspack-dev-client/src/clients/SockJSClient.ts
+++ b/packages/rspack-dev-client/src/clients/SockJSClient.ts
@@ -2,13 +2,4 @@ export * from "webpack-dev-server/client/clients/SockJSClient";
 
 // TODO: hack providerPlugin
 // @ts-ignored
-if (typeof __webpack_require__ !== "undefined") {
-	var id = "/ws-client";
-	// @ts-ignored
-	__webpack_require__.m[id] =
-		// @ts-ignored
-		__webpack_require__.m[id] ||
-		function (module) {
-			module.exports = require("webpack-dev-server/client/clients/SockJSClient");
-		};
-}
+__webpack_require__.$WsClient$ = require("webpack-dev-server/client/clients/SockJSClient");

--- a/packages/rspack-dev-client/src/clients/WebSocketClient.ts
+++ b/packages/rspack-dev-client/src/clients/WebSocketClient.ts
@@ -2,13 +2,4 @@ export * from "webpack-dev-server/client/clients/WebSocketClient";
 
 // TODO: hack providerPlugin
 // @ts-ignored
-if (typeof __webpack_require__ !== "undefined") {
-	var id = "/ws-client";
-	// @ts-ignored
-	__webpack_require__.m[id] =
-		// @ts-ignored
-		__webpack_require__.m[id] ||
-		function (module) {
-			module.exports = require("webpack-dev-server/client/clients/WebSocketClient");
-		};
-}
+__webpack_require__.$WsClient$ = require("webpack-dev-server/client/clients/WebSocketClient");

--- a/packages/rspack-dev-client/src/reactRefresh.ts
+++ b/packages/rspack-dev-client/src/reactRefresh.ts
@@ -15,17 +15,11 @@ if (process.env.NODE_ENV !== "production") {
 
 	var queueUpdate = debounce(RefreshRuntime.performReactRefresh, 16);
 
-	var id = "/react-refresh";
 	// @ts-ignored
-	__webpack_require__.m[id] =
-		// @ts-ignored
-		__webpack_require__.m[id] ||
-		function (module, exports) {
-			module.exports = {
-				queueUpdate,
-				...RefreshRuntime
-			};
-		};
+	__webpack_require__.$ReactRefreshRuntime$ = {
+		queueUpdate,
+		...RefreshRuntime
+	};
 } else {
 	throw Error(
 		"React Refresh runtime should not be included in the production bundle."

--- a/packages/rspack-dev-client/src/socket.ts
+++ b/packages/rspack-dev-client/src/socket.ts
@@ -8,7 +8,7 @@ export interface Handler {
 }
 
 // @ts-ignore
-const __webpack_dev_server_client__ = __webpack_require__("/ws-client");
+const __webpack_dev_server_client__ = __webpack_require__.$WsClient$;
 const Client =
 	typeof __webpack_dev_server_client__ !== "undefined"
 		? typeof __webpack_dev_server_client__.default !== "undefined"


### PR DESCRIPTION

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

#1661 

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
