### PR TITLE
refactor module graph lookups

### DIFF
--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -1,11 +1,4 @@
-use std::cmp::PartialEq;
-use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicUsize, Ordering};
-
 use crate::{DependencyId, ModuleIdentifier};
-
-// FIXME: placing this as global id is not acceptable, move it to somewhere else later
-static NEXT_MODULE_GRAPH_CONNECTION_ID: AtomicUsize = AtomicUsize::new(1);
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ConnectionId(usize);
@@ -24,11 +17,8 @@ impl From<usize> for ConnectionId {
   }
 }
 
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ModuleGraphConnection {
-  /// The unique id of this connection
-  pub id: ConnectionId,
-
   /// The referencing module identifier
   pub original_module_identifier: Option<ModuleIdentifier>,
 
@@ -39,31 +29,13 @@ pub struct ModuleGraphConnection {
   pub dependency_id: DependencyId,
 }
 
-impl Hash for ModuleGraphConnection {
-  fn hash<H: Hasher>(&self, state: &mut H) {
-    self.original_module_identifier.hash(state);
-    self.module_identifier.hash(state);
-    self.dependency_id.hash(state);
-  }
-}
-
-impl PartialEq for ModuleGraphConnection {
-  fn eq(&self, other: &Self) -> bool {
-    self.original_module_identifier == other.original_module_identifier
-      && self.module_identifier == other.module_identifier
-      && self.dependency_id == other.dependency_id
-  }
-}
-
 impl ModuleGraphConnection {
   pub fn new(
     original_module_identifier: Option<ModuleIdentifier>,
     dependency_id: DependencyId,
     module_identifier: ModuleIdentifier,
   ) -> Self {
-    let id = NEXT_MODULE_GRAPH_CONNECTION_ID.fetch_add(1, Ordering::Relaxed);
     Self {
-      id: ConnectionId::from(id),
       original_module_identifier,
       module_identifier,
       dependency_id,


### PR DESCRIPTION
## Summary

There are two bottlenecks around `ModuleIdentifer`:

* it is a long path, which takes a lot of time to compute the hash
* it is a `Ustr`, accessing the contents of the `Ustr` is a roundtrip to the heap, which is slow

When we use `ModuleIdentifier` as the key for `HashMap`s, the profiler shows performance hot spots in hot paths.

This PR removes the need to read `ModuleIdentifier` in hot paths, and uses a vector as the backing storage. `ConnectionId` and `Dependency` Id are the indexes to their respective vectors.

For a large project with 20k modules, code splitting time is now reduced from 7s to 6s.

As a bonus, the `AtomicUsize`s are now gone :-)


