### PR TITLE
fix: bump nodejs-resolver to fix path issue with chinese characaters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,9 +1587,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.76"
+version = "0.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79a6fa36bd571736666b6edbb5ba5fdc53bc65080c4fb59014a3f0e4be10a6a"
+checksum = "79acf3bd073a41a1fcf3aae7e18dd21329317b26ad15a4117bfba2712a89b00c"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1587,9 +1587,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.73"
+version = "0.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ca52098904c39ede5f8f73340787321cf0b3aa4b2f19aa0195654366a24fbb"
+checksum = "a79a6fa36bd571736666b6edbb5ba5fdc53bc65080c4fb59014a3f0e4be10a6a"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ napi               = { version = "=2.11.1" }
 napi-build         = { version = "=2.0.1" }
 napi-derive        = { version = "=2.11.0" }
 napi-sys           = { version = "=2.2.3" }
-nodejs-resolver    = { version = "0.0.76" }
+nodejs-resolver    = { version = "0.0.78" }
 once_cell          = { version = "1.17.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ napi               = { version = "=2.11.1" }
 napi-build         = { version = "=2.0.1" }
 napi-derive        = { version = "=2.11.0" }
 napi-sys           = { version = "=2.2.3" }
-nodejs-resolver    = { version = "0.0.73" }
+nodejs-resolver    = { version = "0.0.76" }
 once_cell          = { version = "1.17.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1276,9 +1276,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.73"
+version = "0.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ca52098904c39ede5f8f73340787321cf0b3aa4b2f19aa0195654366a24fbb"
+checksum = "a79a6fa36bd571736666b6edbb5ba5fdc53bc65080c4fb59014a3f0e4be10a6a"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1276,9 +1276,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.76"
+version = "0.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a79a6fa36bd571736666b6edbb5ba5fdc53bc65080c4fb59014a3f0e4be10a6a"
+checksum = "79acf3bd073a41a1fcf3aae7e18dd21329317b26ad15a4117bfba2712a89b00c"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -335,6 +335,7 @@ export interface RawResolveOptions {
   tsConfigPath?: string
   modules?: Array<string>
   byDependency?: Record<string, RawResolveOptions>
+  fullySpecified?: boolean
 }
 export interface RawSnapshotStrategy {
   hash: boolean

--- a/crates/rspack_binding_options/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_options/src/options/raw_resolve.rs
@@ -27,6 +27,7 @@ pub struct RawResolveOptions {
   pub ts_config_path: Option<String>,
   pub modules: Option<Vec<String>>,
   pub by_dependency: Option<HashMap<String, RawResolveOptions>>,
+  pub fully_specified: Option<bool>,
 }
 
 fn normalize_alias(alias: Option<RawAliasOption>) -> anyhow::Result<Option<Alias>> {
@@ -73,6 +74,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
     let main_fields = value.main_fields;
     let condition_names = value.condition_names;
     let symlinks = value.symlinks;
+    let fully_specified = value.fully_specified;
     let alias = normalize_alias(value.alias)?;
     let fallback = normalize_alias(value.fallback)?;
     let modules = value.modules;
@@ -102,6 +104,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
       tsconfig,
       fallback,
       by_dependency,
+      fully_specified,
     })
   }
 }

--- a/crates/rspack_core/src/options/resolve.rs
+++ b/crates/rspack_core/src/options/resolve.rs
@@ -38,10 +38,13 @@ pub struct Resolve {
   /// A list of directories to resolve modules from, can be absolute path or folder name.
   /// Default is `["node_modules"]`
   pub modules: Option<Vec<String>>,
-  // Same as `alias`, but only used if default resolving fails
-  // Default is `[]`
+  /// Same as `alias`, but only used if default resolving fails
+  /// Default is `[]`
   pub fallback: Option<Alias>,
-
+  /// Request passed to resolve is already fully specified and
+  /// extensions or main files are not resolved for it.
+  /// Default is `false`.
+  pub fully_specified: Option<bool>,
   pub by_dependency: Option<ByDependency>,
 }
 
@@ -82,7 +85,7 @@ impl Resolve {
       .modules
       .unwrap_or_else(|| vec!["node_modules".to_string()]);
     let fallback = options.fallback.unwrap_or_default();
-
+    let fully_specified = options.fully_specified.unwrap_or_default();
     nodejs_resolver::Options {
       fallback,
       modules,
@@ -99,6 +102,7 @@ impl Resolve {
       condition_names,
       tsconfig,
       resolve_to_context,
+      fully_specified,
     }
   }
 
@@ -170,6 +174,9 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
     value
   });
   let symlinks = overwrite(base.symlinks, other.symlinks, |_, value| value);
+  let fully_specified = overwrite(base.fully_specified, other.fully_specified, |_, value| {
+    value
+  });
   let browser_field = overwrite(base.browser_field, other.browser_field, |_, value| value);
   let extensions = overwrite(base.extensions, other.extensions, |base, value| {
     normalize_string_array(&base, value)
@@ -206,6 +213,7 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
     condition_names,
     tsconfig,
     by_dependency,
+    fully_specified,
   }
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -238,6 +238,7 @@ export interface ResolveOptions {
 	modules?: string[];
 	preferRelative?: boolean;
 	tsConfigPath?: string;
+	fullySpecified?: boolean;
 	byDependency?: {
 		[k: string]: ResolveOptions;
 	};


### PR DESCRIPTION
This PR upgrade the version of `nodejs_resolver`, it brings following change:

1. Optimized handling of `extendsions`, which reduces content usage and optimizes execution speed.  relative: https://github.com/web-infra-dev/nodejs_resolver/issues/157
2. Fixed the paths map match in tsconfig.
    - some test: https://github.com/web-infra-dev/nodejs_resolver/pull/172/files#diff-9bfc51173c154df5ab54a96fc510a2c449c578905e2b9be080b19450792d5236R193
4. fix some string slice in utf8. 
    - test case: https://github.com/web-infra-dev/nodejs_resolver/commit/dc99710c2612f01f1ecbf99edfb1b164c6e8e19e#diff-24975acf43b4bc39c4c8b57246e4bfbdc0c76428c86ed68f1db0e1b10a6db277R1093-R1101
    - close https://github.com/web-infra-dev/rspack/issues/2546
5. support `resolve.fullySpecified`, close https://github.com/web-infra-dev/rspack/issues/1125