### PR TITLE
fix: redirect `name_for_condition` in BoxModule

### DIFF
--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -190,6 +190,10 @@ impl Module for Box<dyn Module> {
   fn get_resolve_options(&self) -> Option<&Resolve> {
     (**self).get_resolve_options()
   }
+
+  fn name_for_condition(&self) -> Option<Cow<str>> {
+    (**self).name_for_condition()
+  }
 }
 
 impl PartialEq for dyn Module + '_ {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa048c9</samp>

Add `name_for_condition` method to `Module` trait and use it in `ModuleGraph`. This allows generating descriptive names for modules based on some condition when showing the dependency graph.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa048c9</samp>

* Implement `name_for_condition` method for `Module` trait object ([link](https://github.com/web-infra-dev/rspack/pull/2778/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0R193-R196))

</details>
