### PR TITLE
chore: bump rspack_sources to 0.1.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2854,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762b95142ef8983d3db23a98c137d0093594bc551c3ee154fd2fb0fe3a44525"
+checksum = "67eaf8b9684e4ed3ea8eaa406e9f4dfbde9d265f502df58f7dbaf7a953795289"
 dependencies = [
  "dashmap",
  "dyn-clone",

--- a/crates/loader_runner/Cargo.toml
+++ b/crates/loader_runner/Cargo.toml
@@ -25,6 +25,6 @@ tokio = { version = "1.21.0", features = [
 ] }
 
 rspack_error       = { path = "../rspack_error" }
-rspack_sources     = { version = "0.1.18" }
+rspack_sources     = { version = "0.1.19" }
 tracing            = "0.1.34"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2426,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c762b95142ef8983d3db23a98c137d0093594bc551c3ee154fd2fb0fe3a44525"
+checksum = "67eaf8b9684e4ed3ea8eaa406e9f4dfbde9d265f502df58f7dbaf7a953795289"
 dependencies = [
  "dashmap",
  "dyn-clone",

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -42,6 +42,7 @@ rspack_symbol                     = { path = "../rspack_symbol" }
 anyhow = "1"
 async-trait = "0.1.53"
 once_cell = "1"
+rspack_error = { path = "../rspack_error" }
 rspack_tracing = { path = "../rspack_tracing" }
 tokio = { version = "1.21.0", features = [
   "rt",
@@ -51,10 +52,8 @@ tokio = { version = "1.21.0", features = [
   "parking_lot",
 ] }
 tracing = "0.1.34"
-warp = "0.3"
-# rspack_sources = "0.0.3"
-rspack_error       = { path = "../rspack_error" }
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
+warp = "0.3"
 [[bench]]
 harness = false
 name    = "main"

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -28,7 +28,7 @@ rspack_database = { path = "../rspack_database" }
 rspack_error = { path = "../rspack_error" }
 rspack_loader_runner = { path = "../loader_runner" }
 rspack_regex = { path = "../rspack_regex" }
-rspack_sources = { version = "0.1.18" }
+rspack_sources = { version = "0.1.19" }
 rspack_symbol = { path = "../rspack_symbol" }
 rspack_tracing = { path = "../rspack_tracing" }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
This PR removes an extra clone for each chunk source, which should reduce memory usage and increase performance.

See https://github.com/modern-js-dev/rspack-sources/pull/43

