### PR TITLE
refactor(crates/rspack_error): format internal error with macro

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 
 use async_trait::async_trait;
 use napi::{Env, NapiRaw, Result};
-use rspack_error::{internal_error, Error};
+use rspack_error::internal_error;
 use rspack_napi_utils::NapiResultIntoRspackResult;
 
 use crate::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -52,9 +52,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!("Failed to compilation: {err}",)))
-      })?
+      .map_err(|err| internal_error!("Failed to compilation: {err}"))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::this_compilation", skip_all)]
@@ -74,11 +72,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to this_compilation: {err}",
-        )))
-      })?
+      .map_err(|err| internal_error!("Failed to this_compilation: {err}"))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::make", skip_all)]
@@ -93,9 +87,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!("Failed to call make: {err}",)))
-      })?
+      .map_err(|err| internal_error!("Failed to call make: {err}",))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_additional", skip_all)]
@@ -109,11 +101,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to call process assets stage additional: {err}",
-        )))
-      })?
+      .map_err(|err| internal_error!("Failed to call process assets stage additional: {err}",))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_pre_process", skip_all)]
@@ -127,11 +115,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to call process assets stage pre-process: {err}",
-        )))
-      })?
+      .map_err(|err| internal_error!("Failed to call process assets stage pre-process: {err}",))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_none", skip_all)]
@@ -145,11 +129,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to call process assets: {err}",
-        )))
-      })?
+      .map_err(|err| internal_error!("Failed to call process assets: {err}",))?
   }
 
   #[tracing::instrument(
@@ -167,9 +147,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .into_rspack_result()?
       .await
       .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to call process assets stage optimize inline: {err}",
-        )))
+        internal_error!("Failed to call process assets stage optimize inline: {err}",)
       })?
   }
 
@@ -185,11 +163,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to call process assets stage summarize: {err}",
-        )))
-      })?
+      .map_err(|err| internal_error!("Failed to call process assets stage summarize: {err}",))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_report", skip_all)]
@@ -204,11 +178,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(format!(
-          "Failed to call process assets stage report: {err}",
-        )))
-      })?
+      .map_err(|err| internal_error!("Failed to call process assets stage report: {err}",))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::emit", skip_all)]
@@ -218,7 +188,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| Error::InternalError(internal_error!(format!("Failed to call emit: {err}"))))?
+      .map_err(|err| internal_error!("Failed to call emit: {err}"))?
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::after_emit", skip_all)]
@@ -228,11 +198,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        Error::InternalError(internal_error!(
-          format!("Failed to call after emit: {err}",)
-        ))
-      })?
+      .map_err(|err| internal_error!("Failed to call after emit: {err}",))?
   }
 }
 

--- a/crates/rspack_binding_options/src/options/raw_module.rs
+++ b/crates/rspack_binding_options/src/options/raw_module.rs
@@ -298,7 +298,7 @@ impl rspack_core::Loader<rspack_core::CompilerContext, rspack_core::CompilationC
         .clone()
         .map(|v| v.to_json())
         .transpose()
-        .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?
+        .map_err(|e| internal_error!(e.to_string()))?
         .map(|v| v.into_bytes().into()),
       resource: loader_context.resource.to_owned(),
       resource_path: loader_context.resource_path.to_string_lossy().to_string(),
@@ -332,16 +332,14 @@ impl rspack_core::Loader<rspack_core::CompilerContext, rspack_core::CompilationC
       .call(loader_context, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        rspack_error::Error::InternalError(internal_error!(format!("Failed to call loader: {err}")))
-      })??;
+      .map_err(|err| internal_error!("Failed to call loader: {err}"))??;
 
     let source_map = loader_result
       .as_ref()
       .and_then(|r| r.source_map.as_ref())
       .map(|s| rspack_core::rspack_sources::SourceMap::from_slice(s))
       .transpose()
-      .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+      .map_err(|e| internal_error!(e.to_string()))?;
 
     Ok(loader_result.map(|loader_result| {
       rspack_core::LoaderResult {

--- a/crates/rspack_binding_options/src/threadsafe_function.rs
+++ b/crates/rspack_binding_options/src/threadsafe_function.rs
@@ -143,13 +143,10 @@ impl<R: 'static + Send> ThreadSafeResolver<R> {
               let buf =
                 unsafe { Vec::from_raw_parts(buf.as_mut_ptr() as *mut u8, copied_len, copied_len) };
 
-              let message = String::from_utf8(buf).map_err(|err| {
-                rspack_error::Error::InternalError(internal_error!(
-                  "Failed to convert error to UTF-8".to_owned()
-                ))
-              })?;
+              let message = String::from_utf8(buf)
+                .map_err(|err| internal_error!("Failed to convert error to UTF-8"))?;
 
-              Err(rspack_error::Error::InternalError(internal_error!(message)))
+              Err(internal_error!(message))
             }))
             .map_err(|_| napi::Error::from_reason("Failed to send resolved value".to_owned()))
         },

--- a/crates/rspack_core/src/code_generation_results.rs
+++ b/crates/rspack_core/src/code_generation_results.rs
@@ -1,7 +1,7 @@
 use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
 
-use rspack_error::{internal_error, Error, Result};
+use rspack_error::{internal_error, Result};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use xxhash_rust::xxh3::Xxh3;
 
@@ -84,26 +84,24 @@ impl CodeGenerationResults {
             self.module_generation_result_map.get(m)
           })
           .ok_or_else(|| {
-            Error::InternalError(internal_error!(format!(
+            internal_error!(
               "Failed to code generation result for {module_identifier} with runtime {runtime:?} \n {entry:?}"
-            )))
+            )
           })
       } else {
         if entry.size() > 1 {
           let results = entry.get_values();
           if results.len() != 1 {
-            return Err(Error::InternalError(internal_error!(format!(
+            return Err(internal_error!(
               "No unique code generation entry for unspecified runtime for {module_identifier} ",
-            ))));
+            ));
           }
 
           return results
             .first()
             .copied()
             .and_then(|m| self.module_generation_result_map.get(m))
-            .ok_or_else(|| {
-              Error::InternalError(internal_error!("Expected value exists".to_string()))
-            });
+            .ok_or_else(|| internal_error!("Expected value exists"));
         }
 
         entry
@@ -111,14 +109,14 @@ impl CodeGenerationResults {
           .first()
           .copied()
           .and_then(|m| self.module_generation_result_map.get(m))
-          .ok_or_else(|| Error::InternalError(internal_error!("Expected value exists".to_string())))
+          .ok_or_else(|| internal_error!("Expected value exists"))
       }
     } else {
-      Err(Error::InternalError(internal_error!(format!(
+      Err(internal_error!(
         "No code generation entry for {} (existing entries: {:?})",
         module_identifier,
         self.map.keys().collect::<Vec<_>>()
-      ))))
+      ))
     }
   }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -20,8 +20,8 @@ use petgraph::{algo, prelude::GraphMap, Directed};
 use rayon::prelude::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
 use rspack_database::Database;
 use rspack_error::{
-  errors_to_diagnostics, internal_error, Diagnostic, Error, IntoTWithDiagnosticArray, Result,
-  Severity, TWithDiagnosticArray,
+  errors_to_diagnostics, internal_error, Diagnostic, Error, InternalError,
+  IntoTWithDiagnosticArray, Result, Severity, TWithDiagnosticArray,
 };
 use rspack_sources::{BoxSource, CachedSource, SourceExt};
 use rspack_symbol::{IndirectTopLevelSymbol, IndirectType, Symbol};
@@ -181,9 +181,9 @@ impl Compilation {
         source: Some(source),
         info,
       }) => updater(source, info),
-      _ => Err(Error::InternalError(internal_error!(format!(
+      _ => Err(internal_error!(
         "Called Compilation.updateAsset for not existing filename {filename}"
-      )))),
+      )),
     }
   }
 
@@ -200,12 +200,12 @@ impl Compilation {
           is_source_equal
         );
         self.push_batch_diagnostic(
-          rspack_error::Error::InternalError(internal_error!(format!(
+          internal_error!(
             "Conflict: Multiple assets emit different content to the same filename {}{}",
             filename,
             // TODO: source file name
             ""
-          )))
+          )
           .into(),
         );
         self.assets.insert(filename, asset);
@@ -1889,9 +1889,10 @@ fn mark_symbol(
                   indirect_symbol.id,
                   indirect_symbol.importer()
                 );
-                errors.push(Error::InternalError(
-                  internal_error!(error_message).with_severity(Severity::Warn),
-                ));
+                errors.push(Error::InternalError(InternalError {
+                  error_message,
+                  severity: Severity::Warn,
+                }));
                 return;
               } else {
                 // TODO: This branch should be remove after we analyze module.exports
@@ -1917,9 +1918,10 @@ fn mark_symbol(
                 })
                 .collect::<Vec<_>>();
               error_message += &join_string_component(module_identifier_list);
-              errors.push(Error::InternalError(
-                internal_error!(error_message).with_severity(Severity::Warn),
-              ));
+              errors.push(Error::InternalError(InternalError {
+                error_message,
+                severity: Severity::Warn,
+              }));
               ret[0].1.clone()
             }
           }
@@ -1951,9 +1953,10 @@ fn mark_symbol(
               | crate::ModuleType::Tsx
               | crate::ModuleType::Ts => {
                 let error_message = format!("Can't get analyze result of {src}");
-                errors.push(Error::InternalError(
-                  internal_error!(error_message).with_severity(Severity::Warn),
-                ));
+                errors.push(Error::InternalError(InternalError {
+                  error_message,
+                  severity: Severity::Warn,
+                }));
               }
               _ => {
                 // Ignore result module type
@@ -1961,9 +1964,10 @@ fn mark_symbol(
             },
             None => {
               let error_message = format!("Can't get analyze result of {src}");
-              errors.push(Error::InternalError(
-                internal_error!(error_message).with_severity(Severity::Warn),
-              ));
+              errors.push(Error::InternalError(InternalError {
+                error_message,
+                severity: Severity::Warn,
+              }));
             }
           };
           return;

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -193,9 +193,7 @@ impl TryFrom<&str> for ModuleType {
       "scss" | "sass" => Ok(Self::Css),
       _ => {
         use rspack_error::internal_error;
-        Err(rspack_error::Error::InternalError(internal_error!(
-          format!("invalid module type: {value}")
-        )))
+        Err(internal_error!("invalid module type: {value}"))
       }
     }
   }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::{any::Any, borrow::Cow, fmt::Debug};
 
 use async_trait::async_trait;
-use rspack_error::{internal_error, Error, Result, TWithDiagnosticArray};
+use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_loader_runner::Loader;
 use rspack_sources::Source;
 use rustc_hash::FxHashSet as HashSet;
@@ -184,19 +184,19 @@ macro_rules! impl_module_downcast_helpers {
 
         pub fn [<try_as_ $ident>](&self) -> Result<& $ty> {
           self.[<as_ $ident>]().ok_or_else(|| {
-            Error::InternalError(internal_error!(format!(
+            ::rspack_error::internal_error!(
               "Failed to cast module to a {}",
               stringify!($ty)
-            )))
+            )
           })
         }
 
         pub fn [<try_as_ $ident _mut>](&mut self) -> Result<&mut $ty> {
           self.[<as_ $ident _mut>]().ok_or_else(|| {
-            Error::InternalError(internal_error!(format!(
+            ::rspack_error::internal_error!(
               "Failed to cast module to a {}",
               stringify!($ty)
-            )))
+            )
           })
         }
       }

--- a/crates/rspack_core/src/module_graph.rs
+++ b/crates/rspack_core/src/module_graph.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-use rspack_error::{internal_error, Error, Result};
+use rspack_error::{internal_error, Result};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use xxhash_rust::xxh3::Xxh3;
 
@@ -175,9 +175,9 @@ impl ModuleGraph {
       let mgm = self
         .module_graph_module_by_identifier_mut(&module_identifier)
         .ok_or_else(|| {
-          Error::InternalError(internal_error!(format!(
+          internal_error!(
             "Failed to set resolved module: Module linked to module identifier {module_identifier} cannot be found"
-          )))
+          )
         })?;
 
       mgm.add_incoming_connection(connection_id);

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -13,8 +13,7 @@ use std::{
 use bitflags::bitflags;
 use dashmap::DashMap;
 use rspack_error::{
-  internal_error, Diagnostic, Error, IntoTWithDiagnosticArray, Result, Severity,
-  TWithDiagnosticArray,
+  internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, Severity, TWithDiagnosticArray,
 };
 use rspack_loader_runner::{Content, ResourceData};
 use rspack_sources::{
@@ -140,9 +139,9 @@ impl ModuleGraphModule {
         module_graph
           .connection_by_connection_id(*connection_id)
           .ok_or_else(|| {
-            Error::InternalError(internal_error!(format!(
+            internal_error!(
               "connection_id_to_connection does not have connection_id: {connection_id}"
-            )))
+            )
           })
       })
       .collect::<Result<Vec<_>>>()?
@@ -162,9 +161,9 @@ impl ModuleGraphModule {
         module_graph
           .connection_by_connection_id(*connection_id)
           .ok_or_else(|| {
-            Error::InternalError(internal_error!(format!(
+            internal_error!(
               "connection_id_to_connection does not have connection_id: {connection_id}"
-            )))
+            )
           })
       })
       .collect::<Result<Vec<_>>>()?
@@ -256,9 +255,7 @@ impl AstOrSource {
     match self {
       AstOrSource::Ast(ast) => Ok(ast),
       // TODO: change to user error
-      _ => Err(Error::InternalError(internal_error!(
-        "Failed to convert to ast".into()
-      ))),
+      _ => Err(internal_error!("Failed to convert to ast")),
     }
   }
 
@@ -266,9 +263,7 @@ impl AstOrSource {
     match self {
       AstOrSource::Source(source) => Ok(source),
       // TODO: change to user error
-      _ => Err(Error::InternalError(internal_error!(
-        "Failed to convert to source".into()
-      ))),
+      _ => Err(internal_error!("Failed to convert to source")),
     }
   }
 
@@ -621,10 +616,10 @@ impl Module for NormalModule {
       }
       Ok(code_generation_result)
     } else {
-      Err(Error::InternalError(internal_error!(format!(
+      Err(internal_error!(
         "Failed to generate code because ast or source is not set for module {}",
         self.request
-      ))))
+      ))
     }
   }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -3,7 +3,7 @@ use std::{
   sync::Arc,
 };
 
-use rspack_error::{internal_error, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use swc_core::common::Span;
 use tracing::instrument;
 
@@ -161,9 +161,9 @@ impl NormalModuleFactory {
       .registered_parser_and_generator_builder
       .get(&resolved_module_type)
       .ok_or_else(|| {
-        Error::InternalError(internal_error!(format!(
+        internal_error!(
           "Parser and generator builder for module type {resolved_module_type:?} is not registered"
-        )))
+        )
       })?();
 
     self.context.module_type = Some(resolved_module_type);
@@ -301,9 +301,9 @@ impl NormalModuleFactory {
       return Ok(result);
     }
 
-    Err(Error::InternalError(internal_error!(
-      "Failed to factorize module, neither hook nor factorize method returns".to_owned()
-    )))
+    Err(internal_error!(
+      "Failed to factorize module, neither hook nor factorize method returns"
+    ))
   }
 }
 

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 use std::path::PathBuf;
 
-use rspack_error::{internal_error, Error, Result};
+use rspack_error::{internal_error, Result};
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::ast::css::Ast as CssAst;
@@ -92,14 +92,14 @@ impl ModuleAst {
   pub fn try_into_javascript(self) -> Result<JsAst> {
     match self {
       ModuleAst::JavaScript(program) => Ok(program),
-      ModuleAst::Css(_) => Err(Error::InternalError(internal_error!("Failed".to_owned()))),
+      ModuleAst::Css(_) => Err(internal_error!("Failed")),
     }
   }
 
   pub fn try_into_css(self) -> Result<CssAst> {
     match self {
       ModuleAst::Css(stylesheet) => Ok(stylesheet),
-      ModuleAst::JavaScript(_) => Err(Error::InternalError(internal_error!("Failed".to_owned()))),
+      ModuleAst::JavaScript(_) => Err(internal_error!("Failed")),
     }
   }
 

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -119,11 +119,11 @@ pub async fn resolve(
       } else {
         ResolveError(
           "Failed to resolve {} in context".to_owned(),
-          Error::InternalError(internal_error!(format!(
+          internal_error!(
             "Failed to resolve {} in {}",
             args.specifier,
             plugin_driver.options.context.display()
-          ))),
+          ),
         )
       }
     }

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -32,9 +32,9 @@ pub fn module_rule_matcher(
     && module_rule.exclude.is_none()
     && module_rule.issuer.is_none()
   {
-    return Err(rspack_error::Error::InternalError(internal_error!(
-      "ModuleRule must have at least one condition".to_owned()
-    )));
+    return Err(internal_error!(
+      "ModuleRule must have at least one condition"
+    ));
   }
 
   // Include all modules that pass test assertion. If you supply a Rule.test option, you cannot also supply a `Rule.resource`.

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -2,15 +2,6 @@ use std::{fmt, io};
 
 use crate::Severity;
 
-#[macro_export]
-macro_rules! internal_error {
-  ($str:expr) => {
-    $crate::InternalError {
-      error_message: $str,
-      ..Default::default()
-    }
-  };
-}
 #[derive(Debug, Default)]
 pub struct InternalError {
   pub error_message: String,

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -6,6 +6,8 @@ pub use diagnostic::*;
 pub use error::*;
 pub mod emitter;
 
+mod macros;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A helper struct for change logic from
@@ -71,4 +73,12 @@ impl<T: Sized + std::fmt::Debug> IntoTWithDiagnosticArray for T {
       diagnostic,
     }
   }
+}
+
+#[doc(hidden)]
+pub mod __private {
+  pub use core::result::Result::Err;
+
+  pub use crate::error::{Error, InternalError};
+  pub use crate::internal_error;
 }

--- a/crates/rspack_error/src/macros.rs
+++ b/crates/rspack_error/src/macros.rs
@@ -1,0 +1,35 @@
+#[macro_export]
+macro_rules! internal_error {
+  (@base $expr:expr) => {
+    $crate::__private::Error::InternalError({
+      $crate::__private::InternalError {
+        error_message: $expr,
+        ..Default::default()
+      }
+    })
+  };
+  ($str:literal $(,)?) => {{
+    let err = format!($str);
+    $crate::__private::internal_error!(@base err)
+  }};
+  ($expr:expr $(,)?) => {{
+    $crate::__private::internal_error!(@base $expr)
+  }};
+  ($fmt:expr, $($arg:tt)*) => {{
+    let err = format!($fmt, $($arg)*);
+    $crate::__private::internal_error!(@base err)
+  }};
+}
+
+#[macro_export]
+macro_rules! internal_error_bail {
+  ($str:literal $(,)?) => {
+    return $crate::__private::Err($crate::internal_error!($str));
+  };
+  ($expr:expr $(,)?) => {
+    return $crate::__private::Err($crate::internal_error!($expr));
+  };
+  ($fmt:expr, $($arg:tt)*) => {
+    return $crate::__private::Err($crate::internal_error!($fmt, $($arg)*));
+  };
+}

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -502,8 +502,7 @@ impl Loader<CompilerContext, CompilationContext> for SassLoader {
     let source_map = result
       .map
       .map(|map| -> Result<SourceMap> {
-        let mut map = SourceMap::from_slice(&map)
-          .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+        let mut map = SourceMap::from_slice(&map).map_err(|e| internal_error!(e.to_string()))?;
         for source in map.sources_mut() {
           if source.starts_with("file:") {
             *source = Url::parse(source)
@@ -538,7 +537,7 @@ fn sass_exception_to_error(e: Exception) -> Error {
     && let Some(e) = make_traceable_error("Sass Error", message, span) {
     Error::TraceableError(e.with_kind(DiagnosticKind::Scss))
   } else {
-    Error::InternalError(internal_error!(e.message().to_string()))
+    internal_error!(e.message().to_string())
   }
 }
 

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -18,7 +18,7 @@ use rspack_core::{
   ModuleIdentifier, ParseContext, ParserAndGenerator, PathData, Plugin, PluginContext,
   PluginRenderManifestHookOutput, RenderManifestArgs, RenderManifestEntry, SourceType,
 };
-use rspack_error::{internal_error, Error, IntoTWithDiagnosticArray, Result};
+use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result};
 use sugar_path::SugarPath;
 
 #[derive(Debug)]
@@ -349,9 +349,9 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       }
       SourceType::Asset => {
         if parsed_asset_config.is_source() || parsed_asset_config.is_inline() {
-          Err(Error::InternalError(internal_error!(
-            "Inline or Source asset does not have source type `asset`".to_string()
-          )))
+          Err(internal_error!(
+            "Inline or Source asset does not have source type `asset`"
+          ))
         } else {
           // Safety: This is safe because we returned the source in parser.
           Ok(GenerationResult {
@@ -367,9 +367,9 @@ impl ParserAndGenerator for AssetParserAndGenerator {
           })
         }
       }
-      t => Err(Error::InternalError(internal_error!(format!(
+      t => Err(internal_error!(format!(
         "Unsupported source type {t:?} for plugin JavaScript"
-      )))),
+      ))),
     };
 
     result
@@ -461,7 +461,7 @@ impl Plugin for AssetPlugin {
         let module = compilation
           .module_graph
           .module_by_identifier(&mgm.module_identifier)
-          .ok_or_else(|| Error::InternalError(internal_error!("Failed to get module".to_owned())))
+          .ok_or_else(|| internal_error!("Failed to get module".to_owned()))
           // FIXME: use result
           .expect("Failed to get module");
         module.source_types().contains(&SourceType::Asset)
@@ -474,7 +474,7 @@ impl Plugin for AssetPlugin {
         let module = compilation
           .module_graph
           .module_by_identifier(&mgm.module_identifier)
-          .ok_or_else(|| Error::InternalError(internal_error!("Failed to get module".to_owned())))
+          .ok_or_else(|| internal_error!("Failed to get module".to_owned()))
           .expect("Failed to get module")
           .as_normal_module()
           .expect("Normal module expected");

--- a/crates/rspack_plugin_css/src/lib.rs
+++ b/crates/rspack_plugin_css/src/lib.rs
@@ -63,9 +63,7 @@ impl SwcCssCompiler {
       .flat_map(|error| css_parse_error_to_diagnostic(error, path))
       .collect();
     stylesheet
-      .map_err(|_| {
-        rspack_error::Error::InternalError(internal_error!("Css parsing failed".to_string()))
-      })
+      .map_err(|_| internal_error!("Css parsing failed".to_string()))
       .map(|stylesheet| stylesheet.with_diagnostic(diagnostics))
   }
 
@@ -94,16 +92,14 @@ impl SwcCssCompiler {
     );
 
     let mut gen = CodeGenerator::new(wr, CodegenConfig { minify });
-    gen
-      .emit(ast)
-      .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+    gen.emit(ast).map_err(|e| internal_error!(e.to_string()))?;
 
     if let Some(src_map_buf) = &mut src_map_buf {
       let map = cm.build_source_map_with_config(src_map_buf, None, gen_source_map);
       let mut raw_map = Vec::new();
       map
         .to_writer(&mut raw_map)
-        .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+        .map_err(|e| internal_error!(e.to_string()))?;
       Ok((output, Some(raw_map)))
     } else {
       Ok((output, None))
@@ -133,7 +129,7 @@ impl SwcCssCompiler {
         value: code,
         name: filename,
         source_map: rspack_sources::SourceMap::from_slice(&source_map)
-          .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?,
+          .map_err(|e| internal_error!(e.to_string()))?,
         original_source: Some(input_source),
         inner_source_map: input_source_map,
         remove_original_source: true,

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -28,7 +28,7 @@ use rspack_core::{
   ModuleIdentifier,
 };
 use rspack_error::{
-  internal_error, Diagnostic, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
+  internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
 };
 use sugar_path::SugarPath;
 use swc_core::{
@@ -494,7 +494,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
             value: code,
             name: module.try_as_normal_module()?.request().to_string(),
             source_map: SourceMap::from_slice(&source_map)
-              .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?,
+              .map_err(|e| internal_error!(e.to_string()))?,
             // Safety: original source exists in code generation
             original_source: Some(
               module
@@ -531,10 +531,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
         })
         .boxed(),
       ),
-      _ => Err(Error::InternalError(internal_error!(format!(
+      _ => Err(internal_error!(
         "Unsupported source type: {:?}",
         generate_context.requested_source_type
-      )))),
+      )),
     }?;
 
     Ok(GenerationResult {

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -106,7 +106,7 @@ pub fn css_modules_exports_to_string(
         serde_json::to_string(&key).expect("TODO:"),
         content,
       )
-      .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+      .map_err(|e| internal_error!(e.to_string()))?;
     }
     if locals_convention.camel_case() {
       writeln!(
@@ -115,7 +115,7 @@ pub fn css_modules_exports_to_string(
         serde_json::to_string(&key.to_lower_camel_case()).expect("TODO:"),
         content,
       )
-      .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+      .map_err(|e| internal_error!(e.to_string()))?;
     }
     if locals_convention.dashes() {
       writeln!(
@@ -124,7 +124,7 @@ pub fn css_modules_exports_to_string(
         serde_json::to_string(&key.to_kebab_case()).expect("TODO:"),
         content,
       )
-      .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+      .map_err(|e| internal_error!(e.to_string()))?;
     }
   }
   code += "};\n";

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -99,7 +99,7 @@ impl Plugin for DevtoolPlugin {
           let mut map_buffer = Vec::new();
           map
             .to_writer(&mut map_buffer)
-            .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+            .map_err(|e| internal_error!(e.to_string()))?;
           Ok((filename.to_owned(), map_buffer))
         })
       })
@@ -185,7 +185,7 @@ pub fn wrap_eval_source_map(
   let mut map_buffer = Vec::new();
   map
     .to_writer(&mut map_buffer)
-    .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+    .map_err(|e| internal_error!(e.to_string()))?;
   let base64 = base64::encode(&map_buffer);
   let footer =
     format!("\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,{base64}");

--- a/crates/rspack_plugin_externals/src/external.rs
+++ b/crates/rspack_plugin_externals/src/external.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   Identifiable, Identifier, LibIdentOptions, Module, ModuleType, SourceType, Target,
   TargetPlatform,
 };
-use rspack_error::{internal_error, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 
 static EXTERNAL_MODULE_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
 
@@ -109,7 +109,7 @@ impl Module for ExternalModule {
     let source: AstOrSource = self
       .cached_source
       .as_ref()
-      .ok_or_else(|| Error::InternalError(internal_error!("Source should exist".to_owned())))?
+      .ok_or_else(|| internal_error!("Source should exist"))?
       .clone()
       .into();
     cgr.add(SourceType::JavaScript, source);

--- a/crates/rspack_plugin_javascript/src/ast/stringify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/stringify.rs
@@ -91,7 +91,7 @@ pub fn print(
     source_map
       .build_source_map_with_config(&src_map_buf, None, source_map_config)
       .to_writer(&mut buf)
-      .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?;
+      .map_err(|e| internal_error!(e.to_string()))?;
     // SAFETY: This buffer is already sanitized
     Some(unsafe { String::from_utf8_unchecked(buf) })
   } else {

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   PluginRenderManifestHookOutput, ProcessAssetsArgs, RenderChunkArgs, RenderManifestEntry,
   SourceType,
 };
-use rspack_error::{internal_error, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use swc_core::base::{config::JsMinifyOptions, BoolOrDataConfig};
 use swc_core::common::util::take::Take;
 use swc_core::ecma::ast;
@@ -243,9 +243,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     } = parse_context;
 
     if !module_type.is_js_like() {
-      return Err(Error::InternalError(internal_error!(format!(
+      return Err(internal_error!(format!(
         "`module_type` {module_type:?} not supported for `JsParser`"
-      ))));
+      )));
     }
 
     let syntax = syntax_by_module_type(
@@ -324,8 +324,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         Ok(GenerationResult {
           ast_or_source: SourceMapSource::new(SourceMapSourceOptions {
             value: output.code,
-            source_map: SourceMap::from_json(&map)
-              .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?,
+            source_map: SourceMap::from_json(&map).map_err(|e| internal_error!(e.to_string()))?,
             name: module.try_as_normal_module()?.request().to_string(),
             original_source: {
               Some(
@@ -355,10 +354,10 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         })
       }
     } else {
-      Err(Error::InternalError(internal_error!(format!(
+      Err(internal_error!(
         "Unsupported source type {:?} for plugin JavaScript",
         generate_context.requested_source_type,
-      ))))
+      ))
     }
   }
 }
@@ -531,7 +530,7 @@ impl Plugin for JsPlugin {
               value: output.code,
               name: filename,
               source_map: SourceMap::from_json(map)
-                .map_err(|e| rspack_error::Error::InternalError(internal_error!(e.to_string())))?,
+                .map_err(|e| internal_error!(e.to_string()))?,
               original_source: None,
               inner_source_map: input_source_map,
               remove_original_source: true,

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -59,7 +59,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           )
         }
         ExceededDepthLimit | WrongType(_) | FailedUtf8Parsing => {
-          Error::InternalError(internal_error!(format!("{e}")))
+          internal_error!(format!("{e}"))
         }
         UnexpectedEndOfJson => {
           // End offset of json file
@@ -115,10 +115,10 @@ impl ParserAndGenerator for JsonParserAndGenerator {
         .boxed()
         .into(),
       }),
-      _ => Err(Error::InternalError(internal_error!(format!(
+      _ => Err(internal_error!(format!(
         "Unsupported source type {:?} for plugin Json",
         generate_context.requested_source_type,
-      )))),
+      ))),
     }
   }
 }

--- a/crates/rspack_regex/src/lib.rs
+++ b/crates/rspack_regex/src/lib.rs
@@ -21,20 +21,13 @@ impl RspackRegex {
   pub fn with_flags(expr: &str, flags: &str) -> Result<Self, Error> {
     Regex::with_flags(expr, flags)
       .map(RspackRegex)
-      .map_err(|_| {
-        Error::InternalError(internal_error!(format!(
-          "Can't construct regex `/{expr}/{flags}`"
-        )))
-      })
+      .map_err(|_| internal_error!("Can't construct regex `/{expr}/{flags}`"))
   }
 
   pub fn new(expr: &str) -> Result<Self, Error> {
-    Regex::with_flags(expr, "").map(RspackRegex).map_err(|_| {
-      Error::InternalError(internal_error!(format!(
-        "Can't construct regex `/{}/{}`",
-        expr, ""
-      )))
-    })
+    Regex::with_flags(expr, "")
+      .map(RspackRegex)
+      .map_err(|_| internal_error!("Can't construct regex `/{}/{}`", expr, ""))
   }
 }
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
