### PR TITLE
fix: should not reset `is_founded` in `ReactRefreshUsage`

### DIFF
--- a/.changeset/six-clocks-float.md
+++ b/.changeset/six-clocks-float.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: react refresh usage finder

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -63,6 +63,10 @@ impl Visit for ReactRefreshUsageFinder {
   }
 
   fn visit_call_expr(&mut self, call_expr: &CallExpr) {
+    if self.is_founded {
+      return;
+    }
+
     self.is_founded = matches!(call_expr, CallExpr {
       callee: Callee::Expr(box Expr::Ident(Ident { sym, .. })),
       ..

--- a/examples/react-refresh/rspack.config.js
+++ b/examples/react-refresh/rspack.config.js
@@ -8,16 +8,6 @@ module.exports = {
 		html: [{ template: "./index.html" }],
 		define: {
 			"process.env.NODE_ENV": "'development'"
-		},react: {
-			refresh: true
 		}
-	},
-	// target: ['es5', 'web'],
-
-	devServer: {
-		port: 8082,
-		devMiddleware: {
-			outputFileSystem: require('fs')
-		  }
 	}
 };

--- a/examples/react-refresh/rspack.config.js
+++ b/examples/react-refresh/rspack.config.js
@@ -8,6 +8,16 @@ module.exports = {
 		html: [{ template: "./index.html" }],
 		define: {
 			"process.env.NODE_ENV": "'development'"
+		},react: {
+			refresh: true
 		}
+	},
+	// target: ['es5', 'web'],
+
+	devServer: {
+		port: 8082,
+		devMiddleware: {
+			outputFileSystem: require('fs')
+		  }
 	}
 };

--- a/examples/react-refresh/src/index.tsx
+++ b/examples/react-refresh/src/index.tsx
@@ -1,6 +1,12 @@
-import { createRoot } from 'react-dom/client'
-import App from './App'
+import React from 'react';
 
-const container = document.getElementById('root')
-const root = createRoot(container!)
-root.render(<App />)
+export function ReactRefreshFinder() {
+    return function Component() {
+        inner();
+        return <div id="nest-function">nest-function</div>;
+    };
+}
+
+function inner() { }
+
+ReactRefreshFinder()

--- a/examples/react-refresh/src/index.tsx
+++ b/examples/react-refresh/src/index.tsx
@@ -3,3 +3,4 @@ import App from './App'
 
 const container = document.getElementById('root')
 const root = createRoot(container!)
+root.render(<App />)

--- a/examples/react-refresh/src/index.tsx
+++ b/examples/react-refresh/src/index.tsx
@@ -1,7 +1,5 @@
 import { createRoot } from 'react-dom/client'
 import App from './App'
-import React from 'react';
 
 const container = document.getElementById('root')
 const root = createRoot(container!)
-root.render(<App />)

--- a/examples/react-refresh/src/index.tsx
+++ b/examples/react-refresh/src/index.tsx
@@ -1,12 +1,7 @@
+import { createRoot } from 'react-dom/client'
+import App from './App'
 import React from 'react';
 
-export function ReactRefreshFinder() {
-    return function Component() {
-        inner();
-        return <div id="nest-function">nest-function</div>;
-    };
-}
-
-function inner() { }
-
-ReactRefreshFinder()
+const container = document.getElementById('root')
+const root = createRoot(container!)
+root.render(<App />)

--- a/packages/playground/fixtures/react/src/App.jsx
+++ b/packages/playground/fixtures/react/src/App.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import "./index.css";
 import { ContextComponent  } from "./CountProvider";
+import './ReactRefreshFinder';
 
 const Button = () => {
 	const [count, setCount] = React.useState(10);

--- a/packages/playground/fixtures/react/src/App.jsx
+++ b/packages/playground/fixtures/react/src/App.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./index.css";
 import { ContextComponent  } from "./CountProvider";
-import './ReactRefreshFinder';
+import { ReactRefreshFinder } from './ReactRefreshFinder';
 
 const Button = () => {
 	const [count, setCount] = React.useState(10);
@@ -15,6 +15,7 @@ export const App = () => {
 			<Button />
 			<div className="placeholder">__PLACE_HOLDER__</div>
 			<ContextComponent/>
+			<ReactRefreshFinder/>
 		</div>
 	);
 };

--- a/packages/playground/fixtures/react/src/ReactRefreshFinder.jsx
+++ b/packages/playground/fixtures/react/src/ReactRefreshFinder.jsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-export function ReactRefreshFinder() {
+function CreateReactRefreshFinder() {
     return function Component() {
-        inner();
+        useState(1);
         return <div id="nest-function">nest-function</div>;
     };
 }
 
-function inner() {}
+export const ReactRefreshFinder = CreateReactRefreshFinder()

--- a/packages/playground/fixtures/react/src/ReactRefreshFinder.jsx
+++ b/packages/playground/fixtures/react/src/ReactRefreshFinder.jsx
@@ -1,14 +1,10 @@
 import React from 'react';
 
-export async function ReactRefreshFinder() {
-    async function b() {
-        const a = await 1;
-        return function RootApp() {
-            const [data, setData] = useState(a);
-            return <div />
-        };
+export function ReactRefreshFinder() {
+    return function Component() {
+        inner();
+        return <div id="nest-function">nest-function</div>;
     };
-    await b();
 }
 
-ReactRefreshFinder()
+function inner() {}

--- a/packages/playground/fixtures/react/src/ReactRefreshFinder.jsx
+++ b/packages/playground/fixtures/react/src/ReactRefreshFinder.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export async function ReactRefreshFinder() {
+    async function b() {
+        const a = await 1;
+        return function RootApp() {
+            const [data, setData] = useState(a);
+            return <div />
+        };
+    };
+    await b();
+}
+
+ReactRefreshFinder()

--- a/packages/playground/fixtures/react/test/index.test.ts
+++ b/packages/playground/fixtures/react/test/index.test.ts
@@ -27,3 +27,7 @@ test("context+component should work", async () => {
 		"context-value-update"
 	);
 });
+
+test("ReactRefreshFinder should work", async () => {
+	expect(await page.textContent("#nest-function")).toBe("nest-function");
+});


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- avoid ReactRefreshUsageFinder overwrite scan result, it will cause error match result.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ecd6d0</samp>

This pull request fixes a bug and improves the performance of the `ReactRefreshUsageFinder` feature in the `@rspack/core` package. It adds a changeset file and a short-circuit condition in the `react.rs` file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ecd6d0</samp>

* Add a changeset file to document the patch update for `@rspack/core` ([link](https://github.com/web-infra-dev/rspack/pull/2939/files?diff=unified&w=0#diff-592c247d72f75d724d192ede844e58d0345dd8822d736a786cc070633b85f1f3R1-R5))
* Improve the performance and correctness of the react refresh usage finder by adding a short-circuit condition to the `visit_module_items` method of the `ReactRefreshUsageFinder` struct in `crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2939/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cR66-R69))

</details>
