### PR TITLE
feat: support experiments.css

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -186,6 +186,7 @@ export interface RawExperiments {
   incrementalRebuild: boolean
   asyncWebAssembly: boolean
   newSplitChunks: boolean
+  css: boolean
 }
 export interface RawExternalItem {
   type: "string" | "regexp" | "object" | "function"

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -10,6 +10,7 @@ pub struct RawExperiments {
   pub incremental_rebuild: bool,
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
+  pub css: bool,
 }
 
 impl From<RawExperiments> for Experiments {
@@ -19,6 +20,7 @@ impl From<RawExperiments> for Experiments {
       incremental_rebuild: value.incremental_rebuild,
       async_web_assembly: value.async_web_assembly,
       new_split_chunks: value.new_split_chunks,
+      css: value.css,
     }
   }
 }

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -4,4 +4,5 @@ pub struct Experiments {
   pub incremental_rebuild: bool,
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
+  pub css: bool,
 }

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -522,19 +522,22 @@ function getRawExperiments(
 		lazyCompilation,
 		incrementalRebuild,
 		asyncWebAssembly,
-		newSplitChunks
+		newSplitChunks,
+		css
 	} = experiments;
 	assert(
 		!isNil(lazyCompilation) &&
 			!isNil(incrementalRebuild) &&
 			!isNil(asyncWebAssembly) &&
-			!isNil(newSplitChunks)
+			!isNil(newSplitChunks) &&
+			!isNil(css)
 	);
 	return {
 		lazyCompilation,
 		incrementalRebuild,
 		asyncWebAssembly,
-		newSplitChunks
+		newSplitChunks,
+		css
 	};
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -74,7 +74,8 @@ export const applyRspackOptionsDefaults = (
 
 	applyModuleDefaults(options.module, {
 		// syncWebAssembly: options.experiments.syncWebAssembly,
-		asyncWebAssembly: options.experiments.asyncWebAssembly!
+		asyncWebAssembly: options.experiments.asyncWebAssembly!,
+		css: options.experiments.css!
 	});
 
 	applyOutputDefaults(options.output, {
@@ -145,6 +146,7 @@ const applyExperimentsDefaults = (experiments: Experiments) => {
 	D(experiments, "lazyCompilation", false);
 	D(experiments, "asyncWebAssembly", false);
 	D(experiments, "newSplitChunks", false);
+	D(experiments, "css", true); // we not align with webpack about the default value for better DX
 };
 
 const applySnapshotDefaults = (
@@ -165,7 +167,7 @@ const applySnapshotDefaults = (
 
 const applyModuleDefaults = (
 	module: ModuleOptions,
-	{ asyncWebAssembly }: { asyncWebAssembly: boolean }
+	{ asyncWebAssembly, css }: { asyncWebAssembly: boolean; css: boolean }
 ) => {
 	F(module.parser!, "asset", () => ({}));
 	F(module.parser!.asset!, "dataUrlCondition", () => ({}));
@@ -227,31 +229,34 @@ const applyModuleDefaults = (
 				type: "tsx"
 			}
 		];
-		const cssRule = {
-			type: "css",
-			resolve: {
-				fullySpecified: true,
-				preferRelative: true
-			}
-		};
-		const cssModulesRule = {
-			type: "css/module",
-			resolve: {
-				fullySpecified: true
-			}
-		};
-		rules.push({
-			test: /\.css$/i,
-			oneOf: [
-				{
-					test: /\.module\.css$/i,
-					...cssModulesRule
-				},
-				{
-					...cssRule
+		if (css) {
+			const cssRule = {
+				type: "css",
+				resolve: {
+					fullySpecified: true,
+					preferRelative: true
 				}
-			]
-		});
+			};
+			const cssModulesRule = {
+				type: "css/module",
+				resolve: {
+					fullySpecified: true
+				}
+			};
+			rules.push({
+				test: /\.css$/i,
+				oneOf: [
+					{
+						test: /\.module\.css$/i,
+						...cssModulesRule
+					},
+					{
+						...cssRule
+					}
+				]
+			});
+		}
+
 		if (asyncWebAssembly) {
 			const wasm = {
 				type: "webassembly/async",

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -608,6 +608,7 @@ export interface Experiments {
 	asyncWebAssembly?: boolean;
 	outputModule?: boolean;
 	newSplitChunks?: boolean;
+	css?: boolean;
 }
 
 ///// Watch /////

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -119,6 +119,7 @@ describe("snapshots", () => {
 		  },
 		  "experiments": {
 		    "asyncWebAssembly": false,
+		    "css": true,
 		    "incrementalRebuild": true,
 		    "lazyCompilation": false,
 		    "newSplitChunks": false,
@@ -1364,8 +1365,29 @@ describe("snapshots", () => {
 			+ Received
 
 			@@ ... @@
+			-     "css": true,
 			+     "css": false,
 			+     "futureDefaults": true,
+			@@ ... @@
+			-       },
+			-       Object {
+			-         "oneOf": Array [
+			-           Object {
+			-             "resolve": Object {
+			-               "fullySpecified": true,
+			-             },
+			-             "test": /\\.module\\.css$/i,
+			-             "type": "css/module",
+			-           },
+			-           Object {
+			-             "resolve": Object {
+			-               "fullySpecified": true,
+			-               "preferRelative": true,
+			-             },
+			-             "type": "css",
+			-           },
+			-         ],
+			-         "test": /\\.css$/i,
 		`)
 	);
 });


### PR DESCRIPTION
## Related issue (if exists)
closes #2919
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7fa32b8</samp>

This pull request adds css support as an experimental option for the rspack bundler. It modifies the TypeScript and Rust code in `rspack`, `rspack_binding_options`, and `rspack_core` to handle the new option. It also updates the unit test file to cover the new feature.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7fa32b8</samp>

*  Add a new `css` field to the `Experiments` interface and struct in TypeScript and Rust, respectively, to indicate whether to enable the css support feature for the rspack bundler ([link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-ee356163b888e01f5855248826002b944820b3eac1c6cb3e5868d2a34c3fc11dR13), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-c88be6064f9723a97e920eb73113c11ea487b1be35aa57be4889f5caf4fd2a74R7), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR611))
*  Add a new `css` field to the `RawExperiments` struct in Rust, which mirrors the `Experiments` field and is used for the conversion between TypeScript and Rust options ([link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-ee356163b888e01f5855248826002b944820b3eac1c6cb3e5868d2a34c3fc11dR23), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L525-R526), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L537-R540))
*  Add a validation step and a default value for the `css` field in the `getRawExperiments` and `applyExperimentsDefaults` functions in TypeScript, respectively ([link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L531-R533), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccR149))
*  Add a conditional block to the `applyModuleDefaults` function in TypeScript, which adds a rule for handling css files and css modules to the module rules array if the `css` field is `true` ([link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL77-R78), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL168-R170), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL230-R259))
*  Update the unit test file `Defaults.unittest.ts` in TypeScript, to check the default and overridden values of the `css` field and the corresponding module rules ([link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R122), [link](https://github.com/web-infra-dev/rspack/pull/2930/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9L1367-R1390))

</details>
