### PR TITLE
feat: use memfs in rspack dev middleware

### DIFF
--- a/packages/rspack-dev-middleware/src/index.ts
+++ b/packages/rspack-dev-middleware/src/index.ts
@@ -3,8 +3,7 @@ import wdm from "webpack-dev-middleware";
 const rdm: typeof wdm = (compiler, options) => {
 	return wdm(compiler, {
 		...options,
-		writeToDisk: false,
-		outputFileSystem: require("fs")
+		writeToDisk: false
 	});
 };
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Remove manual `outputFileSystem` to use `memfs`

## Related issue (if exists)
