### PR TITLE
fix(plugin-html): fix template with process

### DIFF
--- a/.changeset/smart-starfishes-perform.md
+++ b/.changeset/smart-starfishes-perform.md
@@ -1,0 +1,5 @@
+---
+"@rspack/plugin-html": patch
+---
+
+fix(plugin-html): fix template with process

--- a/packages/rspack-plugin-html/src/template.ts
+++ b/packages/rspack-plugin-html/src/template.ts
@@ -50,6 +50,7 @@ export async function evaluate(
 	}
 	const vmContext = vm.createContext({
 		...global,
+		process,
 		HTML_WEBPACK_PLUGIN: true,
 		require: require,
 		htmlWebpackPluginPublicPath: publicPath,

--- a/packages/rspack-plugin-html/tests/fixtures/issue2179.html
+++ b/packages/rspack-plugin-html/tests/fixtures/issue2179.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Rspack + React</title>
+		<% if (process.env.NODE_ENV === 'development') { %>
+		<script>
+			console.log(1);
+		</script>
+		<% } %>
+	</head>
+	<body>
+		<div id="root"></div>
+	</body>
+</html>


### PR DESCRIPTION
## Summary

Webpack leverages child-compiler to deal with template compilation. 
So with builtin define functionalities, `process` can be replaced correctly. 
I used a workaround in this PR to achieve almost the same capability.

## Related issue (if exists)

closes https://github.com/web-infra-dev/rspack/issues/2179

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [X] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] I have added changeset via `pnpm run changeset`.
- [X] I have added tests to cover my changes.
