### PR TITLE
perf: reduce stack mem-move

### DIFF
--- a/crates/rspack_core/src/ast/css.rs
+++ b/crates/rspack_core/src/ast/css.rs
@@ -21,7 +21,7 @@ impl fmt::Debug for Context {
 
 #[derive(Debug, Clone)]
 pub struct Ast {
-  root: SwcStylesheet,
+  root: Box<SwcStylesheet>,
   context: Arc<Context>,
 }
 
@@ -34,7 +34,7 @@ impl Hash for Ast {
 impl Ast {
   pub fn new(root: SwcStylesheet, source_map: Arc<SourceMap>) -> Self {
     Self {
-      root,
+      root: box root,
       context: Arc::new(Context::new(source_map)),
     }
   }

--- a/crates/rspack_core/src/ast/javascript.rs
+++ b/crates/rspack_core/src/ast/javascript.rs
@@ -19,11 +19,11 @@ use swc_core::ecma::visit::{
 /// Use this to avoid using `use swc_ecma_visit::*`
 /// and save changes in self
 #[derive(Debug, Clone, Hash)]
-pub struct Program(SwcProgram);
+pub struct Program(Box<SwcProgram>);
 
 impl Program {
   pub fn fold_with<V: ?Sized + Fold>(&mut self, v: &mut V) {
-    let p = std::mem::replace(&mut self.0, SwcProgram::Module(Module::dummy()));
+    let p = std::mem::replace(&mut self.0, box SwcProgram::Module(Module::dummy()));
     self.0 = p.fold_with(v);
   }
 
@@ -126,7 +126,7 @@ impl Ast {
       SwcProgram::Script(_) => false,
     };
     Self {
-      program: Program(program),
+      program: Program(box program),
       context: Arc::new(Context::new(is_esm, source_map)),
     }
   }


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
