### PR TITLE
chore: fix peerDep of rspack-plugin-html

### DIFF
--- a/.changeset/stale-seas-poke.md
+++ b/.changeset/stale-seas-poke.md
@@ -1,0 +1,5 @@
+---
+"@rspack/plugin-html": patch
+---
+
+make rspack-core peerDep

--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -22,14 +22,22 @@
     "directory": "packages/rspack-plugin-html"
   },
   "dependencies": {
-    "@rspack/core": "workspace:*",
     "@types/html-minifier-terser": "7.0.0",
     "html-minifier-terser": "7.0.0",
     "lodash.template": "^4.5.0",
     "parse5": "7.1.1",
     "tapable": "2.2.1"
   },
+  "peerDependencies": {
+    "@rspack/core": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@rspack/core": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@rspack/core": "workspace:*",
     "@types/lodash.template": "^4.5.1",
     "@types/pug": "^2.0.6",
     "html-loader": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,13 +818,13 @@ importers:
       pug: ^3.0.2
       tapable: 2.2.1
     dependencies:
-      '@rspack/core': link:../rspack
       '@types/html-minifier-terser': 7.0.0
       html-minifier-terser: 7.0.0
       lodash.template: 4.5.0
       parse5: 7.1.1
       tapable: 2.2.1
     devDependencies:
+      '@rspack/core': link:../rspack
       '@types/lodash.template': 4.5.1
       '@types/pug': 2.0.6
       html-loader: 4.2.0


### PR DESCRIPTION
## Related issue (if exists)
fixes  #2852  
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44c7269</samp>

Remove local dependencies on `@rspack/core` from `pnpm-lock.yaml`. This improves the stability and compatibility of the web-infra-dev/rspack packages.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44c7269</samp>

* Remove local dependencies on `@rspack/core` from `@rspack/cli` and `@rspack/webpack` packages ([link](https://github.com/web-infra-dev/rspack/pull/2876/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL808), [link](https://github.com/web-infra-dev/rspack/pull/2876/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL821)) in `pnpm-lock.yaml`

</details>
