### PR TITLE
chore: add devcontainer files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# Use the [Choice] comment to indicate option arguments that should appear in VS Code UX. Use a comma separated list.
+FROM rust:1.68-bullseye
+
+RUN export DEBIAN_FRONTEND=noninteractive 
+#
+# ****************************************************************************
+# * TODO: Add any additional OS packages you want included in the definition *
+# * here. We want to do this before cleanup to keep the "layer" small.       *
+# ****************************************************************************
+# && apt-get -y install --no-install-recommends <your-package-list-here> \
+#
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "Rust",
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		// install node 16 and pnpm by nvm, hover on the feature to get more info.
+		"ghcr.io/devcontainers/features/node:1": {
+			"nodeGypDependencies": true,
+			"version": "16.18.0"
+		}
+	},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+	"postAttachCommand": "pnpm run init",
+	// Configure tool-specific properties.
+	// Add extensions for vscode
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"EditorConfig.EditorConfig", // to respect .editorConfig files
+				"mutantdino.resourcemonitor", // watch resource usage
+				"rust-lang.rust-analyzer"
+			]
+		}
+	},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Add an easy way to prepare environment for VSCode. 
- This environment contains rust 1.68, node 16.18.0, and pnpm. 
- The VSCode devcontainer includes "rust-analyzer" extension.
- When attaching to the devcontainer, "pnpm run init" command will be ran automatically.

For details, please reference https://code.visualstudio.com/docs/devcontainers/containers

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->
Maybe improvement?
- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
