### PR TITLE
style: fix clippy warning

### DIFF
--- a/crates/node_binding/src/js_values/compilation.rs
+++ b/crates/node_binding/src/js_values/compilation.rs
@@ -168,7 +168,7 @@ impl JsCompilation {
         Some(module) => {
           let compat_source = CompatSource::from(source).boxed();
           *module.ast_or_source_mut() =
-            NormalModuleAstOrSource::new_built(AstOrSource::Source(compat_source), &vec![]);
+            NormalModuleAstOrSource::new_built(AstOrSource::Source(compat_source), &[]);
           true
         }
         None => false,
@@ -245,7 +245,7 @@ impl JsCompilation {
       .map(|(n, _)| {
         (
           n.clone(),
-          JsChunkGroup::from_chunk_group(self.inner.entrypoint_by_name(n), &self.inner),
+          JsChunkGroup::from_chunk_group(self.inner.entrypoint_by_name(n), self.inner),
         )
       })
       .collect()
@@ -317,7 +317,7 @@ impl JsCompilation {
     self
       .inner
       .file_dependencies
-      .extend(deps.into_iter().map(|i| PathBuf::from(i)))
+      .extend(deps.into_iter().map(PathBuf::from))
   }
 
   #[napi]
@@ -325,7 +325,7 @@ impl JsCompilation {
     self
       .inner
       .context_dependencies
-      .extend(deps.into_iter().map(|i| PathBuf::from(i)))
+      .extend(deps.into_iter().map(PathBuf::from))
   }
 
   #[napi]
@@ -333,7 +333,7 @@ impl JsCompilation {
     self
       .inner
       .missing_dependencies
-      .extend(deps.into_iter().map(|i| PathBuf::from(i)))
+      .extend(deps.into_iter().map(PathBuf::from))
   }
 
   #[napi]
@@ -341,7 +341,7 @@ impl JsCompilation {
     self
       .inner
       .build_dependencies
-      .extend(deps.into_iter().map(|i| PathBuf::from(i)))
+      .extend(deps.into_iter().map(PathBuf::from))
   }
 }
 


### PR DESCRIPTION
- useless use of 'vec!'
- needless borrow
- redundant closure

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7508115</samp>

This pull request optimizes and refactors the `compilation.rs` module in the `node_binding` crate, which handles the conversion of JavaScript values to Rust values. It reduces memory usage and improves performance by avoiding unnecessary operations.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7508115</samp>

*  Simplify the syntax of creating empty vectors and mapping string slices to `PathBuf`s in `crates/node_binding/src/js_values/compilation.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL171-R171), [link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL248-R248), [link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL320-R320), [link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL328-R328), [link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL336-R336), [link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL344-R344))
* Avoid cloning `self.inner` when passing it to `from_chunk_group` method in the same file ([link](https://github.com/web-infra-dev/rspack/pull/2764/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL248-R248))

</details>
