### PR TITLE
fix(crates/rspack_core): should expect shutdown on some occasions

### DIFF
--- a/.changeset/wet-shoes-peel.md
+++ b/.changeset/wet-shoes-peel.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix(crates/rspack_core): should expect shutdown on some occasions


### PR DESCRIPTION
## Summary

Rspack expects shutdown on some occasions:
1. A task results in a recoverable error.
2. All tasks are finished and there's no message buffered in the channel.
3. Senders are gone.

In these expected shutdowns, Rspack neither handles the task nor sends the task result to the main thread. As the receiver might get destructed.
However, in other unexpected shutdowns, like panicking on the main thread, the panic hook would successfully capture the error. Or with a buggy state that results in early destruction for the receiver side(there's no panic or error involved), **the send error should also be captured to the panic hook**.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
