### PR TITLE
feat: align compare_entries with Webpack

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/utils.rs
+++ b/crates/rspack_plugin_split_chunks/src/utils.rs
@@ -44,7 +44,7 @@ pub(crate) fn compare_entries(
   let modules_b_len = b.modules.len();
   let diff = modules_a_len as f64 - modules_b_len as f64;
   if diff != 0f64 {
-    return diff as f64;
+    return diff;
   }
 
   let mut modules_a = a.modules.iter().collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

Align with https://github.com/webpack/webpack/blob/b67626c7b4ffed8737d195b27c8cea1e68d58134/lib/optimize/SplitChunksPlugin.js#L231

- This also fix overflow problem for subtraction between `usize`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
