### PR TITLE
Fix html fallback

### DIFF
--- a/packages/rspack-dev-middleware/src/middleware.ts
+++ b/packages/rspack-dev-middleware/src/middleware.ts
@@ -24,14 +24,19 @@ export function getRspackMemoryAssets(
 					typeof index === "undefined" || typeof index === "boolean"
 						? "index.html"
 						: index;
-				return compiler.getAsset(filename + "/" + indexValue);
+				return compiler.getAsset(filename + indexValue);
 			})();
 		if (!buffer) {
 			return next();
 		}
+		let contentType;
+		if (filename === "") {
+			contentType = "text/html; charset=utf-8";
+		} else {
+			contentType =
+				mime.contentType(extname(path)) || "text/plain; charset=utf-8";
+		}
 
-		let contentType =
-			mime.contentType(extname(path)) || "text/plain; charset=utf-8";
 		res.setHeader("Content-Type", contentType);
 		res.send(buffer);
 	};


### PR DESCRIPTION
## Summary
currently we cant' access index.html by 'localhost:3003/' because we don't handle html fallback correctly on middleware
## Related issue (if exists)
