### PR TITLE
ci: set fail-fast: false for matrix builds

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -11,6 +11,7 @@ jobs:
     name: Release Nightly
     strategy:
       matrix:
+        fail-fast: false # Build and test everything so we can look at all the errors
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
+        fail-fast: false # Build and test everything so we can look at all the errors
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -151,7 +151,7 @@ jobs:
 
       # Mac
       - uses: goto-bus-stop/setup-zig@v2
-        if: ${{ contains(matrix.settings.target, 'apple') }}
+        if: ${{ contains(inputs.target, 'apple') }}
         with:
           version: 0.10.1
 
@@ -186,7 +186,7 @@ jobs:
     # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
     timeout-minutes: 15
     strategy:
-      fail-fast: false
+      fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
         node: [14, 16]
     name: Test Node ${{ matrix.node }}

--- a/.github/workflows/test-main.yml
+++ b/.github/workflows/test-main.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
+        fail-fast: false # Build and test everything so we can look at all the errors
         target:
           - x86_64-unknown-linux-gnu
           - x86_64-pc-windows-msvc

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     strategy:
       matrix:
+        fail-fast: false # Build and test everything so we can look at all the errors
         target:
           - x86_64-unknown-linux-gnu
     uses: ./.github/workflows/reusable-build.yml


### PR DESCRIPTION
Build and test everything so we can look at all the errors

This value is defaulted to true

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99b0aba</samp>

This pull request adds the `fail-fast: false` option to all the GitHub workflows that build and test the `rspack` package, and updates the `reusable-build.yml` template to accept a target parameter. These changes improve the reliability and flexibility of the continuous integration and delivery process.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99b0aba</samp>

*  Add `fail-fast: false` option to all workflows to run all jobs to completion and show all errors ([link](https://github.com/web-infra-dev/rspack/pull/2796/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554R14), [link](https://github.com/web-infra-dev/rspack/pull/2796/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R20), [link](https://github.com/web-infra-dev/rspack/pull/2796/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L189-R189), [link](https://github.com/web-infra-dev/rspack/pull/2796/files?diff=unified&w=0#diff-09f23f0a6351c2baed2aa13637ed1825d61736eeebddd3f1a514d379554a8e72R20), [link](https://github.com/web-infra-dev/rspack/pull/2796/files?diff=unified&w=0#diff-553365cb26b1fc82e9fae16796d827431ccea4d72e0c1420cfed527de0e23fddR29))
*  Replace `matrix.settings.target` with `inputs.target` in `reusable-build.yml` to make the template more flexible and accept different target values from calling workflows ([link](https://github.com/web-infra-dev/rspack/pull/2796/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L154-R154))

</details>
