### PR TITLE
chore(binding): minor cleanup

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -46,8 +46,11 @@ tokio = { version = "1.21.0", features = [
 ] }
 tracing = "0.1.34"
 
-[target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
+[target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = { version = "0.2" }
+
+[target.'cfg(all(target_os = "linux", not(all(target_env = "musl", target_arch = "aarch64"))))'.dependencies]
+mimalloc-rust = { version = "0.2", features = ["local-dynamic-tls"] }
 
 [build-dependencies]
 napi-build = { version = "=2.0.1" }

--- a/crates/node_binding/binding.js
+++ b/crates/node_binding/binding.js
@@ -11,7 +11,8 @@ function isMusl() {
   // For Node 10
   if (!process.report || typeof process.report.getReport !== 'function') {
     try {
-      return readFileSync('/usr/bin/ldd', 'utf8').includes('musl')
+      const lddPath = require('child_process').execSync('which ldd').toString().trim();
+      return readFileSync(lddPath, 'utf8').includes('musl')
     } catch (e) {
       return true
     }

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use napi::bindgen_prelude::SharedReference;
 use rspack_core::Stats;
 


### PR DESCRIPTION
## Summary
- Enable `local-dynamic-tls` in `mimalloc-rust` feature on Linux
- Fix template to works with nix: https://github.com/napi-rs/napi-rs/pull/1391
- Remove useless import
