### PR TITLE
feat(rspack_plugin_dev_friendly_split_chunks): reduce `MAX_MODULES_PER_CHUNK` and add `MAX_SIZE_PER_CHUNK` condition

### DIFF
--- a/.changeset/tame-seals-pull.md
+++ b/.changeset/tame-seals-pull.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat(rspack_plugin_dev_friendly_split_chunks): reduce MAX_MODULES_PER_CHUNK and add MAX_SIZE_PER_CHUNK condition #2578

--- a/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
+++ b/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
@@ -70,7 +70,7 @@ impl Plugin for DevFriendlySplitChunksPlugin {
 
     // First we group modules by MAX_MODULES_PER_CHUNK
 
-    let splitted_modules = shared_modules
+    let split_modules = shared_modules
       .par_chunks(MAX_MODULES_PER_CHUNK)
       .flat_map(|modules| {
         let chunk_size: f64 = modules
@@ -132,7 +132,7 @@ impl Plugin for DevFriendlySplitChunksPlugin {
       .collect::<DashMap<_, _>>();
 
     // Yeah. Leaky abstraction, but fast.
-    let mut chunk_and_cgc = splitted_modules
+    let mut chunk_and_cgc = split_modules
       .map(|modules| {
         let mut chunk = Chunk::new(None, None, rspack_core::ChunkKind::Normal);
         chunk

--- a/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
+++ b/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
@@ -64,7 +64,65 @@ impl Plugin for DevFriendlySplitChunksPlugin {
     });
 
     // The number doesn't go through deep consideration.
-    const MAX_MODULES_PER_CHUNK: usize = 3000;
+    const MAX_MODULES_PER_CHUNK: usize = 500;
+    // About 5mb
+    const MAX_SIZE_PER_CHUNK: f64 = 5000000.0;
+
+    // First we group modules by MAX_MODULES_PER_CHUNK
+
+    let splitted_modules = shared_modules
+      .par_chunks(MAX_MODULES_PER_CHUNK)
+      .flat_map(|modules| {
+        let chunk_size: f64 = modules
+          .iter()
+          .map(|m| {
+            let module = compilation
+              .module_graph
+              .module_by_identifier(&m.module)
+              .expect("Should have a module here");
+
+            // Some code after transpiling will increase it's size a lot.
+            let coefficient = match module.module_type() {
+              // 5.0 is a number in practice
+              rspack_core::ModuleType::Jsx => 5.0,
+              rspack_core::ModuleType::JsxDynamic => 5.0,
+              rspack_core::ModuleType::JsxEsm => 5.0,
+              rspack_core::ModuleType::Tsx => 5.0,
+              _ => 1.5,
+            };
+
+            module.size(&rspack_core::SourceType::JavaScript) * coefficient
+          })
+          .sum();
+
+        if chunk_size > MAX_SIZE_PER_CHUNK {
+          let mut remain_chunk_size = chunk_size;
+          let mut last_end_idx = 0;
+          let mut chunks = vec![];
+          while remain_chunk_size > MAX_SIZE_PER_CHUNK && last_end_idx < modules.len() {
+            let mut new_chunk_size = 0f64;
+            let start_idx = last_end_idx;
+            while new_chunk_size < MAX_SIZE_PER_CHUNK && last_end_idx < modules.len() {
+              let module_size = compilation
+                .module_graph
+                .module_by_identifier(&modules[last_end_idx].module)
+                .expect("Should have a module here")
+                .size(&rspack_core::SourceType::JavaScript);
+              new_chunk_size += module_size;
+              remain_chunk_size -= module_size;
+              last_end_idx += 1;
+            }
+            chunks.push(&modules[start_idx..last_end_idx])
+          }
+
+          if last_end_idx < modules.len() {
+            chunks.push(&modules[last_end_idx..])
+          }
+          chunks
+        } else {
+          vec![modules]
+        }
+      });
 
     // Yeah. Leaky abstraction, but fast.
     let module_to_chunk_graph_module = compilation
@@ -74,8 +132,7 @@ impl Plugin for DevFriendlySplitChunksPlugin {
       .collect::<DashMap<_, _>>();
 
     // Yeah. Leaky abstraction, but fast.
-    let mut chunk_and_cgc = shared_modules
-      .par_chunks(MAX_MODULES_PER_CHUNK)
+    let mut chunk_and_cgc = splitted_modules
       .map(|modules| {
         let mut chunk = Chunk::new(None, None, rspack_core::ChunkKind::Normal);
         chunk


### PR DESCRIPTION
## Summary

The FS project emits a 30MB js asset due to the number `MAX_MODULES_PER_CHUNK`.

This PR reduced the number of `MAX_MODULES_PER_CHUNK` and add a `MAX_SIZE_PER_CHUNK` condition to split chunks that are bigger than `MAX_SIZE_PER_CHUNK`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

Fixes #2529.

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
