### PR TITLE
refactor(progress): use wide_msg instead of msg

### DIFF
--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -28,7 +28,8 @@ impl ProgressPlugin {
   pub fn new(options: ProgressPluginConfig) -> Self {
     let progress_bar = ProgressBar::new(100);
     progress_bar.set_style(
-      ProgressStyle::with_template("{prefix} {bar:40.cyan/blue} {precent} {msg}").expect("TODO:"),
+      ProgressStyle::with_template("{prefix} {bar:40.cyan/blue} {precent} {wide_msg}")
+        .expect("TODO:"),
     );
     progress_bar.set_prefix(
       options


### PR DESCRIPTION
![2ccd7827-cfc1-489f-a074-90ab777517aa](https://user-images.githubusercontent.com/22373761/217152264-d0585b26-96b0-49b5-8a26-af7573905fd0.jpeg)

before:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/22373761/217152850-c88cc3d8-50a0-4075-b752-ed9fd8f5dc60.png">

after:
<img width="871" alt="image" src="https://user-images.githubusercontent.com/22373761/217153008-2d5d8f2c-54d9-43c1-b918-f5ef98ab8007.png">
