### PR TITLE
chore: remove unnecessary std::mem::take

### DIFF
--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -1449,20 +1449,20 @@ pub struct TreeShakingResult {
 }
 
 impl From<ModuleRefAnalyze<'_>> for TreeShakingResult {
-  fn from(mut analyze: ModuleRefAnalyze<'_>) -> Self {
+  fn from(analyze: ModuleRefAnalyze<'_>) -> Self {
     Self {
-      top_level_mark: std::mem::take(&mut analyze.top_level_mark),
-      unresolved_mark: std::mem::take(&mut analyze.unresolved_mark),
-      module_identifier: std::mem::take(&mut analyze.module_identifier),
-      export_map: std::mem::take(&mut analyze.export_map),
-      import_map: std::mem::take(&mut analyze.import_map),
-      inherit_export_maps: std::mem::take(&mut analyze.inherit_export_maps),
-      // current_region: std::mem::take(&mut analyze.current_body_owner_id),
-      // reference_map: std::mem::take(&mut analyze.reference_map),
-      reachable_import_of_export: std::mem::take(&mut analyze.reachable_import_and_export),
-      state: std::mem::take(&mut analyze.state),
-      used_symbol_refs: std::mem::take(&mut analyze.used_symbol_ref),
-      bail_out_module_identifiers: std::mem::take(&mut analyze.bail_out_module_identifiers),
+      top_level_mark: analyze.top_level_mark,
+      unresolved_mark: analyze.unresolved_mark,
+      module_identifier: analyze.module_identifier,
+      export_map: analyze.export_map,
+      import_map: analyze.import_map,
+      inherit_export_maps: analyze.inherit_export_maps,
+      // current_region: analyze.current_body_owner_id),
+      // reference_map: analyze.reference_map),
+      reachable_import_of_export: analyze.reachable_import_and_export,
+      state: analyze.state,
+      used_symbol_refs: analyze.used_symbol_ref,
+      bail_out_module_identifiers: analyze.bail_out_module_identifiers,
       side_effects: analyze.side_effects,
       module_syntax: analyze.module_syntax,
     }

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -34,9 +34,8 @@ impl<T: std::fmt::Debug> TWithDiagnosticArray<T> {
     self.inner
   }
 
-  pub fn split_into_parts(mut self) -> (T, Vec<Diagnostic>) {
-    let diagnostic = std::mem::take(&mut self.diagnostic);
-    (self.inner, diagnostic)
+  pub fn split_into_parts(self) -> (T, Vec<Diagnostic>) {
+    (self.inner, self.diagnostic)
   }
 }
 


### PR DESCRIPTION
## Summary

remove unnecessary std::mem::take

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [x] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [x] I have added tests to cover my changes.
