### PR TITLE
feat: support guided panic info with backtrace

### DIFF
--- a/.changeset/slow-trains-melt.md
+++ b/.changeset/slow-trains-melt.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat: support guided panic info with backtrace

--- a/crates/rspack_error/src/catch_unwind.rs
+++ b/crates/rspack_error/src/catch_unwind.rs
@@ -1,5 +1,4 @@
 use std::{
-  backtrace::Backtrace,
   cell::RefCell,
   future::Future,
   pin::Pin,

--- a/crates/rspack_error/src/catch_unwind.rs
+++ b/crates/rspack_error/src/catch_unwind.rs
@@ -71,9 +71,11 @@ fn panic_hook_handler<S: PanicStrategy::S, R>(f: impl FnOnce() -> R) -> R {
   result
 }
 
+type PanicHook = Box<dyn Fn(&std::panic::PanicInfo<'_>) + 'static + Sync + Send>;
+
 thread_local! {
   static PANIC_INFO_AND_BACKTRACE: RefCell<Option<(String, String)>> = RefCell::new(None);
-  static PANIC_HOOK: RefCell<Option<Box<dyn Fn(&std::panic::PanicInfo<'_>) + 'static + Sync + Send>>> = RefCell::new(None);
+  static PANIC_HOOK: RefCell<Option<PanicHook>> = RefCell::new(None);
 }
 
 pub fn catch_unwind<S: PanicStrategy::S, R>(f: impl FnOnce() -> R) -> Result<R> {

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(let_chains)]
 #![feature(anonymous_lifetime_in_impl_trait)]
 
 mod catch_unwind;


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Panics are not supposed to happen on the user-side. 
But when it occurs, we should provide more clear message to guide user to report the fatal error back to us.

<img width="1068" alt="image" src="https://user-images.githubusercontent.com/10465670/224088589-01fda74d-bc3c-476e-8774-f5dcd401cb43.png">

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [X] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
