### PR TITLE
ci: only cache Rust builds on the main branch

### DIFF
--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -44,6 +44,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           shared-key: check
+          save-if: ${{ github.ref_name == 'main' }}
 
       - name: Spell Check
         uses: crate-ci/typos@master

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           shared-key: build-${{ inputs.target }}
           workspaces: "./crates/node_binding -> target"
+          save-if: ${{ github.ref_name == 'main' }} # This should be safe because we have nightly building the cache every day
 
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache


### PR DESCRIPTION
This should avoid hitting the GitHub 10GB cache limit

This is bad: 

<img width="1913" alt="image" src="https://user-images.githubusercontent.com/1430279/232686456-624d0216-b489-43f7-9462-c039e1110096.png">

we quickly run out of cache because some of the PRs are saving the cache.

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8705c96</samp>

This pull request adds conditions to the `save-cache` steps of the `check-rs` and `reusable-build` workflows in `.github/workflows`. The conditions prevent the Rust build cache from being overwritten by non-main branches, which could cause issues for the CI/CD pipeline.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8705c96</samp>

*  Restrict saving Rust build cache to `main` branch ([link](https://github.com/web-infra-dev/rspack/pull/2798/files?diff=unified&w=0#diff-5b78af515332e94dc01fd5e3712c1f9fe2328e02455fb99d45efb76dcd19fd78R47), [link](https://github.com/web-infra-dev/rspack/pull/2798/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R94))

</details>
