### PR TITLE
fix: tree-shaking visit

### DIFF
--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -880,7 +880,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         }
       };
       let is_export = self.state.contains(AnalyzeState::EXPORT_DECL);
-      if is_export {
+      if is_export && lhs.ctxt.outer() == self.top_level_mark {
         self.add_export(
           lhs.atom.clone(),
           SymbolRef::Direct(Symbol::from_id_and_uri(


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
