### PR TITLE
refactor: builtins.minify to builtins.minifyOptions

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -26,7 +26,6 @@ use crate::RawOptionsApply;
 #[napi(object)]
 pub struct RawMinification {
   pub passes: u32,
-  pub enable: bool,
   pub drop_console: bool,
   pub pure_funcs: Vec<String>,
 }
@@ -34,7 +33,6 @@ pub struct RawMinification {
 impl From<RawMinification> for Minification {
   fn from(value: RawMinification) -> Self {
     Self {
-      enable: value.enable,
       passes: value.passes as usize,
       drop_console: value.drop_console,
       pure_funcs: value.pure_funcs,
@@ -49,7 +47,7 @@ pub struct RawBuiltins {
   pub html: Option<Vec<RawHtmlPluginConfig>>,
   pub css: Option<RawCssPluginConfig>,
   pub postcss: Option<RawPostCssConfig>,
-  pub minify: RawMinification,
+  pub minify_options: Option<RawMinification>,
   pub polyfill: bool,
   pub preset_env: Vec<String>,
   #[napi(ts_type = "Record<string, string>")]
@@ -87,7 +85,7 @@ impl RawOptionsApply for RawBuiltins {
       plugins.push(ProgressPlugin::new(progress.into()).boxed());
     }
     Ok(Builtins {
-      minify: self.minify.into(),
+      minify_options: self.minify_options.map(Into::into),
       polyfill: self.polyfill,
       preset_env: self.preset_env,
       define: self.define,

--- a/crates/rspack_core/src/options/builtins.rs
+++ b/crates/rspack_core/src/options/builtins.rs
@@ -27,7 +27,7 @@ pub struct DecoratorOptions {
 
 #[derive(Debug, Clone, Default)]
 pub struct Builtins {
-  pub minify: Minification,
+  pub minify_options: Option<Minification>,
   pub polyfill: bool,
   pub preset_env: Vec<String>,
   pub define: Define,
@@ -41,7 +41,6 @@ pub struct Builtins {
 
 #[derive(Debug, Clone, Default)]
 pub struct Minification {
-  pub enable: bool,
   pub passes: usize,
   pub drop_console: bool,
   pub pure_funcs: Vec<String>,

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -711,8 +711,8 @@ impl Plugin for CssPlugin {
     args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsOutput {
     let compilation = args.compilation;
-    let minify = &compilation.options.builtins.minify;
-    if !minify.enable {
+    let minify_options = &compilation.options.builtins.minify_options;
+    if minify_options.is_none() {
       return Ok(());
     }
 

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -502,12 +502,10 @@ impl Plugin for JsPlugin {
     args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
     let compilation = args.compilation;
-    let minify = &compilation.options.builtins.minify;
-    if !minify.enable {
-      return Ok(());
-    }
+    let minify_options = &compilation.options.builtins.minify_options;
 
-    compilation
+    if let Some(minify_options) = minify_options {
+      compilation
       .assets
       .par_iter_mut()
       .filter(|(filename, _)| {
@@ -524,9 +522,9 @@ impl Plugin for JsPlugin {
           let input_source_map = original_source.map(&MapOptions::default());
           let output = crate::ast::minify(&JsMinifyOptions {
             compress: BoolOrDataConfig::from_obj(TerserCompressorOptions {
-              passes: minify.passes,
-              drop_console: minify.drop_console,
-              pure_funcs: minify.pure_funcs.clone(),
+              passes: minify_options.passes,
+              drop_console: minify_options.drop_console,
+              pure_funcs: minify_options.pure_funcs.clone(),
               ..Default::default()
             }),
             source_map: BoolOrDataConfig::from_bool(input_source_map.is_some()),
@@ -553,7 +551,7 @@ impl Plugin for JsPlugin {
         original.get_info_mut().minimized = true;
         Ok(())
       })?;
-
+    }
     Ok(())
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -148,7 +148,7 @@ pub fn run_after_pass(
       let unresolved_mark = context.unresolved_mark;
       let top_level_mark = context.top_level_mark;
       let builtin_tree_shaking = generate_context.compilation.options.builtins.tree_shaking;
-      let minify = &generate_context.compilation.options.builtins.minify;
+      let minify_options = &generate_context.compilation.options.builtins.minify_options;
       let comments = None;
       let dependency_visitors =
         collect_dependency_code_generation_visitors(module, generate_context)?;
@@ -199,11 +199,11 @@ pub fn run_after_pass(
         ),
         Optional::new(
           Repeat::new(dce(Config::default(), unresolved_mark)),
-          need_tree_shaking && builtin_tree_shaking && !minify.enable
+          need_tree_shaking && builtin_tree_shaking && minify_options.is_none()
         ),
         Optional::new(
           dce(Config::default(), unresolved_mark),
-          need_tree_shaking && builtin_tree_shaking && minify.enable
+          need_tree_shaking && builtin_tree_shaking && minify_options.is_some()
         ),
         swc_visitor::build_module(
           &cm,

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -103,6 +103,17 @@ pub struct EntryItem {
   pub runtime: Option<String>,
 }
 
+#[derive(Debug, Default, JsonSchema, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Minification {
+  #[serde(default)]
+  pub passes: usize,
+  #[serde(default)]
+  pub drop_console: bool,
+  #[serde(default)]
+  pub pure_funcs: Vec<String>,
+}
+
 #[derive(Debug, JsonSchema, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct Builtins {
@@ -113,7 +124,7 @@ pub struct Builtins {
   #[serde(default)]
   pub html: Vec<HtmlPluginConfig>,
   #[serde(default)]
-  pub minify: bool,
+  pub minify_options: Option<Minification>,
   #[serde(default)]
   pub tree_shaking: bool,
   #[serde(default)]
@@ -283,11 +294,11 @@ impl TestConfig {
       builtins: c::Builtins {
         define: self.builtins.define,
         tree_shaking: self.builtins.tree_shaking,
-        minify: c::Minification {
-          enable: self.builtins.minify,
-          passes: 1,
-          ..Default::default()
-        },
+        minify_options: self.builtins.minify_options.map(|op| c::Minification {
+          passes: op.passes,
+          drop_console: op.drop_console,
+          pure_funcs: op.pure_funcs,
+        }),
         preset_env: self.builtins.preset_env.clone(),
         ..Default::default()
       },

--- a/crates/rspack_testing/test.config.scheme.json
+++ b/crates/rspack_testing/test.config.scheme.json
@@ -58,9 +58,15 @@
             "$ref": "#/definitions/HtmlPluginConfig"
           }
         },
-        "minify": {
-          "default": false,
-          "type": "boolean"
+        "minifyOptions": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Minification"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "postcss": {
           "$ref": "#/definitions/Postcss"
@@ -243,6 +249,29 @@
         "sha384",
         "sha512"
       ]
+    },
+    "Minification": {
+      "type": "object",
+      "properties": {
+        "dropConsole": {
+          "default": false,
+          "type": "boolean"
+        },
+        "passes": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "pureFuncs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
     },
     "Module": {
       "type": "object",

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -122,10 +122,7 @@ export class RspackCLI {
 					? "source-map"
 					: "cheap-module-source-map";
 			}
-			item.builtins = {
-				...item.builtins,
-				minify: item.builtins?.minify ?? item.mode === "production"
-			};
+			item.builtins = item.builtins || {};
 
 			// no emit assets when run dev server, it will use node_binding api get file content
 			if (typeof item.builtins.noEmitAssets === "undefined") {

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -144,9 +144,8 @@ exports[`normalize options snapshot react.development and react.refresh should b
     "devFriendlySplitChunks": false,
     "emotion": undefined,
     "html": [],
-    "minify": {
+    "minifyOptions": {
       "dropConsole": false,
-      "enable": true,
       "passes": 1,
       "pureFuncs": [],
     },

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -95,8 +95,8 @@ export const applyRspackOptionsDefaults = (
 	// TODO: refactor builtins
 	options.builtins = oldBuiltins.resolveBuiltinsOptions(options.builtins, {
 		contextPath: options.context!,
-		production,
-		development
+		optimization: options.optimization,
+		production
 	}) as any;
 };
 

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -28,15 +28,14 @@ export class RspackOptionsApply {
 		) {
 			new NodeTargetPlugin().apply(compiler);
 		}
-		// after we migrate minify to minimze, we could remove it
-		if (options.optimization.minimize || options.builtins.minify) {
-			if (options.optimization.minimizer) {
-				for (const minimizer of options.optimization.minimizer) {
-					if (typeof minimizer === "function") {
-						minimizer.call(compiler, compiler);
-					} else if (minimizer !== "...") {
-						minimizer.apply(compiler);
-					}
+
+		const { minimize, minimizer } = options.optimization;
+		if (minimize && minimizer) {
+			for (const item of minimizer) {
+				if (typeof item === "function") {
+					item.call(compiler, compiler);
+				} else if (item !== "...") {
+					item.apply(compiler);
 				}
 			}
 		}

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -90,12 +90,7 @@ describe("snapshots", () => {
 		    "devFriendlySplitChunks": false,
 		    "emotion": undefined,
 		    "html": [],
-		    "minify": {
-		      "dropConsole": false,
-		      "enable": false,
-		      "passes": 1,
-		      "pureFuncs": [],
-		    },
+		    "minifyOptions": undefined,
 		    "noEmitAssets": false,
 		    "polyfill": true,
 		    "postcss": {
@@ -281,8 +276,12 @@ describe("snapshots", () => {
 		-         "localIdentName": "[path][name][ext]__[local]",
 		+         "localIdentName": "[hash]",
 		@@ ... @@
-		-       "enable": false,
-		+       "enable": true,
+		-     "minifyOptions": undefined,
+		+     "minifyOptions": Object {
+		+       "dropConsole": false,
+		+       "passes": 1,
+		+       "pureFuncs": Array [],
+		+     },
 		@@ ... @@
 		-     "treeShaking": false,
 		+     "treeShaking": true,
@@ -325,8 +324,12 @@ describe("snapshots", () => {
 		-         "localIdentName": "[path][name][ext]__[local]",
 		+         "localIdentName": "[hash]",
 		@@ ... @@
-		-       "enable": false,
-		+       "enable": true,
+		-     "minifyOptions": undefined,
+		+     "minifyOptions": Object {
+		+       "dropConsole": false,
+		+       "passes": 1,
+		+       "pureFuncs": Array [],
+		+     },
 		@@ ... @@
 		-     "treeShaking": false,
 		+     "treeShaking": true,

--- a/packages/rspack/tests/configCases/builtins/minify-drop-console/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/minify-drop-console/webpack.config.js
@@ -1,7 +1,10 @@
 module.exports = {
 	builtins: {
-		minify: {
+		minifyOptions: {
 			dropConsole: true
 		}
+	},
+	optimization: {
+		minimize: true
 	}
 };

--- a/packages/rspack/tests/configCases/builtins/minify-pure-funcs/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/minify-pure-funcs/webpack.config.js
@@ -1,7 +1,10 @@
 module.exports = {
 	builtins: {
-		minify: {
+		minifyOptions: {
 			pureFuncs: ["console.debug", "console.warn"]
 		}
+	},
+	optimization: {
+		minimize: true
 	}
 };

--- a/packages/rspack/tests/configCases/builtins/minify-with-boolean/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/minify-with-boolean/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	builtins: {
-		minify: false
+	optimization: {
+		minimize: false
 	}
 };

--- a/packages/rspack/tests/configCases/builtins/minify/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/minify/webpack.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	builtins: {
-		minify: true
+	optimization: {
+		minimize: true
 	}
 };

--- a/packages/rspack/tests/configCases/plugins/minify-esbuild/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-esbuild/webpack.config.js
@@ -2,9 +2,6 @@ const minifyPlugin = require("@rspack/plugin-minify");
 module.exports = {
 	context: __dirname,
 	target: "node",
-	builtins: {
-		minify: false
-	},
 	entry: {
 		main: "./index.js"
 	},

--- a/packages/rspack/tests/configCases/plugins/minify-terser/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-terser/webpack.config.js
@@ -2,9 +2,6 @@ const minifyPlugin = require("@rspack/plugin-minify");
 module.exports = {
 	context: __dirname,
 	target: "node",
-	builtins: {
-		minify: false
-	},
 	entry: {
 		main: "./index.js"
 	},

--- a/packages/rspack/tests/configCases/source-map/verify-bundle-css-minify/webpack.config.js
+++ b/packages/rspack/tests/configCases/source-map/verify-bundle-css-minify/webpack.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	devtool: "source-map",
-	builtins: {
-		minify: true
+	optimization: {
+		minimize: true
 	}
 };

--- a/packages/rspack/tests/configCases/source-map/verify-es6-minify/webpack.config.js
+++ b/packages/rspack/tests/configCases/source-map/verify-es6-minify/webpack.config.js
@@ -1,6 +1,6 @@
 module.exports = {
 	devtool: "source-map",
-	builtins: {
-		minify: true
+	optimization: {
+		minimize: true
 	}
 };


### PR DESCRIPTION
## Summary

Both `builtins.minify` and `optimization.minimize` can control the enabled state of the builtins minimizer is ambiguous.

In this PR:
1. use `optimization.minimize` to control all minimizer enabled state
2. use `builtins.minifyOption` to control builtin minimizer option

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
