### PR TITLE
fix(starter): add rule to handle svg url

### DIFF
--- a/packages/create-rspack/template-react/rspack.config.js
+++ b/packages/create-rspack/template-react/rspack.config.js
@@ -6,6 +6,14 @@ module.exports = {
 	entry: {
 		main: "./src/main.jsx"
 	},
+	module: {
+		rules: [
+			{
+				test: /\.svg$/i,
+				type: "asset/inline"
+			}
+		]
+	},
 	builtins: {
 		html: [
 			{


### PR DESCRIPTION
## Summary

Current starter template do not handle .svg file as url, causing parse error

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)
