### PR TITLE
chore: remove pin

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -7,7 +7,6 @@ extern crate napi_derive;
 extern crate rspack_binding_macros;
 
 use std::collections::HashSet;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 use dashmap::DashMap;
@@ -234,9 +233,7 @@ impl Rspack {
       let compiler = unsafe {
         std::mem::transmute::<&'_ mut rspack::Compiler, &'static mut rspack::Compiler>(compiler)
       };
-      f(JsCompilation::from_compilation(unsafe {
-        Pin::new_unchecked(&mut compiler.compilation)
-      }))
+      f(JsCompilation::from_compilation(&mut compiler.compilation))
     };
 
     unsafe { COMPILERS.borrow_mut(&self.id, handle_last_compilation) }

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -1,5 +1,4 @@
 use std::fmt::Debug;
-use std::pin::Pin;
 
 use async_trait::async_trait;
 use napi::{Env, NapiRaw, Result};
@@ -41,10 +40,9 @@ impl rspack_core::Plugin for JsHooksAdapter {
     args: rspack_core::CompilationArgs<'_>,
   ) -> rspack_core::PluginCompilationHookOutput {
     let compilation = JsCompilation::from_compilation(unsafe {
-      Pin::new_unchecked(std::mem::transmute::<
-        &'_ mut rspack_core::Compilation,
-        &'static mut rspack_core::Compilation,
-      >(args.compilation))
+      std::mem::transmute::<&'_ mut rspack_core::Compilation, &'static mut rspack_core::Compilation>(
+        args.compilation,
+      )
     });
 
     self
@@ -60,10 +58,9 @@ impl rspack_core::Plugin for JsHooksAdapter {
     args: rspack_core::ThisCompilationArgs<'_>,
   ) -> rspack_core::PluginThisCompilationHookOutput {
     let compilation = JsCompilation::from_compilation(unsafe {
-      Pin::new_unchecked(std::mem::transmute::<
-        &'_ mut rspack_core::Compilation,
-        &'static mut rspack_core::Compilation,
-      >(args.this_compilation))
+      std::mem::transmute::<&'_ mut rspack_core::Compilation, &'static mut rspack_core::Compilation>(
+        args.this_compilation,
+      )
     });
 
     self
@@ -194,10 +191,9 @@ impl rspack_core::Plugin for JsHooksAdapter {
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_error::Result<()> {
     let compilation = JsCompilation::from_compilation(unsafe {
-      Pin::new_unchecked(std::mem::transmute::<
-        &'_ mut rspack_core::Compilation,
-        &'static mut rspack_core::Compilation,
-      >(args.compilation))
+      std::mem::transmute::<&'_ mut rspack_core::Compilation, &'static mut rspack_core::Compilation>(
+        args.compilation,
+      )
     });
 
     self


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Removing `Pin` will make the program definitely **unsound** if you change `Compilation` within it, but still, I don't want to put people's mental burden only by not moving `Compilation` within itself. So I decide to remove this. Making `unsafe` everywhere is not what I want to see, it's better to figure out a better solution. 

## Related issue (if exists)
