### PR TITLE
feat: canary version use commit hash

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,9 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": ["example-*"],
+  "snapshot": {
+    "prereleaseTemplate": "{tag}-{commit}"
+  },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
## Summary

release canary version support use commit hash，example：0.0.0-canary-7eca091b
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
