### PR TITLE
chore: do not initialize output dir ahead

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -5,11 +5,10 @@ mod resolver;
 
 use std::{path::Path, sync::Arc};
 
-use anyhow::Context;
 pub use compilation::*;
 pub use queue::*;
 pub use resolver::*;
-use rspack_error::{Error, Result};
+use rspack_error::Result;
 use rspack_fs::AsyncWritableFileSystem;
 use rspack_futures::FuturesResults;
 use rustc_hash::FxHashSet as HashSet;
@@ -186,11 +185,6 @@ where
       .await?;
 
     let output_path = self.options.context.join(&self.options.output.path);
-    if !output_path.exists() {
-      std::fs::create_dir_all(&output_path)
-        .with_context(|| format!("failed to create dir: {:?}", &output_path))
-        .map_err(|e| Error::Anyhow { source: e })?;
-    }
 
     let _ = self
       .compilation


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
