### PR TITLE
fix(resolve): return query and fragment when alias target had

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,9 +1562,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.79"
+version = "0.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2515135ebd9620daaa7491a79bf4a562acd1a5b27bca4308168724ddbc3f1f1"
+checksum = "8b9ac3f58b4740a0b609d3cb08491be75560893eb0b2116ae1fdc94b4d46d53c"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ napi               = { version = "=2.11.1" }
 napi-build         = { version = "=2.0.1" }
 napi-derive        = { version = "=2.11.0" }
 napi-sys           = { version = "=2.2.3" }
-nodejs-resolver    = { version = "0.0.79" }
+nodejs-resolver    = { version = "0.0.80" }
 once_cell          = { version = "1.17.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1239,9 +1239,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.79"
+version = "0.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2515135ebd9620daaa7491a79bf4a562acd1a5b27bca4308168724ddbc3f1f1"
+checksum = "8b9ac3f58b4740a0b609d3cb08491be75560893eb0b2116ae1fdc94b4d46d53c"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/packages/rspack/tests/configCases/module/issue-2791/answer.js
+++ b/packages/rspack/tests/configCases/module/issue-2791/answer.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/rspack/tests/configCases/module/issue-2791/index.js
+++ b/packages/rspack/tests/configCases/module/issue-2791/index.js
@@ -1,0 +1,12 @@
+import v1 from "./answer";
+import v2 from "./answer?another-query";
+import v3 from "./no-query-answer?raww";
+
+it("should match resourceQuery and return string", () => {
+	// query of target
+	expect(v1).toBe("export const answer = 42;\n");
+	// should use the query of target in alias
+	expect(v2).toBe("export const answer = 42;\n");
+	// the the query in request
+	expect(v3).toBe("export const answer = 42;\n");
+});

--- a/packages/rspack/tests/configCases/module/issue-2791/webpack.config.js
+++ b/packages/rspack/tests/configCases/module/issue-2791/webpack.config.js
@@ -1,0 +1,19 @@
+const path = require("path");
+
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				resourceQuery: /raww/,
+				type: "asset/source"
+			}
+		]
+	},
+	resolve: {
+		alias: {
+			"./answer": path.resolve(__dirname, "./answer.js?raww"),
+			"./no-query-answer": path.resolve(__dirname, "./answer.js")
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

close: https://github.com/web-infra-dev/rspack/issues/2791

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40fb7d7</samp>

Updated nodejs-resolver to fix module loading bug. This dependency is used by `Cargo.toml` to resolve Node.js modules for Rust projects.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 40fb7d7</samp>

* Update nodejs-resolver dependency to fix module loading bug ([link](https://github.com/web-infra-dev/rspack/pull/2869/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L44-R44))

</details>
