### PR TITLE
fix: cannot reading `noEmitAssets`

### DIFF
--- a/.changeset/tiny-badgers-serve.md
+++ b/.changeset/tiny-badgers-serve.md
@@ -1,0 +1,5 @@
+---
+"@rspack/dev-server": patch
+---
+
+fix cannot reading noEmitAssets by always getting the first compiler's noEmitAssets

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -36,13 +36,10 @@ export class RspackDevServer extends WebpackDevServer {
 					const webpackDevMiddlewareIndex = middlewares.findIndex(
 						mid => mid.name === "webpack-dev-middleware"
 					);
-					// @ts-expect-error
-					if (compiler.options.builtins.noEmitAssets) {
+					const compilers =
+						compiler instanceof MultiCompiler ? compiler.compilers : [compiler];
+					if (compilers[0].options.builtins.noEmitAssets) {
 						if (Array.isArray(this.options.static)) {
-							const compilers =
-								compiler instanceof MultiCompiler
-									? compiler.compilers
-									: [compiler];
 							const memoryAssetsMiddlewares = this.options.static.flatMap(
 								staticOptions => {
 									return staticOptions.publicPath.flatMap(publicPath => {

--- a/packages/rspack-dev-server/tests/normalizeOptions.test.ts
+++ b/packages/rspack-dev-server/tests/normalizeOptions.test.ts
@@ -1,4 +1,4 @@
-import type { RspackOptions } from "@rspack/core";
+import { RspackOptions, rspack } from "@rspack/core";
 import { RspackDevServer, Configuration } from "@rspack/dev-server";
 import { createCompiler } from "@rspack/core";
 import serializer from "jest-serializer-path";
@@ -9,6 +9,7 @@ expect.addSnapshotSerializer(serializer);
 // default is to avoid stack overflow trigged
 // by `webpack/schemas/WebpackOption.check.js` in debug mode
 const ENTRY = "./placeholder.js";
+const ENTRY1 = "./placeholder1.js";
 
 describe("normalize options snapshot", () => {
 	it("no options", async () => {
@@ -72,6 +73,22 @@ describe("normalize options snapshot", () => {
 		await server.start();
 		expect(compiler.options.devServer?.hot).toBe(true);
 		expect(server.options.hot).toBe(true);
+		await server.stop();
+	});
+
+	it("should support multi-compiler", async () => {
+		const compiler = rspack([
+			{
+				entry: ENTRY,
+				stats: "none"
+			},
+			{
+				entry: ENTRY1,
+				stats: "none"
+			}
+		]);
+		const server = new RspackDevServer({}, compiler);
+		await server.start();
 		await server.stop();
 	});
 });


### PR DESCRIPTION
## Related issue (if exists)
I fix it by always getting the first compiler's `noEmitAssets` 
<!--- Provide link of related issues -->

## Summary
#2929 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5897bda</samp>

Refactor `server.ts` to access `noEmitAssets` option from the first compiler and remove `@ts-expect-error`. This improves type safety and supports the new webpack feature.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5897bda</samp>

* Refactor code to access `noEmitAssets` option from first compiler and avoid `@ts-expect-error` ([link](https://github.com/web-infra-dev/rspack/pull/2942/files?diff=unified&w=0#diff-6195dbe0219b3b7ba39567cf6de6d629fb3a7b78c582c6b0b2957d1425105922L39-R42))

</details>
