### PR TITLE
fix: remove default empty array for browserslist

### DIFF
--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -15,7 +15,7 @@ exports[`normalize options snapshot additional entires should added 1`] = `
 exports[`normalize options snapshot compier.options.devServer should be equal to server.options when devServer is undefined 1`] = `
 {
   "builtins": {
-    "browserslist": [],
+    "browserslist": undefined,
     "decorator": {
       "emitMetadata": true,
       "legacy": true,
@@ -206,7 +206,7 @@ exports[`normalize options snapshot port string 1`] = `
 exports[`normalize options snapshot react.development and react.refresh should be true in default when hot enabled 1`] = `
 {
   "builtins": {
-    "browserslist": [],
+    "browserslist": undefined,
     "decorator": {
       "emitMetadata": true,
       "legacy": true,

--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -117,7 +117,7 @@ export function resolveBuiltinsOptions(
 	builtins: Builtins,
 	{ contextPath, isProduction }: { contextPath: string; isProduction: boolean }
 ): ResolvedBuiltins {
-	const browserslist = loadConfig({ path: contextPath }) || [];
+	const browserslist = loadConfig({ path: contextPath });
 	return {
 		...builtins,
 		define: resolveDefine(builtins.define || {}),

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -74,7 +74,7 @@ describe("snapshots", () => {
 		expect(baseConfig).toMatchInlineSnapshot(`
 		{
 		  "builtins": {
-		    "browserslist": [],
+		    "browserslist": undefined,
 		    "decorator": {
 		      "emitMetadata": true,
 		      "legacy": true,
@@ -637,7 +637,7 @@ describe("snapshots", () => {
 			+ Received
 
 			@@ ... @@
-			-     "browserslist": Array [],
+			-     "browserslist": undefined,
 			+     "browserslist": Array [
 			+       "ie >= 9",
 			+     ],


### PR DESCRIPTION
## Summary

Empty browserslist query will panic

## Related issue (if exists)
