### PR TITLE
refactor(crates/node_binding): use concurrent compiler error instead of locking

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -83,11 +83,7 @@ impl Rspack {
   }
 
   /// Build with the given option passed to the constructor
-  #[napi(
-    catch_unwind,
-    js_name = "unsafe_build",
-    ts_args_type = "callback: (err: null | Error) => void"
-  )]
+  #[napi(catch_unwind, ts_args_type = "callback: (err: null | Error) => void")]
   pub fn build(&mut self, env: Env, f: JsFunction) -> Result<()> {
     if self
       .lock
@@ -122,7 +118,6 @@ impl Rspack {
   /// Rebuild with the given option passed to the constructor
   #[napi(
     catch_unwind,
-    js_name = "unsafe_rebuild",
     ts_args_type = "changed_files: string[], removed_files: string[], callback: (err: null | Error) => void"
   )]
   pub fn rebuild(

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -318,8 +318,8 @@ class Compiler {
 	}
 	// Safety: This method is only valid to call if the previous build task is finished, or there will be data races.
 	build(cb: (error?: Error) => void) {
-		const unsafe_build = this.#instance.unsafe_build;
-		const build_cb = unsafe_build.bind(this.#instance) as typeof unsafe_build;
+		const build = this.#instance.build;
+		const build_cb = build.bind(this.#instance) as typeof build;
 		build_cb(err => {
 			if (err) {
 				cb(err);
@@ -334,10 +334,8 @@ class Compiler {
 		removedFiles: ReadonlySet<string>,
 		cb: (error?: Error) => void
 	) {
-		const unsafe_rebuild = this.#instance.unsafe_rebuild;
-		const rebuild_cb = unsafe_rebuild.bind(
-			this.#instance
-		) as typeof unsafe_rebuild;
+		const rebuild = this.#instance.rebuild;
+		const rebuild_cb = rebuild.bind(this.#instance) as typeof rebuild;
 		rebuild_cb([...modifiedFiles], [...removedFiles], err => {
 			if (err) {
 				cb(err);


### PR DESCRIPTION
## Summary

Align with webpack's concurrent compiler error if compiler run is called multiple times

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
