### PR TITLE
ci: check team-label only on pr and issue open

### DIFF
--- a/.github/workflows/team-label.yaml
+++ b/.github/workflows/team-label.yaml
@@ -2,7 +2,9 @@ name: team-label
 
 on:
   pull_request:
+    types: [opened]
   issues:
+    types: [opened]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

The team-label action is currently running on every action type, this reduces it by only running on `opend`. See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issues

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
