### PR TITLE
refactor(rust): remove unnecessary usage of crossbeam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,20 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,16 +495,6 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -2360,7 +2336,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "criterion",
- "crossbeam",
  "dashmap",
  "insta",
  "mimalloc-rust",
@@ -2483,7 +2458,6 @@ dependencies = [
  "async-scoped",
  "async-trait",
  "bitflags",
- "crossbeam",
  "dashmap",
  "derivative",
  "dyn-clone",
@@ -2630,7 +2604,6 @@ name = "rspack_loader_sass"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "itertools",
  "once_cell",
  "regex",
@@ -2812,7 +2785,6 @@ dependencies = [
  "base64",
  "better_scoped_tls",
  "bitflags",
- "crossbeam-channel",
  "dashmap",
  "either",
  "linked_hash_set",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ better_scoped_tls  = { version = "0.1.0" }
 bitflags           = { version = "1.3.2" }
 clap               = { version = "4" }
 colored            = { version = "2.0.0" }
-crossbeam          = { version = "0.8.1" }
-crossbeam-channel  = { version = "0.5.6" }
 dashmap            = { version = "5.4.0" }
 derivative         = { version = "2.2.0" }
 derive_builder     = { version = "0.11.2" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -310,20 +310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,16 +341,6 @@ dependencies = [
  "crossbeam-utils",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -1973,7 +1949,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "crossbeam",
  "dashmap",
  "once_cell",
  "rspack_core",
@@ -2064,7 +2039,6 @@ dependencies = [
  "async-scoped",
  "async-trait",
  "bitflags",
- "crossbeam",
  "dashmap",
  "derivative",
  "dyn-clone",
@@ -2201,7 +2175,6 @@ name = "rspack_loader_sass"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "crossbeam-channel",
  "itertools",
  "once_cell",
  "regex",
@@ -2409,7 +2382,6 @@ dependencies = [
  "base64",
  "better_scoped_tls",
  "bitflags",
- "crossbeam-channel",
  "dashmap",
  "either",
  "linked_hash_set",

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -22,7 +22,6 @@ xshell                 = "0.2.2"
 mimalloc-rust = { workspace = true }
 
 [dependencies]
-crossbeam                         = { workspace = true }
 dashmap                           = { workspace = true }
 rspack_core                       = { path = "../rspack_core" }
 rspack_fs                         = { path = "../rspack_fs", features = ["async", "rspack-error"] }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -10,7 +10,6 @@ anyhow = { workspace = true }
 async-scoped = { workspace = true, features = ["use-tokio"] }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
-crossbeam = { workspace = true }
 dashmap = { workspace = true }
 derivative = { workspace = true }
 dyn-clone = "1.0.10"

--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -9,7 +9,6 @@ version    = "0.1.0"
 
 [dependencies]
 async-trait = { workspace = true }
-crossbeam-channel = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -4,10 +4,9 @@ use std::{
   env,
   iter::Peekable,
   path::{Path, PathBuf},
-  sync::Arc,
+  sync::{mpsc, Arc},
 };
 
-use crossbeam_channel::{unbounded, Sender};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -350,7 +349,8 @@ impl LegacyImporter for RspackImporter {
 
 #[derive(Debug)]
 struct RspackLogger {
-  tx: Sender<Vec<Diagnostic>>,
+  // `Sync` is required by the `Logger` trait
+  tx: mpsc::SyncSender<Vec<Diagnostic>>,
 }
 
 impl Logger for RspackLogger {
@@ -471,7 +471,7 @@ impl Loader<CompilerContext, CompilationContext> for SassLoader {
     loader_context: &mut LoaderContext<'_, '_, CompilerContext, CompilationContext>,
   ) -> Result<()> {
     let content = loader_context.content.to_owned();
-    let (tx, rx) = unbounded();
+    let (tx, rx) = mpsc::sync_channel(8);
     let logger = RspackLogger { tx };
     let sass_options = self.get_sass_options(loader_context, content.try_into_string()?, logger);
     let result = Sass::new(&self.options.__exe_path)

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -14,7 +14,6 @@ async-trait = { workspace = true }
 base64 = "0.13"
 better_scoped_tls = { workspace = true }
 bitflags = { workspace = true }
-crossbeam-channel = { workspace = true }
 dashmap = { workspace = true }
 either = "1"
 linked_hash_set = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/ast/minify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/minify.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{mpsc, Arc};
 
 use rspack_core::ModuleType;
 use rspack_error::{internal_error, DiagnosticKind, Error, Result, TraceableError};
@@ -235,7 +235,7 @@ fn minify_file_comments(
 
 // keep this private to make sure with_rspack_error_handler is safety
 struct RspackErrorEmitter {
-  tx: crossbeam_channel::Sender<rspack_error::Error>,
+  tx: mpsc::Sender<rspack_error::Error>,
   source_map: Arc<SourceMap>,
   title: String,
   kind: DiagnosticKind,
@@ -279,7 +279,7 @@ pub fn with_rspack_error_handler<F, Ret>(
 where
   F: FnOnce(&Handler) -> Result<Ret>,
 {
-  let (tx, rx) = crossbeam_channel::unbounded();
+  let (tx, rx) = mpsc::channel();
   let emitter = RspackErrorEmitter {
     title,
     kind,


### PR DESCRIPTION
## Summary

This removes a large dependency which should improve our build speed a bit.

Note: mpsc::channel is now a port of crossbeam, they have no difference.

See: `https://github.com/rust-lang/rust/pull/93563`

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [x] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
