### PR TITLE
fix(resolve): relative path resolve bug

### DIFF
--- a/.changeset/chilled-zoos-behave.md
+++ b/.changeset/chilled-zoos-behave.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix(resolve): relative path resolve bug

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,9 +1569,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.81"
+version = "0.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6123a34b53527098bf3c30efd6762285d6648eb98dfb8fdcff30f86e9cf256e3"
+checksum = "15d0e63899ed02000a03e091468e2ea14dbd0144c146722ca4bb1c82fd65eef0"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ napi              = { version = "=2.12.5" }
 napi-build         = { version = "=2.0.1" }
 napi-derive        = { version = "=2.12.3" }
 napi-sys           = { version = "=2.2.3" }
-nodejs-resolver    = { version = "0.0.81" }
+nodejs-resolver    = { version = "0.0.82" }
 once_cell          = { version = "1.17.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -1246,9 +1246,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.81"
+version = "0.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6123a34b53527098bf3c30efd6762285d6648eb98dfb8fdcff30f86e9cf256e3"
+checksum = "15d0e63899ed02000a03e091468e2ea14dbd0144c146722ca4bb1c82fd65eef0"
 dependencies = [
  "daachorse",
  "dashmap",


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9e806a</samp>

Updated `nodejs-resolver` to fix node module resolution bug. This affects the `Cargo.toml` file of the rspack crate.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a9e806a</samp>

* Updated the `nodejs-resolver` dependency to fix a bug in resolving node modules with symlinks ([link](https://github.com/web-infra-dev/rspack/pull/2952/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L45-R45))

</details>
