### PR TITLE
perf: create hash parallel

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/remove_parent_modules.rs
+++ b/crates/rspack_core/src/build_chunk_graph/remove_parent_modules.rs
@@ -53,7 +53,6 @@ impl<'me> CodeSplitter<'me> {
       }
     }
 
-    #[tracing::instrument(skip_all)]
     fn analyze_loaded_modules(mut ctx: AnalyzeContext) -> Option<DefinitelyLoadedModules> {
       if let Some(loaded_modules) = ctx.cache.try_get(&ctx.target_ukey).try_unwrap() {
         return Some(loaded_modules.clone());


### PR DESCRIPTION
## Summary

1. chunk create hash parallel
2. due to the small number of plugins, the plugin content hash is calculated serially

before: 503ms
![image](https://user-images.githubusercontent.com/9291503/221766653-724894d7-0178-41e3-b858-d0685083d6e5.png)

after: 122ms
![image](https://user-images.githubusercontent.com/9291503/221766787-2fc8f5cd-35e7-4d77-b5b5-c42656e3bb98.png)



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
