### PR TITLE
chore: unify line endings for all files for any new clone

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,8 @@
 root = true
 
+[*]
+end_of_line = lf
+
 [*.{js,ts}]
 indent_style = tab
 indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 benchcases/** linguist-detectable=false
 fixtures/** linguist-detectable=false
 webpack-test/** linguist-detectable=false
+* text=auto


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Motivation: To make .x file work under Linux.

What is changed: The files will be created with "LF" for any new clone, existing files will not be changed. About the details, please reference this great article about CRLF and LF: https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git/

Have to say I am kind of confused, the CONTRIBUTING.md seems to be prepared for Linux, but ".x" is using CRLF as line endings, which make it complains "env: node\r: No such file". Note the strange "\r", which is the problem.

We cloud also add such content to .editorconfig to express intension better, I do not add it for now:
``` .editorconfig
[*]
end_of_line = lf
```

This should not cause any problem in Windows, there is no "bat" or "cmd" file in the repo.

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->
Not sure, I guess it's "refactoring"?
- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [x] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
Does this change need to fill these checkbox?
- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
