### PR TITLE
fix: fix loader arguments

### DIFF
--- a/packages/rspack/src/config/adapter-rule-use.ts
+++ b/packages/rspack/src/config/adapter-rule-use.ts
@@ -260,16 +260,6 @@ function createBuiltinUse(use: RuleSetLoaderWithOptions): RawModuleRuleUse {
 	};
 }
 
-export const toBuffer = (bufLike: string | Buffer): Buffer => {
-	if (Buffer.isBuffer(bufLike)) {
-		return bufLike;
-	} else if (typeof bufLike === "string") {
-		return Buffer.from(bufLike);
-	}
-
-	throw new Error("Buffer or string expected");
-};
-
 export function isUseSourceMap(devtool: RawOptions["devtool"]): boolean {
 	return (
 		devtool.includes("source-map") &&

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -21,10 +21,9 @@ import {
 	LoaderContext,
 	LoaderObject,
 	isUseSimpleSourceMap,
-	isUseSourceMap,
-	toBuffer
+	isUseSourceMap
 } from "../config/adapter-rule-use";
-import { concatErrorMsgAndStack, isNil } from "../util";
+import { concatErrorMsgAndStack, isNil, toBuffer, toObject } from "../util";
 import { absolutify, contextify, makePathsRelative } from "../util/identifier";
 import { memoize } from "../util/memoize";
 import { createHash } from "../util/createHash";
@@ -550,7 +549,15 @@ export async function runLoader(
 			loaderContext.loaderIndex = loaderContext.loaders.length - 1;
 			iterateNormalLoaders(
 				loaderContext,
-				[rawContext.content, rawContext.sourceMap, rawContext.additionalData],
+				[
+					rawContext.content,
+					isNil(rawContext.sourceMap)
+						? undefined
+						: toObject(rawContext.sourceMap),
+					isNil(rawContext.additionalData)
+						? undefined
+						: toObject(rawContext.additionalData)
+				],
 				(err: Error, result: any[]) => {
 					if (err) {
 						return reject(err);

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -11,6 +11,31 @@ export function isNil(value: unknown): value is null | undefined {
 	return value === null || value === undefined;
 }
 
+export const toBuffer = (bufLike: string | Buffer): Buffer => {
+	if (Buffer.isBuffer(bufLike)) {
+		return bufLike;
+	} else if (typeof bufLike === "string") {
+		return Buffer.from(bufLike);
+	}
+
+	throw new Error("Buffer or string expected");
+};
+
+export const toObject = (input: string | Buffer | object): object => {
+	let s: string;
+	if (Buffer.isBuffer(input)) {
+		s = input.toString("utf8");
+	} else if (input && typeof input === "object") {
+		return input;
+	} else if (typeof input === "string") {
+		s = input;
+	} else {
+		throw new Error("Buffer or string or object expected");
+	}
+
+	return JSON.parse(s);
+};
+
 export function isPromiseLike(value: unknown): value is Promise<any> {
 	return (
 		typeof value === "object" &&


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 500984b</samp>

Moved and added utility functions for converting inputs to buffers or objects. This allows the loader-runner module to handle different input types for source map and additional data more consistently and validly.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 500984b</samp>

* Move `toBuffer` function from `adapter-rule-use.ts` to `util/index.ts` as a reusable utility ([link](https://github.com/web-infra-dev/rspack/pull/2898/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L263-L272), [link](https://github.com/web-infra-dev/rspack/pull/2898/files?diff=unified&w=0#diff-4f9ce3f0a4a955f4fe94737ce6792ad1b9b5f04e0d5136c2616eb2de4b4072ebR14-R38))
* Add `toObject` function to `util/index.ts` as a utility to convert strings or buffers to objects ([link](https://github.com/web-infra-dev/rspack/pull/2898/files?diff=unified&w=0#diff-4f9ce3f0a4a955f4fe94737ce6792ad1b9b5f04e0d5136c2616eb2de4b4072ebR14-R38))
* Replace `toBuffer` with `toObject` in `loader-runner/index.ts` to handle source map and additional data arguments of loader context ([link](https://github.com/web-infra-dev/rspack/pull/2898/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L24-R26), [link](https://github.com/web-infra-dev/rspack/pull/2898/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L553-R560))

</details>
