### PR TITLE
ci: cache pnpm globally

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -1,0 +1,19 @@
+name: pnpm cache
+description: Install Node.js with pnpm global cache
+runs:
+  using: composite
+  steps:
+    # https://pnpm.io/continuous-integration#github-actions
+    # Uses `packageManagement` field from package.json
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: "16"
+        cache: 'pnpm'
+
+    - name: Install Npm Dependencies
+      shell: bash
+      run: pnpm install

--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -15,17 +15,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          cache: "pnpm"
-
-      - name: Install Dependencies
-        run: pnpm install
+      - name: Pnpm Cache
+        uses: ./.github/actions/pnpm-cache
 
       - name: Check Changeset
         run: node ./scripts/check_changeset.js

--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -37,21 +37,10 @@ jobs:
       - name: Install toolchain
         run: rustup show
 
-      # https://pnpm.io/continuous-integration#github-actions
-      # Uses `packageManagement` field from package.json
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
+      - name: Pnpm Cache
+        uses: ./.github/actions/pnpm-cache
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-          cache: 'pnpm'
-
-      - name: Install Npm Dependencies
-        run: pnpm install
-
-      - name: Cache
+      - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: check

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -25,14 +25,8 @@ jobs:
         with:
           # getting release note text need to get commit history
           fetch-depth: 100
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - name: Install node_modules
-        run: |
-          npm install -g pnpm@7.25.0
-          pnpm -v
-          pnpm install
+      - name: Pnpm Cache
+        uses: ./.github/actions/pnpm-cache
       - name: Create Release Pull Request
         uses: web-infra-dev/actions@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,8 @@ jobs:
           rustup target add aarch64-apple-darwin
           rustup target add x86_64-apple-darwin
           rustup target add x86_64-unknown-linux-gnu
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - name: Install node_modules
-        run: |
-          npm install -g pnpm@7.25.0
-          pnpm -v
-          pnpm install
+      - name: Pnpm Cache
+        uses: ./.github/actions/pnpm-cache
       - name: Build
         run: |
           set -e

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -81,17 +81,12 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - name: Setup node dependencies
-        run: |
-          npm install -g pnpm@7.25.0
-          pnpm install
+      - name: Pnpm Cache
+        uses: ./.github/actions/pnpm-cache
       - name: Install Rust
         if: ${{ !matrix.settings.docker }}
         run: rustup show
-      - name: Cache
+      - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Setup rust target
         if: ${{ !matrix.settings.docker }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,17 +106,12 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "16"
-      - name: Setup node dependencies
-        run: |
-          npm install -g pnpm@7.25.0
-          pnpm install
+      - name: Pnpm Cache
+        uses: ./.github/actions/pnpm-cache
       - name: Install Rust
         if: ${{ !matrix.settings.docker }}
         run: rustup show
-      - name: Cache
+      - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: build-and-test


### PR DESCRIPTION
## Summary

This PR uses github composite action to make sure all pnpm install are loaded from the global cache.

Relates to #2484. I wanted to make sure all workflows are consistent.

https://github.com/web-infra-dev/rspack/actions/runs/4562783985/jobs/8050437686
https://github.com/web-infra-dev/rspack/actions/runs/4562784369/jobs/8050438485

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/1430279/228793396-c85878c7-3145-4457-bf4d-38bf95ea710b.png">

<img width="1012" alt="image" src="https://user-images.githubusercontent.com/1430279/228793577-f2867d90-0a67-4272-becb-543d7bb6cab9.png">

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [x] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
