### PR TITLE
perf(rspack_plugin_javascript): remove memory allocation inside hot path of `is_hmr_api_call`

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -368,10 +368,9 @@ fn test_dependency_scanner() {
 }
 
 fn match_member_expr(mut expr: &Expr, value: &str) -> bool {
-  let mut parts: Vec<&str> = value.split('.').collect();
-  parts.reverse();
-  let last = parts.pop().expect("should have a last str");
-  for part in parts {
+  let mut parts = value.split('.');
+  let last = parts.next().expect("should have a last str");
+  for part in parts.rev() {
     if let Expr::Member(member_expr) = expr {
       if let MemberProp::Ident(ident) = &member_expr.prop {
         if ident.sym.eq(part) {


### PR DESCRIPTION
<img width="1777" alt="image" src="https://user-images.githubusercontent.com/1430279/216285632-938e1eff-1e99-4878-b62f-a4c60a7e35fc.png">

In arco-pro:
Before: 75ms
After: 29ms