### PR TITLE
ci: add cache to rust build steps

### DIFF
--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -48,6 +48,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Install toolchain
         run: rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
       - name: Run rustfmt
         uses: actions-rs/cargo@v1
         with:
@@ -68,6 +72,10 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install toolchain
         run: rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
       - name: Run cargo check
         run: cargo check --workspace --all-targets --release --locked
 
@@ -100,6 +108,10 @@ jobs:
           node-version: "16"
       - name: Install toolchain
         run: rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: check
       - name: Run test
         # We need to install sass first to enable sass-loader
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,8 @@ jobs:
       - name: Install Rust
         if: ${{ !matrix.settings.docker }}
         run: rustup show
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
       - name: Setup rust target
         if: ${{ !matrix.settings.docker }}
         run: rustup target add ${{ matrix.settings.target }}


### PR DESCRIPTION
We are now using GitHub CI instead of self hosted machines which doesn't have caches.