### PR TITLE
feat: enable allow_top_level_this by default

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -214,6 +214,7 @@ pub fn run_after_pass(
             // here will remove `use strict`
             strict_mode: false,
             no_interop: !context.is_esm,
+            allow_top_level_this: true,
             ..Default::default()
           })),
           comments,


### PR DESCRIPTION
## Summary

![img_v2_618e07f1-339e-4fe6-a64e-19784b13abag](https://user-images.githubusercontent.com/49502170/217418766-9d0f3105-0e44-48eb-999d-14f4af144210.jpg)
Disable replacing `this` with `undefined` 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

Fix #1789
