### PR TITLE
chore: add deprecated notice about rspack package

### DIFF
--- a/packages/rspack-deprecated/README.md
+++ b/packages/rspack-deprecated/README.md
@@ -1,0 +1,7 @@
+# rspack
+
+> Please use [@rspack/cli](https://www.npmjs.com/package/@rspack/cli) instead of this package.
+
+IMPORTANT: This package has moved under @rspack/cli NPM scope.
+
+To learn about the Rspack project. please visit https://www.rspack.dev/

--- a/packages/rspack-deprecated/package.json
+++ b/packages/rspack-deprecated/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "rspack",
+  "version": "0.1.1",
+  "description": "Deprecated Rspack CLI",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "node postinstall.js"
+  },
+  "keywords": [],
+  "author": "hardfist",
+  "license": "MIT"
+}

--- a/packages/rspack-deprecated/postinstall.js
+++ b/packages/rspack-deprecated/postinstall.js
@@ -1,0 +1,19 @@
+function writeErrorInRed(message) {
+	console.error("");
+	console.error("\u001b[31m" + message + "\u001b[39m");
+}
+
+writeErrorInRed(
+	`* * * * * * * * * * * * * THIS PACKAGE WAS RENAMED! * * * * * * * * * * * * * *`
+);
+
+console.error(`
+IMPORTANT: This package has moved under the "@rspack/cli" NPM scope.
+
+To learn about the Rspack project, please visit https://rspack.dev/`);
+
+writeErrorInRed(
+	`* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *\n`
+);
+
+process.exit(1);


### PR DESCRIPTION
## Related issue (if exists)
Don't merge this, it's just used  for code review
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e2d6b9</samp>

This pull request adds files and messages to the `rspack-deprecated` package to make it valid, publishable, and fail on installation. The changes also inform the users of the new package name `@rspack/cli` and the project website.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e2d6b9</samp>

* Create and populate a package.json file for the rspack-deprecated package ([link](https://github.com/web-infra-dev/rspack/pull/2824/files?diff=unified&w=0#diff-5058db30c32012d1fa5dcf6f4137dc41a8502c0e8e1de7868acab3d9ae961587R1-R13))
* Add a postinstall script that writes an error message to the console and fails the installation ([link](https://github.com/web-infra-dev/rspack/pull/2824/files?diff=unified&w=0#diff-74f6546f2ab79f74a2cfc38ac28213b1c29b6093a06959b9dd93b468fd938cbeR1-R19))
* Update the README.md file with a warning message and a link to the new package and website ([link](https://github.com/web-infra-dev/rspack/pull/2824/files?diff=unified&w=0#diff-bc2b633f1a0925c415e4831bf4c252d82cc89902740a06eda8dd3e6de61d3fa9R1-R7))

</details>
