### PR TITLE
chore: fix `make-threejs10x.js` script

### DIFF
--- a/scripts/bench/make-threejs10x.js
+++ b/scripts/bench/make-threejs10x.js
@@ -2,9 +2,11 @@ import "zx/globals";
 
 await import("../meta/check_is_workspace_root.js");
 
-fs.ensureDir("./benchcases/threejs10x/src");
+await fs.ensureDir("./benchcases/threejs10x/src");
 
 for (const i in Array(10).fill(null)) {
+	await fs.ensureDir(`./benchcases/threejs10x/src/copy${i}`);
+
 	await $`cp -r ./benchcases/.three/src ./benchcases/threejs10x/src/copy${i}`;
 }
 


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fa7c4e</samp>

Improve benchmark scripts by ensuring destination directories exist before copying files. This affects the `make-threejs10x.js` script for the three.js benchmark case.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3fa7c4e</samp>

* Ensure destination directory exists before copying source files of three.js benchmark case ([link](https://github.com/web-infra-dev/rspack/pull/2887/files?diff=unified&w=0#diff-deab30c4784cf2f3ef390532a9a4d7f5d56f04367c5f3ca9fd4494a98258faf8L5-R9))

</details>
