### PR TITLE
feat: passthrough panics for parallel-running futures

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -922,11 +922,7 @@ impl Compilation {
       })
       .collect::<FuturesResults<_>>();
 
-    let chunk_ukey_and_manifest = results
-      .into_inner()
-      .into_iter()
-      .collect::<std::result::Result<Vec<_>, _>>()
-      .expect("Failed to resolve render_manifest results");
+    let chunk_ukey_and_manifest = results.into_inner();
 
     chunk_ukey_and_manifest
       .into_iter()
@@ -1169,8 +1165,7 @@ impl Compilation {
       })
       .collect::<FuturesResults<_>>()
       .into_inner();
-    for item in chunk_hash_results {
-      let (chunk_ukey, hash) = item.expect("Failed to resolve chunk_hash results");
+    for (chunk_ukey, hash) in chunk_hash_results {
       if let Some(chunk) = self.chunk_by_ukey.get_mut(&chunk_ukey) {
         hash?.hash(&mut chunk.hash);
       }
@@ -1271,8 +1266,7 @@ impl Compilation {
       .collect::<FuturesResults<_>>()
       .into_inner();
 
-    for item in hash_results {
-      let (chunk_ukey, hashes) = item.expect("Failed to resolve content_hash results");
+    for (chunk_ukey, hashes) in hash_results {
       hashes?.into_iter().for_each(|hash| {
         if let Some(chunk) = self.chunk_by_ukey.get_mut(&chunk_ukey) && let Some((source_type, hash)) = hash {
           chunk.content_hash.insert(source_type, hash);

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -415,13 +415,7 @@ impl CopyPlugin {
           return None;
         }
 
-        Some(
-          copied_result
-            .into_inner()
-            .into_iter()
-            .flat_map(|it| it.ok())
-            .collect::<Vec<_>>(),
-        )
+        Some(copied_result.into_inner())
       }
       Err(e) => {
         if pattern.no_error_on_missing {


### PR DESCRIPTION
## Summary

This PR only passthrough the panics from futures for better debugging purposes.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

copilot:summary

~

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

copilot:walkthrough

</details>
