### PR TITLE
chore(rust): remove cargo warnings around napi

### DIFF
--- a/crates/rspack_binding_macros/Cargo.toml
+++ b/crates/rspack_binding_macros/Cargo.toml
@@ -9,7 +9,7 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi = { workspace = true, default-features = false, features = [
+napi = { workspace = true, features = [
   "async",
   "tokio_rt",
   "serde-json",

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -21,7 +21,7 @@ napi = { workspace = true, features = [
   "serde-json",
   "anyhow",
 ] }
-napi-derive = { workspace = true, version = "2" }
+napi-derive = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 rspack_binding_macros = { path = "../rspack_binding_macros" }

--- a/crates/rspack_napi_shared/Cargo.toml
+++ b/crates/rspack_napi_shared/Cargo.toml
@@ -8,7 +8,7 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi = { workspace = true, default-features = false, features = [
+napi = { workspace = true, features = [
   "async",
   "tokio_rt",
   "serde-json",


### PR DESCRIPTION
## Summary

This removes the following cargo warnings

```
warning: rspack/crates/rspack_binding_options/Cargo.toml: unused manifest key: dependencies.napi-derive.version
warning: rspack/crates/rspack_napi_shared/Cargo.toml: `default-features` is ignored for napi, since `default-features` was not specified for `workspace.dependencies.napi`, this could become a hard error in the future
warning: rspack/crates/rspack_binding_macros/Cargo.toml: `default-features` is ignored for napi, since `default-features` was not specified for `workspace.dependencies.napi`, this could become a hard error in the future
```

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [x] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
