### PR TITLE
chore(bench): add criterion benchmark test   

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +189,7 @@ dependencies = [
 name = "bench"
 version = "0.1.0"
 dependencies = [
+ "criterion 0.4.0",
  "mimalloc-rust",
  "rspack_core",
  "rspack_error",
@@ -325,6 +332,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,13 +371,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef2b3ded6a26dfaec672a742c93c8cf6b689220324da509ec5caa20de55dc83"
+dependencies = [
+ "bitflags 1.3.2",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "textwrap 0.16.0",
+]
+
+[[package]]
+name = "clap"
 version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.3.1",
  "is-terminal",
  "once_cell",
  "strsim",
@@ -361,6 +407,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -439,7 +494,7 @@ dependencies = [
  "atty",
  "cast",
  "clap 2.34.0",
- "criterion-plot",
+ "criterion-plot 0.4.5",
  "csv",
  "futures",
  "itertools",
@@ -459,10 +514,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.24",
+ "criterion-plot 0.5.0",
+ "futures",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
 name = "criterion-plot"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools",
@@ -2258,7 +2351,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "criterion",
+ "criterion 0.3.6",
  "dashmap",
  "insta",
  "mimalloc-rust",
@@ -4622,6 +4715,12 @@ dependencies = [
  "unicode-linebreak",
  "unicode-width",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -26,3 +26,10 @@ rspack_tracing = { path = "../rspack_tracing" }
 [features]
 hmr     = []
 tracing = []
+
+[dev-dependencies]
+criterion = { version = "0.4.0", features = ["async_tokio"] }
+
+[[bench]]
+harness = false
+name    = "my_bench"

--- a/crates/bench/benches/my_bench.rs
+++ b/crates/bench/benches/my_bench.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+use std::time::Instant;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rspack_core::Compiler;
+use rspack_fs::AsyncNativeFileSystem;
+use rspack_testing::apply_from_fixture;
+
+async fn run(relative_path: &str) {
+  let manifest_dir = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
+  // let bundle_dir = manifest_dir.join("tests/fixtures/postcss/pxtorem");
+  let bundle_dir: PathBuf = manifest_dir.join(relative_path);
+  //   println!("{bundle_dir:?}");
+  let (options, plugins) = apply_from_fixture(&bundle_dir);
+  //   let start = Instant::now();
+  // println!("{:?}", options);
+  let mut compiler = Compiler::new(options, plugins, AsyncNativeFileSystem);
+
+  compiler
+    .build()
+    .await
+    .unwrap_or_else(|e| panic!("{e:?}, failed to compile in fixtrue {bundle_dir:?}"));
+  //   println!("{:?}", start.elapsed());
+}
+fn bench(c: &mut Criterion) {
+  c.bench_function("iter", move |b| {
+    b.to_async(tokio::runtime::Runtime::new().unwrap())
+      .iter(|| async {
+        let path_list = vec![
+          // "examples/cjs-tree-shaking-basic",
+          // "examples/basic",
+          "examples/basic",
+          // "examples/export-star-chain",
+          // "examples/bbb",
+          /* "examples/named-export-decl-with-src-eval",
+           * "examples/side-effects-prune",
+           * "examples/side-effects-two", */
+        ];
+        for p in path_list {
+          run(p).await;
+        }
+      })
+  });
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 998fee1</samp>

This pull request adds a new benchmark file `my_bench.rs` and a dependency on the criterion crate to the bench crate. The benchmark file uses the criterion library to measure the execution time of the rspack core compiler for different example inputs.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 998fee1</samp>

* Implement benchmark logic and configuration for the rspack core compiler ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-23e57c31174313c7d5ef01685678fdb46aeb6335656004560286d585a7d58343R1-R47), [link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dR29-R35))
  - Add `my_bench.rs` file to the `benches` folder of the `bench` crate ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-23e57c31174313c7d5ef01685678fdb46aeb6335656004560286d585a7d58343R1-R47))
    * Define `run` function that compiles an example folder using the rspack core compiler ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-23e57c31174313c7d5ef01685678fdb46aeb6335656004560286d585a7d58343R1-R47))
    * Define `bench` function that uses the `criterion` library to measure the execution time of the `run` function ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-23e57c31174313c7d5ef01685678fdb46aeb6335656004560286d585a7d58343R1-R47))
    * Provide some sample example paths for testing ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-23e57c31174313c7d5ef01685678fdb46aeb6335656004560286d585a7d58343R1-R47))
  - Add `criterion` crate as a dev-dependency and a benchmark configuration to the `Cargo.toml` file of the `bench` crate ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dR29-R35))
    * Specify the name and harness of the benchmark file ([link](https://github.com/web-infra-dev/rspack/pull/2956/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dR29-R35))

</details>
