### PR TITLE
feat(new_split_chunks): support `splitChunks.minSize`

### DIFF
--- a/.changeset/gold-bags-hide.md
+++ b/.changeset/gold-bags-hide.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat(new_split_chunks): support splitChunks.minSize

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use napi_derive::napi;
+use rspack_core::SourceType;
 use rspack_plugin_split_chunks::{CacheGroupOptions, ChunkType, SplitChunksOptions, TestFn};
 use serde::Deserialize;
 
@@ -131,6 +132,10 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
       })
       .unwrap_or_else(new_split_chunks_plugin::create_async_chunk_filter);
 
+    let overall_min_size = raw_opts.min_size.unwrap_or(20000.0);
+
+    let default_size_types = [SourceType::JavaScript, SourceType::Unknown];
+
     cache_groups.extend(
       raw_opts
         .cache_groups
@@ -150,6 +155,10 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
             })
             .unwrap_or_else(|| overall_chunk_filter.clone()),
           min_chunks: v.min_chunks.unwrap_or(1),
+          min_size: new_split_chunks_plugin::SplitChunkSizes::with_initial_value(
+            &default_size_types,
+            overall_min_size,
+          ),
         }),
     );
 

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -1,6 +1,6 @@
 use derivative::Derivative;
 
-use crate::common::{ChunkFilter, ModuleFilter};
+use crate::common::{ChunkFilter, ModuleFilter, SplitChunkSizes};
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -12,6 +12,7 @@ pub struct CacheGroup {
   /// `name` is used to create chunk
   pub name: String,
   pub priority: f64,
+  pub min_size: SplitChunkSizes,
   /// number of referenced chunks
   pub min_chunks: u32,
 }

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -66,7 +66,7 @@ impl SplitChunkSizes {
   pub fn with_initial_value(default_size_types: &[SourceType], initial_bytes: f64) -> Self {
     Self(
       default_size_types
-        .into_iter()
+        .iter()
         .map(|ty| (*ty, initial_bytes))
         .collect(),
     )

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+  ops::{Deref, DerefMut},
+  sync::Arc,
+};
 
 use rspack_core::{Chunk, ChunkGroupByUkey, Module, SourceType};
 use rustc_hash::FxHashMap;
@@ -56,4 +59,30 @@ pub fn create_module_filter(re: Option<String>) -> ModuleFilter {
   .unwrap_or_else(create_default_module_filter)
 }
 
-pub(crate) type SplitChunkSizes = FxHashMap<SourceType, f64>;
+#[derive(Debug, Default)]
+pub struct SplitChunkSizes(FxHashMap<SourceType, f64>);
+
+impl SplitChunkSizes {
+  pub fn with_initial_value(default_size_types: &[SourceType], initial_bytes: f64) -> Self {
+    Self(
+      default_size_types
+        .into_iter()
+        .map(|ty| (*ty, initial_bytes))
+        .collect(),
+    )
+  }
+}
+
+impl Deref for SplitChunkSizes {
+  type Target = FxHashMap<SourceType, f64>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl DerefMut for SplitChunkSizes {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.0
+  }
+}

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -10,7 +10,7 @@ pub use crate::{
   common::{
     create_all_chunk_filter, create_async_chunk_filter, create_chunk_filter_from_str,
     create_default_module_filter, create_initial_chunk_filter, create_module_filter,
-    create_module_filter_from_regex, create_module_filter_from_rspack_regex,
+    create_module_filter_from_regex, create_module_filter_from_rspack_regex, SplitChunkSizes,
   },
   plugin::{PluginOptions, SplitChunksPlugin},
 };

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use dashmap::DashMap;
 use rayon::prelude::*;
-use rspack_core::{Chunk, ChunkUkey, Compilation, Module, Plugin};
+use rspack_core::{Chunk, ChunkUkey, Compilation, Module, Plugin, SourceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
@@ -17,18 +17,20 @@ pub struct PluginOptions {
 }
 
 pub struct SplitChunksPlugin {
-  cache_groups: Vec<CacheGroup>,
+  cache_groups: Box<[CacheGroup]>,
 }
 
 impl SplitChunksPlugin {
   pub fn new(options: PluginOptions) -> Self {
     Self {
-      cache_groups: options.cache_groups,
+      cache_groups: options.cache_groups.into(),
     }
   }
 
   fn inner_impl(&self, compilation: &mut Compilation) {
     let mut module_group_map = self.prepare_module_group_map(compilation);
+
+    self.ensure_min_size_fit(compilation, &mut module_group_map);
 
     while !module_group_map.is_empty() {
       let (_module_group_key, module_group) = self.find_best_module_group(&mut module_group_map);
@@ -53,6 +55,71 @@ impl SplitChunksPlugin {
         compilation,
       )
     }
+  }
+
+  /// Affected by `splitChunks.minSize`/`splitChunks.cacheGroups.{cacheGroup}.minSize`
+  fn ensure_min_size_fit(&self, compilation: &Compilation, module_group_map: &mut ModuleGroupMap) {
+    let invalidated_module_groups = module_group_map
+      .par_iter_mut()
+      .filter_map(|(module_group_key, module_group)| {
+        let cache_group = &self.cache_groups[module_group.cache_group_index];
+
+        // Find out what `SourceType`'s size is not fit the min_size
+        let violating_source_types: Box<[SourceType]> = module_group
+          .sizes
+          .iter()
+          .filter_map(|(module_group_ty, module_group_ty_size)| {
+            let cache_group_ty_min_size = cache_group
+              .min_size
+              .get(module_group_ty)
+              .copied()
+              .unwrap_or_default();
+
+            if *module_group_ty_size < cache_group_ty_min_size {
+              Some(*module_group_ty)
+            } else {
+              None
+            }
+          })
+          .collect::<Box<[_]>>();
+
+        // Remove modules having violating SourceType
+        let violating_modules = module_group
+          .modules
+          .par_iter()
+          .filter_map(|module_id| {
+            let module = &**compilation
+              .module_graph
+              .module_by_identifier(module_id)
+              .expect("Should have a module");
+            let having_violating_source_type = violating_source_types
+              .iter()
+              .any(|ty: &SourceType| module.source_types().contains(ty));
+            if having_violating_source_type {
+              Some(module)
+            } else {
+              None
+            }
+          })
+          .collect::<Vec<_>>();
+
+        // question: After removing violating modules, the size of other `SourceType`s of this `ModuleGroup`
+        // may not fit again. But Webpack seems ignore this case. Not sure if it is on purpose.
+        violating_modules
+          .into_iter()
+          .for_each(|violating_module| module_group.remove_module(violating_module));
+
+        if module_group.modules.is_empty() {
+          Some(module_group_key.clone())
+        } else {
+          None
+        }
+      })
+      .collect::<Vec<_>>();
+
+    invalidated_module_groups.into_iter().for_each(|key| {
+      module_group_map.remove(&key);
+    });
   }
 
   fn get_corresponding_chunk(


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d8fdf99</samp>

This pull request adds a new feature and a new plugin to rspack, a web infrastructure development tool. The feature allows setting minimum size limits for different types of code in split chunks, and the plugin implements a new algorithm for splitting modules into cache groups based on size and type. The pull request also includes some code refactoring and bug fixes in the `rspack_binding_options` and `rspack_plugin_split_chunks_new` crates.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d8fdf99</samp>

*  Add a new field `min_size` to the `CacheGroup` struct that holds a `SplitChunkSizes` instance for each `SourceType` ([link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR15), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L1-R4), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812L13-R13))
*  Implement the `SplitChunkSizes` struct as a wrapper around a `FxHashMap` with convenience methods and `Deref` and `DerefMut` traits ([link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L59-R88))
*  Use the `SplitChunkSizes` struct to create a map of minimum sizes for each `SourceType` in the `raw_opts` struct ([link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R4), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R135-R138), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R158-R161))
*  Change the type of the `cache_groups` field in the `SplitChunksPlugin` struct from a `Vec` to a `Box<[CacheGroup]>` for efficiency ([link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L20-R20), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L26-R26))
*  Define a new method `ensure_min_size_fit` for the `SplitChunksPlugin` struct that checks and adjusts the module groups according to the minimum size requirements of each cache group ([link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L5-R5), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R33-R34), [link](https://github.com/web-infra-dev/rspack/pull/2954/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R60-R124))

</details>
