### PR TITLE
fix(testing): resolve context for fixtures controlled by `test.config.js` 

### DIFF
--- a/crates/rspack_testing/src/eval_raw.rs
+++ b/crates/rspack_testing/src/eval_raw.rs
@@ -23,9 +23,10 @@ fn get_evaluate_code(config_path: &Path) -> String {
     r#"
 const rspack = require("{rspack_path}");
 const config = require("{config_path}");
+config.context ??= "{test_dir}";
+config.output ??= {{}};
+config.output.path ??= "{test_dir}/dist";
 const normalized = rspack.getNormalizedRspackOptions(config);
-normalized.context="{test_dir}";
-normalized.output.path = `{test_dir}/dist`; //TODO:
 rspack.applyRspackOptionsDefaults(normalized);
 const raw = rspack.getRawOptions(normalized);
 JSON.stringify(raw)

--- a/crates/rspack_testing/src/eval_raw.rs
+++ b/crates/rspack_testing/src/eval_raw.rs
@@ -17,12 +17,15 @@ fn get_evaluate_code(config_path: &Path) -> String {
   let workspace_dir = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
   let rspack_path = workspace_dir.join("packages").join("rspack");
   let rspack_path = rspack_path.to_string_lossy();
+  let test_dir = config_path.parent().expect("TODO:").to_string_lossy();
   let config_path = config_path.to_string_lossy();
   format!(
     r#"
 const rspack = require("{rspack_path}");
 const config = require("{config_path}");
 const normalized = rspack.getNormalizedRspackOptions(config);
+normalized.context="{test_dir}";
+normalized.output.path = `{test_dir}/dist`; //TODO:
 rspack.applyRspackOptionsDefaults(normalized);
 const raw = rspack.getRawOptions(normalized);
 JSON.stringify(raw)


### PR DESCRIPTION
## Summary

Resolved a serious issue with cargo test fixtures controlled by  `test.config.js` config file was not able to retrieve correctly context information during execution, leading to test failures. 
This optimization improves the contributor maintenance experience.

![image](https://user-images.githubusercontent.com/24775733/224909685-479a5a0d-21d5-43e4-bd22-c1e95a7b0e44.png)

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [x] I have added tests to cover my changes.
