### PR TITLE
chore: add compile and beforeCompile hook

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -444,14 +444,20 @@ export class RspackDevServer extends WebpackDevServer {
 						if (req.url.indexOf("/lazy-compilation-web/") > -1) {
 							const path = req.url.replace("/lazy-compilation-web/", "");
 							if (fs.existsSync(path)) {
-								compiler.rebuild(new Set([path]), new Set(), error => {
-									if (error) {
-										throw error;
+								compiler.compile(
+									error => {
+										if (error) {
+											throw error;
+										}
+										res.write("");
+										res.end();
+										console.log("lazy compiler success");
+									},
+									{
+										modifiedFiles: new Set[path](),
+										removedFiles: new Set()
 									}
-									res.write("");
-									res.end();
-									console.log("lazy compiler success");
-								});
+								);
 							}
 						}
 					}

--- a/packages/rspack/src/watching.ts
+++ b/packages/rspack/src/watching.ts
@@ -247,9 +247,12 @@ class Watching {
 			};
 
 			if (isRebuild) {
-				this.compiler.rebuild(modifiedFiles, deleteFiles, onBuild as any);
+				this.compiler.compile(onBuild as any, {
+					modifiedFiles,
+					removedFiles: deleteFiles
+				});
 			} else {
-				this.compiler.build(onBuild);
+				this.compiler.compile(onBuild);
 				this.#initial = false;
 			}
 		});


### PR DESCRIPTION
## Related issue (if exists)
this is the block of #2669, we need statsFactory hook to make it work
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd20c70</samp>

This pull request updates the `rspack` package to use the webpack 5 API and enable CSP and SRI features for the `example` project. It modifies the `Compiler` and `Watching` classes in the `src` folder and adds two webpack plugins to the `pnpm-lock.yaml` file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cd20c70</samp>

*  Add a new hook `beforeCompile` to the `Compiler` class and rename the `build` method to `compile` to align with the webpack 5 API ([link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR72), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR153), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL476-R478), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL496-R527), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL509-R546), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL520-R555))
*  Update the `Watching` class to use the `compile` method of the `Compiler` class for incremental compilation and hook invocation ([link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-4d50b60f1736e09ee8e9cd235bba1d9bab8e99412926b998e107443fbc7bc8f4L250-R255))
*  Add the `@melloware/csp-webpack-plugin` and the `webpack-subresource-integrity` packages as dependencies and install their transitive dependencies in the `pnpm-lock.yaml` file ([link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR340), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL346-R349), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR356), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4516-R4527), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8202-R8225), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8859-R8868), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9598-R9602), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR13183-R13191), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14667-R14673), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR18218-R18221), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR18978-R18985), [link](https://github.com/web-infra-dev/rspack/pull/2943/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR19010-R19033))

</details>
