### PR TITLE
feat: expose description data to resolve_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,9 +1654,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.69"
+version = "0.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b48f51fc2f907f6781d71de0abecf456877d26a17ed7b4fa263dd52b60c4e46"
+checksum = "06ca52098904c39ede5f8f73340787321cf0b3aa4b2f19aa0195654366a24fbb"
 dependencies = [
  "daachorse",
  "dashmap",
@@ -2612,6 +2612,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "nodejs-resolver",
  "rspack_error",
  "rspack_sources",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ napi               = { version = "=2.11.1" }
 napi-build         = { version = "=2.0.1" }
 napi-derive        = { version = "=2.11.0" }
 napi-sys           = { version = "=2.2.3" }
+nodejs-resolver    = { version = "0.0.73" }
 once_cell          = { version = "1.17.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/loader_runner/Cargo.toml
+++ b/crates/loader_runner/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true, features = [
   "fs",
 ] }
 
+nodejs-resolver    = { workspace = true }
 rspack_error       = { path = "../rspack_error" }
 rspack_sources     = { workspace = true }
 tracing            = { workspace = true }

--- a/crates/loader_runner/src/runner.rs
+++ b/crates/loader_runner/src/runner.rs
@@ -20,6 +20,7 @@ pub struct ResourceData {
   pub resource_query: Option<String>,
   /// Resource fragment with `#` prefix
   pub resource_fragment: Option<String>,
+  pub resource_description: Option<Arc<nodejs_resolver::DescriptionData>>,
 }
 
 #[derive(Debug)]

--- a/crates/loader_runner/tests/load_runner.rs
+++ b/crates/loader_runner/tests/load_runner.rs
@@ -38,6 +38,7 @@ macro_rules! run_loader {
         resource_path: url.to_file_path().unwrap(),
         resource_query: url.query().map(|q| q.to_owned()),
         resource_fragment: url.fragment().map(|f| f.to_owned()),
+        resource_description: None
       },
       vec![]
     )

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1318,9 +1318,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.69"
+version = "0.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b48f51fc2f907f6781d71de0abecf456877d26a17ed7b4fa263dd52b60c4e46"
+checksum = "06ca52098904c39ede5f8f73340787321cf0b3aa4b2f19aa0195654366a24fbb"
 dependencies = [
  "daachorse",
  "dashmap",
@@ -2185,6 +2185,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "nodejs-resolver",
  "rspack_error",
  "rspack_sources",
  "rustc-hash",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -19,7 +19,7 @@ glob-match = "0.2.1"
 hashlink = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-nodejs-resolver = "0.0.69"
+nodejs-resolver = { workspace = true }
 once_cell = { workspace = true }
 paste = { workspace = true }
 petgraph = "0.6.0"

--- a/crates/rspack_core/src/cache/occasion/resolve_module.rs
+++ b/crates/rspack_core/src/cache/occasion/resolve_module.rs
@@ -67,8 +67,8 @@ impl ResolveModuleOccasion {
     // run generator and save to cache
     let data = generator(args).await?;
     let mut paths = Vec::new();
-    if let ResolveResult::Info(info) = &data {
-      paths.push(info.path.as_path());
+    if let ResolveResult::Resource(resource) = &data {
+      paths.push(resource.path.as_path());
     }
 
     let snapshot = self

--- a/crates/rspack_core/src/compiler/resolver.rs
+++ b/crates/rspack_core/src/compiler/resolver.rs
@@ -10,24 +10,7 @@ use rustc_hash::FxHasher;
 use crate::{AliasMap, DependencyType};
 use crate::{DependencyCategory, Resolve};
 
-#[derive(Debug, Clone)]
-pub enum ResolveResult {
-  Info(ResolveInfo),
-  Ignored,
-}
-
-#[derive(Debug, Clone)]
-pub struct ResolveInfo {
-  pub path: PathBuf,
-  pub query: String,
-  pub fragment: String,
-}
-
-impl ResolveInfo {
-  pub fn join(&self) -> String {
-    format!("{}{}{}", self.path.display(), self.query, self.fragment)
-  }
-}
+pub type ResolveResult = nodejs_resolver::ResolveResult<nodejs_resolver::Resource>;
 
 #[derive(Debug)]
 pub struct ResolverFactory {
@@ -266,17 +249,7 @@ pub struct Resolver(pub(crate) nodejs_resolver::Resolver);
 
 impl Resolver {
   pub fn resolve(&self, path: &Path, request: &str) -> nodejs_resolver::RResult<ResolveResult> {
-    self
-      .0
-      .resolve(path, request)
-      .map(|inner_result| match inner_result {
-        nodejs_resolver::ResolveResult::Info(info) => ResolveResult::Info(ResolveInfo {
-          path: info.path().to_path_buf(),
-          query: info.request().query().into(),
-          fragment: info.request().fragment().into(),
-        }),
-        nodejs_resolver::ResolveResult::Ignored => ResolveResult::Ignored,
-      })
+    self.0.resolve(path, request)
   }
 
   pub fn dependencies(&self) -> (Vec<PathBuf>, Vec<PathBuf>) {

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -60,13 +60,13 @@ impl ContextModuleFactory {
       .use_cache(resolve_args, |args| resolve(args, plugin_driver))
       .await;
     let module = match resource_data {
-      Ok(ResolveResult::Info(info)) => {
-        let uri = info.join();
+      Ok(ResolveResult::Resource(resource)) => {
+        let uri = resource.join().display().to_string();
 
         Box::new(ContextModule::new(ContextModuleOptions {
           resource: uri,
-          resource_query: (!info.query.is_empty()).then_some(info.query),
-          resource_fragment: (!info.fragment.is_empty()).then_some(info.fragment),
+          resource_query: resource.query,
+          resource_fragment: resource.fragment,
           context_options: data
             .dependency
             .options()

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -85,13 +85,14 @@ impl NormalModuleFactory {
       .use_cache(resolve_args, |args| resolve(args, plugin_driver))
       .await;
     let resource_data = match resource_data {
-      Ok(ResolveResult::Info(info)) => {
-        let uri = info.join();
+      Ok(ResolveResult::Resource(resource)) => {
+        let uri = resource.join().display().to_string();
         ResourceData {
           resource: uri,
-          resource_path: info.path,
-          resource_query: (!info.query.is_empty()).then_some(info.query),
-          resource_fragment: (!info.fragment.is_empty()).then_some(info.fragment),
+          resource_path: resource.path,
+          resource_query: resource.query,
+          resource_fragment: resource.fragment,
+          resource_description: resource.description,
         }
       }
       Ok(ResolveResult::Ignored) => {

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -1193,7 +1193,6 @@ async fn par_analyze_module(
   std::hash::BuildHasherDefault<ustr::IdentityHasher>,
 > {
   let analyze_results = {
-    let resolver_factory = &compilation.plugin_driver.read().await.resolver_factory;
     compilation
       .module_graph
       .module_graph_modules()
@@ -1230,7 +1229,6 @@ async fn par_analyze_module(
             helper_mark,
             uri_key,
             &compilation.module_graph,
-            resolver_factory,
             &compilation.options,
           );
           program.visit_with(&mut analyzer);

--- a/crates/rspack_core/src/tree_shaking/test.rs
+++ b/crates/rspack_core/src/tree_shaking/test.rs
@@ -2,9 +2,7 @@
 mod test_side_effects {
   use std::path::PathBuf;
 
-  use nodejs_resolver::SideEffects;
-
-  use crate::tree_shaking::visitor::get_side_effects_from_package_json;
+  use crate::tree_shaking::visitor::{get_side_effects_from_package_json, SideEffects};
 
   fn wrap_get_side_effects_from_package_json(
     side_effects_config: Vec<&str>,

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -72,6 +72,10 @@ pub async fn resolve(
         source: anyhow::Error::msg(error),
       },
     ),
+    nodejs_resolver::Error::CantFindTsConfig(path) => ResolveError(
+      format!("{} is not a tsconfig", path.display()),
+      internal_error!("{} is not a tsconfig", path.display()),
+    ),
     _ => {
       if let Some(importer) = args.importer {
         let span = args.span.unwrap_or_default();
@@ -95,7 +99,7 @@ pub async fn resolve(
             format!(
               "Failed to resolve {} in {}",
               args.specifier,
-              importer.relative(&plugin_driver.options.context).display()
+              base_dir.display()
             ),
             format!(
               "Failed to resolve {} in {}",

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -292,11 +292,11 @@ fn start_resolving<'r, 'c, I: Iterator<Item = String>>(
 ) -> Option<PathBuf> {
   let resolution = resolutions.peek_mut()?;
   if let Some(possible_request) = resolution.possible_requests.next() {
-    if let Ok(ResolveResult::Info(info)) = resolution
+    if let Ok(ResolveResult::Resource(resource)) = resolution
       .resolve
       .resolve(resolution.context, &possible_request)
     {
-      Some(info.path)
+      Some(resource.path)
     } else {
       start_resolving(resolutions)
     }

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -25,6 +25,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
       resource_path: url.to_file_path().expect("bad url file path"),
       resource_query: url.query().map(|q| q.to_owned()),
       resource_fragment: url.fragment().map(|f| f.to_owned()),
+      resource_description: None,
     },
     vec![],
   )


### PR DESCRIPTION
This PR brings the following changes:

1. more friendly error tips when tsconfig not founded.
2. expose description data(package.json) to resourceData. close https://github.com/web-infra-dev/rspack/issues/2298