### PR TITLE
chore: move create module hash to make phase

### DIFF
--- a/crates/rspack_core/src/chunk_graph.rs
+++ b/crates/rspack_core/src/chunk_graph.rs
@@ -341,40 +341,40 @@ impl ChunkGraph {
     &cgc.runtime_modules
   }
 
-  pub fn set_module_hashes(
-    &mut self,
-    module_identifier: ModuleIdentifier,
-    runtime: &RuntimeSpec,
-    hash: u64,
-  ) {
-    let cgm = self.get_chunk_graph_module_mut(module_identifier);
+  // pub fn set_module_hashes(
+  //   &mut self,
+  //   module_identifier: ModuleIdentifier,
+  //   runtime: &RuntimeSpec,
+  //   hash: u64,
+  // ) {
+  //   let cgm = self.get_chunk_graph_module_mut(module_identifier);
 
-    if let Some(runtime_spec_map) = &mut cgm.hashes {
-      if let Some(value) = runtime_spec_map.get(runtime) {
-        unreachable!("Hash for runtime already set: {}", value);
-      } else {
-        runtime_spec_map.set(runtime.clone(), hash);
-      }
-    } else {
-      let mut runtime_spec_map = RuntimeSpecMap::default();
-      runtime_spec_map.set(runtime.clone(), hash);
-      cgm.hashes = Some(runtime_spec_map);
-    }
-  }
+  //   if let Some(runtime_spec_map) = &mut cgm.hashes {
+  //     if let Some(value) = runtime_spec_map.get(runtime) {
+  //       unreachable!("Hash for runtime already set: {}", value);
+  //     } else {
+  //       runtime_spec_map.set(runtime.clone(), hash);
+  //     }
+  //   } else {
+  //     let mut runtime_spec_map = RuntimeSpecMap::default();
+  //     runtime_spec_map.set(runtime.clone(), hash);
+  //     cgm.hashes = Some(runtime_spec_map);
+  //   }
+  // }
 
-  pub fn get_module_hash(
-    &self,
-    module_identifier: ModuleIdentifier,
-    runtime: &RuntimeSpec,
-  ) -> Option<&u64> {
-    let cgm = self.get_chunk_graph_module(module_identifier);
-    if let Some(runtime_spec_map) = &cgm.hashes {
-      if let Some(value) = runtime_spec_map.get(runtime) {
-        return Some(value);
-      }
-    }
-    None
-  }
+  // pub fn get_module_hash(
+  //   &self,
+  //   module_identifier: ModuleIdentifier,
+  //   runtime: &RuntimeSpec,
+  // ) -> Option<&u64> {
+  //   let cgm = self.get_chunk_graph_module(module_identifier);
+  //   if let Some(runtime_spec_map) = &cgm.hashes {
+  //     if let Some(value) = runtime_spec_map.get(runtime) {
+  //       return Some(value);
+  //     }
+  //   }
+  //   None
+  // }
 
   pub fn get_chunk_condition_map<F: Fn(&ChunkUkey, &ChunkGraph, &ModuleGraph) -> bool>(
     &self,
@@ -454,7 +454,7 @@ pub struct ChunkGraphModule {
   pub(crate) chunks: HashSet<ChunkUkey>,
   pub(crate) runtime_requirements: Option<RuntimeSpecMap<HashSet<&'static str>>>,
   pub(crate) runtime_in_chunks: HashSet<ChunkUkey>,
-  pub(crate) hashes: Option<RuntimeSpecMap<u64>>,
+  // pub(crate) hashes: Option<RuntimeSpecMap<u64>>,
 }
 
 impl ChunkGraphModule {
@@ -465,7 +465,7 @@ impl ChunkGraphModule {
       chunks: Default::default(),
       runtime_requirements: None,
       runtime_in_chunks: Default::default(),
-      hashes: None,
+      // hashes: None,
     }
   }
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -90,6 +90,7 @@ pub struct ModuleGraphModule {
   pub post_order_index: Option<usize>,
   pub module_syntax: ModuleSyntax,
   pub used: bool,
+  pub hash: Option<u64>,
 }
 
 impl ModuleGraphModule {
@@ -114,6 +115,7 @@ impl ModuleGraphModule {
       post_order_index: None,
       module_syntax: ModuleSyntax::empty(),
       used: default_used,
+      hash: None,
     }
   }
 

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -590,10 +590,7 @@ impl Plugin for CssPlugin {
     );
     let mut hasher = Xxh3::default();
     for module_identifier in ordered_modules {
-      if let Some(hash) = compilation
-        .chunk_graph
-        .get_module_hash(module_identifier, &chunk.runtime)
-      {
+      if let Some(hash) = compilation.module_graph.get_module_hash(&module_identifier) {
         hash.hash(&mut hasher);
       }
     }

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -410,8 +410,8 @@ impl Plugin for JsPlugin {
     ordered_modules.sort_by_key(|m| &m.module_identifier);
     for mgm in ordered_modules {
       if let Some(hash) = compilation
-        .chunk_graph
-        .get_module_hash(mgm.module_identifier, &chunk.runtime)
+        .module_graph
+        .get_module_hash(&mgm.module_identifier)
       {
         hash.hash(&mut hasher);
       }


### PR DESCRIPTION
## Summary

move create module hash to make phase, only calculate changed module hash for hmr
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

###  hmr before
![image](https://user-images.githubusercontent.com/14008915/213114321-4fb6bac8-41d1-40c9-a4da-0994c815c7d7.png)

### hmr after 
![image](https://user-images.githubusercontent.com/14008915/213114386-1d22577c-b604-4884-9d0c-6cabaa3fb890.png)

### first make before
![image](https://user-images.githubusercontent.com/14008915/213115133-c9f64f76-d288-4526-8327-90d4b7ec8594.png)

### first make after
![image](https://user-images.githubusercontent.com/14008915/213115191-9cb25ea2-a5be-405d-bc43-9bb029982500.png)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
