### PR TITLE
perf: replace string-cache with bucket-level version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3364,12 +3364,10 @@ checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
 [[package]]
 name = "string_cache"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+source = "git+https://github.com/boshen/string-cache?rev=33e00b3d9a60322251532a202390c6bc53b7ea45#33e00b3d9a60322251532a202390c6bc53b7ea45"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
  "phf_shared",
  "precomputed-hash",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,8 @@ swc_css           = { version = "0.149.2" }
 swc_html          = { version = "0.105.1" }
 swc_html_minifier = { version = "0.102.1" }
 tracing           = "0.1.34"
+
+[patch.crates-io]
+# Use bucket instead of global mutex for dynamic set
+# See: https://github.com/servo/string-cache/pull/268
+string_cache = { git = "https://github.com/boshen/string-cache", rev = "33e00b3d9a60322251532a202390c6bc53b7ea45" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2132,6 +2132,7 @@ version = "0.1.0"
 dependencies = [
  "dashmap",
  "once_cell",
+ "rayon",
  "rustc-hash",
 ]
 
@@ -2804,12 +2805,10 @@ checksum = "5f026164926842ec52deb1938fae44f83dfdb82d0a5b0270c5bd5935ab74d6dd"
 [[package]]
 name = "string_cache"
 version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+source = "git+https://github.com/boshen/string-cache?rev=33e00b3d9a60322251532a202390c6bc53b7ea45#33e00b3d9a60322251532a202390c6bc53b7ea45"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",
- "parking_lot 0.12.1",
  "phf_shared",
  "precomputed-hash",
  "serde",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -57,3 +57,8 @@ testing_macros = { version = "0.2.5" }
 # debug = true
 # Automatically strip symbols from the binary.
 # lto = true   # disabled by now, because it will significantly increase our compile time.
+
+[patch.crates-io]
+# Use bucket instead of global mutex for dynamic set
+# See: https://github.com/servo/string-cache/pull/268
+string_cache = { git = "https://github.com/boshen/string-cache", rev = "33e00b3d9a60322251532a202390c6bc53b7ea45" }


### PR DESCRIPTION
See https://github.com/servo/string-cache/pull/268

For testing, I ran `rspack build` for 100 iterations for both mgp and apaas, no errors encountered.

Perf gain:
* p1: 15s -> 12s
* p2: 20s -> 18s