### PR TITLE
fix: remove`.d.ts` from the default `resolve.extensions`

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -583,15 +583,7 @@ const getResolveDefaults = ({
 		if (targetProperties.nwjs) conditions.push("nwjs");
 	}
 
-	const jsExtensions = [
-		".tsx",
-		".ts",
-		".jsx",
-		".js",
-		".json",
-		".wasm",
-		".d.ts"
-	];
+	const jsExtensions = [".tsx", ".ts", ".jsx", ".js", ".json", ".wasm"];
 
 	const tp = targetProperties;
 	const browserField =

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -307,7 +307,6 @@ describe("snapshots", () => {
 		          ".js",
 		          ".json",
 		          ".wasm",
-		          ".d.ts",
 		        ],
 		        "mainFields": [
 		          "browser",
@@ -329,7 +328,6 @@ describe("snapshots", () => {
 		          ".js",
 		          ".json",
 		          ".wasm",
-		          ".d.ts",
 		        ],
 		        "mainFields": [
 		          "browser",
@@ -351,7 +349,6 @@ describe("snapshots", () => {
 		          ".js",
 		          ".json",
 		          ".wasm",
-		          ".d.ts",
 		        ],
 		        "mainFields": [
 		          "browser",
@@ -376,7 +373,6 @@ describe("snapshots", () => {
 		          ".js",
 		          ".json",
 		          ".wasm",
-		          ".d.ts",
 		        ],
 		        "mainFields": [
 		          "browser",


### PR DESCRIPTION
## Related issue (if exists)

[Resolve.extensions should not resolve .d.ts by default ](https://github.com/web-infra-dev/rspack/issues/2837)

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 844033e</samp>

This pull request improves the code quality and functionality of `rspack` by fixing indentation, resolving extensions, and correcting a typo in `defaults.ts` and its unit test file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 844033e</samp>

*  Adjust indentation of ternary operators to match style guide and improve readability ([link](https://github.com/web-infra-dev/rspack/pull/2861/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL54-R55), [link](https://github.com/web-infra-dev/rspack/pull/2861/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL100-R101))
*  Remove `.d.ts` extension from default resolve extensions in `defaults.ts`, as it is not a valid output format for webpack and can cause errors when resolving modules ([link](https://github.com/web-infra-dev/rspack/pull/2861/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL592-R592))
*  Update unit test in `Defaults.unittest.ts` to reflect the removal of `.d.ts` extension from default resolve extensions ([link](https://github.com/web-infra-dev/rspack/pull/2861/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9L379))
*  Add space between curly braces of export statement in `Defaults.unittest.ts`, to match style guide and avoid linting errors ([link](https://github.com/web-infra-dev/rspack/pull/2861/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9L1376-R1375))

</details>
