### PR TITLE
refactor: Make `check_changeset.cjs` ESM and use ZX

### DIFF
--- a/.github/workflows/check-changeset.yml
+++ b/.github/workflows/check-changeset.yml
@@ -19,4 +19,4 @@ jobs:
         uses: ./.github/actions/pnpm-cache
 
       - name: Check Changeset
-        run: node ./scripts/check_changeset.cjs
+        run: node ./scripts/check_changeset.js

--- a/scripts/check_changeset.js
+++ b/scripts/check_changeset.js
@@ -1,12 +1,24 @@
-// @ts-nocheck
-const { spawnSync } = require("child_process");
-const path = require("path");
-const util = require("util");
-const readChangesets = require("@changesets/read").default;
+import "zx/globals";
+
+import changesetsRead from "@changesets/read";
+
+/**
+ * @type {typeof changesetsRead}
+ */
+// @ts-expect-error the package seems not cooperate well with ESM
+const readChangesets = changesetsRead.default;
+
+await import("./meta/check_is_workspace_root.js");
 
 async function checkVersion() {
-	const changesets = await readChangesets(path.join(__dirname, "../"));
+	console.log("start checking version");
+	console.log(readChangesets);
+	const changesets = await readChangesets(process.cwd());
+	console.log("validate version");
 
+	/**
+	 * @type {string[]}
+	 */
 	const errors = [];
 	for (const changeset of changesets) {
 		const { releases } = changeset;
@@ -34,22 +46,14 @@ async function checkVersion() {
 }
 
 async function checkBump() {
-	const result = spawnSync("pnpm", ["changeset", "version"], {
-		stdio: "pipe"
-	});
-	if (result.status !== 0) {
-		console.error("Check changeset bump failed", result.stderr.toString());
-		process.exit(1);
-	} else {
+	try {
+		await $`pnpm changeset version`;
 		console.log("Check changeset bump succeed");
+	} catch (err) {
+		console.error("Check changeset bump failed");
+		process.exit(1);
 	}
 }
-async function main() {
-	await checkVersion();
-	await checkBump();
-}
 
-main().catch(err => {
-	console.error("check changeset failed", err);
-	process.exit(1);
-});
+await checkVersion();
+await checkBump();

--- a/scripts/check_changeset.js
+++ b/scripts/check_changeset.js
@@ -12,7 +12,6 @@ await import("./meta/check_is_workspace_root.js");
 
 async function checkVersion() {
 	console.log("start checking version");
-	console.log(readChangesets);
 	const changesets = await readChangesets(process.cwd());
 	console.log("validate version");
 


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f99d37</samp>

Modernized `check_changeset` script with ESM and zx. Improved script usability and maintainability.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f99d37</samp>

* Convert the script to ESM syntax and use zx for shell commands ([link](https://github.com/web-infra-dev/rspack/pull/2878/files?diff=unified&w=0#diff-00c04a208565587d9af0e9a2155712fe21371025c86f238c64e42179ab5d1f87L1-R21))
* Simplify the changeset version command and error handling with zx ([link](https://github.com/web-infra-dev/rspack/pull/2878/files?diff=unified&w=0#diff-00c04a208565587d9af0e9a2155712fe21371025c86f238c64e42179ab5d1f87L37-R59))
* Import and use a helper module to check if the script is run from the workspace root (`scripts/utils.js`) ([link](https://github.com/web-infra-dev/rspack/pull/2878/files?diff=unified&w=0#diff-00c04a208565587d9af0e9a2155712fe21371025c86f238c64e42179ab5d1f87L1-R21))

</details>
