### PR TITLE
feat(cli): add --entry flags

### DIFF
--- a/.changeset/gentle-cherries-lick.md
+++ b/.changeset/gentle-cherries-lick.md
@@ -1,0 +1,5 @@
+---
+"@rspack/cli": patch
+---
+
+add --entry flags

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -3,7 +3,6 @@
  */
 module.exports = {
 	context: __dirname,
-	mode: "development",
 	entry: {
 		main: "./src/index.js"
 	},

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -3,6 +3,7 @@
  */
 module.exports = {
 	context: __dirname,
+	mode: "development",
 	entry: {
 		main: "./src/index.js"
 	},

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -124,22 +124,18 @@ export class RspackCLI {
 		let isBuild = command === "build";
 		let isServe = command === "serve";
 		const internalBuildConfig = async (item: RspackOptions) => {
-			let entry = {};
-			if (!item.entry) {
-				if (options.entry) {
-					entry = {
-						main: options.entry.map(x => path.resolve(process.cwd(), x))[0] // Fix me when entry supports array
-					};
-				} else {
-					const defaultEntryBase = path.resolve(process.cwd(), defaultEntry);
-					const defaultEntryPath =
-						findFileWithSupportedExtensions(defaultEntryBase) ||
-						defaultEntryBase + ".js"; // default entry is js
-					entry = {
-						main: defaultEntryPath
-					};
-				}
-				item.entry = entry;
+			if (options.entry) {
+				item.entry = {
+					main: options.entry.map(x => path.resolve(process.cwd(), x))[0] // Fix me when entry supports array
+				};
+			} else if (!item.entry) {
+				const defaultEntryBase = path.resolve(process.cwd(), defaultEntry);
+				const defaultEntryPath =
+					findFileWithSupportedExtensions(defaultEntryBase) ||
+					defaultEntryBase + ".js"; // default entry is js
+				item.entry = {
+					main: defaultEntryPath
+				};
 			}
 			if (options.analyze) {
 				const { BundleAnalyzerPlugin } = await import(

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -7,6 +7,11 @@ export const commonOptions = (yargs: yargs.Argv<{}>) => {
 			describe: "config file",
 			alias: "c"
 		},
+		entry: {
+			type: "array",
+			string: true,
+			describe: "entry file"
+		},
 		mode: { type: "string", describe: "mode" },
 		watch: {
 			type: "boolean",

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -48,7 +48,9 @@ describe("build command", () => {
 	it("entry option should have higher priority than config", async () => {
 		const { exitCode, stderr, stdout } = await run(__dirname, [
 			"--entry",
-			"./src/other.js"
+			"./src/other.js",
+			"--config",
+			"./entry.config.js"
 		]);
 		const mainJs = await readFile(resolve(__dirname, "dist/main.js"), "utf-8");
 
@@ -56,5 +58,6 @@ describe("build command", () => {
 		expect(stderr).toBeFalsy();
 		expect(stdout).toBeTruthy();
 		expect(mainJs).toContain("other");
+		expect(mainJs).not.toContain("CONFIG");
 	});
 });

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -1,4 +1,6 @@
-import { run } from "../../utils/test-utils";
+import { readFile, run } from "../../utils/test-utils";
+import { resolve } from "path";
+
 describe("build command", () => {
 	it("it should work ", async () => {
 		const { exitCode, stderr, stdout } = await run(__dirname, []);
@@ -42,5 +44,17 @@ describe("build command", () => {
 		expect(exitCode).toBe(0);
 		expect(stderr).toBeFalsy();
 		expect(stdout).toBeTruthy();
+	});
+	it("entry option should have higher priority than config", async () => {
+		const { exitCode, stderr, stdout } = await run(__dirname, [
+			"--entry",
+			"./src/other.js"
+		]);
+		const mainJs = await readFile(resolve(__dirname, "dist/main.js"), "utf-8");
+
+		expect(exitCode).toBe(0);
+		expect(stderr).toBeFalsy();
+		expect(stdout).toBeTruthy();
+		expect(mainJs).toContain("other");
 	});
 });

--- a/packages/rspack-cli/tests/build/basic/src/other.js
+++ b/packages/rspack-cli/tests/build/basic/src/other.js
@@ -1,1 +1,1 @@
-console.log("hello world");
+console.log("other");


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->
#2438 
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e503b8</samp>

This pull request adds the `mode` and `entry` options to the rspack CLI and config file, which allow the user to customize the webpack configuration for different development scenarios. It also refactors and fixes some issues in the rspack CLI code.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e503b8</samp>

*  Add `entry` option to allow custom entry files for webpack ([link](https://github.com/web-infra-dev/rspack/pull/2902/files?diff=unified&w=0#diff-63ac1115f8ddcb7c926c698f4c3b79b51692206b6b5d334e5bfa35b319a85f49R10-R14))
*  Add `mode` property to webpack configuration in `rspack.config.js` ([link](https://github.com/web-infra-dev/rspack/pull/2902/files?diff=unified&w=0#diff-daaa7eb6c8f8733a48f42bc92475fab6bc98ec02b25904537f52724fab7555f3R6))
*  Simplify and fix `internalBuildConfig` function in `rspack-cli.ts` ([link](https://github.com/web-infra-dev/rspack/pull/2902/files?diff=unified&w=0#diff-44dee9ba83d25009b434358408609d864a6ae2c804c084a8d6cfeec82ab64ab4L127-R138))

</details>
