### PR TITLE
perf(loader_runner): use BufReader for reading files

### DIFF
--- a/crates/loader_runner/src/runner.rs
+++ b/crates/loader_runner/src/runner.rs
@@ -7,6 +7,7 @@ use std::{
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
+use tokio::io::AsyncReadExt;
 
 use crate::{Content, LoaderRunnerPlugin};
 
@@ -136,7 +137,10 @@ impl LoaderRunner {
       }
     }
 
-    let result = tokio::fs::read(&self.resource_data.resource_path).await?;
+    let file = tokio::fs::File::open(&self.resource_data.resource_path).await?;
+    let mut reader = tokio::io::BufReader::new(file);
+    let mut result = Vec::new();
+    reader.read_to_end(&mut result).await?;
     Ok(Content::from(result))
   }
 


### PR DESCRIPTION
## Summary

This significantly reduces file reading latency for large files.

e.g. for a 8MB image file, this reduces reading latency from 200ms to 20ms.

![image](https://user-images.githubusercontent.com/1430279/219256842-f8e38e61-ec52-4b41-b23c-62ee3ae6749f.png)

