### PR TITLE
refactor: align `starts_with` with the same semantics

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
@@ -47,71 +47,72 @@ impl VisitAstPath for ImportMetaScanner<'_> {
     expr: &'ast Expr,
     ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
   ) {
-    // exclude import.meta.webpackHot
-    if is_member_expr_starts_with_import_meta_webpack_hot(expr) {
-      return;
-    }
-    // import.meta.url
-    if expr_matcher::is_import_meta_url(expr) {
-      let url = Url::from_file_path(&self.resource_data.resource).expect("should be a path");
-      self.add_presentational_dependency(box ConstDependency::new(
-        Expr::Lit(Lit::Str(Str {
-          span: DUMMY_SP,
-          value: format!("'{}'", url.as_str()).into(),
-          raw: Some(format!("'{}'", url.as_str()).into()),
-        })),
-        None,
-        as_parent_path(ast_path),
-      ));
-    }
-    // import.meta.xxx
-    else if is_member_expr_starts_with_import_meta(expr) {
-      self.add_presentational_dependency(box ConstDependency::new(
-        quote!("undefined" as Expr),
-        None,
-        as_parent_path(ast_path),
-      ));
-    }
-    // import.meta
-    else if expr_matcher::is_import_meta(expr) {
-      // TODO add warning
-      self.add_presentational_dependency(box ConstDependency::new(
-        quote!("({})" as Expr),
-        None,
-        as_parent_path(ast_path),
-      ));
-    } else if let Expr::Unary(UnaryExpr {
+    // Deal with `typeof import.meta.url` and ``typeof import.meta.xxx`
+    if let Expr::Unary(UnaryExpr {
       op: UnaryOp::TypeOf,
       arg: box expr,
       ..
     }) = expr
     {
-      // typeof import.meta.url
-      if expr_matcher::is_import_meta_url(expr) {
+      // typeof import.meta
+      if expr_matcher::is_import_meta(expr) {
+        self.add_presentational_dependency(box ConstDependency::new(
+          quote!("'object'" as Expr),
+          None,
+          as_parent_path(ast_path),
+        ));
+      } else if expr_matcher::is_import_meta_url(expr) {
+        // typeof import.meta.url
         self.add_presentational_dependency(box ConstDependency::new(
           quote!("'string'" as Expr),
           None,
           as_parent_path(ast_path),
         ));
-      }
-      // typeof import.meta.xxx
-      else if is_member_expr_starts_with_import_meta(expr) {
+      } else if is_member_expr_starts_with_import_meta(expr) {
+        // typeof import.meta.xxx
         self.add_presentational_dependency(box ConstDependency::new(
           quote!("undefined" as Expr),
           None,
           as_parent_path(ast_path),
         ));
       }
-      // typeof import.meta
-      else if expr_matcher::is_import_meta(expr) {
+    } else {
+      // Deal with `import.meta` and `import.meta.xxx`
+
+      // exclude import.meta.webpackHot
+      if is_member_expr_starts_with_import_meta_webpack_hot(expr) {
+        return;
+      }
+
+      // import.meta
+      if expr_matcher::is_import_meta(expr) {
+        // TODO(underfin): add warning
         self.add_presentational_dependency(box ConstDependency::new(
-          quote!("'object'" as Expr),
+          quote!("({})" as Expr),
+          None,
+          as_parent_path(ast_path),
+        ));
+      } else if expr_matcher::is_import_meta_url(expr) {
+        // import.meta.url
+        let url = Url::from_file_path(&self.resource_data.resource).expect("should be a path");
+        self.add_presentational_dependency(box ConstDependency::new(
+          Expr::Lit(Lit::Str(Str {
+            span: DUMMY_SP,
+            value: format!("'{}'", url.as_str()).into(),
+            raw: Some(format!("'{}'", url.as_str()).into()),
+          })),
+          None,
+          as_parent_path(ast_path),
+        ));
+      } else if is_member_expr_starts_with_import_meta(expr) {
+        // import.meta.xxx
+        self.add_presentational_dependency(box ConstDependency::new(
+          quote!("undefined" as Expr),
           None,
           as_parent_path(ast_path),
         ));
       }
     }
-
     expr.visit_children_with_path(self, ast_path);
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -112,11 +112,11 @@ pub fn is_import_meta_hot_decline_call(node: &CallExpr) -> bool {
     .unwrap_or_default()
 }
 
-// Notice: Doesn't include `import.meta` itself
+// Notice: Include `import.meta` itself
 pub fn is_member_expr_starts_with_import_meta(mut expr: &Expr) -> bool {
   loop {
     match expr {
-      Expr::Member(MemberExpr { obj, .. }) if expr_matcher::is_import_meta(obj) => return true,
+      _ if expr_matcher::is_import_meta(obj) => return true,
       Expr::Member(MemberExpr { obj, .. }) if obj.is_member() => expr = obj.as_ref(),
       _ => return false,
     }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -116,8 +116,8 @@ pub fn is_import_meta_hot_decline_call(node: &CallExpr) -> bool {
 pub fn is_member_expr_starts_with_import_meta(mut expr: &Expr) -> bool {
   loop {
     match expr {
-      _ if expr_matcher::is_import_meta(obj) => return true,
-      Expr::Member(MemberExpr { obj, .. }) if obj.is_member() => expr = obj.as_ref(),
+      _ if expr_matcher::is_import_meta(expr) => return true,
+      Expr::Member(MemberExpr { obj, .. }) => expr = obj.as_ref(),
       _ => return false,
     }
   }
@@ -135,7 +135,7 @@ pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
         return true
       }
       // The expr is sub-part of `import.meta.webpackHot.xxx`. Recursively look up.
-      ast::Expr::Member(ast::MemberExpr { obj, .. }) => {
+      ast::Expr::Member(ast::MemberExpr { obj, .. }) if obj.is_member() => {
         match_target = obj.as_ref();
       }
       // The expr could never be `import.meta.webpackHot`

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -135,7 +135,7 @@ pub fn is_member_expr_starts_with_import_meta_webpack_hot(expr: &Expr) -> bool {
         return true
       }
       // The expr is sub-part of `import.meta.webpackHot.xxx`. Recursively look up.
-      ast::Expr::Member(ast::MemberExpr { obj, .. }) if obj.is_member() => {
+      ast::Expr::Member(ast::MemberExpr { obj, .. }) => {
         match_target = obj.as_ref();
       }
       // The expr could never be `import.meta.webpackHot`


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- functions named with `starts_with` should match itself.
- Reafctor matching logic of `import.meta`, which uses strict to loose order to do matching after this PR.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93b2022</samp>

This pull request improves the handling of `import.meta` expressions in the JavaScript plugin for rspack. It refactors the scanning code, adds support for `typeof import.meta`, and fixes a possible conflict with `import.meta.webpackHot`. It also moves some functions to a more appropriate module.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 93b2022</samp>

*  Handle `typeof import.meta` and `typeof import.meta.xxx` expressions before other cases of `import.meta` and `import.meta.xxx` in `ImportMetaScanner` visitor to avoid conflicts and simplify code ([link](https://github.com/web-infra-dev/rspack/pull/2872/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L50-R51), [link](https://github.com/web-infra-dev/rspack/pull/2872/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L89-R72), [link](https://github.com/web-infra-dev/rspack/pull/2872/files?diff=unified&w=0#diff-ad7b782965e31fb8bb79ceb8eba596f335978fc16cdf62258b53f4942eca0830L105-R115))
*  Add `import.meta` itself as a valid case for `is_member_expr_starts_with_import_meta` function and move it to `import_meta_scanner.rs` module to reduce imports and simplify logic ([link](https://github.com/web-infra-dev/rspack/pull/2872/files?diff=unified&w=0#diff-0d6cd3664c975cb69a4065b8a727772959105e952cdcb964339d2aacf9cd43c3L115-R119))

</details>
