### PR TITLE
chore: 🤖 remove benchmark history timeout limit

### DIFF
--- a/.github/workflows/bench-history.yaml
+++ b/.github/workflows/bench-history.yaml
@@ -13,7 +13,6 @@ jobs:
   benchmark:
     name: Run Criterion.rs benchmark
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node16


### PR DESCRIPTION
## Summary
![image](https://user-images.githubusercontent.com/17974631/224521782-2f0babd9-856c-4941-b6a1-335dd87a8a2c.png)
The Ci is failed because of the 30min timeout.
1. We don't need 30 min timeout, because we using public CI now.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
