### PR TITLE
chore: add "pending triage" to new issue by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
@@ -1,7 +1,7 @@
 name: "🐞 Bug Report"
 description: Report a bug to Rspack
 title: "[Bug Report]: "
-labels: ["C-bug"]
+labels: ["bug", "pending triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/2-feature-request.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.en-US.yml
@@ -1,7 +1,7 @@
 name: "✨ Feature Request"
 description: Submit a new feature request to Rspack
 title: "[Feature Request]: "
-labels: ["enhancement"]
+labels: ["feat", "pending triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

Using GitHub action to add labels cause some latency.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
