### PR TITLE
fix: 🐛 unexpected export warning

### DIFF
--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -889,7 +889,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
   }
   fn visit_call_expr(&mut self, node: &CallExpr) {
     if let Some(require_lit) = get_require_literal(node, self.unresolved_mark) {
-      self.module_syntax.insert(ModuleSyntax::ESM);
+      self.module_syntax.insert(ModuleSyntax::COMMONJS);
       match self
         .resolve_module_identifier(&require_lit, &DependencyType::CjsRequire)
         .copied()


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7da7541</samp>

Refactor tree shaking visitor to support different module syntaxes and dependency types. Update `visit_call_expr` to use `ModuleSyntax::COMMONJS` for `require` calls.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7da7541</samp>

*  Refactor the tree shaking visitor to support different module syntaxes and dependency types ([link](https://github.com/web-infra-dev/rspack/pull/2959/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L892-R892),                             F

</details>
