### PR TITLE
refactor: loader directly change context fields on rust side

### DIFF
--- a/crates/loader_runner/tests/load_runner.rs
+++ b/crates/loader_runner/tests/load_runner.rs
@@ -84,7 +84,7 @@ macro_rules! run_loader {
 
 #[cfg(test)]
 mod fixtures {
-  use rspack_error::{Diagnostic, Result};
+  use rspack_error::Result;
   use rspack_loader_runner::*;
 
   #[derive(Debug)]
@@ -96,15 +96,12 @@ mod fixtures {
       "direct-pass-loader"
     }
 
-    async fn run(
-      &self,
-      loader_context: &mut LoaderContext<'_, '_, (), ()>,
-    ) -> Result<Vec<Diagnostic>> {
+    async fn run(&self, loader_context: &mut LoaderContext<'_, '_, (), ()>) -> Result<()> {
       let content = loader_context.content.to_owned();
       loader_context.cacheable = true;
       loader_context.content = content;
 
-      Ok(vec![])
+      Ok(())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -125,10 +122,7 @@ mod fixtures {
       "basic-loader"
     }
 
-    async fn run(
-      &self,
-      loader_context: &mut LoaderContext<'_, '_, (), ()>,
-    ) -> Result<Vec<Diagnostic>> {
+    async fn run(&self, loader_context: &mut LoaderContext<'_, '_, (), ()>) -> Result<()> {
       let content = loader_context.content.to_owned().try_into_string()?;
       loader_context.content = Content::String(format!(
         r#"{content}
@@ -136,7 +130,7 @@ html {{
   margin: 0;
 }}"#
       ));
-      Ok(vec![])
+      Ok(())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -157,16 +151,13 @@ html {{
       "chain-loader"
     }
 
-    async fn run(
-      &self,
-      loader_context: &mut LoaderContext<'_, '_, (), ()>,
-    ) -> Result<Vec<Diagnostic>> {
+    async fn run(&self, loader_context: &mut LoaderContext<'_, '_, (), ()>) -> Result<()> {
       let content = loader_context.content.to_owned().try_into_string()?;
       loader_context.content = Content::String(format!(
         r#"{content}
 console.log(2);"#
       ));
-      Ok(vec![])
+      Ok(())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {
@@ -187,16 +178,13 @@ console.log(2);"#
       "chain-loader"
     }
 
-    async fn run(
-      &self,
-      loader_context: &mut LoaderContext<'_, '_, (), ()>,
-    ) -> Result<Vec<Diagnostic>> {
+    async fn run(&self, loader_context: &mut LoaderContext<'_, '_, (), ()>) -> Result<()> {
       let content = loader_context.content.to_owned().try_into_string()?;
       loader_context.content = Content::String(format!(
         r#"{content}
 console.log(3);"#
       ));
-      Ok(vec![])
+      Ok(())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/rspack_binding_options/src/options/raw_module.rs
+++ b/crates/rspack_binding_options/src/options/raw_module.rs
@@ -12,7 +12,7 @@ use {
   crate::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
   napi::NapiRaw,
   rspack_binding_macros::call_js_function_with_napi_objects,
-  rspack_error::{internal_error, Diagnostic, Result},
+  rspack_error::{internal_error, Result},
   rspack_napi_utils::NapiResultExt,
 };
 
@@ -339,7 +339,7 @@ impl rspack_core::Loader<rspack_core::CompilerContext, rspack_core::CompilationC
       rspack_core::CompilerContext,
       rspack_core::CompilationContext,
     >,
-  ) -> Result<Vec<Diagnostic>> {
+  ) -> Result<()> {
     let js_loader_context = JsLoaderContext {
       content: loader_context.content.to_owned().into_bytes().into(),
       additional_data: loader_context
@@ -425,7 +425,7 @@ impl rspack_core::Loader<rspack_core::CompilerContext, rspack_core::CompilationC
         .map(|item| String::from_utf8_lossy(&item).to_string());
     }
 
-    Ok(vec![])
+    Ok(())
   }
 
   fn as_any(&self) -> &dyn std::any::Any {

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -486,7 +486,7 @@ impl Loader<CompilerContext, CompilationContext> for SassLoader {
   async fn run(
     &self,
     loader_context: &mut LoaderContext<'_, '_, CompilerContext, CompilationContext>,
-  ) -> Result<Vec<Diagnostic>> {
+  ) -> Result<()> {
     let content = loader_context.content.to_owned();
     let (tx, rx) = unbounded();
     let logger = RspackLogger { tx };
@@ -517,7 +517,10 @@ impl Loader<CompilerContext, CompilationContext> for SassLoader {
 
     loader_context.content = result.css.into();
     loader_context.source_map = source_map;
-    Ok(rx.into_iter().flatten().collect_vec())
+    loader_context
+      .diagnostic
+      .append(&mut rx.into_iter().flatten().collect_vec());
+    Ok(())
   }
 
   fn as_any(&self) -> &dyn std::any::Any {


### PR DESCRIPTION
## Summary

1. loader directly change context fields when call run method on rust side
2. fix sass loader overwrite file_dependencies bug
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
