### PR TITLE
feat: impl new loader-runner

### DIFF
--- a/.changeset/rich-kings-itch.md
+++ b/.changeset/rich-kings-itch.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat: impl new loader-runner

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2534,6 +2534,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rspack_loader_runner2"
+version = "0.1.0"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "bitflags",
+ "nodejs-resolver",
+ "once_cell",
+ "regex",
+ "rspack_error",
+ "rspack_identifier",
+ "rspack_sources",
+ "rustc-hash",
+ "similar-asserts",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "rspack_loader_sass"
 version = "0.1.0"
 dependencies = [

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+edition    = "2021"
+license    = "MIT"
+name       = "rspack_loader_runner2"
+repository = "https://github.com/web-infra-dev/rspack"
+version    = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+similar-asserts = "1.2.0"
+url             = { workspace = true }
+
+[dependencies]
+async-recursion = { workspace = true }
+async-trait = { workspace = true }
+bitflags = { workspace = true }
+rustc-hash = { workspace = true }
+tokio = { workspace = true, features = [
+  "rt",
+  "rt-multi-thread",
+  "macros",
+  "test-util",
+  "parking_lot",
+  "fs",
+] }
+
+nodejs-resolver    = { workspace = true }
+once_cell          = { workspace = true }
+regex              = { workspace = true }
+rspack_error       = { path = "../rspack_error" }
+rspack_identifier  = { path = "../rspack_identifier" }
+rspack_sources     = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/rspack_loader_runner/LICENSE
+++ b/crates/rspack_loader_runner/LICENSE
@@ -1,0 +1,49 @@
+MIT License
+
+Copyright (c) 2022-present Bytedance, Inc. and its affiliates.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+The code implementation of the external library referenced by Rspack is:
+
+- webpack
+
+  MIT LICENSE
+
+  Copyright JS Foundation and other contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  'Software'), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+  CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+  TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -1,0 +1,80 @@
+use std::fmt::Debug;
+
+use rspack_error::{Error, Result};
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum Content {
+  String(String),
+  Buffer(Vec<u8>),
+}
+
+impl Content {
+  pub fn try_into_string(self) -> Result<String> {
+    match self {
+      Content::String(s) => Ok(s),
+      Content::Buffer(b) => {
+        String::from_utf8(b).map_err(|e| rspack_error::internal_error!(e.to_string()))
+      }
+    }
+  }
+
+  pub fn as_bytes(&self) -> &[u8] {
+    match self {
+      Content::String(s) => s.as_bytes(),
+      Content::Buffer(b) => b,
+    }
+  }
+
+  pub fn into_bytes(self) -> Vec<u8> {
+    match self {
+      Content::String(s) => s.into_bytes(),
+      Content::Buffer(b) => b,
+    }
+  }
+}
+
+impl TryFrom<Content> for String {
+  type Error = Error;
+
+  fn try_from(content: Content) -> Result<Self> {
+    content.try_into_string()
+  }
+}
+
+impl From<Content> for Vec<u8> {
+  fn from(content: Content) -> Self {
+    content.into_bytes()
+  }
+}
+
+impl From<String> for Content {
+  fn from(s: String) -> Self {
+    Self::String(s)
+  }
+}
+
+impl From<Vec<u8>> for Content {
+  fn from(buf: Vec<u8>) -> Self {
+    Self::Buffer(buf)
+  }
+}
+
+impl Debug for Content {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let mut content = f.debug_struct("Content");
+
+    let s = match self {
+      Self::String(s) => s.to_string(),
+      Self::Buffer(b) => String::from_utf8_lossy(b).to_string(),
+    };
+
+    let ty = match self {
+      Self::String(_) => "String",
+      Self::Buffer(_) => "Buffer",
+    };
+
+    content
+      .field(ty, &s[0..usize::min(s.len(), 20)].to_owned())
+      .finish()
+  }
+}

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,0 +1,6 @@
+mod content;
+mod loader;
+mod plugin;
+mod runner;
+
+pub use loader::{DisplayWithSuffix, Loader};

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -3,4 +3,7 @@ mod loader;
 mod plugin;
 mod runner;
 
+pub use content::Content;
 pub use loader::{DisplayWithSuffix, Loader};
+pub use plugin::LoaderRunnerPlugin;
+pub use runner::{run_loaders, LoaderContext, ResourceData};

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -137,7 +137,7 @@ impl Display for LoaderItemData {
 
 impl<C> Display for LoaderItem<C> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.data.to_string())?;
+    write!(f, "{}", self.data)?;
 
     Ok(())
   }
@@ -150,7 +150,7 @@ impl<'l, C> Deref for LoaderItemList<'l, C> {
   type Target = [LoaderItem<C>];
 
   fn deref(&self) -> &Self::Target {
-    &self.0
+    self.0
   }
 }
 
@@ -209,13 +209,12 @@ impl<C> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
     let data = if ident.contains('$') {
       let loaders = ident
         .split('$')
-        .into_iter()
         .map(convert_to_loader_item_inner)
         .collect::<Vec<_>>();
       assert!(loaders.len() > 1);
       LoaderItemData::Composed(loaders)
     } else {
-      LoaderItemData::Normal(convert_to_loader_item_inner(&*ident))
+      LoaderItemData::Normal(convert_to_loader_item_inner(&ident))
     };
 
     Self {
@@ -238,7 +237,7 @@ fn to_segment_owned(v: Option<Match<'_>>) -> Option<String> {
 
 fn convert_to_loader_item_inner(ident: &str) -> LoaderItemDataInner {
   let groups = PATH_QUERY_FRAGMENT_REGEXP
-    .captures(&ident)
+    .captures(ident)
     .expect("Group expected");
 
   LoaderItemDataInner {

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -1,0 +1,455 @@
+use std::{
+  cell::Cell,
+  fmt::{Debug, Display},
+  ops::{Index, Range, RangeFrom, RangeTo},
+  sync::Arc,
+};
+
+use async_trait::async_trait;
+use once_cell::sync::Lazy;
+use regex::{Match, Regex};
+use rspack_error::Result;
+use rspack_identifier::{Identifiable, Identifier};
+
+use crate::runner::LoaderContext;
+
+#[derive(Debug)]
+struct LoaderItemDataInner {
+  /// An absolute path or a virtual path for represent the loader.
+  /// The absolute path is used to represent a loader stayed on the JS side.
+  /// `$` splitted chain may be used to represent a composed loader chain from the JS side.
+  /// Virtual path with a builtin protocol to represent a loader from the native side. e.g "builtin:".
+  path: Box<str>,
+  /// Query of a loader, starts with `?`
+  query: Option<Box<str>>,
+  /// Fragment of a loader, starts with `#`.
+  fragment: Option<Box<str>>,
+  #[allow(unused)]
+  meta: LoaderItemDataMeta,
+}
+
+#[derive(Debug)]
+enum LoaderItemData {
+  /// Composed JavaScript loaders
+  Composed(Vec<LoaderItemDataInner>),
+  /// Normal Loader
+  Normal(LoaderItemDataInner),
+}
+
+pub struct LoaderItem<C> {
+  pub(crate) loader: Arc<dyn Loader<C>>,
+  data: LoaderItemData,
+  pitch_executed: Cell<bool>,
+  normal_executed: Cell<bool>,
+}
+
+impl<C> Debug for LoaderItem<C> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("LoaderItem")
+      .field("data", &self.data)
+      .field("loader", &self.loader.identifier())
+      .finish()
+  }
+}
+
+impl<C> LoaderItem<C> {
+  pub(crate) fn pitch_executed(&self) -> bool {
+    self.pitch_executed.get()
+  }
+
+  pub(crate) fn normal_executed(&self) -> bool {
+    self.normal_executed.get()
+  }
+
+  pub(crate) fn set_pitch_executed(&self) {
+    self.pitch_executed.set(true)
+  }
+
+  pub(crate) fn set_normal_executed(&self) {
+    self.normal_executed.set(true)
+  }
+
+  pub(crate) fn path(&self) -> &str {
+    match &self.data {
+      LoaderItemData::Composed(_) => "",
+      LoaderItemData::Normal(i) => &*i.path,
+    }
+  }
+
+  pub(crate) fn query(&self) -> Option<&str> {
+    match &self.data {
+      LoaderItemData::Composed(_) => None,
+      LoaderItemData::Normal(i) => i.query.as_deref(),
+    }
+  }
+
+  pub(crate) fn fragment(&self) -> Option<&str> {
+    match &self.data {
+      LoaderItemData::Composed(_) => None,
+      LoaderItemData::Normal(i) => i.fragment.as_deref(),
+    }
+  }
+}
+
+bitflags::bitflags! {
+  struct LoaderItemDataMeta: u8 {
+    /// Builtin loader
+    const BUILTIN = 1 << 0;
+  }
+}
+
+impl LoaderItemDataMeta {
+  pub(crate) fn builtin(&mut self) {
+    self.insert(Self::BUILTIN);
+  }
+}
+
+impl From<&str> for LoaderItemDataMeta {
+  fn from(value: &str) -> Self {
+    let mut meta = Self::empty();
+
+    if value.starts_with("builtin:") {
+      meta.builtin();
+    }
+
+    meta
+  }
+}
+
+impl Display for LoaderItemDataInner {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.path)?;
+
+    if let Some(query) = &self.query {
+      if !query.starts_with('?') {
+        write!(f, "?")?;
+      }
+      write!(f, "{query}")?;
+    }
+    if let Some(fragment) = &self.fragment {
+      if !fragment.starts_with('#') {
+        write!(f, "#")?;
+      }
+      write!(f, "{fragment}")?;
+    }
+
+    Ok(())
+  }
+}
+
+impl Display for LoaderItemData {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(
+      f,
+      "{}",
+      match self {
+        Self::Composed(l) => l
+          .iter()
+          .map(|i| i.to_string())
+          .collect::<Vec<_>>()
+          .join("$"),
+        Self::Normal(l) => l.to_string(),
+      }
+    )?;
+
+    Ok(())
+  }
+}
+
+impl<C> Display for LoaderItem<C> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.data.to_string())?;
+
+    Ok(())
+  }
+}
+
+#[derive(Debug)]
+pub struct LoaderItemList<'l, C>(pub(crate) &'l [LoaderItem<C>]);
+
+impl<'l, C> LoaderItemList<'l, C> {
+  pub fn len(&self) -> usize {
+    self.0.len()
+  }
+}
+
+impl<'l, C> Index<usize> for LoaderItemList<'l, C> {
+  type Output = LoaderItem<C>;
+
+  fn index(&self, index: usize) -> &Self::Output {
+    &self.0[index]
+  }
+}
+
+impl<'l, C> Index<Range<usize>> for LoaderItemList<'l, C> {
+  type Output = [LoaderItem<C>];
+
+  fn index(&self, index: Range<usize>) -> &Self::Output {
+    &self.0[..][index]
+  }
+}
+
+impl<'l, C> Index<RangeFrom<usize>> for LoaderItemList<'l, C> {
+  type Output = [LoaderItem<C>];
+
+  fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
+    &self.0[..][index]
+  }
+}
+
+impl<'l, C> Index<RangeTo<usize>> for LoaderItemList<'l, C> {
+  type Output = [LoaderItem<C>];
+
+  fn index(&self, index: RangeTo<usize>) -> &Self::Output {
+    &self.0[..][index]
+  }
+}
+
+impl<'l, C> Default for LoaderItemList<'l, C> {
+  fn default() -> Self {
+    Self(&[])
+  }
+}
+
+pub trait DisplayWithSuffix: Display {
+  fn display_with_suffix(&self, suffix: &str) -> String {
+    self.to_string() + "!" + suffix
+  }
+}
+
+impl<'l, C> DisplayWithSuffix for LoaderItemList<'l, C> {}
+impl<C> DisplayWithSuffix for LoaderItem<C> {}
+impl DisplayWithSuffix for LoaderItemData {}
+
+impl<'l, C> Display for LoaderItemList<'l, C> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    let s = self
+      .0
+      .iter()
+      .map(|item| item.to_string())
+      .collect::<Vec<_>>()
+      .join("!");
+
+    write!(f, "{s}")
+  }
+}
+
+impl<C> Identifiable for LoaderItem<C> {
+  fn identifier(&self) -> Identifier {
+    self.loader.identifier()
+  }
+}
+
+#[async_trait(?Send)]
+pub trait Loader<C>: Identifiable + Send {
+  async fn run(&self, _loader_context: &mut LoaderContext<'_, C>) -> Result<()> {
+    // noop
+    Ok(())
+  }
+  async fn pitch(&self, _loader_context: &mut LoaderContext<'_, C>) -> Result<()> {
+    // noop
+    Ok(())
+  }
+}
+
+impl<C> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
+  fn from(loader: Arc<dyn Loader<C>>) -> Self {
+    let ident = loader.identifier();
+
+    // Passthrough composed Node loader
+    let data = if ident.contains('$') {
+      let loaders = ident
+        .split('$')
+        .into_iter()
+        .map(convert_to_loader_item_inner)
+        .collect::<Vec<_>>();
+      assert!(loaders.len() > 1);
+      LoaderItemData::Composed(loaders)
+    } else {
+      LoaderItemData::Normal(convert_to_loader_item_inner(&*ident))
+    };
+
+    Self {
+      data,
+      loader,
+      pitch_executed: Cell::new(false),
+      normal_executed: Cell::new(false),
+    }
+  }
+}
+
+static PATH_QUERY_FRAGMENT_REGEXP: Lazy<Regex> = Lazy::new(|| {
+  Regex::new("^((?:\0.|[^?#\0])*)(\\?(?:\0.|[^#\0])*)?(#.*)?$")
+    .expect("Failed to initialize `PATH_QUERY_FRAGMENT_REGEXP`")
+});
+
+fn to_segment_owned(v: Option<Match<'_>>) -> Option<String> {
+  v.map(|v| v.as_str().to_owned())
+}
+
+fn convert_to_loader_item_inner(ident: &str) -> LoaderItemDataInner {
+  let groups = PATH_QUERY_FRAGMENT_REGEXP
+    .captures(&ident)
+    .expect("Group expected");
+
+  LoaderItemDataInner {
+    path: to_segment_owned(groups.get(1))
+      .expect("Path expected")
+      .into(),
+    query: to_segment_owned(groups.get(2)).map(Into::into),
+    fragment: to_segment_owned(groups.get(3)).map(Into::into),
+    meta: ident.into(),
+  }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+  use std::sync::Arc;
+
+  use rspack_error::{internal_error, Result};
+  use rspack_identifier::{Identifiable, Identifier};
+
+  use super::{
+    Loader, LoaderContext, LoaderItem, LoaderItemData, LoaderItemDataInner, LoaderItemDataMeta,
+    LoaderItemList,
+  };
+
+  impl LoaderItemData {
+    fn try_as_normal(&self) -> Result<&LoaderItemDataInner> {
+      match self {
+        LoaderItemData::Normal(i) => Ok(i),
+        _ => Err(internal_error!("Failed to cast to normal loader")),
+      }
+    }
+
+    fn try_as_composed(&self) -> Result<&[LoaderItemDataInner]> {
+      match self {
+        LoaderItemData::Composed(i) => Ok(i),
+        _ => Err(internal_error!("Failed to cast to composed loader")),
+      }
+    }
+  }
+
+  pub(crate) struct Custom {}
+
+  #[async_trait::async_trait(?Send)]
+  impl Loader<()> for Custom {
+    async fn run(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+    async fn pitch(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+  }
+
+  impl Identifiable for Custom {
+    fn identifier(&self) -> Identifier {
+      "/rspack/custom-loader-1/index.js?foo=1#baz".into()
+    }
+  }
+
+  pub(crate) struct Custom2 {}
+
+  #[async_trait::async_trait(?Send)]
+  impl Loader<()> for Custom2 {
+    async fn run(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+    async fn pitch(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+  }
+
+  impl Identifiable for Custom2 {
+    fn identifier(&self) -> Identifier {
+      "/rspack/custom-loader-2/index.js?bar=2#baz".into()
+    }
+  }
+
+  pub(crate) struct Composed {}
+
+  #[async_trait::async_trait(?Send)]
+  impl Loader<()> for Composed {
+    async fn run(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+    async fn pitch(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+  }
+
+  impl Identifiable for Composed {
+    fn identifier(&self) -> Identifier {
+      "/rspack/style-loader/index.js?foo=1#baz$/rspack/css-loader/index.js?bar=2#qux".into()
+    }
+  }
+
+  pub(crate) struct Builtin {}
+
+  #[async_trait::async_trait(?Send)]
+  impl Loader<()> for Builtin {
+    async fn run(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+    async fn pitch(&self, _loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      Ok(())
+    }
+  }
+
+  impl Identifiable for Builtin {
+    fn identifier(&self) -> Identifier {
+      "builtin:sass-loader".into()
+    }
+  }
+
+  #[test]
+  fn should_extract_and_compose_loader_info_correctly() {
+    let c1 = Arc::new(Custom {}) as Arc<dyn Loader<()>>;
+    let c2 = Arc::new(Custom2 {}) as Arc<dyn Loader<()>>;
+    let l: Vec<LoaderItem<()>> = vec![c1.into(), c2.into()];
+    let item = l[0].data.try_as_normal().unwrap();
+    assert_eq!(item.path, "/rspack/custom-loader-1/index.js".into());
+    assert_eq!(item.query, Some("?foo=1".into()));
+    assert_eq!(item.fragment, Some("#baz".into()));
+    let ll = LoaderItemList(&l[..]);
+    assert_eq!(
+      ll.to_string(),
+      "/rspack/custom-loader-1/index.js?foo=1#baz!/rspack/custom-loader-2/index.js?bar=2#baz"
+    );
+  }
+
+  #[test]
+  fn should_extract_composed_loader_correctly() {
+    let c1 = Arc::new(Composed {}) as Arc<dyn Loader<()>>;
+    let ident = c1.identifier();
+    let l: LoaderItem<()> = c1.into();
+    let items = l.data.try_as_composed().unwrap();
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].path, "/rspack/style-loader/index.js".into());
+    assert_eq!(items[0].query, Some("?foo=1".into()));
+    assert_eq!(items[0].fragment, Some("#baz".into()));
+
+    assert_eq!(items[1].path, "/rspack/css-loader/index.js".into());
+    assert_eq!(items[1].query, Some("?bar=2".into()));
+    assert_eq!(items[1].fragment, Some("#qux".into()));
+
+    let i = &[l];
+    let ll = LoaderItemList(i);
+    assert_eq!(ll.to_string(), ident.to_string());
+  }
+
+  #[test]
+  fn should_handle_builtin_loader_correctly() {
+    let c1 = Arc::new(Builtin {}) as Arc<dyn Loader<()>>;
+    let ident1 = c1.identifier();
+    let l: LoaderItem<()> = c1.into();
+    let item = l.data.try_as_normal().unwrap();
+    assert!(item.meta.contains(LoaderItemDataMeta::BUILTIN));
+
+    let c2 = Arc::new(Composed {}) as Arc<dyn Loader<()>>;
+    let ident2 = c2.identifier();
+    let l = vec![l, c2.into()];
+    let ll = LoaderItemList(&l[..]);
+    assert_eq!(ll.to_string(), ident1.to_string() + "!" + ident2.as_str());
+  }
+}

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -68,27 +68,6 @@ impl<C> LoaderItem<C> {
   pub(crate) fn set_normal_executed(&self) {
     self.normal_executed.set(true)
   }
-
-  pub(crate) fn path(&self) -> &str {
-    match &self.data {
-      LoaderItemData::Composed(_) => "",
-      LoaderItemData::Normal(i) => &*i.path,
-    }
-  }
-
-  pub(crate) fn query(&self) -> Option<&str> {
-    match &self.data {
-      LoaderItemData::Composed(_) => None,
-      LoaderItemData::Normal(i) => i.query.as_deref(),
-    }
-  }
-
-  pub(crate) fn fragment(&self) -> Option<&str> {
-    match &self.data {
-      LoaderItemData::Composed(_) => None,
-      LoaderItemData::Normal(i) => i.fragment.as_deref(),
-    }
-  }
 }
 
 bitflags::bitflags! {

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -241,7 +241,7 @@ impl<C> Identifiable for LoaderItem<C> {
 }
 
 #[async_trait(?Send)]
-pub trait Loader<C>: Identifiable + Send {
+pub trait Loader<C>: Identifiable + Send + Sync {
   async fn run(&self, _loader_context: &mut LoaderContext<'_, C>) -> Result<()> {
     // noop
     Ok(())

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -1,7 +1,7 @@
 use std::{
   cell::Cell,
   fmt::{Debug, Display},
-  ops::{Index, Range, RangeFrom, RangeTo},
+  ops::Deref,
   sync::Arc,
 };
 
@@ -17,7 +17,7 @@ use crate::runner::LoaderContext;
 struct LoaderItemDataInner {
   /// An absolute path or a virtual path for represent the loader.
   /// The absolute path is used to represent a loader stayed on the JS side.
-  /// `$` splitted chain may be used to represent a composed loader chain from the JS side.
+  /// `$` split chain may be used to represent a composed loader chain from the JS side.
   /// Virtual path with a builtin protocol to represent a loader from the native side. e.g "builtin:".
   path: Box<str>,
   /// Query of a loader, starts with `?`
@@ -167,41 +167,11 @@ impl<C> Display for LoaderItem<C> {
 #[derive(Debug)]
 pub struct LoaderItemList<'l, C>(pub(crate) &'l [LoaderItem<C>]);
 
-impl<'l, C> LoaderItemList<'l, C> {
-  pub fn len(&self) -> usize {
-    self.0.len()
-  }
-}
+impl<'l, C> Deref for LoaderItemList<'l, C> {
+  type Target = [LoaderItem<C>];
 
-impl<'l, C> Index<usize> for LoaderItemList<'l, C> {
-  type Output = LoaderItem<C>;
-
-  fn index(&self, index: usize) -> &Self::Output {
-    &self.0[index]
-  }
-}
-
-impl<'l, C> Index<Range<usize>> for LoaderItemList<'l, C> {
-  type Output = [LoaderItem<C>];
-
-  fn index(&self, index: Range<usize>) -> &Self::Output {
-    &self.0[..][index]
-  }
-}
-
-impl<'l, C> Index<RangeFrom<usize>> for LoaderItemList<'l, C> {
-  type Output = [LoaderItem<C>];
-
-  fn index(&self, index: RangeFrom<usize>) -> &Self::Output {
-    &self.0[..][index]
-  }
-}
-
-impl<'l, C> Index<RangeTo<usize>> for LoaderItemList<'l, C> {
-  type Output = [LoaderItem<C>];
-
-  fn index(&self, index: RangeTo<usize>) -> &Self::Output {
-    &self.0[..][index]
+  fn deref(&self) -> &Self::Target {
+    &self.0
   }
 }
 

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -53,6 +53,10 @@ impl<C> Debug for LoaderItem<C> {
 }
 
 impl<C> LoaderItem<C> {
+  pub fn is_composed(&self) -> bool {
+    matches!(self.data, LoaderItemData::Composed(_))
+  }
+
   pub(crate) fn pitch_executed(&self) -> bool {
     self.pitch_executed.get()
   }

--- a/crates/rspack_loader_runner/src/plugin.rs
+++ b/crates/rspack_loader_runner/src/plugin.rs
@@ -1,0 +1,12 @@
+use rspack_error::Result;
+
+use crate::{content::Content, runner::ResourceData};
+
+#[async_trait::async_trait]
+pub trait LoaderRunnerPlugin: Send + Sync {
+  fn name(&self) -> &'static str {
+    "unknown"
+  }
+
+  async fn process_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>>;
+}

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -85,10 +85,6 @@ impl<'c, C> LoaderContext<'c, C> {
   }
 }
 
-/// Process resource
-///
-/// Plugins are loaded in order, if a plugin returns `Some(Content)`, then the returning content will be used as the result.
-/// If plugins returned nothing, the runner will read via the `resource_path`.
 async fn process_resource<C>(
   loader_context: &mut LoaderContext<'_, C>,
   resource_data: &ResourceData,

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -1,0 +1,271 @@
+use std::{
+  collections::HashSet,
+  fmt::Debug,
+  path::{Path, PathBuf},
+  sync::Arc,
+};
+
+use nodejs_resolver::DescriptionData;
+use rspack_error::{Diagnostic, Result};
+use rspack_sources::SourceMap;
+
+use crate::{
+  content::Content,
+  loader::{Loader, LoaderItem, LoaderItemList},
+  plugin::LoaderRunnerPlugin,
+};
+
+#[derive(Debug, Clone)]
+pub struct ResourceData {
+  /// Resource with absolute path, query and fragment
+  pub resource: String,
+  /// Absolute resource path only
+  pub resource_path: PathBuf,
+  /// Resource query with `?` prefix
+  pub resource_query: Option<String>,
+  /// Resource fragment with `#` prefix
+  pub resource_fragment: Option<String>,
+  pub resource_description: Option<Arc<DescriptionData>>,
+}
+
+#[derive(Debug)]
+pub struct LoaderContext<'c, C> {
+  /// Content of loader, represented by string or buffer
+  /// Content should always be exist if at normal stage,
+  /// However, it might be `None` at pitching stage.
+  pub content: Option<Content>,
+
+  /// The resource part of the request, including query and fragment.
+  /// E.g. /abc/resource.js?query=1#some-fragment
+  pub resource: &'c str,
+  /// The resource part of the request.
+  /// E.g. /abc/resource.js
+  pub resource_path: &'c Path,
+  /// The query of the request
+  /// E.g. query=1
+  pub resource_query: Option<&'c str>,
+  /// The fragment of the request
+  /// E.g. some-fragment
+  pub resource_fragment: Option<&'c str>,
+
+  pub context: C,
+  pub source_map: Option<SourceMap>,
+  pub additional_data: Option<String>,
+  pub cacheable: bool,
+  /// Is this a JS composed loader
+  pub is_composed: bool,
+
+  pub file_dependencies: HashSet<PathBuf>,
+  pub context_dependencies: HashSet<PathBuf>,
+  pub missing_dependencies: HashSet<PathBuf>,
+  pub build_dependencies: HashSet<PathBuf>,
+
+  pub loader_index: usize,
+  pub loader_items: LoaderItemList<'c, C>,
+
+  pub diagnostic: Vec<Diagnostic>,
+}
+
+impl<'c, C> LoaderContext<'c, C> {
+  pub fn remaining_request(&self) -> LoaderItemList<'_, C> {
+    if self.loader_index >= self.loader_items.len() - 1 {
+      return Default::default();
+    }
+    LoaderItemList(&self.loader_items[self.loader_index + 1..])
+  }
+
+  pub fn current_request(&self) -> LoaderItemList<'_, C> {
+    LoaderItemList(&self.loader_items[self.loader_index..])
+  }
+
+  pub fn previous_request(&self) -> LoaderItemList<'_, C> {
+    LoaderItemList(&self.loader_items[..self.loader_index])
+  }
+}
+
+/// Process resource
+///
+/// Plugins are loaded in order, if a plugin returns `Some(Content)`, then the returning content will be used as the result.
+/// If plugins returned nothing, the runner will read via the `resource_path`.
+async fn process_resource<C>(
+  loader_context: &mut LoaderContext<'_, C>,
+  resource_data: &ResourceData,
+  plugins: &[Box<dyn LoaderRunnerPlugin>],
+) -> Result<()> {
+  for plugin in plugins {
+    if let Some(processed_resource) = plugin.process_resource(&resource_data).await? {
+      loader_context.content = Some(processed_resource);
+      return Ok(());
+    }
+  }
+
+  // let result = tokio::fs::read(&resource_data.resource_path).await?;
+  // Ok(Content::from(result))
+  loader_context.content = Some(Content::Buffer(vec![]));
+  Ok(())
+}
+
+async fn create_loader_context<'c, C: 'c>(
+  loader_items: &'c [LoaderItem<C>],
+  resource_data: &'c ResourceData,
+  plugins: &[Box<dyn LoaderRunnerPlugin>],
+  context: C,
+  is_composed: bool,
+) -> Result<LoaderContext<'c, C>> {
+  // let content = process_resource(resource_data, plugins).await?;
+
+  // TODO: FileUriPlugin
+  let mut file_dependencies: HashSet<PathBuf> = Default::default();
+  file_dependencies.insert(resource_data.resource_path.clone());
+
+  let loader_context = LoaderContext {
+    cacheable: true,
+    file_dependencies,
+    context_dependencies: Default::default(),
+    missing_dependencies: Default::default(),
+    build_dependencies: Default::default(),
+    content: None,
+    resource: &resource_data.resource,
+    resource_path: &resource_data.resource_path,
+    resource_query: resource_data.resource_query.as_deref(),
+    resource_fragment: resource_data.resource_fragment.as_deref(),
+    context,
+    is_composed,
+    source_map: None,
+    additional_data: None,
+    loader_index: 0,
+    loader_items: LoaderItemList(loader_items),
+    diagnostic: vec![],
+  };
+
+  Ok(loader_context)
+}
+
+#[async_recursion::async_recursion(?Send)]
+async fn iterate_normal_loaders<C>(
+  loader_context: &mut LoaderContext<'_, C>,
+  resource_data: &ResourceData,
+) -> Result<()> {
+  let current_loader_item = &loader_context.loader_items[loader_context.loader_index];
+
+  if current_loader_item.normal_executed() {
+    if loader_context.loader_index == 0 {
+      return Ok(());
+    }
+    loader_context.loader_index -= 1;
+    return iterate_normal_loaders(loader_context, resource_data).await;
+  }
+
+  let loader = current_loader_item.loader.clone();
+  current_loader_item.set_normal_executed();
+  loader.run(loader_context).await?;
+
+  iterate_normal_loaders(loader_context, resource_data).await
+}
+
+#[async_recursion::async_recursion(?Send)]
+async fn iterate_pitching_loaders<C>(
+  loader_context: &mut LoaderContext<'_, C>,
+  resource_data: &ResourceData,
+  plugins: &[Box<dyn LoaderRunnerPlugin>],
+) -> Result<()> {
+  if loader_context.loader_index >= loader_context.loader_items.len() {
+    return process_resource(loader_context, resource_data, plugins).await;
+  }
+
+  let current_loader_item = &loader_context.loader_items[loader_context.loader_index];
+
+  if current_loader_item.pitch_executed() {
+    loader_context.loader_index += 1;
+    return iterate_pitching_loaders(loader_context, resource_data, plugins).await;
+  }
+
+  let loader = current_loader_item.loader.clone();
+  current_loader_item.set_pitch_executed();
+  loader.pitch(loader_context).await?;
+
+  // If pitching loader modifies the content,
+  // runner should skip the remaining pitching loaders
+  // and redirect pipeline to the normal stage.
+  if loader_context.content.is_some() {
+    if loader_context.loader_index == 0 {
+      return Ok(());
+    }
+    loader_context.loader_index -= 1;
+    iterate_normal_loaders(loader_context, resource_data).await?;
+  } else {
+    iterate_pitching_loaders(loader_context, resource_data, plugins).await?;
+  }
+
+  Ok(())
+}
+
+pub async fn run_loaders<C: Debug>(
+  loaders: &[Arc<dyn Loader<C>>],
+  resource_data: &ResourceData,
+  plugins: &[Box<dyn LoaderRunnerPlugin>],
+  context: C,
+) -> Result<()> {
+  let loaders = loaders
+    .into_iter()
+    .map(|i| i.clone().into())
+    .collect::<Vec<LoaderItem<C>>>();
+
+  let mut loader_context =
+    create_loader_context(&loaders[..], resource_data, plugins, context, false).await?;
+
+  assert!(loader_context.content.is_none());
+  iterate_pitching_loaders(&mut loader_context, resource_data, plugins).await?;
+
+  Ok(())
+}
+
+#[cfg(test)]
+mod test {
+  use std::sync::Arc;
+
+  use rspack_error::Result;
+  use rspack_identifier::{Identifiable, Identifier};
+
+  use super::{run_loaders, Loader, LoaderContext, ResourceData};
+  use crate::loader::test::{Custom, Custom2};
+
+  struct Pitching {}
+
+  impl Identifiable for Pitching {
+    fn identifier(&self) -> Identifier {
+      "/rspack/pitching-loader".into()
+    }
+  }
+
+  #[async_trait::async_trait(?Send)]
+  impl Loader<()> for Pitching {
+    async fn pitch(&self, loader_context: &mut LoaderContext<'_, ()>) -> Result<()> {
+      dbg!(loader_context.remaining_request());
+      dbg!(loader_context.previous_request());
+      Ok(())
+    }
+  }
+
+  #[tokio::test]
+  async fn should_() {
+    let c1 = Arc::new(Custom {}) as Arc<dyn Loader<()>>;
+    let c2 = Arc::new(Custom2 {}) as Arc<dyn Loader<()>>;
+    let p1 = Arc::new(Pitching {}) as Arc<dyn Loader<()>>;
+
+    run_loaders(
+      &[c1, p1, c2],
+      &ResourceData {
+        resource: Default::default(),
+        resource_description: None,
+        resource_fragment: None,
+        resource_query: None,
+        resource_path: Default::default(),
+      },
+      &[],
+      (),
+    )
+    .await
+    .unwrap();
+  }
+}

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -111,13 +111,9 @@ async fn process_resource<C>(
 async fn create_loader_context<'c, C: 'c>(
   loader_items: &'c [LoaderItem<C>],
   resource_data: &'c ResourceData,
-  plugins: &[Box<dyn LoaderRunnerPlugin>],
   context: C,
   is_composed: bool,
 ) -> Result<LoaderContext<'c, C>> {
-  // let content = process_resource(resource_data, plugins).await?;
-
-  // TODO: FileUriPlugin
   let mut file_dependencies: HashSet<PathBuf> = Default::default();
   file_dependencies.insert(resource_data.resource_path.clone());
 
@@ -215,7 +211,7 @@ pub async fn run_loaders<C: Debug>(
     .collect::<Vec<LoaderItem<C>>>();
 
   let mut loader_context =
-    create_loader_context(&loaders[..], resource_data, plugins, context, false).await?;
+    create_loader_context(&loaders[..], resource_data, context, false).await?;
 
   assert!(loader_context.content.is_none());
   iterate_pitching_loaders(&mut loader_context, resource_data, plugins).await?;
@@ -494,7 +490,6 @@ mod test {
       .await
       .unwrap();
     IDENTS.with(|i| {
-      dbg!(&i.borrow());
       // should not execute p3, as p2 pitched successfully.
       assert!(!i.borrow().contains(&"pitch-normal-normal-2".to_string()));
       assert!(!i.borrow().contains(&"pitch-normal-pitch-2".to_string()));


### PR DESCRIPTION
## Related issue (if exists)

Part of https://github.com/web-infra-dev/rspack/issues/2643

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Port loader-runner to Rspack, which enables us the support, on top of the normal loader, of pitching loader. Due to different mechanism of dealing with composed JS loaders, rspack now separates the composed JS loaders with `$` to easily interop with the JS loader-runner in the future.

Integration of the new loader-runner with be added in the next PR.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee88f89</samp>

Added a new crate `rspack_loader_runner2` that provides a framework for loading and processing resources with custom plugins. The crate defines a `Content` enum for different types of content, a `LoaderRunnerPlugin` trait for plugin implementation, and a `Loader` struct for loading resources from various sources.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee88f89</samp>

*  Add a new crate `rspack_loader_runner2` with metadata and dependencies ([link](https://github.com/web-infra-dev/rspack/pull/2789/files?diff=unified&w=0#diff-4168cbe766389af33fc1d0840ddf230a49d5e3d77b4cfa9bcfcae55d293238dcR1-R35))
*  Define an enum `Content` for the types of content handled by the loader runner ([link](https://github.com/web-infra-dev/rspack/pull/2789/files?diff=unified&w=0#diff-04a996d40b8c56014b3e248b468b747b3c3cfc01008f1d7aa9079b2e46fe65a0R1-R80))
*  Re-export the main modules and types of the crate in `lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2789/files?diff=unified&w=0#diff-df66648edef24ca7ddd956da4a7b822f0a6de2da3ec1ee7fa9bc4fb5955a52c4R1-R6))
*  Define a trait `LoaderRunnerPlugin` for custom plugins that can process resources ([link](https://github.com/web-infra-dev/rspack/pull/2789/files?diff=unified&w=0#diff-e02a81163aefff3828a8a3d8992a0cd76bd46917a35ce0b2d80c71597e778bdbR1-R12))

</details>
