### PR TITLE
fix: support magic comment `import( /* webpackChunkName: "/user/[id]/page" */ './foo')` containing `[id]`

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -99,7 +99,7 @@ impl DependencyScanner<'_> {
     use once_cell::sync::Lazy;
     use swc_core::common::comments::CommentKind;
     static WEBPACK_CHUNK_NAME_CAPTURE_RE: Lazy<regex::Regex> = Lazy::new(|| {
-      regex::Regex::new(r#"webpackChunkName\s*:\s*("(?P<_1>(\./)?([\w0-9_\-]+/)*?[\w0-9_\-]+)"|'(?P<_2>(\./)?([\w0-9_\-]+/)*?[\w0-9_\-]+)'|`(?P<_3>(\./)?([\w0-9_\-]+/)*?[\w0-9_\-]+)`)"#)
+      regex::Regex::new(r#"webpackChunkName\s*:\s*("(?P<_1>(\./)?([\w0-9_\-\[\]]+/)*?[\w0-9_\-\[\]]+)"|'(?P<_2>(\./)?([\w0-9_\-\[\]]+/)*?[\w0-9_\-\[\]]+)'|`(?P<_3>(\./)?([\w0-9_\-\[\]]+/)*?[\w0-9_\-\[\]]+)`)"#)
         .expect("invalid regex")
     });
     self

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
@@ -4,6 +4,8 @@ __webpack_require__.el("./normal.js").then(__webpack_require__.bind(__webpack_re
 __webpack_require__.el("./sub_fold.js").then(__webpack_require__.bind(__webpack_require__, "./sub_fold.js")).then(__webpack_require__.ir);
 __webpack_require__.el("./single_quote.js").then(__webpack_require__.bind(__webpack_require__, "./single_quote.js")).then(__webpack_require__.ir);
 __webpack_require__.el("./other.js").then(__webpack_require__.bind(__webpack_require__, "./other.js")).then(__webpack_require__.ir);
+__webpack_require__.el("./user/1.js").then(__webpack_require__.bind(__webpack_require__, "./user/1.js")).then(__webpack_require__.ir);
+__webpack_require__.el("./user/page/2.js").then(__webpack_require__.bind(__webpack_require__, "./user/page/2.js")).then(__webpack_require__.ir);
 __webpack_require__.el("./bug_only_single_quote.js").then(__webpack_require__.bind(__webpack_require__, "./bug_only_single_quote.js")).then(__webpack_require__.ir);
 },
 

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/user/user/[id].js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/user/user/[id].js
@@ -1,0 +1,6 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["./user/[id]"], {
+"./user/1.js": function (module, exports, __webpack_require__) {
+console.log('user [id]');
+},
+
+}]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/user/user/[id]/page/page.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/user/user/[id]/page/page.js
@@ -1,0 +1,6 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["user/[id]/page"], {
+"./user/page/2.js": function (module, exports, __webpack_require__) {
+console.log('user [id]/page2');
+},
+
+}]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/index.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/index.js
@@ -3,6 +3,8 @@ import(/* webpackChunkName: "./sub/fold" */ './sub_fold')
 import(/* webpackChunkName: './sub/single' */ './single_quote')
 
 import(/* webpackChunkName: `./sub/other` */ './other')
+import(/* webpackChunkName: "./user/[id]" */ './user/1')
+import(/* webpackChunkName: `user/[id]/page`*/ './user/page/2')
 import(/* 'bug_' */ './bug_only_single_quote.js')
 
 

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/user/1.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/user/1.js
@@ -1,0 +1,1 @@
+console.log('user [id]')

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/user/page/2.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/user/page/2.js
@@ -1,0 +1,1 @@
+console.log('user [id]/page2')


### PR DESCRIPTION
## Related issue (if exists)

https://github.com/web-infra-dev/rspack/issues/2829
<!--- Provide link of related issues -->

## Summary



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b4c4cf</samp>

Support square brackets in webpack chunk names for dynamic imports with parameters. Update the dependency scanner, the test fixture input and output files, and the plugin output code to handle this feature.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b4c4cf</samp>

*  Allow square brackets in webpack chunk names for dynamic imports with parameters ([link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL102-R102))
*  Update test fixture for magic comment feature to include dynamic imports with parameters ([link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-90a6cb45918dbd03fa7560798ab4eb28dc019f4cab94e02900ab977feff506e5R6-R7), [link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-813c9e887dc77f7eef89a7e997b49a87d1f08b6fdee0614d47479026d5156284L1-L-1), [link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-c103702daa140c72fc10df7d17110e4e294f8b55e3faa75c2fce87a5937cbf8bL1-L-1))
*  Update expected output of test fixture for magic comment feature to show transformed dynamic imports and chunk arrays with square brackets ([link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-896ce47440c79b9f60c65faac7b527f1186a7faf40e9a1c4bf9afdbab32bcc55R7-R8), [link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-a02329997214cc9a746d0feb52e0ad877cbe532798909e69f506f752d46f0a73L1-R5), [link](https://github.com/web-infra-dev/rspack/pull/2835/files?diff=unified&w=0#diff-c55f4fbaa58ac4930a992e2e2613c9310ce42ce7ae58e2b0203b8981f6506259L1-R5))

</details>
