### PR TITLE
chore(examples): integrate `solid-refresh` into solid example

### DIFF
--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -10,6 +10,7 @@
     "babel-loader": "9.1.2",
     "solid-js": "1.6.9",
     "babel-preset-solid": "1.6.9",
+    "solid-refresh": "0.4.3",
     "@rspack/cli": "workspace:*"
   },
   "keywords": [],

--- a/examples/solid/rspack.config.js
+++ b/examples/solid/rspack.config.js
@@ -21,6 +21,9 @@ module.exports = {
             options: {
               presets: [
                 ["solid"]
+              ],
+              plugins: [
+                "solid-refresh/babel"
               ]
             }
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,11 +228,13 @@ importers:
       babel-loader: 9.1.2
       babel-preset-solid: 1.6.9
       solid-js: 1.6.9
+      solid-refresh: 0.4.3
     dependencies:
       '@rspack/cli': link:../../packages/rspack-cli
       babel-loader: 9.1.2
       babel-preset-solid: 1.6.9
       solid-js: 1.6.9
+      solid-refresh: 0.4.3_solid-js@1.6.9
 
   examples/svelte:
     specifiers:
@@ -935,6 +937,7 @@ packages:
       '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: true
 
   /@babel/generator/7.20.5:
     resolution: {integrity: sha512-jl7JY2Ykn9S0yj4DQP82sYvPU+T3g0HFcWTqDLqiuA9tGRNIj9VfbtXGAYTTkyNEnQk1jkMGOdYka8aG/lulCA==}
@@ -943,7 +946,6 @@ packages:
       '@babel/types': 7.20.7
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
-    dev: true
 
   /@babel/helper-annotate-as-pure/7.18.6:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
@@ -2210,7 +2212,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.1
+      '@babel/generator': 7.20.5
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-function-name': 7.19.0
       '@babel/helper-hoist-variables': 7.18.6
@@ -9620,7 +9622,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/generator': 7.20.1
+      '@babel/generator': 7.20.5
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.6
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.19.6
       '@babel/traverse': 7.20.1
@@ -12677,6 +12679,17 @@ packages:
     resolution: {integrity: sha512-kV3fMmm+1C2J95c8eDOPKGfZHnuAkHUBLG4hX1Xu08bXeAIPqmxuz/QdH3B8SIdTp3EatBVIyA6RCes3hrGzpg==}
     dependencies:
       csstype: 3.1.1
+    dev: false
+
+  /solid-refresh/0.4.3_solid-js@1.6.9:
+    resolution: {integrity: sha512-7+4/gYsVi0BlM4PzT1PU1TB5nW3Hv8FWuB+Kw/ofWui7KQkWBf+dVZOrReQYHEmLCzytHUa2JysUXgzVALJmSw==}
+    peerDependencies:
+      solid-js: ^1.3
+    dependencies:
+      '@babel/generator': 7.20.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/types': 7.20.7
+      solid-js: 1.6.9
     dev: false
 
   /sorcery/0.11.0:


### PR DESCRIPTION
## Summary

Current solid example doesn't have HMR, while this PR integrate [solid-refresh](https://github.com/solidjs/solid-refresh) into solid example, It works as following snapshot, thus verifying that rspack has good support for [Webpack Hot API](https://github.com/solidjs/solid-refresh/blob/cbee7949dd8cde9c12fd546dbd9dbb04ad69d457/src/babel.ts#L71).

<img width="1729" alt="image" src="https://user-images.githubusercontent.com/23133919/217333338-fd0f508d-b9b5-4492-b4a5-a1d3779c671b.png">


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

N/A
