### PR TITLE
fix(html): html inject public path incorrect

### DIFF
--- a/.changeset/dry-camels-tie.md
+++ b/.changeset/dry-camels-tie.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix(html): html inject public path incorrect

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -218,9 +218,7 @@ impl PublicPath {
           .options
           .output
           .path
-          .join(dirname)
-          .resolve()
-          .relative(&compilation.options.output.path)
+          .relative(compilation.options.output.path.join(dirname).resolve())
           .to_string_lossy()
           .to_string(),
       },

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -134,7 +134,7 @@ impl HtmlPluginConfig {
         .public_path
         .render(compilation, filename),
     };
-    if !public_path.ends_with('/') {
+    if !public_path.is_empty() && !public_path.ends_with('/') {
       public_path + "/"
     } else {
       public_path

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -132,7 +132,7 @@ impl Plugin for HtmlPlugin {
       if let Some(extension) = Path::new(&asset_name).extension() {
         let asset_uri = format!(
           "{}{asset_name}",
-          config.get_public_path(compilation, &asset_name),
+          config.get_public_path(compilation, &self.config.filename),
         );
         let mut tag: Option<HTMLPluginTag> = None;
         if extension.eq_ignore_ascii_case("css") {

--- a/packages/rspack/tests/configCases/builtins/html-public-path-auto/index.js
+++ b/packages/rspack/tests/configCases/builtins/html-public-path-auto/index.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+
+it("html plugin should public path auto works", () => {
+	const htmlPath = path.join(__dirname, "./main_page/index.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(htmlContent.includes('<script src="../main.js" defer>')).toBe(true);
+});

--- a/packages/rspack/tests/configCases/builtins/html-public-path-auto/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/html-public-path-auto/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require("path");
+
+module.exports = {
+	target: "web",
+	externals: {
+		path: "require('path')",
+		fs: "require('fs')"
+	},
+	builtins: {
+		define: {
+			__dirname: JSON.stringify(path.join(__dirname, "./dist"))
+		},
+		html: [
+			{
+				filename: "main_page/index.html"
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Summary

The builtins html will inject the assets into the html, but injection path is wrong when public path is auto.

https://github.com/web-infra-dev/rspack/issues/2710

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
