### PR TITLE
feat: built-in support for ProvidePlugin

### DIFF
--- a/.changeset/wet-spies-fold.md
+++ b/.changeset/wet-spies-fold.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat: built-in support for ProvidePlugin

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -128,6 +128,7 @@ export interface RawBuiltins {
   minifyOptions?: RawMinification
   presetEnv?: RawPresetEnv
   define: Record<string, string>
+  provide: Record<string, string[]>
   treeShaking: boolean
   progress?: RawProgressPluginConfig
   react: RawReactOptions

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -1,5 +1,5 @@
 use napi_derive::napi;
-use rspack_core::{Builtins, Define, Minification, PluginExt, PresetEnv};
+use rspack_core::{Builtins, Define, Minification, PluginExt, PresetEnv, Provide};
 use rspack_error::internal_error;
 use rspack_plugin_copy::CopyPlugin;
 use rspack_plugin_css::{plugin::CssConfig, CssPlugin};
@@ -84,6 +84,8 @@ pub struct RawBuiltins {
   pub preset_env: Option<RawPresetEnv>,
   #[napi(ts_type = "Record<string, string>")]
   pub define: Define,
+  #[napi(ts_type = "Record<string, string[]>")]
+  pub provide: Provide,
   pub tree_shaking: bool,
   pub progress: Option<RawProgressPluginConfig>,
   pub react: RawReactOptions,
@@ -134,6 +136,7 @@ impl RawOptionsApply for RawBuiltins {
       minify_options: self.minify_options.map(Into::into),
       preset_env: self.preset_env.map(Into::into),
       define: self.define,
+      provide: self.provide,
       tree_shaking: self.tree_shaking,
       react: self.react.into(),
       decorator: self.decorator.map(|i| i.into()),

--- a/crates/rspack_core/src/options/builtins.rs
+++ b/crates/rspack_core/src/options/builtins.rs
@@ -7,6 +7,7 @@ use swc_plugin_import::PluginImportConfig;
 use crate::AssetInfo;
 
 pub type Define = HashMap<String, String>;
+pub type Provide = HashMap<String, Vec<String>>;
 
 #[derive(Debug, Clone, Default)]
 pub struct ReactOptions {
@@ -34,6 +35,7 @@ pub struct Builtins {
   pub minify_options: Option<Minification>,
   pub preset_env: Option<PresetEnv>,
   pub define: Define,
+  pub provide: Provide,
   pub tree_shaking: bool,
   pub react: ReactOptions,
   pub decorator: Option<DecoratorOptions>,

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -132,7 +132,7 @@ pub fn run_before_pass(
         !options.builtins.define.is_empty()
       ),
       Optional::new(
-        swc_visitor::provide_builtin(&options.builtins.provide),
+        swc_visitor::provide_builtin(&options.builtins.provide, unresolved_mark),
         !options.builtins.provide.is_empty()
       ),
       Optional::new(

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -132,6 +132,10 @@ pub fn run_before_pass(
         !options.builtins.define.is_empty()
       ),
       Optional::new(
+        swc_visitor::provide_builtin(&options.builtins.provide, handler, &cm),
+        !options.builtins.provide.is_empty()
+      ),
+      Optional::new(
         swc_visitor::export_default_from(),
         syntax.export_default_from()
       ),

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -132,7 +132,7 @@ pub fn run_before_pass(
         !options.builtins.define.is_empty()
       ),
       Optional::new(
-        swc_visitor::provide_builtin(&options.builtins.provide, handler, &cm),
+        swc_visitor::provide_builtin(&options.builtins.provide),
         !options.builtins.provide.is_empty()
       ),
       Optional::new(

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/mod.rs
@@ -13,6 +13,9 @@ pub use react::{fold_react_refresh, react};
 mod define;
 pub use define::define;
 
+mod provide;
+pub use provide::provide_builtin;
+
 mod compat;
 pub use compat::compat;
 

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
@@ -1,0 +1,156 @@
+use std::sync::Arc;
+
+use rspack_core::Provide;
+use swc_core::common::Span;
+use swc_core::common::{errors::Handler, SourceMap, DUMMY_SP};
+use swc_core::ecma::ast::{
+  CallExpr, Callee, ComputedPropName, Expr, ExprOrSpread, Ident, ImportDecl, Lit, MemberExpr,
+  MemberProp, ModuleDecl, ModuleItem, Str,
+};
+use swc_core::ecma::visit::{Fold, FoldWith, VisitMut};
+
+pub fn provide_builtin<'a>(
+  opts: &'a Provide,
+  handler: &'a Handler,
+  cm: &'a Arc<SourceMap>,
+) -> ProvideBuiltin<'a> {
+  ProvideBuiltin::new(opts, handler, cm)
+}
+
+pub struct ProvideBuiltin<'a> {
+  opts: &'a Provide,
+  handler: &'a Handler,
+  cm: &'a Arc<SourceMap>,
+}
+
+impl<'a> ProvideBuiltin<'a> {
+  pub fn new(opts: &'a Provide, handler: &'a Handler, cm: &'a Arc<SourceMap>) -> Self {
+    ProvideBuiltin { opts, handler, cm }
+  }
+
+  fn handle_ident(&self, ident: Ident) -> Expr {
+    if let Some(module_path) = self.opts.get(&ident.sym.to_string()) {
+      self.create_obj_expr(ident.span, module_path)
+    } else {
+      Expr::Ident(ident)
+    }
+  }
+
+  fn handle_member_expr(&self, member_expr: MemberExpr) -> Expr {
+    if let Expr::Ident(ident) = &*member_expr.obj {
+      if let Some(member_prop) = member_expr.prop.as_ident() {
+        let identifier_name = format!("{}.{}", ident.sym.to_string(), member_prop.sym.to_string());
+        if let Some(module_path) = self.opts.get(&identifier_name) {
+          self.create_obj_expr_with_prop(ident.span, module_path)
+        } else {
+          Expr::Member(member_expr)
+        }
+      } else {
+        Expr::Member(member_expr)
+      }
+    } else {
+      Expr::Member(member_expr)
+    }
+  }
+
+  fn create_obj_expr(&self, span: Span, module_path: &[String]) -> Expr {
+    let call_expr = self.create_call_expr(span, &module_path[0]);
+    let mut obj_expr = Expr::Call(call_expr);
+
+    for module_name in module_path.iter().skip(1) {
+      let member_expr = MemberExpr {
+        span,
+        obj: Box::new(obj_expr),
+        prop: MemberProp::Computed(ComputedPropName {
+          span,
+          expr: Box::new(Expr::Lit(Lit::Str(Str {
+            span,
+            value: module_name.to_string().into(),
+            raw: None,
+          }))),
+        }),
+      };
+
+      obj_expr = Expr::Member(member_expr);
+    }
+
+    obj_expr
+  }
+
+  fn create_obj_expr_with_prop(&self, span: Span, module_path: &[String]) -> Expr {
+    let call_expr = self.create_call_expr(span, &module_path[0]);
+
+    if module_path.len() > 1 {
+      let prop_sym = module_path[1..].join(".").to_string();
+
+      let member_expr = MemberExpr {
+        span,
+        obj: Box::new(Expr::Call(call_expr)),
+        prop: MemberProp::Ident(Ident::new(prop_sym.into(), span)),
+      };
+
+      Expr::Member(member_expr)
+    } else {
+      Expr::Call(call_expr)
+    }
+  }
+
+  fn create_call_expr(&self, span: Span, module_path: &str) -> CallExpr {
+    CallExpr {
+      span,
+      callee: Callee::Expr(Box::new(Expr::Ident(Ident::new("require".into(), span)))),
+      args: vec![ExprOrSpread {
+        spread: None,
+        expr: Box::new(Expr::Lit(Lit::Str(Str {
+          span,
+          value: module_path.to_string().into(),
+          raw: None,
+        }))),
+      }],
+      type_args: Default::default(),
+    }
+  }
+}
+
+impl<'a> VisitMut for ProvideBuiltin<'a> {
+  fn visit_mut_ident(&mut self, i: &mut Ident) {
+    *i = self.fold_ident(i.clone());
+  }
+}
+
+impl<'a> Fold for ProvideBuiltin<'a> {
+  fn fold_expr(&mut self, expr: Expr) -> Expr {
+    let new_expr = match expr {
+      Expr::Ident(ident) => self.handle_ident(ident),
+      Expr::Member(member_expr) => self.handle_member_expr(member_expr),
+      _ => expr,
+    };
+    new_expr.fold_children_with(self)
+  }
+
+  fn fold_module_items(&mut self, items: Vec<ModuleItem>) -> Vec<ModuleItem> {
+    let mut new_items: Vec<ModuleItem> = vec![];
+
+    for (_key, module_paths) in self.opts {
+      // println!("key: {:?}", key);
+      // println!("module_paths: {:?}", module_paths);
+
+      let import_decl = ImportDecl {
+        span: DUMMY_SP,
+        specifiers: vec![],
+        src: Box::new(Str {
+          span: DUMMY_SP,
+          value: module_paths[0].to_string().into(),
+          raw: Option::None,
+        }),
+        type_only: false,
+        asserts: None,
+      };
+      new_items.push(ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)));
+    }
+
+    new_items.extend(items.fold_children_with(self));
+
+    new_items
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
@@ -91,13 +91,13 @@ impl<'a> ProvideBuiltin<'a> {
         }
         Expr::Ident(ident) => {
           if !identifier_name.is_empty() {
-            identifier_name.push_str(".");
+            identifier_name.push('.');
           }
-          identifier_name.push_str(&ident.sym.to_string());
+          identifier_name.push_str(&ident.sym);
         }
         Expr::This(_) => {
           if !identifier_name.is_empty() {
-            identifier_name.push_str(".");
+            identifier_name.push('.');
           }
           identifier_name.push_str("this");
         }
@@ -105,8 +105,8 @@ impl<'a> ProvideBuiltin<'a> {
       }
 
       if let Some(ident_prop) = member_expr.prop.as_ident() {
-        identifier_name.push_str(".");
-        identifier_name.push_str(&ident_prop.sym.to_string());
+        identifier_name.push('.');
+        identifier_name.push_str(&ident_prop.sym);
       }
     }
 

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
@@ -25,11 +25,7 @@ impl<'a> ProvideBuiltin<'a> {
 
   fn handle_ident(&self, ident: &mut Ident) -> Expr {
     if let Some(module_path) = self.opts.get(&ident.sym.to_string()) {
-      // println!("Before Ident transformation Span: {:?}", ident.span);
-
-      let new_ident = self.create_obj_expr(ident.span, module_path);
-      // println!("After Ident transformation Span: {:?}", new_ident);
-      new_ident
+      self.create_obj_expr(ident.span, module_path)
     } else {
       Expr::Ident(ident.clone())
     }
@@ -38,13 +34,8 @@ impl<'a> ProvideBuiltin<'a> {
   fn handle_member_expr(&self, member_expr: &mut MemberExpr) -> Expr {
     let identifier_name = self.get_nested_identifier_name(member_expr);
     if let Some(module_path) = self.opts.get(&identifier_name) {
-      // println!("Before Member transformation Span: {:?}", member_expr.span);
-
       let unresolved_span = DUMMY_SP.apply_mark(self.unresolved_mark);
-
-      let new_expr = self.create_obj_expr(unresolved_span, module_path);
-      // println!("After Member transformation Span: {:?}", new_expr);
-      new_expr
+      self.create_obj_expr(unresolved_span, module_path)
     } else {
       Expr::Member(member_expr.clone())
     }
@@ -52,10 +43,7 @@ impl<'a> ProvideBuiltin<'a> {
 
   fn create_obj_expr(&self, span: Span, module_path: &[String]) -> Expr {
     let call_expr = self.create_call_expr(span, &module_path[0]);
-    println!("call_expr: {:?}", call_expr);
     let mut obj_expr = Expr::Call(call_expr);
-
-    // println!("obj_expr_sym: {:?}", obj_expr.as_call().unwrap().callee);
 
     for module_name in module_path.iter().skip(1) {
       let member_expr = MemberExpr {
@@ -72,17 +60,12 @@ impl<'a> ProvideBuiltin<'a> {
       };
 
       obj_expr = Expr::Member(member_expr);
-      // println!("obj_expr_sym: {:?}", obj_expr.as_member().unwrap().obj);
     }
 
-    // println!("obj_expr_sym: {:?}", obj_expr.as_call().unwrap().callee);
     obj_expr
   }
 
   fn create_call_expr(&self, span: Span, module_path: &str) -> CallExpr {
-    // println!("module_path: {}", module_path);
-    // println!("span: {:?}", span);
-
     CallExpr {
       span,
       callee: Callee::Expr(Box::new(Expr::Ident(Ident::new("require".into(), span)))),

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
@@ -6,7 +6,7 @@ use swc_core::ecma::ast::{
 };
 use swc_core::ecma::visit::{as_folder, Fold, VisitMut, VisitMutWith};
 
-pub fn provide_builtin<'a>(opts: &'a Provide, unresolved_mark: Mark) -> impl Fold + 'a {
+pub fn provide_builtin(opts: &Provide, unresolved_mark: Mark) -> impl Fold + '_ {
   as_folder(ProvideBuiltin::new(opts, unresolved_mark))
 }
 
@@ -115,7 +115,7 @@ impl<'a> ProvideBuiltin<'a> {
   }
 }
 
-impl<'a> VisitMut for ProvideBuiltin<'a> {
+impl VisitMut for ProvideBuiltin<'_> {
   fn visit_mut_expr(&mut self, expr: &mut Expr) {
     *expr = match expr {
       Expr::Ident(ident) => self.handle_ident(ident),

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -140,6 +140,8 @@ pub struct Builtins {
   #[serde(default)]
   pub define: HashMap<String, String>,
   #[serde(default)]
+  pub provide: HashMap<String, Vec<String>>,
+  #[serde(default)]
   pub postcss: Postcss,
   #[serde(default)]
   pub html: Vec<HtmlPluginConfig>,
@@ -399,6 +401,7 @@ impl TestConfig {
       },
       builtins: c::Builtins {
         define: self.builtins.define,
+        provide: self.builtins.provide,
         tree_shaking: self.builtins.tree_shaking,
         minify_options: self.builtins.minify_options.map(|op| c::Minification {
           passes: op.passes,

--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -51,6 +51,7 @@ export interface Builtins {
 	react?: RawReactOptions;
 	noEmitAssets?: boolean;
 	define?: Record<string, string | boolean | undefined>;
+	provide?: Record<string, string | string[]>;
 	html?: Array<BuiltinsHtmlPluginConfig>;
 	decorator?: boolean | Partial<RawDecoratorOptions>;
 	minifyOptions?: Partial<RawMinification>;
@@ -139,6 +140,18 @@ function resolveDefine(define: Builtins["define"]): RawBuiltins["define"] {
 	const entries = Object.entries(define).map(([key, value]) => {
 		if (typeof value !== "string") {
 			value = value === undefined ? "undefined" : JSON.stringify(value);
+		}
+		return [key, value];
+	});
+	return Object.fromEntries(entries);
+}
+
+function resolveProvide(
+	provide: Builtins["provide"] = {}
+): RawBuiltins["provide"] {
+	const entries = Object.entries(provide).map(([key, value]) => {
+		if (typeof value === "string") {
+			value = [value];
 		}
 		return [key, value];
 	});
@@ -326,6 +339,7 @@ export function resolveBuiltinsOptions(
 		react: builtins.react ?? {},
 		noEmitAssets: builtins.noEmitAssets ?? false,
 		define: resolveDefine(builtins.define || {}),
+		provide: resolveProvide(builtins.provide),
 		html: resolveHtml(builtins.html || []),
 		presetEnv,
 		progress: resolveProgress(builtins.progress),

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -99,6 +99,7 @@ describe("snapshots", () => {
 		    },
 		    "presetEnv": undefined,
 		    "progress": undefined,
+		    "provide": {},
 		    "react": {},
 		    "relay": undefined,
 		    "treeShaking": false,

--- a/packages/rspack/tests/configCases/builtins/provide/a.js
+++ b/packages/rspack/tests/configCases/builtins/provide/a.js
@@ -1,0 +1,2 @@
+export * as c from "./b";
+export * as c2 from "./harmony2";

--- a/packages/rspack/tests/configCases/builtins/provide/aaa.js
+++ b/packages/rspack/tests/configCases/builtins/provide/aaa.js
@@ -1,0 +1,1 @@
+module.exports = "aaa";

--- a/packages/rspack/tests/configCases/builtins/provide/b.js
+++ b/packages/rspack/tests/configCases/builtins/provide/b.js
@@ -1,0 +1,7 @@
+export function square(x) {
+	return x * x;
+}
+
+export function cube(x) {
+	return x * x * x;
+}

--- a/packages/rspack/tests/configCases/builtins/provide/bbbccc.js
+++ b/packages/rspack/tests/configCases/builtins/provide/bbbccc.js
@@ -1,0 +1,1 @@
+module.exports = "bbbccc";

--- a/packages/rspack/tests/configCases/builtins/provide/ddd.js
+++ b/packages/rspack/tests/configCases/builtins/provide/ddd.js
@@ -1,0 +1,7 @@
+var ddd = {
+	eee: {
+		"3-f": "fff"
+	}
+};
+
+module.exports = ddd;

--- a/packages/rspack/tests/configCases/builtins/provide/env.js
+++ b/packages/rspack/tests/configCases/builtins/provide/env.js
@@ -1,0 +1,1 @@
+module.exports = "development";

--- a/packages/rspack/tests/configCases/builtins/provide/esm.js
+++ b/packages/rspack/tests/configCases/builtins/provide/esm.js
@@ -1,0 +1,1 @@
+module.exports = "esm";

--- a/packages/rspack/tests/configCases/builtins/provide/foo.mjs
+++ b/packages/rspack/tests/configCases/builtins/provide/foo.mjs
@@ -1,0 +1,3 @@
+export default function foo() {
+	return esm;
+}

--- a/packages/rspack/tests/configCases/builtins/provide/harmony.js
+++ b/packages/rspack/tests/configCases/builtins/provide/harmony.js
@@ -1,0 +1,3 @@
+export default "ECMAScript 2015";
+export const alias = "ECMAScript Harmony";
+export const year = 2015;

--- a/packages/rspack/tests/configCases/builtins/provide/harmony2.js
+++ b/packages/rspack/tests/configCases/builtins/provide/harmony2.js
@@ -1,0 +1,2 @@
+export const a = 1;
+// export const aUsed = __webpack_exports_info__.a.used;

--- a/packages/rspack/tests/configCases/builtins/provide/index.js
+++ b/packages/rspack/tests/configCases/builtins/provide/index.js
@@ -16,9 +16,9 @@ it("should provide a module for a nested var", function () {
 // 	})(process);
 // });
 
-it("should provide a module for thisExpression", () => {
-	expect(this.aaa).toBe("aaa");
-});
+// it("should provide a module for thisExpression", () => {
+// 	expect(this.aaa).toBe("aaa");
+// });
 
 // it("should provide a module for a nested var within a IIFE's this", function () {
 // 	(function () {

--- a/packages/rspack/tests/configCases/builtins/provide/index.js
+++ b/packages/rspack/tests/configCases/builtins/provide/index.js
@@ -20,24 +20,6 @@ it("should provide a module for thisExpression", () => {
 	expect(this.aaa).toBe("aaa");
 });
 
-// it("should provide a module for a nested var within a IIFE's this", function () {
-// 	(function () {
-// 		expect(this.env.NODE_ENV).toBe("development");
-// 		var x = this.env.NODE_ENV;
-// 		expect(x).toBe("development");
-// 	}.call(process));
-// });
-
-// it("should provide a module for a nested var within a nested IIFE's this", function () {
-// 	(function () {
-// 		(function () {
-// 			expect(this.env.NODE_ENV).toBe("development");
-// 			var x = this.env.NODE_ENV;
-// 			expect(x).toBe("development");
-// 		}.call(this));
-// 	}.call(process));
-// });
-
 it("should not provide a module for a part of a var", function () {
 	expect(typeof bbb).toBe("undefined");
 });
@@ -66,3 +48,22 @@ it("should not provide for mjs", function () {
 	var foo = require("./foo.mjs").default;
 	expect(foo()).toBe("esm");
 });
+
+// TODO: Add support for these cases
+// it("should provide a module for a nested var within a IIFE's this", function () {
+// 	(function () {
+// 		expect(this.env.NODE_ENV).toBe("development");
+// 		var x = this.env.NODE_ENV;
+// 		expect(x).toBe("development");
+// 	}.call(process));
+// });
+
+// it("should provide a module for a nested var within a nested IIFE's this", function () {
+// 	(function () {
+// 		(function () {
+// 			expect(this.env.NODE_ENV).toBe("development");
+// 			var x = this.env.NODE_ENV;
+// 			expect(x).toBe("development");
+// 		}.call(this));
+// 	}.call(process));
+// });

--- a/packages/rspack/tests/configCases/builtins/provide/index.js
+++ b/packages/rspack/tests/configCases/builtins/provide/index.js
@@ -8,17 +8,17 @@ it("should provide a module for a nested var", function () {
 	expect(x).toBe("bbbccc");
 });
 
-// it("should provide a module for a nested var within a IIFE's argument", function () {
-// 	(function (process) {
-// 		expect(process.env.NODE_ENV).toBe("development");
-// 		var x = process.env.NODE_ENV;
-// 		expect(x).toBe("development");
-// 	})(process);
-// });
+it("should provide a module for a nested var within a IIFE's argument", function () {
+	(function (process) {
+		expect(process.env.NODE_ENV).toBe("development");
+		var x = process.env.NODE_ENV;
+		expect(x).toBe("development");
+	})(process);
+});
 
-// it("should provide a module for thisExpression", () => {
-// 	expect(this.aaa).toBe("aaa");
-// });
+it("should provide a module for thisExpression", () => {
+	expect(this.aaa).toBe("aaa");
+});
 
 // it("should provide a module for a nested var within a IIFE's this", function () {
 // 	(function () {

--- a/packages/rspack/tests/configCases/builtins/provide/index.js
+++ b/packages/rspack/tests/configCases/builtins/provide/index.js
@@ -1,0 +1,68 @@
+it("should provide a module for a simple free var", function () {
+	expect(aaa).toBe("aaa");
+});
+
+it("should provide a module for a nested var", function () {
+	expect(bbb.ccc).toBe("bbbccc");
+	var x = bbb.ccc;
+	expect(x).toBe("bbbccc");
+});
+
+// it("should provide a module for a nested var within a IIFE's argument", function () {
+// 	(function (process) {
+// 		expect(process.env.NODE_ENV).toBe("development");
+// 		var x = process.env.NODE_ENV;
+// 		expect(x).toBe("development");
+// 	})(process);
+// });
+
+it("should provide a module for thisExpression", () => {
+	expect(this.aaa).toBe("aaa");
+});
+
+// it("should provide a module for a nested var within a IIFE's this", function () {
+// 	(function () {
+// 		expect(this.env.NODE_ENV).toBe("development");
+// 		var x = this.env.NODE_ENV;
+// 		expect(x).toBe("development");
+// 	}.call(process));
+// });
+
+// it("should provide a module for a nested var within a nested IIFE's this", function () {
+// 	(function () {
+// 		(function () {
+// 			expect(this.env.NODE_ENV).toBe("development");
+// 			var x = this.env.NODE_ENV;
+// 			expect(x).toBe("development");
+// 		}.call(this));
+// 	}.call(process));
+// });
+
+it("should not provide a module for a part of a var", function () {
+	expect(typeof bbb).toBe("undefined");
+});
+
+it("should provide a module for a property request", function () {
+	expect(dddeeefff).toBe("fff");
+	var x = dddeeefff;
+	expect(x).toBe("fff");
+});
+
+it("should tree-shake unused exports", function () {
+	expect(aa1(2)).toBe(8);
+	// expect(es2015_aUsed).toBe(false);
+});
+
+it("should provide ES2015 modules", function () {
+	expect(es2015.default).toBe("ECMAScript 2015");
+	expect(es2015.alias).toBe("ECMAScript Harmony");
+	expect(es2015.year).toBe(2015);
+	expect(es2015_name).toBe("ECMAScript 2015");
+	expect(es2015_alias).toBe("ECMAScript Harmony");
+	expect(es2015_year).toBe(2015);
+});
+
+it("should not provide for mjs", function () {
+	var foo = require("./foo.mjs").default;
+	expect(foo()).toBe("esm");
+});

--- a/packages/rspack/tests/configCases/builtins/provide/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/provide/webpack.config.js
@@ -3,9 +3,6 @@ module.exports = {
 		main: ["./index.js"]
 	},
 	builtins: {
-		define: {
-			"process.env.NODE_ENV": "development"
-		},
 		provide: {
 			aaa: "./aaa",
 			"bbb.ccc": "./bbbccc",

--- a/packages/rspack/tests/configCases/builtins/provide/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/provide/webpack.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+	entry: {
+		main: ["./index.js"]
+	},
+	builtins: {
+		define: {
+			"process.env.NODE_ENV": "development"
+		},
+		provide: {
+			aaa: "./aaa",
+			"bbb.ccc": "./bbbccc",
+			dddeeefff: ["./ddd", "eee", "3-f"],
+			aa1: ["./a", "c", "cube"],
+			// es2015_aUsed: ["./harmony2", "aUsed"],
+			"process.env.NODE_ENV": "./env",
+			es2015: "./harmony",
+			es2015_name: ["./harmony", "default"],
+			es2015_alias: ["./harmony", "alias"],
+			es2015_year: ["./harmony", "year"],
+			"this.aaa": "./aaa",
+			esm: "./esm.js"
+		},
+		treeShaking: true
+	}
+};


### PR DESCRIPTION
## Summary

Support the `ProvidePlugin` as a `provide` builtin in rspack

## Related issue (if exists)

#1358 

## Types of changes

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [x] I have added tests to cover my changes.
