### PR TITLE
fix: fix compile time is NaN in watch

### DIFF
--- a/packages/rspack/src/watching.ts
+++ b/packages/rspack/src/watching.ts
@@ -280,13 +280,15 @@ class Watching {
 
 		const cbs = this.callbacks;
 		this.callbacks = [];
+		const startTime = this.startTime; // store last startTime for compilation
+		// reset startTime for next compilation, before throwing error
 		this.startTime = undefined;
 		if (error) {
 			return handleError(error);
 		}
 		assert(compilation);
 
-		compilation.startTime = this.startTime;
+		compilation.startTime = startTime;
 		compilation.endTime = Date.now();
 		stats = new Stats(compilation);
 


### PR DESCRIPTION
## Summary

fix #2654, we should store last startTime before resetting

## Related issue (if exists)

#2654 

<!--- Provide link of related issues -->

## Types of changes


- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [x] I have added tests to cover my changes.
