### PR TITLE
feat: add render_module_content hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2763,6 +2763,7 @@ name = "rspack_plugin_devtool"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "dashmap",
  "once_cell",
  "pathdiff",
  "rayon",
@@ -2832,6 +2833,7 @@ dependencies = [
  "regex",
  "rspack_core",
  "rspack_error",
+ "rspack_futures",
  "rspack_identifier",
  "rspack_plugin_devtool",
  "rspack_regex",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2336,6 +2336,7 @@ name = "rspack_plugin_devtool"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "dashmap",
  "once_cell",
  "pathdiff",
  "rayon",
@@ -2403,6 +2404,7 @@ dependencies = [
  "regex",
  "rspack_core",
  "rspack_error",
+ "rspack_futures",
  "rspack_identifier",
  "rspack_plugin_devtool",
  "rspack_regex",

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -9,7 +9,8 @@ use crate::{
   AdditionalChunkRuntimeRequirementsArgs, BoxModule, ChunkUkey, Compilation, CompilationArgs,
   ContentHashArgs, DoneArgs, FactorizeArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
   NormalModuleFactoryContext, OptimizeChunksArgs, ParserAndGenerator, PluginContext,
-  ProcessAssetsArgs, RenderChunkArgs, RenderManifestArgs, SourceType, ThisCompilationArgs,
+  ProcessAssetsArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs, SourceType,
+  ThisCompilationArgs,
 };
 
 // use anyhow::{Context, Result};
@@ -27,6 +28,7 @@ pub type PluginRenderChunkHookOutput = Result<Option<BoxSource>>;
 pub type PluginProcessAssetsOutput = Result<()>;
 pub type PluginOptimizeChunksOutput = Result<()>;
 pub type PluginAdditionalChunkRuntimeRequirementsOutput = Result<()>;
+pub type PluginRenderModuleContentOutput = Result<Option<BoxSource>>;
 
 #[async_trait::async_trait]
 pub trait Plugin: Debug + Send + Sync {
@@ -104,6 +106,14 @@ pub trait Plugin: Debug + Send + Sync {
     _ctx: PluginContext,
     _args: &RenderChunkArgs,
   ) -> PluginRenderChunkHookOutput {
+    Ok(None)
+  }
+
+  fn render_module_content(
+    &self,
+    _ctx: PluginContext,
+    _args: &RenderModuleContentArgs,
+  ) -> PluginRenderModuleContentOutput {
     Ok(None)
   }
 

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 
 use rspack_error::{internal_error, Result};
+use rspack_sources::BoxSource;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::ast::css::Ast as CssAst;
@@ -10,7 +11,6 @@ use crate::{
   Chunk, ChunkUkey, Compilation, DependencyCategory, DependencyType, ErrorSpan, ModuleDependency,
   ModuleIdentifier, Resolve, SharedPluginDriver, Stats,
 };
-
 // #[derive(Debug)]
 // pub struct ParseModuleArgs<'a> {
 //   pub uri: &'a str,
@@ -160,4 +160,10 @@ impl<'me> RenderChunkArgs<'me> {
       .get(self.chunk_ukey)
       .expect("chunk should exsit in chunk_by_ukey")
   }
+}
+
+#[derive(Debug)]
+pub struct RenderModuleContentArgs<'a> {
+  pub module_source: &'a BoxSource,
+  pub compilation: &'a Compilation,
 }

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -16,8 +16,9 @@ use crate::{
   PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
   PluginCompilationHookOutput, PluginContext, PluginFactorizeHookOutput, PluginMakeHookOutput,
   PluginModuleHookOutput, PluginProcessAssetsOutput, PluginRenderChunkHookOutput,
-  PluginRenderManifestHookOutput, PluginThisCompilationHookOutput, ProcessAssetsArgs,
-  RenderChunkArgs, RenderManifestArgs, ResolverFactory, SourceType, Stats, ThisCompilationArgs,
+  PluginRenderManifestHookOutput, PluginRenderModuleContentOutput, PluginThisCompilationHookOutput,
+  ProcessAssetsArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs, ResolverFactory,
+  SourceType, Stats, ThisCompilationArgs,
 };
 
 pub struct PluginDriver {
@@ -208,6 +209,18 @@ impl PluginDriver {
   pub fn render_chunk(&self, args: RenderChunkArgs) -> PluginRenderChunkHookOutput {
     for plugin in &self.plugins {
       if let Some(source) = plugin.render_chunk(PluginContext::new(), &args)? {
+        return Ok(Some(source));
+      }
+    }
+    Ok(None)
+  }
+
+  pub fn render_module_content(
+    &self,
+    args: RenderModuleContentArgs,
+  ) -> PluginRenderModuleContentOutput {
+    for plugin in &self.plugins {
+      if let Some(source) = plugin.render_module_content(PluginContext::new(), &args)? {
         return Ok(Some(source));
       }
     }

--- a/crates/rspack_futures/src/lib.rs
+++ b/crates/rspack_futures/src/lib.rs
@@ -8,7 +8,6 @@ use tokio::task::JoinError;
 
 type FuturesResult<T> = Vec<Result<T, JoinError>>;
 
-/// A set of futures that are spawned and executed in parallel and the results are returned in the order they were.
 ///
 /// A rough demo of how this works:
 ///

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -9,6 +9,7 @@ version    = "0.1.0"
 
 [dependencies]
 async-trait   = "0.1"
+dashmap       = "5.4.0"
 once_cell     = "1"
 pathdiff      = "0.2"
 rayon         = "1"

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -24,6 +24,7 @@ rayon = "1.5.3"
 regex = "1.6.0"
 rspack_core = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
+rspack_futures = { path = "../rspack_futures" }
 rspack_identifier = { path = "../rspack_identifier" }
 rspack_plugin_devtool = { path = "../rspack_plugin_devtool" }
 rspack_regex = { path = "../rspack_regex" }


### PR DESCRIPTION
## Summary

- add render_module_content hook to mut module content, usage by eval sourcemap and will be used at wasm plugin

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
