### PR TITLE
fix: use inline_globals2 flod for module vaiables

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -198,12 +198,7 @@ pub fn run_after_pass(
           generate_context.compilation.options.target.es_version
         ),
         inject_runtime_helper(unresolved_mark, generate_context.runtime_requirements),
-        module_variables(
-          module,
-          unresolved_mark,
-          top_level_mark,
-          generate_context.compilation,
-        ),
+        module_variables(module, generate_context.compilation),
         finalize(module, generate_context.compilation, unresolved_mark),
         swc_visitor::hygiene(false, top_level_mark),
         swc_visitor::fixer(comments.map(|v| v as &dyn Comments)),

--- a/packages/rspack/tests/cases/module-variables/webpack_modules/index.js
+++ b/packages/rspack/tests/cases/module-variables/webpack_modules/index.js
@@ -1,0 +1,5 @@
+it("__webpack_modules__", function () {
+	expect(__webpack_modules__).not.toBeUndefined();
+	__webpack_modules__.a = 1;
+	expect(__webpack_modules__.a).toBe(1);
+});


### PR DESCRIPTION

## Summary

before assgin left expr not be replaced.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
