### PR TITLE
chore: add rspack_build for profiling rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 dependencies = [
  "backtrace",
 ]
@@ -2487,6 +2487,19 @@ dependencies = [
  "swc_plugin_import",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "rspack_build"
+version = "0.1.0"
+dependencies = [
+ "mimalloc-rust",
+ "rspack",
+ "rspack_core",
+ "rspack_error",
+ "rspack_fs",
+ "rspack_testing",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/rspack_build/Cargo.toml
+++ b/crates/rspack_build/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+edition = "2021"
+name    = "rspack_build"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rspack = { path = "../rspack" }
+rspack_core = { path = "../rspack_core" }
+rspack_error = { path = "../rspack_error" }
+rspack_fs = { path = "../rspack_fs", features = ["async"] }
+rspack_testing = { path = "../rspack_testing" }
+tokio = { version = "1.21.0", features = [
+  "rt",
+  "rt-multi-thread",
+  "macros",
+  "test-util",
+  "parking_lot",
+] }
+
+[target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
+mimalloc-rust = { version = "0.2" }
+
+[[bin]]
+name = "rspack_build"

--- a/crates/rspack_build/README.md
+++ b/crates/rspack_build/README.md
@@ -1,0 +1,7 @@
+# rspack_build
+
+This is only used for profiling
+
+## profiling
+
+cargo run --bin rspack_build --release your_project_root_contains_test.config.json

--- a/crates/rspack_build/fixture/app.js
+++ b/crates/rspack_build/fixture/app.js
@@ -1,0 +1,2 @@
+console.log("helo");
+export const answer = 42;

--- a/crates/rspack_build/fixture/test.config.json
+++ b/crates/rspack_build/fixture/test.config.json
@@ -1,0 +1,7 @@
+{
+  "entry": {
+    "index": {
+      "import": ["./app.js"]
+    }
+  }
+}

--- a/crates/rspack_build/src/main.rs
+++ b/crates/rspack_build/src/main.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use rspack_core::Compiler;
+use rspack_fs::AsyncNativeFileSystem;
+use rspack_testing::apply_from_fixture;
+
+#[tokio::main]
+async fn main() {
+  let args = std::env::args().collect::<Vec<_>>();
+  let config_path = PathBuf::from(
+    &args
+      .get(1)
+      .unwrap_or(&String::from("crates/rspack_build/fixture")),
+  );
+  run(config_path).await;
+}
+
+async fn run(config_path: PathBuf) {
+  let manifest_dir = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
+  let abs_path = if config_path.is_absolute() {
+    config_path
+  } else {
+    manifest_dir.join(config_path)
+  };
+  let config_path = abs_path.join("test.config.json");
+  if !config_path.exists() {
+    panic!("{config_path:?} not exits, please make sure {config_path:?} exit")
+  }
+  let (options, plugins) = apply_from_fixture(&abs_path);
+  let mut compiler = Compiler::new(options, plugins, AsyncNativeFileSystem);
+  compiler
+    .build()
+    .await
+    .unwrap_or_else(|err| panic!("{err:?}, failed to compile {abs_path:?}"));
+}


### PR DESCRIPTION
## Summary
add a simple rust rspack cli for profiling, learn from https://turbo.build/pack/docs/advanced/profiling
but i can't make cargo instruments work in rspack so we have to run `xcrun xctrace record`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
