### PR TITLE
fix(core): make version be compatible with webpack

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -88,6 +88,9 @@ class Compiler {
 			},
 			Compilation,
 			get version() {
+				return "5.75.0"; // this is a hack to be compatible with plugin which detect webpack's version
+			},
+			get rspackVersion() {
 				return require("../package.json").version;
 			}
 		};


### PR DESCRIPTION
## Summary
lots of webpack plugin detect webpack version to decide which api to use, we have to be compatible with it otherwise lots plugins will be broken
## Related issue (if exists)
