### PR TITLE
ci: add write permission to team-label

### DIFF
--- a/.github/workflows/team-label.yaml
+++ b/.github/workflows/team-label.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   team-labeler:


### PR DESCRIPTION
## Summary

The team-label action is currently failing on writing to issues, this adds the permission to do so.

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
