### PR TITLE
fix(cli): set stats default to errors-warning to avoid server info flushhed by module stats

### DIFF
--- a/.changeset/happy-berries-wonder.md
+++ b/.changeset/happy-berries-wonder.md
@@ -1,0 +1,5 @@
+---
+"@rspack/cli": patch
+---
+
+fix(cli): set stats default to errors-warning to avoid server info flushhed by module stats

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -155,7 +155,7 @@ export class RspackCLI {
 			}
 
 			if (typeof item.stats === "undefined") {
-				item.stats = { preset: "normal" };
+				item.stats = { preset: "errors-warnings" };
 			} else if (typeof item.stats === "boolean") {
 				item.stats = item.stats ? { preset: "normal" } : { preset: "none" };
 			} else if (typeof item.stats === "string") {


### PR DESCRIPTION

## Summary

none of react cli prints stats.modules info expect webpack-cli, which is not friendly to developer since it will flush server info out of screen
## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
