### PR TITLE
fix(cli): fix default NODE_ENV of command

### DIFF
--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -29,18 +29,20 @@ export class RspackCLI {
 	}
 	async createCompiler(
 		options: RspackCLIOptions,
-		rspackEnv: Command,
+		rspackCommand: Command,
 		callback?: (e: Error, res?: Stats | MultiStats) => void
 	): Promise<Compiler | MultiCompiler> {
 		process.env.RSPACK_CONFIG_VALIDATE = "loose";
 		let nodeEnv = process?.env?.NODE_ENV;
+		let rspackCommandDefaultEnv =
+			rspackCommand === "build" ? "production" : "development";
 		if (typeof options.nodeEnv === "string") {
 			process.env.NODE_ENV = nodeEnv || options.nodeEnv;
 		} else {
-			process.env.NODE_ENV = nodeEnv || rspackEnv;
+			process.env.NODE_ENV = nodeEnv || rspackCommandDefaultEnv;
 		}
 		let config = await this.loadConfig(options);
-		config = await this.buildConfig(config, options, rspackEnv);
+		config = await this.buildConfig(config, options, rspackCommand);
 
 		const isWatch = Array.isArray(config)
 			? (config as MultiRspackOptions).some(i => i.watch)


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 3b90dfc</samp>

### Summary
📝🚚🚀

<!--
1.  📝 - This emoji represents the addition of a changeset file, which is a form of documentation for the changes made to the package.
2.  🚚 - This emoji represents the removal of the unused `entry` argument from the `build` command, which is a form of simplification and cleanup for the codebase.
3.  🚀 - This emoji represents the addition of the `dev` alias for the `serve` command, which is a form of enhancement and convenience for the users.
-->
This pull request refactors and improves the `@rspack/cli` package by enabling strict mode, simplifying the `build` command, adding an alias for the `serve` command, and removing an unused argument. It also adds a changeset file to document the patch update.

> _Sing, O Muse, of the skillful changes wrought by the coder_
> _Who refined the `@rspack/cli` package with wisdom and order_
> _He removed the unused `entry` from the `build` command_
> _And made it simpler and clearer for the users to understand_

### Walkthrough
*  Simplify `build` command by removing unused `entry` argument ([link](https://github.com/web-infra-dev/rspack/pull/2724/files?diff=unified&w=0#diff-a0e6eb46e65055c0a94d02423fbc193054ae66afbca8c6264a5f2b0cda5ad755L12-R12))
*  Add `dev` alias for `serve` command and define `entry` argument for it ([link](https://github.com/web-infra-dev/rspack/pull/2724/files?diff=unified&w=0#diff-d922f47df3f149a574de3c92413cc0483b128c9dd414b2be26342850df788044L9-R9), [link](https://github.com/web-infra-dev/rspack/pull/2724/files?diff=unified&w=0#diff-63ac1115f8ddcb7c926c698f4c3b79b51692206b6b5d334e5bfa35b319a85f49L3-R35))
*  Refactor `createCompiler` method to take `rspackCommand` parameter and set `process.env.NODE_ENV` accordingly ([link](https://github.com/web-infra-dev/rspack/pull/2724/files?diff=unified&w=0#diff-44dee9ba83d25009b434358408609d864a6ae2c804c084a8d6cfeec82ab64ab4L32-R45))
*  Enable strict mode for `program` property to fail on unknown commands or options ([link](https://github.com/web-infra-dev/rspack/pull/2724/files?diff=unified&w=0#diff-44dee9ba83d25009b434358408609d864a6ae2c804c084a8d6cfeec82ab64ab4R90))
*  Add changeset file to document patch update for `@rspack/cli` package ([link](https://github.com/web-infra-dev/rspack/pull/2724/files?diff=unified&w=0#diff-63fc53411bfb3282a5c040b26b409bea46db99fba1736b1851aaec2408a7a12dR1-R5))

