### PR TITLE
fix(dev-middleware): compatibility with native node handler

### DIFF
--- a/.changeset/eleven-falcons-approve.md
+++ b/.changeset/eleven-falcons-approve.md
@@ -1,0 +1,5 @@
+---
+"@rspack/dev-middleware": patch
+---
+
+Use native Node compatible methods in middleware

--- a/packages/rspack-dev-middleware/src/middleware.ts
+++ b/packages/rspack-dev-middleware/src/middleware.ts
@@ -1,4 +1,5 @@
-import { extname, relative } from "path";
+import { extname } from "path";
+import type { IncomingMessage, ServerResponse } from "http";
 import type { Compiler } from "@rspack/core";
 import wdm from "webpack-dev-middleware";
 import type { RequestHandler } from "express";
@@ -8,14 +9,15 @@ export function getRspackMemoryAssets(
 	compiler: Compiler,
 	rdm: ReturnType<typeof wdm>
 ): RequestHandler {
-	return function (req, res, next) {
-		const { method, path } = req;
+	const publicPath = compiler.options.output.publicPath ? compiler.options.output.publicPath.replace(/\/$/, '') + '/' : '/';
+	return function (req: IncomingMessage, res: ServerResponse, next: () => void) {
+		const { method, url } = req;
 		if (method !== "GET") {
 			return next();
 		}
 
 		// asset name is not start with /, so path need to slice 1
-		const filename = path.slice(1);
+		const filename = url.startsWith(publicPath) ? url.slice(publicPath.length) : url.slice(1);
 		let buffer =
 			compiler.getAsset(filename) ??
 			(() => {
@@ -34,10 +36,10 @@ export function getRspackMemoryAssets(
 			contentType = "text/html; charset=utf-8";
 		} else {
 			contentType =
-				mime.contentType(extname(path)) || "text/plain; charset=utf-8";
+				mime.contentType(extname(url)) || "text/plain; charset=utf-8";
 		}
 
 		res.setHeader("Content-Type", contentType);
-		res.send(buffer);
+		res.end(buffer);
 	};
 }


### PR DESCRIPTION
## Summary

Currently there are two issues I'm facing with dev-middleware:

1. it uses `express`-only handlers like `req.path` and `res.send()`
2. it does not respect a public path (I may be misunderstanding how this is meant to be used though - should this only be registered to handle paths beginning with the publicPath?

This PR uses node-compatible methods (`req.url` and `res.end()`) which will also work in express, expanding the compatibility of this library. It also normalises any URLs beginning with `publicPath` so they can be handled in this middleware.

(I am happy to remove the change to publicPath handling if this is intended.)

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
