### PR TITLE
ci: 🎡 fix ci tee reset exit code

### DIFF
--- a/.github/workflows/bench-history.yaml
+++ b/.github/workflows/bench-history.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install toolchain
         run: rustup show
       - name: Run benchmark
-        run: cargo bench --bench main -- --output-format bencher | tee output.txt
+        run: set -o pipefail && cargo bench --bench main -- --output-format bencher | tee output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.14.0

--- a/xtask/src/copy_three.rs
+++ b/xtask/src/copy_three.rs
@@ -78,7 +78,11 @@ pub fn three_production_config() {
 {
     "devtool": "source-map",
     "builtins": {
-      "minify": true
+      "minifyOptions": {
+        "passes": 1,
+        "dropConsole": true,
+        "pureFuncs": []
+      }
     },
     "optimization": {
       "moduleIds": "deterministic"


### PR DESCRIPTION
## Summary
1. https://stackoverflow.com/questions/6871859/piping-command-output-to-tee-but-also-save-exit-code-of-command
tee will reset the exit code even the previous process return none 0 code, this will cause our benchmark CI pass even rspack panic.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
