### PR TITLE
ci: use pnpm/action-setup in check-changeset

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install Pnpm
-        run: npm install -g pnpm@7.25.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Summary

pnpm cache is not being used, let's see if this fixes that

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
