### PR TITLE
fix: hash chunkLoadingGlobal

### DIFF
--- a/.changeset/pretty-apes-pretend.md
+++ b/.changeset/pretty-apes-pretend.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: hash chunk_loading_global

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -74,13 +74,9 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
     }
 
     self.name().hash(&mut args.hasher);
-
-    args
-      .compilation
-      .options
-      .output
-      .global_object
-      .hash(&mut args.hasher);
+    let output = &args.compilation.options.output;
+    output.global_object.hash(&mut args.hasher);
+    output.chunk_loading_global.hash(&mut args.hasher);
 
     update_hash_for_entry_startup(
       args.hasher,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- hash chunkLoadingGlobal 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2ab3d5</samp>

Refactor chunk format hashing to support different chunk loading strategies. Include `chunk_loading_global` option in `ArrayPushCallbackChunkFormat::hash`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2ab3d5</samp>

*  Include `chunk_loading_global` option in hash calculation of `ArrayPushCallbackChunkFormat` to ensure consistency with chunk loading strategy ([link](https://github.com/web-infra-dev/rspack/pull/2946/files?diff=unified&w=0#diff-642bde562c4bac7d3a7e5f2a4036a9e7deac1c97428d86cdf4be20a2edad82adL77-R80))

</details>
