### PR TITLE
chore: add version in compiler.webpack

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -81,7 +81,10 @@ class Compiler {
 			get sources(): typeof import("webpack-sources") {
 				return require("webpack-sources");
 			},
-			Compilation
+			Compilation,
+			get version() {
+				return require("../package.json").version;
+			}
 		};
 		this.root = this;
 		this.running = false;


### PR DESCRIPTION
## Summary
compiler.webpack.version is useful to track version usage 
## Related issue (if exists)
