### PR TITLE
[Bug Fix]: ERR_UNSUPPORTED_ESM_URL_SCHEME since version 0.1.2 on Windows OS 

### DIFF
--- a/.changeset/pink-points-retire.md
+++ b/.changeset/pink-points-retire.md
@@ -1,0 +1,5 @@
+---
+"@rspack/cli": minor
+---
+
+Fix path resolution on Windows OS

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { pathToFileURL } from 'url';
 import fs from "fs";
 import { RspackCLIOptions } from "../types";
 import { RspackOptions, MultiRspackOptions } from "@rspack/core";
@@ -12,9 +13,9 @@ export type LoadedRspackConfig =
 	| RspackOptions
 	| MultiRspackOptions
 	| ((
-			env: Record<string, any>,
-			argv: Record<string, any>
-	  ) => RspackOptions | MultiRspackOptions);
+		env: Record<string, any>,
+		argv: Record<string, any>
+	) => RspackOptions | MultiRspackOptions);
 
 export async function loadRspackConfig(
 	options: RspackCLIOptions
@@ -84,7 +85,8 @@ async function requireWithAdditionalExtension(resolvedPath: string) {
 		loadedConfig = require(resolvedPath);
 	} else {
 		// dynamic import can handle both cjs & mjs
-		loadedConfig = (await import(resolvedPath)).default;
+		const fileUrl = pathToFileURL(resolvedPath).href;
+		loadedConfig = (await import(fileUrl)).default;
 	}
 	return loadedConfig;
 }


### PR DESCRIPTION
## Summary

Attempt to fix issue https://github.com/web-infra-dev/rspack/issues/2449

## Related issue (if exists)

https://github.com/web-infra-dev/rspack/issues/2449

## Types of changes

Fix path resolution for windows OS following 

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

- [x] I have added changeset via `pnpm run changeset`.
- [] I have added tests to cover my changes.
