### PR TITLE
fix: support webpack-manifest-plugin

### DIFF
--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -709,6 +709,12 @@ export class Compilation {
 			case Compilation.PROCESS_ASSETS_STAGE_REPORT:
 				return this.hooks.processAssets.stageReport;
 			default:
+				if (stage < Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL) {
+					return this.hooks.processAssets.stageAdditional;
+				}
+				if (stage > Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL) {
+					return this.hooks.processAssets.stageReport;
+				}
 				throw new Error(
 					"processAssets hook uses custom stage number is not supported."
 				);


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->
https://github.com/web-infra-dev/rspack/issues/2196
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7af1c1f</samp>

Add support for new asset processing stages in `compilation.ts`. This enables plugins to hook into different phases of the webpack compilation and process assets more flexibly.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7af1c1f</samp>

* Add logic to handle new asset processing stages ([link](https://github.com/web-infra-dev/rspack/pull/2945/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R712-R717))

</details>
