### PR TITLE
refactor(runtime): unwrap the function in ir

### DIFF
--- a/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
@@ -39,56 +39,54 @@ __webpack_require__.e = function (chunkId) {
 })();
 // ir
 (function() {
-(function () {
-	function _getRequireCache(nodeInterop) {
-		if (typeof WeakMap !== "function") return null;
+function _getRequireCache(nodeInterop) {
+	if (typeof WeakMap !== "function") return null;
 
-		var cacheBabelInterop = new WeakMap();
-		var cacheNodeInterop = new WeakMap();
-		return (_getRequireCache = function (nodeInterop) {
-			return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
-		})(nodeInterop);
+	var cacheBabelInterop = new WeakMap();
+	var cacheNodeInterop = new WeakMap();
+	return (_getRequireCache = function (nodeInterop) {
+		return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+	})(nodeInterop);
+}
+
+__webpack_require__.ir = function (obj, nodeInterop) {
+	if (!nodeInterop && obj && obj.__esModule) {
+		return obj;
 	}
 
-	__webpack_require__.ir = function (obj, nodeInterop) {
-		if (!nodeInterop && obj && obj.__esModule) {
-			return obj;
-		}
+	if (
+		obj === null ||
+		(typeof obj !== "object" && typeof obj !== "function")
+	) {
+		return { default: obj };
+	}
 
-		if (
-			obj === null ||
-			(typeof obj !== "object" && typeof obj !== "function")
-		) {
-			return { default: obj };
-		}
+	var cache = _getRequireCache(nodeInterop);
+	if (cache && cache.has(obj)) {
+		return cache.get(obj);
+	}
 
-		var cache = _getRequireCache(nodeInterop);
-		if (cache && cache.has(obj)) {
-			return cache.get(obj);
-		}
-
-		var newObj = {};
-		var hasPropertyDescriptor =
-			Object.defineProperty && Object.getOwnPropertyDescriptor;
-		for (var key in obj) {
-			if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
-				var desc = hasPropertyDescriptor
-					? Object.getOwnPropertyDescriptor(obj, key)
-					: null;
-				if (desc && (desc.get || desc.set)) {
-					Object.defineProperty(newObj, key, desc);
-				} else {
-					newObj[key] = obj[key];
-				}
+	var newObj = {};
+	var hasPropertyDescriptor =
+		Object.defineProperty && Object.getOwnPropertyDescriptor;
+	for (var key in obj) {
+		if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+			var desc = hasPropertyDescriptor
+				? Object.getOwnPropertyDescriptor(obj, key)
+				: null;
+			if (desc && (desc.get || desc.set)) {
+				Object.defineProperty(newObj, key, desc);
+			} else {
+				newObj[key] = obj[key];
 			}
 		}
-		newObj.default = obj;
-		if (cache) {
-			cache.set(obj, newObj);
-		}
-		return newObj;
-	};
-})();
+	}
+	newObj.default = obj;
+	if (cache) {
+		cache.set(obj, newObj);
+	}
+	return newObj;
+};
 
 })();
 // webpack/runtime/load_chunk_with_module

--- a/crates/rspack_plugin_runtime/src/runtime/common/_export_star.js
+++ b/crates/rspack_plugin_runtime/src/runtime/common/_export_star.js
@@ -1,14 +1,12 @@
-(function () {
-	__webpack_require__.es = function (from, to) {
-		Object.keys(from).forEach(function (k) {
-			if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k))
-				Object.defineProperty(to, k, {
-					enumerable: true,
-					get: function () {
-						return from[k];
-					}
-				});
-		});
-		return from;
-	};
-})();
+__webpack_require__.es = function (from, to) {
+	Object.keys(from).forEach(function (k) {
+		if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k))
+			Object.defineProperty(to, k, {
+				enumerable: true,
+				get: function () {
+					return from[k];
+				}
+			});
+	});
+	return from;
+};

--- a/crates/rspack_plugin_runtime/src/runtime/common/_interop_require.js
+++ b/crates/rspack_plugin_runtime/src/runtime/common/_interop_require.js
@@ -1,50 +1,48 @@
-(function () {
-	function _getRequireCache(nodeInterop) {
-		if (typeof WeakMap !== "function") return null;
+function _getRequireCache(nodeInterop) {
+	if (typeof WeakMap !== "function") return null;
 
-		var cacheBabelInterop = new WeakMap();
-		var cacheNodeInterop = new WeakMap();
-		return (_getRequireCache = function (nodeInterop) {
-			return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
-		})(nodeInterop);
+	var cacheBabelInterop = new WeakMap();
+	var cacheNodeInterop = new WeakMap();
+	return (_getRequireCache = function (nodeInterop) {
+		return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+	})(nodeInterop);
+}
+
+__webpack_require__.ir = function (obj, nodeInterop) {
+	if (!nodeInterop && obj && obj.__esModule) {
+		return obj;
 	}
 
-	__webpack_require__.ir = function (obj, nodeInterop) {
-		if (!nodeInterop && obj && obj.__esModule) {
-			return obj;
-		}
+	if (
+		obj === null ||
+		(typeof obj !== "object" && typeof obj !== "function")
+	) {
+		return { default: obj };
+	}
 
-		if (
-			obj === null ||
-			(typeof obj !== "object" && typeof obj !== "function")
-		) {
-			return { default: obj };
-		}
+	var cache = _getRequireCache(nodeInterop);
+	if (cache && cache.has(obj)) {
+		return cache.get(obj);
+	}
 
-		var cache = _getRequireCache(nodeInterop);
-		if (cache && cache.has(obj)) {
-			return cache.get(obj);
-		}
-
-		var newObj = {};
-		var hasPropertyDescriptor =
-			Object.defineProperty && Object.getOwnPropertyDescriptor;
-		for (var key in obj) {
-			if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
-				var desc = hasPropertyDescriptor
-					? Object.getOwnPropertyDescriptor(obj, key)
-					: null;
-				if (desc && (desc.get || desc.set)) {
-					Object.defineProperty(newObj, key, desc);
-				} else {
-					newObj[key] = obj[key];
-				}
+	var newObj = {};
+	var hasPropertyDescriptor =
+		Object.defineProperty && Object.getOwnPropertyDescriptor;
+	for (var key in obj) {
+		if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+			var desc = hasPropertyDescriptor
+				? Object.getOwnPropertyDescriptor(obj, key)
+				: null;
+			if (desc && (desc.get || desc.set)) {
+				Object.defineProperty(newObj, key, desc);
+			} else {
+				newObj[key] = obj[key];
 			}
 		}
-		newObj.default = obj;
-		if (cache) {
-			cache.set(obj, newObj);
-		}
-		return newObj;
-	};
-})();
+	}
+	newObj.default = obj;
+	if (cache) {
+		cache.set(obj, newObj);
+	}
+	return newObj;
+};

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`HashTestCases should print correct hash for package-path-change-0 1`] = `
 [
-  "runtime.ced6a4f438676fab.js",
+  "runtime.a17237b43fe1b025.js",
   "main.8ba66a6d562c9f41.js",
   "0.28a2cb9e99b496d6.js",
 ]
@@ -10,7 +10,7 @@ exports[`HashTestCases should print correct hash for package-path-change-0 1`] =
 
 exports[`HashTestCases should print correct hash for package-path-change-1 1`] = `
 [
-  "runtime.bbbe2a6c0d629b10.js",
+  "runtime.d522d0dcd5f062c3.js",
   "main.b11af1dbcee032b1.js",
   "0.1984e8e54b0d14de.js",
 ]

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -129,7 +129,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
-  "hash": "972260076b16494b",
+  "hash": "1896652891bba34c",
   "modules": [
     {
       "chunks": [
@@ -188,7 +188,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for filename 2`] = `
-"Hash: 972260076b16494b
+"Hash: 1896652891bba34c
              Asset       Size      Chunks             Chunk Names
       main.xxxx.js   1.39 KiB        main  [emitted]  main
 dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]  
@@ -1460,7 +1460,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
     },
   ],
   "errorsCount": 1,
-  "hash": "a7d46af5c732ee4a",
+  "hash": "178bdd60e81ac756",
   "modules": [
     {
       "chunks": [
@@ -1519,7 +1519,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-unexpected-exports-in-pkg 2`] = `
-"Hash: a7d46af5c732ee4a
+"Hash: 178bdd60e81ac756
     Asset       Size  Chunks             Chunk Names
 bundle.js  972 bytes    main  [emitted]  main
 Entrypoint main = bundle.js


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9fda91d</samp>

This pull request refactors and optimizes the runtime code of the rspack plugin. It removes unnecessary function wrappers, moves some functions to the main runtime file, and reduces the number of files and imports. These changes aim to improve the performance, readability, and maintainability of the runtime code.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9fda91d</samp>

*  Simplify and optimize the runtime code by moving and removing self-invoking function wrappers ([link](https://github.com/web-infra-dev/rspack/pull/2860/files?diff=unified&w=0#diff-a2f4891c4ae8e3baa6d340d93ee2434fc1738949ecb57a5941f6ab9227f8461dL1-R12), [link](https://github.com/web-infra-dev/rspack/pull/2860/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72L42-R89))
*  Consolidate the `_getRequireCache` and `__webpack_require__.ir` functions into the main `runtime/common/_interop_require.js` file ([link](https://github.com/web-infra-dev/rspack/pull/2860/files?diff=unified&w=0#diff-62f289a9d79d154002da1132ce4d98b71cf41f3bb35207eb6dcb0e1d5809265dL1-R48))
*  Update the `dynamic-import` test fixture to reflect the changes in the runtime code ([link](https://github.com/web-infra-dev/rspack/pull/2860/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72L42-R89))

</details>
