### PR TITLE
fix: use `require` in node external

### DIFF
--- a/crates/rspack_plugin_externals/src/external.rs
+++ b/crates/rspack_plugin_externals/src/external.rs
@@ -88,10 +88,7 @@ impl Module for ExternalModule {
             format!("module.exports = {}", self.specifier)
           }
           TargetPlatform::Node(_) => {
-            format!(
-              r#"module.exports = __webpack_require__.nr("{}")"#,
-              self.specifier
-            )
+            format!(r#"module.exports = require("{}")"#, self.specifier)
           }
         },
       })

--- a/packages/rspack/tests/case.template.ts
+++ b/packages/rspack/tests/case.template.ts
@@ -7,7 +7,6 @@ import assert from "assert";
 import createLazyTestEnv from "./helpers/createLazyTestEnv";
 
 // most of these could be removed when we support external builtins by default
-const externalModule = ["uvu", "path", "fs", "expect", "source-map", "util"];
 export function describeCases(config: { name: string; casePath: string }) {
 	const casesPath = path.resolve(__dirname, config.casePath);
 	let categoriesDir = fs.readdirSync(casesPath);
@@ -45,9 +44,6 @@ export function describeCases(config: { name: string; casePath: string }) {
 							if (fs.existsSync(configFile)) {
 								config = require(configFile);
 							}
-							const externals = Object.fromEntries(
-								externalModule.map(x => [x, x])
-							);
 							const options: RspackOptions = {
 								target: "node",
 								context: testRoot,
@@ -61,8 +57,7 @@ export function describeCases(config: { name: string; casePath: string }) {
 								infrastructureLogging: {
 									debug: false
 								},
-								externals,
-								externalsType: "node-commonjs",
+								externals: { "source-map": "source-map" },
 								...config, // we may need to use deepMerge to handle config merge, but we may fix it until we need it
 								output: {
 									publicPath: "/",

--- a/packages/rspack/tests/configCases/builtins/node-externals/index.js
+++ b/packages/rspack/tests/configCases/builtins/node-externals/index.js
@@ -1,4 +1,7 @@
-it("util", () => {
-	// FIXME: target set to node will break
-	// const vm = require("vm");
+const fs_cjs = require("fs");
+import fs_esm from "fs";
+
+it("node external should works", () => {
+	expect(fs_cjs.existsSync(__filename)).toBeTruthy();
+	expect(fs_esm.existsSync(__filename)).toBeTruthy();
 });

--- a/packages/rspack/tests/configCases/plugins/polyfill/index.js
+++ b/packages/rspack/tests/configCases/plugins/polyfill/index.js
@@ -1,7 +1,5 @@
+const path = require("path");
+
 it("node-polyfill", () => {
-	const vm = require("vm");
-	const fs = require("fs");
-	const content = fs.readFileSync(__filename, "utf-8");
-	expect(content).toMatch(/vm-browserify/);
-	console.log("vm:", vm);
+	expect(path.resolve("/a/b/c/../../d")).toBe("/a/d");
 });


### PR DESCRIPTION
This PR brings these changes:

1. use `require` rather than `webpack_require.nr` for node external
2. remove most filed in external option at `configCase.test.ts`
3. some changes about the node polyfill test