### PR TITLE
chore: use corepack instead of engine to force pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,13 @@
     "release": "changeset publish --no-git-checks",
     "bump": "changeset version",
     "changeset": "changeset",
-    "prepare": "is-ci || husky install"
+    "prepare": "is-ci || husky install",
+    "pnpm:devPreinstall": "node scripts/preinstall.js"
   },
   "lint-staged": {
     "*.rs": "rustfmt --edition 2021",
     "*.js": "pnpm run format:js",
     "*.toml": "pnpm run format:toml"
-  },
-  "engines": {
-    "pnpm": "7.25.0"
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,0 +1,6 @@
+if (!process.env.COREPACK_ROOT) {
+	console.error(
+		"please ensure corepack is enabled https://pnpm.io/installation#using-corepack"
+	);
+	process.exit(1);
+}


### PR DESCRIPTION
## Summary
engine will force user to use single global pnpm version which may hurt developer experience but we did need to enforce developer use same pnpm version to ensure lockfile doesn't change unintentionally, so we 
* use packageManager to control pnpm version
* use preInstall to check whether developer enable corepack
## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
