### PR TITLE
feat: support passing function to `externals`

### DIFF
--- a/.changeset/new-apricots-glow.md
+++ b/.changeset/new-apricots-glow.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+feat: support externals function

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -167,15 +167,23 @@ export interface RawExperiments {
   newSplitChunks: boolean
 }
 export interface RawExternalItem {
-  type: "string" | "regexp" | "object"
+  type: "string" | "regexp" | "object" | "function"
   stringPayload?: string
   regexpPayload?: string
   objectPayload?: Record<string, RawExternalItemValue>
+  fnPayload?: (value: any) => any
 }
 export interface RawExternalItemValue {
   type: "string" | "bool"
   stringPayload?: string
   boolPayload?: boolean
+}
+export interface RawExternalItemFnResult {
+  externalType?: string
+  result?: RawExternalItemValue
+}
+export interface RawExternalItemFnCtx {
+  request: string
 }
 export interface RawExternalsPresets {
   node: boolean

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -184,6 +184,8 @@ export interface RawExternalItemFnResult {
 }
 export interface RawExternalItemFnCtx {
   request: string
+  context: string
+  dependencyType: string
 }
 export interface RawExternalsPresets {
   node: boolean

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug};
+use std::collections::HashMap;
 
 use indexmap::IndexMap;
 use napi_derive::napi;
@@ -129,7 +129,10 @@ impl RawOptionsApply for RawOptions {
       plugins.push(
         rspack_plugin_externals::ExternalPlugin::new(
           self.externals_type,
-          externals.into_iter().map(Into::into).collect(),
+          externals
+            .into_iter()
+            .map(|e| e.try_into())
+            .collect::<Result<Vec<_>, _>>()?,
         )
         .boxed(),
       );

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -1,19 +1,46 @@
 use std::collections::HashMap;
+use std::fmt::Debug;
 
+use napi::JsFunction;
 use napi_derive::napi;
-use rspack_core::{ExternalItem, ExternalItemObject, ExternalItemValue};
+use rspack_core::ExternalItemFnCtx;
+use rspack_core::{ExternalItem, ExternalItemFnResult, ExternalItemObject, ExternalItemValue};
 use rspack_regex::RspackRegex;
 use serde::Deserialize;
+#[cfg(feature = "node-api")]
+use {
+  napi::Env,
+  rspack_error::internal_error,
+  rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
+  rspack_napi_shared::NapiResultExt,
+  rspack_napi_shared::NAPI_ENV,
+  std::sync::Arc,
+};
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct RawExternalItem {
-  #[napi(ts_type = r#""string" | "regexp" | "object""#)]
+  #[napi(ts_type = r#""string" | "regexp" | "object" | "function""#)]
   pub r#type: String,
   pub string_payload: Option<String>,
   pub regexp_payload: Option<String>,
   pub object_payload: Option<HashMap<String, RawExternalItemValue>>,
+  #[serde(skip_deserializing)]
+  #[napi(ts_type = r#"(value: any) => any"#)]
+  pub fn_payload: Option<JsFunction>,
+}
+
+impl Debug for RawExternalItem {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("RawExternalItem")
+      .field("r#type", &self.r#type)
+      .field("string_payload", &self.string_payload)
+      .field("regexp_payload", &self.regexp_payload)
+      .field("object_payload", &self.object_payload)
+      .field("fn_payload", &"Function")
+      .finish()
+  }
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -44,21 +71,54 @@ impl From<RawExternalItemValue> for ExternalItemValue {
   }
 }
 
-impl From<RawExternalItem> for ExternalItem {
-  fn from(value: RawExternalItem) -> Self {
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
+pub struct RawExternalItemFnResult {
+  pub external_type: Option<String>,
+  pub result: Option<RawExternalItemValue>,
+}
+
+impl From<RawExternalItemFnResult> for ExternalItemFnResult {
+  fn from(value: RawExternalItemFnResult) -> Self {
+    Self {
+      external_type: value.external_type,
+      result: value.result.map(Into::into),
+    }
+  }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
+pub struct RawExternalItemFnCtx {
+  pub request: String,
+}
+
+impl From<ExternalItemFnCtx> for RawExternalItemFnCtx {
+  fn from(value: ExternalItemFnCtx) -> Self {
+    Self {
+      request: value.request,
+    }
+  }
+}
+
+impl TryFrom<RawExternalItem> for ExternalItem {
+  type Error = anyhow::Error;
+
+  #[allow(clippy::unwrap_in_result)]
+  fn try_from(value: RawExternalItem) -> anyhow::Result<Self> {
     match value.r#type.as_str() {
-      "string" => Self::from(
-        value
-          .string_payload
-          .expect("should have a string_payload when RawExternalItem.type is \"string\""),
-      ),
+      "string" => Ok(Self::from(value.string_payload.expect(
+        "should have a string_payload when RawExternalItem.type is \"string\"",
+      ))),
       "regexp" => {
         let payload = value
           .regexp_payload
           .expect("should have a regexp_payload when RawExternalItem.type is \"regexp\"");
         let reg =
           RspackRegex::new(&payload).expect("regex_payload is not a legal regex in rust side");
-        Self::from(reg)
+        Ok(Self::from(reg))
       }
       "object" => {
         let payload: ExternalItemObject = value
@@ -67,7 +127,32 @@ impl From<RawExternalItem> for ExternalItem {
           .into_iter()
           .map(|(k, v)| (k, v.into()))
           .collect();
-        payload.into()
+        Ok(payload.into())
+      }
+      #[cfg(feature = "node-api")]
+      "function" => {
+        let fn_payload = value
+          .fn_payload
+          .expect("should have a fn_payload for external");
+        let fn_payload: ThreadsafeFunction<RawExternalItemFnCtx, RawExternalItemFnResult> =
+          NAPI_ENV.with(|env| -> anyhow::Result<_> {
+            let env = env.borrow().expect("Failed to get env with external");
+            let fn_payload =
+              rspack_binding_macros::js_fn_into_theadsafe_fn!(fn_payload, &Env::from(env));
+            Ok(fn_payload)
+          })?;
+        let fn_payload = Arc::new(fn_payload);
+        Ok(Self::Fn(Box::new(move |ctx: ExternalItemFnCtx| {
+          let fn_payload = fn_payload.clone();
+          Box::pin(async move {
+            fn_payload
+              .call(ctx.into(), ThreadsafeFunctionCallMode::NonBlocking)
+              .into_rspack_result()?
+              .await
+              .map_err(|err| internal_error!("Failed to call external function: {err}"))?
+              .map(|r| r.into())
+          })
+        })))
       }
       _ => unreachable!(),
     }

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -93,12 +93,16 @@ impl From<RawExternalItemFnResult> for ExternalItemFnResult {
 #[napi(object)]
 pub struct RawExternalItemFnCtx {
   pub request: String,
+  pub context: String,
+  pub dependency_type: String,
 }
 
 impl From<ExternalItemFnCtx> for RawExternalItemFnCtx {
   fn from(value: ExternalItemFnCtx) -> Self {
     Self {
       request: value.request,
+      dependency_type: value.dependency_type,
+      context: value.context,
     }
   }
 }

--- a/crates/rspack_core/src/options/externals.rs
+++ b/crates/rspack_core/src/options/externals.rs
@@ -1,3 +1,7 @@
+use std::fmt::Debug;
+
+use futures::future::BoxFuture;
+use rspack_error::Result;
 use rspack_regex::RspackRegex;
 use rustc_hash::FxHashMap as HashMap;
 
@@ -12,11 +16,23 @@ pub enum ExternalItemValue {
 
 pub type ExternalItemObject = HashMap<String, ExternalItemValue>;
 
-#[derive(Debug)]
+pub struct ExternalItemFnCtx {
+  pub request: String,
+}
+
+pub struct ExternalItemFnResult {
+  pub external_type: Option<ExternalType>,
+  pub result: Option<ExternalItemValue>,
+}
+
+pub type ExternalItemFn =
+  Box<dyn Fn(ExternalItemFnCtx) -> BoxFuture<'static, Result<ExternalItemFnResult>> + Sync + Send>;
+
 pub enum ExternalItem {
   Object(ExternalItemObject),
   String(String),
   RegExp(RspackRegex),
+  Fn(ExternalItemFn),
 }
 
 impl From<ExternalItemObject> for ExternalItem {

--- a/crates/rspack_core/src/options/externals.rs
+++ b/crates/rspack_core/src/options/externals.rs
@@ -18,6 +18,8 @@ pub type ExternalItemObject = HashMap<String, ExternalItemValue>;
 
 pub struct ExternalItemFnCtx {
   pub request: String,
+  pub context: String,
+  pub dependency_type: String,
 }
 
 pub struct ExternalItemFnResult {

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, path::PathBuf};
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -113,8 +113,15 @@ impl Plugin for ExternalPlugin {
         }
         ExternalItem::Fn(f) => {
           let request = args.dependency.request();
+
           let result = f(ExternalItemFnCtx {
+            context: PathBuf::from(request.to_string())
+              .parent()
+              .expect("should have context")
+              .to_string_lossy()
+              .to_string(),
             request: request.to_string(),
+            dependency_type: args.dependency.dependency_type().to_string(),
           })
           .await?;
           if let Some(r) = result.result {

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -358,6 +358,13 @@ module.exports = {
 					additionalProperties: {
 						$ref: "#/definitions/ExternalItemValue"
 					}
+				},
+				{
+					description:
+						"The function is called on each dependency (`function(context, request, callback(err, result))`).",
+					instanceof: "Function",
+					tsType:
+						"(((data: ExternalItemFunctionData, callback: (err?: Error, result?: ExternalItemValue) => void) => void) | ((data: ExternalItemFunctionData) => Promise<ExternalItemValue>))"
 				}
 			]
 		},

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -363,8 +363,8 @@ module.exports = {
 					description:
 						"The function is called on each dependency (`function(context, request, callback(err, result))`).",
 					instanceof: "Function",
-					tsType:
-						"(((data: ExternalItemFunctionData, callback: (err?: Error, result?: ExternalItemValue) => void) => void) | ((data: ExternalItemFunctionData) => Promise<ExternalItemValue>))"
+					// tsType:
+					// 	"(((data: ExternalItemFunctionData, callback: (err?: Error, result?: ExternalItemValue) => void) => void) | ((data: ExternalItemFunctionData) => Promise<ExternalItemValue>))"
 				}
 			]
 		},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -356,7 +356,52 @@ export type Target = false | AvailableTarget[] | AvailableTarget;
 
 ///// Externals /////
 export type Externals = ExternalItem[] | ExternalItem;
-export type ExternalItem = string | RegExp | ExternalItemObjectUnknown;
+export type ExternalItem =
+	| string
+	| RegExp
+	| ExternalItemObjectUnknown
+	| (
+			| ((
+					data: ExternalItemFunctionData,
+					callback: (
+						err?: Error,
+						result?: ExternalItemValue,
+						type?: ExternalsType
+					) => void
+			  ) => void)
+			| ((data: ExternalItemFunctionData) => Promise<ExternalItemValue>)
+	  );
+
+export interface ExternalItemFunctionData {
+	// /**
+	//  * The directory in which the request is placed.
+	//  */
+	// context?: string;
+	// /**
+	//  * Contextual information.
+	//  */
+	// contextInfo?: import("../lib/ModuleFactory").ModuleFactoryCreateDataContextInfo;
+	// /**
+	//  * The category of the referencing dependencies.
+	//  */
+	// dependencyType?: string;
+	// /**
+	//  * Get a resolve function with the current resolver options.
+	//  */
+	// getResolve?: (
+	// 	options?: ResolveOptions
+	// ) =>
+	// 	| ((
+	// 		context: string,
+	// 		request: string,
+	// 		callback: (err?: Error, result?: string) => void
+	// 	) => void)
+	// 	| ((context: string, request: string) => Promise<string>);
+	/**
+	 * The request as written by the user in the require/import expression/statement.
+	 */
+	request?: string;
+}
 export interface ExternalItemObjectUnknown {
 	[k: string]: ExternalItemValue;
 }

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -373,21 +373,21 @@ export type ExternalItem =
 	  );
 
 export interface ExternalItemFunctionData {
-	// /**
-	//  * The directory in which the request is placed.
-	//  */
-	// context?: string;
-	// /**
-	//  * Contextual information.
-	//  */
+	/**
+	 * The directory in which the request is placed.
+	 */
+	context?: string;
+	/**
+	 * Contextual information.
+	 */
 	// contextInfo?: import("../lib/ModuleFactory").ModuleFactoryCreateDataContextInfo;
-	// /**
-	//  * The category of the referencing dependencies.
-	//  */
-	// dependencyType?: string;
-	// /**
-	//  * Get a resolve function with the current resolver options.
-	//  */
+	/**
+	 * The category of the referencing dependencies.
+	 */
+	dependencyType?: string;
+	/**
+	 * Get a resolve function with the current resolver options.
+	 */
 	// getResolve?: (
 	// 	options?: ResolveOptions
 	// ) =>

--- a/packages/rspack/tests/configCases/externals/array-externals/index.js
+++ b/packages/rspack/tests/configCases/externals/array-externals/index.js
@@ -5,11 +5,15 @@ import raz from "raz";
 const myos = require("myos");
 const bar = require("bar");
 const baz = require("baz");
+const fn = require("fn");
+const asyncFn = require("asyncFn");
 
 it("should work with array type of externals", function () {
 	expect(foo).toBe("foo");
 	expect(bar).toBe("bar");
 	expect(baz).toBe("baz");
 	expect(raz).toBe("raz");
+	expect(fn).toBe("fn");
+	expect(asyncFn).toBe("asyncFn");
 	expect(typeof myos.constants.errno.EBUSY).toBe("number");
 });

--- a/packages/rspack/tests/configCases/externals/array-externals/webpack.config.js
+++ b/packages/rspack/tests/configCases/externals/array-externals/webpack.config.js
@@ -6,6 +6,17 @@ module.exports = {
 			bar: "'bar'",
 			baz: "var 'baz'",
 			myos: "commonjs os"
+		},
+		function ({ request }, callback) {
+			if (request === "fn") {
+				callback(null, "'fn'");
+			}
+			callback();
+		},
+		async function ({ request }) {
+			if (request === "asyncFn") {
+				return "'asyncFn'";
+			}
 		}
 	],
 	externalsPresets: {


### PR DESCRIPTION
## Related issue (if exists)

#2227 

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b02f29a</samp>

Added support for function external items in `rspack` configuration and plugins. Function external items are functions that can dynamically resolve external dependencies based on a given context. The `rspack_binding_options`, `rspack_core`, and `rspack_plugin_externals` crates were updated to handle function external items. The `rspack` package was updated to validate, type, and wrap function external items in the configuration schema and adapter.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b02f29a</samp>

*  Replace `From` trait with `TryFrom` trait for converting `RawExternalItem` to `ExternalItem` and add `Fn` variant for function external item ([link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-b3d4e4741437a4af781bf0c7ffc91117b42dcefe17fd5ad19fb175e303124332L47-R114), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L132-R135), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-b3d4e4741437a4af781bf0c7ffc91117b42dcefe17fd5ad19fb175e303124332L61-R121), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-b3d4e4741437a4af781bf0c7ffc91117b42dcefe17fd5ad19fb175e303124332L70-R156))
*  Extend `ExternalItem` enum with `Fn` variant and add related types and imports ([link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-90e7702e216b9360380bdd38640d32f2175b85523397e1ebac4097327acc42dbR1-R4), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-90e7702e216b9360380bdd38640d32f2175b85523397e1ebac4097327acc42dbL15-R35), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-b3d4e4741437a4af781bf0c7ffc91117b42dcefe17fd5ad19fb175e303124332L2-R45))
*  Handle `Fn` variant in `ExternalPlugin::handle_external` function and add custom `Debug` trait implementation for `ExternalPlugin` struct ([link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L1-R8), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L13), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3R20-R28), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3R114-R124))
*  Extend `getRawExternalItem` function to handle function external item and add `getRawExternalItemValueFormFnResult` function ([link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R354-R378), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R387-R389))
*  Extend `schema.js` and `types.ts` files to validate and define TypeScript type of function external item ([link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R361-R367), [link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL359-R404))
*  Remove unused `std::fmt::Debug` import from `mod.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/2866/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L1-R1))

</details>
