### PR TITLE
feat: config validate strategy

### DIFF
--- a/.changeset/good-frogs-kneel.md
+++ b/.changeset/good-frogs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+feat: config validate strategy

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -34,6 +34,7 @@ export class RspackCLI {
 		options: RspackCLIOptions,
 		rspackEnv: RspackEnv
 	): Promise<Compiler | MultiCompiler> {
+		process.env.RSPACK_CONFIG_VALIDATE = 'loose';
 		let nodeEnv = process?.env?.NODE_ENV;
 		if (typeof options.nodeEnv === "string") {
 			process.env.NODE_ENV = nodeEnv || options.nodeEnv;

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -129,8 +129,7 @@ module.exports = {
 		EntryDescription: {
 			description: "An object with entry point description.",
 			type: "object",
-			// TODO: change to false once all properties is aligned with webpack
-			additionalProperties: true,
+			additionalProperties: false,
 			properties: {
 				import: {
 					$ref: "#/definitions/EntryItem"
@@ -647,8 +646,7 @@ module.exports = {
 		Optimization: {
 			description: "Enables/Disables integrated optimizations.",
 			type: "object",
-			// TODO: change to false once all properties is aligned with webpack
-			additionalProperties: true,
+			additionalProperties: false,
 			properties: {
 				chunkIds: {
 					description:
@@ -750,8 +748,7 @@ module.exports = {
 			description:
 				"Options object for describing behavior of a cache group selecting modules that should be cached together.",
 			type: "object",
-			// TODO: change to false once all properties is aligned with webpack
-			additionalProperties: true,
+			additionalProperties: false,
 			properties: {
 				chunks: {
 					description:
@@ -808,8 +805,7 @@ module.exports = {
 		OptimizationSplitChunksOptions: {
 			description: "Options object for splitting chunks into smaller chunks.",
 			type: "object",
-			// TODO: change to false once all properties is aligned with webpack
-			additionalProperties: true,
+			additionalProperties: false,
 			properties: {
 				cacheGroups: {
 					description:
@@ -893,8 +889,7 @@ module.exports = {
 			description:
 				"Options affecting the output of the compilation. `output` options tell rspack how to write the compiled files to disk.",
 			type: "object",
-			// TODO: change to false once all properties is aligned with webpack
-			additionalProperties: true,
+			additionalProperties: false,
 			properties: {
 				assetModuleFilename: {
 					$ref: "#/definitions/AssetModuleFilename"
@@ -1068,8 +1063,7 @@ module.exports = {
 		ResolveOptions: {
 			description: "Options object for resolving requests.",
 			type: "object",
-			// TODO: change to false once all properties is aligned with webpack
-			additionalProperties: true,
+			additionalProperties: false,
 			properties: {
 				alias: {
 					$ref: "#/definitions/ResolveAlias"
@@ -1698,8 +1692,7 @@ module.exports = {
 	title: "RspackOptions",
 	description: "Options object as provided by the user.",
 	type: "object",
-	// TODO: change to false once all properties is aligned with webpack
-	additionalProperties: true,
+	additionalProperties: false,
 	properties: {
 		cache: {
 			$ref: "#/definitions/CacheOptions"

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -23,6 +23,7 @@ import { asArray, isNil } from "./util";
 import rspackOptionsCheck from "./config/schema.check.js";
 import type { DefinedError } from "ajv";
 import InvalidateConfigurationError from "./error/InvalidateConfiguration";
+import { validate, ValidationError } from "schema-utils";
 
 function createMultiCompiler(options: MultiRspackOptions): MultiCompiler {
 	const compilers = options.map(createCompiler);
@@ -84,6 +85,24 @@ function isMultiRspackOptions(o: unknown): o is MultiRspackOptions {
 	return Array.isArray(o);
 }
 
+function revalidateWithStrategy(options: RspackOptions | MultiRspackOptions) {
+	try {
+		validate(require("./config/schema.js"), options);
+	} catch (e) {
+		if (!(e instanceof ValidationError)) {
+			throw e;
+		}
+		// 'strict', 'loose', 'loose-silent'
+		const strategy = process.env.RSPACK_CONFIG_VALIDATE ?? "strict";
+		if (strategy === "loose-silent") return;
+		if (strategy === "loose") {
+			console.error(e.message);
+			return;
+		}
+		throw new InvalidateConfigurationError(e.message);
+	}
+}
+
 function rspack(
 	options: MultiRspackOptions,
 	callback?: Callback<Error, MultiStats>
@@ -97,11 +116,8 @@ function rspack(
 	callback?: Callback<Error, MultiStats> | Callback<Error, Stats>
 ) {
 	if (!asArray(options as any).every(i => rspackOptionsCheck(i))) {
-		// TODO: more readable error message
-		const msg = (rspackOptionsCheck as any).errors
-			.map((e: DefinedError) => `\n  ${e.instancePath}: ${e.message}`)
-			.join("");
-		throw new InvalidateConfigurationError(msg);
+		// slow path
+		revalidateWithStrategy(options);
 	}
 	const create = () => {
 		if (isMultiRspackOptions(options)) {


### PR DESCRIPTION
## Summary

For more smoother migration from webpack

```sh
rspack serve # same as strict, strict is default strategy and encouraged
RSPACK_CONFIG_VALIDATE=strict rspack serve # throw error and tell where is invalidate

RSPACK_CONFIG_VALIDATE=loose rspack serve # report invalidate config but not throw error
RSPACK_CONFIG_VALIDATE=loose-silent rspack serve # not report and not throw error
```
## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
