### PR TITLE
fix(progress): should not display empty progress bar

### DIFF
--- a/.changeset/shiny-squids-matter.md
+++ b/.changeset/shiny-squids-matter.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix(progress): should not display empty progress bar

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -31,12 +31,6 @@ impl ProgressPlugin {
       ProgressStyle::with_template("{prefix} {bar:40.cyan/blue} {percent}% {wide_msg}")
         .expect("TODO:"),
     );
-    progress_bar.set_prefix(
-      options
-        .prefix
-        .clone()
-        .unwrap_or_else(|| "Rspack".to_string()),
-    );
     Self {
       options,
       progress_bar,
@@ -55,6 +49,13 @@ impl Plugin for ProgressPlugin {
 
   async fn make(&self, _ctx: PluginContext, _compilation: &Compilation) -> PluginMakeHookOutput {
     self.progress_bar.reset();
+    self.progress_bar.set_prefix(
+      self
+        .options
+        .prefix
+        .clone()
+        .unwrap_or_else(|| "Rspack".to_string()),
+    );
     self.modules_count.store(0, SeqCst);
     self.modules_done.store(0, SeqCst);
     self.progress_bar.set_message("make");


### PR DESCRIPTION
## Summary

The `progress_bar.set_prefix` method will immediately draw an empty progress bar, which looks ugly.

![image](https://user-images.githubusercontent.com/7237365/231358161-7fc76f36-eccf-486a-bf19-621ea7ad643b.png)

We can move the `progress_bar.set_prefix` to `make` stage, so the empty progress bar will not be printed:

![image](https://user-images.githubusercontent.com/7237365/231358754-93e54025-c0e3-4000-a097-1c9ad7c9b8e6.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in the boxes that apply: -->

- [ ] Docs change / Dependency upgrade
- [x] Bug fix
- [ ] New feature / Improvement
- [ ] Refactoring
- [ ] Breaking change

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run changeset`.
- [ ] I have added tests to cover my changes.
