### PR TITLE
feat(@rspack/core): add typings about `LoaderDefinition`

### DIFF
--- a/packages/rspack/src/config/adapter-rule-use.ts
+++ b/packages/rspack/src/config/adapter-rule-use.ts
@@ -51,21 +51,21 @@ export interface LoaderObject {
 	normalExecuted: boolean;
 }
 
-export interface LoaderContext {
+export interface LoaderContext<OptionsType = {}> {
 	version: 2;
 	resource: string;
 	resourcePath: string;
 	resourceQuery: string;
 	resourceFragment: string;
 	async(): (
-		err: Error | null,
-		content: string | Buffer,
+		err?: Error | null,
+		content?: string | Buffer,
 		sourceMap?: string | SourceMap,
 		additionalData?: AdditionalData
 	) => void;
 	callback(
-		err: Error | null,
-		content: string | Buffer,
+		err?: Error | null,
+		content?: string | Buffer,
 		sourceMap?: string | SourceMap,
 		additionalData?: AdditionalData
 	): void;
@@ -99,7 +99,7 @@ export interface LoaderContext {
 	loaders: LoaderObject[];
 	mode?: Mode;
 	hot?: boolean;
-	getOptions(schema?: any): unknown;
+	getOptions(schema?: any): OptionsType;
 	resolve(
 		context: string,
 		request: string,
@@ -136,7 +136,7 @@ export interface LoaderContext {
 		contextify: (context: string, request: string) => string;
 		createHash: (algorithm?: string) => Hash;
 	};
-	query: unknown;
+	query: string | OptionsType;
 	data: unknown;
 	_compiler: Compiler;
 	_compilation: Compiler["compilation"];
@@ -147,6 +147,7 @@ export interface LoaderContext {
 	 * @internal
 	 */
 	__internal__isPitching: boolean;
+	// TODO: LoaderPluginLoaderContext
 }
 
 export interface LoaderResult {
@@ -159,6 +160,38 @@ export interface LoaderResult {
 	missingDependencies: string[];
 	buildDependencies: string[];
 }
+
+export interface LoaderDefinitionFunction<
+	OptionsType = {},
+	ContextAdditions = {}
+> {
+	(
+		this: LoaderContext<OptionsType> & ContextAdditions,
+		content: string,
+		sourceMap?: string | SourceMap,
+		additionalData?: AdditionalData
+	): string | void | Buffer | Promise<string | Buffer>;
+}
+
+export interface PitchLoaderDefinitionFunction<
+	OptionsType = {},
+	ContextAdditions = {}
+> {
+	(
+		this: LoaderContext<OptionsType> & ContextAdditions,
+		remainingRequest: string,
+		previousRequest: string,
+		data: object
+	): string | void | Buffer | Promise<string | Buffer>;
+}
+
+export type LoaderDefinition<
+	OptionsType = {},
+	ContextAdditions = {}
+> = LoaderDefinitionFunction<OptionsType, ContextAdditions> & {
+	raw?: false;
+	pitch?: PitchLoaderDefinitionFunction;
+};
 
 export function createRawModuleRuleUses(
 	uses: RuleSetUse,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -15,7 +15,11 @@ import * as oldBuiltins from "./builtins";
 
 export type { BannerConditions, BannerCondition } from "./builtins";
 
-export type { LoaderContext } from "./adapter-rule-use";
+export type {
+	LoaderContext,
+	LoaderDefinitionFunction,
+	LoaderDefinition
+} from "./adapter-rule-use";
 
 export type Configuration = RspackOptions;
 

--- a/packages/rspack/tests/configCases/loader/pre-post-loader/loader1.js
+++ b/packages/rspack/tests/configCases/loader/pre-post-loader/loader1.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + 'module.exports += " loader1";\n';
 };

--- a/packages/rspack/tests/configCases/loader/pre-post-loader/loader2.js
+++ b/packages/rspack/tests/configCases/loader/pre-post-loader/loader2.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + 'module.exports += " loader2";\n';
 };

--- a/packages/rspack/tests/configCases/loader/pre-post-loader/loader3.js
+++ b/packages/rspack/tests/configCases/loader/pre-post-loader/loader3.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + 'module.exports += " loader3";\n';
 };

--- a/packages/rspack/tests/fixtures/count-loader.js
+++ b/packages/rspack/tests/fixtures/count-loader.js
@@ -1,6 +1,6 @@
 let counter = 0;
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	return `module.exports = ${counter++};`;
 };

--- a/packages/rspack/tests/fixtures/delay-loader.js
+++ b/packages/rspack/tests/fixtures/delay-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	var cb = this.async();
 	setTimeout(function () {

--- a/packages/rspack/tests/fixtures/errors/add-comment-loader.js
+++ b/packages/rspack/tests/fixtures/errors/add-comment-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + "// some comment";
 };

--- a/packages/rspack/tests/fixtures/errors/async-error-loader.js
+++ b/packages/rspack/tests/fixtures/errors/async-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	const callback = this.async();
 	const error = new Error("this is a callback error");

--- a/packages/rspack/tests/fixtures/errors/emit-error-loader.js
+++ b/packages/rspack/tests/fixtures/errors/emit-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	this.emitWarning(new Error("this is a warning"));
 	this.emitError(new Error("this is an error"));

--- a/packages/rspack/tests/fixtures/errors/identity-loader.js
+++ b/packages/rspack/tests/fixtures/errors/identity-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source;
 };

--- a/packages/rspack/tests/fixtures/errors/irregular-error-loader.js
+++ b/packages/rspack/tests/fixtures/errors/irregular-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	const empty = null;
 	const emptyError = new Error();

--- a/packages/rspack/tests/fixtures/errors/no-return-loader.js
+++ b/packages/rspack/tests/fixtures/errors/no-return-loader.js
@@ -1,2 +1,2 @@
-/** @type {import("../../../../").LoaderDefinition} */
-module.exports = function () {};
+/** @type {import("@rspack/core").LoaderDefinition} */
+module.exports = function () { };

--- a/packages/rspack/tests/fixtures/errors/throw-error-loader.js
+++ b/packages/rspack/tests/fixtures/errors/throw-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	throw new Error("this is a thrown error");
 };

--- a/webpack-test/cases/async-modules/runtime-performance/loader.js
+++ b/webpack-test/cases/async-modules/runtime-performance/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ i: string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ i: string }>} */
 module.exports = function () {
 	const options = this.getOptions();
 	const i = +options.i;

--- a/webpack-test/cases/compile/error-hide-stack/loader.js
+++ b/webpack-test/cases/compile/error-hide-stack/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	var err = new Error("Message");
 	err.stack = "Stack";

--- a/webpack-test/cases/errors/load-module-cycle-multiple/loader.js
+++ b/webpack-test/cases/errors/load-module-cycle-multiple/loader.js
@@ -1,6 +1,6 @@
 const { promisify } = require("util");
 
-/** @type {import("../../../../").LoaderDefinitionFunction} */
+/** @type {import("@rspack/core").LoaderDefinitionFunction} */
 exports.default = function (source) {
 	const content = JSON.parse(source);
 	// content is one reference or an array of references
@@ -13,11 +13,11 @@ exports.default = function (source) {
 		// bug from https://github.com/webpack/webpack/issues/14379 doesn't occur if
 		// they are loaded in parallel.
 		const loadedRefs = []
-		for(const ref of refs) {
+		for (const ref of refs) {
 			try {
 				const source = await loadModulePromise("../loader!" + ref);
 				loadedRefs.push([ref, JSON.parse(source)]);
-			} catch(err) {
+			} catch (err) {
 				loadedRefs.push([ref, `err: ${err && err.message}`]);
 			}
 		}

--- a/webpack-test/cases/errors/load-module-cycle/loader.js
+++ b/webpack-test/cases/errors/load-module-cycle/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinitionFunction} */
+/** @type {import("@rspack/core").LoaderDefinitionFunction} */
 exports.default = function (source) {
 	const ref = JSON.parse(source);
 	const callback = this.async();

--- a/webpack-test/cases/errors/load-module-error/error-loader.js
+++ b/webpack-test/cases/errors/load-module-error/error-loader.js
@@ -1,5 +1,5 @@
-/** @type {import("../../../../types").LoaderDefinition} */
-module.exports = function(source) {
+/** @type {import("@rspack/core").LoaderDefinition} */
+module.exports = function (source) {
 	const callback = this.async();
 	callback(new Error("err: abc"));
 }

--- a/webpack-test/cases/errors/load-module-error/loader.js
+++ b/webpack-test/cases/errors/load-module-error/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinitionFunction} */
+/** @type {import("@rspack/core").LoaderDefinitionFunction} */
 exports.default = function (source) {
 	const callback = this.async();
 	const ref = JSON.parse(source);

--- a/webpack-test/cases/errors/loader-error-warning/error-loader.js
+++ b/webpack-test/cases/errors/loader-error-warning/error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<string>} */
+/** @type {import("@rspack/core").LoaderDefinition<string>} */
 module.exports = function (source) {
 	//@ts-expect-error errors must be Errors, string is not recommended and should lead to type error
 	this.emitError(this.query.slice(1));

--- a/webpack-test/cases/errors/loader-error-warning/warning-loader.js
+++ b/webpack-test/cases/errors/loader-error-warning/warning-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<string>} */
+/** @type {import("@rspack/core").LoaderDefinition<string>} */
 module.exports = function (source) {
 	//@ts-expect-error warnings must be Errors, string is not recommended and should lead to type error
 	this.emitWarning(this.query.slice(1));

--- a/webpack-test/cases/loaders/async/loaders/asyncloader.js
+++ b/webpack-test/cases/loaders/async/loaders/asyncloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	var cb = this.async();
 	if (!cb) throw new Error("Loader should allow async mode");

--- a/webpack-test/cases/loaders/async/loaders/syncloader.js
+++ b/webpack-test/cases/loaders/async/loaders/syncloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	return content;
 };

--- a/webpack-test/cases/loaders/emit-file/loader.js
+++ b/webpack-test/cases/loaders/emit-file/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	this.emitFile("extra-file.js", content);
 	return "";

--- a/webpack-test/cases/loaders/import-module/loader.js
+++ b/webpack-test/cases/loaders/import-module/loader.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const callback = this.async();
 	this.importModule(
@@ -16,8 +16,7 @@ module.exports = function () {
 
 			callback(
 				null,
-				`module.exports = ${
-					exports.asset ? JSON.stringify(exports.asset) : undefined
+				`module.exports = ${exports.asset ? JSON.stringify(exports.asset) : undefined
 				}`
 			);
 		}

--- a/webpack-test/cases/loaders/issue-10725/loader.js
+++ b/webpack-test/cases/loaders/issue-10725/loader.js
@@ -2,7 +2,7 @@ const { getRemainingRequest, stringifyRequest } = require("loader-utils");
 
 const loaderPath = require.resolve("./loader");
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	if (this.query === "?load") {
 		return `

--- a/webpack-test/cases/loaders/module-description-file/reverseloader.js
+++ b/webpack-test/cases/loaders/module-description-file/reverseloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	return content.split("").reverse().join("");
 };

--- a/webpack-test/cases/loaders/query/loaders/queryloader.js
+++ b/webpack-test/cases/loaders/query/loaders/queryloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	return (
 		"module.exports = " +

--- a/webpack-test/cases/loaders/resolve/loader.js
+++ b/webpack-test/cases/loaders/resolve/loader.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const resolve1 = this.getResolve();
 	const resolve2 = this.getResolve({

--- a/webpack-test/cases/loaders/utils/loader.js
+++ b/webpack-test/cases/loaders/utils/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	return `module.exports = {
 	request1: ${JSON.stringify(

--- a/webpack-test/cases/parsing/context/loaders/queryloader.js
+++ b/webpack-test/cases/parsing/context/loaders/queryloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	return (
 		"module.exports = " +

--- a/webpack-test/cases/parsing/precreated-ast/ast-loader.js
+++ b/webpack-test/cases/parsing/precreated-ast/ast-loader.js
@@ -3,7 +3,7 @@
 const acorn = require("acorn");
 const acornParser = acorn.Parser;
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	const comments = [];
 
@@ -23,7 +23,7 @@ module.exports = function (source) {
 
 	//@ts-ignore
 	ast.comments = comments;
-	this.callback(null, source, null, {
+	this.callback(null, source, undefined, {
 		webpackAST: ast
 	});
 };

--- a/webpack-test/cases/resolving/context/loaders/queryloader.js
+++ b/webpack-test/cases/resolving/context/loaders/queryloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	return (
 		"module.exports = " +

--- a/webpack-test/configCases/asset-modules/data-url/loader.js
+++ b/webpack-test/configCases/asset-modules/data-url/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ f(): any }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ f(): any }>} */
 module.exports = function (source) {
 	return `${source}, World!`;
 };

--- a/webpack-test/configCases/cache-dependencies/managed-items-unsafe-cache/loader.js
+++ b/webpack-test/configCases/cache-dependencies/managed-items-unsafe-cache/loader.js
@@ -1,6 +1,6 @@
 const path = require("path");
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	this.addDependency(path.resolve(__dirname, "node_modules/package/extra.js"));
 	this.addDependency(path.resolve(__dirname, "extra.js"));

--- a/webpack-test/configCases/cache-dependencies/managed-items/loader.js
+++ b/webpack-test/configCases/cache-dependencies/managed-items/loader.js
@@ -1,6 +1,6 @@
 const path = require("path");
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	this.addDependency(path.resolve(__dirname, "node_modules/package/extra.js"));
 	this.addDependency(path.resolve(__dirname, "extra.js"));

--- a/webpack-test/configCases/concatenate-modules/import-module/loader.js
+++ b/webpack-test/configCases/concatenate-modules/import-module/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinitionFunction} */
+/** @type {import("@rspack/core").LoaderDefinitionFunction} */
 module.exports = function () {
 	const callback = this.async();
 	this.importModule("./module1", { baseUri: "webpack://" }, (err, exports) => {

--- a/webpack-test/configCases/context-replacement/d/queryloader.js
+++ b/webpack-test/configCases/context-replacement/d/queryloader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (content) {
 	return (
 		"module.exports = " +

--- a/webpack-test/configCases/deprecations/invalid-dependencies/loader.js
+++ b/webpack-test/configCases/deprecations/invalid-dependencies/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	this.addDependency("loader.js");
 	this.addDependency("../**/dir/*.js");

--- a/webpack-test/configCases/dll-plugin/0-create-dll/g-loader.js
+++ b/webpack-test/configCases/dll-plugin/0-create-dll/g-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source;
 };

--- a/webpack-test/configCases/inner-graph/_helpers/entryLoader.js
+++ b/webpack-test/configCases/inner-graph/_helpers/entryLoader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<string>} */
+/** @type {import("@rspack/core").LoaderDefinition<string>} */
 module.exports = function () {
 	const { name, expect, usedExports } = JSON.parse(this.query.slice(1));
 	return [

--- a/webpack-test/configCases/inner-graph/_helpers/testModuleLoader.js
+++ b/webpack-test/configCases/inner-graph/_helpers/testModuleLoader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<string>} */
+/** @type {import("@rspack/core").LoaderDefinition<string>} */
 module.exports = function () {
 	const usedExports = JSON.parse(this.query.slice(1));
 	return [

--- a/webpack-test/configCases/layer/rules/loader.js
+++ b/webpack-test/configCases/layer/rules/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ value: any }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ value: any }>} */
 module.exports = function (source) {
 	const options = this.getOptions();
 	return `${source}

--- a/webpack-test/configCases/loaders/generate-ident/loader2.js
+++ b/webpack-test/configCases/loaders/generate-ident/loader2.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ f(): any }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ f(): any }>} */
 module.exports = function (source) {
 	if (typeof this.query === "string")
 		throw new Error("query must be an object");

--- a/webpack-test/configCases/loaders/hot-in-context/loader.js
+++ b/webpack-test/configCases/loaders/hot-in-context/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition}} */
+/** @type {import("@rspack/core").LoaderDefinition}} */
 module.exports = function () {
 	return `module.exports = ${JSON.stringify(!!this.hot)};`;
 };

--- a/webpack-test/configCases/loaders/mode-default/loader.js
+++ b/webpack-test/configCases/loaders/mode-default/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return `module.exports = "${this.mode}";`;
 };

--- a/webpack-test/configCases/loaders/mode-development/loader.js
+++ b/webpack-test/configCases/loaders/mode-development/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return `module.exports = "${this.mode}";`;
 };

--- a/webpack-test/configCases/loaders/mode-none/loader.js
+++ b/webpack-test/configCases/loaders/mode-none/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return `module.exports = "${this.mode}";`;
 };

--- a/webpack-test/configCases/loaders/mode-production/loader.js
+++ b/webpack-test/configCases/loaders/mode-production/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return `module.exports = "${this.mode}";`;
 };

--- a/webpack-test/configCases/loaders/options/loader-1.js
+++ b/webpack-test/configCases/loaders/options/loader-1.js
@@ -1,6 +1,6 @@
 const schema = require("./loader-1.options.json");
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const options = this.getOptions(schema);
 

--- a/webpack-test/configCases/loaders/options/loader-2.js
+++ b/webpack-test/configCases/loaders/options/loader-2.js
@@ -1,6 +1,6 @@
 const schema = require("./loader-2.options.json");
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const options = this.getOptions(schema);
 

--- a/webpack-test/configCases/loaders/options/loader.js
+++ b/webpack-test/configCases/loaders/options/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const options = this.getOptions();
 

--- a/webpack-test/configCases/loaders/pr-14384/loader.js
+++ b/webpack-test/configCases/loaders/pr-14384/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	return `module.exports = "success";`;
 };

--- a/webpack-test/configCases/loaders/pre-post-loader/loader1.js
+++ b/webpack-test/configCases/loaders/pre-post-loader/loader1.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + 'module.exports += " loader1";\n';
 };

--- a/webpack-test/configCases/loaders/pre-post-loader/loader2.js
+++ b/webpack-test/configCases/loaders/pre-post-loader/loader2.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + 'module.exports += " loader2";\n';
 };

--- a/webpack-test/configCases/loaders/pre-post-loader/loader3.js
+++ b/webpack-test/configCases/loaders/pre-post-loader/loader3.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + 'module.exports += " loader3";\n';
 };

--- a/webpack-test/configCases/loaders/remaining-request/loader2.js
+++ b/webpack-test/configCases/loaders/remaining-request/loader2.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ f(): any }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ f(): any }>} */
 module.exports = function (source) {
 	if (typeof this.query === "string")
 		throw new Error("query must be an object");

--- a/webpack-test/configCases/module-name/different-issuers-for-same-module/loader-a.js
+++ b/webpack-test/configCases/module-name/different-issuers-for-same-module/loader-a.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (src) {
 	return `module.exports = "loader-a" + module.id`;
 };

--- a/webpack-test/configCases/module-name/different-issuers-for-same-module/loader-b.js
+++ b/webpack-test/configCases/module-name/different-issuers-for-same-module/loader-b.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (src) {
 	return `module.exports = "loader-b" + module.id`;
 };

--- a/webpack-test/configCases/performance/many-async-imports/reexport.loader.js
+++ b/webpack-test/configCases/performance/many-async-imports/reexport.loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	var str = "export default Promise.all([\n";
 	for (var i = 0; i < 6; i++) {

--- a/webpack-test/configCases/performance/many-exports/file.loader.js
+++ b/webpack-test/configCases/performance/many-exports/file.loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	var str = "";
 	for (var i = 0; i < 1000; i++) {

--- a/webpack-test/configCases/performance/many-exports/reexport.loader.js
+++ b/webpack-test/configCases/performance/many-exports/reexport.loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	var str = 'import * as i from "./file.loader.js!";\n';
 	str += "var sum = 0;\n";

--- a/webpack-test/configCases/plugins/loader-options-plugin/loader.js
+++ b/webpack-test/configCases/plugins/loader-options-plugin/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{}, { minimize: boolean, jsfile: boolean }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{}, { minimize: boolean, jsfile: boolean }>} */
 module.exports = function () {
 	return (
 		"module.exports = " +

--- a/webpack-test/configCases/race-conditions/load-module/loader.js
+++ b/webpack-test/configCases/race-conditions/load-module/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const callback = this.async();
 	let finished = false;

--- a/webpack-test/configCases/rebuild/finishModules/loader.js
+++ b/webpack-test/configCases/rebuild/finishModules/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{}, { shouldReplace: boolean }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{}, { shouldReplace: boolean }>} */
 module.exports = function (source) {
 	if (this.shouldReplace) {
 		this._module.buildInfo._isReplaced = true;

--- a/webpack-test/configCases/rebuild/rebuildWithNewDependencies/loader.js
+++ b/webpack-test/configCases/rebuild/rebuildWithNewDependencies/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{}, { shouldReplace: boolean }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{}, { shouldReplace: boolean }>} */
 module.exports = function (source) {
 	if (this.shouldReplace) {
 		this._module.buildInfo._isReplaced = true;

--- a/webpack-test/configCases/records/issue-295/loader.js
+++ b/webpack-test/configCases/records/issue-295/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source;
 };

--- a/webpack-test/configCases/resolve-merging/override/loader.js
+++ b/webpack-test/configCases/resolve-merging/override/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = async function () {
 	const defaultResolve = this.getResolve({});
 	const overrideResolve = this.getResolve({

--- a/webpack-test/configCases/rule-set/chaining/loader.js
+++ b/webpack-test/configCases/rule-set/chaining/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ get(): string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ get(): string }>} */
 module.exports = function (source) {
 	var query = this.query;
 	if (typeof query === "object" && typeof query.get === "function") {

--- a/webpack-test/configCases/rule-set/compiler/loader.js
+++ b/webpack-test/configCases/rule-set/compiler/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return "module.exports = " + JSON.stringify("loader matched");
 };

--- a/webpack-test/configCases/rule-set/custom/loader.js
+++ b/webpack-test/configCases/rule-set/custom/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ get(): string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ get(): string }>} */
 module.exports = function (source) {
 	var query = this.query;
 	if (typeof query === "object" && typeof query.get === "function") {

--- a/webpack-test/configCases/rule-set/query/loader.js
+++ b/webpack-test/configCases/rule-set/query/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ get(): string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ get(): string }>} */
 module.exports = function (source) {
 	var query = this.query;
 	if (typeof query === "object" && typeof query.get === "function") {

--- a/webpack-test/configCases/rule-set/simple-use-array-fn/loader.js
+++ b/webpack-test/configCases/rule-set/simple-use-array-fn/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ get(): string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ get(): string }>} */
 module.exports = function (source) {
 	var query = this.query;
 	if (typeof query === "object" && typeof query.get === "function") {

--- a/webpack-test/configCases/rule-set/simple-use-fn-array/loader.js
+++ b/webpack-test/configCases/rule-set/simple-use-fn-array/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ get(): string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ get(): string }>} */
 module.exports = function (source) {
 	var query = this.query;
 	if (typeof query === "object" && typeof query.get === "function") {

--- a/webpack-test/configCases/rule-set/simple/loader.js
+++ b/webpack-test/configCases/rule-set/simple/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition<{ get(): string }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{ get(): string }>} */
 module.exports = function (source) {
 	var query = this.query;
 	if (typeof query === "object" && typeof query.get === "function") {

--- a/webpack-test/configCases/source-map/no-source-map/loader.js
+++ b/webpack-test/configCases/source-map/no-source-map/loader.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-no-source-root.js
+++ b/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-no-source-root.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-pre-relative.js
+++ b/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-pre-relative.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root-2-slash.js
+++ b/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root-2-slash.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root-slash.js
+++ b/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root-slash.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root-source-slash.js
+++ b/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root-source-slash.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root.js
+++ b/webpack-test/configCases/source-map/relative-source-maps-by-loader/loader-source-root.js
@@ -1,5 +1,5 @@
 const path = require("path");
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.callback(null, "module.exports = 'ok';", {
 		version: 3,

--- a/webpack-test/fixtures/count-loader.js
+++ b/webpack-test/fixtures/count-loader.js
@@ -1,6 +1,6 @@
 let counter = 0;
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	return `module.exports = ${counter++};`;
 };

--- a/webpack-test/fixtures/delay-loader.js
+++ b/webpack-test/fixtures/delay-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	var cb = this.async();
 	setTimeout(function () {

--- a/webpack-test/fixtures/errors/add-comment-loader.js
+++ b/webpack-test/fixtures/errors/add-comment-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source + "// some comment";
 };

--- a/webpack-test/fixtures/errors/async-error-loader.js
+++ b/webpack-test/fixtures/errors/async-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	const callback = this.async();
 	const error = new Error("this is a callback error");

--- a/webpack-test/fixtures/errors/emit-error-loader.js
+++ b/webpack-test/fixtures/errors/emit-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	this.emitWarning(new Error("this is a warning"));
 	this.emitError(new Error("this is an error"));

--- a/webpack-test/fixtures/errors/identity-loader.js
+++ b/webpack-test/fixtures/errors/identity-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	return source;
 };

--- a/webpack-test/fixtures/errors/irregular-error-loader.js
+++ b/webpack-test/fixtures/errors/irregular-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	const empty = null;
 	const emptyError = new Error();

--- a/webpack-test/fixtures/errors/no-return-loader.js
+++ b/webpack-test/fixtures/errors/no-return-loader.js
@@ -1,2 +1,2 @@
-/** @type {import("../../../../").LoaderDefinition} */
-module.exports = function () {};
+/** @type {import("@rspack/core").LoaderDefinition} */
+module.exports = function () { };

--- a/webpack-test/fixtures/errors/throw-error-loader.js
+++ b/webpack-test/fixtures/errors/throw-error-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	throw new Error("this is a thrown error");
 };

--- a/webpack-test/hotCases/child-compiler/issue-9706/report-child-assets-loader.js
+++ b/webpack-test/hotCases/child-compiler/issue-9706/report-child-assets-loader.js
@@ -5,7 +5,7 @@ const {
 
 const compilerCache = new WeakMap();
 
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	let childCompiler = compilerCache.get(this._compiler);
 	if (childCompiler === undefined) {

--- a/webpack-test/hotCases/fake-update-loader.js
+++ b/webpack-test/hotCases/fake-update-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../").LoaderDefinition<{}, { updateIndex: number }>} */
+/** @type {import("@rspack/core").LoaderDefinition<{}, { updateIndex: number }>} */
 module.exports = function (source) {
 	var idx = this.updateIndex;
 	var items = source.split(/---+\r?\n/g);

--- a/webpack-test/hotCases/recover/recover-after-loader-error/loader.js
+++ b/webpack-test/hotCases/recover/recover-after-loader-error/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	if (source.indexOf("error") >= 0) throw new Error(source.trim());
 	return source;

--- a/webpack-test/watchCases/cache/child-compilation-cache/0/report-cache-counters-loader.js
+++ b/webpack-test/watchCases/cache/child-compilation-cache/0/report-cache-counters-loader.js
@@ -16,7 +16,7 @@ const getCache = (associate, path) => {
 	return c;
 };
 
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	if (map.has(currentWatchStepModule.step))
 		return map.get(currentWatchStepModule.step);

--- a/webpack-test/watchCases/context/loader-context-dep/0/loader.js
+++ b/webpack-test/watchCases/context/loader-context-dep/0/loader.js
@@ -1,7 +1,7 @@
 const path = require("path");
 const directory = path.resolve(__dirname, "directory");
 
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	this.addContextDependency(directory);
 	const callback = this.async();

--- a/webpack-test/watchCases/resolve/in-loader/0/loader.js
+++ b/webpack-test/watchCases/resolve/in-loader/0/loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function () {
 	const callback = this.async();
 	this.resolve(this.context, "./file", (err, file) => {

--- a/webpack-test/watchCases/warnings/warnings-contribute-to-hash/0/warning-loader.js
+++ b/webpack-test/watchCases/warnings/warnings-contribute-to-hash/0/warning-loader.js
@@ -1,4 +1,4 @@
-/** @type {import("../../../../../").LoaderDefinition} */
+/** @type {import("@rspack/core").LoaderDefinition} */
 module.exports = function (source) {
 	this.emitWarning(new Error(source.trim()));
 	return "";


### PR DESCRIPTION
## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 10df027</samp>

This pull request enhances the loader system of `@rspack/core` by adding generic types and interfaces to the `LoaderContext` and loader definitions in `packages/rspack/src/config/adapter-rule-use.ts`. It also updates various test cases in `webpack-test` to use the new types and interfaces from the `@rspack/core` package instead of relative paths, improving code consistency and readability.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 10df027</samp>

*  Make `LoaderContext` interface generic and optional ([link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L54-R54), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L61-R68), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L102-R102), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L139-R139))
* Add new interfaces for loader definition functions and pitch functions ([link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0R150), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0R164-R195))
* Export new interfaces and `LoaderContext` from `types.ts` ([link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL18-R22))
* Update test case loaders to import interfaces from `@rspack/core` package ([link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-64c8ab11cf6a63208afa30ae907aff4fe8ee53a1f5098846a36980fbb620fa6fL1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-97d8abe63c2699b14a65921cdc624b4966bd2b1d6082f55c1c7d22fbaa9d2df1L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-c757f2bef2af56be388ce24b8441fac7ea6fcc15018c84acb0d5394045a73af9L3-R3), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-38faef87126faed1a904140eaac4ec4838a4cc6f222396589d4ac07c0a791ed9L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-5fe8ba35fc2dd3036ad1e3f30328dd87d9aab601ff76a31cdb26bc925222f787L1-R2), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-555d032ae538b2f42bc69c55e733ec7fe6cd7da5e7369b6e5a78265dd2b8cf91L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-1907beb28f18e7dbafcc48b0a6891d1ffde60067c0df862755f84720e34cf62eL1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-18e7b56a41d9c60d50762a350af1d40adaf9a676b9cd592c9dce3ee395cea375L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-53c3f3ffb9215aae655b8aed70cbf37ec51f3aba3f699e66c9576def2d857b06L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-98ebcc814493f01cdb3514a853536f354887ae50d487353a72dd0aa421b645e9L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-c29646f96d4ca64ba62a69b4ce0515a33ae0c83a9915d5cdc8eda2d730cd7a56L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-1d0eb2860a9da94855f4801dc613f0b6a167f72255e30d79f64a0b4bf6e8fe93L5-R5), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-0463b59c352a0350a92235da9bfd76d67b32461609d7271ab3651bd8e1679dc9L5-R5), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-e188d540af1db970e1022c22bde1cc4a8fd098dd922c5f741b888bb8e758a6dbL1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-8af225e9cf0ce39d9270e653a371124e0da1da2e280739de5e76ff68e89c3e0cL1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-f579f60e4eed2df06db800035ab9613a8c75d83ea135705f3a4825ec5def26ddL2-R2), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-c14f9546ff0729323d7e072048b8b3b1633c219acdb88cfced52a9404b85337dL1-R1), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-417c6fbc2d2ee0af48cd3fcea240518732396d715957c465b44e37e9fee98258L1-R1))
* Format test case loaders to follow code style conventions ([link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-c757f2bef2af56be388ce24b8441fac7ea6fcc15018c84acb0d5394045a73af9L16-R20), [link](https://github.com/web-infra-dev/rspack/pull/2908/files?diff=unified&w=0#diff-1d0eb2860a9da94855f4801dc613f0b6a167f72255e30d79f64a0b4bf6e8fe93L19-R19))

</details>
