### PR TITLE
chore: update lock

### DIFF
--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2380,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36469c1e43237bc74138fc05c9803568723e1a9741ebc0534e74ad24d009390b"
+checksum = "9fead20ec220d19054978c80631028519c6e002deaf4c86655a292fae8b7df44"
 dependencies = [
  "dashmap",
  "dyn-clone",
@@ -2393,7 +2393,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "smol_str",
  "substring",
 ]
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
