### PR TITLE
refactor: Remove impl `Module` for `Box<dyn Module>` in codebase

### DIFF
--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -249,7 +249,7 @@ impl WorkerTask for BuildTask {
           })
           .await;
 
-        plugin_driver.read().await.succeed_module(module).await?;
+        plugin_driver.read().await.succeed_module(&**module).await?;
 
         result
       })

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -150,67 +150,50 @@ impl Identifiable for Box<dyn Module> {
 
 #[async_trait::async_trait]
 impl Module for Box<dyn Module> {
-  fn module_type(&self) -> &ModuleType {
-    (**self).module_type()
-  }
+    fn module_type(&self) -> &ModuleType {
+        (**self).module_type()
+    }
 
-  fn source_types(&self) -> &[SourceType] {
-    (**self).source_types()
-  }
+    fn source_types(&self) -> &[SourceType] {
+        (**self).source_types()
+    }
 
-  fn original_source(&self) -> Option<&dyn Source> {
-    (**self).original_source()
-  }
+    fn original_source(&self) -> Option<&dyn Source> {
+        (**self).original_source()
+    }
 
-  fn readable_identifier(&self, context: &Context) -> Cow<str> {
-    (**self).readable_identifier(context)
-  }
+    fn readable_identifier(&self, context: &Context) -> Cow<str> {
+        (**self).readable_identifier(context)
+    }
 
-  fn size(&self, source_type: &SourceType) -> f64 {
-    (**self).size(source_type)
-  }
+    fn size(&self, source_type: &SourceType) -> f64 {
+        (**self).size(source_type)
+    }
 
-  async fn build(
-    &mut self,
-    build_context: BuildContext<'_>,
-  ) -> Result<TWithDiagnosticArray<BuildResult>> {
-    (**self).build(build_context).await
-  }
+    async fn build(
+        &mut self,
+        build_context: BuildContext<'_>,
+    ) -> Result<TWithDiagnosticArray<BuildResult>> {
+        (**self).build(build_context).await
+    }
 
-  fn code_generation(&self, compilation: &Compilation) -> Result<CodeGenerationResult> {
-    (**self).code_generation(compilation)
-  }
+    fn code_generation(&self, compilation: &Compilation) -> Result<CodeGenerationResult> {
+        (**self).code_generation(compilation)
+    }
 
-  fn lib_ident(&self, options: LibIdentOptions) -> Option<Cow<str>> {
-    (**self).lib_ident(options)
-  }
+    fn lib_ident(&self, options: LibIdentOptions) -> Option<Cow<str>> {
+        (**self).lib_ident(options)
+    }
 
-  fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
-    (**self).get_code_generation_dependencies()
-  }
+    fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
+        (**self).get_code_generation_dependencies()
+    }
 
-  fn get_resolve_options(&self) -> Option<&Resolve> {
-    (**self).get_resolve_options()
-  }
-
-  fn name_for_condition(&self) -> Option<Cow<str>> {
-    (**self).name_for_condition()
-  }
+    fn get_resolve_options(&self) -> Option<&Resolve> {
+        (**self).get_resolve_options()
+    }
 }
 
-impl PartialEq for dyn Module + '_ {
-  fn eq(&self, other: &Self) -> bool {
-    self.dyn_eq(other.as_any())
-  }
-}
-
-impl Eq for dyn Module + '_ {}
-
-impl Hash for dyn Module + '_ {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.dyn_hash(state)
-  }
-}
 
 impl dyn Module + '_ {
   pub fn downcast_ref<T: Module + Any>(&self) -> Option<&T> {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -8,7 +8,6 @@ use rspack_identifier::{Identifiable, Identifier};
 use rspack_sources::Source;
 use rustc_hash::FxHashSet as HashSet;
 
-
 use crate::{
   AsAny, CodeGenerationResult, Compilation, CompilerContext, CompilerOptions, Context,
   ContextModule, Dependency, DynEq, DynHash, ExternalModule, ModuleDependency, ModuleType,
@@ -130,11 +129,11 @@ pub trait Module: Debug + Send + Sync + AsAny + DynHash + DynEq + Identifiable {
 }
 
 pub trait ModuleExt {
-  fn boxed(self) -> Option<dyn Module>;
+  fn boxed(self) -> Box<dyn Module>;
 }
 
 impl<T: Module + 'static> ModuleExt for T {
-  fn boxed(self) -> Option<dyn Module> {
+  fn boxed(self) -> Box<dyn Module> {
     Box::new(self)
   }
 }
@@ -306,8 +305,8 @@ mod test {
 
   #[test]
   fn hash_should_work() {
-    let e1: Option<&dyn Module> = ExternalModule("e").boxed();
-    let e2: Option<&dyn Module> = ExternalModule("e").boxed();
+    let e1: Box<&dyn Module> = ExternalModule("e").boxed();
+    let e2: Box<&dyn Module> = ExternalModule("e").boxed();
 
     let mut state1 = xxhash_rust::xxh3::Xxh3::default();
     let mut state2 = xxhash_rust::xxh3::Xxh3::default();
@@ -318,7 +317,7 @@ mod test {
     let hash2 = format!("{:016x}", state2.finish());
     assert_eq!(hash1, hash2);
 
-    let e3: Option<&dyn Module> = ExternalModule("e3").boxed();
+    let e3: Box<&dyn Module> = ExternalModule("e3").boxed();
     let mut state3 = xxhash_rust::xxh3::Xxh3::default();
     e3.hash(&mut state3);
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -148,6 +148,20 @@ impl Identifiable for Box<dyn Module> {
   }
 }
 
+impl PartialEq for dyn Module + '_ {
+  fn eq(&self, other: &Self) -> bool {
+    self.dyn_eq(other.as_any())
+  }
+}
+
+impl Eq for dyn Module + '_ {}
+
+impl Hash for dyn Module + '_ {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    self.dyn_hash(state)
+  }
+}
+
 impl dyn Module + '_ {
   pub fn downcast_ref<T: Module + Any>(&self) -> Option<&T> {
     self.as_any().downcast_ref::<T>()

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -319,8 +319,8 @@ mod test {
 
   #[test]
   fn hash_should_work() {
-    let e1: Box<&dyn Module> = ExternalModule("e").boxed();
-    let e2: Box<&dyn Module> = ExternalModule("e").boxed();
+    let e1: Box<dyn Module> = ExternalModule("e").boxed();
+    let e2: Box<dyn Module> = ExternalModule("e").boxed();
 
     let mut state1 = xxhash_rust::xxh3::Xxh3::default();
     let mut state2 = xxhash_rust::xxh3::Xxh3::default();
@@ -331,7 +331,7 @@ mod test {
     let hash2 = format!("{:016x}", state2.finish());
     assert_eq!(hash1, hash2);
 
-    let e3: Box<&dyn Module> = ExternalModule("e3").boxed();
+    let e3: Box<dyn Module> = ExternalModule("e3").boxed();
     let mut state3 = xxhash_rust::xxh3::Xxh3::default();
     e3.hash(&mut state3);
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -151,46 +151,46 @@ impl Identifiable for Box<dyn Module> {
 #[async_trait::async_trait]
 impl Module for Box<dyn Module> {
     fn module_type(&self) -> &ModuleType {
-        (**self).module_type()
+        self.as_ref().module_type()
     }
 
     fn source_types(&self) -> &[SourceType] {
-        (**self).source_types()
+        self.as_ref().source_types()
     }
 
     fn original_source(&self) -> Option<&dyn Source> {
-        (**self).original_source()
+        self.as_ref().original_source()
     }
 
     fn readable_identifier(&self, context: &Context) -> Cow<str> {
-        (**self).readable_identifier(context)
+        self.as_ref().readable_identifier(context)
     }
 
     fn size(&self, source_type: &SourceType) -> f64 {
-        (**self).size(source_type)
+        self.as_ref().size(source_type)
     }
 
     async fn build(
         &mut self,
         build_context: BuildContext<'_>,
     ) -> Result<TWithDiagnosticArray<BuildResult>> {
-        (**self).build(build_context).await
+        self.as_mut().build(build_context).await
     }
 
     fn code_generation(&self, compilation: &Compilation) -> Result<CodeGenerationResult> {
-        (**self).code_generation(compilation)
+        self.as_ref().code_generation(compilation)
     }
 
     fn lib_ident(&self, options: LibIdentOptions) -> Option<Cow<str>> {
-        (**self).lib_ident(options)
+        self.as_ref().lib_ident(options)
     }
 
     fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
-        (**self).get_code_generation_dependencies()
+        self.as_ref().get_code_generation_dependencies()
     }
 
     fn get_resolve_options(&self) -> Option<&Resolve> {
-        (**self).get_resolve_options()
+        self.as_ref().get_resolve_options()
     }
 }
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -194,6 +194,18 @@ impl Module for Box<dyn Module> {
     }
 }
 
+impl DynEq for Box<dyn Module> {
+  fn dyn_eq(&self, other: &dyn Any) -> bool {
+      if let Some(other) = other.as_any().downcast_ref::<Self>() {
+          // If the concrete types are the same, compare their DynHash values
+          self.dyn_hash() == other.dyn_hash()
+      } else {
+          // If the concrete types are different, they cannot be equal
+          false
+      }
+  }
+}
+
 
 impl dyn Module + '_ {
   pub fn downcast_ref<T: Module + Any>(&self) -> Option<&T> {

--- a/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
+++ b/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
@@ -137,11 +137,11 @@ impl Plugin for DevFriendlySplitChunksPlugin {
             let mut size_of_new_modules = 0.0;
             let start_idx = last_end_idx;
             while size_of_new_modules < MAX_SIZE_PER_CHUNK && last_end_idx < modules.len() {
-              let module_size = compilation
+              let module_size = (**compilation
                 .module_graph
                 .module_by_identifier(&modules[last_end_idx].module)
-                .expect("Should have a module here")
-                .estimated_size(&rspack_core::SourceType::JavaScript);
+                .expect("Should have a module here"))
+              .estimated_size(&rspack_core::SourceType::JavaScript);
               // about 500kb
               let pre_calculated_size_of_new_modules = size_of_new_modules + module_size;
               if pre_calculated_size_of_new_modules > MAX_SIZE_PER_CHUNK
@@ -248,7 +248,7 @@ trait EstimatedSize {
   fn estimated_size(&self, source_type: &rspack_core::SourceType) -> f64;
 }
 
-impl<T: Module> EstimatedSize for T {
+impl<T: Module + ?Sized> EstimatedSize for T {
   fn estimated_size(&self, source_type: &rspack_core::SourceType) -> f64 {
     use rspack_core::ModuleType;
     let coefficient: f64 = match self.module_type() {

--- a/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
+++ b/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
@@ -746,7 +746,7 @@ impl Plugin for SplitChunksPlugin {
                 item_cache_group,
                 item.cache_group_index,
                 &chunk_arr,
-                compilation
+                &**compilation
                   .module_graph
                   .module_by_identifier(module)
                   .expect("Module not found"),

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -165,7 +165,7 @@ impl SplitChunksPlugin {
               .module_graph
               .module_by_identifier(module)
               .unwrap_or_else(|| panic!("Module({module}) not found"));
-            each_module_group.remove_module(module);
+            each_module_group.remove_module(&**module);
           }
         });
 

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use rayon::prelude::*;
 use rspack_core::{
-  ApplyContext, AssetInfo, Module, ModuleType, ParserAndGenerator, PathData, Plugin, PluginContext,
+  ApplyContext, AssetInfo, ModuleType, ParserAndGenerator, PathData, Plugin, PluginContext,
   PluginRenderManifestHookOutput, RenderManifestArgs, RenderManifestEntry, SourceType,
 };
 use rspack_error::Result;


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->
https://github.com/web-infra-dev/rspack/issues/2820
## Summary

There's no need for returning Box<&dyn Module> due to no use cases(so far) caring about the Box in Box<&dyn Module>. Returning Option<&dyn Module> would be enough.

The argument also applies to using &BoxModule in function parameters. So, we just need to replace all &BoxModule with &dyn Module, which would also achieve the goal: reduce boilerplate code for deref Box and avoid the traps mentioned above.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18b8efa</samp>

Removed `name_for_condition` and `PartialEq`, `Eq` and `Hash` traits from `dyn Module` in `module.rs`. This simplified the module interface and improved performance for conditional exports and imports.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18b8efa</samp>

* Remove `name_for_condition` method and `PartialEq`, `Eq` and `Hash` implementations for `dyn Module` ([link](https://github.com/web-infra-dev/rspack/pull/2831/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0L151-R195)) to simplify module interface and avoid unnecessary hashing and equality checks

</details>
