### PR TITLE
perf: replace string-cache's global HashMap with DashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3332,12 +3332,11 @@ checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
 [[package]]
 name = "string_cache"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+source = "git+https://github.com/boshen/string-cache?branch=dashmap#3ac4aab3953a610ef4e16fa29e639da96c8e9218"
 dependencies = [
+ "dashmap",
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
  "phf_shared",
  "precomputed-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ swc_css           = { version = "0.149.2" }
 swc_html          = { version = "0.105.1" }
 swc_html_minifier = { version = "0.102.1" }
 tracing           = "0.1.34"
+
+[patch.crates-io]
+string_cache = { git = "https://github.com/boshen/string-cache", branch = "dashmap" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2772,12 +2772,11 @@ checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
 [[package]]
 name = "string_cache"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+source = "git+https://github.com/boshen/string-cache?branch=dashmap#3ac4aab3953a610ef4e16fa29e639da96c8e9218"
 dependencies = [
+ "dashmap",
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
  "phf_shared",
  "precomputed-hash",
  "serde",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -52,6 +52,9 @@ napi-build = { version = "=2.0.1" }
 [dev-dependencies]
 testing_macros = { version = "0.2.5" }
 
+[patch.crates-io]
+string_cache = { git = "https://github.com/boshen/string-cache", branch = "dashmap" }
+
 [profile.release]
 # debug = true
 # Automatically strip symbols from the binary.


### PR DESCRIPTION
Diff in https://github.com/Boshen/string-cache/pull/1

Profile:

![image](https://user-images.githubusercontent.com/1430279/218381032-8b547dc5-2f93-42bb-aa31-8adb3c7f7497.png)

Bottleneck of string-cache is removed almost entirely. 10s -> 1s.

In real project mgp, the build time is reduced from 4.4s -> 3.2s (30%).