### PR TITLE
chore: remove useless trace::instrument

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -35,7 +35,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
     "rspack_plugin_js_hooks_adapter"
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::compilation", skip_all)]
   async fn compilation(
     &mut self,
     args: rspack_core::CompilationArgs<'_>,
@@ -55,7 +54,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to compilation: {err}"))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::this_compilation", skip_all)]
   async fn this_compilation(
     &mut self,
     args: rspack_core::ThisCompilationArgs<'_>,
@@ -90,7 +88,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call make: {err}",))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_additional", skip_all)]
   async fn process_assets_stage_additional(
     &mut self,
     _ctx: rspack_core::PluginContext,
@@ -104,7 +101,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call process assets stage additional: {err}",))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_pre_process", skip_all)]
   async fn process_assets_stage_pre_process(
     &mut self,
     _ctx: rspack_core::PluginContext,
@@ -118,7 +114,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call process assets stage pre-process: {err}",))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_none", skip_all)]
   async fn process_assets_stage_none(
     &mut self,
     _ctx: rspack_core::PluginContext,
@@ -132,10 +127,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call process assets: {err}",))?
   }
 
-  #[tracing::instrument(
-    name = "js_hooks_adapter::process_assets_stage_optimize_inline",
-    skip_all
-  )]
   async fn process_assets_stage_optimize_inline(
     &mut self,
     _ctx: rspack_core::PluginContext,
@@ -151,7 +142,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       })?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_summarize", skip_all)]
   async fn process_assets_stage_summarize(
     &mut self,
     _ctx: rspack_core::PluginContext,
@@ -166,7 +156,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call process assets stage summarize: {err}",))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::process_assets_stage_report", skip_all)]
   async fn process_assets_stage_report(
     &mut self,
     _ctx: rspack_core::PluginContext,
@@ -181,7 +170,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call process assets stage report: {err}",))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::emit", skip_all)]
   async fn emit(&mut self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
     self
       .emit_tsfn
@@ -191,7 +179,6 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call emit: {err}"))?
   }
 
-  #[tracing::instrument(name = "js_hooks_adapter::after_emit", skip_all)]
   async fn after_emit(&mut self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
     self
       .after_emit_tsfn

--- a/crates/rspack_binding_options/src/options/raw_module.rs
+++ b/crates/rspack_binding_options/src/options/raw_module.rs
@@ -277,7 +277,6 @@ impl rspack_core::Loader<rspack_core::CompilerContext, rspack_core::CompilationC
     "js_loader_adapter"
   }
 
-  #[tracing::instrument(name = "js_loader_adapter::run", fields(name = &self.name, resource = &loader_context.resource), skip(self, loader_context))]
   async fn run(
     &self,
     loader_context: &rspack_core::LoaderContext<

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -31,7 +31,6 @@ impl<'me> CodeSplitter<'me> {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   fn prepare_input_entrypoints_and_modules(
     &mut self,
   ) -> Result<HashMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -196,7 +196,6 @@ impl Compiler {
       .await
   }
 
-  #[instrument(name = "emit_asset", skip_all)]
   fn emit_asset(&self, output_path: &Path, filename: &str, asset: &CompilationAsset) -> Result<()> {
     if let Some(source) = asset.get_source() {
       let file_path = Path::new(&output_path).join(filename);

--- a/crates/rspack_core/src/compiler/resolver.rs
+++ b/crates/rspack_core/src/compiler/resolver.rs
@@ -6,7 +6,6 @@ use std::{
 
 use dashmap::DashMap;
 use rustc_hash::FxHasher;
-use tracing::instrument;
 
 use crate::{AliasMap, DependencyType};
 use crate::{DependencyCategory, Resolve};
@@ -267,7 +266,6 @@ impl Resolver {
     self.0.clear_entries();
   }
 
-  #[instrument(name = "nodejs_resolver", skip_all)]
   pub fn resolve(&self, path: &Path, request: &str) -> nodejs_resolver::RResult<ResolveResult> {
     self
       .0

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -5,7 +5,6 @@ pub use rspack_loader_runner::{
   Content, Loader, LoaderContext, LoaderResult, LoaderRunner, LoaderRunnerAdditionalContext,
   ResourceData,
 };
-use tracing::instrument;
 
 use crate::{
   CompilerOptions, LoaderRunnerPluginProcessResource, ResolverFactory, SharedPluginDriver,
@@ -45,7 +44,6 @@ impl LoaderRunnerRunner {
       compiler_context,
     }
   }
-  #[instrument(name = "loader:run", skip_all)]
   pub async fn run(
     &self,
     resource_data: ResourceData,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -5,7 +5,6 @@ use std::{
 
 use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use swc_core::common::Span;
-use tracing::instrument;
 
 use crate::{
   cache::Cache, module_rule_matcher, resolve, AssetGeneratorOptions, AssetParserOptions,
@@ -24,7 +23,6 @@ pub struct NormalModuleFactory {
 
 #[async_trait::async_trait]
 impl ModuleFactory for NormalModuleFactory {
-  #[instrument(name = "normal_module_factory:create", skip_all)]
   async fn create(
     mut self,
     data: ModuleFactoryCreateData,
@@ -54,7 +52,6 @@ impl NormalModuleFactory {
     resolve_module_type_by_uri(&resource_data.resource_path)
   }
 
-  // #[instrument(name = "normal_module_factory:factory_normal_module", skip_all)]
   pub async fn factorize_normal_module(
     &mut self,
     data: ModuleFactoryCreateData,
@@ -274,7 +271,6 @@ impl NormalModuleFactory {
     resolved_module_type
   }
 
-  #[instrument(name = "normal_module_factory:factorize", skip_all)]
   pub async fn factorize(
     &mut self,
     data: ModuleFactoryCreateData,

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -85,7 +85,6 @@ impl PluginDriver {
   /// Warning:
   /// Webpack does not expose this as the documented API, even though you can reach this with `NormalModule.getCompilationHooks(compilation)`.
   /// For the most of time, you would not need this.
-  #[instrument(name = "plugin:read_resource", skip_all)]
   pub async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
     for plugin in &self.plugins {
       let result = plugin.read_resource(resource_data).await?;
@@ -147,7 +146,6 @@ impl PluginDriver {
   /// Executed while initializing the compilation, right before emitting the compilation event. This hook is not copied to child compilers.
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#thiscompilation
-  #[instrument(name = "plugin:this_compilation", skip_all)]
   pub async fn this_compilation(
     &mut self,
     compilation: &mut Compilation,
@@ -163,7 +161,6 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[instrument(name = "plugin:this_compilation", skip_all)]
   pub async fn content_hash(&self, args: &mut ContentHashArgs<'_>) -> PluginContentHashHookOutput {
     for plugin in &self.plugins {
       plugin.content_hash(PluginContext::new(), args).await?;
@@ -171,7 +168,6 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[instrument(name = "plugin:render_manifest", skip_all)]
   pub async fn render_manifest(
     &self,
     args: RenderManifestArgs<'_>,
@@ -204,7 +200,6 @@ impl PluginDriver {
     Ok(None)
   }
 
-  #[instrument(name = "plugin:factorize", skip_all)]
   pub async fn factorize(
     &self,
     args: FactorizeArgs<'_>,
@@ -221,7 +216,6 @@ impl PluginDriver {
     Ok(None)
   }
 
-  #[instrument(name = "plugin:module", skip_all)]
   pub async fn module(&self, args: ModuleArgs) -> PluginModuleHookOutput {
     for plugin in &self.plugins {
       tracing::trace!("running render runtime:{}", plugin.name());
@@ -317,7 +311,6 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[instrument(name = "plugin:build_module", skip_all)]
   pub async fn build_module(&self, module: &mut dyn Module) -> Result<()> {
     for plugin in &self.plugins {
       plugin.build_module(module).await?;
@@ -325,7 +318,6 @@ impl PluginDriver {
     Ok(())
   }
 
-  #[instrument(name = "plugin:succeed_module", skip_all)]
   pub async fn succeed_module(&self, module: &dyn Module) -> Result<()> {
     for plugin in &self.plugins {
       plugin.succeed_module(module).await?;

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -2,7 +2,6 @@ use std::path::Path;
 
 use rspack_error::{internal_error, Error, TraceableError};
 use sugar_path::{AsPath, SugarPath};
-use tracing::instrument;
 
 use crate::{ResolveArgs, ResolveOptionsWithDependencyType, ResolveResult, SharedPluginDriver};
 
@@ -10,7 +9,6 @@ use crate::{ResolveArgs, ResolveOptionsWithDependencyType, ResolveResult, Shared
 /// The first element is the error message for runtime and the second element is the error used for stats and so on.
 pub struct ResolveError(pub String, pub Error);
 
-#[instrument(name = "resolve", skip_all)]
 pub async fn resolve(
   args: ResolveArgs<'_>,
   plugin_driver: &SharedPluginDriver,

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -31,7 +31,6 @@ use sass_embedded::{
 use serde::Deserialize;
 use str_indices::utf16;
 use tokio::sync::Mutex;
-use tracing::instrument;
 
 static IS_SPECIAL_MODULE_IMPORT: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^~[^/]+$").expect("TODO:"));
@@ -484,7 +483,6 @@ impl Loader<CompilerContext, CompilationContext> for SassLoader {
   fn name(&self) -> &'static str {
     "sass-loader"
   }
-  #[instrument("sass-loader", skip_self)]
   async fn run(
     &self,
     loader_context: &LoaderContext<'_, '_, CompilerContext, CompilationContext>,

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -40,7 +40,6 @@ use swc_core::{
   },
   ecma::atoms::JsWord,
 };
-use tracing::instrument;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::utils::{css_modules_exports_to_string, ModulesTransformConfig};
@@ -365,7 +364,6 @@ impl ParserAndGenerator for CssParserAndGenerator {
     }
   }
 
-  #[instrument(name = "css:parse", skip_all)]
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>> {
     let ParseContext {
       source,
@@ -461,7 +459,6 @@ impl ParserAndGenerator for CssParserAndGenerator {
   }
 
   #[allow(clippy::unwrap_in_result)]
-  #[instrument(name = "css:generate", skip_all)]
   fn generate(
     &self,
     ast_or_source: &rspack_core::AstOrSource,

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -14,7 +14,6 @@ use rspack_core::{
 use rspack_error::{internal_error, Result};
 use rustc_hash::FxHashMap as HashMap;
 use serde_json::json;
-use tracing::instrument;
 
 static IS_CSS_FILE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\.css($|\?)").expect("TODO:"));
 
@@ -61,7 +60,6 @@ impl Plugin for DevtoolPlugin {
     "devtool"
   }
 
-  #[instrument(skip_all)]
   async fn process_assets_stage_dev_tooling(
     &mut self,
     _ctx: PluginContext,

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -18,7 +18,6 @@ use swc_core::base::{config::JsMinifyOptions, BoolOrDataConfig};
 use swc_core::common::util::take::Take;
 use swc_core::ecma::ast;
 use swc_core::ecma::minifier::option::terser::TerserCompressorOptions;
-use tracing::instrument;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::runtime::{generate_chunk_entry_code, render_chunk_modules, render_runtime_modules};
@@ -231,7 +230,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     module.original_source().map_or(0, |source| source.size()) as f64
   }
 
-  #[instrument(name = "js:parse", skip_all)]
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>> {
     let ParseContext {
       source,
@@ -301,7 +299,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
   }
 
   #[allow(clippy::unwrap_in_result)]
-  #[instrument(name = "js:generate", skip_all)]
   fn generate(
     &self,
     ast_or_source: &AstOrSource,

--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -6,7 +6,6 @@ use rspack_core::{Compilation, Plugin};
 pub struct RemoveEmptyChunksPlugin;
 
 impl RemoveEmptyChunksPlugin {
-  #[tracing::instrument]
   fn remove_empty_chunks(&self, compilation: &mut Compilation) {
     let chunk_graph = &mut compilation.chunk_graph;
     let mut empty_chunks = compilation

--- a/crates/rspack_plugin_split_chunks/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin.rs
@@ -173,7 +173,6 @@ pub fn create_cache_group_source(
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) fn remove_modules_with_source_type(
   info: &mut ChunksInfoItem,
   source_types: &[SourceType],
@@ -196,7 +195,6 @@ pub(crate) fn remove_modules_with_source_type(
   });
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) fn remove_min_size_violating_modules(
   info: &mut ChunksInfoItem,
   cache_group_by_key: &HashMap<String, CacheGroup>,

--- a/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
+++ b/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
@@ -183,7 +183,6 @@ impl SplitChunksPlugin {
 
   #[allow(clippy::format_in_format_args)]
   #[allow(clippy::too_many_arguments)]
-  #[tracing::instrument(skip_all)]
   fn add_module_to_chunks_info_map(
     &self,
     cache_group: &CacheGroup,
@@ -303,7 +302,6 @@ impl SplitChunksPlugin {
     );
   }
 
-  #[tracing::instrument(skip_all)]
   fn create_chunks_info_map(
     &self,
     compilation: &mut Compilation,
@@ -376,7 +374,6 @@ impl SplitChunksPlugin {
     chunks_info_map
   }
 
-  #[tracing::instrument(skip_all)]
   fn find_best_entry(&self, chunks_info_map: &mut ChunksInfoMap) -> (String, ChunksInfoItem) {
     let mut chunks_info_map_iter = chunks_info_map.iter();
     let (best_entry_key, mut best_entry) = chunks_info_map_iter.next().expect("item should exist");
@@ -398,7 +395,6 @@ impl SplitChunksPlugin {
 
   #[allow(clippy::unwrap_in_result)]
   #[allow(clippy::if_same_then_else)]
-  #[tracing::instrument(skip_all)]
   fn find_reusable_chunk(
     &self,
     compilation: &Compilation,
@@ -454,7 +450,6 @@ impl SplitChunksPlugin {
     new_chunk
   }
 
-  #[tracing::instrument(skip_all)]
   fn remove_unrelated_chunk(
     &self,
     compilation: &Compilation,
@@ -472,7 +467,6 @@ impl SplitChunksPlugin {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   fn filter_items_lesser_than_min_size(
     &self,
     chunks_info_map: &mut ChunksInfoMap,
@@ -506,7 +500,6 @@ impl SplitChunksPlugin {
     });
   }
 
-  #[tracing::instrument(skip_all)]
   fn remove_all_modules_from_other_entries_and_update_size(
     &self,
     item: &mut ChunksInfoItem,
@@ -572,7 +565,6 @@ impl SplitChunksPlugin {
     });
   }
 
-  #[tracing::instrument(skip_all)]
   fn link_module_new_chunk_and_remove_in_old_chunks(
     &self,
     is_reused_with_all_modules: bool,
@@ -620,7 +612,6 @@ impl SplitChunksPlugin {
     }
   }
 
-  #[tracing::instrument(skip_all)]
   fn split_used_chunks(
     &self,
     item: &ChunksInfoItem,

--- a/crates/rspack_plugin_split_chunks/src/utils.rs
+++ b/crates/rspack_plugin_split_chunks/src/utils.rs
@@ -82,7 +82,6 @@ fn compare_modules(a: &[&ModuleIdentifier], b: &[&ModuleIdentifier]) -> Ordering
   }
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) fn check_min_size(sizes: &SplitChunkSizes, min_size: &SplitChunkSizes) -> bool {
   for key in sizes.keys() {
     let size = sizes.get(key).expect("key should exist");
@@ -96,7 +95,6 @@ pub(crate) fn check_min_size(sizes: &SplitChunkSizes, min_size: &SplitChunkSizes
   true
 }
 
-#[tracing::instrument(skip_all)]
 pub(crate) fn get_violating_min_sizes(
   sizes: &SplitChunkSizes,
   min_size: &SplitChunkSizes,


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output. -->

## Related issue (if exists)

## How does Webpack handle this? (if exists)

**Is this a workaround for the Webpack's implementation?** 

> Check if Webpack has the same feature and but we're taking a workaround for it.

- [ ] Yes. Issue for resolving the workaround:  <!-- Please create an issue for the workaround you made. You issue should also be tracked here: https://github.com/speedy-js/rspack/issues/794 -->
- [ ] No

<!-- How does webpack handle this feature? If webpack has its original implementation, the implementor should paste the related information about the implementation(permanent link should be preferred). E.g [NormalModule](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/NormalModule.js#L220) -->

## Further reading

<!-- Reference that may help understand this pull request -->
