### PR TITLE
perf: avoid `clone` while matching `import.meta.webpackHot`

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
@@ -7,8 +7,8 @@ use swc_core::quote;
 use url::Url;
 
 use super::{
-  as_parent_path, is_import_meta, is_import_meta_hot, is_import_meta_member_expr,
-  match_import_meta_member_expr,
+  as_parent_path, is_import_meta, is_import_meta_member_expr,
+  is_member_expr_starts_with_import_meta_webpack_hot, match_import_meta_member_expr,
 };
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/ImportMetaPlugin.js
@@ -48,7 +48,7 @@ impl VisitAstPath for ImportMetaScanner<'_> {
     ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
   ) {
     // exclude import.meta.webpackHot
-    if is_import_meta_hot(expr) {
+    if is_member_expr_starts_with_import_meta_webpack_hot(expr) {
       return;
     }
     // import.meta.url

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -102,36 +102,39 @@ pub fn is_import_meta_hot_decline_call(node: &CallExpr) -> bool {
   is_hmr_import_meta_api_call(node, "import.meta.webpackHot.decline")
 }
 
-pub fn is_import_meta_hot(expr: &Expr) -> bool {
-  let v = member_expr_to_string(expr);
-  v.starts_with("import.meta.webpackHot")
+/// Match the expr is `import.meta.webpackHot`
+pub fn is_expr_exact_import_meta_webpack_hot(expr: &Expr) -> bool {
+  use swc_core::ecma::ast;
+  match expr {
+    ast::Expr::Member(ast::MemberExpr {
+      obj:
+        box ast::Expr::MetaProp(ast::MetaPropExpr {
+          kind: ast::MetaPropKind::ImportMeta,
+          ..
+        }),
+      prop: ast::MemberProp::Ident(ast::Ident { sym: prop, .. }),
+      ..
+    }) if prop == "webpackHot" => true,
+    _ => false,
+  }
 }
 
-pub fn member_expr_to_string(expr: &Expr) -> String {
-  fn collect_member_expr(expr: &Expr, arr: &mut Vec<String>) {
-    if let Expr::Member(member_expr) = expr {
-      if let MemberProp::Ident(ident) = &member_expr.prop {
-        arr.push(ident.sym.to_string());
+pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
+  use swc_core::ecma::ast;
+  let mut match_target = expr;
+
+  loop {
+    match match_target {
+      // If the target self is `import.meta.webpackHot` just return true
+      ast::Expr::Member(..) if is_expr_exact_import_meta_webpack_hot(match_target) => return true,
+      // The expr is sub-part of `import.meta.webpackHot.xxx`. Recursively look up.
+      ast::Expr::Member(ast::MemberExpr { obj, .. }) if obj.is_member() => {
+        match_target = obj.as_ref();
       }
-      collect_member_expr(&member_expr.obj, arr);
-    }
-    // add length check to improve performance, avoid match extra expr
-    if arr.is_empty() {
-      return;
-    }
-    if is_import_meta(expr) {
-      arr.push("meta".to_string());
-      arr.push("import".to_string());
-    }
-    if let Expr::Ident(ident) = expr {
-      arr.push(ident.sym.to_string());
+      // The expr could never be `import.meta.webpackHot`
+      _ => return false,
     }
   }
-
-  let mut res = vec![];
-  collect_member_expr(expr, &mut res);
-  res.reverse();
-  res.join(".")
 }
 
 #[test]
@@ -162,7 +165,9 @@ fn test() {
     prop: MemberProp::Ident(Ident::new("accept".into(), DUMMY_SP)),
   });
   assert!(is_import_meta_member_expr(&import_meta_expr));
-  assert!(is_import_meta_hot(&import_meta_expr));
+  assert!(is_member_expr_starts_with_import_meta_webpack_hot(
+    &import_meta_expr
+  ));
   assert!(match_import_meta_member_expr(
     &import_meta_expr,
     "import.meta.webpackHot.accept"

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -105,18 +105,15 @@ pub fn is_import_meta_hot_decline_call(node: &CallExpr) -> bool {
 /// Match the expr is `import.meta.webpackHot`
 pub fn is_expr_exact_import_meta_webpack_hot(expr: &Expr) -> bool {
   use swc_core::ecma::ast;
-  match expr {
-    ast::Expr::Member(ast::MemberExpr {
-      obj:
-        box ast::Expr::MetaProp(ast::MetaPropExpr {
-          kind: ast::MetaPropKind::ImportMeta,
-          ..
-        }),
-      prop: ast::MemberProp::Ident(ast::Ident { sym: prop, .. }),
-      ..
-    }) if prop == "webpackHot" => true,
-    _ => false,
-  }
+  matches!(expr, ast::Expr::Member(ast::MemberExpr {
+    obj:
+      box ast::Expr::MetaProp(ast::MetaPropExpr {
+        kind: ast::MetaPropKind::ImportMeta,
+        ..
+      }),
+    prop: ast::MemberProp::Ident(ast::Ident { sym: prop, .. }),
+    ..
+  }) if prop == "webpackHot")
 }
 
 pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {


### PR DESCRIPTION
## Related issue (if exists)

Fixes #2842.

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f01d53</samp>

Refactored the code for scanning `import.meta.webpackHot` expressions in JavaScript files. Moved and renamed a function from `util.rs` to `import_meta_scanner.rs`, and replaced some helper functions with more efficient and clear ones. The goal was to improve the performance and readability of the dependency analysis.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f01d53</samp>

*  Rename and move `is_import_meta_hot` function to `import_meta_scanner.rs` and split it into two functions: `is_expr_exact_import_meta_webpack_hot` and `is_member_expr_starts_with_import_meta_webpack_hot` ([link](https://github.com/web-infra-dev/rspack/pull/2857/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L10-R11), [link](https://github.com/web-infra-dev/rspack/pull/2857/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L105-R137))
* Replace `is_import_meta_hot` function call with `is_member_expr_starts_with_import_meta_webpack_hot` in `import_meta_scanner.rs` and update comment ([link](https://github.com/web-infra-dev/rspack/pull/2857/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L51-R51))
* Update test case for `is_import_meta_hot` to use the new function name `is_member_expr_starts_with_import_meta_webpack_hot` in `util.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2857/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L165-R170))

</details>
