### PR TITLE
feat: array type for externals

### DIFF
--- a/.changeset/nasty-taxis-protect.md
+++ b/.changeset/nasty-taxis-protect.md
@@ -1,0 +1,6 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+---
+
+feat: array type of externals

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -160,6 +160,12 @@ export interface RawExperiments {
   lazyCompilation: boolean
   incrementalRebuild: boolean
 }
+export interface RawExternalItem {
+  type: "string" | "regexp" | "object"
+  stringPayload?: string
+  regexpPayload?: string
+  objectPayload?: Record<string, string>
+}
 /**
  * `loader` is for js side loader, `builtin_loader` is for rust side loader,
  * which is mapped to real rust side loader by [get_builtin_loader].
@@ -351,7 +357,7 @@ export interface RawOptions {
   resolve: RawResolveOptions
   module: RawModuleOptions
   builtins: RawBuiltins
-  externals: Record<string, string>
+  externals?: Array<RawExternalItem>
   externalsType: string
   devtool: string
   optimization: RawOptimizationOptions

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -31,7 +31,7 @@ impl From<RawExternalItem> for ExternalItem {
       "object" => Self::from(
         value
           .object_payload
-          .expect("should have a regexp_payload when RawExternalItem.type is \"regexp\""),
+          .expect("should have a object_payload when RawExternalItem.type is \"object\""),
       ),
       _ => unreachable!(),
     }

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -1,3 +1,39 @@
 use std::collections::HashMap;
 
-pub type RawExternal = HashMap<String, String>;
+use napi_derive::napi;
+use rspack_core::ExternalItem;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
+pub struct RawExternalItem {
+  #[napi(ts_type = r#""string" | "regexp" | "object""#)]
+  pub r#type: String,
+  pub string_payload: Option<String>,
+  pub regexp_payload: Option<String>,
+  pub object_payload: Option<HashMap<String, String>>,
+}
+
+impl From<RawExternalItem> for ExternalItem {
+  fn from(value: RawExternalItem) -> Self {
+    match value.r#type.as_str() {
+      "string" => Self::from(
+        value
+          .string_payload
+          .expect("should have a string_payload when RawExternalItem.type is \"string\""),
+      ),
+      "regexp" => Self::from(
+        value
+          .regexp_payload
+          .expect("should have a regexp_payload when RawExternalItem.type is \"regexp\""),
+      ),
+      "object" => Self::from(
+        value
+          .object_payload
+          .expect("should have a regexp_payload when RawExternalItem.type is \"regexp\""),
+      ),
+      _ => unreachable!(),
+    }
+  }
+}

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -1,7 +1,7 @@
 use crate::{
-  Builtins, BundleEntries, CacheOptions, Context, DevServerOptions, Devtool, Experiments,
-  ExternalType, Externals, Mode, ModuleOptions, NodeOption, Optimization, OutputOptions, Resolve,
-  SnapshotOptions, StatsOptions, Target,
+  Builtins, BundleEntries, CacheOptions, Context, DevServerOptions, Devtool, Experiments, Mode,
+  ModuleOptions, NodeOption, Optimization, OutputOptions, Resolve, SnapshotOptions, StatsOptions,
+  Target,
 };
 
 #[derive(Debug)]
@@ -16,8 +16,6 @@ pub struct CompilerOptions {
   pub builtins: Builtins,
   pub module: ModuleOptions,
   pub devtool: Devtool,
-  pub externals: Externals,
-  pub externals_type: ExternalType,
   pub stats: StatsOptions,
   pub snapshot: SnapshotOptions,
   pub cache: CacheOptions,

--- a/crates/rspack_core/src/options/externals.rs
+++ b/crates/rspack_core/src/options/externals.rs
@@ -1,22 +1,31 @@
 use std::collections::HashMap;
 
-pub type Externals = Vec<External>;
+use rspack_regex::RspackRegex;
+
+pub type Externals = Vec<ExternalItem>;
 
 #[derive(Debug)]
-pub enum External {
+pub enum ExternalItem {
   Object(HashMap<String, String>),
   String(String),
+  RegExp(RspackRegex),
 }
 
-impl From<HashMap<String, String>> for External {
+impl From<HashMap<String, String>> for ExternalItem {
   fn from(value: HashMap<String, String>) -> Self {
     Self::Object(value)
   }
 }
 
-impl From<String> for External {
+impl From<String> for ExternalItem {
   fn from(value: String) -> Self {
     Self::String(value)
+  }
+}
+
+impl From<RspackRegex> for ExternalItem {
+  fn from(value: RspackRegex) -> Self {
+    Self::RegExp(value)
   }
 }
 

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -58,8 +58,6 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
           resolve: rspack_core::Resolve::default(),
           builtins: Default::default(),
           module: Default::default(),
-          externals: Default::default(),
-          externals_type: "commonjs".to_string(),
           stats: Default::default(),
           cache: Default::default(),
           snapshot: Default::default(),

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -396,8 +396,6 @@ impl TestConfig {
         ..Default::default()
       },
       devtool: c::Devtool::from(self.devtool),
-      externals: Default::default(),
-      externals_type: "commonjs".to_string(),
       stats: Default::default(),
       snapshot: Default::default(),
       cache: c::CacheOptions::Disabled,
@@ -469,7 +467,7 @@ impl TestConfig {
     if options.experiments.lazy_compilation {
       plugins.push(rspack_plugin_runtime::LazyCompilationPlugin {}.boxed());
     }
-    plugins.push(rspack_plugin_externals::ExternalPlugin::default().boxed());
+    // plugins.push(rspack_plugin_externals::ExternalPlugin::default().boxed());
     plugins.push(rspack_plugin_javascript::JsPlugin::new().boxed());
     plugins.push(
       rspack_plugin_devtool::DevtoolPlugin::new(rspack_plugin_devtool::DevtoolPluginOptions {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -3,7 +3,8 @@ import {
 	RawModuleRule,
 	RawRuleSetCondition,
 	RawRuleSetLogicalConditions,
-	RawOptions
+	RawOptions,
+	RawExternalItem
 } from "@rspack/binding";
 import assert from "assert";
 import { normalizeStatsPreset } from "../stats";
@@ -11,6 +12,7 @@ import { isNil } from "../util";
 import {
 	EntryNormalized,
 	Experiments,
+	ExternalItem,
 	Externals,
 	LibraryOptions,
 	ModuleOptionsNormalized,
@@ -54,7 +56,9 @@ export const getRawOptions = (
 			devtool,
 			context: options.context
 		}),
-		externals: options.externals ? getRawExternals(options.externals) : {},
+		externals: options.externals
+			? getRawExternals(options.externals)
+			: undefined,
 		externalsType:
 			options.externalsType === undefined ? "" : options.externalsType,
 		devtool,
@@ -269,7 +273,7 @@ function getRawRuleSetCondition(
 			arrayMatcher: condition.map(i => getRawRuleSetCondition(i))
 		};
 	}
-	if (condition instanceof Object && condition !== null) {
+	if (typeof condition === "object" && condition !== null) {
 		return {
 			type: "logical",
 			logicalMatcher: [getRawRuleSetLogicalConditions(condition)]
@@ -293,12 +297,19 @@ function getRawRuleSetLogicalConditions(
 }
 
 function getRawExternals(externals: Externals): RawOptions["externals"] {
-	if (typeof externals === "string") {
-		return {
-			[externals]: externals
-		};
+	function getRawExternalItem(item: ExternalItem): RawExternalItem {
+		if (typeof item === "string") {
+			return { type: "string", stringPayload: item };
+		} else if (item instanceof RegExp) {
+			return { type: "regexp", regexpPayload: item.source };
+		}
+		return { type: "object", objectPayload: item };
 	}
-	return externals;
+
+	if (Array.isArray(externals)) {
+		return externals.map(i => getRawExternalItem(i));
+	}
+	return [getRawExternalItem(externals)];
 }
 
 function getRawOptimization(

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -247,6 +247,10 @@ module.exports = {
 				"Specify dependency that shouldn't be resolved by rspack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.",
 			anyOf: [
 				{
+					description: "Every matched dependency becomes external.",
+					instanceof: "RegExp"
+				},
+				{
 					description:
 						"An exact matched dependency becomes external. The same string is used as external dependency.",
 					type: "string"
@@ -274,6 +278,12 @@ module.exports = {
 			description:
 				"Specify dependencies that shouldn't be resolved by rspack, but should become dependencies of the resulting bundle. The kind of the dependency depends on `output.libraryTarget`.",
 			anyOf: [
+				{
+					type: "array",
+					items: {
+						$ref: "#/definitions/ExternalItem"
+					}
+				},
 				{
 					$ref: "#/definitions/ExternalItem"
 				}

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -298,8 +298,8 @@ export interface ModuleOptionsNormalized {
 export type Target = false | string[] | string;
 
 ///// Externals /////
-export type Externals = ExternalItem;
-export type ExternalItem = string | ExternalItemObjectUnknown;
+export type Externals = ExternalItem[] | ExternalItem;
+export type ExternalItem = string | RegExp | ExternalItemObjectUnknown;
 export interface ExternalItemObjectUnknown {
 	[k: string]: ExternalItemValue;
 }

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -30,7 +30,6 @@ import MultiStats from "./multiStats";
 import assert from "assert";
 import { asArray, isNil } from "./util";
 import rspackOptionsCheck from "./config/schema.check.js";
-import type { DefinedError } from "ajv";
 import InvalidateConfigurationError from "./error/InvalidateConfiguration";
 import { validate, ValidationError } from "schema-utils";
 


### PR DESCRIPTION
## Summary

```js
externals: ['vue', 'react']
```

## Related issue (if exists)

fix part of #2149, when target is `"node"` externals will be modified by `NodeTargetPlugin`, we need implement `externalsPresets` first to completely fix it.

Didn't add tests because tests needs `target: "node"`...

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.

