### PR TITLE
chore: remove continue-on-error from reusable-build

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -185,8 +185,6 @@ jobs:
     runs-on: ${{ needs.select.outputs.host }}
     # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
     timeout-minutes: 15
-    # Failing tests are unavoidable right now, let them fall through and build a binary for debugging purposes.
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The current setup is stable, let's fail the build if tests fail

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 47d3a26</samp>

Remove `continue-on-error` option from `test` job in `.github/workflows/reusable-build.yml`. This ensures that the workflow will fail if any tests fail, which improves the quality and reliability of the rspack project.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 47d3a26</samp>

* Remove `continue-on-error` option from `test` job to ensure workflow fails on test failures ([link](https://github.com/web-infra-dev/rspack/pull/2743/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L188-L189))

</details>
