### PR TITLE
feat: new experimental `SplitChunksPlugin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,6 +2300,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "better_scoped_tls",
  "cfg-if",
  "dashmap",
  "glob",
@@ -2328,6 +2329,7 @@ dependencies = [
  "rspack_plugin_remove_empty_chunks",
  "rspack_plugin_runtime",
  "rspack_plugin_split_chunks",
+ "rspack_plugin_split_chunks_new",
  "rspack_plugin_wasm",
  "rspack_regex",
  "serde",
@@ -2779,6 +2781,22 @@ dependencies = [
  "derivative",
  "rspack_core",
  "rspack_identifier",
+ "rspack_util",
+ "rustc-hash",
+ "tracing",
+]
+
+[[package]]
+name = "rspack_plugin_split_chunks_new"
+version = "0.1.0"
+dependencies = [
+ "dashmap",
+ "derivative",
+ "rayon",
+ "regex",
+ "rspack_core",
+ "rspack_identifier",
+ "rspack_regex",
  "rspack_util",
  "rustc-hash",
  "tracing",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1899,6 +1899,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "better_scoped_tls",
  "cfg-if",
  "dashmap",
  "glob",
@@ -1927,6 +1928,7 @@ dependencies = [
  "rspack_plugin_remove_empty_chunks",
  "rspack_plugin_runtime",
  "rspack_plugin_split_chunks",
+ "rspack_plugin_split_chunks_new",
  "rspack_plugin_wasm",
  "rspack_regex",
  "serde",
@@ -2377,6 +2379,22 @@ dependencies = [
  "derivative",
  "rspack_core",
  "rspack_identifier",
+ "rspack_util",
+ "rustc-hash",
+ "tracing",
+]
+
+[[package]]
+name = "rspack_plugin_split_chunks_new"
+version = "0.1.0"
+dependencies = [
+ "dashmap",
+ "derivative",
+ "rayon",
+ "regex",
+ "rspack_core",
+ "rspack_identifier",
+ "rspack_regex",
  "rspack_util",
  "rustc-hash",
  "tracing",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -164,6 +164,7 @@ export interface RawExperiments {
   lazyCompilation: boolean
   incrementalRebuild: boolean
   asyncWebAssembly: boolean
+  newSplitChunks: boolean
 }
 export interface RawExternalItem {
   type: "string" | "regexp" | "object"

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -369,7 +369,6 @@ export interface RawSplitChunksOptions {
 }
 export interface RawCacheGroupOptions {
   priority?: number
-  reuseExistingChunk?: boolean
   test?: string
   /** What kind of chunks should be selected. */
   chunks?: string

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -44,6 +44,7 @@ rspack_plugin_progress = { path = "../rspack_plugin_progress" }
 rspack_plugin_remove_empty_chunks = { path = "../rspack_plugin_remove_empty_chunks" }
 rspack_plugin_runtime = { path = "../rspack_plugin_runtime" }
 rspack_plugin_split_chunks = { path = "../rspack_plugin_split_chunks" }
+rspack_plugin_split_chunks_new = { path = "../rspack_plugin_split_chunks_new" }
 rspack_plugin_wasm = { path = "../rspack_plugin_wasm" }
 rspack_regex = { path = "../rspack_regex" }
 serde = { workspace = true, features = ["derive"] }
@@ -54,6 +55,7 @@ swc_core = { workspace = true, default-features = false, features = [
 # swc_ecma_transforms = { workspace = true, features = [
 #   "swc_ecma_transforms_react",
 # ] }
+better_scoped_tls = { workspace = true }
 swc_emotion = { workspace = true }
 swc_plugin_import = { workspace = true }
 tokio = { workspace = true, features = [

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -104,7 +104,9 @@ impl RawOptionsApply for RawOptions {
     let stats = self.stats.into();
     let cache = self.cache.into();
     let snapshot = self.snapshot.into();
-    let optimization = self.optimization.apply(plugins)?;
+    let optimization = IS_ENABLE_NEW_SPLIT_CHUNKS.set(&experiments.new_split_chunks, || {
+      self.optimization.apply(plugins)
+    })?;
     let node = self.node.map(|n| n.into());
     let dev_server: DevServerOptions = self.dev_server.into();
     let builtins = self.builtins.apply(plugins)?;

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -9,6 +9,7 @@ pub struct RawExperiments {
   pub lazy_compilation: bool,
   pub incremental_rebuild: bool,
   pub async_web_assembly: bool,
+  pub new_split_chunks: bool,
 }
 
 impl From<RawExperiments> for Experiments {
@@ -17,6 +18,7 @@ impl From<RawExperiments> for Experiments {
       lazy_compilation: value.lazy_compilation,
       incremental_rebuild: value.incremental_rebuild,
       async_web_assembly: value.async_web_assembly,
+      new_split_chunks: value.new_split_chunks,
     }
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -190,6 +190,10 @@ impl Module for Box<dyn Module> {
   fn get_resolve_options(&self) -> Option<&Resolve> {
     (**self).get_resolve_options()
   }
+
+  fn name_for_condition(&self) -> Option<Cow<str>> {
+    (**self).name_for_condition()
+  }
 }
 
 impl PartialEq for dyn Module + '_ {

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -3,4 +3,5 @@ pub struct Experiments {
   pub lazy_compilation: bool,
   pub incremental_rebuild: bool,
   pub async_web_assembly: bool,
+  pub new_split_chunks: bool,
 }

--- a/crates/rspack_plugin_split_chunks_new/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks_new/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+edition    = "2021"
+license    = "MIT"
+name       = "rspack_plugin_split_chunks_new"
+repository = "https://github.com/web-infra-dev/rspack"
+version    = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+dashmap           = { workspace = true }
+derivative        = { workspace = true }
+rayon             = { worksapce = true }
+regex             = { workspace = true }
+rspack_core       = { path = "../rspack_core" }
+rspack_identifier = { path = "../rspack_identifier" }
+rspack_regex      = { path = "../rspack_regex" }
+rspack_util       = { path = "../rspack_util" }
+rustc-hash        = { workspace = true }
+tracing           = { workspace = true }

--- a/crates/rspack_plugin_split_chunks_new/LICENSE
+++ b/crates/rspack_plugin_split_chunks_new/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2022-present Bytedance, Inc. and its affiliates.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -1,0 +1,17 @@
+use derivative::Derivative;
+
+use crate::common::{ChunkFilter, ModuleFilter};
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct CacheGroup {
+  #[derivative(Debug = "ignore")]
+  pub chunk_filter: ChunkFilter,
+  #[derivative(Debug = "ignore")]
+  pub test: ModuleFilter,
+  /// `name` is used to create chunk
+  pub name: String,
+  pub priority: f64,
+  /// number of referenced chunks
+  pub min_chunks: u32,
+}

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use rspack_core::{Chunk, ChunkGroupByUkey, Module, SourceType};
+use rustc_hash::FxHashMap;
+
+pub type ChunkFilter = Arc<dyn Fn(&Chunk, &ChunkGroupByUkey) -> bool + Send + Sync>;
+
+pub fn create_async_chunk_filter() -> ChunkFilter {
+  Arc::new(|chunk, chunk_group_db| !chunk.can_be_initial(chunk_group_db))
+}
+
+pub fn create_initial_chunk_filter() -> ChunkFilter {
+  Arc::new(|chunk, chunk_group_db| chunk.can_be_initial(chunk_group_db))
+}
+
+pub fn create_all_chunk_filter() -> ChunkFilter {
+  Arc::new(|_chunk, _chunk_group_db| true)
+}
+
+pub fn create_chunk_filter_from_str(chunks: &str) -> ChunkFilter {
+  match chunks {
+    "initial" => create_initial_chunk_filter(),
+    "async" => create_async_chunk_filter(),
+    "all" => create_all_chunk_filter(),
+    _ => panic!("Invalid chunk type: {chunks}"),
+  }
+}
+
+pub type ModuleFilter = Arc<dyn Fn(&dyn Module) -> bool + Send + Sync>;
+
+pub fn create_default_module_filter() -> ModuleFilter {
+  Arc::new(|_| true)
+}
+
+pub fn create_module_filter_from_rspack_regex(re: rspack_regex::RspackRegex) -> ModuleFilter {
+  Arc::new(move |module| {
+    module
+      .name_for_condition()
+      .map_or(false, |name| re.test(&name))
+  })
+}
+
+pub fn create_module_filter_from_regex(re: regex::Regex) -> ModuleFilter {
+  Arc::new(move |module| {
+    module
+      .name_for_condition()
+      .map_or(false, |name| re.is_match(&name))
+  })
+}
+
+pub fn create_module_filter(re: Option<String>) -> ModuleFilter {
+  re.map(|test| {
+    let re = regex::Regex::new(&test).unwrap_or_else(|_| panic!("Invalid regex: {}", &test));
+    create_module_filter_from_regex(re)
+  })
+  .unwrap_or_else(create_default_module_filter)
+}
+
+pub(crate) type SplitChunkSizes = FxHashMap<SourceType, f64>;
+
+// pub type CacheGroupNameGetter = Arc<dyn Fn(&dyn Module) -> String + Send + Sync>;

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -1,0 +1,16 @@
+#![feature(map_many_mut)]
+
+pub(crate) mod cache_group;
+pub(crate) mod common;
+pub(crate) mod module_group;
+pub(crate) mod plugin;
+
+pub use crate::{
+  cache_group::CacheGroup,
+  common::{
+    create_all_chunk_filter, create_async_chunk_filter, create_chunk_filter_from_str,
+    create_default_module_filter, create_initial_chunk_filter, create_module_filter,
+    create_module_filter_from_regex, create_module_filter_from_rspack_regex,
+  },
+  plugin::{PluginOptions, SplitChunksPlugin},
+};

--- a/crates/rspack_plugin_split_chunks_new/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/module_group.rs
@@ -1,0 +1,93 @@
+use derivative::Derivative;
+use rspack_core::{ChunkUkey, Module};
+use rspack_identifier::IdentifierSet;
+use rustc_hash::FxHashSet;
+
+use crate::common::SplitChunkSizes;
+
+/// `ModuleGroup` is a abstraction of middle step for splitting chunks.
+///
+/// `ModuleGroup` captures/contains a bunch of modules due to the `optimization.splitChunks` configuration.
+///
+/// `ModuleGroup` would be transform into `Chunk` in the end.
+///
+/// The original name of `ModuleGroup` is `ChunkInfoItem` borrowed from Webpack
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub(crate) struct ModuleGroup {
+  #[derivative(Debug = "ignore")]
+  pub modules: IdentifierSet,
+  pub cache_group_index: usize,
+  pub cache_group_priority: f64,
+  pub name: String,
+  pub sizes: SplitChunkSizes,
+  #[derivative(Debug = "ignore")]
+  pub chunks: FxHashSet<ChunkUkey>,
+}
+
+impl ModuleGroup {
+  pub fn add_module(&mut self, module: &dyn Module) {
+    let old_len = self.modules.len();
+    self.modules.insert(module.identifier());
+
+    if self.modules.len() != old_len {
+      module.source_types().iter().for_each(|ty| {
+        let size = self.sizes.entry(*ty).or_default();
+        *size += module.size(ty);
+      });
+    }
+  }
+
+  pub fn remove_module(&mut self, module: &dyn Module) {
+    let old_len = self.modules.len();
+    self.modules.remove(&module.identifier());
+
+    if self.modules.len() != old_len {
+      module.source_types().iter().for_each(|ty| {
+        let size = self.sizes.entry(*ty).or_default();
+        *size -= module.size(ty);
+        *size = size.max(0.0)
+      });
+    }
+  }
+}
+
+pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
+  // 1. by priority
+  let diff_priority = a.cache_group_priority - b.cache_group_priority;
+  if diff_priority != 0f64 {
+    return diff_priority;
+  }
+  // 2. by number of chunks
+  let diff_count = a.chunks.len() as f64 - b.chunks.len() as f64;
+  if diff_count != 0f64 {
+    return diff_count;
+  }
+
+  // // 3. by size reduction
+  // let a_size_reduce = total_size(&a.sizes) * (a.chunks.len() - 1) as f64;
+  // let b_size_reduce = total_size(&b.sizes) * (b.chunks.len() - 1) as f64;
+  // let diff_size_reduce = a_size_reduce - b_size_reduce;
+  // if diff_size_reduce != 0f64 {
+  //   return diff_size_reduce;
+  // }
+  // 4. by cache group index
+  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
+  if index_diff != 0f64 {
+    return index_diff;
+  }
+
+  // 5. by number of modules (to be able to compare by identifier)
+  let modules_a_len = a.modules.len();
+  let modules_b_len = b.modules.len();
+  let diff = modules_a_len as f64 - modules_b_len as f64;
+  if diff != 0f64 {
+    return diff;
+  }
+
+  let mut modules_a = a.modules.iter().collect::<Vec<_>>();
+  let mut modules_b = b.modules.iter().collect::<Vec<_>>();
+  modules_a.sort_unstable();
+  modules_b.sort_unstable();
+  modules_a.cmp(&modules_b) as usize as f64
+}

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -1,0 +1,288 @@
+use std::fmt::Debug;
+
+use dashmap::DashMap;
+use rayon::prelude::*;
+use rspack_core::{ChunkUkey, Compilation, Module, Plugin};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::{
+  cache_group::CacheGroup,
+  module_group::{compare_entries, ModuleGroup},
+};
+
+struct _OverallOptions {
+  pub cache_groups: Vec<CacheGroup>,
+  pub min_chunks: u32,
+  pub max_size: f64,
+  pub min_size: f64,
+}
+
+type ModuleGroupMap = FxHashMap<String, ModuleGroup>;
+
+pub struct PluginOptions {
+  pub cache_groups: Vec<CacheGroup>,
+}
+
+pub struct SplitChunksPlugin {
+  // overall: OverallOptions,
+  cache_groups: Vec<CacheGroup>,
+}
+
+impl SplitChunksPlugin {
+  pub fn new(options: PluginOptions) -> Self {
+    Self {
+      cache_groups: options.cache_groups,
+    }
+  }
+
+  fn inner_impl(&self, compilation: &mut Compilation) {
+    let mut module_group_map = self.prepare_module_and_chunks_info_map(compilation);
+
+    while !module_group_map.is_empty() {
+      let (_module_group_key, module_group) = self.find_best_module_group(&mut module_group_map);
+
+      let new_chunk = if let Some(chunk) = compilation.named_chunks.get(&module_group.name) {
+        *chunk
+      } else {
+        let chunk = Compilation::add_named_chunk(
+          module_group.name.clone(),
+          &mut compilation.chunk_by_ukey,
+          &mut compilation.named_chunks,
+        );
+
+        chunk
+          .chunk_reasons
+          .push("Create by split chunks".to_string());
+        chunk.ukey
+      };
+      compilation.chunk_graph.add_chunk(new_chunk);
+
+      let used_chunks = &module_group.chunks;
+      self.move_modules_to_new_chunk_and_remove_from_old_chunks(
+        &module_group,
+        new_chunk,
+        used_chunks,
+        compilation,
+      );
+      self.split_from_original_chunks(&module_group, used_chunks, new_chunk, compilation);
+
+      self.remove_all_modules_from_other_module_groups(
+        &module_group,
+        &mut module_group_map,
+        used_chunks,
+        compilation,
+      )
+    }
+  }
+
+  fn _ensure_max_size_fit(&self, _compilation: &mut Compilation) {}
+
+  fn remove_all_modules_from_other_module_groups(
+    &self,
+    item: &ModuleGroup,
+    module_group_map: &mut ModuleGroupMap,
+    used_chunks: &FxHashSet<ChunkUkey>,
+    compilation: &mut Compilation,
+  ) {
+    // remove all modules from other entries and update size
+    let keys_of_empty_group = module_group_map
+      .iter_mut()
+      .par_bridge()
+      .filter_map(|(key, each_module_group)| {
+        let has_overlap = each_module_group.chunks.union(used_chunks).next().is_some();
+        if has_overlap {
+          let mut updated = false;
+          for module in &item.modules {
+            if each_module_group.modules.contains(module) {
+              let module = compilation
+                .module_graph
+                .module_by_identifier(module)
+                .unwrap_or_else(|| panic!("Module({module}) not found"));
+              each_module_group.remove_module(module);
+              updated = true;
+            }
+          }
+
+          if updated && each_module_group.modules.is_empty() {
+            return Some(key.clone());
+          }
+        }
+
+        None
+      })
+      .collect::<Vec<_>>();
+
+    keys_of_empty_group.into_iter().for_each(|key| {
+      module_group_map.remove(&key);
+    });
+  }
+
+  /// This de-duplicated each module fro other chunks, make sure there's only one copy of each module.
+  fn move_modules_to_new_chunk_and_remove_from_old_chunks(
+    &self,
+    item: &ModuleGroup,
+    new_chunk: ChunkUkey,
+    used_chunks: &FxHashSet<ChunkUkey>,
+    compilation: &mut Compilation,
+  ) {
+    for module_identifier in &item.modules {
+      // First, we remove modules from old chunks
+
+      // Remove module from old chunks
+      for used_chunk in used_chunks {
+        compilation
+          .chunk_graph
+          .disconnect_chunk_and_module(used_chunk, *module_identifier);
+      }
+
+      // Add module to new chunk
+      compilation
+        .chunk_graph
+        .connect_chunk_and_module(new_chunk, *module_identifier);
+    }
+  }
+
+  /// Since the modules are moved into the `new_chunk`, we should
+  /// create a connection between the `new_chunk` and `original_chunks`.
+  /// Thus, if `original_chunks` want to know which chunk contains moved modules,
+  /// it could easily find out.
+  fn split_from_original_chunks(
+    &self,
+    _item: &ModuleGroup,
+    original_chunks: &FxHashSet<ChunkUkey>,
+    new_chunk: ChunkUkey,
+    compilation: &mut Compilation,
+  ) {
+    let new_chunk_ukey = new_chunk;
+    for original_chunk in original_chunks {
+      let [new_chunk, original_chunk] = compilation
+        .chunk_by_ukey
+        ._todo_should_remove_this_method_inner_mut()
+        .get_many_mut([&new_chunk_ukey, original_chunk])
+        .expect("TODO:");
+      original_chunk.split(new_chunk, &mut compilation.chunk_group_by_ukey);
+    }
+  }
+
+  fn find_best_module_group(&self, module_group_map: &mut ModuleGroupMap) -> (String, ModuleGroup) {
+    // perf(hyf): I wonder if we could use BinaryHeap to avoid sorting for find_best_module_group call
+    debug_assert!(!module_group_map.is_empty());
+    let mut iter = module_group_map.iter();
+    let (key, mut best_module_group) = iter.next().expect("at least have one item");
+
+    let mut best_entry_key = key.clone();
+    for (key, each_module_group) in iter {
+      if compare_entries(best_module_group, each_module_group) < 0f64 {
+        best_entry_key = key.clone();
+        best_module_group = each_module_group;
+      }
+    }
+
+    let best_module_group = module_group_map
+      .remove(&best_entry_key)
+      .expect("item should exist");
+    (best_entry_key, best_module_group)
+  }
+
+  fn prepare_module_and_chunks_info_map(&self, compilation: &mut Compilation) -> ModuleGroupMap {
+    let chunk_db = &compilation.chunk_by_ukey;
+    let chunk_group_db = &compilation.chunk_group_by_ukey;
+
+    let module_and_corresponding_cache_group = compilation
+      .module_graph
+      .modules()
+      .values()
+      .par_bridge()
+      .flat_map(|module| {
+        let belong_to_chunks = compilation
+          .chunk_graph
+          .get_modules_chunks((*module).identifier());
+
+        // A module may match multiple CacheGroups
+        self.cache_groups.par_iter().enumerate().filter_map(
+          move |(cache_group_index, cache_group)| {
+            let is_match_the_test = (cache_group.test)(module);
+
+            if !is_match_the_test {
+              return None;
+            }
+
+            let selected_chunks = belong_to_chunks
+              .iter()
+              .map(|c| chunk_db.get(c).expect("Should have a chunk here"))
+              .filter(|c| (cache_group.chunk_filter)(c, chunk_group_db))
+              .collect::<Vec<_>>();
+
+            if selected_chunks.len() < cache_group.min_chunks as usize {
+              return None;
+            }
+
+            Some((module, cache_group_index, cache_group, selected_chunks))
+          },
+        )
+      });
+
+    let chunks_info_map: DashMap<String, ModuleGroup> = DashMap::default();
+
+    module_and_corresponding_cache_group.for_each(
+      |(module, cache_group_index, cache_group, selected_chunks)| {
+        let key = ["name: ", &cache_group.name].join("");
+
+        let mut chunks_info_item = chunks_info_map.entry(key).or_insert_with(|| ModuleGroup {
+          // The ChunkInfoItem is not existed. Initialize it.
+          modules: Default::default(),
+          cache_group_index,
+          cache_group_priority: cache_group.priority,
+          sizes: Default::default(),
+          chunks: Default::default(),
+          name: cache_group.name.clone(),
+        });
+
+        chunks_info_item.add_module(module);
+        chunks_info_item
+          .chunks
+          .extend(selected_chunks.iter().map(|c| c.ukey))
+      },
+    );
+
+    chunks_info_map.into_iter().collect()
+  }
+}
+
+trait EstimatedSize {
+  fn estimated_size(&self, source_type: &rspack_core::SourceType) -> f64;
+}
+
+impl<T: Module> EstimatedSize for T {
+  fn estimated_size(&self, source_type: &rspack_core::SourceType) -> f64 {
+    use rspack_core::ModuleType;
+    let coefficient: f64 = match self.module_type() {
+      // 5.0 is a number in practice
+      rspack_core::ModuleType::Jsx
+      | ModuleType::JsxDynamic
+      | ModuleType::JsxEsm
+      | ModuleType::Tsx => 7.5,
+      ModuleType::Js | ModuleType::JsDynamic => 1.5,
+      _ => 1.0,
+    };
+
+    self.size(source_type) * coefficient
+  }
+}
+
+impl Debug for SplitChunksPlugin {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("SplitChunksPlugin").finish()
+  }
+}
+
+impl Plugin for SplitChunksPlugin {
+  fn optimize_chunks(
+    &mut self,
+    _ctx: rspack_core::PluginContext,
+    args: rspack_core::OptimizeChunksArgs,
+  ) -> rspack_core::PluginOptimizeChunksOutput {
+    self.inner_impl(args.compilation);
+    Ok(())
+  }
+}

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -447,16 +447,23 @@ function getRawSnapshotOptions(
 function getRawExperiments(
 	experiments: Experiments
 ): RawOptions["experiments"] {
-	const { lazyCompilation, incrementalRebuild, asyncWebAssembly } = experiments;
+	const {
+		lazyCompilation,
+		incrementalRebuild,
+		asyncWebAssembly,
+		newSplitChunks
+	} = experiments;
 	assert(
 		!isNil(lazyCompilation) &&
 			!isNil(incrementalRebuild) &&
-			!isNil(asyncWebAssembly)
+			!isNil(asyncWebAssembly) &&
+			!isNil(newSplitChunks)
 	);
 	return {
 		lazyCompilation,
 		incrementalRebuild,
-		asyncWebAssembly
+		asyncWebAssembly,
+		newSplitChunks
 	};
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -137,6 +137,7 @@ const applyExperimentsDefaults = (experiments: Experiments) => {
 	D(experiments, "incrementalRebuild", true);
 	D(experiments, "lazyCompilation", false);
 	D(experiments, "asyncWebAssembly", false);
+	D(experiments, "newSplitChunks", false);
 };
 
 const applySnapshotDefaults = (

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -517,6 +517,7 @@ export interface Experiments {
 	lazyCompilation?: boolean;
 	incrementalRebuild?: boolean;
 	asyncWebAssembly?: boolean;
+	newSplitChunks?: boolean;
 }
 
 ///// Watch /////

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -120,6 +120,7 @@ describe("snapshots", () => {
 		    "asyncWebAssembly": false,
 		    "incrementalRebuild": true,
 		    "lazyCompilation": false,
+		    "newSplitChunks": false,
 		  },
 		  "externals": undefined,
 		  "externalsPresets": {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- This is a complete rewrite of `SplitChunksPlugin` without breaking the existing and exposed options of Rspack
- The new implementation is disabled by default
- I would use this implementation to solve problems related to initial loading performance on the FS project
- I would keep adding integration tests of Webpack for this implementation.

The key reason for this rewrite is to have clean and understandable code for `SplitChunks` feature. And more importantly __the behaviors of this new `SplitChunksPlugin` is more predictable and easy for debugging__.

---

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff8922b</samp>

This pull request introduces a new crate `rspack_plugin_split_chunks_new` that implements an experimental feature for splitting chunks based on the `optimization.splitChunks` configuration. The feature can be enabled by setting the `experiments.newSplitChunks` option in the `rspack.config.js` file. The pull request also updates the `rspack_binding_options` and `rspack_core` crates to support the new feature and the new plugin. The pull request modifies the `Cargo.toml`, `LICENSE`, and `src` files of the new crate, and the `src/options` and `src/module.rs` files of the existing crates.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff8922b</samp>

*  Add a new crate `rspack_plugin_split_chunks_new` that implements a new algorithm for splitting chunks based on the `optimization.splitChunks` configuration ([link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-bb77f4a776a00a1377e31ab5f38a079c93e6767ba399c09227c2def2a2067056R1-R20), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-bf71320a0a90af993418781a96c7ac16b55237e2d3898aac60ba3f4eb9057b6eR1-R22), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR1-R17), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9R1-R61), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812R1-R16), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-9fe0bd2bb40e0e56daf84e7c76107d80d06b5b306b639db5194b24e5daaca8c7R1-R93), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R1-R288))
*  Add a dependency on the new crate in the `rspack_binding_options` crate and use a thread-local variable to enable the new plugin as an experimental feature controlled by the `experiments.newSplitChunks` option in the `rspack.config.js` file ([link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aR47), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aR58), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L107-R109), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-ee356163b888e01f5855248826002b944820b3eac1c6cb3e5868d2a34c3fc11dR12), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-ee356163b888e01f5855248826002b944820b3eac1c6cb3e5868d2a34c3fc11dR21), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062R1), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062R11-R12), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062L28-R38), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-c88be6064f9723a97e920eb73113c11ea487b1be35aa57be4889f5caf4fd2a74R6))
*  Modify the `From` implementations of the `RawCacheGroupOptions` and `RawSplitChunksOptions` structs to map the existing configuration format to the new plugin options and disable the `reuseExistingChunk` option for the new plugin ([link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L61-R61), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L93-R93), [link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R117-R158))
*  Add a new method `name_for_condition` to the `Module` trait to provide a common interface for the new plugin to filter modules based on their names ([link](https://github.com/web-infra-dev/rspack/pull/2773/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0R193-R196))

</details>
