### PR TITLE
feat: async-node target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ English | [简体中文](./README.zh-CN.md)
 ## ✨ Features
 
 - 🚀 **Fast**: Based on Rust, the build speed is extremely fast, bringing you the ultimate development experience.
-- 📦 **Webpack Interoperable**: Interoperable well with the Webpack ecosystem, no need to build your ecosystem from scratch.
+- 📦 **Webpack Interoperable**: Targeted interoperability the Webpack ecosystem, no need to build your ecosystem from scratch.
 - 🎨 **Batteries Included**: Out-of-the-box support for Typescript, JSX, CSS, CSS Modules, Sass, and more.
 
 Read [Introduction](https://rspack-docs.vercel.app/guide/introduction.html) for details.

--- a/crates/rspack/src/lib.rs
+++ b/crates/rspack/src/lib.rs
@@ -31,6 +31,15 @@ pub fn rspack(mut options: CompilerOptions, mut plugins: Vec<Box<dyn Plugin>>) -
         rspack_plugin_runtime::CommonJsChunkLoadingPlugin {},
       ));
     }
+    TargetPlatform::AsyncNode(_) => {
+      plugins.push(Box::new(
+        rspack_plugin_runtime::CommonJsChunkFormatPlugin {},
+      ));
+      plugins.push(Box::new(rspack_plugin_runtime::RuntimePlugin {}));
+      plugins.push(Box::new(
+        rspack_plugin_runtime::AsyncNodeChunkLoadingPlugin {},
+      ));
+    }
     _ => {
       plugins.push(Box::new(rspack_plugin_runtime::RuntimePlugin {}));
     }

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -112,6 +112,16 @@ impl Chunk {
     !chunk_graph.get_chunk_entry_modules(&self.ukey).is_empty()
   }
 
+  pub fn get_entry_options(&self) -> Option<&ChunkGroupOptions> {
+    for group in &self.groups {
+      if group.kind == ChunkGroupKind::Entrypoint {
+        // should return options of entrypoint.
+        return Some(&group.options);
+      }
+    }
+    None
+  }
+
   pub fn get_all_referenced_chunks(
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,

--- a/crates/rspack_core/src/options/target.rs
+++ b/crates/rspack_core/src/options/target.rs
@@ -7,6 +7,7 @@ pub enum TargetPlatform {
   Web,
   WebWorker,
   Node(String),
+  AsyncNode(String),
   None,
 }
 

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -142,3 +142,8 @@ pub const EXTERNAL_INSTALL_CHUNK: &str = "__webpack_require__.C";
  * the webpack hash
  */
 pub const GET_FULL_HASH: &str = "__webpack_require__.h";
+
+/**
+ * the baseURI of current document
+ */
+pub const BASE_URI: &str = "__webpack_require__.b";

--- a/crates/rspack_plugin_externals/src/external.rs
+++ b/crates/rspack_plugin_externals/src/external.rs
@@ -94,6 +94,12 @@ impl Module for ExternalModule {
               self.specifier
             )
           }
+          TargetPlatform::AsyncNode(_) => {
+            format!(
+              r#"module.exports = __rspack_require__.nr("{}")"#,
+              self.specifier
+            )
+          }
         },
       })
       .boxed();

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
@@ -5,6 +5,7 @@ use rspack_core::{
 };
 use rspack_error::Result;
 
+use crate::runtime_module::ReadFileChunkLoadingRuntimeModule;
 use crate::runtime_module::RequireChunkLoadingRuntimeModule;
 
 #[derive(Debug)]

--- a/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
@@ -11,6 +11,7 @@ mod load_chunk_with_module;
 mod load_script;
 mod on_chunk_loaded;
 mod public_path;
+mod read_file_js_chunk_loading;
 mod require_js_chunk_loading;
 mod utils;
 
@@ -27,4 +28,5 @@ pub use load_chunk_with_module::LoadChunkWithModuleRuntimeModule;
 pub use load_script::LoadScriptRuntimeModule;
 pub use on_chunk_loaded::OnChunkLoadedRuntimeModule;
 pub use public_path::PublicPathRuntimeModule;
+pub use read_file_js_chunk_loading::ReadFileChunkLoadingRuntimeModule;
 pub use require_js_chunk_loading::RequireChunkLoadingRuntimeModule;

--- a/crates/rspack_plugin_runtime/src/runtime_module/read_file_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/read_file_js_chunk_loading.rs
@@ -86,7 +86,7 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
       .contains(runtime_globals::ON_CHUNKS_LOADED)
     {
       source.add(RawSource::from(include_str!(
-        "runtime/require_chunk_loading.js"
+        "runtime/read_file_chunk_loading_with_on_chunk_load.js"
       )));
     } else {
       source.add(RawSource::from("// no on chunks loaded"));
@@ -97,9 +97,16 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
       .contains(runtime_globals::ENSURE_CHUNK_HANDLERS);
 
     if with_loading || with_external_install_chunk {
-      source.add(RawSource::from(include_str!(
-        "runtime/require_chunk_loading.js"
-      )));
+      source.add(
+        RawSource::from(include_str!("runtime/read_file_chunk_loading.js"))
+          //TODO
+          .replace(
+            "ON_CHUNK_LOAD_CONDITION",
+            self
+              .runtime_requirements
+              .contains(runtime_globals::ON_CHUNKS_LOADED),
+          ),
+      );
     }
 
     if with_loading {

--- a/crates/rspack_plugin_runtime/src/runtime_module/read_file_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/read_file_js_chunk_loading.rs
@@ -3,6 +3,7 @@ use rspack_core::{
   runtime_globals, ChunkUkey, Compilation, RuntimeModule, RUNTIME_MODULE_STAGE_ATTACH,
 };
 use rustc_hash::FxHashSet as HashSet;
+use serde_json::json;
 
 use super::utils::chunk_has_js;
 use crate::runtime_module::utils::{get_initial_chunk_ids, stringify_chunks};
@@ -26,8 +27,8 @@ impl ReadFileChunkLoadingRuntimeModule {
       if let Some(base_uri) = entry_options.base_uri {
         return format!(
           "{} = {};",
-          RuntimeGlobals::baseURI,
-          serde_json::to_string(&base_uri).unwrap()
+          runtime_globals::base_uri,
+          &base_uri.toString().unwrap()
         );
       }
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/read_file_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/read_file_js_chunk_loading.rs
@@ -1,0 +1,155 @@
+use rspack_core::{
+  rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt},
+  runtime_globals, ChunkUkey, Compilation, RuntimeModule, RUNTIME_MODULE_STAGE_ATTACH,
+};
+use rustc_hash::FxHashSet as HashSet;
+
+use super::utils::chunk_has_js;
+use crate::runtime_module::utils::{get_initial_chunk_ids, stringify_chunks};
+
+#[derive(Debug, Default)]
+pub struct ReadFileChunkLoadingRuntimeModule {
+  chunk: Option<ChunkUkey>,
+  runtime_requirements: HashSet<&'static str>,
+}
+
+impl ReadFileChunkLoadingRuntimeModule {
+  pub fn new(runtime_requirements: HashSet<&'static str>) -> Self {
+    Self {
+      chunk: None,
+      runtime_requirements,
+    }
+  }
+  pub fn generate_base_uri(&self, root_output_dir: &str) -> String {
+    let options = self.chunk.get_entry_options();
+    if let Some(entry_options) = options {
+      if let Some(base_uri) = entry_options.base_uri {
+        return format!(
+          "{} = {};",
+          RuntimeGlobals::baseURI,
+          serde_json::to_string(&base_uri).unwrap()
+        );
+      }
+    }
+
+    let file_path = if let Some(dir) = root_output_dir.strip_prefix("/") {
+      format!("__dirname + {:?}", dir)
+    } else {
+      String::from("__filename")
+    };
+
+    return format!(
+      "{} = require(\"url\").pathToFileURL({});",
+      runtime_globals::BASE_URI,
+      file_path
+    );
+  }
+}
+
+impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
+  fn identifier(&self) -> String {
+    "webpack/runtime/read_file_js_chunk_loading".to_string()
+  }
+
+  fn generate(&self, compilation: &Compilation) -> BoxSource {
+    let with_hmr = self
+      .runtime_requirements
+      .contains(runtime_globals::HMR_DOWNLOAD_UPDATE_HANDLERS);
+
+    let with_base_uri = self
+      .runtime_requirements
+      .contains(runtime_globals::BASE_URI);
+
+    let with_external_install_chunk = self
+      .runtime_requirements
+      .contains(runtime_globals::EXTERNAL_INSTALL_CHUNK);
+    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+    let mut source = ConcatSource::default();
+
+    if with_hmr {
+      source.add(RawSource::from(format!(
+        "var installedChunks = {} = {} || {};\n",
+        runtime_globals::HMR_RUNTIME_STATE_PREFIX,
+        runtime_globals::HMR_RUNTIME_STATE_PREFIX,
+        &stringify_chunks(&initial_chunks, 0)
+      )));
+    } else {
+      source.add(RawSource::from(format!(
+        "var installedChunks = {};\n",
+        &stringify_chunks(&initial_chunks, 0)
+      )));
+    }
+
+    if self
+      .runtime_requirements
+      .contains(runtime_globals::ON_CHUNKS_LOADED)
+    {
+      source.add(RawSource::from(include_str!(
+        "runtime/require_chunk_loading.js"
+      )));
+    } else {
+      source.add(RawSource::from("// no on chunks loaded"));
+    }
+
+    let with_loading = self
+      .runtime_requirements
+      .contains(runtime_globals::ENSURE_CHUNK_HANDLERS);
+
+    if with_loading || with_external_install_chunk {
+      source.add(RawSource::from(include_str!(
+        "runtime/require_chunk_loading.js"
+      )));
+    }
+
+    if with_loading {
+      source.add(RawSource::from(
+        include_str!("runtime/require_chunk_loading_with_loading.js")
+          // TODO
+          .replace("JS_MATCHER", "chunkId"),
+      ));
+    }
+
+    if with_hmr {
+      source.add(RawSource::from(
+        include_str!("runtime/require_chunk_loading_with_hmr.js").to_string(),
+      ));
+      source.add(RawSource::from(
+        include_str!("runtime/javascript_hot_module_replacement.js").replace("$key$", "jsonp"),
+      ));
+    }
+
+    if self
+      .runtime_requirements
+      .contains(runtime_globals::HMR_DOWNLOAD_MANIFEST)
+    {
+      source.add(RawSource::from(
+        include_str!("runtime/require_chunk_loading_with_hmr_manifest.js").to_string(),
+      ));
+    }
+
+    if self
+      .runtime_requirements
+      .contains(runtime_globals::ON_CHUNKS_LOADED)
+    {
+      source.add(RawSource::from(
+        include_str!("runtime/require_chunk_loading_with_on_chunk_load.js").to_string(),
+      ));
+    }
+
+    if with_external_install_chunk {
+      source.add(RawSource::from(
+        include_str!("runtime/require_chunk_loading_with_external_install_chunk.js").to_string(),
+      ));
+    }
+
+    source.boxed()
+  }
+
+  fn attach(&mut self, chunk: ChunkUkey) {
+    self.chunk = Some(chunk);
+  }
+
+  fn stage(&self) -> u8 {
+    RUNTIME_MODULE_STAGE_ATTACH
+  }
+}

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/read_file_chunk_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/read_file_chunk_loading.js
@@ -1,0 +1,16 @@
+// object to store loaded chunks
+// "1" means "loaded", otherwise not loaded yet
+
+var installChunk = function (chunk) {
+	var moreModules = chunk.modules,
+		chunkIds = chunk.ids,
+		runtime = chunk.runtime;
+	for (var moduleId in moreModules) {
+		if (__webpack_require__.o(moreModules, moduleId)) {
+			__webpack_require__.m[moduleId] = moreModules[moduleId];
+		}
+	}
+	if (runtime) runtime(__webpack_require__);
+	for (var i = 0; i < chunkIds.length; i++) installedChunks[chunkIds[i]] = 1;
+	if (ONCHUNKLOAD_CONDITION) __webpack_require__.O();
+};

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/read_file_chunk_loading_with_on_chunk_load.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/read_file_chunk_loading_with_on_chunk_load.js
@@ -1,0 +1,3 @@
+__webpack_require__.O.readFileVm = function (chunkId) {
+	return installedChunks[chunkId] === 0;
+};


### PR DESCRIPTION
## Summary

Work in progress of adding the "async-node" target to rspack

ReadFileChunkLoading is based off this: 
https://github.com/ScriptedAlchemy/webpack/blob/49dab4cc5ec8507ab4cad766e2a37a23d9f8a8d1/lib/node/ReadFileChunkLoadingRuntimeModule.js

and would require commonjs chunk plugin to be aware of if its async-node or node
https://github.com/ScriptedAlchemy/webpack/blob/2df826722016f844e7a618f5f787ffa6de43c9b7/lib/node/CommonJsChunkLoadingPlugin.js

this lets you use fs.readFile instead of require.

This is very useful as a modified version of this enabled module federation on node servers
