### PR TITLE
chore: 🤖 remove benchmark timeout

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -20,7 +20,6 @@ jobs:
     name: Bench
     if: github.event.issue.pull_request && contains(github.event.comment.body, '!bench')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
 
     steps:
       - name: Get PR SHA


### PR DESCRIPTION
## Summary
1. Because the public ci resource is too slow, then can't  finish Benchmark in 30 minutes, so we need to remove this timeout
you can refer to https://github.com/web-infra-dev/rspack/actions/runs/4401579159
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
