### PR TITLE
chore: enable strictCommand & strictOption check

### DIFF
--- a/.changeset/bright-carrots-behave.md
+++ b/.changeset/bright-carrots-behave.md
@@ -1,0 +1,5 @@
+---
+"@rspack/cli": patch
+---
+
+check cli command and options

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -9,7 +9,7 @@ import MultiStats from "@rspack/core/src/multiStats";
 export class BuildCommand implements RspackCommand {
 	async apply(cli: RspackCLI): Promise<void> {
 		cli.program.command(
-			["build [entry..]", "$0", "bundle", "b"],
+			["build", "$0", "bundle", "b"],
 			"run the rspack build",
 			yargs =>
 				commonOptions(yargs).options({

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -6,7 +6,7 @@ import { Compiler, DevServer } from "@rspack/core";
 export class ServeCommand implements RspackCommand {
 	async apply(cli: RspackCLI): Promise<void> {
 		cli.program.command(
-			["serve [entry..]", "server", "s"],
+			["serve", "server", "s", "dev"],
 			"run the rspack dev server.",
 			commonOptions,
 			async options => {

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -85,6 +85,7 @@ export class RspackCLI {
 
 		this.program.usage("[options]");
 		this.program.scriptName("rspack");
+		this.program.strictCommands(true).strict(true);
 		this.program.middleware(normalizeEnv);
 		this.registerCommands();
 		await this.program.parseAsync(hideBin(argv));

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -1,44 +1,38 @@
 import yargs from "yargs";
 export const commonOptions = (yargs: yargs.Argv<{}>) => {
-	return yargs
-		.positional("entry", {
+	return yargs.options({
+		config: {
+			g: true,
 			type: "string",
-			array: true,
-			describe: "entry"
-		})
-		.options({
-			config: {
-				g: true,
-				type: "string",
-				describe: "config file",
-				alias: "c"
-			},
-			mode: { type: "string", describe: "mode" },
-			watch: {
-				type: "boolean",
-				default: false,
-				describe: "watch"
-			},
-			env: {
-				type: "array",
-				string: true,
-				describe: "env passed to config function"
-			},
-			"node-env": {
-				string: true,
-				describe: "sets process.env.NODE_ENV to be specified value"
-			},
-			devtool: {
-				type: "boolean",
-				default: false,
-				describe: "devtool"
-			},
-			configName: {
-				type: "array",
-				string: true,
-				describe: "Name of the configuration to use."
-			}
-		});
+			describe: "config file",
+			alias: "c"
+		},
+		mode: { type: "string", describe: "mode" },
+		watch: {
+			type: "boolean",
+			default: false,
+			describe: "watch"
+		},
+		env: {
+			type: "array",
+			string: true,
+			describe: "env passed to config function"
+		},
+		"node-env": {
+			string: true,
+			describe: "sets process.env.NODE_ENV to be specified value"
+		},
+		devtool: {
+			type: "boolean",
+			default: false,
+			describe: "devtool"
+		},
+		configName: {
+			type: "array",
+			string: true,
+			describe: "Name of the configuration to use."
+		}
+	});
 };
 
 export function normalizeEnv(argv) {

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -16,57 +16,8 @@ describe("build command", () => {
 		expect(stderr).toBeFalsy();
 		expect(stdout).toBeTruthy();
 	});
-	it("should work with multiple entries syntax without command (default command)", async () => {
-		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js"
-		]);
-
-		expect(exitCode).toBe(0);
-		expect(stderr).toBeFalsy();
-		expect(stdout).toBeTruthy();
-	});
-
-	it("should work with multiple entries syntax without command with options (default command)", async () => {
-		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js",
-			"--mode",
-			"development"
-		]);
-
-		expect(exitCode).toBe(0);
-		expect(stderr).toBeFalsy();
-		expect(stdout).toBeTruthy();
-	});
-	it("should work with multiple entries syntax without command with options #3 (default command)", async () => {
-		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js",
-			"--entry",
-			"./src/again.js"
-		]);
-
-		expect(exitCode).toBe(0);
-		expect(stderr).toBeFalsy();
-		expect(stdout).toBeTruthy();
-	});
-
-	it("should work with and override entries from the configuration", async () => {
-		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js",
-			"--config",
-			"./entry.config.js"
-		]);
-		expect(exitCode).toBe(0);
-		expect(stderr).toBeFalsy();
-		expect(stdout).toBeTruthy();
-	});
 	it("should work with configuration return function", async () => {
 		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js",
 			"--config",
 			"./entry.function.js"
 		]);
@@ -76,8 +27,6 @@ describe("build command", () => {
 	});
 	it("should work with configuration return promise", async () => {
 		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js",
 			"--config",
 			"./entry.promise.js"
 		]);
@@ -87,8 +36,6 @@ describe("build command", () => {
 	});
 	it("should work with mjs configuration ", async () => {
 		const { exitCode, stderr, stdout } = await run(__dirname, [
-			"./src/index.js",
-			"./src/other.js",
 			"--config",
 			"./entry.config.mjs"
 		]);


### PR DESCRIPTION
## Summary
* check unknown command to avoid user passing unknown options or command
* add rspack dev as a alias of rspack serve
![image](https://user-images.githubusercontent.com/8898718/231354468-511e1ec4-cdd2-4ccc-b357-67ee6446e4ee.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Related issue (if exists)

<!--- Provide link of related issues -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [ ] Bug fix
- [x] New feature / Improvement
- [ ] Refactoring
- [x] Breaking change
This remove the behavior of passing entry by post options which is not documented 
## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
