### PR TITLE
feat(core): print the module identifier if not founded

### DIFF
--- a/crates/rspack_core/src/chunk_graph.rs
+++ b/crates/rspack_core/src/chunk_graph.rs
@@ -68,7 +68,7 @@ impl ChunkGraph {
     self
       .chunk_graph_module_by_module_identifier
       .get_mut(&module_identifier)
-      .expect("Module should be added before")
+      .unwrap_or_else(|| panic!("Module({}) should be added before using", module_identifier))
   }
 
   pub(crate) fn get_chunk_graph_module(
@@ -78,7 +78,7 @@ impl ChunkGraph {
     self
       .chunk_graph_module_by_module_identifier
       .get(&module_identifier)
-      .expect("Module should be added before")
+      .unwrap_or_else(|| panic!("Module({}) should be added before using", module_identifier))
   }
 
   pub(crate) fn get_chunk_graph_chunk_mut(
@@ -155,7 +155,7 @@ impl ChunkGraph {
     let chunk_graph_module = self
       .chunk_graph_module_by_module_identifier
       .get(&module_identifier)
-      .expect("Module should be added before");
+      .unwrap_or_else(|| panic!("Module({}) should be added before using", module_identifier));
     &chunk_graph_module.chunks
   }
 


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b03e191</samp>

Improved error handling and debugging for chunk graph access. Added module identifier to panic messages in `chunk_graph.rs`.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b03e191</samp>

* Improve error handling and debugging of chunk graph methods by using `unwrap_or_else` and informative panic messages ([link](https://github.com/web-infra-dev/rspack/pull/2731/files?diff=unified&w=0#diff-55c3b71279b426dd25a724fc9b0dca23246b0c99805634b6c203543d7ceb4673L71-R71), [link](https://github.com/web-infra-dev/rspack/pull/2731/files?diff=unified&w=0#diff-55c3b71279b426dd25a724fc9b0dca23246b0c99805634b6c203543d7ceb4673L81-R81), [link](https://github.com/web-infra-dev/rspack/pull/2731/files?diff=unified&w=0#diff-55c3b71279b426dd25a724fc9b0dca23246b0c99805634b6c203543d7ceb4673L158-R158)) in `crates/rspack_core/src/chunk_graph.rs`

</details>
