### PR TITLE
docs: fix banner background color in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-![rspack banner](https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610-dark.png">
+  <img alt="Rspack Banner" src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610.png">
+</picture>
 
 <h2 align="center">A fast Rust-based web bundler</h2>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,7 @@
-![rspack banner](https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610-dark.png">
+  <img alt="Rspack Banner" src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610.png">
+</picture>
 
 <h2 align="center">基于 Rust 的高性能模块打包工具</h2>
 


### PR DESCRIPTION
## Summary

Fix banner background color in dark mode.

### Dark Mode

![image](https://user-images.githubusercontent.com/7237365/220287973-a68e03f8-535d-4ca9-a4ca-28c049909425.png)

### Light Mode

![image](https://user-images.githubusercontent.com/7237365/220288115-a340f649-81fd-4c79-9993-fe92b6bc83d4.png)

