### PR TITLE
Small fix to improve the readme file 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
   <a href="https://discord.gg/79ZZ66GH9E">
     <img src="https://img.shields.io/discord/977448667919286283?logo=discord&label=discord&colorB=EDED91" alt="discord channel" />
   </a>
-  <a href="https://www.npmjs.com/package/@rspack/core?activeTab=versions">
+  <a href="https://www.npmjs.com/package/@rspack/core?activeTab=readme">
    <img src="https://img.shields.io/npm/v/@rspack/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" />
   </a>
   <a href="https://npmcharts.com/compare/@rspack/core?minimal=true">


### PR DESCRIPTION
## Summary

Initially the NPM badge was redirecting to https://www.npmjs.com/package/@rspack/core?activeTab=versions
With this change it will now redirect to the main NPM page https://www.npmjs.com/package/@rspack/core?activeTab=readme

## Related issue (if exists)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ X] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
