### PR TITLE
fix(react-refresh): lazily access `module.exports` to prevent unexpected/potential TDZ error

### DIFF
--- a/.changeset/pretty-rocks-cross.md
+++ b/.changeset/pretty-rocks-cross.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix(react-refresh): lazily access module.exports to prevent unexpected/potential TDZ error

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -68,8 +68,9 @@ var $RefreshReg$ = function (type, id) {
 }
 var $RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;"#;
 
-static HMR_FOOTER: &str =
-  r#"__webpack_modules__.$ReactRefreshRuntime$.refresh(__webpack_module__.id, module.hot);"#;
+static HMR_FOOTER: &str = r#"Promise.resolve().then(function(){ 
+  __webpack_modules__.$ReactRefreshRuntime$.refresh(__webpack_module__.id, module.hot);
+})"#;
 
 static HMR_HEADER_AST: Lazy<Program> =
   Lazy::new(|| parse_js_code(HMR_HEADER.to_string(), &ModuleType::Js).expect("TODO:"));

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -68,6 +68,7 @@ var $RefreshReg$ = function (type, id) {
 }
 var $RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;"#;
 
+// See https://github.com/web-infra-dev/rspack/pull/2714 why we have a promise here
 static HMR_FOOTER: &str = r#"Promise.resolve().then(function(){ 
   __webpack_modules__.$ReactRefreshRuntime$.refresh(__webpack_module__.id, module.hot);
 })"#;


### PR DESCRIPTION
## Summary

The causes/details could be seen at https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/190.

---

The problem is caused by eagerly accessing some un-initialized variables declared by `const`. The accessing is done due to the react-refresh need to access each export of modules. By making accessing laziness, we solved the problem.

This PR solves the problem by lazily accessing `module.exports`.

This PR may have potential performance problems:

- react-refresh would only start to work after the next tick of the event loop, aka all synchronous code is executed.

---

Credit to @underfin for pair programming with me.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

Closes #2697.

---

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93d5641</samp>

This pull request fixes a potential error with the react-refresh plugin and the temporal dead zone issue by lazily accessing the `module.exports` object. It also improves the hot module replacement functionality by deferring the refresh function with a promise. The changes affect the `@rspack/binding` package and the `crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs` file.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93d5641</samp>

* Fix potential TDZ error with react-refresh plugin by lazily accessing `module.exports` ([link](https://github.com/web-infra-dev/rspack/pull/2714/files?diff=unified&w=0#diff-4e7095a34eb064794b9f0295a15071398afad37250c5ea2e8b96e9d3eb1d9013R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/2714/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL71-R74))
* Defer refresh function call with a promise to ensure modules are fully loaded and initialized before updating components ([link](https://github.com/web-infra-dev/rspack/pull/2714/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL71-R74))
* Update changelog for `@rspack/binding` package with patch version and message ([link](https://github.com/web-infra-dev/rspack/pull/2714/files?diff=unified&w=0#diff-4e7095a34eb064794b9f0295a15071398afad37250c5ea2e8b96e9d3eb1d9013R1-R5))

</details>
