### PR TITLE
fix: remove unnecessary for loop in split chunks

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
+++ b/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
@@ -587,11 +587,9 @@ impl SplitChunksPlugin {
             .chunk_by_ukey
             .get(used_chunk)
             .expect("Chunk should exist");
-          for module_identifier in &item.modules {
-            compilation
-              .chunk_graph
-              .disconnect_chunk_and_module(&used_chunk.ukey, *module_identifier);
-          }
+          compilation
+            .chunk_graph
+            .disconnect_chunk_and_module(&used_chunk.ukey, *module_identifier);
         }
       }
     } else {


### PR DESCRIPTION
## Summary

Align with code in

https://github.com/webpack/webpack/blob/b67626c7b4ffed8737d195b27c8cea1e68d58134/lib/optimize/SplitChunksPlugin.js#L1515-L1520

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
