### PR TITLE
fix(css): should generate css assets even if the imported css file is empty

### DIFF
--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -701,9 +701,11 @@ impl Plugin for CssPlugin {
         output
       })
       .collect::<Vec<ConcatSource>>();
+    let is_no_sources = sources.is_empty();
+
     let source = ConcatSource::new(sources);
 
-    if source.source().is_empty() {
+    if is_no_sources {
       Ok(Default::default())
     } else {
       let filename_template = get_css_chunk_filename_template(

--- a/packages/playground/fixtures/import-empty-css-file/package.json
+++ b/packages/playground/fixtures/import-empty-css-file/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-case",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/packages/playground/fixtures/import-empty-css-file/package.json
+++ b/packages/playground/fixtures/import-empty-css-file/package.json
@@ -1,8 +1,5 @@
 {
   "name": "test-case",
   "private": true,
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  }
+  "dependencies": {}
 }

--- a/packages/playground/fixtures/import-empty-css-file/rspack.config.js
+++ b/packages/playground/fixtures/import-empty-css-file/rspack.config.js
@@ -1,0 +1,27 @@
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	mode: "development",
+	entry: "./src/index.js",
+	devServer: {
+		hot: true
+	},
+	cache: false,
+	stats: "none",
+	infrastructureLogging: {
+		debug: false
+	},
+	builtins: {
+		html: [
+			{
+				template: "./src/index.html"
+			}
+		],
+		define: {
+			"process.env.NODE_ENV": JSON.stringify("development")
+		}
+	},
+	watchOptions: {
+		poll: 1000
+	}
+};

--- a/packages/playground/fixtures/import-empty-css-file/src/empty.js
+++ b/packages/playground/fixtures/import-empty-css-file/src/empty.js
@@ -1,0 +1,1 @@
+import "./empty.css";

--- a/packages/playground/fixtures/import-empty-css-file/src/index.html
+++ b/packages/playground/fixtures/import-empty-css-file/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Document</title>
+	</head>
+	<body>
+		<div id="root"></div>
+	</body>
+</html>

--- a/packages/playground/fixtures/import-empty-css-file/src/index.js
+++ b/packages/playground/fixtures/import-empty-css-file/src/index.js
@@ -1,0 +1,3 @@
+import("./empty").then(() => {
+	document.getElementById("root").innerText = "ok";
+});

--- a/packages/playground/fixtures/import-empty-css-file/test/index.test.ts
+++ b/packages/playground/fixtures/import-empty-css-file/test/index.test.ts
@@ -1,0 +1,5 @@
+test("should not throw error for importing empty css files", async () => {
+	expect(await page.textContent("#root")).toBe("ok");
+});
+
+export {};


### PR DESCRIPTION


## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fa8689d</samp>

Fix a bug in `rspack_plugin_css` crate and add a test case for importing an empty CSS file. The test case consists of a fixture with a `package.json`, a `rspack.config.js`, a `index.html`, a `index.js`, a `empty.js`, and a `index.test.ts` file.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fa8689d</samp>

*  Fix bug in `rspack_plugin_css` crate for importing empty CSS files ([link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-1bae8ad181bae8cff98c62704b7918cca060f3b5d1a27c7e0c3c6da55da70b25L704-R708))
* Add test case for importing empty CSS files using `rspack_plugin_css` crate ([link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-173a4c942e25586c11b322e44596962a879d53d9fafd5bb9ec3869fbf093b46aR1-R5), [link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-7ddcd3bdbeda0a98b83074839b263d8613515411d39540a3d5c0f97c017ad4efR1-R27), [link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-a7d21364744f201153dbf5c3bdb6acfa3650677a514756d61149b011f18a615fR1), [link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-2169229bdf81e5b0a6b886cab0d8ff655475597ad8b140486fc4fe5e0221ba25R1-R12), [link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-3c674a7f6878c5f6be52f8ac17e3a323a808feffbf363590bc4c1cf114f68c79R1-R3), [link](https://github.com/web-infra-dev/rspack/pull/2747/files?diff=unified&w=0#diff-906686fccf5a4c1d15abe36f35b20b693d9a2478803277d13bad880ad1d00edbR1-R5))

</details>
