### PR TITLE
chore: Revert "chore: 🤖 bump napi (#2717)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,12 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,7 +324,7 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "textwrap 0.11.0",
  "unicode-width",
 ]
@@ -341,7 +335,7 @@ version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -1503,18 +1497,18 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "napi"
-version = "2.12.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fadcfd21e9bc06b4d4c307f5072c4ac341bd059f950f060c59eb32ec3613283"
+checksum = "2412d19892730f62fd592f8af41606ca6717ea1eca026103cd44b447829f00c1"
 dependencies = [
  "anyhow",
- "bitflags 2.1.0",
+ "bitflags",
  "ctor",
- "napi-derive",
  "napi-sys",
  "once_cell",
  "serde",
  "serde_json",
+ "thread_local",
  "tokio",
 ]
 
@@ -1526,9 +1520,9 @@ checksum = "882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e"
 
 [[package]]
 name = "napi-derive"
-version = "2.12.3"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2ac63101a19228b0881694cac07468d642fd10e4f943a9c9feebeebf1a4787"
+checksum = "03f15c1ac0eac01eca2a24c27905ab47f7411acefd829d0d01fb131dc39befd7"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -1539,16 +1533,15 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.49"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e32b5bc4d803e40b783b0aa3fe488eac8711cfaa4c5c9915293dfd3d0b99925"
+checksum = "4930d5fa70f5663b9e7d6b4f0816b70d095574ee7f3c865fdb8c43b0f7e6406d"
 dependencies = [
  "convert_case",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.16",
  "syn 1.0.109",
 ]
 
@@ -2189,7 +2182,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -2366,7 +2359,7 @@ dependencies = [
  "async-recursion",
  "async-scoped",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags",
  "dashmap",
  "dyn-clone",
  "futures",
@@ -2587,7 +2580,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "dashmap",
  "data-encoding",
  "heck",
@@ -2693,7 +2686,7 @@ dependencies = [
  "async-trait",
  "base64",
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "dashmap",
  "either",
  "linked_hash_set",
@@ -2843,7 +2836,7 @@ dependencies = [
 name = "rspack_symbol"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "rspack_identifier",
  "serde",
  "serde_json",
@@ -2932,7 +2925,7 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
@@ -3553,7 +3546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f717f3ff4c3352e8291785692668f44f1cb5455078da8ab55e648d5c7b24f325"
 dependencies = [
  "auto_impl",
- "bitflags 1.3.2",
+ "bitflags",
  "rustc-hash",
  "serde",
  "swc_atoms",
@@ -3582,7 +3575,7 @@ version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7e2ab24d5ce9a2d41085f498ef82d58e128d6b3a9be9f85ed4f1ac87257293"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "once_cell",
  "serde",
  "serde_json",
@@ -3629,7 +3622,7 @@ version = "0.145.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b26c2eece61ff5be8f2ca0600d2cf48a42ccfa83c10b5ea4c5e0e6700f9b20"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "lexical",
  "serde",
  "swc_atoms",
@@ -3688,7 +3681,7 @@ version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bc96ac4740ddd7e09baaa153b6cf74e62ed7436d674606c060ea01fd7c20cd0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "is-macro",
  "num-bigint",
  "scoped-tls",
@@ -3949,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0020e7cccbe4f1a9cae29d8b3bc54fcdc2cff1396cd6a4006977c1008c7b4fe3"
 dependencies = [
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "indexmap",
  "once_cell",
  "phf",
@@ -3972,7 +3965,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b87668640fe6d63ecabaae1805534d1445ff63382ab8961cd623ccdeb1bfbc"
 dependencies = [
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "indexmap",
  "once_cell",
  "phf",
@@ -4051,7 +4044,7 @@ dependencies = [
  "Inflector",
  "ahash",
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags",
  "indexmap",
  "is-macro",
  "path-clean",
@@ -4320,7 +4313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21020157564ad5b02728a2874687b14cf192b4af46f544fbf87adab5626fbb67"
 dependencies = [
  "auto_impl",
- "bitflags 1.3.2",
+ "bitflags",
  "rustc-hash",
  "swc_atoms",
  "swc_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ itertools          = { version = "0.10.1" }
 json               = { version = "0.12.4" }
 linked_hash_set    = { version = "0.1.4" }
 mimalloc-rust      = { version = "0.2" }
-napi               = { version = "=2.12.2" }
+napi               = { version = "=2.11.1" }
 napi-build         = { version = "=2.0.1" }
-napi-derive        = { version = "=2.12.3" }
+napi-derive        = { version = "=2.11.0" }
 napi-sys           = { version = "=2.2.3" }
 nodejs-resolver    = { version = "0.0.78" }
 once_cell          = { version = "1.17.0" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -195,12 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
-
-[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,18 +1174,18 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "napi"
-version = "2.12.2"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fadcfd21e9bc06b4d4c307f5072c4ac341bd059f950f060c59eb32ec3613283"
+checksum = "2412d19892730f62fd592f8af41606ca6717ea1eca026103cd44b447829f00c1"
 dependencies = [
  "anyhow",
- "bitflags 2.1.0",
+ "bitflags",
  "ctor",
- "napi-derive",
  "napi-sys",
  "once_cell",
  "serde",
  "serde_json",
+ "thread_local",
  "tokio",
 ]
 
@@ -1203,9 +1197,9 @@ checksum = "882a73d9ef23e8dc2ebbffb6a6ae2ef467c0f18ac10711e4cc59c5485d41df0e"
 
 [[package]]
 name = "napi-derive"
-version = "2.12.3"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2ac63101a19228b0881694cac07468d642fd10e4f943a9c9feebeebf1a4787"
+checksum = "03f15c1ac0eac01eca2a24c27905ab47f7411acefd829d0d01fb131dc39befd7"
 dependencies = [
  "convert_case",
  "napi-derive-backend",
@@ -1216,16 +1210,15 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.49"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e32b5bc4d803e40b783b0aa3fe488eac8711cfaa4c5c9915293dfd3d0b99925"
+checksum = "4930d5fa70f5663b9e7d6b4f0816b70d095574ee7f3c865fdb8c43b0f7e6406d"
 dependencies = [
  "convert_case",
  "once_cell",
  "proc-macro2",
  "quote",
  "regex",
- "semver 1.0.16",
  "syn 1.0.107",
 ]
 
@@ -1826,7 +1819,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -1953,7 +1946,7 @@ dependencies = [
  "async-recursion",
  "async-scoped",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags",
  "dashmap",
  "dyn-clone",
  "futures",
@@ -2192,7 +2185,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "dashmap",
  "data-encoding",
  "heck",
@@ -2293,7 +2286,7 @@ dependencies = [
  "async-trait",
  "base64",
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "dashmap",
  "either",
  "linked_hash_set",
@@ -2440,7 +2433,7 @@ dependencies = [
 name = "rspack_symbol"
 version = "0.1.0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "rspack_identifier",
  "serde",
  "serde_json",
@@ -3019,7 +3012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f717f3ff4c3352e8291785692668f44f1cb5455078da8ab55e648d5c7b24f325"
 dependencies = [
  "auto_impl",
- "bitflags 1.3.2",
+ "bitflags",
  "rustc-hash",
  "serde",
  "swc_atoms",
@@ -3048,7 +3041,7 @@ version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7e2ab24d5ce9a2d41085f498ef82d58e128d6b3a9be9f85ed4f1ac87257293"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "once_cell",
  "serde",
  "serde_json",
@@ -3095,7 +3088,7 @@ version = "0.145.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b26c2eece61ff5be8f2ca0600d2cf48a42ccfa83c10b5ea4c5e0e6700f9b20"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "lexical",
  "serde",
  "swc_atoms",
@@ -3154,7 +3147,7 @@ version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bc96ac4740ddd7e09baaa153b6cf74e62ed7436d674606c060ea01fd7c20cd0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
  "is-macro",
  "num-bigint",
  "scoped-tls",
@@ -3415,7 +3408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0020e7cccbe4f1a9cae29d8b3bc54fcdc2cff1396cd6a4006977c1008c7b4fe3"
 dependencies = [
  "better_scoped_tls",
- "bitflags 1.3.2",
+ "bitflags",
  "indexmap",
  "once_cell",
  "phf",
@@ -3517,7 +3510,7 @@ dependencies = [
  "Inflector",
  "ahash",
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags",
  "indexmap",
  "is-macro",
  "path-clean",
@@ -3786,7 +3779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21020157564ad5b02728a2874687b14cf192b4af46f544fbf87adab5626fbb67"
 dependencies = [
  "auto_impl",
- "bitflags 1.3.2",
+ "bitflags",
  "rustc-hash",
  "swc_atoms",
  "swc_common",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -17,8 +17,8 @@ async-trait = "0.1.53"
 backtrace = "0.3"
 dashmap = "5.4.0"
 futures = "0.3"
-napi = { version = "=2.12.2" }
-napi-derive = { version = "=2.12.3" }
+napi = { version = "=2.11.1" }
+napi-derive = { version = "=2.11.0" }
 napi-sys = { version = "=2.2.3" }
 once_cell = "1"
 regex = "1.6.0"

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -28,7 +28,7 @@
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
-    "@napi-rs/cli": "2.15.2",
+    "@napi-rs/cli": "2.14.2",
     "cross-env": "^7.0.3",
     "npm-run-all": "4.1.5",
     "why-is-node-running": "2.2.1"

--- a/packages/playground/fixtures/import-empty-css-file/test/index.test.ts
+++ b/packages/playground/fixtures/import-empty-css-file/test/index.test.ts
@@ -1,3 +1,4 @@
 test("should not throw error for importing empty css files", async () => {
 	expect(await page.textContent("#root")).toBe("ok");
 });
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
 
   crates/node_binding:
     specifiers:
-      '@napi-rs/cli': 2.15.2
+      '@napi-rs/cli': 2.14.2
       '@rspack/binding-darwin-arm64': workspace:*
       '@rspack/binding-darwin-x64': workspace:*
       '@rspack/binding-linux-x64-gnu': workspace:*
@@ -85,7 +85,7 @@ importers:
       '@rspack/binding-linux-x64-gnu': link:../../npm/linux-x64-gnu
       '@rspack/binding-win32-x64-msvc': link:../../npm/win32-x64-msvc
     devDependencies:
-      '@napi-rs/cli': 2.15.2
+      '@napi-rs/cli': 2.14.2
       cross-env: 7.0.3
       npm-run-all: 4.1.5
       why-is-node-running: 2.2.1
@@ -4366,12 +4366,6 @@ packages:
 
   /@napi-rs/cli/2.14.2:
     resolution: {integrity: sha512-g2bGIhu+p/+wZJlNYGYbb2feQs7vF0dKIMJY8jOBdhU4r14TqxBPEr7P/xoFzHiJ7vCNdJ0rldcC+nOSnJwCTw==}
-    engines: {node: '>= 10'}
-    hasBin: true
-    dev: true
-
-  /@napi-rs/cli/2.15.2:
-    resolution: {integrity: sha512-80tBCtCnEhAmFtB9oPM0FL74uW7fAmtpeqjvERH7Q1z/aZzCAs/iNfE7U3ehpwg9Q07Ob2Eh/+1guyCdX/p24w==}
     engines: {node: '>= 10'}
     hasBin: true
     dev: true

--- a/scripts/check_rust_dependency.js
+++ b/scripts/check_rust_dependency.js
@@ -5,11 +5,7 @@ const child_process = require("child_process");
 const TOML = require("@iarna/toml");
 
 const crates_dir = path.resolve(__dirname, "../crates");
-
-// 'bitflags': napi has upgraded to latest `bitfalgs@2.x.x`, but there are still lots of dependencies still use `bitflags@1.x.x`, like `clap, swc`,
-// this cause CI failed in version checking, `bitflags@2.x.x` still need some time to adopt in rust community, but we need upgrade napi-rs to latest to fix some bug.
-// so bypass `bitflags` for now.
-const ignore_deps = ['bitflags'];
+const ignore_deps = [];
 
 function getRepeatDeps() {
 	const treeResult = child_process


### PR DESCRIPTION
This reverts commit 59c42ba3f16778abd6ea761adeda6120faae9c38.

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary
1. I noticed that the napi bump caused x86_64-apple-darwin test to fail, revert it for now.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b531c55</samp>

Downgraded napi-related dependencies to fix compatibility issues with nodejs-resolver and Node.js 16. Added a placeholder test file for an import-empty-css-file fixture in the playground package. Removed an obsolete ignore_deps value from the check_rust_dependency script.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b531c55</samp>

*  Downgrade napi, napi-derive, and napi-sys dependencies from 2.12.x to 2.11.x in `Cargo.toml` files of root and node_binding crate to fix compatibility issue with nodejs-resolver crate ([link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L40-R42), [link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L20-R21))
* Downgrade @napi-rs/cli devDependency from 2.15.2 to 2.14.2 in `package.json` and `pnpm-lock.yaml` files of node_binding crate to match napi version and avoid conflicts or bugs with newer CLI tool ([link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-1c9c1e09f463e90b0e5966c4ae0ee5cb7de494eb9a5eec3c1a2b22c77134d257L31-R31), [link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL74-R74), [link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL88-R88), [link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4373-L4378))
* Add empty TypeScript file to test folder of import-empty-css-file fixture in playground package to create placeholder for writing test case for importing empty CSS files in rspack ([link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-906686fccf5a4c1d15abe36f35b20b693d9a2478803277d13bad880ad1d00edbR4))
* Empty ignore_deps array in check_rust_dependency.js script to remove irrelevant value of bitflags, which was resolved by napi upgrade to bitflags 2.x.x ([link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-bfa11886488b90a39c99ac709c2ca4777c12be0335c776b584a40abe095a17b2L8-R9))
* Add newline at end of `package.json` file of node_binding crate to ensure consistent formatting and avoid warnings or errors ([link](https://github.com/web-infra-dev/rspack/pull/2783/files?diff=unified&w=0#diff-1c9c1e09f463e90b0e5966c4ae0ee5cb7de494eb9a5eec3c1a2b22c77134d257L45-L44))

</details>
