### PR TITLE
Make peer optional

### DIFF
--- a/.changeset/thick-pillows-unite.md
+++ b/.changeset/thick-pillows-unite.md
@@ -1,0 +1,5 @@
+---
+"@rspack/dev-client": patch
+---
+
+make react-refresh optional

--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -23,6 +23,11 @@
     "@rspack/core": "*",
     "react-refresh": ">=0.10.0 <1.0.0"
   },
+  "peerDependenciesMeta": {
+    "react-refresh": {
+      "optional": true
+    }
+  },
   "exports": {
     ".": "./dist/index.js",
     "./devServer": "./dist/devServer.js",


### PR DESCRIPTION
## Summary
since we resolve react-refresh to internal react-refresh in rspack, so it's optional to peerDep react-refresh, this could remove the warning when install rspack without install react-refresh
## Related issue (if exists)
![image](https://user-images.githubusercontent.com/8898718/217745292-c0444021-5f4c-47ea-b916-f21fd70bb98c.png)
