### PR TITLE
chore: Update all package.json#repository fields to include the monorepo-relative directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,10 @@
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack"
+  },
   "devDependencies": {
     "@changesets/cli": "2.24.4",
     "@rspack/cli": "workspace:*",

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -8,7 +8,11 @@
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/create-rspack"
+  },
   "dependencies": {
     "yargs": "17.6.2",
     "prompts": "2.4.2"

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,6 +5,11 @@
   "scripts": {
     "test": "jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/playground"
+  },
   "devDependencies": {
     "playwright-chromium": "1.32.1",
     "fs-extra": "11.1.1",

--- a/packages/postcss-loader/package.json
+++ b/packages/postcss-loader/package.json
@@ -9,7 +9,11 @@
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/postcss-loader"
+  },
   "dependencies": {
     "@rspack/binding": "workspace:*",
     "postcss-modules": "^5.0.0",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -20,7 +20,11 @@
   ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-cli"
+  },
   "devDependencies": {
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "concat-stream": "^2.0.0",

--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -10,7 +10,11 @@
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-dev-client"
+  },
   "devDependencies": {
     "typescript": "^4.7.4",
     "@types/node": "16.11.7",

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -11,7 +11,11 @@
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-dev-middleware"
+  },
   "dependencies": {
     "@rspack/core": "workspace:*",
     "webpack-dev-middleware": "6.0.2",

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -12,7 +12,11 @@
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-dev-server"
+  },
   "devDependencies": {
     "@rspack/core": "workspace:*",
     "typescript": "^4.7.4",

--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -16,7 +16,11 @@
   ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-plugin-html"
+  },
   "dependencies": {
     "@rspack/core": "workspace:*",
     "@types/html-minifier-terser": "7.0.0",

--- a/packages/rspack-plugin-minify/package.json
+++ b/packages/rspack-plugin-minify/package.json
@@ -7,7 +7,11 @@
   "scripts": {},
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-plugin-minify"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/rspack-plugin-node-polyfill/package.json
+++ b/packages/rspack-plugin-node-polyfill/package.json
@@ -10,7 +10,11 @@
   "access": "public",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack-plugin-node-polyfill"
+  },
   "dependencies": {
     "assert": "^2.0.0",
     "browserify-zlib": "^0.2.0",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -17,7 +17,11 @@
   ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
-  "repository": "web-infra-dev/rspack",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack"
+  },
   "devDependencies": {
     "@rspack/core": "workspace:*",
     "@rspack/plugin-minify": "workspace:^",


### PR DESCRIPTION
## Summary

From https://docs.npmjs.com/cli/v9/configuring-npm/package-json#repository:

> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:

---

1. It allows a more accurate direct link to the source code from www.npmjs.com/package
1. When `rspack` is installed in your project's `node_modules`, if you encounter an error with a stack trace, it makes it easy for the IDE/Terminal to open the Github source code directly by examining the closest `package.json` file.

## Related issue (if exists)

Nil.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [x] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
