### PR TITLE
fix: undefined reasons with stats.toJson

### DIFF
--- a/.changeset/unlucky-geckos-hug.md
+++ b/.changeset/unlucky-geckos-hug.md
@@ -1,0 +1,6 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+---
+
+fix: undefined reasons with stats.toJson({ reasons: true })

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -411,7 +411,6 @@ export interface RawCacheGroupOptions {
 }
 export interface RawStatsOptions {
   colors: boolean
-  reasons: boolean
 }
 export interface RawOptions {
   entry: Record<string, RawEntryItem>
@@ -642,8 +641,8 @@ export class JsCompilation {
 }
 export class JsStats {
   getAssets(): JsStatsGetAssets
-  getModules(): Array<JsStatsModule>
-  getChunks(chunkModules: boolean, chunksRelations: boolean): Array<JsStatsChunk>
+  getModules(reasons: boolean): Array<JsStatsModule>
+  getChunks(chunkModules: boolean, chunksRelations: boolean, reasons: boolean): Array<JsStatsChunk>
   getEntrypoints(): Array<JsStatsChunkGroup>
   getNamedChunkGroups(): Array<JsStatsChunkGroup>
   getErrors(): Array<JsStatsError>

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -264,10 +264,10 @@ impl JsStats {
   }
 
   #[napi]
-  pub fn get_modules(&self) -> Vec<JsStatsModule> {
+  pub fn get_modules(&self, reasons: bool) -> Vec<JsStatsModule> {
     self
       .inner
-      .get_modules()
+      .get_modules(reasons)
       .expect("Failed to get modules")
       .into_iter()
       .map(Into::into)
@@ -275,10 +275,15 @@ impl JsStats {
   }
 
   #[napi]
-  pub fn get_chunks(&self, chunk_modules: bool, chunks_relations: bool) -> Vec<JsStatsChunk> {
+  pub fn get_chunks(
+    &self,
+    chunk_modules: bool,
+    chunks_relations: bool,
+    reasons: bool,
+  ) -> Vec<JsStatsChunk> {
     self
       .inner
-      .get_chunks(chunk_modules, chunks_relations)
+      .get_chunks(chunk_modules, chunks_relations, reasons)
       .expect("Failed to get chunks")
       .into_iter()
       .map(Into::into)

--- a/crates/rspack_binding_options/src/options/raw_stats.rs
+++ b/crates/rspack_binding_options/src/options/raw_stats.rs
@@ -7,14 +7,12 @@ use serde::Deserialize;
 #[napi(object)]
 pub struct RawStatsOptions {
   pub colors: bool,
-  pub reasons: bool,
 }
 
 impl From<RawStatsOptions> for StatsOptions {
   fn from(value: RawStatsOptions) -> Self {
     Self {
       colors: value.colors,
-      reasons: value.reasons,
     }
   }
 }

--- a/crates/rspack_core/src/options/stats.rs
+++ b/crates/rspack_core/src/options/stats.rs
@@ -1,5 +1,4 @@
 #[derive(Debug, Default)]
 pub struct StatsOptions {
   pub colors: bool,
-  pub reasons: bool,
 }

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -109,19 +109,24 @@ impl Stats<'_> {
     (assets, assets_by_chunk_name)
   }
 
-  pub fn get_modules(&self) -> Result<Vec<StatsModule>> {
+  pub fn get_modules(&self, reasons: bool) -> Result<Vec<StatsModule>> {
     let mut modules: Vec<StatsModule> = self
       .compilation
       .module_graph
       .modules()
       .values()
-      .map(|module| self.get_module(module, self.compilation.options.stats.reasons))
+      .map(|module| self.get_module(module, reasons))
       .collect::<Result<_>>()?;
     Self::sort_modules(&mut modules);
     Ok(modules)
   }
 
-  pub fn get_chunks(&self, chunk_modules: bool, chunk_relations: bool) -> Result<Vec<StatsChunk>> {
+  pub fn get_chunks(
+    &self,
+    chunk_modules: bool,
+    chunk_relations: bool,
+    reasons: bool,
+  ) -> Result<Vec<StatsChunk>> {
     let mut chunks: Vec<StatsChunk> = self
       .compilation
       .chunk_by_ukey
@@ -136,7 +141,7 @@ impl Stats<'_> {
             .get_chunk_modules(&c.ukey, &self.compilation.module_graph);
           let mut chunk_modules = chunk_modules
             .into_iter()
-            .map(|m| self.get_module(m, self.compilation.options.stats.reasons))
+            .map(|m| self.get_module(m, reasons))
             .collect::<Result<Vec<_>>>()?;
           Self::sort_modules(&mut chunk_modules);
           Some(chunk_modules)

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -526,7 +526,6 @@ function getRawNode(node: Node): RawOptions["node"] {
 function getRawStats(stats: StatsValue): RawOptions["stats"] {
 	const statsOptions = normalizeStatsPreset(stats);
 	return {
-		colors: statsOptions.colors ?? false,
-		reasons: statsOptions.reasons ?? false
+		colors: statsOptions.colors ?? false
 	};
 }

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -89,11 +89,12 @@ export class Stats {
 		if (options.chunks) {
 			obj.chunks = this.#inner.getChunks(
 				options.chunkModules!,
-				options.chunkRelations!
+				options.chunkRelations!,
+				options.reasons!
 			);
 		}
 		if (options.modules) {
-			obj.modules = this.#inner.getModules();
+			obj.modules = this.#inner.getModules(options.reasons!);
 		}
 		if (options.entrypoints) {
 			obj.entrypoints = this.#inner

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -62,6 +62,12 @@ describe("Stats", () => {
 		          "issuerPath": [],
 		          "moduleType": "javascript/auto",
 		          "name": "./fixtures/a.js",
+		          "reasons": [
+		            {
+		              "type": "entry",
+		              "userRequest": "./fixtures/a",
+		            },
+		          ],
 		          "size": 55,
 		          "type": "module",
 		        },
@@ -103,6 +109,12 @@ describe("Stats", () => {
 		      "issuerPath": [],
 		      "moduleType": "javascript/auto",
 		      "name": "./fixtures/a.js",
+		      "reasons": [
+		        {
+		          "type": "entry",
+		          "userRequest": "./fixtures/a",
+		        },
+		      ],
 		      "size": 55,
 		      "type": "module",
 		    },
@@ -136,7 +148,9 @@ describe("Stats", () => {
 		Entrypoint main = main.js
 		chunk {main} main.js (main) 55 bytes [entry]
 		 [777] ./fixtures/a.js 55 bytes {main}
-		[777] ./fixtures/a.js 55 bytes {main}"
+		     entry ./fixtures/a 
+		[777] ./fixtures/a.js 55 bytes {main}
+		    entry ./fixtures/a "
 	`);
 	});
 

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -67,6 +67,15 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
           ],
           "moduleType": "javascript/auto",
           "name": "./dynamic.js",
+          "reasons": [
+            {
+              "moduleId": "2",
+              "moduleIdentifier": "javascript/auto|<PROJECT_ROOT>/tests/statsCases/filename/index.js",
+              "moduleName": "./index.js",
+              "type": "dynamic import",
+              "userRequest": "./dynamic",
+            },
+          ],
           "size": 32,
           "type": "module",
         },
@@ -99,6 +108,12 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
           "issuerPath": [],
           "moduleType": "javascript/auto",
           "name": "./index.js",
+          "reasons": [
+            {
+              "type": "entry",
+              "userRequest": "./index",
+            },
+          ],
           "size": 38,
           "type": "module",
         },
@@ -140,6 +155,12 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       "issuerPath": [],
       "moduleType": "javascript/auto",
       "name": "./index.js",
+      "reasons": [
+        {
+          "type": "entry",
+          "userRequest": "./index",
+        },
+      ],
       "size": 38,
       "type": "module",
     },
@@ -161,6 +182,15 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       ],
       "moduleType": "javascript/auto",
       "name": "./dynamic.js",
+      "reasons": [
+        {
+          "moduleId": "2",
+          "moduleIdentifier": "javascript/auto|<PROJECT_ROOT>/tests/statsCases/filename/index.js",
+          "moduleName": "./index.js",
+          "type": "dynamic import",
+          "userRequest": "./dynamic",
+        },
+      ],
       "size": 32,
       "type": "module",
     },
@@ -195,10 +225,14 @@ dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]
 Entrypoint main = main.xxxx.js
 chunk {dynamic_js} dynamic_js.xxxx.js 32 bytes
  [471] ./dynamic.js 32 bytes {dynamic_js}
+     dynamic import ./dynamic [2]
 chunk {main} main.xxxx.js (main) 38 bytes [entry]
  [2] ./index.js 38 bytes {main}
+     entry ./index 
 [2] ./index.js 38 bytes {main}
-[471] ./dynamic.js 32 bytes {dynamic_js}"
+    entry ./index 
+[471] ./dynamic.js 32 bytes {dynamic_js}
+    dynamic import ./dynamic [2]"
 `;
 
 exports[`StatsTestCases should print correct stats for hot+production 1`] = `
@@ -245,6 +279,12 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
           "issuerPath": [],
           "moduleType": "javascript/auto",
           "name": "./index.js",
+          "reasons": [
+            {
+              "type": "entry",
+              "userRequest": "./index.js",
+            },
+          ],
           "size": 25,
           "type": "module",
         },
@@ -286,6 +326,12 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
       "issuerPath": [],
       "moduleType": "javascript/auto",
       "name": "./index.js",
+      "reasons": [
+        {
+          "type": "entry",
+          "userRequest": "./index.js",
+        },
+      ],
       "size": 25,
       "type": "module",
     },
@@ -319,7 +365,9 @@ bundle.js  8.83 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 25 bytes [entry]
  [2] ./index.js 25 bytes {main}
-[2] ./index.js 25 bytes {main}"
+     entry ./index.js 
+[2] ./index.js 25 bytes {main}
+    entry ./index.js "
 `;
 
 exports[`StatsTestCases should print correct stats for identifier-let-strict-mode 1`] = `
@@ -1218,6 +1266,12 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
           "issuerPath": [],
           "moduleType": "javascript/auto",
           "name": "./index.js",
+          "reasons": [
+            {
+              "type": "entry",
+              "userRequest": "./index",
+            },
+          ],
           "size": 51,
           "type": "module",
         },
@@ -1239,6 +1293,15 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
           ],
           "moduleType": "javascript/auto",
           "name": "<PROJECT_ROOT>/tests/statsCases/resolve-overflowcycle-alias/a (missing)",
+          "reasons": [
+            {
+              "moduleId": "2",
+              "moduleIdentifier": "javascript/auto|<PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js",
+              "moduleName": "./index.js",
+              "type": "esm import",
+              "userRequest": "cycle-alias/a",
+            },
+          ],
           "size": 160,
           "type": "module",
         },
@@ -1291,6 +1354,12 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
       "issuerPath": [],
       "moduleType": "javascript/auto",
       "name": "./index.js",
+      "reasons": [
+        {
+          "type": "entry",
+          "userRequest": "./index",
+        },
+      ],
       "size": 51,
       "type": "module",
     },
@@ -1312,6 +1381,15 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
       ],
       "moduleType": "javascript/auto",
       "name": "<PROJECT_ROOT>/tests/statsCases/resolve-overflowcycle-alias/a (missing)",
+      "reasons": [
+        {
+          "moduleId": "2",
+          "moduleIdentifier": "javascript/auto|<PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js",
+          "moduleName": "./index.js",
+          "type": "esm import",
+          "userRequest": "cycle-alias/a",
+        },
+      ],
       "size": 160,
       "type": "module",
     },
@@ -1346,9 +1424,13 @@ bundle.js  363 bytes    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 211 bytes [entry]
  [2] ./index.js 51 bytes {main}
+     entry ./index 
  [193] <PROJECT_ROOT>/tests/statsCases/resolve-overflowcycle-alias/a (missing) 160 bytes {main}
+     esm import cycle-alias/a [2]
 [2] ./index.js 51 bytes {main}
+    entry ./index 
 [193] <PROJECT_ROOT>/tests/statsCases/resolve-overflowcycle-alias/a (missing) 160 bytes {main}
+    esm import cycle-alias/a [2]
 
 error[internal]: Resolve error
   ┌─ tests/statsCases/resolve-overflow/index.js:1:1
@@ -1403,6 +1485,12 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
           "issuerPath": [],
           "moduleType": "javascript/auto",
           "name": "./index.js",
+          "reasons": [
+            {
+              "type": "entry",
+              "userRequest": "./index",
+            },
+          ],
           "size": 39,
           "type": "module",
         },
@@ -1424,6 +1512,15 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
           ],
           "moduleType": "javascript/auto",
           "name": "<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkgpkg-a (missing)",
+          "reasons": [
+            {
+              "moduleId": "2",
+              "moduleIdentifier": "javascript/auto|<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/index.js",
+              "moduleName": "./index.js",
+              "type": "esm import",
+              "userRequest": "pkg-a",
+            },
+          ],
           "size": 160,
           "type": "module",
         },
@@ -1471,6 +1568,12 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
       "issuerPath": [],
       "moduleType": "javascript/auto",
       "name": "./index.js",
+      "reasons": [
+        {
+          "type": "entry",
+          "userRequest": "./index",
+        },
+      ],
       "size": 39,
       "type": "module",
     },
@@ -1492,6 +1595,15 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
       ],
       "moduleType": "javascript/auto",
       "name": "<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkgpkg-a (missing)",
+      "reasons": [
+        {
+          "moduleId": "2",
+          "moduleIdentifier": "javascript/auto|<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/index.js",
+          "moduleName": "./index.js",
+          "type": "esm import",
+          "userRequest": "pkg-a",
+        },
+      ],
       "size": 160,
       "type": "module",
     },
@@ -1525,9 +1637,13 @@ bundle.js  972 bytes    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 199 bytes [entry]
  [2] ./index.js 39 bytes {main}
+     entry ./index 
  [481] <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkgpkg-a (missing) 160 bytes {main}
+     esm import pkg-a [2]
 [2] ./index.js 39 bytes {main}
+    entry ./index 
 [481] <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkgpkg-a (missing) 160 bytes {main}
+    esm import pkg-a [2]
 
 Export should be relative path and start with "./", but got ../../index.js
 "
@@ -1577,6 +1693,12 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
           "issuerPath": [],
           "moduleType": "javascript/auto",
           "name": "./index.js",
+          "reasons": [
+            {
+              "type": "entry",
+              "userRequest": "./index",
+            },
+          ],
           "size": 26,
           "type": "module",
         },
@@ -1618,6 +1740,12 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
       "issuerPath": [],
       "moduleType": "javascript/auto",
       "name": "./index.js",
+      "reasons": [
+        {
+          "type": "entry",
+          "userRequest": "./index",
+        },
+      ],
       "size": 26,
       "type": "module",
     },
@@ -1651,5 +1779,7 @@ bundle.js  317 bytes    main  [emitted]  main
 Entrypoint main = bundle.js
 chunk {main} bundle.js (main) 26 bytes [entry]
  [2] ./index.js 26 bytes {main}
-[2] ./index.js 26 bytes {main}"
+     entry ./index 
+[2] ./index.js 26 bytes {main}
+    entry ./index "
 `;


### PR DESCRIPTION
## Related issue (if exists)

fixes #2573

`stats.toJson({ colors: false })` should be the same, but `Diagnostic` depend on `options.stats.colors`, which need move render diagnostic from rust side to js side, I will refactor it in the following PR. @IWANABETHATGUY cc
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8260b8</samp>

Removed the `reasons` field from the stats options and added it as a parameter to the stats methods that return module and chunk information. This simplifies the stats configuration and allows more flexibility in the stats output. Updated the node and TypeScript bindings to reflect this change.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a8260b8</samp>

*  Remove `reasons` field from `StatsOptions` and `RawStatsOptions` structs, as it is no longer needed to configure `Stats` ([link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-2034b42b01c282fc3a902e9ee36c4fb095bd63935392028d392ce7d7742f4f3eL10), [link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-2034b42b01c282fc3a902e9ee36c4fb095bd63935392028d392ce7d7742f4f3eL17), [link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-95ba9d83cb8399956af47ec1cc8d24ea1946be89f337354901aafd3a9dd4ecc4L4))
*  Add `reasons` parameter to `get_modules` and `get_chunks` methods of `Stats` struct, which indicates whether to include the reasons why a module was included in the bundle or chunk ([link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L112-R112), [link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L124-R129))
*  Add `reasons` parameter to `get_module` method of `Stats` struct, which populates the optional `reasons` field of `StatsModule` struct with a vector of `StatsReason` structs that describe the dependencies that caused the module to be included ([link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L118-R118), [link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L139-R144))
*  Add `reasons` parameter to `get_modules` and `get_chunks` methods of `JsStats` struct, which passes it to the underlying `Stats` struct ([link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8L267-R270), [link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8L278-R286))
*  Remove `reasons` field from the object returned by `getRawStats` function of `config/adapter.ts` module, as it is no longer needed to configure `Stats` ([link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L529-R529))
*  Pass `reasons` option to `get_chunks` and `get_modules` methods of `JsStats` struct in `toJson` method of `Stats` class of `stats.ts` module, which allows the JSON output to include the reasons why a module was included in a chunk or a bundle, if requested by the user ([link](https://github.com/web-infra-dev/rspack/pull/2859/files?diff=unified&w=0#diff-dabb493b406bdc4bd957c1580c51c7003d0aef67411624e6664c7b1c50b67705L92-R97))

</details>
