### PR TITLE
perf: use Identifier for RuntimeSpec

### DIFF
--- a/crates/rspack_core/src/chunk_spliter/split_chunks.rs
+++ b/crates/rspack_core/src/chunk_spliter/split_chunks.rs
@@ -5,7 +5,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tracing::instrument;
 
 use crate::{
-  ChunkGroup, ChunkGroupKind, ChunkGroupUkey, ChunkUkey, Compilation, IdentifierSet,
+  ChunkGroup, ChunkGroupKind, ChunkGroupUkey, ChunkUkey, Compilation, Identifier, IdentifierSet,
   ModuleIdentifier,
 };
 
@@ -78,7 +78,7 @@ impl<'me> CodeSplitter<'me> {
 
       let mut entrypoint = ChunkGroup::new(
         ChunkGroupKind::Entrypoint,
-        HashSet::from_iter([name.to_string()]),
+        HashSet::from_iter([Identifier::from(name.as_str())]),
         Some(name.to_string()),
       );
       if options.runtime.is_none() {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -44,7 +44,8 @@ use crate::{
   IdentifierLinkedSet, IdentifierMap, IdentifierSet, LoaderRunnerRunner, Module, ModuleDependency,
   ModuleGraph, ModuleIdentifier, ModuleType, NormalModuleAstOrSource, ProcessAssetsArgs,
   ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs,
-  Resolve, RuntimeModule, SharedPluginDriver, Stats, TaskResult, VisitedModuleIdentity, WorkerTask,
+  Resolve, RuntimeModule, RuntimeSpec, SharedPluginDriver, Stats, TaskResult,
+  VisitedModuleIdentity, WorkerTask,
 };
 
 #[derive(Debug)]
@@ -1206,8 +1207,7 @@ impl Compilation {
           .get_number_of_module_chunks(module.identifier())
           > 0
         {
-          let mut module_runtime_requirements: Vec<(HashSet<String>, HashSet<&'static str>)> =
-            vec![];
+          let mut module_runtime_requirements: Vec<(RuntimeSpec, HashSet<&'static str>)> = vec![];
           for runtime in self
             .chunk_graph
             .get_module_runtimes(module.identifier(), &self.chunk_by_ukey)

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -10,7 +10,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use crate::{
   fast_set, AssetInfo, CacheOptions, Chunk, ChunkKind, Compilation, CompilationAsset, Compiler,
-  IdentifierMap, IdentifierSet, ModuleIdentifier, RenderManifestArgs, RuntimeSpec, SetupMakeParam,
+  Identifier, IdentifierMap, IdentifierSet, ModuleIdentifier, RenderManifestArgs, RuntimeSpec,
+  SetupMakeParam,
 };
 
 const HOT_UPDATE_MAIN_FILENAME: &str = "hot-update.json";
@@ -105,8 +106,8 @@ impl Compiler {
 
     let mut hot_update_main_content_by_runtime = all_old_runtime
       .iter()
-      .map(|id| (id.clone(), HotUpdateContent::new(id)))
-      .collect::<HashMap<String, HotUpdateContent>>();
+      .map(|id| (*id, HotUpdateContent::new(id)))
+      .collect::<HashMap<Identifier, HotUpdateContent>>();
 
     let mut old_chunks: Vec<(String, IdentifierSet, RuntimeSpec)> = vec![];
     for (ukey, chunk) in &old.compilation.chunk_by_ukey {
@@ -271,7 +272,7 @@ impl Compiler {
         // intersectRuntime
         for old_runtime in &all_old_runtime {
           if current_chunk.runtime.contains(old_runtime) {
-            new_runtime.insert(old_runtime.clone());
+            new_runtime.insert(*old_runtime);
           }
         }
         // ------

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -3,9 +3,9 @@ use std::{fmt::Debug, hash::Hash};
 use rspack_sources::{BoxSource, RawSource, SourceExt};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use crate::{ChunkUkey, Compilation};
+use crate::{ChunkUkey, Compilation, Identifier};
 
-pub type RuntimeSpec = HashSet<String>;
+pub type RuntimeSpec = HashSet<Identifier>;
 pub type RuntimeKey = String;
 
 #[derive(Default, Clone, Copy, Debug)]
@@ -21,8 +21,8 @@ pub fn is_runtime_equal(a: &RuntimeSpec, b: &RuntimeSpec) -> bool {
     return false;
   }
 
-  let mut a: Vec<String> = Vec::from_iter(a.iter().cloned());
-  let mut b: Vec<String> = Vec::from_iter(b.iter().cloned());
+  let mut a: Vec<&str> = Vec::from_iter(a.iter().map(|s| s.as_str()));
+  let mut b: Vec<&str> = Vec::from_iter(b.iter().map(|s| s.as_str()));
 
   a.sort();
   b.sort();
@@ -31,7 +31,7 @@ pub fn is_runtime_equal(a: &RuntimeSpec, b: &RuntimeSpec) -> bool {
 }
 
 pub fn get_runtime_key(runtime: RuntimeSpec) -> String {
-  let mut runtime: Vec<String> = Vec::from_iter(runtime.into_iter());
+  let mut runtime: Vec<&str> = Vec::from_iter(runtime.iter().map(|s| s.as_str()));
   runtime.sort();
   runtime.join("\n")
 }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
