### PR TITLE
fix: preset env use unresolved_mark

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/compat.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/compat.rs
@@ -9,7 +9,7 @@ use swc_core::ecma::visit::Fold;
 
 fn compat_by_preset_env(
   preset_env_config: Option<PresetEnv>,
-  top_level_mark: Mark,
+  unresolved_mark: Mark,
   assumptions: Assumptions,
   comments: Option<&SingleThreadedComments>,
 ) -> impl Fold + '_ {
@@ -21,7 +21,7 @@ fn compat_by_preset_env(
     };
 
     Either::Left(swc_ecma_preset_env::preset_env(
-      top_level_mark,
+      unresolved_mark, // here should be unresolved_mark, swc not update function signature
       comments,
       swc_ecma_preset_env::Config {
         mode: mode.map(Into::into),
@@ -151,13 +151,13 @@ pub fn compat(
   preset_env_config: Option<PresetEnv>,
   es_version: Option<EsVersion>,
   assumptions: Assumptions,
-  top_level_mark: Mark,
+  _top_level_mark: Mark,
   unresolved_mark: Mark,
   comments: Option<&SingleThreadedComments>,
   is_typescript: bool,
 ) -> impl Fold + '_ {
   chain!(
-    compat_by_preset_env(preset_env_config, top_level_mark, assumptions, comments),
+    compat_by_preset_env(preset_env_config, unresolved_mark, assumptions, comments),
     compat_by_es_version(
       es_version,
       unresolved_mark,

--- a/packages/rspack/tests/configCases/builtins/preset-env/index.js
+++ b/packages/rspack/tests/configCases/builtins/preset-env/index.js
@@ -9,3 +9,19 @@ it("builtins preset env code check", () => {
 	const content = fs.readFileSync(__filename, "utf-8");
 	expect(content).not.toMatch(/\=\>/);
 });
+
+it("should transfrom arrow", () => {
+	const obj = {};
+
+	function fn() {
+		expect(this).toBe(obj);
+		expect(arguments[0]).toBe(1);
+		const b = () => {
+			expect(this).toBe(obj);
+			expect(arguments[0]).toBe(1);
+		};
+		b();
+	}
+
+	a.apply(obj, [1]);
+});


### PR DESCRIPTION
## Related issue (if exists)

close https://github.com/web-infra-dev/rspack/issues/2733

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b25fd63</samp>

Improved the swc visitor module for the JavaScript plugin and added a new test case for the preset env plugin. Fixed a bug with arrow function transformation and `this` and `arguments` bindings.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b25fd63</samp>

*  Rename `top_level_mark` to `unresolved_mark` in `compat.rs` to match the `swc_ecma_preset_env::preset_env` function signature ([link](https://github.com/web-infra-dev/rspack/pull/2807/files?diff=unified&w=0#diff-22cd15c4187a0f2d2989ec0a9fe27a6c55622c085e28c6f59fd49f6e1d67e97cL12-R12), [link](https://github.com/web-infra-dev/rspack/pull/2807/files?diff=unified&w=0#diff-22cd15c4187a0f2d2989ec0a9fe27a6c55622c085e28c6f59fd49f6e1d67e97cL24-R24), [link](https://github.com/web-infra-dev/rspack/pull/2807/files?diff=unified&w=0#diff-22cd15c4187a0f2d2989ec0a9fe27a6c55622c085e28c6f59fd49f6e1d67e97cL160-R160))
*  Add a comment in `compat.rs` to explain the temporary name mismatch with the `swc` crate ([link](https://github.com/web-infra-dev/rspack/pull/2807/files?diff=unified&w=0#diff-22cd15c4187a0f2d2989ec0a9fe27a6c55622c085e28c6f59fd49f6e1d67e97cL24-R24))
*  Prefix unused `top_level_mark` with an underscore in `compat_by_es_version` function in `compat.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2807/files?diff=unified&w=0#diff-22cd15c4187a0f2d2989ec0a9fe27a6c55622c085e28c6f59fd49f6e1d67e97cL154-R154))
*  Add a new test case in `index.js` to check the arrow function transformation by the `preset-env` plugin ([link](https://github.com/web-infra-dev/rspack/pull/2807/files?diff=unified&w=0#diff-9f5f43b6bdbc0559a40e623e527245deff5d4115c1cdc4153cc2729083782b1bR12-R27))

</details>
