### PR TITLE
ci: share rust target directory in check-rs

### DIFF
--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Run Cargo Check
         run: |
           cargo check --workspace --all-targets --release --locked
-          cd crates/node_binding && cargo check --workspace --all-targets --release --locked && cd ../../
+          cd crates/node_binding && cargo check --workspace --all-targets --release --locked --target-dir ../../target && cd ../../
 
       - name: Run Clippy
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 807214a</samp>

This pull request adds a build configuration option to share the target directory for the cargo build command across the project. This improves the integration of the `node_binding` crate with the RSPack server.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 807214a</samp>

*  Add build configuration option to share target directory for Node.js binding ([link](https://github.com/web-infra-dev/rspack/pull/2818/files?diff=unified&w=0#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R5-R7))

</details>
