### PR TITLE
fix: 🐛 reset fg_color after emit a diagnostic

### DIFF
--- a/crates/rspack_error/src/emitter.rs
+++ b/crates/rspack_error/src/emitter.rs
@@ -203,7 +203,8 @@ fn emit_diagnostic<T: Write + WriteColor>(
     writer.set_color(ColorSpec::new().set_fg(Some(color)))?;
     writeln!(writer, "{}", diagnostic.message)?;
   }
-  Ok(())
+  // reset to original color after emitting a diagnostic, this avoids interference stdio of other procedure.
+  writer.reset().map_err(|e| e.into())
 }
 
 impl From<crate::Severity> for Severity {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
