### PR TITLE
fix: try rs test run in single thread

### DIFF
--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -118,4 +118,5 @@ jobs:
           node -e "console.log(process.arch)"
           npm install -g pnpm@7.25.0
           pnpm install
-          cargo test --all -- --nocapture
+          cargo test --all -- 
+          cargo test --all -- --nocapture --test-threads=1

--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -118,5 +118,4 @@ jobs:
           node -e "console.log(process.arch)"
           npm install -g pnpm@7.25.0
           pnpm install
-          cargo test --all -- 
           cargo test --all -- --nocapture --test-threads=1

--- a/x
+++ b/x
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 const { createCLI } = require("./scripts/cmd.js");
 
-/// use `./x --help` to get more information..
+/// use `./x --help` to get more information.
 void (function () {
 	const cli = createCLI();
 	cli.parse(process.argv);


### PR DESCRIPTION
## Summary
1. Try to fix random test fail and retry success
here is the time cost  between test-threads=1, and test-threads=${defualt-value}
2. Notice that our rspack is still running in multi-thread, this change only makes the testing tasks run in single thread.
### default
![image](https://user-images.githubusercontent.com/17974631/224911799-e2e8c4d6-7ae3-4665-b41b-885a3cd9d07d.png)
### test-threds=1
![image](https://user-images.githubusercontent.com/17974631/224911882-073bca81-88ac-4580-a7f6-ee2b054cbdbe.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
