### PR TITLE
feat: add styled-jsx support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,6 +779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
+name = "easy-error"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cc9717c61d2908f50d16ebb5677c7e82ea2bdf7cb52f66b30fe079f3212e16"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,6 +2657,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sourcemap",
+ "styled_jsx",
  "sugar_path",
  "swc_core",
  "tracing",
@@ -3236,6 +3243,17 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "styled_jsx"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a86c4a4d6b61091379312f0d31a9929be758d87ae7aaf8e6a32e2174b941ae"
+dependencies = [
+ "easy-error",
+ "swc_core",
+ "tracing",
+]
 
 [[package]]
 name = "substring"

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -536,6 +536,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9b0705efd4599c15a38151f4721f7bc388306f61084d3bfd50bd07fbca5cb60"
 
 [[package]]
+name = "easy-error"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cc9717c61d2908f50d16ebb5677c7e82ea2bdf7cb52f66b30fe079f3212e16"
+
+[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2326,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sourcemap",
+ "styled_jsx",
  "sugar_path",
  "swc_core",
  "tracing",
@@ -2786,6 +2793,17 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "styled_jsx"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a86c4a4d6b61091379312f0d31a9929be758d87ae7aaf8e6a32e2174b941ae"
+dependencies = [
+ "easy-error",
+ "swc_core",
+ "tracing",
+]
 
 [[package]]
 name = "substring"

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -49,6 +49,7 @@ pub struct RawBuiltins {
   pub react: Option<RawReactOptions>,
   pub decorator: Option<RawDecoratorOptions>,
   pub no_emit_assets: Option<bool>,
+  pub styled_jsx: Option<bool>,
 }
 
 pub(super) fn normalize_builtin(
@@ -115,6 +116,7 @@ pub(super) fn normalize_builtin(
     react: RawOption::raw_to_compiler_option(builtins.react, options)?,
     decorator: transform_to_decorator_options(builtins.decorator),
     no_emit_assets: builtins.no_emit_assets.unwrap_or(false),
+    styled_jsx: builtins.styled_jsx.unwrap_or(false),
   };
   Ok(ret)
 }

--- a/crates/rspack_core/src/options/builtins.rs
+++ b/crates/rspack_core/src/options/builtins.rs
@@ -36,6 +36,7 @@ pub struct Builtins {
   pub react: ReactOptions,
   pub decorator: Option<DecoratorOptions>,
   pub no_emit_assets: bool,
+  pub styled_jsx: bool,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -25,6 +25,7 @@ rspack_symbol = { path = "../rspack_symbol" }
 rustc-hash = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 sourcemap = "6.2.0"
+styled_jsx = "0.30.4"
 sugar_path = "0.0.9"
 swc_core = { workspace = true, features = [
   "__parser",

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -69,6 +69,10 @@ pub fn run_before_pass(
         syntax.typescript()
       ),
       Optional::new(
+        swc_visitor::styled_jsx(&cm),
+        options.builtins.styled_jsx && should_transform_by_react
+      ),
+      Optional::new(
         swc_visitor::react(top_level_mark, comments, &cm, &options.builtins.react),
         should_transform_by_react
       ),

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/mod.rs
@@ -10,6 +10,9 @@ pub use typescript::typescript;
 mod react;
 pub use react::{fold_react_refresh, react};
 
+mod styled_jsx;
+pub use self::styled_jsx::styled_jsx;
+
 mod define;
 pub use define::define;
 

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/styled_jsx.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/styled_jsx.rs
@@ -1,0 +1,8 @@
+use std::sync::Arc;
+
+use swc_core::common::{FileName, SourceMap};
+use swc_core::ecma::visit::Fold;
+
+pub fn styled_jsx(cm: &Arc<SourceMap>) -> impl Fold {
+  styled_jsx::visitor::styled_jsx(cm.clone(), FileName::Anon)
+}

--- a/examples/react-with-styled-jsx/index.html
+++ b/examples/react-with-styled-jsx/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/react-with-styled-jsx/package.json
+++ b/examples/react-with-styled-jsx/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "example-react-styled-jsx",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve -c ./rspack.config.js",
+    "build": "rspack build -c ./rspack.config.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@rspack/cli": "workspace:*",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-refresh": "0.14.0",
+    "styled-jsx": "^5.1.2"
+  }
+}

--- a/examples/react-with-styled-jsx/rspack.config.js
+++ b/examples/react-with-styled-jsx/rspack.config.js
@@ -1,0 +1,54 @@
+const path = require('path');
+
+/**
+ * @type {import('@rspack/cli').Configuration}
+ */
+module.exports = {
+  context: __dirname,
+  mode: 'development',
+  entry: {
+    main: {
+      import: ["./src/index.js"],
+    }
+  },
+  output: {
+    publicPath: '/',
+    // filename: '[name].[contenthash:8][ext]',
+  },
+  devServer: {
+    webSocketServer: 'ws',
+    hot: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        type: 'css'
+      },
+    ],
+    parser: {
+      asset: {
+        dataUrlCondition: {
+          maxSize: 1,
+        },
+      },
+    },
+  },
+  infrastructureLogging: {
+    debug: true,
+  },
+  builtins: {
+    html: [{
+      template: './index.html'
+    }],
+    define: {
+      'process.env.NODE_ENV': "'development'"
+    },
+    progress: {},
+    react: {
+      development: true,
+      refresh: true,
+    },
+    styledJsx: true
+  },
+};

--- a/examples/react-with-styled-jsx/src/app.jsx
+++ b/examples/react-with-styled-jsx/src/app.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export const App = () => {
+  return (
+    <React.Suspense fallback={<div>loading...</div>}>
+      <div>
+        <div>
+          <h1>I am Red</h1>
+          <style jsx>{`
+            h1 {
+              color: red;
+            }
+          `}</style>
+        </div>
+        <div>
+          <h1>I am NOT Red</h1>
+        </div>
+      </div>
+
+    </React.Suspense>
+  );
+};

--- a/examples/react-with-styled-jsx/src/index.js
+++ b/examples/react-with-styled-jsx/src/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { App } from './app';
+const container = createRoot(document.getElementById('root'));
+container.render(React.createElement(App));

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -41,6 +41,7 @@
     "sass-loader": "^13.2.0",
     "sinon": "14.0.0",
     "source-map": "^0.7.4",
+    "styled-jsx": "^5.1.2",
     "ts-node": "10.9.1",
     "tsm": "^2.2.2",
     "typescript": "4.7.3",

--- a/packages/rspack/tests/configCases/builtins/styled-jsx/index.jsx
+++ b/packages/rspack/tests/configCases/builtins/styled-jsx/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const element = <div>
+  <style jsx>{`
+    div {
+      color: red;
+    }
+  `}</style>
+</div>;
+
+it("has jsx- className", () => {
+  // scoped css class should be added like jsx-7b844396f2efe2ef
+  expect(element.props.className).toMatch(/jsx-(.+)/);
+});

--- a/packages/rspack/tests/configCases/builtins/styled-jsx/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/styled-jsx/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		styledJsx: true
+	}
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,20 @@ importers:
       react: 17.0.0
       react-dom: 17.0.0_react@17.0.0
 
+  examples/react-with-styled-jsx:
+    specifiers:
+      '@rspack/cli': workspace:*
+      react: 18.2.0
+      react-dom: 18.2.0
+      react-refresh: 0.14.0
+      styled-jsx: ^5.1.2
+    dependencies:
+      '@rspack/cli': link:../../packages/rspack-cli
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-refresh: 0.14.0
+      styled-jsx: 5.1.2_react@18.2.0
+
   examples/solid:
     specifiers:
       '@rspack/cli': workspace:*
@@ -368,6 +382,7 @@ importers:
       schema-utils: ^4.0.0
       sinon: 14.0.0
       source-map: ^0.7.4
+      styled-jsx: ^5.1.2
       tapable: 2.2.1
       ts-node: 10.9.1
       tsm: ^2.2.2
@@ -426,6 +441,7 @@ importers:
       sass-loader: 13.2.0_sass@1.56.2
       sinon: 14.0.0
       source-map: 0.7.4
+      styled-jsx: 5.1.2
       ts-node: 10.9.1_iqqktkndlpjcw7xba3ta44d6ve
       tsm: 2.2.2
       typescript: 4.7.3
@@ -6152,6 +6168,9 @@ packages:
       slice-ansi: 5.0.0
       string-width: 5.1.2
     dev: true
+
+  /client-only/0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   /clipboardy/3.0.0:
     resolution: {integrity: sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==}
@@ -12670,6 +12689,39 @@ packages:
     dependencies:
       webpack: 5.74.0_id63hl4ti3a2o54kosxu7nkk2i
     dev: true
+
+  /styled-jsx/5.1.2:
+    resolution: {integrity: sha512-FI5r0a5ED2/+DSdG2ZRz3a4FtNQnKPLadauU5v76a9QsscwZrWggQKOmyxGGP5EWKbyY3bsuWAJYzyKaDAVAcw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      client-only: 0.0.1
+    dev: true
+
+  /styled-jsx/5.1.2_react@18.2.0:
+    resolution: {integrity: sha512-FI5r0a5ED2/+DSdG2ZRz3a4FtNQnKPLadauU5v76a9QsscwZrWggQKOmyxGGP5EWKbyY3bsuWAJYzyKaDAVAcw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      client-only: 0.0.1
+      react: 18.2.0
+    dev: false
 
   /superstruct/1.0.3:
     resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add [styled-jsx](https://github.com/vercel/styled-jsx) transform support via [styled_jsx](https://crates.io/crates/styled_jsx).

A new switch added to `builtins` to control this behavior: 

```js
module.exports = {
  builtins: {
    styledJsx: true
  }
}
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
