### PR TITLE
fix: fix chunkLoading for web-worker

### DIFF
--- a/.changeset/tall-mails-check.md
+++ b/.changeset/tall-mails-check.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix chunkLoading failed when target set to web-worker

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -391,7 +391,7 @@ const applyOutputDefaults = (
 			switch (output.chunkFormat) {
 				case "array-push":
 					if (tp.document) return "jsonp";
-					if (tp.importScripts) return "import-scripts";
+					if (tp.importScripts) return false; // temporarily takedown import-scripts since we don't support it yet
 					break;
 				case "commonjs":
 					if (tp.require) return "require";

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -913,10 +913,12 @@ describe("snapshots", () => {
 
 		@@ ... @@
 		-     "chunkLoading": "jsonp",
-		+     "chunkLoading": "import-scripts",
+		+     "chunkLoading": false,
 		@@ ... @@
+		-     "enabledChunkLoadingTypes": Array [
 		-       "jsonp",
-		+       "import-scripts",
+		-     ],
+		+     "enabledChunkLoadingTypes": Array [],
 		@@ ... @@
 		+       "worker",
 		@@ ... @@


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f77416</samp>

Disabled import-scripts feature for array-push libraryTarget in `defaults.ts`. This avoids bundling errors until the feature is implemented in rspack.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f77416</samp>

* Disable import-scripts feature for array-push libraryTarget ([link](https://github.com/web-infra-dev/rspack/pull/2816/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL394-R394))

</details>
