### PR TITLE
refactor: `crates/rspack_plugin_javascript/src/visitors/dependency/util.rs`

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -2,7 +2,7 @@ use rspack_core::{Dependency, RuntimeGlobals, RuntimeRequirementsDependency};
 use swc_core::ecma::ast::Expr;
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
-use super::match_member_expr;
+use super::expr_matcher;
 
 pub struct CommonJsScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn Dependency>>,
@@ -24,12 +24,12 @@ impl Visit for CommonJsScanner<'_> {
   noop_visit_type!();
 
   fn visit_expr(&mut self, expr: &Expr) {
-    if match_member_expr(expr, "module.id") {
+    if expr_matcher::is_module_id(expr) {
       self.add_presentational_dependency(box RuntimeRequirementsDependency::new(
         RuntimeGlobals::MODULE_ID,
       ));
     }
-    if match_member_expr(expr, "module.loaded") {
+    if expr_matcher::is_module_loaded(expr) {
       self.add_presentational_dependency(box RuntimeRequirementsDependency::new(
         RuntimeGlobals::MODULE_LOADED,
       ));

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hmr_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hmr_scanner.rs
@@ -4,14 +4,12 @@ use swc_core::common::pass::AstNodePath;
 use swc_core::ecma::ast::{CallExpr, Expr, Lit, Str};
 use swc_core::ecma::visit::{AstParentNodeRef, VisitAstPath, VisitWithPath};
 
-use super::{
-  as_parent_path, is_import_meta_hot_accept_call, is_import_meta_hot_decline_call,
-  is_module_hot_accept_call, is_module_hot_decline_call,
-};
+use super::{as_parent_path, is_module_hot_accept_call, is_module_hot_decline_call};
 use crate::dependency::{
   ImportMetaModuleHotAcceptDependency, ImportMetaModuleHotDeclineDependency,
   ModuleHotAcceptDependency, ModuleHotDeclineDependency,
 };
+use crate::visitors::{is_import_meta_hot_accept_call, is_import_meta_hot_decline_call};
 
 bitflags! {
   #[derive(Default)]

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -16,7 +16,7 @@ use swc_core::ecma::utils::{member_expr, quote_ident, quote_str};
 use swc_core::ecma::visit::{AstParentNodeRef, VisitAstPath, VisitWithPath};
 use swc_core::quote;
 
-use super::{as_parent_path, is_require_context_call, match_member_expr};
+use super::{as_parent_path, expr_matcher, is_require_context_call};
 use crate::dependency::{
   CommonJSRequireDependency, EsmExportDependency, EsmImportDependency, URLDependency,
 };
@@ -417,13 +417,13 @@ impl VisitAstPath for DependencyScanner<'_> {
           _ => {}
         }
       }
-    } else if match_member_expr(expr, "require.cache") {
+    } else if expr_matcher::is_require_cache(expr) {
       self.add_presentational_dependency(box ConstDependency::new(
         *member_expr!(DUMMY_SP, __webpack_require__.c),
         Some(RuntimeGlobals::MODULE_CACHE),
         as_parent_path(ast_path),
       ));
-    } else if match_member_expr(expr, "__webpack_module__.id") {
+    } else if expr_matcher::is_webpack_module_id(expr) {
       self.add_presentational_dependency(box ConstDependency::new(
         *member_expr!(DUMMY_SP, module.id),
         Some(RuntimeGlobals::MODULE_CACHE),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -112,16 +112,18 @@ pub fn is_import_meta_hot_decline_call(node: &CallExpr) -> bool {
     .unwrap_or_default()
 }
 
+// Notice: Doesn't include `import.meta` itself
 pub fn is_member_expr_starts_with_import_meta(mut expr: &Expr) -> bool {
   loop {
     match expr {
-      _ if expr_matcher::is_import_meta(expr) => return true,
-      Expr::Member(MemberExpr { obj, .. }) => expr = obj.as_ref(),
+      Expr::Member(MemberExpr { obj, .. }) if expr_matcher::is_import_meta(obj) => return true,
+      Expr::Member(MemberExpr { obj, .. }) if obj.is_member() => expr = obj.as_ref(),
       _ => return false,
     }
   }
 }
 
+// Notice: Include `import.meta.webpackHot` itself
 pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
   use swc_core::ecma::ast;
   let mut match_target = expr;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -1,7 +1,7 @@
 use swc_core::{
   common::pass::AstNodePath,
   ecma::{
-    ast::{CallExpr, Expr, MemberProp, MetaPropKind},
+    ast::{CallExpr, Expr, MemberExpr},
     visit::{AstParentKind, AstParentNodeRef},
   },
 };
@@ -10,110 +10,116 @@ pub fn as_parent_path(ast_path: &AstNodePath<AstParentNodeRef<'_>>) -> Vec<AstPa
   ast_path.iter().map(|n| n.kind()).collect()
 }
 
-pub fn match_member_expr(mut expr: &Expr, value: &str) -> bool {
-  let mut parts = value.split('.');
-  let first = parts.next().expect("should have a last str");
-  for part in parts.rev() {
-    if let Expr::Member(member_expr) = expr {
-      if let MemberProp::Ident(ident) = &member_expr.prop {
-        if ident.sym.eq(part) {
-          expr = &member_expr.obj;
-          continue;
-        }
-      }
-    }
-    return false;
-  }
-  matches!(&expr, Expr::Ident(ident) if ident.sym.eq(first))
-}
+pub(crate) mod expr_matcher {
+  use std::sync::Arc;
 
-#[inline]
-fn is_hmr_api_call(node: &CallExpr, value: &str) -> bool {
-  node
-    .callee
-    .as_expr()
-    .map(|expr| match_member_expr(expr, value))
-    .unwrap_or_default()
+  use once_cell::sync::Lazy;
+  use swc_core::{
+    common::{EqIgnoreSpan, SourceMap},
+    ecma::{ast::Ident, parser::parse_file_as_expr},
+  };
+
+  static PARSED_MEMBER_EXPR_CM: Lazy<Arc<SourceMap>> = Lazy::new(Default::default);
+
+  // The usage of define_member_expr_matchers is limited in `member_expr_matcher`.
+  // Do not extends it's usage out of this mod.
+  macro_rules! define_expr_matchers {
+    ({
+      $($fn_name:ident: $first:expr,)*
+    }) => {
+          use super::Expr;
+          $(pub(crate) fn $fn_name(expr: &Expr) -> bool {
+            static TARGET: Lazy<Box<Expr>> = Lazy::new(|| {
+              let mut errors = vec![];
+              let fm =
+                 PARSED_MEMBER_EXPR_CM.new_source_file(swc_core::common::FileName::Anon, $first.to_string());
+                 let expr = parse_file_as_expr(
+                  &fm,
+                  Default::default(),
+                  Default::default(),
+                  None,
+                  &mut errors,
+                )
+                .unwrap_or_else(|_| panic!("Member matcher parsed failed {:?}", $first));
+                assert!(errors.is_empty());
+                expr
+            });
+            Ident::within_ignored_ctxt(|| {
+              (&**TARGET).eq_ignore_span(expr)
+            })
+          })+
+
+      };
+  }
+
+  // Notice:
+  // - `import.meta` is not a MemberExpr
+  // - `import.meta.xxx` is a MemberExpr
+  // - Matching would ignore Span and SyntaxContext
+  define_expr_matchers!({
+    is_require_context: "require.context",
+    is_module_hot_accept: "module.hot.accept",
+    is_module_hot_decline: "module.hot.decline",
+    is_module_id: "module.id",
+    is_module_loaded: "module.loaded",
+    is_require_cache: "require.cache",
+    is_webpack_module_id: "__webpack_module__.id",
+    is_import_meta_webpack_hot: "import.meta.webpackHot",
+    is_import_meta_webpack_hot_accept: "import.meta.webpackHot.accept",
+    is_import_meta_webpack_hot_decline: "import.meta.webpackHot.decline",
+    is_import_meta_url: "import.meta.url",
+    is_import_meta: "import.meta",
+  });
 }
 
 pub fn is_require_context_call(node: &CallExpr) -> bool {
-  is_hmr_api_call(node, "require.context")
-}
-
-pub fn is_module_hot_accept_call(node: &CallExpr) -> bool {
-  is_hmr_api_call(node, "module.hot.accept")
-}
-
-pub fn is_module_hot_decline_call(node: &CallExpr) -> bool {
-  is_hmr_api_call(node, "module.hot.decline")
-}
-
-pub fn match_import_meta_member_expr(mut expr: &Expr, value: &str) -> bool {
-  let mut parts = value.split('.');
-  // pop import.meta
-  parts.next();
-  parts.next();
-  for part in parts.rev() {
-    if let Expr::Member(member_expr) = expr {
-      if let MemberProp::Ident(ident) = &member_expr.prop {
-        if ident.sym.eq(part) {
-          expr = &member_expr.obj;
-          continue;
-        }
-      }
-    }
-    return false;
-  }
-  is_import_meta(expr)
-}
-
-#[inline]
-pub fn is_import_meta(expr: &Expr) -> bool {
-  matches!(&expr, Expr::MetaProp(meta) if meta.kind == MetaPropKind::ImportMeta)
-}
-
-pub fn is_import_meta_member_expr(expr: &Expr) -> bool {
-  fn valid_member_expr_obj(expr: &Expr) -> bool {
-    if is_import_meta(expr) {
-      return true;
-    }
-    is_import_meta_member_expr(expr)
-  }
-
-  if let Expr::Member(member_expr) = expr {
-    return valid_member_expr_obj(&member_expr.obj);
-  }
-  false
-}
-
-fn is_hmr_import_meta_api_call(node: &CallExpr, value: &str) -> bool {
   node
     .callee
     .as_expr()
-    .map(|expr| match_import_meta_member_expr(expr, value))
+    .map(|expr| expr_matcher::is_require_context(expr))
+    .unwrap_or_default()
+}
+
+pub fn is_module_hot_accept_call(node: &CallExpr) -> bool {
+  node
+    .callee
+    .as_expr()
+    .map(|expr| expr_matcher::is_module_hot_accept(expr))
+    .unwrap_or_default()
+}
+
+pub fn is_module_hot_decline_call(node: &CallExpr) -> bool {
+  node
+    .callee
+    .as_expr()
+    .map(|expr| expr_matcher::is_module_hot_decline(expr))
     .unwrap_or_default()
 }
 
 pub fn is_import_meta_hot_accept_call(node: &CallExpr) -> bool {
-  is_hmr_import_meta_api_call(node, "import.meta.webpackHot.accept")
+  node
+    .callee
+    .as_expr()
+    .map(|expr| expr_matcher::is_import_meta_webpack_hot_accept(expr))
+    .unwrap_or_default()
 }
 
 pub fn is_import_meta_hot_decline_call(node: &CallExpr) -> bool {
-  is_hmr_import_meta_api_call(node, "import.meta.webpackHot.decline")
+  node
+    .callee
+    .as_expr()
+    .map(|expr| expr_matcher::is_import_meta_webpack_hot_decline(expr))
+    .unwrap_or_default()
 }
 
-/// Match the expr is `import.meta.webpackHot`
-pub fn is_expr_exact_import_meta_webpack_hot(expr: &Expr) -> bool {
-  use swc_core::ecma::ast;
-  matches!(expr, ast::Expr::Member(ast::MemberExpr {
-    obj:
-      box ast::Expr::MetaProp(ast::MetaPropExpr {
-        kind: ast::MetaPropKind::ImportMeta,
-        ..
-      }),
-    prop: ast::MemberProp::Ident(ast::Ident { sym: prop, .. }),
-    ..
-  }) if prop == "webpackHot")
+pub fn is_member_expr_starts_with_import_meta(mut expr: &Expr) -> bool {
+  loop {
+    match expr {
+      _ if expr_matcher::is_import_meta(expr) => return true,
+      Expr::Member(MemberExpr { obj, .. }) => expr = obj.as_ref(),
+      _ => return false,
+    }
+  }
 }
 
 pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
@@ -123,7 +129,9 @@ pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
   loop {
     match match_target {
       // If the target self is `import.meta.webpackHot` just return true
-      ast::Expr::Member(..) if is_expr_exact_import_meta_webpack_hot(match_target) => return true,
+      ast::Expr::Member(..) if expr_matcher::is_import_meta_webpack_hot(match_target) => {
+        return true
+      }
       // The expr is sub-part of `import.meta.webpackHot.xxx`. Recursively look up.
       ast::Expr::Member(ast::MemberExpr { obj, .. }) if obj.is_member() => {
         match_target = obj.as_ref();
@@ -137,11 +145,12 @@ pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
 #[test]
 fn test() {
   use swc_core::common::DUMMY_SP;
-  use swc_core::ecma::ast::{Ident, MemberExpr, MetaPropExpr};
+  use swc_core::ecma::ast::{Ident, MemberExpr, MemberProp, MetaPropExpr, MetaPropKind};
   use swc_core::ecma::utils::member_expr;
   use swc_core::ecma::utils::ExprFactory;
   let expr = *member_expr!(DUMMY_SP, module.hot.accept);
-  assert!(match_member_expr(&expr, "module.hot.accept"));
+  assert!(expr_matcher::is_module_hot_accept(&expr));
+  assert!(!expr_matcher::is_module_hot_decline(&expr));
   assert!(is_module_hot_accept_call(&CallExpr {
     span: DUMMY_SP,
     callee: expr.as_callee(),
@@ -161,13 +170,12 @@ fn test() {
     })),
     prop: MemberProp::Ident(Ident::new("accept".into(), DUMMY_SP)),
   });
-  assert!(is_import_meta_member_expr(&import_meta_expr));
+  assert!(is_member_expr_starts_with_import_meta(&import_meta_expr));
   assert!(is_member_expr_starts_with_import_meta_webpack_hot(
     &import_meta_expr
   ));
-  assert!(match_import_meta_member_expr(
+  assert!(expr_matcher::is_import_meta_webpack_hot_accept(
     &import_meta_expr,
-    "import.meta.webpackHot.accept"
   ));
   assert!(is_import_meta_hot_accept_call(&CallExpr {
     span: DUMMY_SP,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f340baf</samp>

Refactor the dependency scanner logic in the `rspack_plugin_javascript` crate using a new `expr_matcher` module. This module provides functions for matching different expressions related to module imports and exports. The refactoring improves the code readability, consistency, and modularity.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f340baf</samp>

*  Refactor the expression matching logic in the dependency scanners by introducing a new `expr_matcher` module that defines a set of functions to match different expressions using a macro and a source map ([link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-10b6a135ab190733f6911a73a0c2b4375bc380b657f03cfa3a235c37e5f0a788L5-R5), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-10b6a135ab190733f6911a73a0c2b4375bc380b657f03cfa3a235c37e5f0a788L27-R32), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L10-R11), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L55-R55), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L76-R76), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L90-R90), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L106-R106), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL19-R19), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL420-R420), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL426-R426), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L4-R4), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L13-R122), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L126-R134), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L140-R153), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L164-R178))
* Reorganize the dependency scanner modules to separate the common logic from the specific logic for different module systems, and move the functions related to `import.meta` and `import.meta.hot` from the `util.rs` file to the `hmr_scanner.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-9f989cdc890867689a83990b0bf32db3be0f24ddd221f10767ada84b7b891d2dL7-R12), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L126-R134))
* Add a new function `is_member_expr_starts_with_import_meta` in the `util.rs` file to check if an expression is a member expression that starts with `import.meta`, regardless of the property name, and use it in the `import_meta_scanner.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L68-R68), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L98-R98), [link](https://github.com/web-infra-dev/rspack/pull/2865/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L13-R122))

</details>
