### PR TITLE
feat: 🎸 compiler. getCache

### DIFF
--- a/.changeset/clever-students-shake.md
+++ b/.changeset/clever-students-shake.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+feat: compiler.getCache

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -41,6 +41,7 @@ import * as ErrorHelpers from "./ErrorHelpers";
 import { concatErrorMsgAndStack } from "./util";
 import { normalizeStatsPreset, Stats } from "./stats";
 import { NormalModuleFactory } from "./normalModuleFactory";
+import CacheFacade from "./lib/CacheFacade";
 
 const hashDigestLength = 8;
 const EMPTY_ASSET_INFO = {};
@@ -189,6 +190,10 @@ export class Compilation {
 				new ChunkGroup(e)
 			])
 		);
+	}
+
+	getCache(name: string) {
+		return this.compiler.getCache(name);
 	}
 
 	createStatsOptions(

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -75,6 +75,8 @@ export interface RspackOptionsNormalized {
 	builtins: Builtins;
 }
 
+export type HashFunction = string | typeof import("../util/hash");
+
 ///// Name /////
 export type Name = string;
 
@@ -241,6 +243,10 @@ export interface OutputNormalized {
 	chunkLoading?: string | false;
 	enabledChunkLoadingTypes?: string[];
 	trustedTypes?: TrustedTypes;
+	/**
+	 * Algorithm used for generation the hash (see node.js crypto package).
+	 */
+	hashFunction?: HashFunction;
 }
 
 ///// Resolve /////

--- a/packages/rspack/src/lib/Cache.js
+++ b/packages/rspack/src/lib/Cache.js
@@ -1,0 +1,161 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { AsyncParallelHook, AsyncSeriesBailHook, SyncHook } = require("tapable");
+const {
+	makeWebpackError,
+	makeWebpackErrorCallback
+} = require("./HookWebpackError.js");
+
+/** @typedef {import("./WebpackError")} WebpackError */
+
+/**
+ * @typedef {Object} Etag
+ * @property {function(): string} toString
+ */
+
+/**
+ * @template T
+ * @callback CallbackCache
+ * @param {(WebpackError | null)=} err
+ * @param {T=} result
+ * @returns {void}
+ */
+
+/**
+ * @callback GotHandler
+ * @param {any} result
+ * @param {function(Error=): void} callback
+ * @returns {void}
+ */
+
+const needCalls = (times, callback) => {
+	return err => {
+		if (--times === 0) {
+			return callback(err);
+		}
+		if (err && times > 0) {
+			times = 0;
+			return callback(err);
+		}
+	};
+};
+
+class Cache {
+	constructor() {
+		this.hooks = {
+			/** @type {AsyncSeriesBailHook<[string, Etag | null, GotHandler[]], any>} */
+			get: new AsyncSeriesBailHook(["identifier", "etag", "gotHandlers"]),
+			/** @type {AsyncParallelHook<[string, Etag | null, any]>} */
+			store: new AsyncParallelHook(["identifier", "etag", "data"]),
+			/** @type {AsyncParallelHook<[Iterable<string>]>} */
+			storeBuildDependencies: new AsyncParallelHook(["dependencies"]),
+			/** @type {SyncHook<[]>} */
+			beginIdle: new SyncHook([]),
+			/** @type {AsyncParallelHook<[]>} */
+			endIdle: new AsyncParallelHook([]),
+			/** @type {AsyncParallelHook<[]>} */
+			shutdown: new AsyncParallelHook([])
+		};
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {CallbackCache<T>} callback signals when the value is retrieved
+	 * @returns {void}
+	 */
+	get(identifier, etag, callback) {
+		const gotHandlers = [];
+		this.hooks.get.callAsync(identifier, etag, gotHandlers, (err, result) => {
+			if (err) {
+				callback(makeWebpackError(err, "Cache.hooks.get"));
+				return;
+			}
+			if (result === null) {
+				result = undefined;
+			}
+			if (gotHandlers.length > 1) {
+				const innerCallback = needCalls(gotHandlers.length, () =>
+					callback(null, result)
+				);
+				for (const gotHandler of gotHandlers) {
+					gotHandler(result, innerCallback);
+				}
+			} else if (gotHandlers.length === 1) {
+				gotHandlers[0](result, () => callback(null, result));
+			} else {
+				callback(null, result);
+			}
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {T} data the value to store
+	 * @param {CallbackCache<void>} callback signals when the value is stored
+	 * @returns {void}
+	 */
+	store(identifier, etag, data, callback) {
+		this.hooks.store.callAsync(
+			identifier,
+			etag,
+			data,
+			makeWebpackErrorCallback(callback, "Cache.hooks.store")
+		);
+	}
+
+	/**
+	 * After this method has succeeded the cache can only be restored when build dependencies are
+	 * @param {Iterable<string>} dependencies list of all build dependencies
+	 * @param {CallbackCache<void>} callback signals when the dependencies are stored
+	 * @returns {void}
+	 */
+	storeBuildDependencies(dependencies, callback) {
+		this.hooks.storeBuildDependencies.callAsync(
+			dependencies,
+			makeWebpackErrorCallback(callback, "Cache.hooks.storeBuildDependencies")
+		);
+	}
+
+	/**
+	 * @returns {void}
+	 */
+	beginIdle() {
+		this.hooks.beginIdle.call();
+	}
+
+	/**
+	 * @param {CallbackCache<void>} callback signals when the call finishes
+	 * @returns {void}
+	 */
+	endIdle(callback) {
+		this.hooks.endIdle.callAsync(
+			makeWebpackErrorCallback(callback, "Cache.hooks.endIdle")
+		);
+	}
+
+	/**
+	 * @param {CallbackCache<void>} callback signals when the call finishes
+	 * @returns {void}
+	 */
+	shutdown(callback) {
+		this.hooks.shutdown.callAsync(
+			makeWebpackErrorCallback(callback, "Cache.hooks.shutdown")
+		);
+	}
+}
+
+Cache.STAGE_MEMORY = -10;
+Cache.STAGE_DEFAULT = 0;
+Cache.STAGE_DISK = 10;
+Cache.STAGE_NETWORK = 20;
+
+module.exports = Cache;

--- a/packages/rspack/src/lib/CacheFacade.js
+++ b/packages/rspack/src/lib/CacheFacade.js
@@ -1,0 +1,345 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { forEachBail } = require("enhanced-resolve");
+const asyncLib = require("neo-async");
+const getLazyHashedEtag = require("./cache/getLazyHashedEtag.js");
+const mergeEtags = require("./cache/mergeEtags.js");
+
+/** @typedef {import("./Cache")} Cache */
+/** @typedef {import("./Cache").Etag} Etag */
+/** @typedef {import("./WebpackError")} WebpackError */
+/** @typedef {import("./cache/getLazyHashedEtag").HashableObject} HashableObject */
+/** @typedef {typeof import("./util/Hash")} HashConstructor */
+
+/**
+ * @template T
+ * @callback CallbackCache
+ * @param {(WebpackError | null)=} err
+ * @param {T=} result
+ * @returns {void}
+ */
+
+/**
+ * @template T
+ * @callback CallbackNormalErrorCache
+ * @param {(Error | null)=} err
+ * @param {T=} result
+ * @returns {void}
+ */
+
+class MultiItemCache {
+	/**
+	 * @param {ItemCacheFacade[]} items item caches
+	 */
+	constructor(items) {
+		this._items = items;
+		if (items.length === 1) return /** @type {any} */ (items[0]);
+	}
+
+	/**
+	 * @template T
+	 * @param {CallbackCache<T>} callback signals when the value is retrieved
+	 * @returns {void}
+	 */
+	get(callback) {
+		forEachBail(this._items, (item, callback) => item.get(callback), callback);
+	}
+
+	/**
+	 * @template T
+	 * @returns {Promise<T>} promise with the data
+	 */
+	getPromise() {
+		const next = i => {
+			return this._items[i].getPromise().then(result => {
+				if (result !== undefined) return result;
+				if (++i < this._items.length) return next(i);
+			});
+		};
+		return next(0);
+	}
+
+	/**
+	 * @template T
+	 * @param {T} data the value to store
+	 * @param {CallbackCache<void>} callback signals when the value is stored
+	 * @returns {void}
+	 */
+	store(data, callback) {
+		asyncLib.each(
+			this._items,
+			(item, callback) => item.store(data, callback),
+			callback
+		);
+	}
+
+	/**
+	 * @template T
+	 * @param {T} data the value to store
+	 * @returns {Promise<void>} promise signals when the value is stored
+	 */
+	storePromise(data) {
+		return Promise.all(this._items.map(item => item.storePromise(data))).then(
+			() => {}
+		);
+	}
+}
+
+class ItemCacheFacade {
+	/**
+	 * @param {Cache} cache the root cache
+	 * @param {string} name the child cache item name
+	 * @param {Etag | null} etag the etag
+	 */
+	constructor(cache, name, etag) {
+		this._cache = cache;
+		this._name = name;
+		this._etag = etag;
+	}
+
+	/**
+	 * @template T
+	 * @param {CallbackCache<T>} callback signals when the value is retrieved
+	 * @returns {void}
+	 */
+	get(callback) {
+		this._cache.get(this._name, this._etag, callback);
+	}
+
+	/**
+	 * @template T
+	 * @returns {Promise<T>} promise with the data
+	 */
+	getPromise() {
+		return new Promise((resolve, reject) => {
+			this._cache.get(this._name, this._etag, (err, data) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve(data);
+				}
+			});
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {T} data the value to store
+	 * @param {CallbackCache<void>} callback signals when the value is stored
+	 * @returns {void}
+	 */
+	store(data, callback) {
+		this._cache.store(this._name, this._etag, data, callback);
+	}
+
+	/**
+	 * @template T
+	 * @param {T} data the value to store
+	 * @returns {Promise<void>} promise signals when the value is stored
+	 */
+	storePromise(data) {
+		return new Promise((resolve, reject) => {
+			this._cache.store(this._name, this._etag, data, err => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {function(CallbackNormalErrorCache<T>): void} computer function to compute the value if not cached
+	 * @param {CallbackNormalErrorCache<T>} callback signals when the value is retrieved
+	 * @returns {void}
+	 */
+	provide(computer, callback) {
+		this.get((err, cacheEntry) => {
+			if (err) return callback(err);
+			if (cacheEntry !== undefined) return cacheEntry;
+			computer((err, result) => {
+				if (err) return callback(err);
+				this.store(result, err => {
+					if (err) return callback(err);
+					callback(null, result);
+				});
+			});
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {function(): Promise<T> | T} computer function to compute the value if not cached
+	 * @returns {Promise<T>} promise with the data
+	 */
+	async providePromise(computer) {
+		const cacheEntry = await this.getPromise();
+		if (cacheEntry !== undefined) return cacheEntry;
+		const result = await computer();
+		await this.storePromise(result);
+		return result;
+	}
+}
+
+class CacheFacade {
+	/**
+	 * @param {Cache} cache the root cache
+	 * @param {string} name the child cache name
+	 * @param {string | HashConstructor} hashFunction the hash function to use
+	 */
+	constructor(cache, name, hashFunction) {
+		this._cache = cache;
+		this._name = name;
+		this._hashFunction = hashFunction;
+	}
+
+	/**
+	 * @param {string} name the child cache name#
+	 * @returns {CacheFacade} child cache
+	 */
+	getChildCache(name) {
+		return new CacheFacade(
+			this._cache,
+			`${this._name}|${name}`,
+			this._hashFunction
+		);
+	}
+
+	/**
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @returns {ItemCacheFacade} item cache
+	 */
+	getItemCache(identifier, etag) {
+		return new ItemCacheFacade(
+			this._cache,
+			`${this._name}|${identifier}`,
+			etag
+		);
+	}
+
+	/**
+	 * @param {HashableObject} obj an hashable object
+	 * @returns {Etag} an etag that is lazy hashed
+	 */
+	getLazyHashedEtag(obj) {
+		return getLazyHashedEtag(obj, this._hashFunction);
+	}
+
+	/**
+	 * @param {Etag} a an etag
+	 * @param {Etag} b another etag
+	 * @returns {Etag} an etag that represents both
+	 */
+	mergeEtags(a, b) {
+		return mergeEtags(a, b);
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {CallbackCache<T>} callback signals when the value is retrieved
+	 * @returns {void}
+	 */
+	get(identifier, etag, callback) {
+		this._cache.get(`${this._name}|${identifier}`, etag, callback);
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @returns {Promise<T>} promise with the data
+	 */
+	getPromise(identifier, etag) {
+		return new Promise((resolve, reject) => {
+			this._cache.get(`${this._name}|${identifier}`, etag, (err, data) => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve(data);
+				}
+			});
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {T} data the value to store
+	 * @param {CallbackCache<void>} callback signals when the value is stored
+	 * @returns {void}
+	 */
+	store(identifier, etag, data, callback) {
+		this._cache.store(`${this._name}|${identifier}`, etag, data, callback);
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {T} data the value to store
+	 * @returns {Promise<void>} promise signals when the value is stored
+	 */
+	storePromise(identifier, etag, data) {
+		return new Promise((resolve, reject) => {
+			this._cache.store(`${this._name}|${identifier}`, etag, data, err => {
+				if (err) {
+					reject(err);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {function(CallbackNormalErrorCache<T>): void} computer function to compute the value if not cached
+	 * @param {CallbackNormalErrorCache<T>} callback signals when the value is retrieved
+	 * @returns {void}
+	 */
+	provide(identifier, etag, computer, callback) {
+		this.get(identifier, etag, (err, cacheEntry) => {
+			if (err) return callback(err);
+			if (cacheEntry !== undefined) return cacheEntry;
+			computer((err, result) => {
+				if (err) return callback(err);
+				this.store(identifier, etag, result, err => {
+					if (err) return callback(err);
+					callback(null, result);
+				});
+			});
+		});
+	}
+
+	/**
+	 * @template T
+	 * @param {string} identifier the cache identifier
+	 * @param {Etag | null} etag the etag
+	 * @param {function(): Promise<T> | T} computer function to compute the value if not cached
+	 * @returns {Promise<T>} promise with the data
+	 */
+	async providePromise(identifier, etag, computer) {
+		const cacheEntry = await this.getPromise(identifier, etag);
+		if (cacheEntry !== undefined) return cacheEntry;
+		const result = await computer();
+		await this.storePromise(identifier, etag, result);
+		return result;
+	}
+}
+
+module.exports = CacheFacade;
+module.exports.ItemCacheFacade = ItemCacheFacade;
+module.exports.MultiItemCache = MultiItemCache;

--- a/packages/rspack/src/lib/HookWebpackError.js
+++ b/packages/rspack/src/lib/HookWebpackError.js
@@ -1,0 +1,93 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Sean Larkin @thelarkinn
+*/
+
+"use strict";
+
+const WebpackError = require("./WebpackError.js");
+
+/** @typedef {import("./Module")} Module */
+
+/**
+ * @template T
+ * @callback Callback
+ * @param {Error=} err
+ * @param {T=} stats
+ * @returns {void}
+ */
+
+class HookWebpackError extends WebpackError {
+	/**
+	 * Creates an instance of HookWebpackError.
+	 * @param {Error} error inner error
+	 * @param {string} hook name of hook
+	 */
+	constructor(error, hook) {
+		super(error.message);
+
+		this.name = "HookWebpackError";
+		this.hook = hook;
+		this.error = error;
+		this.hideStack = true;
+		this.details = `caused by plugins in ${hook}\n${error.stack}`;
+
+		this.stack += `\n-- inner error --\n${error.stack}`;
+	}
+}
+
+module.exports = HookWebpackError;
+
+/**
+ * @param {Error} error an error
+ * @param {string} hook name of the hook
+ * @returns {WebpackError} a webpack error
+ */
+const makeWebpackError = (error, hook) => {
+	if (error instanceof WebpackError) return error;
+	return new HookWebpackError(error, hook);
+};
+module.exports.makeWebpackError = makeWebpackError;
+
+/**
+ * @template T
+ * @param {function((WebpackError | null)=, T=): void} callback webpack error callback
+ * @param {string} hook name of hook
+ * @returns {Callback<T>} generic callback
+ */
+const makeWebpackErrorCallback = (callback, hook) => {
+	return (err, result) => {
+		if (err) {
+			if (err instanceof WebpackError) {
+				callback(err);
+				return;
+			}
+			callback(new HookWebpackError(err, hook));
+			return;
+		}
+		callback(null, result);
+	};
+};
+
+module.exports.makeWebpackErrorCallback = makeWebpackErrorCallback;
+
+/**
+ * @template T
+ * @param {function(): T} fn function which will be wrapping in try catch
+ * @param {string} hook name of hook
+ * @returns {T} the result
+ */
+const tryRunOrWebpackError = (fn, hook) => {
+	let r;
+	try {
+		r = fn();
+	} catch (err) {
+		if (err instanceof WebpackError) {
+			throw err;
+		}
+		throw new HookWebpackError(err, hook);
+	}
+	return r;
+};
+
+module.exports.tryRunOrWebpackError = tryRunOrWebpackError;

--- a/packages/rspack/src/lib/WebpackError.js
+++ b/packages/rspack/src/lib/WebpackError.js
@@ -1,0 +1,60 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Jarid Margolin @jaridmargolin
+*/
+
+"use strict";
+
+const inspect = require("util").inspect.custom;
+
+/** @typedef {import("./Chunk")} Chunk */
+/** @typedef {import("./Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("./Module")} Module */
+
+class WebpackError extends Error {
+	/**
+	 * Creates an instance of WebpackError.
+	 * @param {string=} message error message
+	 */
+	constructor(message) {
+		super(message);
+
+		this.details = undefined;
+		/** @type {Module} */
+		this.module = undefined;
+		/** @type {DependencyLocation} */
+		this.loc = undefined;
+		/** @type {boolean} */
+		this.hideStack = undefined;
+		/** @type {Chunk} */
+		this.chunk = undefined;
+		/** @type {string} */
+		this.file = undefined;
+	}
+
+	[inspect]() {
+		return this.stack + (this.details ? `\n${this.details}` : "");
+	}
+
+	// serialize({ write }) {
+	// 	write(this.name);
+	// 	write(this.message);
+	// 	write(this.stack);
+	// 	write(this.details);
+	// 	write(this.loc);
+	// 	write(this.hideStack);
+	// }
+	//
+	// deserialize({ read }) {
+	// 	this.name = read();
+	// 	this.message = read();
+	// 	this.stack = read();
+	// 	this.details = read();
+	// 	this.loc = read();
+	// 	this.hideStack = read();
+	// }
+}
+
+// makeSerializable(WebpackError, "webpack/lib/WebpackError");
+
+module.exports = WebpackError;

--- a/packages/rspack/src/lib/cache/getLazyHashedEtag.js
+++ b/packages/rspack/src/lib/cache/getLazyHashedEtag.js
@@ -1,0 +1,81 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const createHash = require("../../util/createHash");
+
+/** @typedef {import("../util/Hash")} Hash */
+/** @typedef {typeof import("../util/Hash")} HashConstructor */
+
+/**
+ * @typedef {Object} HashableObject
+ * @property {function(Hash): void} updateHash
+ */
+
+class LazyHashedEtag {
+	/**
+	 * @param {HashableObject} obj object with updateHash method
+	 * @param {string | HashConstructor} hashFunction the hash function to use
+	 */
+	constructor(obj, hashFunction = "md4") {
+		this._obj = obj;
+		this._hash = undefined;
+		this._hashFunction = hashFunction;
+	}
+
+	/**
+	 * @returns {string} hash of object
+	 */
+	toString() {
+		if (this._hash === undefined) {
+			const hash = createHash(this._hashFunction);
+			this._obj.updateHash(hash);
+			this._hash = /** @type {string} */ (hash.digest("base64"));
+		}
+		return this._hash;
+	}
+}
+
+/** @type {Map<string | HashConstructor, WeakMap<HashableObject, LazyHashedEtag>>} */
+const mapStrings = new Map();
+
+/** @type {WeakMap<HashConstructor, WeakMap<HashableObject, LazyHashedEtag>>} */
+const mapObjects = new WeakMap();
+
+/**
+ * @param {HashableObject} obj object with updateHash method
+ * @param {string | HashConstructor} hashFunction the hash function to use
+ * @returns {LazyHashedEtag} etag
+ */
+const getter = (obj, hashFunction = "md4") => {
+	let innerMap;
+	if (typeof hashFunction === "string") {
+		innerMap = mapStrings.get(hashFunction);
+		if (innerMap === undefined) {
+			const newHash = new LazyHashedEtag(obj, hashFunction);
+			innerMap = new WeakMap();
+			innerMap.set(obj, newHash);
+			mapStrings.set(hashFunction, innerMap);
+			return newHash;
+		}
+	} else {
+		innerMap = mapObjects.get(hashFunction);
+		if (innerMap === undefined) {
+			const newHash = new LazyHashedEtag(obj, hashFunction);
+			innerMap = new WeakMap();
+			innerMap.set(obj, newHash);
+			mapObjects.set(hashFunction, innerMap);
+			return newHash;
+		}
+	}
+	const hash = innerMap.get(obj);
+	if (hash !== undefined) return hash;
+	const newHash = new LazyHashedEtag(obj, hashFunction);
+	innerMap.set(obj, newHash);
+	return newHash;
+};
+
+module.exports = getter;

--- a/packages/rspack/src/lib/cache/mergeEtags.js
+++ b/packages/rspack/src/lib/cache/mergeEtags.js
@@ -1,0 +1,74 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/** @typedef {import("../Cache").Etag} Etag */
+
+class MergedEtag {
+	/**
+	 * @param {Etag} a first
+	 * @param {Etag} b second
+	 */
+	constructor(a, b) {
+		this.a = a;
+		this.b = b;
+	}
+
+	toString() {
+		return `${this.a.toString()}|${this.b.toString()}`;
+	}
+}
+
+const dualObjectMap = new WeakMap();
+const objectStringMap = new WeakMap();
+
+/**
+ * @param {Etag} a first
+ * @param {Etag} b second
+ * @returns {Etag} result
+ */
+const mergeEtags = (a, b) => {
+	if (typeof a === "string") {
+		if (typeof b === "string") {
+			return `${a}|${b}`;
+		} else {
+			const temp = b;
+			b = a;
+			a = temp;
+		}
+	} else {
+		if (typeof b !== "string") {
+			// both a and b are objects
+			let map = dualObjectMap.get(a);
+			if (map === undefined) {
+				dualObjectMap.set(a, (map = new WeakMap()));
+			}
+			const mergedEtag = map.get(b);
+			if (mergedEtag === undefined) {
+				const newMergedEtag = new MergedEtag(a, b);
+				map.set(b, newMergedEtag);
+				return newMergedEtag;
+			} else {
+				return mergedEtag;
+			}
+		}
+	}
+	// a is object, b is string
+	let map = objectStringMap.get(a);
+	if (map === undefined) {
+		objectStringMap.set(a, (map = new Map()));
+	}
+	const mergedEtag = map.get(b);
+	if (mergedEtag === undefined) {
+		const newMergedEtag = new MergedEtag(a, b);
+		map.set(b, newMergedEtag);
+		return newMergedEtag;
+	} else {
+		return mergedEtag;
+	}
+};
+
+module.exports = mergeEtags;

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -458,7 +458,6 @@ export async function runLoader(
 		},
 		createHash: type => {
 			return createHash(
-				// @ts-expect-error hashFunction should also available in rust side, then we can make the type right
 				type || compiler.compilation.outputOptions.hashFunction
 			);
 		}

--- a/packages/rspack/tests/Compiler.test.ts
+++ b/packages/rspack/tests/Compiler.test.ts
@@ -1280,5 +1280,25 @@ describe("Compiler", () => {
 				done(err);
 			});
 		});
+
+		it("should call getCache function correctly", done => {
+			class MyPlugin {
+				apply(compiler: Compiler) {
+					compiler.hooks.compilation.tap("MyPlugin", compilation => {
+						let cache = compilation.getCache("MyPlugin");
+						expect(cache).not.toBeNull();
+					});
+				}
+			}
+			const compiler = rspack({
+				entry: "./d",
+				context: path.join(__dirname, "fixtures"),
+				plugins: [new MyPlugin()]
+			});
+
+			compiler.build(err => {
+				done(err);
+			});
+		});
 	});
 });


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca89a48</samp>

This pull request adds caching support to the rspack compiler and compilation objects, using a new Cache class and a CacheFacade interface. It also introduces new types and options for configuring the hash function and the etag for the cache items. Additionally, it defines new error classes for handling errors that occur in webpack and its hooks. Finally, it removes an unnecessary comment from the loader runner file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca89a48</samp>

*  Add caching support to the compiler and compilation objects ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R44), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R195-R198), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR28-R29), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR61-R62), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR94-R95), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR169-R180), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR78-R79), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR246-R249), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-9e6f549c5018162ddd2079701f4afe1bac022138b651af3a7e843ca700cf2d91R1-R161), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-f13d689a7f5ceec79b6500f939411af786f1016c272f60bbc3fe39a56c202f52R1-R345), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-88790c38256722096da5c0512100ea7b5a38653c24c5d025327c269d76525c3dR1-R81), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-b02e019ec45cc16227f323f85e86f2a6f2c295296505bcafa9d63859c15599f9R1-R74))
  * Import the `CacheFacade` and `Cache` modules from `./lib/CacheFacade` and `./lib/Cache` in the `compiler.ts` and `compilation.ts` files ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R44), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR28-R29))
  * Add a `cache` property to the `Compiler` class that holds a `Cache` instance for the root cache ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR61-R62), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR94-R95))
  * Add a `compilerPath` property to the `Compiler` class that holds a string identifier for the compiler instance in the cache hierarchy ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR61-R62), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR94-R95))
  * Add a `getCache` method to the `Compiler` and `Compilation` classes that returns a `CacheFacade` instance for a given cache name ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R195-R198), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR169-R180))
  * Add a `hashFunction` property to the `OutputNormalized` interface that specifies the algorithm for generating the hash for the output files ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR246-R249))
  * Add a type definition for `HashFunction` that represents either a string or a `Hash` constructor ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR78-R79))
  * Define the `Cache` class in the `Cache.js` file that represents the root cache with hooks for getting, storing, and managing the cache data ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-9e6f549c5018162ddd2079701f4afe1bac022138b651af3a7e843ca700cf2d91R1-R161))
  * Define the `CacheFacade` class in the `CacheFacade.js` file that wraps the `Cache` class and provides a convenient interface for accessing and manipulating the cache data ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-f13d689a7f5ceec79b6500f939411af786f1016c272f60bbc3fe39a56c202f52R1-R345))
  * Define the `getLazyHashedEtag` function in the `getLazyHashedEtag.js` file that returns a lazy hashed etag for a given hashable object and a hash function ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-88790c38256722096da5c0512100ea7b5a38653c24c5d025327c269d76525c3dR1-R81))
  * Define the `mergeEtags` function in the `mergeEtags.js` file that merges two etags into one ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-b02e019ec45cc16227f323f85e86f2a6f2c295296505bcafa9d63859c15599f9R1-R74))
* Add error handling for hooks using the `HookWebpackError` and `WebpackError` classes ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-8b20209110bee663bbfbdb09827567ba8b1dabe80f23d8095485b864198a993bR1-R93), [link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-ea16309ba7b23412de2a61716b4ffc66fe19ede62f208cb3ec52f8c44c5bf1e0R1-R60))
  * Define the `HookWebpackError` class in the `HookWebpackError.js` file that extends the `WebpackError` class and represents an error that occurred in a hook ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-8b20209110bee663bbfbdb09827567ba8b1dabe80f23d8095485b864198a993bR1-R93))
  * Define the `WebpackError` class in the `WebpackError.js` file that extends the `Error` class and represents a generic error that occurred in webpack ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-ea16309ba7b23412de2a61716b4ffc66fe19ede62f208cb3ec52f8c44c5bf1e0R1-R60))
* Remove a ts-expect-error comment from the `runLoader` function in the `loader-runner/index.ts` file ([link](https://github.com/web-infra-dev/rspack/pull/2892/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L461))

</details>
