### PR TITLE
fix(resolve): delay the directory check in exportsFieldPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,9 +1562,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.80"
+version = "0.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ac3f58b4740a0b609d3cb08491be75560893eb0b2116ae1fdc94b4d46d53c"
+checksum = "6123a34b53527098bf3c30efd6762285d6648eb98dfb8fdcff30f86e9cf256e3"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ napi               = { version = "=2.11.1" }
 napi-build         = { version = "=2.0.1" }
 napi-derive        = { version = "=2.11.0" }
 napi-sys           = { version = "=2.2.3" }
-nodejs-resolver    = { version = "0.0.80" }
+nodejs-resolver    = { version = "0.0.81" }
 once_cell          = { version = "1.17.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1239,9 +1239,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.80"
+version = "0.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ac3f58b4740a0b609d3cb08491be75560893eb0b2116ae1fdc94b4d46d53c"
+checksum = "6123a34b53527098bf3c30efd6762285d6648eb98dfb8fdcff30f86e9cf256e3"
 dependencies = [
  "daachorse",
  "dashmap",


### PR DESCRIPTION
fix the bug that check request directory in the beginning of `exportsFiledPlugin`.

example:

```js
require('lib/'); // it may failed because it request a directory and it a bug of resolve
```

- code: https://github.com/web-infra-dev/nodejs_resolver/pull/182/files#diff-fe578df785ccf4882dd5f8d9e85f8b4d9597ad8704a2c6c9491a935980229149R34-R42
- test: https://github.com/web-infra-dev/nodejs_resolver/pull/182/files#diff-24975acf43b4bc39c4c8b57246e4bfbdc0c76428c86ed68f1db0e1b10a6db277R2448-R2471

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 143cd53</samp>

Updated nodejs-resolver to fix module loading bug. This dependency is used by `Cargo.toml` to resolve Node.js modules for Rust projects.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 143cd53</samp>

* Update nodejs-resolver dependency to fix module loading bug ([link](https://github.com/web-infra-dev/rspack/pull/2883/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L44-R44))

</details>
