### PR TITLE
perf(rspack_core): reduce memory allocation when cloning RuntimeSpec

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::anyhow;
 use rspack_error::Result;
 use rspack_identifier::{IdentifierMap, IdentifierSet};
@@ -73,7 +75,7 @@ impl<'me> CodeSplitter<'me> {
 
       let mut entrypoint = ChunkGroup::new(
         ChunkGroupKind::Entrypoint,
-        HashSet::from_iter([name.to_string()]),
+        HashSet::from_iter([Arc::from(name.to_string())]),
         Some(name.to_string()),
       );
       if options.runtime.is_none() {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -45,7 +45,7 @@ use crate::{
   FactorizeTask, FactorizeTaskResult, LoaderRunnerRunner, Module, ModuleGraph, ModuleIdentifier,
   ModuleType, NormalModuleAstOrSource, ProcessAssetsArgs, ProcessDependenciesQueue,
   ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs, Resolve, RuntimeGlobals,
-  RuntimeModule, SharedPluginDriver, Stats, TaskResult, WorkerTask,
+  RuntimeModule, RuntimeSpec, SharedPluginDriver, Stats, TaskResult, WorkerTask,
 };
 
 #[derive(Debug)]
@@ -1046,7 +1046,7 @@ impl Compilation {
           .get_number_of_module_chunks(module.identifier())
           > 0
         {
-          let mut module_runtime_requirements: Vec<(HashSet<String>, RuntimeGlobals)> = vec![];
+          let mut module_runtime_requirements: Vec<(RuntimeSpec, RuntimeGlobals)> = vec![];
           for runtime in self
             .chunk_graph
             .get_module_runtimes(module.identifier(), &self.chunk_by_ukey)

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -109,7 +109,7 @@ where
 
     let mut hot_update_main_content_by_runtime = all_old_runtime
       .iter()
-      .map(|id| (id.clone(), HotUpdateContent::new(id)))
+      .map(|id| (id.to_string(), HotUpdateContent::new(id.as_ref())))
       .collect::<HashMap<String, HotUpdateContent>>();
 
     let mut old_chunks: Vec<(String, IdentifierSet, RuntimeSpec)> = vec![];
@@ -323,7 +323,7 @@ where
       }
 
       for removed in removed_from_runtime {
-        if let Some(info) = hot_update_main_content_by_runtime.get_mut(&removed) {
+        if let Some(info) = hot_update_main_content_by_runtime.get_mut(removed.as_ref()) {
           info.removed_chunk_ids.insert(chunk_id.to_string());
         }
         // TODO:
@@ -407,7 +407,7 @@ where
         }
 
         new_runtime.iter().for_each(|runtime| {
-          if let Some(info) = hot_update_main_content_by_runtime.get_mut(runtime) {
+          if let Some(info) = hot_update_main_content_by_runtime.get_mut(runtime.as_ref()) {
             info.updated_chunk_ids.insert(chunk_id.to_string());
           }
         });

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -1,8 +1,8 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, sync::Arc};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-pub type RuntimeSpec = HashSet<String>;
+pub type RuntimeSpec = HashSet<Arc<str>>;
 pub type RuntimeKey = String;
 
 #[derive(Default, Clone, Copy, Debug)]
@@ -18,8 +18,8 @@ pub fn is_runtime_equal(a: &RuntimeSpec, b: &RuntimeSpec) -> bool {
     return false;
   }
 
-  let mut a: Vec<String> = Vec::from_iter(a.iter().cloned());
-  let mut b: Vec<String> = Vec::from_iter(b.iter().cloned());
+  let mut a: Vec<Arc<str>> = Vec::from_iter(a.iter().cloned());
+  let mut b: Vec<Arc<str>> = Vec::from_iter(b.iter().cloned());
 
   a.sort_unstable();
   b.sort_unstable();
@@ -28,7 +28,7 @@ pub fn is_runtime_equal(a: &RuntimeSpec, b: &RuntimeSpec) -> bool {
 }
 
 pub fn get_runtime_key(runtime: RuntimeSpec) -> String {
-  let mut runtime: Vec<String> = Vec::from_iter(runtime.into_iter());
+  let mut runtime: Vec<Arc<str>> = Vec::from_iter(runtime.into_iter());
   runtime.sort_unstable();
   runtime.join("\n")
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -51,5 +51,5 @@ impl_runtime_module!(GetMainFilenameRuntimeModule);
 
 #[inline]
 fn stringify_runtime(runtime: &RuntimeSpec) -> String {
-  Vec::from_iter(runtime.iter().map(|s| s.as_str())).join("_")
+  Vec::from_iter(runtime.iter().map(|s| (*s).as_ref())).join("_")
 }


### PR DESCRIPTION
## Summary

This removes the 11ms overhead during HMR.

<img width="2475" alt="image" src="https://user-images.githubusercontent.com/1430279/233323764-b0557c36-1ca7-4b7f-b519-e35dbaea0610.png">


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 30d18ea</samp>

This pull request optimizes the memory usage and performance of the `rspack_core` crate by using `Arc<str>` pointers to share runtime names across different modules and data structures. It also updates the `rspack_plugin_runtime` crate to work with the new type and enables serialization of the `HotUpdateContent` struct.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 30d18ea</samp>

*  Introduce `Arc<str>` as the type for `RuntimeSpec` and `RuntimeKey` to avoid string allocations ([link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-7ee3386f1d14753555fdc96b4060cafd0ab57a4c1bb907dc04f54b486d43e482L1-R5), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-7ee3386f1d14753555fdc96b4060cafd0ab57a4c1bb907dc04f54b486d43e482L21-R22), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-7ee3386f1d14753555fdc96b4060cafd0ab57a4c1bb907dc04f54b486d43e482L31-R31), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L48-R48), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L76-R78))
*  Import `std::sync::Arc` in `code_splitter.rs` to use `Arc<str>` ([link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8R1-R2))
*  Use `Arc::from` instead of `to_string` when creating `RuntimeSpec` from string slices in `code_splitter.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L76-R78))
*  Use `as_ref` when converting `Arc<str>` to `&str` for `HashMap` keys or `stringify_runtime` function in `hmr.rs` and `get_main_filename.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L112-R112), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L326-R326), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L410-R410), [link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-4132bef47c76ddfe3655d7a5d1d16caceb49d4543fab5493aecb2ad015558732L54-R54))
*  Use `to_string` and `as_ref` when serializing and deserializing `HotUpdateContent` with `String` keys in `hmr.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2844/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L112-R112))

</details>
