### PR TITLE
fix(rspack): fix synatx error when external contains @xx/yy

### DIFF
--- a/crates/rspack_plugin_externals/src/external.rs
+++ b/crates/rspack_plugin_externals/src/external.rs
@@ -81,7 +81,7 @@ impl Module for ExternalModule {
           format!(r#"module.exports = require("{}")"#, self.specifier)
         }
         ExternalType::Window => {
-          format!("module.exports = window.{}", self.specifier)
+          format!(r#"module.exports = window["{}"]"#, self.specifier)
         }
         ExternalType::Auto => match self.target.platform {
           TargetPlatform::BrowsersList


### PR DESCRIPTION
## Summary
when using config like following
```js
module.exports = {
  externals: {
   "@babel/core": "@babel/core"
 }
}
```
will wrongly transform the code to the following
```js
const babel = window.@babel/core
```
which is contains syntax error
## Related issue (if exists)
