### PR TITLE
fix: Fix type checking in config examples

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -3,10 +3,8 @@ const { default: HtmlPlugin } = require("@rspack/plugin-html");
 
 const prod = process.env.NODE_ENV === "production";
 
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: { main: "./src/index.tsx" },
 	devServer: {
@@ -70,3 +68,4 @@ module.exports = {
 		debug: false
 	}
 };
+module.exports = config;

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/index.js"
@@ -14,3 +12,4 @@ module.exports = {
 		],
 	}
 };
+module.exports = config;

--- a/examples/bundle-splitting/rspack.config.js
+++ b/examples/bundle-splitting/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	entry: {
 		main: {
@@ -39,3 +37,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/code-splitting/rspack.config.js
+++ b/examples/code-splitting/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	entry: {
 		main: {
@@ -12,3 +13,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/cra-ts/rspack.config.js
+++ b/examples/cra-ts/rspack.config.js
@@ -1,8 +1,6 @@
 const CopyPlugin = require("copy-webpack-plugin");
-/*
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.tsx"
 	},
@@ -29,3 +27,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/cra/rspack.config.js
+++ b/examples/cra/rspack.config.js
@@ -1,8 +1,6 @@
 const CopyPlugin = require("copy-webpack-plugin");
-/*
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.jsx"
 	},
@@ -29,3 +27,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/emotion/rspack.config.js
+++ b/examples/emotion/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.jsx"
 	},
@@ -18,3 +16,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/eslint/rspack.config.js
+++ b/examples/eslint/rspack.config.js
@@ -1,8 +1,6 @@
 const EslintPlugin = require("eslint-rspack-plugin");
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	context: __dirname,
 	entry: {
@@ -10,3 +8,4 @@ module.exports = {
 	},
 	plugins: [new EslintPlugin()]
 };
+module.exports = config;

--- a/examples/eslint/rspack.config.loader.js
+++ b/examples/eslint/rspack.config.loader.js
@@ -1,8 +1,6 @@
 const EslintPlugin = require("eslint-rspack-plugin");
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	context: __dirname,
 	entry: {
@@ -23,3 +21,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/library/rspack.config.js
+++ b/examples/library/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = [
+/** @type {import('@rspack/cli').Configuration} */
+const config = [
 	"var",
 	"module",
 	"assign",
@@ -33,3 +31,4 @@ module.exports = [
 		}
 	}
 }));
+module.exports = config;

--- a/examples/loader-compat/rspack.config.js
+++ b/examples/loader-compat/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.js"
 	},
@@ -118,3 +116,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/multi-entry/rspack.config.js
+++ b/examples/multi-entry/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	entry: {
 		index: "./index.js",
@@ -14,3 +15,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/nestjs/rspack.config.js
+++ b/examples/nestjs/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	target: "node",
 	entry: {
@@ -46,3 +44,4 @@ module.exports = {
 		}
 	]
 };
+module.exports = config;

--- a/examples/perfsee/rspack.config.js
+++ b/examples/perfsee/rspack.config.js
@@ -1,8 +1,6 @@
 const { PerfseePlugin } = require("@perfsee/webpack");
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/index.js"
@@ -16,3 +14,4 @@ module.exports = {
 	},
 	plugins: [new PerfseePlugin({})]
 };
+module.exports = config;

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -4,10 +4,8 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin')
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	target: "node",
 	mode: "development",
 	stats: { all: true },
@@ -38,6 +36,7 @@ module.exports = {
 		new GeneratePackageJsonPlugin(basePackage, {})
 	]
 };
+module.exports = config;
 
 
 

--- a/examples/polyfill/rspack.config.js
+++ b/examples/polyfill/rspack.config.js
@@ -1,8 +1,6 @@
 const path = require("path");
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/index.js"
@@ -25,3 +23,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/postcss/rspack.config.js
+++ b/examples/postcss/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	entry: "./index.js",
 	builtins: {
@@ -8,3 +9,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/proxy/rspack.config.js
+++ b/examples/proxy/rspack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
-module.exports = (env, argv) => {
+/** @type {import('@rspack/cli').Configuration} */
+const config = (env, argv) => {
 	console.log("env:", env, argv);
 	return {
 		context: __dirname,
@@ -19,3 +20,4 @@ module.exports = (env, argv) => {
 		}
 	};
 };
+module.exports = config;

--- a/examples/proxy/rspack.config.js
+++ b/examples/proxy/rspack.config.js
@@ -1,6 +1,5 @@
 const path = require("path");
-/** @type {import('@rspack/cli').Configuration} */
-const config = (env, argv) => {
+module.exports = (env, argv) => {
 	console.log("env:", env, argv);
 	return {
 		context: __dirname,
@@ -20,4 +19,3 @@ const config = (env, argv) => {
 		}
 	};
 };
-module.exports = config;

--- a/examples/react-15-classic/rspack.config.js
+++ b/examples/react-15-classic/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.jsx"
 	},
@@ -21,3 +22,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/react-15/rspack.config.js
+++ b/examples/react-15/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.jsx"
 	},
@@ -18,3 +19,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/react-refresh/rspack.config.js
+++ b/examples/react-refresh/rspack.config.js
@@ -1,7 +1,7 @@
 /**
  * @type {import('@rspack/cli').Configuration}
  */
-module.exports = {
+const config = {
 	mode: "development",
 	entry: { main: "./src/index.tsx" },
 	builtins: {
@@ -11,3 +11,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/react-with-less/rspack.config.js
+++ b/examples/react-with-less/rspack.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	mode: "development",
 	entry: {
@@ -24,3 +25,4 @@ module.exports = {
 		path: path.resolve(__dirname, "dist")
 	}
 };
+module.exports = config;

--- a/examples/react-with-sass/rspack.config.js
+++ b/examples/react-with-sass/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	entry: {
 		main: ["./src/index.jsx"]
@@ -19,3 +20,4 @@ module.exports = {
 		html: [{}]
 	}
 };
+module.exports = config;

--- a/examples/react/rspack.config.js
+++ b/examples/react/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.jsx"
 	},
@@ -18,3 +19,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/solid/rspack.config.js
+++ b/examples/solid/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/index.jsx"

--- a/examples/styled-components/rspack.config.js
+++ b/examples/styled-components/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./src/index.tsx"
 	},
@@ -13,3 +11,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/svelte/rspack.config.js
+++ b/examples/svelte/rspack.config.js
@@ -4,8 +4,8 @@ const { default: HtmlPlugin } = require("@rspack/plugin-html");
 
 const mode = process.env.NODE_ENV || "development";
 const prod = mode === "production";
-
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: ["./src/main.ts"]
 	},
@@ -56,3 +56,4 @@ module.exports = {
 		historyApiFallback: true
 	}
 };
+module.exports = config;

--- a/examples/svgr/rspack.config.js
+++ b/examples/svgr/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./index.jsx"
 	},
@@ -17,3 +15,4 @@ module.exports = {
 		html: [{ template: "./index.html" }]
 	}
 };
+module.exports = config;

--- a/examples/tailwind-jit/rspack.config.js
+++ b/examples/tailwind-jit/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/index.js"
@@ -35,3 +33,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/tailwind/tailwind.config.js
+++ b/examples/tailwind/tailwind.config.js
@@ -1,8 +1,9 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+const config = {
 	content: ["src/**/*.js"],
 	theme: {
 		extend: {}
 	},
 	plugins: []
 };
+module.exports = config;

--- a/examples/vue/rspack.config.js
+++ b/examples/vue/rspack.config.js
@@ -1,4 +1,5 @@
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	mode: "development",
 	entry: {
 		main: "./src/main.js"
@@ -36,3 +37,4 @@ module.exports = {
 		]
 	}
 };
+module.exports = config;

--- a/examples/vue3-jsx/rspack.config.js
+++ b/examples/vue3-jsx/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/main.jsx"
@@ -37,3 +35,4 @@ module.exports = {
 		}
 	}
 };
+module.exports = config;

--- a/examples/wasm-simple/rspack.config.js
+++ b/examples/wasm-simple/rspack.config.js
@@ -1,7 +1,5 @@
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
 	entry: {
 		main: "./example.js"
 	},
@@ -16,3 +14,4 @@ module.exports = {
 		html: [{}]
 	}
 };
+module.exports = config;


### PR DESCRIPTION
Hello there! 

Thanks for rspack! 

Just a quick PR to fix the type checking in the configuration file examples you have, similar to [the config page](https://www.rspack.dev/config/index.html#type-checking). 

It was already discussed and merged [here](https://github.com/web-infra-dev/rspack-website/pull/286). 

The underlying TypeScript problem is found [here](https://github.com/microsoft/TypeScript/issues/47107). 

Thanks to @karlhorky for letting me take this over. 