### PR TITLE
feat(cli): support mjs&cjs as default config file

### DIFF
--- a/.changeset/curvy-weeks-burn.md
+++ b/.changeset/curvy-weeks-burn.md
@@ -1,0 +1,5 @@
+---
+"@rspack/cli": patch
+---
+
+support rspack.config.mjs as default config file

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { RspackCLIOptions } from "../types";
 import { RspackOptions, MultiRspackOptions } from "@rspack/core";
 
-const supportedExtensions = [".js", ".ts"];
+const supportedExtensions = [".js", ".ts", ".mjs"];
 const defaultConfig = "rspack.config";
 const defaultEntry = "src/index";
 

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { RspackCLIOptions } from "../types";
 import { RspackOptions, MultiRspackOptions } from "@rspack/core";
 
-const supportedExtensions = [".js", ".ts", ".mjs"];
+const supportedExtensions = [".js", ".ts", ".mjs", ".cjs"];
 const defaultConfig = "rspack.config";
 const defaultEntry = "src/index";
 


### PR DESCRIPTION
## Summary
since we support mjs as config file now, we should support `rspack.config.mjs` as default config file
## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
