### PR TITLE
ci: labeling PR with release: xxx automatically

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,8 @@
+# See context at https://github.com/web-infra-dev/rspack/discussions/2760
+
+"release: feature":
+  - "/^feat/"
+"release: performance":
+  - "/^perf/"
+"release: bug fix":
+  - "/^fix/"

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -44,3 +44,16 @@ jobs:
           disallowScopes: |
             [A-Z]+
           # Configure additional validation for the subject based on a regex.
+
+  release-labeling:
+    # See context at https://github.com/web-infra-dev/rspack/discussions/2760
+    name: Labeling for releasing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v2.5 #May not be the latest version
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/pr-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          sync-labels: 1


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!-- Delete the following copilot command if you prefer to write the summary manually -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c18c11d</samp>

This pull request adds automatic labeling of pull requests based on their titles using the github/issue-labeler action and a custom configuration file. This helps to streamline the release process for the `rspack` project.

## Related issue (if exists)

<!--- Provide link of related issues -->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c18c11d</samp>

* Add a configuration file for automatic pull request labeling ([link](https://github.com/web-infra-dev/rspack/pull/2767/files?diff=unified&w=0#diff-8c03f9af3dc7a8d6403f006a7c45be856010dac04aea2c0fddf73b49849646a9R1-R8))
* Add a job to the lint-pr workflow to run the issue-labeler action ([link](https://github.com/web-infra-dev/rspack/pull/2767/files?diff=unified&w=0#diff-fc98139577eb07d54e24aa5d41da856c636f5ad318d0ad700f13a457c136cb80R47-R59))

</details>
