### PR TITLE
deps(node_binding): dashmap v5.4.0

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 anyhow = { version = "1.0.65", features = ["backtrace"] }
 async-trait = "0.1.53"
 backtrace = "0.3"
-dashmap = "5.0.0"
+dashmap = "5.4.0"
 futures = "0.3"
 napi = { version = "=2.11.1" }
 napi-derive = { version = "=2.11.0" }


### PR DESCRIPTION
closes #2081

## Summary

Dashmap is already synced to v5.4.0, this bumps the version in Cargo.tom and closes #2081

https://github.com/web-infra-dev/rspack/blob/9d02abc78d14215e7b747fdc09c944d7a970f9a2/crates/node_binding/Cargo.lock#L466-L477

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
