### PR TITLE
feat: add moduleAssets for stats

### DIFF
--- a/.changeset/fair-buttons-fail.md
+++ b/.changeset/fair-buttons-fail.md
@@ -1,0 +1,7 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+"@rspack/cli": patch
+---
+
+feat: add moduleAssets for stats

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -219,6 +219,7 @@ export interface JsLoaderContext {
   contextDependencies: Array<string>
   missingDependencies: Array<string>
   buildDependencies: Array<string>
+  assetFilenames: Array<string>
   currentLoader: string
   isPitching: boolean
 }
@@ -563,6 +564,7 @@ export interface JsStatsModule {
   issuerId?: string
   issuerPath: Array<JsStatsModuleIssuer>
   reasons?: Array<JsStatsModuleReason>
+  assets?: Array<string>
 }
 export interface JsStatsModuleIssuer {
   identifier: string
@@ -648,8 +650,8 @@ export class JsCompilation {
 }
 export class JsStats {
   getAssets(): JsStatsGetAssets
-  getModules(reasons: boolean): Array<JsStatsModule>
-  getChunks(chunkModules: boolean, chunksRelations: boolean, reasons: boolean): Array<JsStatsChunk>
+  getModules(reasons: boolean, moduleAssets: boolean): Array<JsStatsModule>
+  getChunks(chunkModules: boolean, chunksRelations: boolean, reasons: boolean, moduleAssets: boolean): Array<JsStatsChunk>
   getEntrypoints(): Array<JsStatsChunkGroup>
   getNamedChunkGroups(): Array<JsStatsChunkGroup>
   getErrors(): Array<JsStatsError>

--- a/crates/node_binding/src/js_values/compilation.rs
+++ b/crates/node_binding/src/js_values/compilation.rs
@@ -88,7 +88,7 @@ impl JsCompilation {
 
   #[napi(ts_return_type = "Readonly<JsAsset>[]")]
   pub fn get_assets(&self) -> Result<Vec<JsAsset>> {
-    let mut assets = Vec::<JsAsset>::with_capacity(self.inner.assets.len());
+    let mut assets = Vec::<JsAsset>::with_capacity(self.inner.assets().len());
 
     for (filename, asset) in self.inner.assets() {
       assets.push(JsAsset {
@@ -107,7 +107,7 @@ impl JsCompilation {
 
   #[napi]
   pub fn get_asset(&self, name: String) -> Result<Option<JsAsset>> {
-    match self.inner.assets.get(&name) {
+    match self.inner.assets().get(&name) {
       Some(asset) => Ok(Some(JsAsset {
         name,
         source: asset
@@ -125,7 +125,7 @@ impl JsCompilation {
   pub fn get_asset_source(&self, name: String) -> Result<Option<JsCompatSource>> {
     self
       .inner
-      .assets
+      .assets()
       .get(&name)
       .and_then(|v| v.source.as_ref().map(|s| s.to_js_compat_source()))
       .transpose()
@@ -181,7 +181,7 @@ impl JsCompilation {
   #[napi]
   pub fn set_asset_source(&mut self, name: String, source: JsCompatSource) {
     let source = CompatSource::from(source).boxed();
-    match self.inner.assets.entry(name) {
+    match self.inner.assets_mut().entry(name) {
       std::collections::hash_map::Entry::Occupied(mut e) => e.get_mut().set_source(Some(source)),
       std::collections::hash_map::Entry::Vacant(e) => {
         e.insert(rspack_core::CompilationAsset::with_source(source));
@@ -193,7 +193,7 @@ impl JsCompilation {
   pub fn delete_asset_source(&mut self, name: String) {
     self
       .inner
-      .assets
+      .assets_mut()
       .entry(name)
       .and_modify(|a| a.set_source(None));
   }
@@ -202,7 +202,7 @@ impl JsCompilation {
   pub fn get_asset_filenames(&self) -> Result<Vec<String>> {
     let filenames = self
       .inner
-      .assets
+      .assets()
       .iter()
       .filter(|(_, asset)| asset.get_source().is_some())
       .map(|(filename, _)| filename)
@@ -213,7 +213,7 @@ impl JsCompilation {
 
   #[napi]
   pub fn has_asset(&self, name: String) -> Result<bool> {
-    Ok(self.inner.assets.contains_key(&name))
+    Ok(self.inner.assets().contains_key(&name))
   }
 
   #[napi]

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -88,6 +88,7 @@ pub struct JsStatsModule {
   pub issuer_id: Option<String>,
   pub issuer_path: Vec<JsStatsModuleIssuer>,
   pub reasons: Option<Vec<JsStatsModuleReason>>,
+  pub assets: Option<Vec<String>>,
 }
 
 impl From<rspack_core::StatsModule> for JsStatsModule {
@@ -107,6 +108,7 @@ impl From<rspack_core::StatsModule> for JsStatsModule {
       reasons: stats
         .reasons
         .map(|i| i.into_iter().map(Into::into).collect()),
+      assets: stats.assets,
     }
   }
 }
@@ -264,10 +266,10 @@ impl JsStats {
   }
 
   #[napi]
-  pub fn get_modules(&self, reasons: bool) -> Vec<JsStatsModule> {
+  pub fn get_modules(&self, reasons: bool, module_assets: bool) -> Vec<JsStatsModule> {
     self
       .inner
-      .get_modules(reasons)
+      .get_modules(reasons, module_assets)
       .expect("Failed to get modules")
       .into_iter()
       .map(Into::into)
@@ -280,10 +282,11 @@ impl JsStats {
     chunk_modules: bool,
     chunks_relations: bool,
     reasons: bool,
+    module_assets: bool
   ) -> Vec<JsStatsChunk> {
     self
       .inner
-      .get_chunks(chunk_modules, chunks_relations, reasons)
+      .get_chunks(chunk_modules, chunks_relations, reasons, module_assets)
       .expect("Failed to get chunks")
       .into_iter()
       .map(Into::into)

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -12,9 +12,7 @@ use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use rspack_napi_shared::NapiResultExt;
 
-use crate::js_values::{
-  JsChunk, JsChunkAssetArgs, JsResourceData, JsStatsChunk, SchemeAndJsResourceData,
-};
+use crate::js_values::{JsChunkAssetArgs, JsResourceData, SchemeAndJsResourceData};
 use crate::{DisabledHooks, Hook, JsCompilation, JsHooks};
 
 pub struct JsHooksAdapter {

--- a/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
@@ -215,6 +215,7 @@ pub struct JsLoaderContext {
   pub context_dependencies: Vec<String>,
   pub missing_dependencies: Vec<String>,
   pub build_dependencies: Vec<String>,
+  pub asset_filenames: Vec<String>,
 
   pub current_loader: String,
   pub is_pitching: bool,
@@ -267,6 +268,7 @@ impl TryFrom<&rspack_core::LoaderContext<'_, rspack_core::LoaderRunnerContext>>
         .iter()
         .map(|i| i.to_string_lossy().to_string())
         .collect(),
+      asset_filenames: cx.asset_filenames.iter().map(|i| i.to_owned()).collect(),
 
       current_loader: cx.current_loader().to_string(),
       is_pitching: true,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -75,7 +75,7 @@ pub struct Compilation {
   pub chunk_by_ukey: Database<Chunk>,
   pub chunk_group_by_ukey: Database<ChunkGroup>,
   pub entrypoints: IndexMap<String, ChunkGroupUkey>,
-  pub assets: CompilationAssets,
+  assets: CompilationAssets,
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,
   diagnostics: IndexSet<Diagnostic, BuildHasherDefault<FxHasher>>,
   pub plugin_driver: SharedPluginDriver,
@@ -240,6 +240,10 @@ impl Compilation {
 
   pub fn assets(&self) -> &CompilationAssets {
     &self.assets
+  }
+
+  pub fn assets_mut(&mut self) -> &mut CompilationAssets {
+    &mut self.assets
   }
 
   pub fn entrypoints(&self) -> &IndexMap<String, ChunkGroupUkey> {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -30,6 +30,7 @@ pub struct BuildInfo {
   pub context_dependencies: HashSet<PathBuf>,
   pub missing_dependencies: HashSet<PathBuf>,
   pub build_dependencies: HashSet<PathBuf>,
+  pub asset_filenames: HashSet<String>,
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -576,6 +576,7 @@ impl Module for NormalModule {
     build_info.context_dependencies = loader_result.context_dependencies;
     build_info.missing_dependencies = loader_result.missing_dependencies;
     build_info.build_dependencies = loader_result.build_dependencies;
+    build_info.asset_filenames = loader_result.asset_filenames;
 
     // TODO: match package.json type files
     build_meta.strict_harmony_module = matches!(self.module_type, ModuleType::JsEsm);

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -44,27 +44,32 @@ impl Stats<'_> {
       }
     }
 
-    let mut assets: HashMap<&String, StatsAsset> =
-      HashMap::from_iter(self.compilation.assets.iter().filter_map(|(name, asset)| {
-        asset.get_source().map(|source| {
-          (
-            name,
-            StatsAsset {
-              r#type: "asset",
-              name: name.clone(),
-              size: source.size() as f64,
-              chunks: Vec::new(),
-              chunk_names: Vec::new(),
-              info: StatsAssetInfo {
-                development: asset.info.development,
-                hot_module_replacement: asset.info.hot_module_replacement,
+    let mut assets: HashMap<&String, StatsAsset> = HashMap::from_iter(
+      self
+        .compilation
+        .assets()
+        .iter()
+        .filter_map(|(name, asset)| {
+          asset.get_source().map(|source| {
+            (
+              name,
+              StatsAsset {
+                r#type: "asset",
+                name: name.clone(),
+                size: source.size() as f64,
+                chunks: Vec::new(),
+                chunk_names: Vec::new(),
+                info: StatsAssetInfo {
+                  development: asset.info.development,
+                  hot_module_replacement: asset.info.hot_module_replacement,
+                },
+                emitted: self.compilation.emitted_assets.contains(name),
               },
-              emitted: self.compilation.emitted_assets.contains(name),
-            },
-          )
-        })
-      }));
-    for asset in self.compilation.assets.values() {
+            )
+          })
+        }),
+    );
+    for asset in self.compilation.assets().values() {
       if let Some(source_map) = &asset.get_info().related.source_map {
         assets.remove(source_map);
       }
@@ -109,13 +114,19 @@ impl Stats<'_> {
     (assets, assets_by_chunk_name)
   }
 
-  pub fn get_modules(&self, reasons: bool) -> Result<Vec<StatsModule>> {
+  pub fn get_modules(&self, reasons: bool, module_assets: bool) -> Result<Vec<StatsModule>> {
     let mut modules: Vec<StatsModule> = self
       .compilation
       .module_graph
       .modules()
       .values()
-      .map(|module| self.get_module(module, reasons))
+      .map(|module| {
+        self.get_module(
+          module,
+          reasons,
+          module_assets,
+        )
+      })
       .collect::<Result<_>>()?;
     Self::sort_modules(&mut modules);
     Ok(modules)
@@ -126,6 +137,7 @@ impl Stats<'_> {
     chunk_modules: bool,
     chunk_relations: bool,
     reasons: bool,
+    module_assets: bool,
   ) -> Result<Vec<StatsChunk>> {
     let mut chunks: Vec<StatsChunk> = self
       .compilation
@@ -141,7 +153,7 @@ impl Stats<'_> {
             .get_chunk_modules(&c.ukey, &self.compilation.module_graph);
           let mut chunk_modules = chunk_modules
             .into_iter()
-            .map(|m| self.get_module(m, reasons))
+            .map(|m| self.get_module(m, reasons, module_assets))
             .collect::<Result<Vec<_>>>()?;
           Self::sort_modules(&mut chunk_modules);
           Some(chunk_modules)
@@ -284,7 +296,12 @@ impl Stats<'_> {
     });
   }
 
-  fn get_module(&self, module: &BoxModule, show_reasons: bool) -> Result<StatsModule> {
+  fn get_module(
+    &self,
+    module: &BoxModule,
+    reasons: bool,
+    module_assets: bool,
+  ) -> Result<StatsModule> {
     let identifier = module.identifier();
     let mgm = self
       .compilation
@@ -309,7 +326,7 @@ impl Stats<'_> {
     }
     issuer_path.reverse();
 
-    let reasons = show_reasons
+    let reasons = reasons
       .then(|| -> Result<_> {
         let mut reasons: Vec<StatsModuleReason> = mgm
           .incoming_connections_unordered(&self.compilation.module_graph)?
@@ -359,6 +376,16 @@ impl Stats<'_> {
       .collect();
     chunks.sort_unstable();
 
+    let assets = module_assets.then(|| {
+      let mut assets: Vec<_> = mgm
+        .build_info
+        .as_ref()
+        .map(|info| info.asset_filenames.iter().map(|i| i.to_string()).collect())
+        .unwrap_or_default();
+      assets.sort();
+      assets
+    });
+
     Ok(StatsModule {
       r#type: "module",
       module_type: *module.module_type(),
@@ -374,6 +401,7 @@ impl Stats<'_> {
       issuer_id,
       issuer_path,
       reasons,
+      assets,
     })
   }
 
@@ -484,6 +512,7 @@ pub struct StatsModule {
   pub issuer_id: Option<String>,
   pub issuer_path: Vec<StatsModuleIssuer>,
   pub reasons: Option<Vec<StatsModuleReason>>,
+  pub assets: Option<Vec<String>>,
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -120,13 +120,7 @@ impl Stats<'_> {
       .module_graph
       .modules()
       .values()
-      .map(|module| {
-        self.get_module(
-          module,
-          reasons,
-          module_assets,
-        )
-      })
+      .map(|module| self.get_module(module, reasons, module_assets))
       .collect::<Result<_>>()?;
     Self::sort_modules(&mut modules);
     Ok(modules)

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -62,6 +62,8 @@ pub struct LoaderContext<'c, C> {
   pub missing_dependencies: HashSet<PathBuf>,
   pub build_dependencies: HashSet<PathBuf>,
 
+  pub asset_filenames: HashSet<String>,
+
   pub(crate) loader_index: usize,
   pub(crate) loader_items: LoaderItemList<'c, C>,
   #[derivative(Debug = "ignore")]
@@ -147,6 +149,7 @@ async fn create_loader_context<'c, C: 'c>(
     context_dependencies: Default::default(),
     missing_dependencies: Default::default(),
     build_dependencies: Default::default(),
+    asset_filenames: Default::default(),
     content: None,
     resource: &resource_data.resource,
     resource_path: &resource_data.resource_path,
@@ -230,6 +233,7 @@ pub struct LoaderResult {
   pub context_dependencies: HashSet<PathBuf>,
   pub missing_dependencies: HashSet<PathBuf>,
   pub build_dependencies: HashSet<PathBuf>,
+  pub asset_filenames: HashSet<String>,
   pub content: Content,
   pub source_map: Option<SourceMap>,
   pub additional_data: Option<String>,
@@ -254,6 +258,7 @@ impl<C> TryFrom<LoaderContext<'_, C>> for TWithDiagnosticArray<LoaderResult> {
         context_dependencies: loader_context.context_dependencies,
         missing_dependencies: loader_context.missing_dependencies,
         build_dependencies: loader_context.build_dependencies,
+        asset_filenames: loader_context.asset_filenames,
         content,
         source_map: loader_context.source_map,
         additional_data: loader_context.additional_data,

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -499,7 +499,7 @@ impl Plugin for CopyPlugin {
 
     copied_result.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     copied_result.into_iter().for_each(|(_priority, result)| {
-      if let Some(exist_asset) = args.compilation.assets.get_mut(&result.filename) {
+      if let Some(exist_asset) = args.compilation.assets_mut().get_mut(&result.filename) {
         if !result.force {
           return;
         }

--- a/crates/rspack_plugin_css/src/lib.rs
+++ b/crates/rspack_plugin_css/src/lib.rs
@@ -146,6 +146,7 @@ impl SwcCssCompiler {
   }
 }
 
+#[derive(Debug, Clone)]
 pub struct SwcCssSourceMapGenConfig {
   pub enable: bool,
   pub emit_columns: bool,

--- a/crates/rspack_plugin_css/src/plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin.rs
@@ -745,8 +745,14 @@ impl Plugin for CssPlugin {
       return Ok(());
     }
 
+    let gen_source_map_config = crate::SwcCssSourceMapGenConfig {
+      enable: compilation.options.devtool.source_map(),
+      inline_sources_content: !compilation.options.devtool.no_sources(),
+      emit_columns: !compilation.options.devtool.cheap(),
+    };
+
     compilation
-      .assets
+      .assets_mut()
       .par_iter_mut()
       .filter(|(filename, _)| filename.ends_with(".css"))
       .try_for_each(|(filename, original)| -> Result<()> {
@@ -761,11 +767,7 @@ impl Plugin for CssPlugin {
             filename,
             input,
             input_source_map,
-            crate::SwcCssSourceMapGenConfig {
-              enable: compilation.options.devtool.source_map(),
-              inline_sources_content: !compilation.options.devtool.no_sources(),
-              emit_columns: !compilation.options.devtool.cheap(),
-            },
+            gen_source_map_config.clone(),
           )?;
           original.set_source(Some(minimized_source));
         }

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -122,7 +122,7 @@ impl Plugin for HtmlPlugin {
       .map(|asset_name| {
         (
           asset_name.clone(),
-          compilation.assets.get(&asset_name).expect("TODO:"),
+          compilation.assets().get(&asset_name).expect("TODO:"),
         )
       })
       .collect::<Vec<_>>();

--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -6,7 +6,7 @@ import {
 	DevServer,
 	rspack,
 	RspackOptions,
-	MultiRspackOptions,
+	MultiRspackOptions
 } from "@rspack/core";
 import path from "node:path";
 

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -105,7 +105,7 @@ export class Compilation {
 			/** @deprecated */
 			additionalAssets: processAssetsHooks.stageAdditional,
 			log: new tapable.SyncBailHook(["origin", "logEntry"]),
-			optimizeModules: new tapable.SyncBailHook(['modules']),
+			optimizeModules: new tapable.SyncBailHook(["modules"]),
 			optimizeChunkModules: new tapable.AsyncSeriesBailHook([
 				"chunks",
 				"modules"
@@ -244,6 +244,7 @@ export class Compilation {
 			options.builtAt,
 			!context.forToString
 		);
+		options.moduleAssets = optionOrLocalFallback(options.moduleAssets, true);
 
 		return options;
 	}
@@ -666,8 +667,8 @@ export class Compilation {
 		return this.#inner;
 	}
 
-	seal() { }
-	unseal() { }
+	seal() {}
+	unseal() {}
 
 	static PROCESS_ASSETS_STAGE_ADDITIONAL = -2000;
 	static PROCESS_ASSETS_STAGE_PRE_PROCESS = -1000;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -492,6 +492,7 @@ export interface StatsOptions {
 	chunkRelations?: boolean;
 	timings?: boolean;
 	builtAt?: boolean;
+	moduleAssets?: boolean;
 }
 
 ///// Optimization /////

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -177,6 +177,7 @@ export async function runLoader(
 	let contextDependencies: string[] = rawContext.contextDependencies.slice();
 	let missingDependencies: string[] = rawContext.missingDependencies.slice();
 	let buildDependencies: string[] = rawContext.buildDependencies.slice();
+	let assetFilenames = rawContext.assetFilenames.slice();
 
 	const loaders = rawContext.currentLoader
 		.split("$")
@@ -429,8 +430,9 @@ export async function runLoader(
 				content
 			);
 		}
-		// @ts-expect-error
-		compiler.compilation.emitAsset(name, source, assetInfo);
+		assetFilenames.push(name),
+			// @ts-expect-error
+			compiler.compilation.emitAsset(name, source, assetInfo);
 	};
 	loaderContext.fs = compiler.inputFileSystem;
 
@@ -540,6 +542,7 @@ export async function runLoader(
 					fileDependencies,
 					contextDependencies,
 					missingDependencies,
+					assetFilenames,
 					isPitching: loaderContext.__internal__isPitching
 				});
 			});
@@ -571,6 +574,7 @@ export async function runLoader(
 						fileDependencies,
 						contextDependencies,
 						missingDependencies,
+						assetFilenames,
 						isPitching: loaderContext.__internal__isPitching
 					});
 				}

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -90,11 +90,12 @@ export class Stats {
 			obj.chunks = this.#inner.getChunks(
 				options.chunkModules!,
 				options.chunkRelations!,
-				options.reasons!
+				options.reasons!,
+				options.moduleAssets!,
 			);
 		}
 		if (options.modules) {
-			obj.modules = this.#inner.getModules(options.reasons!);
+			obj.modules = this.#inner.getModules(options.reasons!, options.moduleAssets!);
 		}
 		if (options.entrypoints) {
 			obj.entrypoints = this.#inner

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -91,11 +91,14 @@ export class Stats {
 				options.chunkModules!,
 				options.chunkRelations!,
 				options.reasons!,
-				options.moduleAssets!,
+				options.moduleAssets!
 			);
 		}
 		if (options.modules) {
-			obj.modules = this.#inner.getModules(options.reasons!, options.moduleAssets!);
+			obj.modules = this.#inner.getModules(
+				options.reasons!,
+				options.moduleAssets!
+			);
 		}
 		if (options.entrypoints) {
 			obj.entrypoints = this.#inner

--- a/packages/rspack/tests/Compiler.test.ts
+++ b/packages/rspack/tests/Compiler.test.ts
@@ -264,7 +264,7 @@ describe("Compiler", () => {
 				const response3 = compiler.isChild();
 				expect(response3).toBe(true);
 
-				compiler.parentCompilation = ["Array", 123, true, null, [], () => { }];
+				compiler.parentCompilation = ["Array", 123, true, null, [], () => {}];
 				const response4 = compiler.isChild();
 				expect(response4).toBe(true);
 
@@ -475,7 +475,7 @@ describe("Compiler", () => {
 					filename: "bundle.js"
 				}
 			},
-			() => { }
+			() => {}
 		);
 		compiler.outputFileSystem = createFsFromVolume(new Volume());
 		compiler.run((err, stats) => {
@@ -1262,12 +1262,12 @@ describe("Compiler", () => {
 		it("should call optimizeModules hook correctly", done => {
 			class MyPlugin {
 				apply(compiler: Compiler) {
-					compiler.hooks.compilation.tap("MyPlugin", (compilation) => {
-						compilation.hooks.optimizeModules.tap("MyPlugin", (modules) => {
+					compiler.hooks.compilation.tap("MyPlugin", compilation => {
+						compilation.hooks.optimizeModules.tap("MyPlugin", modules => {
 							expect(modules.length).toEqual(1);
 							expect(modules[0].resource.includes("d.js")).toBeTruthy();
-						})
-					})
+						});
+					});
 				}
 			}
 			const compiler = rspack({
@@ -1276,9 +1276,9 @@ describe("Compiler", () => {
 				plugins: [new MyPlugin()]
 			});
 
-			compiler.build((err) => {
+			compiler.build(err => {
 				done(err);
 			});
-		})
+		});
 	});
 });

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -54,6 +54,7 @@ describe("Stats", () => {
 		      "initial": true,
 		      "modules": [
 		        {
+		          "assets": [],
 		          "chunks": [
 		            "main",
 		          ],
@@ -101,6 +102,7 @@ describe("Stats", () => {
 		  "hash": "a8535b55b7de03c8",
 		  "modules": [
 		    {
+		      "assets": [],
 		      "chunks": [
 		        "main",
 		      ],

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -50,6 +50,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       "initial": false,
       "modules": [
         {
+          "assets": [],
           "chunks": [
             "dynamic_js",
           ],
@@ -100,6 +101,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       "initial": true,
       "modules": [
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -147,6 +149,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   "hash": "1896652891bba34c",
   "modules": [
     {
+      "assets": [],
       "chunks": [
         "main",
       ],
@@ -165,6 +168,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
       "type": "module",
     },
     {
+      "assets": [],
       "chunks": [
         "dynamic_js",
       ],
@@ -271,6 +275,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
       "initial": true,
       "modules": [
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -318,6 +323,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
   "hash": "e8bd6cade6020867",
   "modules": [
     {
+      "assets": [],
       "chunks": [
         "main",
       ],
@@ -1258,6 +1264,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
       "initial": true,
       "modules": [
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -1276,6 +1283,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
           "type": "module",
         },
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -1346,6 +1354,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
   "hash": "f56e1f7517aed26d",
   "modules": [
     {
+      "assets": [],
       "chunks": [
         "main",
       ],
@@ -1364,6 +1373,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
       "type": "module",
     },
     {
+      "assets": [],
       "chunks": [
         "main",
       ],
@@ -1477,6 +1487,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
       "initial": true,
       "modules": [
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -1495,6 +1506,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
           "type": "module",
         },
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -1560,6 +1572,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
   "hash": "178bdd60e81ac756",
   "modules": [
     {
+      "assets": [],
       "chunks": [
         "main",
       ],
@@ -1578,6 +1591,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
       "type": "module",
     },
     {
+      "assets": [],
       "chunks": [
         "main",
       ],
@@ -1685,6 +1699,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
       "initial": true,
       "modules": [
         {
+          "assets": [],
           "chunks": [
             "main",
           ],
@@ -1732,6 +1747,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
   "hash": "340f80f80633a87",
   "modules": [
     {
+      "assets": [],
       "chunks": [
         "main",
       ],


### PR DESCRIPTION
## Related issue (if exists)

part of #2610 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72d58f6</samp>

This pull request refactors the code related to the `assets` field of the `Compilation` struct and its wrappers, and adds support for tracking and including assets information in the statistics and the output of the compilation. It also introduces minor improvements to some plugins and structs that use or produce assets. The main files affected are `crates/rspack_core/src/compiler/compilation.rs`, `crates/rspack_core/src/stats.rs`, and `crates/node_binding/src/js_values/stats.rs`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 72d58f6</samp>

*  Refactor the `Compilation` struct to use getter and setter methods for the `assets` field, instead of direct field access, to improve encapsulation and avoid direct mutation of the assets ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL91-R91),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL110-R110),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL128-R128),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL184-R184),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL196-R196),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL205-R205),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefL216-R216),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L78-R78),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R245-R248),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L47-R72),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-cde7edc635e72d8f64c982c4e78298d248e671f6f022318cc20440f6091b70baL502-R502),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-1bae8ad181bae8cff98c62704b7918cca060f3b5d1a27c7e0c3c6da55da70b25L748-R755),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9L105-R108),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9L152-R156),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9L175-R183),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL622-R631))
* Add a new field `assets` to the `JsStats` struct in `crates/node_binding/src/js_values/stats.rs`, which stores the names of the assets associated with each module or chunk, if the `moduleAssets` option is enabled ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8R91),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8R111),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8L267-R272),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8L278-R288))
* Add a new field `asset_filenames` to the `Module` struct in `crates/rspack_core/src/module.rs`, which stores the names of the assets associated with the module ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0R33))
* Add a new field `asset_filenames` to the `LoaderResult` and `LoaderContext` structs in `crates/rspack_loader_runner/src/runner.rs`, which stores the names of the assets emitted by the loader ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R65-R66),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R152),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R236),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R261))
* Add a new field `asset_filenames` to the `JsLoaderResult` struct in `crates/rspack_binding_options/src/options/raw_module/js_loader.rs`, which stores the names of the assets emitted by the loader ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-3d952b60d975e6d9e1af6638d7a3cba2af369fb7f520a6cfc1e734e0b9b17ce4R218),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-3d952b60d975e6d9e1af6638d7a3cba2af369fb7f520a6cfc1e734e0b9b17ce4R271))
* Initialize the `asset_filenames` field of the `Module` struct from the `LoaderResult` struct in `crates/rspack_core/src/normal_module.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90R579))
* Add a new parameter `module_assets` to the `get_modules` and `get_chunks` methods of the `Stats` struct in `crates/rspack_core/src/stats.rs`, which indicates whether to include the assets associated with each module or chunk in the output ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L112-R117),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L118-R129),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L124-R140),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L139-R155))
* Add a new field `assets` to the `StatsModule` and `StatsChunk` structs in `crates/rspack_core/src/stats.rs`, which stores the names of the assets associated with the module or chunk, if the `moduleAssets` option is enabled ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37R403),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37R514))
* Initialize the `assets` field of the `StatsModule` struct from the `Module` struct in `crates/rspack_core/src/stats.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L282-R303),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37R378-R387))
* Add the `#[derive(Debug, Clone)]` attribute to the `CssMinifyOptions` struct in `crates/rspack_plugin_css/src/lib.rs`, which enables the implementation of the `Debug` and `Clone` traits for the struct ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-db4ae8ef13237bee509d3125b0f615da21d6c0e8dbf5ee7f5411842a9b674677R149))
* Replace the inline creation of the `SwcCssSourceMapGenConfig` and `JsMinifyOptions` structs with variables that are initialized once and cloned for each file, in `crates/rspack_plugin_css/src/plugin.rs` and `crates/rspack_plugin_javascript/src/plugin.rs`, to avoid repeating the same code and improve readability and performance ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-1bae8ad181bae8cff98c62704b7918cca060f3b5d1a27c7e0c3c6da55da70b25L764-R770),[link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL639-R649))
* Add a new variable `context` that stores the value of the `compilation.options.context` field, in `crates/rspack_plugin_devtool/src/lib.rs`, to avoid repeating the field access multiple times and improve readability and performance ([link](https://github.com/web-infra-dev/rspack/pull/2864/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9L115-R120))

</details>
