### PR TITLE
fix: sourcemap lost when enable builtins.banner

### DIFF
--- a/.changeset/strong-peaches-warn.md
+++ b/.changeset/strong-peaches-warn.md
@@ -1,0 +1,6 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+---
+
+fix: source map lost when enable builtins.banner

--- a/packages/rspack/tests/configCases/builtins/banner/index.js
+++ b/packages/rspack/tests/configCases/builtins/banner/index.js
@@ -8,16 +8,26 @@ import("./b.js").then(res => {
 it("add comment should works", () => {
 	const mainFile = fs.readFileSync(__filename, "utf-8");
 	expect(mainFile.startsWith("/*! MMMMMMM */")).toBeTruthy();
-	expect(mainFile.endsWith("/** MMMMMMM */")).toBeTruthy();
+	expect(
+		mainFile.endsWith("/** MMMMMMM */\n//# sourceMappingURL=main.js.map")
+	).toBeTruthy();
 
 	const aFile = fs.readFileSync(path.resolve(__dirname, "a.js"), "utf-8");
 	expect(aFile.startsWith("/*! MMMMMMM */")).toBeTruthy();
-	expect(aFile.endsWith("/** MMMMMMM */")).toBeFalsy();
+	expect(
+		aFile.endsWith("/** MMMMMMM */\n//# sourceMappingURL=a.js.map")
+	).toBeFalsy();
 
 	const asyncFile = fs.readFileSync(
 		path.resolve(__dirname, "b_js.js"),
 		"utf-8"
 	);
 	expect(asyncFile.startsWith("/*! MMMMMMM */")).toBeTruthy();
-	expect(asyncFile.endsWith("/** MMMMMMM */")).toBeFalsy();
+	expect(
+		asyncFile.endsWith("/** MMMMMMM */\n//# sourceMappingURL=b_js.js.map")
+	).toBeFalsy();
+});
+
+it("should keep source map", () => {
+	expect(fs.existsSync(path.resolve(__dirname, "main.js.map"))).toBe(true);
 });

--- a/packages/rspack/tests/configCases/builtins/banner/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/banner/webpack.config.js
@@ -3,6 +3,7 @@ module.exports = {
 		main: "./index",
 		a: "./a"
 	},
+	devtool: "source-map",
 	builtins: {
 		banner: [
 			"MMMMMMM",


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ecece7</samp>

This pull request improves the banner plugin for `rspack`, a Rust-based web packer. It refactors the plugin code, simplifies the asset updating logic, and enhances the source map support. It also updates the test cases and fixes some minor issues in the `node_binding` crate.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ecece7</samp>

*  Add and modify imports for new types and functions in `js_values/compilation.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefR6-R7))
*  Change the type of `new_source` to match the return type of `updater` in `js_values/compilation.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL36-R38))
*  Map and transpose the `asset_info_update_or_function` argument to get `new_info` in `js_values/compilation.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL56-R65))
*  Change the `updater` function to return a tuple of `(BoxSource, AssetInfo)` and construct `asset_info` from `asset_info_fn` in `js_values/compilation.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL73-R84))
*  Use the `remove` and `emit_asset` methods to update the assets in the `Compilation` struct in `rspack_core/src/compiler/compilation.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L173-R196))
*  Remove the unused import, the `CachedStruct` struct, and the `cache` field from the `BannerPlugin` struct in `rspack_plugin_banner/src/lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-f84cf2ba28a1730ebd4bbb4ee6c307fa65bcfd3e5c308130a31b64522f25d481L3), [link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-f84cf2ba28a1730ebd4bbb4ee6c307fa65bcfd3e5c308130a31b64522f25d481L136-R137))
*  Rename and modify the `update_source` method of the `BannerPlugin` struct to take and return a `BoxSource` in `rspack_plugin_banner/src/lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-f84cf2ba28a1730ebd4bbb4ee6c307fa65bcfd3e5c308130a31b64522f25d481L155-R166))
*  Simplify the `apply` method of the `BannerPlugin` struct by calling the `update_source` and `update_asset` methods in `rspack_plugin_banner/src/lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-f84cf2ba28a1730ebd4bbb4ee6c307fa65bcfd3e5c308130a31b64522f25d481L222-R208))
*  Update the test case for the banner plugin to include the expected source map comments in `rspack/tests/configCases/builtins/banner/index.js` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-f0bcdf020f9f7e6a15473040f06b2c343a05ed476a90fd8c1224ddf6ed5911a4L11-R19))
*  Add a new test case for the banner plugin to check the existence of the source map files in `rspack/tests/configCases/builtins/banner/index.js` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-f0bcdf020f9f7e6a15473040f06b2c343a05ed476a90fd8c1224ddf6ed5911a4L22-R33))
*  Enable the `devtool` option for the banner plugin test case in `rspack/tests/configCases/builtins/banner/webpack.config.js` ([link](https://github.com/web-infra-dev/rspack/pull/2858/files?diff=unified&w=0#diff-622a3941ff7dc6cd83a3fb459fbf26b2086b9a531cd0e3faee2b1654126ccb0cR6))

</details>
