### PR TITLE
fix: react refresh runtime inject for nest function call

### DIFF
--- a/.changeset/light-students-jog.md
+++ b/.changeset/light-students-jog.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix: react refresh runtime inject for nest function call

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -58,6 +58,7 @@ impl Visit for FoundReactRefreshVisitor {
         }
       }
     }
+    call_expr.visit_children_with(self);
   }
 }
 


### PR DESCRIPTION
## Related issue (if exists)

close https://github.com/web-infra-dev/rspack/issues/2873
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a9be3d</samp>

Refactor ReactVisitor to use swc_ecma_visit crate and handle nested nodes in call expressions. Update `react.rs` to visit call expression children.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a9be3d</samp>

*  Add a line to visit call expression children with the current visitor ([link](https://github.com/web-infra-dev/rspack/pull/2874/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cR61)). This ensures that the ReactVisitor can handle nested nodes within a call expression, such as arguments or callee. The ReactVisitor is defined in `crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs` and implements the swc_ecma_visit::Node trait to traverse the AST and handle React-specific syntax.

</details>
