### PR TITLE
chore: ignore the PRs created by github-actions in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -11,13 +11,13 @@ changelog:
     - title: Breaking Changes 🛠
       labels:
         - "release: breaking change"
-    - title: Performance improvements ⚡
+    - title: Performance Improvements ⚡
       labels:
         - "release: performance"
     - title: Exciting New Features 🎉
       labels:
         - "release: feature"
-    - title: Bug fixes 🐞
+    - title: Bug Fixes 🐞
       labels:
         - "release: bug fix"
     - title: Other Changes

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,6 +4,9 @@ changelog:
   exclude:
     labels:
       - "release: ignore"
+    authors:
+      # Ignore the release PR created by github-actions
+      - github-actions
   categories:
     - title: Breaking Changes 🛠
       labels:


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a130481</samp>

Added `authors` field to `.github/release.yml` to exclude release PR from release notes. This improves the readability and relevance of the release notes generated by the `release-drafter` action.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a130481</samp>

*  Add `authors` field to `release-drafter` configuration to exclude release PR from release notes ([link](https://github.com/web-infra-dev/rspack/pull/2766/files?diff=unified&w=0#diff-409fea45635f464aa0592700a92cf483be2f5b21b60f8f1b383756067ee79213R7-R9))

</details>
