### PR TITLE
fix: :bug: fix crash in multiCompiler

### DIFF
--- a/.changeset/metal-dodos-play.md
+++ b/.changeset/metal-dodos-play.md
@@ -1,0 +1,6 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+---
+
+fix: fix crash in multiCompiler

--- a/.github/actions/docker-test/action.yml
+++ b/.github/actions/docker-test/action.yml
@@ -42,7 +42,6 @@ runs:
           pnpm install
           pnpm run build:js
           pnpm run test:unit
-          # These two breaks on many targets, diabled for now
-          # pnpm run test:example
+          pnpm run test:example
           # e2e is disabled because this does not run on some targets
           # pnpm run test:e2e

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -279,8 +279,7 @@ jobs:
           pnpm install
           pnpm run build:js
           pnpm run test:unit
-          # These two breaks on many targets, diabled for now
-          # pnpm run test:example
+          pnpm run test:example
           # pnpm run test:e2e
 
       ### x86_64-pc-windows-msvc
@@ -303,6 +302,5 @@ jobs:
           pnpm install
           pnpm run build:js
           pnpm run test:unit
-          # These two breaks on many targets, diabled for now
-          # pnpm run test:example
+          pnpm run test:example
           # pnpm run test:e2e

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -221,6 +221,9 @@ impl Rspack {
   ) -> Result<()> {
     let handle_rebuild = |compiler: &mut Pin<Box<rspack_core::Compiler<_>>>| {
       // Safety: compiler is stored in a global hashmap, so it's guaranteed to be alive.
+      // The reason why use Box<Compiler> here instead of Compiler itself is that:
+      // Compilers may expand and change its layout underneath, make Compiler layout change.
+      // Use Box to make sure the Compiler layout won't change
       let compiler: &'static mut Pin<Box<rspack_core::Compiler<AsyncNodeWritableFileSystem>>> =
         unsafe { std::mem::transmute::<&'_ mut _, &'static mut _>(compiler) };
 
@@ -251,6 +254,9 @@ impl Rspack {
   pub fn unsafe_last_compilation<F: Fn(JsCompilation) -> Result<()>>(&self, f: F) -> Result<()> {
     let handle_last_compilation = |compiler: &mut Pin<Box<rspack_core::Compiler<_>>>| {
       // Safety: compiler is stored in a global hashmap, and compilation is only available in the callback of this function, so it is safe to cast to a static lifetime. See more in the warning part of this method.
+      // The reason why use Box<Compiler> here instead of Compiler itself is that:
+      // Compilers may expand and change its layout underneath, make Compiler layout change.
+      // Use Box to make sure the Compiler layout won't change
       let compiler: &'static mut Pin<Box<rspack_core::Compiler<AsyncNodeWritableFileSystem>>> =
         unsafe { std::mem::transmute::<&'_ mut _, &'static mut _>(compiler) };
       f(JsCompilation::from_compilation(&mut compiler.compilation))


### PR DESCRIPTION
## Summary

Fix crash in multiCompiler

fix: #2585 
fix: #2567 
fix: #2566 

The reason for the multiCompiler crash is that, In the Rust binding layer, there is a global HashMap that stores the mapping between Js object ID and Rust object. When JS calls, it uses the ID to get a reference from the Map and then calls compile. However, if another compiler is executing at the same time, creating a new Rust-side Compiler may cause the HashMap to expand, which may cause the memory underneath the HashMap to change. This can cause the moduleGraph in the seal phase to become the moduleGraph of another compiler, or cause illegal access, segfault and other strange errors.

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 539766b</samp>

This pull request fixes a memory error in the `node_binding` crate by using `Pin<Box<>>` wrappers, and improves the test coverage of the `MultiCompiler` class in `rspack`. It also updates the patch versions and the changeset file for two packages.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 539766b</samp>

*  Add a changeset file to document the patch versions and the fix message for the packages `@rspack/binding` and `@rspack/core` ([link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-671f81bdfda5ac5fed3bb0e3e931e5a36bea603eeb2bc3fda05976eabd4b595dR1-R6))
*  Wrap the `rspack_core::Compiler` type in a `Pin<Box<_>>` to prevent moving or dropping self-referential fields in the `node_binding` crate ([link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaR10), [link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL55-R56), [link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL115-R116), [link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL162-R163), [link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL188-R191), [link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL221-R224), [link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL251-R254))
*  Import the `Compiler` type from the `@rspack/core` package in the `MultiCompiler.test.ts` file ([link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-dd199b9c1f8104e907063ad5b91c898ab2f35bafb723d93fb653817d74d7bbfcL4-R4))
*  Add two new test cases to check the performance and concurrency of the multiCompiler under high pressure in the `MultiCompiler.test.ts` file ([link](https://github.com/web-infra-dev/rspack/pull/2744/files?diff=unified&w=0#diff-dd199b9c1f8104e907063ad5b91c898ab2f35bafb723d93fb653817d74d7bbfcR675-R729))

</details>
