### PR TITLE
feat(new_split_chunks): support `splitChunks.name`

### DIFF
--- a/.changeset/fair-rivers-tickle.md
+++ b/.changeset/fair-rivers-tickle.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat(new_split_chunks): support `splitChunks.name`

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -759,6 +759,7 @@ export interface RawSnapshotStrategy {
 }
 
 export interface RawSplitChunksOptions {
+  name?: string
   cacheGroups?: Record<string, RawCacheGroupOptions>
   /** What kind of chunks should be selected. */
   chunks?: string

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -5,6 +5,17 @@ use crate::common::{ChunkFilter, ChunkNameGetter, ModuleFilter, SplitChunkSizes}
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct CacheGroup {
+  /// For `splitChunks.cacheGroups` config
+  /// ```js
+  /// splitChunks: {
+  ///   hello: {
+  ///     test: /hello-world\.js/,
+  ///     name: 'hello-world',
+  ///   }
+  /// }
+  /// ```
+  /// `hello` is the `key` here
+  pub key: String,
   #[derivative(Debug = "ignore")]
   pub chunk_filter: ChunkFilter,
   #[derivative(Debug = "ignore")]

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -92,8 +92,12 @@ impl DerefMut for SplitChunkSizes {
 
 type PinFutureBox<T> = Pin<Box<dyn Future<Output = T> + Send>>;
 
-pub type ChunkNameGetter = Box<dyn Fn(&dyn Module) -> PinFutureBox<Option<String>> + Send + Sync>;
+pub type ChunkNameGetter = Arc<dyn Fn(&dyn Module) -> PinFutureBox<Option<String>> + Send + Sync>;
 
 pub fn create_chunk_name_getter_by_const_name(name: String) -> ChunkNameGetter {
-  Box::new(move |_module| future::ready(Some(name.clone())).boxed())
+  Arc::new(move |_module| future::ready(Some(name.clone())).boxed())
+}
+
+pub fn create_empty_chunk_name_getter() -> ChunkNameGetter {
+  Arc::new(move |_module| future::ready(None).boxed())
 }

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -11,8 +11,8 @@ pub use crate::{
   common::{
     create_all_chunk_filter, create_async_chunk_filter, create_chunk_filter_from_str,
     create_chunk_name_getter_by_const_name, create_default_module_filter,
-    create_initial_chunk_filter, create_module_filter, create_module_filter_from_regex,
-    create_module_filter_from_rspack_regex, SplitChunkSizes,
+    create_empty_chunk_name_getter, create_initial_chunk_filter, create_module_filter,
+    create_module_filter_from_regex, create_module_filter_from_rspack_regex, SplitChunkSizes,
   },
   plugin::{PluginOptions, SplitChunksPlugin},
 };

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -434,13 +434,14 @@ impl SplitChunksPlugin {
                 selected_chunks,
               } = matched_item;
 
-              // Merge the `Module` of `MatchedItem` into the `ModuleGroup` which has the same `key`/`cache_group.name`
+              // `Module`s with the same chunk_name would be merged togother.
+              // `Module`s could be in different `ModuleGroup`s.
               let chunk_name: Option<String> = (cache_group.name)(module).await;
 
               let key: String = if let Some(cache_group_name) = &chunk_name {
-                ["name: ", cache_group_name].join("")
+                [&cache_group.key, " name:", cache_group_name].join("")
               } else {
-                ["index: ", &cache_group_index.to_string()].join("")
+                [&cache_group.key, " index:", &cache_group_index.to_string()].join("")
               };
 
               let mut module_group = module_group_map.entry(key).or_insert_with(|| ModuleGroup {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -466,6 +466,7 @@ function getRawSplitChunksOptions(
 	sc: OptimizationSplitChunksOptions
 ): RawOptions["optimization"]["splitChunks"] {
 	return {
+		name: sc.name,
 		cacheGroups: sc.cacheGroups
 			? Object.fromEntries(
 					Object.entries(sc.cacheGroups).map(([key, group]) => {

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -969,6 +969,14 @@ module.exports = {
 			type: "object",
 			additionalProperties: false,
 			properties: {
+				name: {
+					description: "The name or name for chunks.",
+					anyOf: [
+						{
+							type: "string"
+						}
+					]
+				},
 				cacheGroups: {
 					description:
 						"Assign modules to a cache group (modules from different cache groups are tried to keep in separate chunks, default categories: 'default', 'defaultVendors').",

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -582,6 +582,7 @@ export interface OptimizationSplitChunksOptions {
 	minSize?: OptimizationSplitChunksSizes;
 	enforceSizeThreshold?: OptimizationSplitChunksSizes;
 	minRemainingSize?: OptimizationSplitChunksSizes;
+	name?: string;
 }
 export interface OptimizationSplitChunksCacheGroup {
 	chunks?: "initial" | "async" | "all";

--- a/packages/rspack/tests/configCases/split-chunks-common/simple/a.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/simple/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/configCases/split-chunks-common/simple/index.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/simple/index.js
@@ -3,6 +3,7 @@ it("should run", function () {
 	expect(a).toBe("a");
 });
 
-it("should be main", function () {
-	expect(require.main).toBe(module);
-});
+// TODO: Rspack doesn't support `require.main`
+// it("should be main", function () {
+// 	expect(require.main).toBe(module);
+// });

--- a/packages/rspack/tests/configCases/split-chunks-common/simple/index.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/simple/index.js
@@ -1,0 +1,8 @@
+it("should run", function () {
+	var a = require("./a");
+	expect(a).toBe("a");
+});
+
+it("should be main", function () {
+	expect(require.main).toBe(module);
+});

--- a/packages/rspack/tests/configCases/split-chunks-common/simple/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/simple/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["./vendor.js", "./main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks-common/simple/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/simple/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		vendor: ["./a"],
+		main: "./index"
+	},
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		newSplitChunks: true
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 1,
+			name: "vendor"
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks/extract-css-to-single-chunk/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/extract-css-to-single-chunk/index.js
@@ -11,5 +11,3 @@ it("should extract css to single chunk", () => {
 	expect(fs.existsSync(path.resolve(__dirname, "./main.css"))).toBe(false);
 	expect(fs.existsSync(path.resolve(__dirname, "./styles.css"))).toBe(true);
 });
-
-console.log(__dirname);

--- a/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/foo-2.js
+++ b/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/foo-2.js
@@ -1,0 +1,1 @@
+export default "foo-2.js";

--- a/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/foo.js
+++ b/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/foo.js
@@ -1,0 +1,2 @@
+import "./foo-2";
+export default "foo.js";

--- a/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/index.js
@@ -1,0 +1,12 @@
+() => import("./foo");
+
+import fs from "fs";
+import path from "path";
+
+export default "index.js";
+
+it("split-chunks-dot-name", () => {
+	expect(fs.existsSync(path.resolve(__dirname, "./overall-foo.js"))).toBe(true);
+	expect(fs.existsSync(path.resolve(__dirname, "./main.js"))).toBe(true);
+	expect(fs.existsSync(path.resolve(__dirname, "./foo_js.js"))).toBe(false);
+});

--- a/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/split-chunks-dot-name/webpack.config.js
@@ -1,0 +1,27 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		newSplitChunks: true
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 1,
+			name: "overall-foo",
+			cacheGroups: {
+				foo: {
+					test: /foo\.js/,
+					priority: 0
+				},
+				foo2: {
+					test: /foo-2\.js/,
+					priority: 0
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- migrate split-chunks-common/simple of Webpack
- Support `splitChunks.name`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0564b81</samp>

This pull request adds support for naming chunks and cache groups in the split chunks plugin of `rspack`, a web development tool. It introduces a new `name` field to the user configuration and the internal options, and a new `ChunkNameGetter` function to generate chunk names. It also adds and modifies some test cases to demonstrate the new feature and fix some minor issues.


<details open=true>
  <summary><h2>Walkthrough</h2></summary>


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0564b81</samp>

*  Add a `name` field to the split chunks options and cache groups, and use it to assign names to the chunks based on the modules they contain ([link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R12), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R139-R143), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L145-R156), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R469), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R964-R971), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR585))
*  Add a `key` field to the cache groups, and use it to identify and merge modules that belong to the same cache group ([link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR8-R18), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L437-R444))
*  Change the `ChunkNameGetter` type from a `Box` to an `Arc`, and add a function to create an empty `ChunkNameGetter` that returns `None` ([link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L95-R103), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812L14-R15))
*  Add a new test case `split-chunks-common/simple` that uses the `name` field to create a single vendor chunk that contains the `a.js` module ([link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-fb5cae54f8f1878a05abb4edf99b4aae9e36235c973c2e51cce0ab254c628002R1), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-4a7fc4c6ea1c0da120f5642fcf36b3671883962060022e5eb0c8b832a474d1deR1-R9), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-4f317340c832898085da9d15a0fbbb3d1bd77969f96e7b0166247732e34a4498R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-c2daf3ada132b90c41b6de90a419f4e76cbb65602491bec2ee8df5ef65525342R1-R20))
*  Add a new test case `split-chunks/split-chunks-dot-name` that uses the `name` field and cache groups to create a single chunk that contains the `foo.js` and `foo-2.js` modules, and does not treat the dot in the name as a separator ([link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-c6e8e2c36f6cc2dc4448d207c077c91f6dcabe3a42eead9604a4a5de2273ae4fR1), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-57861f3678296d680f84d3b19f074e09b28f0833d41a25f1b998357fa1d6e10eR1-R2), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-ea916fce071e018b93baa81d8c1a30dd95945a4bad005aaaaca5e50183580b28R1-R12), [link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-95194ffe2f76c9d2cca8938c42c8851ce30d5f0fdab8f0d0976694b30beeae12R1-R27))
*  Remove a console log statement from the `split-chunks/extract-css-to-single-chunk` test case ([link](https://github.com/web-infra-dev/rspack/pull/2955/files?diff=unified&w=0#diff-54ff5cecc7dedb241b95c1eef968fcd5c34ea995e7bf343e2cbb53b813c59bd7L14-L15))

</details>
