### PR TITLE
fix: should not remove empty initial chunk

### DIFF
--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -14,7 +14,7 @@ impl RemoveEmptyChunksPlugin {
       .filter(|chunk| {
         chunk_graph.get_number_of_chunk_modules(&chunk.ukey) == 0
           && !chunk.has_runtime(&compilation.chunk_group_by_ukey)
-          && chunk_graph.get_number_of_chunk_modules(&chunk.ukey) == 0
+          && chunk_graph.get_number_of_entry_modules(&chunk.ukey) == 0
       })
       .collect::<Vec<_>>();
 


### PR DESCRIPTION
## Summary

- A initial chunk may contain zero modules due to splitChunks
- We should not remove the empty initial chunks because that rspack will inject some bootstrap code in it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
