### PR TITLE
feat: add catch_unwind panic handling strategy

### DIFF
--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2114,6 +2114,7 @@ version = "0.1.0"
 dependencies = [
  "napi",
  "rspack_error",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/rspack_error/src/catch_unwind.rs
+++ b/crates/rspack_error/src/catch_unwind.rs
@@ -8,8 +8,59 @@ use futures::{future::BoxFuture, FutureExt};
 
 use super::{internal_error, Result};
 
-pub fn catch_unwind<F: FnOnce() -> R, R>(f: F) -> Result<R> {
-  match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+#[allow(non_snake_case)]
+pub mod PanicStrategy {
+  /// Strategy for panic handling.
+  /// [`PanicStrategy::Suppressed`] means that panic for `catch_unwind` is suppressed.
+  /// [`PanicStrategy::NotSuppressed`] means that panic for `catch_unwind` is not suppressed.
+  pub trait S: 'static + Unpin + Send + Sync {
+    fn is_suppressed() -> bool;
+  }
+
+  /// Panic for `catch_unwind` is suppressed. But it is not
+  /// suppressed for those which are not wrapped by `catch_unwind`.
+  pub struct Suppressed;
+
+  impl S for Suppressed {
+    #[inline]
+    fn is_suppressed() -> bool {
+      true
+    }
+  }
+
+  /// Panic for `catch_unwind` is not suppressed.
+  /// Every panic will be preserved and propagated to the panic hook set before.
+  pub struct NotSuppressed;
+
+  impl S for NotSuppressed {
+    #[inline]
+    fn is_suppressed() -> bool {
+      false
+    }
+  }
+}
+
+#[inline]
+fn panic_hook_handler<S: PanicStrategy::S, R>(f: impl FnOnce() -> R) -> R {
+  let prev_hook = if S::is_suppressed() {
+    let prev = Some(std::panic::take_hook());
+    std::panic::set_hook(Box::new(|_| {}));
+    prev
+  } else {
+    None
+  };
+  let result = f();
+  if let Some(prev_hook) = prev_hook {
+    std::panic::set_hook(prev_hook);
+  }
+
+  result
+}
+
+pub fn catch_unwind<S: PanicStrategy::S, R>(f: impl FnOnce() -> R) -> Result<R> {
+  match panic_hook_handler::<S, _>(move || {
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(f))
+  }) {
     Ok(res) => Ok(res),
     Err(cause) => match cause.downcast_ref::<&'static str>() {
       None => match cause.downcast_ref::<String>() {
@@ -37,7 +88,7 @@ impl<F: Future + Send + 'static> Future for CatchUnwindFuture<F> {
   fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
     let inner = &mut self.inner;
 
-    match catch_unwind(move || inner.poll_unpin(cx)) {
+    match catch_unwind::<PanicStrategy::Suppressed, _>(move || inner.poll_unpin(cx)) {
       Ok(Poll::Pending) => Poll::Pending,
       Ok(Poll::Ready(value)) => Poll::Ready(Ok(value)),
       Err(cause) => Poll::Ready(Err(cause)),


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implements a panic-handling strategy for flexibility.

By default, the default panic hook could be overridden. The panic handling strategy leverages the user input to set whether the panic should be used as the default one to report or be suppressed. 

`CatchUnwindFuture` will use `PanicStrategy::Suppressed` by default.

## Related issue (if exists)
