### PR TITLE
feat: add chunkFormat & chunkLoading & enabledChunkLoadingTypes config

### DIFF
--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -3438,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b87668640fe6d63ecabaae1805534d1445ff63382ab8961cd623ccdeb1bfbc"
 dependencies = [
  "better_scoped_tls",
- "bitflags",
+ "bitflags 1.3.2",
  "indexmap",
  "once_cell",
  "phf",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -332,6 +332,9 @@ export interface RawOutputOptions {
   importFunctionName: string
   iife: boolean
   module: boolean
+  chunkFormat?: string
+  chunkLoading?: string
+  enabledChunkLoadingTypes?: Array<string>
 }
 export interface RawResolveOptions {
   preferRelative?: boolean

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use napi_derive::napi;
 use rspack_core::{
   BoxPlugin, CompilerOptions, DevServerOptions, Devtool, EntryItem, Experiments, ModuleOptions,
-  OutputOptions, PluginExt, TargetPlatform,
+  OutputOptions, PluginExt,
 };
 use serde::Deserialize;
 
@@ -116,22 +116,6 @@ impl RawOptionsApply for RawOptions {
       .boxed(),
     );
     plugins.push(rspack_plugin_json::JsonPlugin {}.boxed());
-    match &target.platform {
-      TargetPlatform::Web => {
-        plugins.push(rspack_plugin_runtime::ArrayPushCallbackChunkFormatPlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::CssModulesPlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::JsonpChunkLoadingPlugin {}.boxed());
-      }
-      TargetPlatform::Node(_) => {
-        plugins.push(rspack_plugin_runtime::CommonJsChunkFormatPlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::CommonJsChunkLoadingPlugin {}.boxed());
-      }
-      _ => {
-        plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
-      }
-    };
     if dev_server.hot {
       plugins.push(rspack_plugin_runtime::HotModuleReplacementPlugin {}.boxed());
     }

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -106,11 +106,13 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
       .compilation
       .chunk_graph
       .get_chunk_runtime_modules_in_order(args.chunk_ukey);
+    let global_object: &String = &args.compilation.options.output.global_object;
     let mut source = ConcatSource::default();
 
     if matches!(chunk.kind, ChunkKind::HotUpdate) {
       source.add(RawSource::Source(format!(
-        "self['hotUpdate']('{}', ",
+        "{}['hotUpdate']('{}', ",
+        global_object,
         chunk.expect_id()
       )));
       source.add(render_chunk_modules(args.compilation, args.chunk_ukey)?);
@@ -126,8 +128,10 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
       let chunk_loading_global = &args.compilation.options.output.chunk_loading_global;
 
       source.add(RawSource::from(format!(
-        r#"(self['{}'] = self['{}'] || []).push([["{}"], "#,
+        r#"({}['{}'] = {}['{}'] || []).push([["{}"], "#,
+        global_object,
         chunk_loading_global,
+        global_object,
         chunk_loading_global,
         chunk.expect_id(),
       )));

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -72,9 +72,10 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       .runtime_requirements
       .contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS)
     {
-      source.add(RawSource::from(include_str!(
-        "runtime/jsonp_chunk_loading_with_hmr.js"
-      )));
+      source.add(RawSource::from(
+        include_str!("runtime/jsonp_chunk_loading_with_hmr.js")
+          .replace("$globalObject$", &compilation.options.output.global_object),
+      ));
       source.add(RawSource::from(
         include_str!("runtime/javascript_hot_module_replacement.js").replace("$key$", "jsonp"),
       ));
@@ -107,7 +108,8 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
 
       source.add(RawSource::from(
         include_str!("runtime/jsonp_chunk_loading_with_callback.js")
-          .replace("CHUNK_LOADING_GLOBAL_NAME", chunk_loading_global),
+          .replace("CHUNK_LOADING_GLOBAL_NAME", chunk_loading_global)
+          .replace("$globalObject$", &compilation.options.output.global_object),
       ));
     }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.js
@@ -28,8 +28,8 @@ var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
 	return __webpack_require__.O(result);
 };
 
-var chunkLoadingGlobal = (self["CHUNK_LOADING_GLOBAL_NAME"] =
-	self["CHUNK_LOADING_GLOBAL_NAME"] || []);
+var chunkLoadingGlobal = ($globalObject$["CHUNK_LOADING_GLOBAL_NAME"] =
+	$globalObject$["CHUNK_LOADING_GLOBAL_NAME"] || []);
 chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
 chunkLoadingGlobal.push = webpackJsonpCallback.bind(
 	null,

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_hmr.js
@@ -33,7 +33,7 @@ function loadUpdateChunk(chunkId, updatedModulesList) {
 	});
 }
 
-self["hotUpdate"] = function (chunkId, moreModules, runtime) {
+$globalObject$["hotUpdate"] = function (chunkId, moreModules, runtime) {
 	for (var moduleId in moreModules) {
 		if (__webpack_require__.o(moreModules, moduleId)) {
 			currentUpdate[moduleId] = moreModules[moduleId];

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -164,7 +164,10 @@ function getRawOutput(output: OutputNormalized): RawOptions["output"] {
 		clean: output.clean!,
 		assetModuleFilename: output.assetModuleFilename!,
 		filename: output.filename!,
+		chunkFormat: output.chunkFormat === false ? undefined : output.chunkFormat!,
 		chunkFilename: output.chunkFilename!,
+		chunkLoading:
+			output.chunkLoading === false ? undefined : output.chunkLoading!,
 		crossOriginLoading: getRawCrossOriginLoading(output.crossOriginLoading!),
 		cssFilename: output.cssFilename!,
 		cssChunkFilename: output.cssChunkFilename!,
@@ -179,6 +182,7 @@ function getRawOutput(output: OutputNormalized): RawOptions["output"] {
 		module: output.module!,
 		wasmLoading: wasmLoading === false ? "false" : wasmLoading,
 		enabledWasmLoadingTypes: output.enabledWasmLoadingTypes!,
+		enabledChunkLoadingTypes: output.enabledChunkLoadingTypes!,
 		webassemblyModuleFilename: output.webassemblyModuleFilename!
 	};
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -78,7 +78,12 @@ export const applyRspackOptionsDefaults = (
 
 	applyOutputDefaults(options.output, {
 		context: options.context!,
-		targetProperties
+		targetProperties,
+		isAffectedByBrowserslist:
+			target === undefined ||
+			(typeof target === "string" && target.startsWith("browserslist")) ||
+			(Array.isArray(target) &&
+				target.some(target => target.startsWith("browserslist")))
 	});
 
 	applyExternalsPresetsDefaults(options.externalsPresets, {
@@ -282,7 +287,15 @@ const applyModuleDefaults = (
 
 const applyOutputDefaults = (
 	output: OutputNormalized,
-	{ context, targetProperties: tp }: { context: Context; targetProperties: any }
+	{
+		context,
+		targetProperties: tp,
+		isAffectedByBrowserslist
+	}: {
+		context: Context;
+		targetProperties: any;
+		isAffectedByBrowserslist: boolean;
+	}
 ) => {
 	F(output, "uniqueName", () => {
 		const pkgPath = path.resolve(context, "package.json");
@@ -341,6 +354,78 @@ const applyOutputDefaults = (
 	if (output.library) {
 		F(output.library, "type", () => (output.module ? "module" : "var"));
 	}
+	F(output, "chunkFormat", () => {
+		if (tp) {
+			const helpMessage = isAffectedByBrowserslist
+				? "Make sure that your 'browserslist' includes only platforms that support these features or select an appropriate 'target' to allow selecting a chunk format by default. Alternatively specify the 'output.chunkFormat' directly."
+				: "Select an appropriate 'target' to allow selecting one by default, or specify the 'output.chunkFormat' directly.";
+			if (output.module) {
+				if (tp.dynamicImport) return "module";
+				if (tp.document) return "array-push";
+				throw new Error(
+					"For the selected environment is no default ESM chunk format available:\n" +
+						"ESM exports can be chosen when 'import()' is available.\n" +
+						"JSONP Array push can be chosen when 'document' is available.\n" +
+						helpMessage
+				);
+			} else {
+				if (tp.document) return "array-push";
+				if (tp.require) return "commonjs";
+				if (tp.nodeBuiltins) return "commonjs";
+				if (tp.importScripts) return "array-push";
+				throw new Error(
+					"For the selected environment is no default script chunk format available:\n" +
+						"JSONP Array push can be chosen when 'document' or 'importScripts' is available.\n" +
+						"CommonJs exports can be chosen when 'require' or node builtins are available.\n" +
+						helpMessage
+				);
+			}
+		}
+		throw new Error(
+			"Chunk format can't be selected by default when no target is specified"
+		);
+	});
+	F(output, "chunkLoading", () => {
+		if (tp) {
+			switch (output.chunkFormat) {
+				case "array-push":
+					if (tp.document) return "jsonp";
+					if (tp.importScripts) return "import-scripts";
+					break;
+				case "commonjs":
+					if (tp.require) return "require";
+					if (tp.nodeBuiltins) return "async-node";
+					break;
+				case "module":
+					if (tp.dynamicImport) return "import";
+					break;
+			}
+			if (
+				tp.require === null ||
+				tp.nodeBuiltins === null ||
+				tp.document === null ||
+				tp.importScripts === null
+			) {
+				return "universal";
+			}
+		}
+		return false;
+	});
+	A(output, "enabledChunkLoadingTypes", () => {
+		const enabledChunkLoadingTypes = new Set<string>();
+		if (output.chunkLoading) {
+			enabledChunkLoadingTypes.add(output.chunkLoading);
+		}
+		// if (output.workerChunkLoading) {
+		// 	enabledChunkLoadingTypes.add(output.workerChunkLoading);
+		// }
+		// forEachEntry(desc => {
+		// 	if (desc.chunkLoading) {
+		// 		enabledChunkLoadingTypes.add(desc.chunkLoading);
+		// 	}
+		// });
+		return Array.from(enabledChunkLoadingTypes);
+	});
 	F(output, "wasmLoading", () => {
 		if (tp) {
 			if (tp.fetchWasm) return "fetch";

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -50,12 +50,17 @@ export const getNormalizedRspackOptions = (
 				publicPath: output.publicPath,
 				filename: output.filename,
 				clean: output.clean,
+				chunkFormat: output.chunkFormat,
+				chunkLoading: output.chunkLoading,
 				chunkFilename: output.chunkFilename,
 				crossOriginLoading: output.crossOriginLoading,
 				cssFilename: output.cssFilename,
 				cssChunkFilename: output.cssChunkFilename,
 				assetModuleFilename: output.assetModuleFilename,
 				wasmLoading: output.wasmLoading,
+				enabledChunkLoadingTypes: output.enabledChunkLoadingTypes
+					? [...output.enabledChunkLoadingTypes]
+					: ["..."],
 				enabledWasmLoadingTypes: output.enabledWasmLoadingTypes
 					? [...output.enabledWasmLoadingTypes]
 					: ["..."],

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -62,6 +62,42 @@ module.exports = {
 				}
 			]
 		},
+		ChunkFormat: {
+			description:
+				"The format of chunks (formats included by default are 'array-push' (web/WebWorker), 'commonjs' (node.js), 'module' (ESM), but others might be added by plugins).",
+			anyOf: [
+				{
+					enum: ["array-push", "commonjs", "module", false]
+				},
+				{
+					type: "string"
+				}
+			]
+		},
+		ChunkLoading: {
+			description:
+				"The method of loading chunks (methods included by default are 'jsonp' (web), 'import' (ESM), 'importScripts' (WebWorker), 'require' (sync node.js), 'async-node' (async node.js), but others might be added by plugins).",
+			anyOf: [
+				{
+					enum: [false]
+				},
+				{
+					$ref: "#/definitions/ChunkLoadingType"
+				}
+			]
+		},
+		ChunkLoadingType: {
+			description:
+				"The method of loading chunks (methods included by default are 'jsonp' (web), 'import' (ESM), 'importScripts' (WebWorker), 'require' (sync node.js), 'async-node' (async node.js), but others might be added by plugins).",
+			anyOf: [
+				{
+					enum: ["jsonp", "import-scripts", "require", "async-node", "import"]
+				},
+				{
+					type: "string"
+				}
+			]
+		},
 		CrossOriginLoading: {
 			description: "This option enables cross-origin loading of chunks.",
 			enum: [false, "anonymous", "use-credentials"]
@@ -100,6 +136,14 @@ module.exports = {
 			type: "array",
 			items: {
 				$ref: "#/definitions/WasmLoadingType"
+			}
+		},
+		EnabledChunkLoadingTypes: {
+			description:
+				"List of chunk loading types enabled for use by entry points.",
+			type: "array",
+			items: {
+				$ref: "#/definitions/ChunkLoadingType"
 			}
 		},
 		WasmLoading: {
@@ -994,6 +1038,15 @@ module.exports = {
 							$ref: "#/definitions/AuxiliaryComment"
 						}
 					]
+				},
+				chunkFormat: {
+					$ref: "#/definitions/ChunkFormat"
+				},
+				chunkLoading: {
+					$ref: "#/definitions/ChunkLoading"
+				},
+				enabledChunkLoadingTypes: {
+					$ref: "#/definitions/EnabledChunkLoadingTypes"
 				},
 				chunkFilename: {
 					$ref: "#/definitions/ChunkFilename"

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -135,6 +135,9 @@ export interface Output {
 	wasmLoading?: WasmLoading;
 	enabledWasmLoadingTypes?: EnabledWasmLoadingTypes;
 	webassemblyModuleFilename?: WebassemblyModuleFilename;
+	chunkFormat?: string | false;
+	chunkLoading?: string | false;
+	enabledChunkLoadingTypes?: string[];
 }
 export type Path = string;
 export type PublicPath = "auto" | RawPublicPath;
@@ -228,6 +231,9 @@ export interface OutputNormalized {
 	wasmLoading?: WasmLoading;
 	enabledWasmLoadingTypes?: EnabledWasmLoadingTypes;
 	webassemblyModuleFilename?: WebassemblyModuleFilename;
+	chunkFormat?: string | false;
+	chunkLoading?: string | false;
+	enabledChunkLoadingTypes?: string[];
 }
 
 ///// Resolve /////

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -259,11 +259,16 @@ describe("snapshots", () => {
 		  "output": {
 		    "assetModuleFilename": "[hash][ext][query]",
 		    "chunkFilename": "[name].js",
+		    "chunkFormat": "array-push",
+		    "chunkLoading": "jsonp",
 		    "chunkLoadingGlobal": "webpackChunk@rspack/core",
 		    "clean": false,
 		    "crossOriginLoading": false,
 		    "cssChunkFilename": "[name].css",
 		    "cssFilename": "[name].css",
+		    "enabledChunkLoadingTypes": [
+		      "jsonp",
+		    ],
 		    "enabledLibraryTypes": [],
 		    "enabledWasmLoadingTypes": [
 		      "fetch",
@@ -850,6 +855,14 @@ describe("snapshots", () => {
 		+     "__filename": "eval-only",
 		+     "global": false,
 		@@ ... @@
+		-     "chunkFormat": "array-push",
+		-     "chunkLoading": "jsonp",
+		+     "chunkFormat": "commonjs",
+		+     "chunkLoading": "require",
+		@@ ... @@
+		-       "jsonp",
+		+       "require",
+		@@ ... @@
 		-       "fetch",
 		+       "async-node",
 		@@ ... @@
@@ -898,6 +911,12 @@ describe("snapshots", () => {
 		+ Received
 
 		@@ ... @@
+		-     "chunkLoading": "jsonp",
+		+     "chunkLoading": "import-scripts",
+		@@ ... @@
+		-       "jsonp",
+		+       "import-scripts",
+		@@ ... @@
 		+       "worker",
 		@@ ... @@
 		-   "target": "web",
@@ -919,6 +938,14 @@ describe("snapshots", () => {
 		+     "__dirname": "eval-only",
 		+     "__filename": "eval-only",
 		+     "global": false,
+		@@ ... @@
+		-     "chunkFormat": "array-push",
+		-     "chunkLoading": "jsonp",
+		+     "chunkFormat": "commonjs",
+		+     "chunkLoading": "require",
+		@@ ... @@
+		-       "jsonp",
+		+       "require",
 		@@ ... @@
 		-       "fetch",
 		+       "async-node",
@@ -978,6 +1005,14 @@ describe("snapshots", () => {
 		+     "__dirname": "eval-only",
 		+     "__filename": "eval-only",
 		+     "global": false,
+		@@ ... @@
+		-     "chunkFormat": "array-push",
+		-     "chunkLoading": "jsonp",
+		+     "chunkFormat": "commonjs",
+		+     "chunkLoading": "require",
+		@@ ... @@
+		-       "jsonp",
+		+       "require",
 		@@ ... @@
 		-       "fetch",
 		+       "async-node",
@@ -1273,6 +1308,8 @@ describe("snapshots", () => {
 			- Expected
 			+ Received
 
+			@@ ... @@
+			+       "require",
 			@@ ... @@
 			+       "async-node",
 		`)

--- a/packages/rspack/tests/configCases/plugins/polyfill/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/polyfill/webpack.config.js
@@ -1,5 +1,8 @@
 const polyfillNodePlugin = require("@rspack/plugin-node-polyfill");
 module.exports = {
 	target: ["webworker"],
-	plugins: [new polyfillNodePlugin()]
+	plugins: [new polyfillNodePlugin()],
+	output: {
+		chunkLoading: "jsonp"
+	}
 };

--- a/packages/rspack/tests/configCases/umd/issue-15545/index.js
+++ b/packages/rspack/tests/configCases/umd/issue-15545/index.js
@@ -1,0 +1,7 @@
+it("should compile and run", () => {
+	expect(hello()).toBe("hello");
+});
+
+export function hello() {
+	return "hello";
+}

--- a/packages/rspack/tests/configCases/umd/issue-15545/test.config.js
+++ b/packages/rspack/tests/configCases/umd/issue-15545/test.config.js
@@ -1,0 +1,9 @@
+const CONTEXT = {};
+module.exports = {
+	nonEsmThis(module) {
+		return CONTEXT;
+	},
+	findBundle() {
+		return ["./runtime.js", "./main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/umd/issue-15545/webpack.config.js
+++ b/packages/rspack/tests/configCases/umd/issue-15545/webpack.config.js
@@ -1,0 +1,19 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js",
+		library: "MyLibrary",
+		libraryTarget: "umd",
+		chunkLoading: "jsonp",
+		chunkFormat: "array-push",
+		globalObject: "this"
+	},
+	optimization: {
+		minimize: false,
+		runtimeChunk: "single"
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

closed at https://github.com/web-infra-dev/rspack/issues/2672

<!--- Provide link of related issues -->

## Summary

- add chunkFormat & chunkLoading & enabledChunkLoadingTypes config
- fix globalObject at runtime

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61edfd3</samp>

Added and improved chunk format and loading options for `rspack` output bundles. Fixed a bug with the UMD library target and the runtime chunk. Added tests for the new features and the bug fix. Refactored some code in `rspack_binding_options` and `config` modules.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 61edfd3</samp>

*  Remove unused `TargetPlatform` import from `options/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L7-R7))
*  Replace `match` expression with more flexible output options in `options/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L119-L134))
*  Import `rspack_error` crate and add fields and methods for output options in `options/raw_output.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-ef5856a7fec8410383d58cc835932b263f5df692fd8d31fb1ea236182a162b00R6), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-ef5856a7fec8410383d58cc835932b263f5df692fd8d31fb1ea236182a162b00R124-R126), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-ef5856a7fec8410383d58cc835932b263f5df692fd8d31fb1ea236182a162b00R132-R134), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-ef5856a7fec8410383d58cc835932b263f5df692fd8d31fb1ea236182a162b00R171-R220))
*  Convert and normalize output options in `config/adapter.ts` and `config/normalization.ts` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L167-R169), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L182-R185), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL81-R86), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL285-R298), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-78648f723799beccc94c4b2e506997d12d1ace8216aeb31c0731c37a6dce024aR53-R54), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-78648f723799beccc94c4b2e506997d12d1ace8216aeb31c0731c37a6dce024aR61-R63))
*  Fix indentation issues in `config/adapter.ts` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L208-R215), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L219-R222), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L226-R234), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L272-R279), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L380-R384), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L400-R413), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L431-R436), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L453-R457))
*  Add definitions and fields for output options in `config/schema.js` and `config/types.ts` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R65-R100), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R141-R148), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R1042-R1050), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR138-R140), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR234-R236))
*  Update and add test cases for output options and UMD library target in `tests/` ([link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R262-R263), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R269-R271), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R858-R865), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R914-R919), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R942-R949), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R1009-R1016), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R1312-R1313), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-ecdc6c34607483a3fa62a5ff51e6cbd6fbacb7ca9e1f6302ebe645a18a986cd9R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-601deec5a45b08a96d1f4c59c8db14fdd566335c8e8e1190b5009beb6bae6fe1R1-R9), [link](https://github.com/web-infra-dev/rspack/pull/2792/files?diff=unified&w=0#diff-a44cd9eceb1119aef67cb1496f7ac9b3f5c6ee5ffc9d054cd3ab5d8d41c690bfR1-R19))

</details>
