### PR TITLE
fix: use webworker instead of web-worker in AvailableTarget type

### DIFF
--- a/.changeset/real-eagles-do.md
+++ b/.changeset/real-eagles-do.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: use webworker instead of web-worker in AvailableTarget type

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -338,7 +338,7 @@ export interface ModuleOptionsNormalized {
 export type AvailableTarget =
 	| "node"
 	| "web"
-	| "web-worker"
+	| "webworker"
 	| "es3"
 	| "es5"
 	| "es2015"


### PR DESCRIPTION
## Related issue (if exists)

Releted PR: https://github.com/web-infra-dev/rspack/pull/2826

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c413b0</samp>

This pull request fixes a typo in the `@rspack/core` package that affected the `AvailableTarget` type. The change ensures that the `rspack` CLI accepts `webworker` as a valid target value for webpack.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c413b0</samp>

* Fix typo in `AvailableTarget` type to use `webworker` instead of `web-worker` ([link](https://github.com/web-infra-dev/rspack/pull/2834/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL341-R341), [link](https://github.com/web-infra-dev/rspack/pull/2834/files?diff=unified&w=0#diff-09a8689fc494071e7b1ec2be2ca926c6e964dcd8edbb472b3e43bbfbe3bad839R1-R5))

</details>
