### PR TITLE
refactor: enable strict mode of rspack/core

### DIFF
--- a/packages/rspack/jest.config.js
+++ b/packages/rspack/jest.config.js
@@ -1,6 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-	preset: "ts-jest",
 	testEnvironment: "node",
 	testMatch: [
 		"<rootDir>/tests/*.test.ts",
@@ -8,5 +7,13 @@ module.exports = {
 		"<rootDir>/tests/*.longtest.ts",
 		"<rootDir>/tests/*.unittest.ts"
 	],
-	cache: false
+	cache: false,
+	transform: {
+		"^.+\\.tsx?$": [
+			"ts-jest",
+			{
+				isolatedModules: true
+			}
+		]
+	}
 };

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -60,6 +60,7 @@ export class Compilation {
 	name: string;
 
 	constructor(compiler: Compiler, inner: JsCompilation) {
+		// @ts-expect-error
 		this.name = undefined;
 		this.hooks = {
 			processAssets: createFakeProcessAssetsHook(this),
@@ -152,6 +153,7 @@ export class Compilation {
 		let options: Partial<StatsOptionsObj> = {};
 		if (typeof optionsOrPreset === "object" && optionsOrPreset !== null) {
 			for (const key in optionsOrPreset) {
+				// @ts-expect-error
 				options[key] = optionsOrPreset[key];
 			}
 		}
@@ -262,6 +264,7 @@ export class Compilation {
 		const assets = this.#inner.getAssets();
 
 		return assets.map(asset => {
+			// @ts-expect-error
 			const source = createSourceFromRaw(asset.source);
 			return {
 				...asset,
@@ -277,6 +280,7 @@ export class Compilation {
 		}
 		return {
 			...asset,
+			// @ts-expect-error
 			source: createSourceFromRaw(asset.source)
 		};
 	}
@@ -325,10 +329,11 @@ export class Compilation {
 	}
 
 	// TODO: full alignment
+	// @ts-expect-error
 	getAssetPath(filename, data) {
 		return filename;
 	}
-
+	// @ts-expect-error
 	getLogger(name: string | (() => string)) {
 		if (!name) {
 			throw new TypeError("Compilation.getLogger(name) called without a name");
@@ -357,7 +362,9 @@ export class Compilation {
 				const logEntry: LogEntry = {
 					time: Date.now(),
 					type,
+					// @ts-expect-error
 					args,
+					// @ts-expect-error
 					trace
 				};
 				if (this.hooks.log.call(name, logEntry) === undefined) {

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -22,21 +22,28 @@ class HotModuleReplacementPlugin {
 }
 
 class Compiler {
+	// @ts-expect-error
 	#_instance: binding.Rspack;
 
 	webpack: any;
+	// @ts-expect-error
 	compilation: Compilation;
 	root: Compiler;
 	running: boolean;
 	resolverFactory: ResolverFactory;
 	infrastructureLogger: any;
+	// @ts-expect-error
 	watching: Watching;
+	// @ts-expect-error
 	outputPath: string;
+	// @ts-expect-error
 	name: string;
 	inputFileSystem: any;
 	outputFileSystem: any;
+	// @ts-expect-error
 	watchFileSystem: WatchFileSystem;
 	intermediateFileSystem: any;
+	// @ts-expect-error
 	watchMode: boolean;
 	context: string;
 	modifiedFiles?: ReadonlySet<string>;
@@ -181,6 +188,7 @@ class Compiler {
 					}
 				} else {
 					if (
+						// @ts-expect-error
 						this.hooks.infrastructureLog.call(name, type, args) === undefined
 					) {
 						if (this.infrastructureLogger !== undefined) {
@@ -189,9 +197,10 @@ class Compiler {
 					}
 				}
 			},
-			childName => {
+			(childName): any => {
 				if (typeof name === "function") {
 					if (typeof childName === "function") {
+						// @ts-expect-error
 						return this.getInfrastructureLogger(_ => {
 							if (typeof name === "function") {
 								name = name();
@@ -277,6 +286,7 @@ class Compiler {
 		}
 		this.running = true;
 		const doRun = () => {
+			// @ts-expect-error
 			const finalCallback = (err, stats?) => {
 				this.running = false;
 				if (err) {
@@ -322,6 +332,7 @@ class Compiler {
 			if (err) {
 				cb(err);
 			} else {
+				// @ts-expect-error
 				cb(null);
 			}
 		});
@@ -340,6 +351,7 @@ class Compiler {
 			if (err) {
 				cb(err);
 			} else {
+				// @ts-expect-error
 				cb(null);
 			}
 		});
@@ -352,11 +364,13 @@ class Compiler {
 		if (this.running) {
 			return handler(
 				new ConcurrentCompilationError(),
+				// @ts-expect-error
 				null
 			) as unknown as Watching;
 		}
 		this.running = true;
 		this.watchMode = true;
+		// @ts-expect-error
 		this.watching = new Watching(this, watchOptions, handler);
 		return this.watching;
 	}
@@ -370,7 +384,9 @@ class Compiler {
 	/**
 	 * @todo
 	 */
+	// @ts-expect-error
 	close(callback) {
+		// @ts-expect-error
 		this.#_instance = null;
 		if (this.watching) {
 			// When there is still an active watching, close this first
@@ -381,6 +397,7 @@ class Compiler {
 		}
 		callback();
 	}
+	// @ts-expect-error
 	emitAssets(compilation: Compilation, callback) {
 		const outputPath = compilation.getPath(this.outputPath, {});
 		fs.mkdirSync(outputPath, { recursive: true });
@@ -403,7 +420,7 @@ class Compiler {
 						}
 					}
 				};
-
+				// @ts-expect-error
 				const doWrite = content => {
 					this.outputFileSystem.writeFile(absPath, content, callback);
 				};

--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -27,6 +27,7 @@ export type ResolvedBuiltins = Omit<RawBuiltins, "html"> & {
 };
 
 function resolveDefine(define: Builtins["define"]): RawBuiltins["define"] {
+	// @ts-expect-error
 	const entries = Object.entries(define).map(([key, value]) => [
 		key,
 		value === undefined ? "undefined" : value
@@ -35,6 +36,7 @@ function resolveDefine(define: Builtins["define"]): RawBuiltins["define"] {
 }
 
 function resolveHtml(html: Builtins["html"]): BuiltinsHtmlPluginConfig[] {
+	// @ts-expect-error
 	return html.map(c => {
 		for (const key in c.meta) {
 			const value = c.meta[key];

--- a/packages/rspack/src/config/cache.ts
+++ b/packages/rspack/src/config/cache.ts
@@ -41,6 +41,7 @@ export function resolveCacheOptions(cache: Cache): ResolvedCache {
 	}
 
 	if (cache.type === "memory") {
+		// @ts-expect-error
 		cache.maxGenerations = isFinite(cache.maxGenerations)
 			? cache.maxGenerations
 			: 0;

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -30,6 +30,7 @@ const A = <T, P extends keyof T>(
 			if (item === "...") {
 				if (newArray === undefined) {
 					newArray = value.slice(0, i);
+					// @ts-expect-error
 					obj[prop] = newArray;
 				}
 				const items = factory();
@@ -55,6 +56,7 @@ export function applyRspackOptionsBaseDefaults(
  * @param {InfrastructureLogging} infrastructureLogging options
  * @returns {void}
  */
+// @ts-expect-error
 const applyInfrastructureLoggingDefaults = infrastructureLogging => {
 	F(infrastructureLogging, "stream", () => process.stderr);
 	const tty =
@@ -65,15 +67,17 @@ const applyInfrastructureLoggingDefaults = infrastructureLogging => {
 	D(infrastructureLogging, "colors", tty);
 	D(infrastructureLogging, "appendOnly", !tty);
 };
+// @ts-expect-error
 const applyOutputDefaults = (output: ResolvedOutput, context) => {
 	D(output, "hashFunction", "xxhash64");
 	F(output, "path", () => path.resolve(context, "dist"));
 	D(output, "publicPath", "auto");
 	return output;
 };
+
 const applyOptimizationDefaults = (
-	optimization,
-	{ production, development, css, records }
+	optimization: any,
+	{ production, development, css, records }: any
 ) => {
 	D(optimization, "removeAvailableModules", false);
 	D(optimization, "removeEmptyChunks", true);

--- a/packages/rspack/src/config/entry.ts
+++ b/packages/rspack/src/config/entry.ts
@@ -40,6 +40,7 @@ export function resolveEntryOptions(
 	if (normalizedRuntimeChunk) {
 		Object.entries(normalized).forEach(([entryName, value]) => {
 			if (value.runtime === undefined) {
+				// @ts-expect-error
 				value.runtime = normalizedRuntimeChunk.name({ name: entryName });
 			}
 		});

--- a/packages/rspack/src/config/index.ts
+++ b/packages/rspack/src/config/index.ts
@@ -114,6 +114,7 @@ export function getNormalizedRspackOptions(
 	const context = config.context ?? process.cwd();
 	const mode = config.mode ?? "production";
 	const entry = resolveEntryOptions(
+		// @ts-expect-error
 		config.entry,
 		{
 			context

--- a/packages/rspack/src/config/module.ts
+++ b/packages/rspack/src/config/module.ts
@@ -226,10 +226,13 @@ function composeJsUse(
 				let isSync = true;
 				let isError = false; // internal error
 				let reportedError = false;
-
+				// @ts-expect-error
 				const fileDependencies = [];
+				// @ts-expect-error
 				const contextDependencies = [];
+				// @ts-expect-error
 				const missingDependencies = [];
+				// @ts-expect-error
 				const buildDependencies = [];
 
 				function callback(
@@ -256,9 +259,13 @@ function composeJsUse(
 						content,
 						sourceMap,
 						additionalData,
+						// @ts-expect-error
 						fileDependencies,
+						// @ts-expect-error
 						contextDependencies,
+						// @ts-expect-error
 						missingDependencies,
+						// @ts-expect-error
 						buildDependencies
 					});
 				}
@@ -267,16 +274,19 @@ function composeJsUse(
 					// FIXME: resolve's fileDependencies will includes lots of dir, '/', etc.
 					return {
 						fileDependencies: {
+							// @ts-expect-error
 							add: d => {
 								// loaderContext.addDependency(d)
 							}
 						},
 						contextDependencies: {
+							// @ts-expect-error
 							add: d => {
 								// loaderContext.addContextDependency(d)
 							}
 						},
 						missingDependencies: {
+							// @ts-expect-error
 							add: d => {
 								// loaderContext.addMissingDependency(d)
 							}
@@ -297,16 +307,19 @@ function composeJsUse(
 					contextify.bindContextCache(moduleContext, compiler.root)
 				);
 				const utils = {
+					// @ts-expect-error
 					absolutify: (context, request) => {
 						return context === moduleContext
 							? getAbsolutifyInContext()(request)
 							: getAbsolutify()(context, request);
 					},
+					// @ts-expect-error
 					contextify: (context, request) => {
 						return context === moduleContext
 							? getContextifyInContext()(request)
 							: getContextify()(context, request);
 					},
+					// @ts-expect-error
 					createHash: type => {
 						return createHash(
 							type || compiler.compilation.outputOptions.hashFunction
@@ -365,6 +378,7 @@ function composeJsUse(
 							callback
 						);
 					},
+					// @ts-expect-error
 					getResolve(options) {
 						const child = options ? resolver.withOptions(options) : resolver;
 						return (context, request, callback) => {
@@ -400,6 +414,7 @@ function composeJsUse(
 					cacheable(value = true) {
 						cacheable = value;
 					},
+					// @ts-expect-error
 					async() {
 						if (isDone) {
 							if (reportedError) return; // ignore
@@ -447,7 +462,7 @@ function composeJsUse(
 								);
 							}
 
-							if (this.useSourceMap) {
+							if (this.sourceMap) {
 								source = new SourceMapSource(
 									content as any, // webpack-sources type declaration is wrong
 									name,
@@ -457,7 +472,7 @@ function composeJsUse(
 						} else {
 							source = new RawSource(content as any); // webpack-sources type declaration is wrong
 						}
-
+						// @ts-expect-error
 						compiler.compilation.emitAsset(name, source, assetInfo);
 					},
 					fs: compiler.inputFileSystem,
@@ -480,12 +495,15 @@ function composeJsUse(
 						missingDependencies.length = 0;
 					},
 					getDependencies() {
+						// @ts-expect-error
 						return fileDependencies.slice();
 					},
 					getContextDependencies() {
+						// @ts-expect-error
 						return contextDependencies.slice();
 					},
 					getMissingDependencies() {
+						// @ts-expect-error
 						return missingDependencies.slice();
 					}
 				};
@@ -515,7 +533,9 @@ function composeJsUse(
 				let result: Promise<string | Buffer> | string | Buffer | undefined =
 					undefined;
 				try {
+					// @ts-expect-error
 					result = loader.apply(loaderContext, [
+						// @ts-expect-error
 						loader.raw ? Buffer.from(content) : content.toString("utf-8"),
 						sourceMap,
 						additionalData
@@ -525,12 +545,16 @@ function composeJsUse(
 						if (result === undefined) {
 							resolve({
 								content,
+								// @ts-expect-error
 								buildDependencies,
 								sourceMap,
 								additionalData,
 								cacheable,
+								// @ts-expect-error
 								fileDependencies,
+								// @ts-expect-error
 								contextDependencies,
+								// @ts-expect-error
 								missingDependencies
 							});
 							return;
@@ -539,24 +563,32 @@ function composeJsUse(
 							return result.then(function (result) {
 								resolve({
 									content: result,
+									// @ts-expect-error
 									buildDependencies,
 									sourceMap,
 									additionalData,
 									cacheable,
+									// @ts-expect-error
 									fileDependencies,
+									// @ts-expect-error
 									contextDependencies,
+									// @ts-expect-error
 									missingDependencies
 								});
 							}, reject);
 						}
 						return resolve({
 							content: result,
+							// @ts-expect-error
 							buildDependencies,
 							sourceMap,
 							additionalData,
 							cacheable,
+							// @ts-expect-error
 							fileDependencies,
+							// @ts-expect-error
 							contextDependencies,
+							// @ts-expect-error
 							missingDependencies
 						});
 					}
@@ -568,6 +600,7 @@ function composeJsUse(
 					if (isDone) {
 						// loader is already "done", so we cannot use the callback function
 						// for better debugging we print the error on the console
+						// @ts-expect-error
 						if (typeof err === "object" && err.stack) console.error(err.stack);
 						else console.error(err);
 						reject(err);
@@ -685,6 +718,7 @@ function createRawModuleRuleUsesImpl(
 	}
 	const index = uses.findIndex(use => "builtinLoader" in use);
 	if (index < 0) {
+		// @ts-expect-error
 		return [composeJsUse(uses, options, allUses)];
 	}
 
@@ -794,6 +828,7 @@ export function resolveModuleOptions(
 	});
 	return {
 		parser: module.parser,
+		// @ts-expect-error
 		rules
 	};
 }

--- a/packages/rspack/src/config/optimization.ts
+++ b/packages/rspack/src/config/optimization.ts
@@ -44,6 +44,7 @@ export interface ResolvedOptimization {
 export function getNormalizedOptimizationRuntimeChunk(
 	runtimeChunk: OptimizationRuntimeChunk
 ): OptimizationRuntimeChunkNormalized {
+	// @ts-expect-error
 	if (runtimeChunk === undefined) return undefined;
 	if (runtimeChunk === false) return false;
 	if (runtimeChunk === "single") {
@@ -53,6 +54,7 @@ export function getNormalizedOptimizationRuntimeChunk(
 	}
 	if (runtimeChunk === true || runtimeChunk === "multiple") {
 		return {
+			// @ts-expect-error
 			name: entrypoint => `runtime~${entrypoint.name}`
 		};
 	}

--- a/packages/rspack/src/config/resolve.ts
+++ b/packages/rspack/src/config/resolve.ts
@@ -69,6 +69,7 @@ export function resolveResolveOptions(
 		mainFiles,
 		mainFields,
 		browserField,
+		// @ts-expect-error
 		conditionNames,
 		alias,
 		tsConfigPath,

--- a/packages/rspack/src/config/stats.ts
+++ b/packages/rspack/src/config/stats.ts
@@ -33,6 +33,7 @@ export function resolveStatsOptions(
 	const colors = optionsOrFallback(options.colors, false);
 	return {
 		...options,
+		// @ts-expect-error
 		colors
 	};
 }

--- a/packages/rspack/src/logging/Logger.ts
+++ b/packages/rspack/src/logging/Logger.ts
@@ -41,33 +41,35 @@ export type GetChildLogger = (name: string | (() => string)) => Logger;
 
 export class Logger {
 	getChildLogger: GetChildLogger;
-
+	[LOG_SYMBOL]: any;
+	[TIMERS_SYMBOL]: any;
+	[TIMERS_AGGREGATES_SYMBOL]: any;
 	constructor(log: LogFunction, getChildLogger: GetChildLogger) {
 		this[LOG_SYMBOL] = log;
 		this.getChildLogger = getChildLogger;
 	}
 
-	error(...args) {
+	error(...args: any[]) {
 		this[LOG_SYMBOL](LogType.error, args);
 	}
 
-	warn(...args) {
+	warn(...args: any[]) {
 		this[LOG_SYMBOL](LogType.warn, args);
 	}
 
-	info(...args) {
+	info(...args: any[]) {
 		this[LOG_SYMBOL](LogType.info, args);
 	}
 
-	log(...args) {
+	log(...args: any[]) {
 		this[LOG_SYMBOL](LogType.log, args);
 	}
 
-	debug(...args) {
+	debug(...args: string[]) {
 		this[LOG_SYMBOL](LogType.debug, args);
 	}
 
-	assert(assertion, ...args) {
+	assert(assertion: any, ...args: any[]) {
 		if (!assertion) {
 			this[LOG_SYMBOL](LogType.error, args);
 		}
@@ -81,36 +83,36 @@ export class Logger {
 		this[LOG_SYMBOL](LogType.clear);
 	}
 
-	status(...args) {
+	status(...args: any[]) {
 		this[LOG_SYMBOL](LogType.status, args);
 	}
 
-	group(...args) {
+	group(...args: any[]) {
 		this[LOG_SYMBOL](LogType.group, args);
 	}
 
-	groupCollapsed(...args) {
+	groupCollapsed(...args: any[]) {
 		this[LOG_SYMBOL](LogType.groupCollapsed, args);
 	}
 
-	groupEnd(...args) {
+	groupEnd(...args: any[]) {
 		this[LOG_SYMBOL](LogType.groupEnd, args);
 	}
 
-	profile(label) {
+	profile(label: any) {
 		this[LOG_SYMBOL](LogType.profile, [label]);
 	}
 
-	profileEnd(label) {
+	profileEnd(label: any) {
 		this[LOG_SYMBOL](LogType.profileEnd, [label]);
 	}
 
-	time(label) {
+	time(label: any) {
 		this[TIMERS_SYMBOL] = this[TIMERS_SYMBOL] || new Map();
 		this[TIMERS_SYMBOL].set(label, process.hrtime());
 	}
 
-	timeLog(label) {
+	timeLog(label: any) {
 		const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
 		if (!prev) {
 			throw new Error(`No such label '${label}' for WebpackLogger.timeLog()`);
@@ -119,7 +121,7 @@ export class Logger {
 		this[LOG_SYMBOL](LogType.time, [label, ...time]);
 	}
 
-	timeEnd(label) {
+	timeEnd(label: any) {
 		const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
 		if (!prev) {
 			throw new Error(`No such label '${label}' for WebpackLogger.timeEnd()`);
@@ -129,7 +131,7 @@ export class Logger {
 		this[LOG_SYMBOL](LogType.time, [label, ...time]);
 	}
 
-	timeAggregate(label) {
+	timeAggregate(label: any) {
 		const prev = this[TIMERS_SYMBOL] && this[TIMERS_SYMBOL].get(label);
 		if (!prev) {
 			throw new Error(
@@ -153,7 +155,7 @@ export class Logger {
 		this[TIMERS_AGGREGATES_SYMBOL].set(label, time);
 	}
 
-	timeAggregateEnd(label) {
+	timeAggregateEnd(label: any) {
 		if (this[TIMERS_AGGREGATES_SYMBOL] === undefined) return;
 		const time = this[TIMERS_AGGREGATES_SYMBOL].get(label);
 		if (time === undefined) return;

--- a/packages/rspack/src/logging/runtime.ts
+++ b/packages/rspack/src/logging/runtime.ts
@@ -24,13 +24,16 @@ let currentDefaultLogger = createConsoleLogger(currentDefaultLoggerOptions);
  * @param {string} name name of the logger
  * @returns {Logger} a logger
  */
+// @ts-expect-error
 export const getLogger = name => {
 	return new Logger(
+		// @ts-expect-error
 		(type, args) => {
 			if (exports.hooks.log.call(name, type, args) === undefined) {
 				currentDefaultLogger(name, type, args);
 			}
 		},
+		// @ts-expect-error
 		childName => exports.getLogger(`${name}/${childName}`)
 	);
 };
@@ -39,6 +42,7 @@ export const getLogger = name => {
  * @param {createConsoleLogger.LoggerOptions} options new options, merge with old options
  * @returns {void}
  */
+// @ts-expect-error
 export const configureDefaultLogger = options => {
 	Object.assign(currentDefaultLoggerOptions, options);
 	currentDefaultLogger = createConsoleLogger(currentDefaultLoggerOptions);

--- a/packages/rspack/src/logging/truncateArgs.ts
+++ b/packages/rspack/src/logging/truncateArgs.ts
@@ -8,7 +8,7 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
-const arraySum = array => {
+const arraySum = (array: any) => {
 	let sum = 0;
 	for (const item of array) sum += item;
 	return sum;
@@ -19,7 +19,9 @@ const arraySum = array => {
  * @param {number} maxLength maximum length of args including spaces between
  * @returns {string[]} truncated args
  */
+// @ts-expect-error
 const truncateArgs = (args, maxLength) => {
+	// @ts-expect-error
 	const lengths = args.map(a => `${a}`.length);
 	const availableLength = maxLength - lengths.length + 1;
 
@@ -34,6 +36,7 @@ const truncateArgs = (args, maxLength) => {
 	}
 
 	// Check if there is space for at least 4 chars per arg
+	// @ts-expect-error
 	if (availableLength < arraySum(lengths.map(i => Math.min(i, 6)))) {
 		// remove args
 		if (args.length > 1)
@@ -49,6 +52,7 @@ const truncateArgs = (args, maxLength) => {
 	// Try to remove chars from the longest items until it fits
 	while (currentLength > availableLength) {
 		const maxLength = Math.max(...lengths);
+		// @ts-expect-error
 		const shorterItems = lengths.filter(l => l !== maxLength);
 		const nextToMaxLength =
 			shorterItems.length > 0 ? Math.max(...shorterItems) : 0;
@@ -67,6 +71,7 @@ const truncateArgs = (args, maxLength) => {
 	}
 
 	// Return args reduced to length in lengths
+	// @ts-expect-error
 	return args.map((a, i) => {
 		const str = `${a}`;
 		const length = lengths[i];

--- a/packages/rspack/src/multiCompiler.ts
+++ b/packages/rspack/src/multiCompiler.ts
@@ -58,8 +58,10 @@ export type MultiCompilerOptions = {
 } & RspackOptions[];
 
 export class MultiCompiler {
+	// @ts-expect-error
 	context: string;
 	compilers: Compiler[];
+	// @ts-expect-error
 	compilation: Compilation;
 	dependencies: WeakMap<Compiler, string[]>;
 	hooks: {
@@ -70,13 +72,18 @@ export class MultiCompiler {
 		watchRun: MultiHook<Any>;
 		infrastructureLog: MultiHook<Any>;
 	};
+	// @ts-expect-error
 	name: string;
 	infrastructureLogger: Any;
 	_options: { parallelism?: number };
+	// @ts-expect-error
 	root: Compiler;
+	// @ts-expect-error
 	resolverFactory: ResolverFactory;
 	running: boolean;
+	// @ts-expect-error
 	watching: Watching;
+	// @ts-expect-error
 	watchMode: boolean;
 
 	constructor(
@@ -85,7 +92,9 @@ export class MultiCompiler {
 	) {
 		if (!Array.isArray(compilers)) {
 			compilers = Object.keys(compilers).map(name => {
+				// @ts-expect-error
 				compilers[name].name = name;
+				// @ts-expect-error
 				return compilers[name];
 			});
 		}
@@ -229,6 +238,7 @@ export class MultiCompiler {
 	validateDependencies(callback: Callback<Error, MultiStats>): boolean {
 		const edges = new Set<{ source: Compiler; target: Compiler }>();
 		const missing: string[] = [];
+		// @ts-expect-error
 		const targetFound = compiler => {
 			for (const edge of edges) {
 				if (edge.target === compiler) {
@@ -237,6 +247,7 @@ export class MultiCompiler {
 			}
 			return false;
 		};
+		// @ts-expect-error
 		const sortEdges = (e1, e2) => {
 			return (
 				e1.source.name.localeCompare(e2.source.name) ||
@@ -424,6 +435,7 @@ export class MultiCompiler {
 		 * @param {Node} node node
 		 * @returns {void}
 		 */
+		// @ts-expect-error
 		const nodeChange = node => {
 			nodeInvalid(node);
 			if (node.state === "pending") {
@@ -441,6 +453,7 @@ export class MultiCompiler {
 				(node.setupResult = setup(
 					node.compiler,
 					i,
+					// @ts-expect-error
 					nodeDone.bind(null, node),
 					() => node.state !== "starting" && node.state !== "running",
 					() => nodeChange(node),
@@ -464,6 +477,7 @@ export class MultiCompiler {
 				) {
 					running++;
 					node.state = "starting";
+					// @ts-expect-error
 					run(node.compiler, node.setupResult!, nodeDone.bind(null, node));
 					node.state = "running";
 				}
@@ -507,9 +521,12 @@ export class MultiCompiler {
 
 		if (this.validateDependencies(handler)) {
 			const watchings = this.#runGraph(
+				// @ts-expect-error
 				(compiler: Compiler, idx, done, isBlocked, setChanged, setInvalid) => {
 					const watching = compiler.watch(
+						// @ts-expect-error
 						Array.isArray(watchOptions) ? watchOptions[idx] : watchOptions,
+						// @ts-expect-error
 						done
 					);
 					if (watching) {
@@ -525,6 +542,7 @@ export class MultiCompiler {
 				},
 				handler
 			);
+			// @ts-expect-error
 			return new MultiWatching(watchings, this);
 		}
 
@@ -566,6 +584,7 @@ export class MultiCompiler {
 			(compiler, cb) => {
 				compiler.close(cb);
 			},
+			// @ts-expect-error
 			callback
 		);
 	}

--- a/packages/rspack/src/multiStats.ts
+++ b/packages/rspack/src/multiStats.ts
@@ -8,6 +8,7 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
+import { KnownCreateStatsOptionsContext } from ".";
 import { StatsOptionsObj } from "./config/stats";
 import { Stats, StatsCompilation } from "./stats";
 import { indent } from "./util";
@@ -32,7 +33,10 @@ export default class MultiStats {
 		return this.stats.some(stat => stat.hasWarnings());
 	}
 
-	#createChildOptions(options, context): StatsOptionsObj {
+	#createChildOptions(
+		options: { [x: string]: any; children?: any },
+		context: (KnownCreateStatsOptionsContext & Record<string, any>) | undefined
+	): StatsOptionsObj {
 		if (!options) {
 			options = {};
 		}
@@ -85,7 +89,7 @@ export default class MultiStats {
 		if (options.hash) {
 			obj.hash = obj.children.map(j => j.hash).join("");
 		}
-		const mapError = (j, obj) => {
+		const mapError = (j: any, obj: any) => {
 			return {
 				...obj,
 				compilerPath: obj.compilerPath
@@ -124,7 +128,7 @@ export default class MultiStats {
 		return obj;
 	}
 
-	toString(options) {
+	toString(options: any) {
 		options = this.#createChildOptions(options, { forToString: true });
 		const results = this.stats.map((stat, idx) => {
 			const str = stat.toString(options.children[idx]);

--- a/packages/rspack/src/multiWatching.ts
+++ b/packages/rspack/src/multiWatching.ts
@@ -35,7 +35,7 @@ class MultiWatching {
 		this.watchings = watchings;
 		this.compiler = compiler;
 	}
-
+	// @ts-expect-error
 	invalidate(callback) {
 		if (callback) {
 			asyncLib.each(
@@ -54,6 +54,7 @@ class MultiWatching {
 	 * @param {Callback<void>} callback signals when the watcher is closed
 	 * @returns {void}
 	 */
+	// @ts-expect-error
 	close(callback) {
 		asyncLib.forEach(
 			this.watchings,

--- a/packages/rspack/src/node/NodeEnvironmentPlugin.ts
+++ b/packages/rspack/src/node/NodeEnvironmentPlugin.ts
@@ -7,7 +7,7 @@
  * Copyright (c) JS Foundation and other contributors
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
-
+// @ts-expect-error
 import CachedInputFileSystem from "enhanced-resolve/lib/CachedInputFileSystem";
 import fs from "graceful-fs";
 import createConsoleLogger from "../logging/createConsoleLogger";

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -93,7 +93,9 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
 				}
 			}
 			const { fileTimeInfoEntries, contextTimeInfoEntries } = fetchTimeInfo();
+
 			callback(
+				// @ts-expect-error
 				null,
 				fileTimeInfoEntries,
 				contextTimeInfoEntries,
@@ -111,6 +113,7 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
 			close: () => {
 				if (this.watcher) {
 					this.watcher.close();
+					// @ts-expect-error
 					this.watcher = null;
 				}
 			},

--- a/packages/rspack/src/node/nodeConsole.ts
+++ b/packages/rspack/src/node/nodeConsole.ts
@@ -10,13 +10,14 @@
 
 const util = require("util");
 const truncateArgs = require("../logging/truncateArgs");
-
+// @ts-expect-error
 export = ({ colors, appendOnly, stream }) => {
+	// @ts-expect-error
 	let currentStatusMessage = undefined;
 	let hasStatusMessage = false;
 	let currentIndent = "";
 	let currentCollapsed = 0;
-
+	// @ts-expect-error
 	const indent = (str, prefix, colorPrefix, colorSuffix) => {
 		if (str === "") return str;
 		prefix = currentIndent + prefix;
@@ -40,18 +41,22 @@ export = ({ colors, appendOnly, stream }) => {
 	};
 
 	const writeStatusMessage = () => {
+		// @ts-expect-error
 		if (!currentStatusMessage) return;
 		const l = stream.columns;
 		const args = l
-			? truncateArgs(currentStatusMessage, l - 1)
-			: currentStatusMessage;
+			? // @ts-ignore
+			  truncateArgs(currentStatusMessage, l - 1)
+			: // @ts-ignore
+			  currentStatusMessage;
 		const str = args.join(" ");
 		const coloredStr = `\u001b[1m${str}\u001b[39m\u001b[22m`;
 		stream.write(`\x1b[2K\r${coloredStr}`);
 		hasStatusMessage = true;
 	};
-
+	// @ts-expect-error
 	const writeColored = (prefix, colorPrefix, colorSuffix) => {
+		// @ts-expect-error
 		return (...args) => {
 			if (currentCollapsed > 0) return;
 			clearStatusMessage();
@@ -90,6 +95,7 @@ export = ({ colors, appendOnly, stream }) => {
 			"\u001b[1m\u001b[35m",
 			"\u001b[39m\u001b[22m"
 		),
+		// @ts-expect-error
 		group: (...args) => {
 			writeGroupMessage(...args);
 			if (currentCollapsed > 0) {
@@ -98,6 +104,7 @@ export = ({ colors, appendOnly, stream }) => {
 				currentIndent += "  ";
 			}
 		},
+		// @ts-expect-error
 		groupCollapsed: (...args) => {
 			writeGroupCollapsedMessage(...args);
 			currentCollapsed++;
@@ -108,8 +115,10 @@ export = ({ colors, appendOnly, stream }) => {
 				currentIndent = currentIndent.slice(0, currentIndent.length - 2);
 		},
 		// eslint-disable-next-line node/no-unsupported-features/node-builtins
+		// @ts-expect-error
 		profile: console.profile && (name => console.profile(name)),
 		// eslint-disable-next-line node/no-unsupported-features/node-builtins
+		// @ts-expect-error
 		profileEnd: console.profileEnd && (name => console.profileEnd(name)),
 		clear:
 			!appendOnly &&
@@ -123,7 +132,8 @@ export = ({ colors, appendOnly, stream }) => {
 			}),
 		status: appendOnly
 			? writeColored("<s> ", "", "")
-			: (name, ...args) => {
+			: // @ts-expect-error
+			  (name, ...args) => {
 					args = args.filter(Boolean);
 					if (name === undefined && args.length === 0) {
 						clearStatusMessage();

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -21,6 +21,7 @@ function createMultiCompiler(options: MultiCompilerOptions): MultiCompiler {
 		 * Missing features: WebpackOptionsApply
 		 * `compiler.name` should be set by WebpackOptionsApply.
 		 */
+		// @ts-expect-error
 		compiler.name = option.name;
 		return compiler;
 	});
@@ -92,6 +93,7 @@ function rspack(options: any, callback?: Callback<any>) {
 	}
 
 	if (callback) {
+		// @ts-expect-error
 		compiler.run(callback);
 		return compiler;
 	} else {

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -7,15 +7,20 @@ import { cleverMerge } from "./util/cleverMerge";
 export class RspackOptionsApply {
 	constructor() {}
 	process(options: RspackOptionsNormalized, compiler: Compiler) {
+		// @ts-expect-error
 		compiler.outputPath = options.output.path;
+		// @ts-expect-error
 		compiler.name = options.name;
 		compiler.outputFileSystem = fs;
 		if (compiler.options.target.includes("node")) {
 			new NodeTargetPlugin().apply(compiler);
 		}
 		// after we migrate minify to minimze, we could remove it
+		// @ts-expect-error
 		if (options.optimization.minimize || options.builtins.minify) {
+			// @ts-expect-error
 			if (options.optimization.minimizer) {
+				// @ts-expect-error
 				for (const minimizer of options.optimization.minimizer) {
 					if (minimizer !== "...") {
 						minimizer.apply(compiler);

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -35,6 +35,7 @@ export class Stats {
 	}
 
 	toJson(opts?: StatsOptions, forToString?: boolean) {
+		// @ts-expect-error
 		const options = this.compilation.createStatsOptions(opts, {
 			forToString
 		});
@@ -51,10 +52,12 @@ export class Stats {
 			obj.chunks = this.#inner.getChunks();
 		}
 		if (options.modules) {
+			// @ts-expect-error
 			obj.modules = this.#inner.getModules(options.reasons);
 		}
 		if (options.entrypoints) {
 			obj.entrypoints = this.#inner.getEntrypoints().reduce((acc, cur) => {
+				// @ts-expect-error
 				acc[cur.name] = cur;
 				return acc;
 			}, {});
@@ -79,14 +82,16 @@ export class Stats {
 	}
 
 	toString(opts?: StatsOptions) {
+		// @ts-expect-error
 		const options = this.compilation.createStatsOptions(opts, {
 			forToString: true
 		});
 		const useColors = optionsOrFallback(options.colors, false);
 		const obj: any = this.toJson(options, true);
+		// @ts-expect-error
 		return Stats.jsonToString(obj, useColors);
 	}
-
+	// @ts-expect-error
 	static jsonToString(obj, useColors: boolean) {
 		const buf = [];
 
@@ -101,11 +106,13 @@ export class Stats {
 
 		const colors: any = Object.keys(defaultColors).reduce(
 			(obj, color) => {
+				// @ts-expect-error
 				obj[color] = str => {
 					if (useColors) {
 						buf.push(
 							useColors === true || useColors[color] === undefined
-								? defaultColors[color]
+								? // @ts-expect-error
+								  defaultColors[color]
 								: useColors[color]
 						);
 					}
@@ -117,11 +124,12 @@ export class Stats {
 				return obj;
 			},
 			{
+				// @ts-expect-error
 				normal: str => buf.push(str)
 			}
 		);
 
-		const coloredTime = time => {
+		const coloredTime = (time: number) => {
 			let times = [800, 400, 200, 100];
 			if (obj.time) {
 				times = [obj.time / 2, obj.time / 4, obj.time / 8, obj.time / 16];
@@ -135,11 +143,19 @@ export class Stats {
 
 		const newline = () => buf.push("\n");
 
-		const getText = (arr, row, col) => {
+		const getText = (
+			arr: { [x: string]: { [x: string]: { value: any } } },
+			row: number,
+			col: number
+		) => {
 			return arr[row][col].value;
 		};
 
-		const table = (array, align, splitter?: string) => {
+		const table = (
+			array: string | any[],
+			align: string | string[],
+			splitter?: string
+		) => {
 			const rows = array.length;
 			const cols = array[0].length;
 			const colSizes = new Array(cols);
@@ -148,6 +164,7 @@ export class Stats {
 			}
 			for (let row = 0; row < rows; row++) {
 				for (let col = 0; col < cols; col++) {
+					// @ts-expect-error
 					const value = `${getText(array, row, col)}`;
 					if (value.length > colSizes[col]) {
 						colSizes[col] = value.length;
@@ -157,6 +174,7 @@ export class Stats {
 			for (let row = 0; row < rows; row++) {
 				for (let col = 0; col < cols; col++) {
 					const format = array[row][col].color;
+					// @ts-expect-error
 					const value = `${getText(array, row, col)}`;
 					let l = value.length;
 					if (align[col] === "l") {
@@ -176,7 +194,10 @@ export class Stats {
 			}
 		};
 
-		const getAssetColor = (asset, defaultColor) => {
+		const getAssetColor = (
+			asset: { isOverSizeLimit: any },
+			defaultColor: any
+		) => {
 			if (asset.isOverSizeLimit) {
 				return colors.yellow;
 			}
@@ -310,7 +331,10 @@ export class Stats {
 			newline();
 		}
 
-		const processChunkGroups = (namedGroups, prefix) => {
+		const processChunkGroups = (
+			namedGroups: { [x: string]: any },
+			prefix: string
+		) => {
 			for (const name of Object.keys(namedGroups)) {
 				const cg = namedGroups[name];
 				colors.normal(`${prefix} `);
@@ -350,6 +374,7 @@ export class Stats {
 				outputChunkGroups = Object.keys(outputChunkGroups)
 					.filter(name => !obj.entrypoints[name])
 					.reduce((result, name) => {
+						// @ts-expect-error
 						result[name] = obj.namedChunkGroups[name];
 						return result;
 					}, {});
@@ -360,19 +385,33 @@ export class Stats {
 		const modulesByIdentifier = {};
 		if (obj.modules) {
 			for (const module of obj.modules) {
+				// @ts-expect-error
 				modulesByIdentifier[`$${module.identifier}`] = module;
 			}
 		} else if (obj.chunks) {
 			for (const chunk of obj.chunks) {
 				if (chunk.modules) {
 					for (const module of chunk.modules) {
+						// @ts-expect-error
 						modulesByIdentifier[`$${module.identifier}`] = module;
 					}
 				}
 			}
 		}
 
-		const processModuleAttributes = module => {
+		const processModuleAttributes = (module: {
+			size: any;
+			chunks: any;
+			depth: any;
+			cacheable: boolean;
+			optional: any;
+			built: any;
+			assets: string | any[];
+			prefetched: any;
+			failed: any;
+			warnings: number;
+			errors: number;
+		}) => {
 			colors.normal(" ");
 			colors.normal(SizeFormatHelpers.formatSize(module.size));
 			if (module.chunks) {
@@ -417,7 +456,18 @@ export class Stats {
 			}
 		};
 
-		const processModuleContent = (module, prefix) => {
+		const processModuleContent = (
+			module: {
+				providedExports: any[];
+				usedExports: boolean | any[] | null | undefined;
+				optimizationBailout: any;
+				reasons: any;
+				profile: { [x: string]: any };
+				issuerPath: any;
+				modules: any;
+			},
+			prefix: string
+		) => {
 			if (Array.isArray(module.providedExports)) {
 				colors.normal(prefix);
 				if (module.providedExports.length === 0) {
@@ -524,11 +574,15 @@ export class Stats {
 				newline();
 			}
 			if (module.modules) {
+				// @ts-expect-error
 				processModulesList(module, prefix + "| ");
 			}
 		};
 
-		const processModulesList = (obj, prefix) => {
+		const processModulesList = (
+			obj: { modules: string | any[]; filteredModules: number },
+			prefix: string
+		) => {
 			if (obj.modules) {
 				let maxModuleId = 0;
 				for (const module of obj.modules) {
@@ -659,6 +713,7 @@ export class Stats {
 							colors.normal("[");
 							colors.normal(origin.moduleId);
 							colors.normal("] ");
+							// @ts-expect-error
 							const module = modulesByIdentifier[`$${origin.module}`];
 							if (module) {
 								colors.bold(module.name);
@@ -789,6 +844,7 @@ export class Stats {
 		}
 		if (obj.children) {
 			for (const child of obj.children) {
+				// @ts-expect-error
 				const childString = Stats.jsonToString(child, useColors);
 				if (childString) {
 					if (child.name) {
@@ -819,7 +875,7 @@ export class Stats {
 }
 
 const SizeFormatHelpers = {
-	formatSize: size => {
+	formatSize: (size: unknown) => {
 		if (typeof size !== "number" || Number.isNaN(size) === true) {
 			return "unknown size";
 		}
@@ -841,7 +897,7 @@ const formatError = (e: binding.JsStatsError) => {
 	return e.formatted;
 };
 
-export const optionsOrFallback = (...args) => {
+export const optionsOrFallback = (...args: (boolean | undefined)[]) => {
 	let optionValues = [];
 	optionValues.push(...args);
 	return optionValues.find(optionValue => optionValue !== undefined);

--- a/packages/rspack/src/util/fake.ts
+++ b/packages/rspack/src/util/fake.ts
@@ -6,6 +6,7 @@ export const createFakeProcessAssetsHook = (compilation: Compilation) => {
 
 	const createFakeTap = (
 		options: FakeProcessAssetsOptions,
+		// @ts-expect-error
 		fn,
 		tap: string
 	) => {
@@ -13,6 +14,7 @@ export const createFakeProcessAssetsHook = (compilation: Compilation) => {
 		const hook = compilation.__internal_getProcessAssetsHookByStage(
 			options.stage ?? 0
 		);
+		// @ts-expect-error
 		hook[tap](options.name, fn);
 	};
 	return {

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -23,7 +23,7 @@ export function concatErrorMsgAndStack(err: Error): string {
 	return `${err.message}${err.stack ? `\n${err.stack}` : ""}`;
 }
 
-export function indent(str, prefix) {
+export function indent(str: string, prefix: string) {
 	const rem = str.replace(/\n([^\n])/g, "\n" + prefix + "$1");
 	return prefix + rem;
 }

--- a/packages/rspack/src/util/memoize.ts
+++ b/packages/rspack/src/util/memoize.ts
@@ -1,14 +1,17 @@
 export const memoize = <T>(fn: () => T): (() => T) => {
 	let cache = false;
+	// @ts-expect-error
 	let result = undefined;
 	return () => {
 		if (cache) {
+			// @ts-expect-error
 			return result;
 		} else {
 			result = fn();
 			cache = true;
 			// Allow to clean up memory for fn
 			// and all dependent resources
+			// @ts-expect-error
 			fn = undefined;
 			return result;
 		}

--- a/packages/rspack/src/watching.ts
+++ b/packages/rspack/src/watching.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { Callback } from "tapable";
 import type { Compilation, Compiler } from ".";
 import { Stats } from ".";

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -4,10 +4,9 @@
     "outDir": "dist",
     "rootDir": "src",
     "allowJs": true,
+    "strict": true
   },
-  "include": [
-    "src"
-  ],
+  "include": ["src"],
   "ts-node": {
     "transpileOnly": true
   },


### PR DESCRIPTION
## Summary
* It's my fault no enable strict mode by default(and webpack doesn't use strict mode either https://github.com/webpack/webpack/blob/main/tsconfig.json#L9) and this pr enables strict mode of rspack/core,
we don't correctly all the type error in this pr since it involves lots of work, so this pr only enables strict mode and use ts-expect-error to bypass the type error, we can correct these errors in other pr.
* this pr not modify any runtime code except we find a typo here and correct it here https://github.com/modern-js-dev/rspack/pull/1734/files#diff-2ee22fdc21ea6ef2161e58640a109219c2201b55c6e9caa23ed41cdc1aeb1c37L447
## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
