### PR TITLE
fix: revert changes in benchmarks

### DIFF
--- a/crates/rspack/benches/main.rs
+++ b/crates/rspack/benches/main.rs
@@ -3,6 +3,7 @@ use std::{hint::black_box, path::PathBuf, time::Duration};
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use mimalloc_rust::GlobalMiMalloc;
+use rspack_test::read_test_config_and_normalize;
 use xshell::{cmd, Shell};
 
 #[cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))]
@@ -11,7 +12,7 @@ static GLOBAL: GlobalMiMalloc = GlobalMiMalloc;
 
 async fn bench(cur_dir: &PathBuf) {
   // cur_dir = cur_dir.join("webpack_css_cases_to_be_migrated/bootstrap");
-  let options = rspack_test_utils::TestConfig::compiler_options_from_fixture(cur_dir);
+  let options = read_test_config_and_normalize(cur_dir);
   let mut compiler = rspack::rspack(options, Default::default());
 
   compiler


### PR DESCRIPTION
## Summary

The revert part of changes #1711. We would migrate benchmarks to native rust config in the future. For now, just make it work.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
