### PR TITLE
perf: computing chunk ids in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,7 @@ dependencies = [
 name = "rspack_ids"
 version = "0.1.0"
 dependencies = [
+ "rayon",
  "regex",
  "rspack_core",
  "rspack_error",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2118,6 +2118,7 @@ dependencies = [
 name = "rspack_ids"
 version = "0.1.0"
 dependencies = [
+ "rayon",
  "regex",
  "rspack_core",
  "rspack_error",

--- a/crates/rspack_ids/Cargo.toml
+++ b/crates/rspack_ids/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rayon        = "1.5.3"
 regex        = "1.7.0"
 rspack_core  = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use rspack_core::{Chunk, Plugin};
 
 use crate::id_helpers::{
-  assign_ascending_chunk_ids, assign_names, get_long_chunk_name, get_short_chunk_name,
+  assign_ascending_chunk_ids, assign_names_par, get_long_chunk_name, get_short_chunk_name,
   get_used_chunk_ids,
 };
 
@@ -46,7 +46,7 @@ impl Plugin for NamedChunkIdsPlugin {
       .map(|chunk| chunk as &Chunk)
       .collect::<Vec<_>>();
     let mut chunk_id_to_name = HashMap::with_capacity(chunks.len());
-    let unnamed_chunks = assign_names(
+    let unnamed_chunks = assign_names_par(
       chunks,
       |chunk| get_short_chunk_name(chunk, chunk_graph, &context, &self.delimiter, module_graph),
       |chunk, _| get_long_chunk_name(chunk, chunk_graph, &context, &self.delimiter, module_graph),

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -2,8 +2,8 @@ use rspack_core::Plugin;
 use rspack_error::Result;
 
 use crate::id_helpers::{
-  assign_ascending_module_ids, assign_names, compare_modules_by_identifier, get_long_module_name,
-  get_short_module_name, get_used_module_ids_and_modules,
+  assign_ascending_module_ids, assign_names_par, compare_modules_by_identifier,
+  get_long_module_name, get_short_module_name, get_used_module_ids_and_modules,
 };
 
 #[derive(Debug)]
@@ -24,7 +24,7 @@ impl Plugin for NamedModuleIdsPlugin {
       .collect::<Vec<_>>();
     let chunk_graph = &mut compilation.chunk_graph;
 
-    let unnamed_modules = assign_names(
+    let unnamed_modules = assign_names_par(
       modules,
       |m| get_short_module_name(m, context),
       |module, short_name| get_long_module_name(short_name, module, context),


### PR DESCRIPTION
## Summary

computing chunk ids in parallel

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Before: 4.6s
![image](https://user-images.githubusercontent.com/9291503/215465297-5e63a62f-c527-4ef6-afd0-87936ea83d3b.png)

After: 0.2s
![image](https://user-images.githubusercontent.com/9291503/215465404-16caaae1-1e1b-43d2-9e0a-ef9dbe682a18.png)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information abount the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
