### PR TITLE
fix: require.resolve(Weak) should eval to true in if stmt test expr

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -45,12 +45,12 @@ impl<'a> CommonJsScanner<'a> {
     ast_path.pop();
     if !node.args.is_empty() {
       if let Some(Lit::Str(str)) = node.args.get(0).and_then(|x| x.expr.as_lit()) {
-        self.add_dependency(box RequireResolveDependency::new(
+        self.add_dependency(Box::new(RequireResolveDependency::new(
           str.value.to_string(),
           weak,
           node.span.into(),
           ast_path,
-        ));
+        )));
       }
     }
   }
@@ -72,19 +72,18 @@ impl VisitAstPath for CommonJsScanner<'_> {
         RuntimeGlobals::MODULE_LOADED,
       )));
     }
-    // only evalute require.resolveWeak and require.resolve to true in IfStmt::Test
+    // only evaluate require.resolveWeak and require.resolve to true in IfStmt::Test
     if (expr_matcher::is_require_resolve_weak(expr) || expr_matcher::is_require_resolve(expr))
       && ast_path
         .iter()
         .rev()
-        .find(|i| i.kind() == AstParentKind::IfStmt(IfStmtField::Test))
-        .is_some()
+        .any(|i| i.kind() == AstParentKind::IfStmt(IfStmtField::Test))
     {
-      self.add_presentational_dependency(box ConstDependency::new(
+      self.add_presentational_dependency(Box::new(ConstDependency::new(
         quote!("true" as Expr),
         None,
         as_parent_path(ast_path),
-      ));
+      )));
     }
     expr.visit_children_with_path(self, ast_path);
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -1,29 +1,67 @@
-use rspack_core::{Dependency, RuntimeGlobals, RuntimeRequirementsDependency};
-use swc_core::ecma::ast::Expr;
-use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
+use rspack_core::{
+  ConstDependency, Dependency, ModuleDependency, RequireResolveDependency, RuntimeGlobals,
+  RuntimeRequirementsDependency,
+};
+use swc_core::common::pass::AstNodePath;
+use swc_core::ecma::ast::{CallExpr, Expr, Lit};
+use swc_core::ecma::visit::fields::IfStmtField;
+use swc_core::ecma::visit::{AstParentKind, AstParentNodeRef, VisitAstPath, VisitWithPath};
+use swc_core::quote;
 
-use super::expr_matcher;
+use super::{as_parent_path, expr_matcher, is_require_resolve_call, is_require_resolve_weak_call};
 
 pub struct CommonJsScanner<'a> {
+  pub dependencies: &'a mut Vec<Box<dyn ModuleDependency>>,
   pub presentational_dependencies: &'a mut Vec<Box<dyn Dependency>>,
 }
 
 impl<'a> CommonJsScanner<'a> {
-  pub fn new(presentational_dependencies: &'a mut Vec<Box<dyn Dependency>>) -> Self {
+  pub fn new(
+    dependencies: &'a mut Vec<Box<dyn ModuleDependency>>,
+    presentational_dependencies: &'a mut Vec<Box<dyn Dependency>>,
+  ) -> Self {
     Self {
+      dependencies,
       presentational_dependencies,
     }
+  }
+
+  fn add_dependency(&mut self, dependency: Box<dyn ModuleDependency>) {
+    self.dependencies.push(dependency);
   }
 
   fn add_presentational_dependency(&mut self, dependency: Box<dyn Dependency>) {
     self.presentational_dependencies.push(dependency);
   }
+
+  fn add_require_resolve(
+    &mut self,
+    node: &CallExpr,
+    ast_path: &AstNodePath<AstParentNodeRef<'_>>,
+    weak: bool,
+  ) {
+    let mut ast_path = as_parent_path(ast_path);
+    // add_require_resolve at visit_call_expr, but we want use visit_expr at generate
+    ast_path.pop();
+    if !node.args.is_empty() {
+      if let Some(Lit::Str(str)) = node.args.get(0).and_then(|x| x.expr.as_lit()) {
+        self.add_dependency(box RequireResolveDependency::new(
+          str.value.to_string(),
+          weak,
+          node.span.into(),
+          ast_path,
+        ));
+      }
+    }
+  }
 }
 
-impl Visit for CommonJsScanner<'_> {
-  noop_visit_type!();
-
-  fn visit_expr(&mut self, expr: &Expr) {
+impl VisitAstPath for CommonJsScanner<'_> {
+  fn visit_expr<'ast: 'r, 'r>(
+    &mut self,
+    expr: &'ast Expr,
+    ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+  ) {
     if expr_matcher::is_module_id(expr) {
       self.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::new(
         RuntimeGlobals::MODULE_ID,
@@ -34,6 +72,34 @@ impl Visit for CommonJsScanner<'_> {
         RuntimeGlobals::MODULE_LOADED,
       )));
     }
-    expr.visit_children_with(self);
+    // only evalute require.resolveWeak and require.resolve to true in IfStmt::Test
+    if (expr_matcher::is_require_resolve_weak(expr) || expr_matcher::is_require_resolve(expr))
+      && ast_path
+        .iter()
+        .rev()
+        .find(|i| i.kind() == AstParentKind::IfStmt(IfStmtField::Test))
+        .is_some()
+    {
+      self.add_presentational_dependency(box ConstDependency::new(
+        quote!("true" as Expr),
+        None,
+        as_parent_path(ast_path),
+      ));
+    }
+    expr.visit_children_with_path(self, ast_path);
+  }
+
+  fn visit_call_expr<'ast: 'r, 'r>(
+    &mut self,
+    node: &'ast CallExpr,
+    ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
+  ) {
+    if is_require_resolve_call(node) {
+      return self.add_require_resolve(node, ast_path, false);
+    }
+    if is_require_resolve_weak_call(node) {
+      return self.add_require_resolve(node, ast_path, true);
+    }
+    node.visit_children_with_path(self, ast_path);
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -49,7 +49,10 @@ pub fn scan_dependencies(
   );
 
   if module_type.is_js_auto() || module_type.is_js_dynamic() {
-    program.visit_with(&mut CommonJsScanner::new(&mut presentational_dependencies));
+    program.visit_with_path(
+      &mut CommonJsScanner::new(&mut dependencies, &mut presentational_dependencies),
+      &mut Default::default(),
+    );
 
     if let Some(node_option) = &compiler_options.node {
       program.visit_with_path(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -1,8 +1,7 @@
 use rspack_core::{
   CommonJsRequireContextDependency, CompilerOptions, ConstDependency, ContextMode, ContextOptions,
   Dependency, DependencyCategory, EsmDynamicImportDependency, ImportContextDependency,
-  ModuleDependency, RequireContextDependency, RequireResolveDependency, ResourceData,
-  RuntimeGlobals,
+  ModuleDependency, RequireContextDependency, ResourceData, RuntimeGlobals,
 };
 use rspack_regex::RspackRegex;
 use swc_core::common::comments::Comments;
@@ -17,10 +16,7 @@ use swc_core::ecma::utils::{member_expr, quote_ident, quote_str};
 use swc_core::ecma::visit::{AstParentNodeRef, VisitAstPath, VisitWithPath};
 use swc_core::quote;
 
-use super::{
-  as_parent_path, expr_matcher, is_require_context_call, is_require_resolve_call,
-  is_require_resolve_weak_call,
-};
+use super::{as_parent_path, expr_matcher, is_require_context_call};
 use crate::dependency::{
   CommonJSRequireDependency, EsmExportDependency, EsmImportDependency, URLDependency,
 };
@@ -318,34 +314,6 @@ impl DependencyScanner<'_> {
       }
     }
   }
-
-  fn scan_require_resolve(
-    &mut self,
-    node: &CallExpr,
-    ast_path: &AstNodePath<AstParentNodeRef<'_>>,
-  ) {
-    if !node.args.is_empty() {
-      if is_require_resolve_call(node) {
-        if let Some(Lit::Str(str)) = node.args.get(0).and_then(|x| x.expr.as_lit()) {
-          self.add_dependency(Box::new(RequireResolveDependency::new(
-            str.value.to_string(),
-            false,
-            node.span.into(),
-            as_parent_path(ast_path),
-          )));
-        }
-      } else if is_require_resolve_weak_call(node) {
-        if let Some(Lit::Str(str)) = node.args.get(0).and_then(|x| x.expr.as_lit()) {
-          self.add_dependency(Box::new(RequireResolveDependency::new(
-            str.value.to_string(),
-            true,
-            node.span.into(),
-            as_parent_path(ast_path),
-          )));
-        }
-      }
-    }
-  }
 }
 
 impl VisitAstPath for DependencyScanner<'_> {
@@ -387,10 +355,6 @@ impl VisitAstPath for DependencyScanner<'_> {
     expr: &'ast Expr,
     ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
   ) {
-    if let Expr::Call(call) = expr {
-      self.scan_require_resolve(call, ast_path);
-    }
-
     if let Expr::Assign(AssignExpr {
       op: AssignOp::Assign,
       left: PatOrExpr::Pat(box Pat::Ident(ident)),

--- a/packages/rspack/tests/cases/chunks/weak-dependencies/index.js
+++ b/packages/rspack/tests/cases/chunks/weak-dependencies/index.js
@@ -6,8 +6,14 @@ it("should not include a module with a weak dependency", function () {
 	import("./c");
 	require("./d");
 
-	expect(a).toBe(false);
-	expect(b).toBe(true);
-	expect(c).toBe(false);
-	expect(d).toBe(true);
+	if (require.resolveWeak && require.resolve) {
+		expect(a).toBe(false);
+		expect(b).toBe(true);
+		expect(c).toBe(false);
+		expect(d).toBe(true);
+	} else {
+		throw new Error(
+			`'require.resolveWeak && require.resolve' should evalute to truthy in IfStmt::Test`
+		);
+	}
 });

--- a/packages/rspack/tests/cases/chunks/weak-dependencies/index.js
+++ b/packages/rspack/tests/cases/chunks/weak-dependencies/index.js
@@ -13,7 +13,7 @@ it("should not include a module with a weak dependency", function () {
 		expect(d).toBe(true);
 	} else {
 		throw new Error(
-			`'require.resolveWeak && require.resolve' should evalute to truthy in IfStmt::Test`
+			`'require.resolveWeak && require.resolve' should evaluate to truthy in IfStmt::Test`
 		);
 	}
 });


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 772d237</samp>

Refactored the dependency scanning logic for CommonJS modules in `rspack_plugin_javascript` crate. Added support for `require.resolveWeak` and `require.resolve` calls in different contexts and improved code generation and chunking. Fixed a syntax error in `schema.js`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 772d237</samp>

*  Refactor `CommonJsScanner` to store `RequireResolveDependency` instances and handle `require.resolveWeak` and `require.resolve` calls in different contexts ([link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-10b6a135ab190733f6911a73a0c2b4375bc380b657f03cfa3a235c37e5f0a788L1-R64), [link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-10b6a135ab190733f6911a73a0c2b4375bc380b657f03cfa3a235c37e5f0a788L37-R104), [link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L52-R55), [link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL4-R4), [link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL20-R19), [link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL321-L348), [link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL390-L393))
* Fix syntax error in `schema.js` by removing trailing comma from `instanceof` property in `external` schema definition ([link](https://github.com/web-infra-dev/rspack/pull/2935/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88L365-R365))

</details>
