### PR TITLE
chore: upgrade webpack-dev-server & webpack-dev-middleware

### DIFF
--- a/.changeset/breezy-parents-reflect.md
+++ b/.changeset/breezy-parents-reflect.md
@@ -1,0 +1,6 @@
+---
+"@rspack/dev-middleware": patch
+"@rspack/dev-server": patch
+---
+
+upgrade webpack-dev-server & webpack-dev-middleware

--- a/.changeset/strange-shirts-impress.md
+++ b/.changeset/strange-shirts-impress.md
@@ -1,0 +1,5 @@
+---
+"@rspack/dev-server": patch
+---
+
+upgrade webpack-dev-server

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -14,7 +14,7 @@
   "repository": "web-infra-dev/rspack",
   "dependencies": {
     "@rspack/core": "workspace:*",
-    "webpack-dev-middleware": "6.0.0",
+    "webpack-dev-middleware": "6.0.2",
     "mime-types": "2.1.35"
   },
   "devDependencies": {

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -30,7 +30,7 @@
     "@rspack/dev-client": "workspace:*",
     "@rspack/dev-middleware": "workspace:*",
     "@rspack/dev-server": "workspace:*",
-    "webpack-dev-server": "4.11.1",
+    "webpack-dev-server": "4.13.1",
     "connect-history-api-fallback": "2.0.0",
     "http-proxy-middleware": "2.0.6"
   },

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.7.4",
     "util": "0.12.5",
     "uvu": "0.5.6",
-    "webpack-dev-server": "4.11.1"
+    "webpack-dev-server": "4.13.1"
   },
   "dependencies": {
     "@rspack/binding": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,7 +561,7 @@ importers:
       util: 0.12.5
       uvu: 0.5.6
       watchpack: ^2.4.0
-      webpack-dev-server: 4.11.1
+      webpack-dev-server: 4.13.1
       webpack-sources: 3.2.3
     dependencies:
       '@rspack/binding': link:../../crates/node_binding
@@ -610,7 +610,7 @@ importers:
       typescript: 4.9.4
       util: 0.12.5
       uvu: 0.5.6
-      webpack-dev-server: 4.11.1
+      webpack-dev-server: 4.13.1
 
   packages/rspack-cli:
     specifiers:
@@ -665,11 +665,11 @@ importers:
       '@rspack/core': workspace:*
       '@types/mime-types': 2.1.1
       mime-types: 2.1.35
-      webpack-dev-middleware: 6.0.0
+      webpack-dev-middleware: 6.0.2
     dependencies:
       '@rspack/core': link:../rspack
       mime-types: 2.1.35
-      webpack-dev-middleware: 6.0.0
+      webpack-dev-middleware: 6.0.2
     devDependencies:
       '@types/mime-types': 2.1.1
 
@@ -690,7 +690,7 @@ importers:
       http-proxy-middleware: 2.0.6
       puppeteer: 19.4.0
       typescript: ^4.7.4
-      webpack-dev-server: 4.11.1
+      webpack-dev-server: 4.13.1
       ws: 8.8.1
     dependencies:
       '@rspack/dev-client': link:../rspack-dev-client
@@ -700,7 +700,7 @@ importers:
       connect-history-api-fallback: 2.0.0
       express: 4.18.1
       http-proxy-middleware: 2.0.6_@types+express@4.17.14
-      webpack-dev-server: 4.11.1
+      webpack-dev-server: 4.13.1
       ws: 8.8.1
     devDependencies:
       '@rspack/core': link:../rspack
@@ -11033,6 +11033,12 @@ packages:
       package-json: 6.5.0
     dev: true
 
+  /launch-editor/2.6.0:
+    resolution: {integrity: sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==}
+    dependencies:
+      picocolors: 1.0.0
+      shell-quote: 1.7.4
+
   /lazy-cache/1.0.4:
     resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
     engines: {node: '>=0.10.0'}
@@ -14242,7 +14248,6 @@ packages:
 
   /shell-quote/1.7.4:
     resolution: {integrity: sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==}
-    dev: true
 
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -15902,11 +15907,14 @@ packages:
       webpack: 5.74.0
     dev: false
 
-  /webpack-dev-middleware/6.0.0:
-    resolution: {integrity: sha512-A7jSXBifCJsJqUCVISlcbx9pkmCuP0KriMRcOJ13pOb6/xMXZvh4/ygeJeSArjRd50IT5IVbBFuejGDA/zWrNQ==}
+  /webpack-dev-middleware/6.0.2:
+    resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       webpack: ^5.0.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
     dependencies:
       colorette: 2.0.19
       memfs: 3.4.12
@@ -15914,52 +15922,6 @@ packages:
       range-parser: 1.2.1
       schema-utils: 4.0.0
     dev: false
-
-  /webpack-dev-server/4.11.1:
-    resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
-    engines: {node: '>= 12.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
-      '@types/express': 4.17.14
-      '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.0
-      '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.3
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.0.14
-      chokidar: 3.5.3
-      colorette: 2.0.19
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.1
-      graceful-fs: 4.2.10
-      html-entities: 2.3.3
-      http-proxy-middleware: 2.0.6_@types+express@4.17.14
-      ipaddr.js: 2.0.1
-      open: 8.4.0
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.0.0
-      selfsigned: 2.1.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3
-      ws: 8.10.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
 
   /webpack-dev-server/4.11.1_webpack@5.74.0:
     resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
@@ -16008,6 +15970,55 @@ packages:
       - supports-color
       - utf-8-validate
     dev: false
+
+  /webpack-dev-server/4.13.1:
+    resolution: {integrity: sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==}
+    engines: {node: '>= 12.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack: ^4.37.0 || ^5.0.0
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/bonjour': 3.5.10
+      '@types/connect-history-api-fallback': 1.3.5
+      '@types/express': 4.17.14
+      '@types/serve-index': 1.9.1
+      '@types/serve-static': 1.15.0
+      '@types/sockjs': 0.3.33
+      '@types/ws': 8.5.3
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.0.14
+      chokidar: 3.5.3
+      colorette: 2.0.19
+      compression: 1.7.4
+      connect-history-api-fallback: 2.0.0
+      default-gateway: 6.0.3
+      express: 4.18.1
+      graceful-fs: 4.2.10
+      html-entities: 2.3.3
+      http-proxy-middleware: 2.0.6_@types+express@4.17.14
+      ipaddr.js: 2.0.1
+      launch-editor: 2.6.0
+      open: 8.4.0
+      p-retry: 4.6.2
+      rimraf: 3.0.2
+      schema-utils: 4.0.0
+      selfsigned: 2.1.1
+      serve-index: 1.9.1
+      sockjs: 0.3.24
+      spdy: 4.0.2
+      webpack-dev-middleware: 5.3.3
+      ws: 8.13.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   /webpack-log/2.0.0:
     resolution: {integrity: sha512-cX8G2vR/85UYG59FgkoMamwHUIkSSlV3bBMRsbxVXVUk2j6NleCKjQ/WE9eYg9WY4w25O9w8wKP4rzNZFmUcUg==}
@@ -16296,6 +16307,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  /ws/8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true


### PR DESCRIPTION
## Summary
remove the peerDep Warning of webpack-dev-server & webpack-dev-middleware and  fixes #2318
## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
