### PR TITLE
chore: support run release-snapshot manually

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -2,6 +2,10 @@ name: release snapshot
 on:
   issue_comment:
     types: [created]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   release:
     name: release-snapshot


### PR DESCRIPTION
## Summary

Allows run release-snapshot workflow manually from the Actions tab

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
