### PR TITLE
feat: enable compression and cache with `noEmitAssets: true`

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -64,10 +64,6 @@ export class RspackDevServer extends WebpackDevServer {
 								0,
 								...memoryAssetsMiddlewares
 							);
-							console.log(
-								"memoryAssetsMiddlewares",
-								middlewares.map(m => m.name)
-							);
 						}
 					}
 

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -29,7 +29,54 @@ export class RspackDevServer extends WebpackDevServer {
 	webSocketServer: WebpackDevServer.WebSocketServerImplementation | undefined;
 
 	constructor(options: DevServer, compiler: Compiler | MultiCompiler) {
-		super(options, compiler as any);
+		super(
+			{
+				...options,
+				setupMiddlewares: (middlewares, devServer) => {
+					const webpackDevMiddlewareIndex = middlewares.findIndex(
+						mid => mid.name === "webpack-dev-middleware"
+					);
+					// @ts-expect-error
+					if (compiler.options.builtins.noEmitAssets) {
+						if (Array.isArray(this.options.static)) {
+							const compilers =
+								compiler instanceof MultiCompiler
+									? compiler.compilers
+									: [compiler];
+							const memoryAssetsMiddlewares = this.options.static.flatMap(
+								staticOptions => {
+									return staticOptions.publicPath.flatMap(publicPath => {
+										return compilers.map(compiler => {
+											return {
+												name: "rspack-memory-assets",
+												path: publicPath,
+												middleware: getRspackMemoryAssets(
+													compiler,
+													this.middleware
+												)
+											};
+										});
+									});
+								}
+							);
+							middlewares.splice(
+								webpackDevMiddlewareIndex,
+								0,
+								...memoryAssetsMiddlewares
+							);
+							console.log(
+								"memoryAssetsMiddlewares",
+								middlewares.map(m => m.name)
+							);
+						}
+					}
+
+					options.setupMiddlewares?.call(this, middlewares, devServer);
+					return middlewares;
+				}
+			},
+			compiler as any
+		);
 	}
 
 	addAdditionalEntries(compiler: Compiler) {
@@ -381,21 +428,21 @@ export class RspackDevServer extends WebpackDevServer {
 				? this.compiler.compilers
 				: [this.compiler];
 
-		if (Array.isArray(this.options.static)) {
-			this.options.static.forEach(staticOptions => {
-				staticOptions.publicPath.forEach(publicPath => {
-					compilers.forEach(compiler => {
-						if (compiler.options.builtins.noEmitAssets) {
-							middlewares.push({
-								name: "rspack-memory-assets",
-								path: publicPath,
-								middleware: getRspackMemoryAssets(compiler, this.middleware)
-							});
-						}
-					});
-				});
-			});
-		}
+		// if (Array.isArray(this.options.static)) {
+		// 	this.options.static.forEach(staticOptions => {
+		// 		staticOptions.publicPath.forEach(publicPath => {
+		// 			compilers.forEach(compiler => {
+		// 				if (compiler.options.builtins.noEmitAssets) {
+		// 					middlewares.push({
+		// 						name: "rspack-memory-assets",
+		// 						path: publicPath,
+		// 						middleware: getRspackMemoryAssets(compiler, this.middleware)
+		// 					});
+		// 				}
+		// 			});
+		// 		});
+		// 	});
+		// }
 
 		compilers.forEach(compiler => {
 			if (compiler.options.experiments.lazyCompilation) {

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -34,6 +34,7 @@ exports[`normalize options snapshot no options 1`] = `
     "type": "http",
   },
   "setupExitSignals": true,
+  "setupMiddlewares": [Function],
   "static": [
     {
       "directory": "<PROJECT_ROOT>/public",
@@ -90,6 +91,7 @@ exports[`normalize options snapshot port string 1`] = `
     "type": "http",
   },
   "setupExitSignals": true,
+  "setupMiddlewares": [Function],
   "static": [
     {
       "directory": "<PROJECT_ROOT>/public",


### PR DESCRIPTION
## Related issue (if exists)

Closes #2696.
Closes #2751.

<!--- Provide link of related issues -->

## Summary

I've tested this on the FS project.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19c5700</samp>

This pull request adds a new feature to the `rspack` development tools that allows serving files from memory instead of disk when using the `noEmitAssets` option. It implements ETag support and custom middlewares for the memory assets, and integrates them with the `RspackDevServer` class.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19c5700</samp>

* Implement ETag header for memory assets middleware ([link](https://github.com/web-infra-dev/rspack/pull/2907/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L2-R15), [link](https://github.com/web-infra-dev/rspack/pull/2907/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L52-R65))
* Change type of `res` parameter from `ServerResponse` to `Response` in memory assets middleware ([link](https://github.com/web-infra-dev/rspack/pull/2907/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L16-R28))
* Add `setupMiddlewares` option to `RspackDevServer` constructor ([link](https://github.com/web-infra-dev/rspack/pull/2907/files?diff=unified&w=0#diff-6195dbe0219b3b7ba39567cf6de6d629fb3a7b78c582c6b0b2957d1425105922L32-R79))
* Comment out previous logic that added memory assets middleware to middlewares array ([link](https://github.com/web-infra-dev/rspack/pull/2907/files?diff=unified&w=0#diff-6195dbe0219b3b7ba39567cf6de6d629fb3a7b78c582c6b0b2957d1425105922L384-R445))

</details>
