### PR TITLE
refactor: remove unnecessary mutex

### DIFF
--- a/crates/rspack_core/src/cache/snapshot/manager.rs
+++ b/crates/rspack_core/src/cache/snapshot/manager.rs
@@ -116,7 +116,7 @@ impl SnapshotManager {
     Ok(true)
   }
 
-  pub async fn clear(&self) {
+  pub fn clear(&self) {
     self.update_time_cache.clear();
     self.hash_cache.clear();
   }

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -129,7 +129,7 @@ where
 
     // build without stats
     {
-      self.cache.end_idle().await;
+      self.cache.end_idle();
       self
         .plugin_driver
         .read()
@@ -207,7 +207,7 @@ where
         SetupMakeParam::ForceBuildDeps(deps)
       };
       self.compile(setup_make_params).await?;
-      self.cache.begin_idle().await;
+      self.cache.begin_idle();
     }
 
     // ----

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -82,7 +82,7 @@ where
 
   #[instrument(name = "build", skip_all)]
   pub async fn build(&mut self) -> Result<()> {
-    self.cache.end_idle().await;
+    self.cache.end_idle();
     // TODO: clear the outdate cache entires in resolver,
     // TODO: maybe it's better to use external entries.
     self
@@ -129,7 +129,7 @@ where
       .flat_map(|(_, deps)| deps.clone())
       .collect::<HashSet<_>>();
     self.compile(SetupMakeParam::ForceBuildDeps(deps)).await?;
-    self.cache.begin_idle().await;
+    self.cache.begin_idle();
 
     Ok(())
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6125,7 +6125,7 @@ packages:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.74.0_id63hl4ti3a2o54kosxu7nkk2i
+      webpack: 5.74.0_s76zm2l7l4ywgel5skomka3v5u
       webpack-cli: 4.10.0_webpack@5.74.0
     dev: true
 
@@ -15990,7 +15990,7 @@ packages:
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.74.0_id63hl4ti3a2o54kosxu7nkk2i
+      webpack: 5.74.0_s76zm2l7l4ywgel5skomka3v5u
       webpack-merge: 5.8.0
     dev: true
 


### PR DESCRIPTION
## Summary

Remove needless mutex in Rspack cache
Remove lock that causes sass file can't be processed in parallel

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
