### PR TITLE
chore: give turbo credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Thanks to:
 - The [Vite](https://github.com/vitejs/vite) project created by [Evan You](https://github.com/yyx990803) which inspired Rspack's compatibility design of webpack's ecosystem.
 - The [Rolldown](https://github.com/rolldown-rs/rolldown) project created by [Rolldown team](https://github.com/sponsors/rolldown-rs), which explores the possibility of making a performant bundler in Rust with Rollup-compatible API. It inspires the design principles of Rspack.
 - The [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) project created by [@jantimon](https://github.com/jantimon), which inspired `@rspack/html-plugin`.
+- The [Turbopack](https://github.com/vercel/turbo) project which inspired the ast path logic of Rspack.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -61,6 +61,7 @@
 - [Vite](https://github.com/vitejs/vite) 由[尤雨溪](https://github.com/yyx990803)创建，它和 rollup 社区的兼容性设计启发了 Rspack 和 Webpack 社区的兼容设计。
 - [Rolldown](https://github.com/rolldown-rs/rolldown) 项目(由 [Rolldown 团队](https://github.com/sponsors/rolldown-rs)创建)，它探索了使用 Rust 构建高性能 Bundler + 兼容 Rollup API 的可能性，启发了 Rspack 的设计方向。
 - [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 项目（由 [@jantimon](https://github.com/jantimon) 创建）, 它启发了 Rspack 的 `@rspack/html-plugin`。
+- [Turbopack](https://github.com/vercel/turbo) 项目，它启发了 Rspack 里基于 AST 的路径重写逻辑。
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "bugs": "https://github.com/modern-js-dev/rspack/issues",
   "repository": "modern-js-dev/rspack",
   "devDependencies": {
+    "@rspack/cli": "workspace:*",
     "@types/react": "17.0.52",
     "@types/react-dom": "17.0.19",
     "@changesets/cli": "2.24.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
   .:
     specifiers:
       '@changesets/cli': 2.24.4
+      '@rspack/cli': workspace:*
       '@taplo/cli': ^0.5.2
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.19
@@ -22,6 +23,7 @@ importers:
       why-is-node-running: 2.2.1
     devDependencies:
       '@changesets/cli': 2.24.4
+      '@rspack/cli': link:packages/rspack-cli
       '@taplo/cli': 0.5.2
       '@types/react': 17.0.52
       '@types/react-dom': 17.0.19
@@ -278,6 +280,9 @@ importers:
       '@rspack/cli': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+
+  examples/proxy:
+    specifiers: {}
 
   examples/react:
     specifiers:


### PR DESCRIPTION
## Summary
we should give turbopack credit since we learn from  their ast path rewrite logic
## Related issue (if exists)
