### PR TITLE
refactor(new_split_chunks): remove unused code and add more comments

### DIFF
--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -57,5 +57,3 @@ pub fn create_module_filter(re: Option<String>) -> ModuleFilter {
 }
 
 pub(crate) type SplitChunkSizes = FxHashMap<SourceType, f64>;
-
-// pub type CacheGroupNameGetter = Arc<dyn Fn(&dyn Module) -> String + Send + Sync>;

--- a/crates/rspack_plugin_split_chunks_new/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/module_group.rs
@@ -9,7 +9,9 @@ use crate::common::SplitChunkSizes;
 ///
 /// `ModuleGroup` captures/contains a bunch of modules due to the `optimization.splitChunks` configuration.
 ///
-/// `ModuleGroup` would be transform into `Chunk` in the end.
+/// `ModuleGroup` would be transform into `Chunk`s in the end.
+///
+///  A `ModuleGroup` would be transform into multiple `Chunk`s if the `name` dynamic computed
 ///
 /// The original name of `ModuleGroup` is `ChunkInfoItem` borrowed from Webpack
 #[derive(Derivative)]
@@ -19,8 +21,11 @@ pub(crate) struct ModuleGroup {
   pub modules: IdentifierSet,
   pub cache_group_index: usize,
   pub cache_group_priority: f64,
-  pub name: String,
+  /// If the `ModuleGroup` is going to create a chunk, which will be named using `chunk_name`
+  /// A module
+  pub chunk_name: String,
   pub sizes: SplitChunkSizes,
+  /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[derivative(Debug = "ignore")]
   pub chunks: FxHashSet<ChunkUkey>,
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- No behaviors change
- Add more comments
- Remove unused code
- Extract some code into separate functions.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4f70db</samp>

This pull request refactors the `rspack_plugin_split_chunks_new` crate, which implements a plugin for the `rspack` web bundler that splits modules into chunks based on cache groups. It introduces new structs `Chunk` and `MatchedItem` to simplify the logic and data structures of the plugin, and it improves the readability, error handling, and debugging of the code. It also removes some unused and redundant types and fields.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b4f70db</samp>

*  Refactor the logic of the split chunks plugin to use chunks and module groups instead of modules and cache groups ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L5-R5), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L39-R52), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L78-R79), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L170-R171), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L187-R201), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L204-R215), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L213-R271))
  * Extract a new method `get_corresponding_chunk` to create or find a chunk for a module group ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L78-R79))
  * Rename the `name` field of `ModuleGroup` to `chunk_name` and move the struct definition to `common.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-9fe0bd2bb40e0e56daf84e7c76107d80d06b5b306b639db5194b24e5daaca8c7L12-R15), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-9fe0bd2bb40e0e56daf84e7c76107d80d06b5b306b639db5194b24e5daaca8c7L22-R28))
  * Rename the `prepare_module_and_chunks_info_map` method to `prepare_module_group_map` and change the return type to `DashMap<String, ModuleGroup>` ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L39-R52), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L187-R201))
  * Introduce a new struct `MatchedItem` to represent a module that meets the requirements of a cache group ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L204-R215), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L213-R271))
  * Rename the `used_chunks` parameter and variable to `original_chunks` in the `move_modules_to_new_chunk_and_remove_from_old_chunks` method ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L125-R125), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L132-R132))
* Improve the error handling and debugging of the plugin code ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L158-R163))
  * Add a debug assertion that the `new_chunk_ukey` is not equal to the `original_chunk` in the `split_from_original_chunks` method ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L158-R163))
* Remove unused and unnecessary code from the plugin code ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L60-L61), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L13-L19), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L27))
  * Remove an unused type alias for `CacheGroupNameGetter` from `common.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L60-L61))
  * Remove an unused struct definition for `_OverallOptions` and an unused field for `overall` from the `SplitChunksPlugin` struct ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L13-L19), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L27))
* Add type annotations and comments to improve the readability and type safety of the code ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L170-R171), [link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L204-R215))
  * Add a type annotation for the `iter` variable in the `find_best_module_group` method ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L170-R171))
  * Add comments to explain the filtering logic and the fields of the `MatchedItem` struct ([link](https://github.com/web-infra-dev/rspack/pull/2947/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L204-R215))

</details>
