### PR TITLE
chore: should exit if the exitCode is not zero at `check_changeset.js`

### DIFF
--- a/scripts/check_changeset.js
+++ b/scripts/check_changeset.js
@@ -46,7 +46,11 @@ async function checkVersion() {
 
 async function checkBump() {
 	try {
-		await $`pnpm changeset version`;
+		const result = await $`pnpm changeset version`;
+		if (result.exitCode !== 0) {
+			console.error("Check changeset bump failed", result.stderr.toString());
+			process.exit(1);
+		}
 		console.log("Check changeset bump succeed");
 	} catch (err) {
 		console.error("Check changeset bump failed");


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e6fc6e</samp>

Improved error handling for `checkBump` function in `scripts/check_changeset.js`. The function now checks the exit code of `pnpm changeset version` and exits with an error message if it fails.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e6fc6e</samp>

* Add a check for the exit code of `pnpm changeset version` and exit with an error message if it is not zero ([link](https://github.com/web-infra-dev/rspack/pull/2880/files?diff=unified&w=0#diff-00c04a208565587d9af0e9a2155712fe21371025c86f238c64e42179ab5d1f87L49-R53))

</details>
