### PR TITLE
refactor: use `Database<ChunkGroup>` instead of `HashMap<Ukey, ChunkGroup>`

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -93,7 +93,7 @@ impl<'me> CodeSplitter<'me> {
 
       let entrypoint = {
         let ukey = entrypoint.ukey;
-        compilation.chunk_group_by_ukey.insert(ukey, entrypoint);
+        compilation.chunk_group_by_ukey.add(entrypoint);
 
         compilation
           .chunk_group_by_ukey
@@ -402,10 +402,7 @@ impl<'me> CodeSplitter<'me> {
 
       let chunk_group = {
         let ukey = chunk_group.ukey;
-        self
-          .compilation
-          .chunk_group_by_ukey
-          .insert(ukey, chunk_group);
+        self.compilation.chunk_group_by_ukey.add(chunk_group);
 
         self
           .compilation

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -1,9 +1,16 @@
+use rspack_database::DatabaseItem;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   Chunk, ChunkByUkey, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, IdentifierMap, ModuleIdentifier,
   RuntimeSpec,
 };
+
+impl DatabaseItem for ChunkGroup {
+  fn ukey(&self) -> rspack_database::Ukey<Self> {
+    self.ukey
+  }
+}
 
 #[derive(Debug)]
 pub struct ChunkGroup {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -71,7 +71,7 @@ pub struct Compilation {
   pub runtime_module_hashes: IdentifierMap<u64>,
   pub chunk_graph: ChunkGraph,
   pub chunk_by_ukey: Database<Chunk>,
-  pub chunk_group_by_ukey: HashMap<ChunkGroupUkey, ChunkGroup>,
+  pub chunk_group_by_ukey: Database<ChunkGroup>,
   pub entrypoints: HashMap<String, ChunkGroupUkey>,
   pub assets: CompilationAssets,
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -7,7 +7,6 @@
 use std::{fmt, sync::Arc};
 
 use rspack_database::Database;
-use rustc_hash::FxHashMap as HashMap;
 
 pub mod ast;
 pub mod cache;
@@ -207,5 +206,5 @@ impl TryFrom<&str> for ModuleType {
 // pub(crate) type VisitedModuleIdentity = HashSet<(ModuleIdentifier, DependencyCategory, String)>;
 
 pub type ChunkByUkey = Database<Chunk>;
-pub type ChunkGroupByUkey = HashMap<ChunkGroupUkey, ChunkGroup>;
+pub type ChunkGroupByUkey = Database<ChunkGroup>;
 pub(crate) type SharedPluginDriver = Arc<RwLock<PluginDriver>>;

--- a/crates/rspack_core/src/ukey.rs
+++ b/crates/rspack_core/src/ukey.rs
@@ -1,53 +1,6 @@
-use std::{
-  hash::Hash,
-  sync::atomic::{AtomicUsize, Ordering},
-};
+use rspack_database::Ukey;
 
-use rspack_database::Ukey as DatabaseUkey;
+use crate::{Chunk, ChunkGroup};
 
-use crate::Chunk;
-
-pub type ChunkUkey = DatabaseUkey<Chunk>;
-pub type ChunkGroupUkey = Ukey;
-
-static NEXT_UNIQUE_KEY: AtomicUsize = AtomicUsize::new(0);
-
-/// Ukey stands for Unique key
-#[derive(Debug, Clone, Copy, Eq, PartialOrd, Ord)]
-pub struct Ukey(usize, Option<&'static str>);
-
-impl Default for Ukey {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
-impl Ukey {
-  fn gen_ukey() -> usize {
-    NEXT_UNIQUE_KEY.fetch_add(1, Ordering::Relaxed)
-  }
-
-  pub fn new() -> Self {
-    Self(Self::gen_ukey(), None)
-  }
-
-  pub fn with_debug_info(info: &'static str) -> Self {
-    Self(Self::gen_ukey(), Some(info))
-  }
-
-  pub fn ukey(&self) -> usize {
-    self.0
-  }
-}
-
-impl Hash for Ukey {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.0.hash(state);
-  }
-}
-
-impl PartialEq for Ukey {
-  fn eq(&self, other: &Self) -> bool {
-    self.0 == other.0
-  }
-}
+pub type ChunkUkey = Ukey<Chunk>;
+pub type ChunkGroupUkey = Ukey<ChunkGroup>;


### PR DESCRIPTION
## Summary

- Finally, get rid of the old and buggy `Ukey`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
