### PR TITLE
perf: compose loaders on the native side

### DIFF
--- a/.changeset/curly-peaches-study.md
+++ b/.changeset/curly-peaches-study.md
@@ -1,0 +1,6 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+---
+
+perf: compose loaders on the native side

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -282,7 +282,7 @@ impl JsStats {
     chunk_modules: bool,
     chunks_relations: bool,
     reasons: bool,
-    module_assets: bool
+    module_assets: bool,
   ) -> Vec<JsStatsChunk> {
     self
       .inner

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -149,7 +149,7 @@ impl Rspack {
 
     let js_loader_runner: JsLoaderRunner = JsLoaderRunner::try_from(js_loader_runner)?;
     plugins.push(
-      InlineLoaderResolver {
+      JsLoaderResolver {
         js_loader_runner: js_loader_runner.clone(),
       }
       .boxed(),

--- a/crates/node_binding/src/plugins/loader.rs
+++ b/crates/node_binding/src/plugins/loader.rs
@@ -4,23 +4,23 @@ use rspack_binding_options::{JsLoaderAdapter, JsLoaderRunner};
 use rspack_core::{BoxLoader, CompilerOptions, NormalModule, Plugin, ResolveResult, Resolver};
 use rspack_error::{internal_error, Result};
 
-pub struct InlineLoaderResolver {
+pub struct JsLoaderResolver {
   pub js_loader_runner: JsLoaderRunner,
 }
 
-impl Debug for InlineLoaderResolver {
+impl Debug for JsLoaderResolver {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("InlineLoaderResolver")
+    f.debug_struct("JsLoaderResolver")
       .field("js_loader_runner", &"..")
       .finish()
   }
 }
 
 #[async_trait::async_trait]
-impl Plugin for InlineLoaderResolver {
+impl Plugin for JsLoaderResolver {
   async fn before_loaders(&self, module: &mut NormalModule) -> Result<()> {
     let old_loaders = module.loaders_mut_vec();
-    if old_loaders.is_empty() {
+    if old_loaders.is_empty() || old_loaders.len() == 1 {
       return Ok(());
     }
 

--- a/crates/node_binding/src/plugins/loader.rs
+++ b/crates/node_binding/src/plugins/loader.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, path::Path, sync::Arc};
 
 use rspack_binding_options::{JsLoaderAdapter, JsLoaderRunner};
-use rspack_core::{BoxLoader, CompilerOptions, Plugin, ResolveResult, Resolver};
+use rspack_core::{BoxLoader, CompilerOptions, NormalModule, Plugin, ResolveResult, Resolver};
 use rspack_error::{internal_error, Result};
 
 pub struct InlineLoaderResolver {
@@ -18,6 +18,49 @@ impl Debug for InlineLoaderResolver {
 
 #[async_trait::async_trait]
 impl Plugin for InlineLoaderResolver {
+  async fn before_loaders(&self, module: &mut NormalModule) -> Result<()> {
+    let old_loaders = module.loaders_mut_vec();
+    if old_loaders.is_empty() {
+      return Ok(());
+    }
+
+    let mut loaders: Vec<BoxLoader> = vec![];
+
+    let mut starting_point = 0;
+    for (idx, l) in old_loaders.iter().enumerate() {
+      if l.identifier().starts_with("builtin:") {
+        // Compose JS loaders
+        let composed = old_loaders[starting_point..idx]
+          .iter()
+          .map(|l| l.identifier().as_str())
+          .collect::<Vec<_>>()
+          .join("$");
+        loaders.push(Arc::new(JsLoaderAdapter {
+          runner: self.js_loader_runner.clone(),
+          identifier: composed.into(),
+        }));
+        loaders.push(l.clone());
+        starting_point = idx + 1;
+      }
+    }
+    // Compose the rest of JS loaders
+    if starting_point < old_loaders.len() {
+      let composed = old_loaders[starting_point..]
+        .iter()
+        .map(|l| l.identifier().as_str())
+        .collect::<Vec<_>>()
+        .join("$");
+      loaders.push(Arc::new(JsLoaderAdapter {
+        runner: self.js_loader_runner.clone(),
+        identifier: composed.into(),
+      }));
+    }
+
+    *module.loaders_mut_vec() = loaders;
+
+    Ok(())
+  }
+
   async fn resolve_loader(
     &self,
     _compiler_options: &CompilerOptions,
@@ -31,22 +74,35 @@ impl Plugin for InlineLoaderResolver {
       return Ok(None);
     }
 
-    let resolve_result = resolver.resolve(context, loader_request).map_err(|err| {
-      let context = context.display();
-      internal_error!("Failed to resolve loader: {loader_request} in {context} {err:?}")
-    })?;
+    let mut rest = None;
+    let loader_request = if let Some(index) = loader_request.find('?') {
+      rest = Some(&loader_request[index..]);
+      Path::new(&loader_request[0..index])
+    } else {
+      Path::new(loader_request)
+    };
+    let resolve_result = resolver
+      .resolve(context, &loader_request.to_string_lossy())
+      .map_err(|err| {
+        let loader_request = loader_request.display();
+        let context = context.display();
+        internal_error!("Failed to resolve loader: {loader_request} in {context} {err:?}")
+      })?;
 
     match resolve_result {
       ResolveResult::Resource(resource) => {
-        let resource = resource.join().display().to_string();
+        let resource = resource.path.to_string_lossy().to_string() + rest.unwrap_or_default();
         Ok(Some(Arc::new(JsLoaderAdapter {
           identifier: resource.into(),
           runner: self.js_loader_runner.clone(),
         })))
       }
-      ResolveResult::Ignored => Err(internal_error!(
-        "Failed to resolve loader: {loader_request}"
-      )),
+      ResolveResult::Ignored => {
+        let loader_request = loader_request.display();
+        Err(internal_error!(
+          "Failed to resolve loader: {loader_request}"
+        ))
+      }
     }
   }
 }

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-pub use loader::InlineLoaderResolver;
+pub use loader::JsLoaderResolver;
 use napi::{Env, Result};
 use rspack_binding_macros::js_fn_into_theadsafe_fn;
 use rspack_core::{

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -461,6 +461,10 @@ impl NormalModule {
   pub fn ast_or_source_mut(&mut self) -> &mut NormalModuleAstOrSource {
     &mut self.ast_or_source
   }
+
+  pub fn loaders_mut_vec(&mut self) -> &mut Vec<BoxLoader> {
+    &mut self.loaders
+  }
 }
 
 impl Identifiable for NormalModule {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

closes #2870

## Summary

In the old architecture, loaders are dispatched without delegation. So the original implementation of JS loader composition is implemented on the JS side, which makes hard for us to create composition cross rules.
In the new architecture, native JS loader composition is implemented for minimize the cost of interoperation for JS loaders.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ddfd882</samp>

This pull request introduces a new `LoaderPlugin` struct in the `node_binding` crate that handles the logic of transforming and resolving JS loaders. The `rspack` package and the `rspack_core` crate are updated to use this new struct and simplify their code. The pull request also improves the error handling of JS loaders with query strings.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ddfd882</samp>

*  Add `before_loaders` method to `LoaderPlugin` struct to transform and compose JS loaders and insert builtin loaders for each `NormalModule` ([link](https://github.com/web-infra-dev/rspack/pull/2894/files?diff=unified&w=0#diff-20fdab381355c53cd87d4b782507c4fd40b8c356a5deb5025f5eb9e8051ad79cR21-R63), [link](https://github.com/web-infra-dev/rspack/pull/2894/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90R464-R467))
*  Modify `resolve_loader` method of `LoaderPlugin` struct to handle query strings in loader requests and improve error messages ([link](https://github.com/web-infra-dev/rspack/pull/2894/files?diff=unified&w=0#diff-20fdab381355c53cd87d4b782507c4fd40b8c356a5deb5025f5eb9e8051ad79cL34-R94), [link](https://github.com/web-infra-dev/rspack/pull/2894/files?diff=unified&w=0#diff-20fdab381355c53cd87d4b782507c4fd40b8c356a5deb5025f5eb9e8051ad79cL47-R105))
*  Simplify `createRawModuleRuleUsesImpl` function in `packages/rspack/src/config/adapter-rule-use.ts` to map each use to a builtin or JS use without splitting the array ([link](https://github.com/web-infra-dev/rspack/pull/2894/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L201-R198))
*  Remove unused or moved imports from `packages/rspack/src/config/adapter-rule-use.ts` ([link](https://github.com/web-infra-dev/rspack/pull/2894/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L1-R7))

</details>
