### PR TITLE
fix: panic hook failed to restore after being suppressed

### DIFF
--- a/.changeset/honest-actors-smoke.md
+++ b/.changeset/honest-actors-smoke.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix: panic hook failed to restore after being suppressed


### PR DESCRIPTION
## Summary

Fix where default panic hook failed being restored after being suppressed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49f8730</samp>

Optimize `panic_hook_handler` function in `rspack_error` crate. Simplify panic hook logic and remove unused thread-local storage to improve panic handling performance and correctness.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 49f8730</samp>

*  Simplify and optimize the logic of setting and restoring the panic hook in `catch_unwind.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2734/files?diff=unified&w=0#diff-7bb4e9024cab90a4c63d8ffcec482e64feb6e2f0a6778e7b465dc102dc8a61f6L46-R47), [link](https://github.com/web-infra-dev/rspack/pull/2734/files?diff=unified&w=0#diff-7bb4e9024cab90a4c63d8ffcec482e64feb6e2f0a6778e7b465dc102dc8a61f6L63-R65))
*  Remove the unused thread-local storage for the panic hook in `catch_unwind.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2734/files?diff=unified&w=0#diff-7bb4e9024cab90a4c63d8ffcec482e64feb6e2f0a6778e7b465dc102dc8a61f6L63-R65))

</details>
