### PR TITLE
refactor: idiomatic set_id

### DIFF
--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -20,9 +20,11 @@ impl Dependency for ContextElementDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
+
   fn parent_module_identifier(&self) -> Option<&crate::ModuleIdentifier> {
     None
   }

--- a/crates/rspack_core/src/dependency/css/import.rs
+++ b/crates/rspack_core/src/dependency/css/import.rs
@@ -54,8 +54,8 @@ impl Dependency for CssImportDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_core/src/dependency/css/url.rs
+++ b/crates/rspack_core/src/dependency/css/url.rs
@@ -55,8 +55,8 @@ impl Dependency for CssUrlDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -31,8 +31,9 @@ impl Dependency for EntryDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
 }
 

--- a/crates/rspack_core/src/dependency/import_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/import_context_dependency.rs
@@ -39,8 +39,8 @@ impl Dependency for ImportContextDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn category(&self) -> &crate::DependencyCategory {
     &crate::DependencyCategory::Esm

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -65,7 +65,7 @@ pub trait Dependency:
   fn id(&self) -> Option<&DependencyId> {
     None
   }
-  fn set_id(&mut self, _id: usize) {}
+  fn set_id(&mut self, _id: Option<DependencyId>) {}
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier>;
   fn set_parent_module_identifier(&mut self, _module_identifier: Option<ModuleIdentifier>) {
     // noop
@@ -239,7 +239,7 @@ impl Dependency for Box<dyn ModuleDependency> {
   fn id(&self) -> Option<&DependencyId> {
     (**self).id()
   }
-  fn set_id(&mut self, id: DependencyId) {
+  fn set_id(&mut self, id: Option<DependencyId>) {
     (**self).set_id(id)
   }
 }

--- a/crates/rspack_core/src/module_graph.rs
+++ b/crates/rspack_core/src/module_graph.rs
@@ -103,7 +103,7 @@ impl ModuleGraph {
       return *id;
     }
     let id = NEXT_DEPENDENCY_ID.fetch_add(1, Ordering::Relaxed);
-    dep.set_id(id);
+    dep.set_id(Some(id));
     self.dependency_id_to_dependency.insert(id, dep);
 
     id

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require.rs
@@ -60,8 +60,8 @@ impl Dependency for CommonJSRequireDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/dynamic_import.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/dynamic_import.rs
@@ -63,8 +63,8 @@ impl Dependency for EsmDynamicImportDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/export.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/export.rs
@@ -59,8 +59,8 @@ impl Dependency for EsmExportDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import.rs
@@ -58,8 +58,8 @@ impl Dependency for EsmImportDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -56,8 +56,8 @@ impl Dependency for ImportMetaModuleHotAcceptDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -60,8 +60,8 @@ impl Dependency for ImportMetaModuleHotDeclineDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -56,8 +56,8 @@ impl Dependency for ModuleHotAcceptDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -60,8 +60,8 @@ impl Dependency for ModuleHotDeclineDependency {
   fn id(&self) -> Option<&DependencyId> {
     self.id.as_ref()
   }
-  fn set_id(&mut self, id: DependencyId) {
-    self.id = Some(id);
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
   }
   fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
     self.parent_module_identifier.as_ref()


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
