### PR TITLE
fix: add entry startup to fix async script chunk loading

### DIFF
--- a/.changeset/thirty-boxes-listen.md
+++ b/.changeset/thirty-boxes-listen.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: add entry startup to fix async script chunk loading

--- a/.typos.toml
+++ b/.typos.toml
@@ -4,7 +4,7 @@
 
 [files]
 extend-exclude = [
-  "**/*.{css,map,json,txt,ts,tsx,js,snap,bak,diff}",
+  "**/*.{css,map,json,txt,ts,tsx,js,snap,bak,diff,html}",
   "webpack-examples",
   "webpack-test",
   "./examples",

--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -6,7 +6,8 @@ __webpack_require__.el("./b.js").then(__webpack_require__.bind(__webpack_require
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
@@ -32,8 +32,7 @@ __webpack_require__('./child Lazy  recursive ^.*.js$')("./child/".concat(request
 },
 
 };
-
 var __webpack_require__ = require('./runtime.js');
-
 __webpack_require__.C(exports)
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));

--- a/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
@@ -139,6 +139,7 @@ var installChunk = function (chunk) {
 	}
 	if (runtime) runtime(__webpack_require__);
 	for (var i = 0; i < chunkIds.length; i++) installedChunks[chunkIds[i]] = 1;
+	
 };
 // require() chunk loading for javascript
 __webpack_require__.f.require = function (chunkId, promises) {

--- a/crates/rspack/tests/fixtures/simple-with-query/expected/main.js
+++ b/crates/rspack/tests/fixtures/simple-with-query/expected/main.js
@@ -38,7 +38,8 @@ const a = 3;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/fixtures/static-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/static-import/expected/main.js
@@ -20,7 +20,8 @@ console.log('hello, world');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-dynamic-entry/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-dynamic-entry/expected/main.js
@@ -6,7 +6,8 @@ console.log('index');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index.js
@@ -13,7 +13,8 @@ console.log('shared');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index2.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index2.js
@@ -13,7 +13,8 @@ console.log('shared');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index2.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index2.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index.js
@@ -17,7 +17,8 @@ console.log('shared');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index2.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index2.js
@@ -17,7 +17,8 @@ console.log('shared');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index2.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index2.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/self-import/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/self-import/expected/main.js
@@ -5,7 +5,8 @@ console.log('index');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/simple/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/simple/expected/main.js
@@ -13,7 +13,8 @@ console.log('shared');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/array-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/array-side-effects/expected/main.js
@@ -44,7 +44,8 @@ _app.app;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/assign-with-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/assign-with-side-effects/expected/main.js
@@ -37,7 +37,8 @@ const result = 20000;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/basic/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/basic/expected/main.js
@@ -48,7 +48,8 @@ const myanswer = _answer.answer;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/bb/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/bb/expected/main.js
@@ -44,7 +44,8 @@ _a.ccc;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
@@ -55,7 +55,8 @@ var _default = _zh_locale.default;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.ts');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.ts'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/expected/main.js
@@ -49,7 +49,8 @@ const myanswer = 'anyser';
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/expected/main.js
@@ -15,7 +15,8 @@ __webpack_require__.es(__webpack_require__("./bar.js"), exports);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/context-module/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/context-module/expected/main.js
@@ -57,7 +57,8 @@ __webpack_require__('./child Sync  recursive ^.*.js$')(`./child/${a}.js`.replace
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/default_export/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/default_export/expected/main.js
@@ -68,7 +68,8 @@ const myanswer = _answer.answer;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/expected/main.js
@@ -26,7 +26,8 @@ console.log(_foo.a);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/expected/main.js
@@ -39,7 +39,8 @@ console.log(_foo.a);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export-star-chain/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export-star-chain/expected/main.js
@@ -107,7 +107,8 @@ __webpack_require__.es(__webpack_require__("./something/Something.js"), exports)
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export_star/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star/expected/main.js
@@ -63,7 +63,8 @@ const c = 103330;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export_star2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star2/expected/main.js
@@ -34,7 +34,8 @@ __webpack_require__.es(__webpack_require__("./bar.js"), exports);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/expected/main.js
@@ -40,7 +40,8 @@ __webpack_require__.es(__webpack_require__("./bar.js"), exports);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-imported-unused/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-imported-unused/expected/main.js
@@ -5,7 +5,8 @@ console.log('something');
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
@@ -116,7 +116,8 @@ function _instanceof1(left, right) {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/expected/main.js
@@ -36,7 +36,8 @@ var _export = __webpack_require__("./export.js");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/expected/main.js
@@ -56,7 +56,8 @@ _c.c;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable1/expected/main.js
@@ -42,7 +42,8 @@ var _export = __webpack_require__("./export.js");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable2/expected/main.js
@@ -42,7 +42,8 @@ var _export = __webpack_require__("./export.js");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects1/expected/main.js
@@ -26,7 +26,8 @@ _a.a;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects2/expected/main.js
@@ -26,7 +26,8 @@ _a.a;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/expected/main.js
@@ -65,7 +65,8 @@ var _export = __webpack_require__("./export.js");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/named_export_alias/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/named_export_alias/expected/main.js
@@ -38,7 +38,8 @@ _export.default;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/prune-bailout-module/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/prune-bailout-module/expected/main.js
@@ -35,7 +35,8 @@ var _a = __webpack_require__.ir(__webpack_require__("./a.js"));
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
@@ -68,7 +68,8 @@ function useSelector() {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/reexport_default_as/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/reexport_default_as/expected/main.js
@@ -35,7 +35,8 @@ var _foo = __webpack_require__("./foo.js");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/reexport_entry_elimination/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/reexport_entry_elimination/expected/main.js
@@ -49,7 +49,8 @@ _a.b;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rename-export-from-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rename-export-from-import/expected/main.js
@@ -35,7 +35,8 @@ const question = "2";
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/expected/main.js
@@ -38,7 +38,8 @@ console.log(answer);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/expected/main.js
@@ -31,7 +31,8 @@ new _foo.default();
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-called-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-called-import/expected/main.js
@@ -28,7 +28,8 @@ assert.equal((0, _foo.default)(), "foo");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/expected/main.js
@@ -29,7 +29,8 @@ assert.equal(_foo.foo.value, 2);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/expected/main.js
@@ -49,7 +49,8 @@ function Baz() {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-var/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-var/expected/main.js
@@ -22,7 +22,8 @@ console.log(_foo.foo);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-analyzed/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-analyzed/expected/main.js
@@ -35,7 +35,8 @@ function _default() {}
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-flagged-only/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-flagged-only/expected/main.js
@@ -39,7 +39,8 @@ function _default() {}
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
@@ -29,7 +29,8 @@ const something = function() {};
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
@@ -35,7 +35,8 @@ function _default() {}
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
@@ -56,7 +56,8 @@ function ccc() {}
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/static-class/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/static-class/expected/main.js
@@ -42,7 +42,8 @@ _a.a;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/expected/main.js
@@ -26,7 +26,8 @@ console.log("side effect");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/expected/main.js
@@ -37,7 +37,8 @@ _b.b;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
@@ -31,7 +31,8 @@ var _foo = __webpack_require__.ir(__webpack_require__("./foo.js"));
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/main.js
@@ -24,7 +24,8 @@ a;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -236,7 +236,8 @@ function _test() {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.ts');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.ts'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/var-function-expr/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/var-function-expr/expected/main.js
@@ -49,7 +49,8 @@ const something = function() {};
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/expected/main.js
@@ -227,7 +227,8 @@ it("f should be used", ()=>{
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/expected/main.js
@@ -99,7 +99,8 @@ class Document {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
@@ -96,7 +96,8 @@ function withB(v) {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/expected/main.js
@@ -141,7 +141,8 @@ function f4() {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/expected/main.js
@@ -44,7 +44,8 @@ function a() {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
@@ -48,7 +48,8 @@ try {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/expected/main.js
@@ -105,7 +105,8 @@ var _default = 1;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
@@ -126,7 +126,8 @@ _tracker.log.should.be.eql([
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
@@ -108,7 +108,8 @@ _tracker.log.should.be.eql([
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/with-assets/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/with-assets/expected/main.js
@@ -26,7 +26,8 @@ _asvg.default;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_binding_options/src/options/raw_output.rs
+++ b/crates/rspack_binding_options/src/options/raw_output.rs
@@ -367,14 +367,17 @@ impl RawOutputOptions {
             );
           }
           "umd" | "umd2" => {
+            plugins.push(rspack_plugin_library::ExportPropertyLibraryPlugin::default().boxed());
             plugins.push(rspack_plugin_library::UmdLibraryPlugin::new("umd2".eq(library)).boxed());
           }
           "amd" | "amd-require" => {
+            plugins.push(rspack_plugin_library::ExportPropertyLibraryPlugin::default().boxed());
             plugins.push(
               rspack_plugin_library::AmdLibraryPlugin::new("amd-require".eq(library)).boxed(),
             );
           }
           "module" => {
+            plugins.push(rspack_plugin_library::ExportPropertyLibraryPlugin::default().boxed());
             plugins.push(rspack_plugin_library::ModuleLibraryPlugin::default().boxed());
           }
           _ => {}

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -215,6 +215,7 @@ pub struct RenderStartupArgs<'a> {
   pub compilation: &'a Compilation,
   pub chunk: &'a ChunkUkey,
   pub module: ModuleIdentifier,
+  pub source: BoxSource,
 }
 
 impl<'me> RenderStartupArgs<'me> {

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -247,12 +247,19 @@ impl PluginDriver {
   }
 
   pub fn render_startup(&self, args: RenderStartupArgs) -> PluginRenderStartupHookOutput {
+    let mut source = args.source;
     for plugin in &self.plugins {
-      if let Some(source) = plugin.render_startup(PluginContext::new(), &args)? {
-        return Ok(Some(source));
+      if let Some(s) = plugin.render_startup(
+        PluginContext::new(),
+        &RenderStartupArgs {
+          source: source.clone(),
+          ..args
+        },
+      )? {
+        source = s;
       }
     }
-    Ok(None)
+    Ok(Some(source))
   }
 
   pub fn js_chunk_hash(&self, mut args: JsChunkHashArgs) -> PluginJsChunkHashHookOutput {

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -196,6 +196,8 @@ bitflags! {
     const GET_TRUSTED_TYPES_POLICY = 1 << 37;
 
     const DEFINE_PROPERTY_GETTERS = 1 << 38;
+
+    const ENTRY_MODULE_ID = 1 << 39;
   }
 }
 
@@ -261,6 +263,7 @@ impl RuntimeGlobals {
       R::CREATE_SCRIPT => "__webpack_require__.ts",
       R::GET_TRUSTED_TYPES_POLICY => "__webpack_require__.tt",
       R::DEFINE_PROPERTY_GETTERS => "__webpack_require__.d",
+      R::ENTRY_MODULE_ID => "__webpack_require__.s",
       r => panic!(
         "Unexpected flag `{r:?}`. RuntimeGlobals should only be printed for one single flag."
       ),

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -14,6 +14,10 @@ pub trait RuntimeModule: Module {
   fn cacheable(&self) -> bool {
     true
   }
+  // if wrap iife
+  fn should_isolate(&self) -> bool {
+    false
+  }
 }
 
 /**

--- a/crates/rspack_plugin_asset/tests/fixtures/rspack/asset-source/expected/main.js
+++ b/crates/rspack_plugin_asset/tests/fixtures/rspack/asset-source/expected/main.js
@@ -11,7 +11,8 @@ console.log(_datatxt.default);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-advanced/expected/main.js
+++ b/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-advanced/expected/main.js
@@ -33,7 +33,8 @@ function createImageElement(title, src) {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-simple/expected/main.js
+++ b/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-simple/expected/main.js
@@ -41,7 +41,8 @@ function createImageElement(title, src) {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_html/tests/fixtures/variant/expected/output.html
+++ b/crates/rspack_plugin_html/tests/fixtures/variant/expected/output.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Rspack App</title>
-<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-BO3cF5U4IDGVl4kvgfcnEb3lP6Bp2HDptnR65UjCu4kuE+qZHYZFDV+ZlRDHO06oz7K5dsMdgHArJMERcwU7TA=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-mxPJ4uV5XOF7lWizgX0GrHjcTK9lbOfv4c5vpYG3CegTmn0y8wIWKrvfPrnMxDpCzxv4fweoG5D+CQ6mbLYMNQ=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-Z8PU3Ii4d2SPUxyN8IIBT+qeVhwEyS0gDBnVwfr1XrN7r20CMILhZ1GhnoENqrJIUHI9/6UVEdorpIqMuDavdQ==" /></head>
+<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-+rvnKFBVF0WA40coHk0mfBA8+rK5eWjL0V9/K8pSggP7yfG/WBXmyz8Yo9lTwwVQ3YYxEhs/ZE4ig5W+VlkwhQ=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-rNIhhygsXYy5WFggyapEFvcwZpMaZjgK2pxGloogKSrcptB4oZnGckX0NOE8QqTtYecYYXQBtr/SAqQ3myFEwA=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-Z8PU3Ii4d2SPUxyN8IIBT+qeVhwEyS0gDBnVwfr1XrN7r20CMILhZ1GhnoENqrJIUHI9/6UVEdorpIqMuDavdQ==" /></head>
 
 <body>
 

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -28,8 +28,7 @@ use swc_ecma_minifier::option::terser::TerserCompressorOptions;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::runtime::{
-  generate_chunk_entry_code, render_chunk_init_fragments, render_chunk_modules,
-  render_runtime_modules,
+  render_chunk_init_fragments, render_chunk_modules, render_runtime_modules, stringify_array,
 };
 use crate::utils::syntax_by_module_type;
 use crate::visitors::{run_after_pass, run_before_pass, scan_dependencies};
@@ -132,44 +131,124 @@ impl JsPlugin {
     sources.boxed()
   }
 
-  pub fn render_bootstrap(&self, chunk_ukey: &ChunkUkey, compilation: &Compilation) -> BoxSource {
+  pub fn render_bootstrap(
+    &self,
+    chunk_ukey: &ChunkUkey,
+    compilation: &Compilation,
+  ) -> (BoxSource, BoxSource) {
     let runtime_requirements = compilation
       .chunk_graph
       .get_chunk_runtime_requirements(chunk_ukey);
-
+    let chunk = compilation
+      .chunk_by_ukey
+      .get(chunk_ukey)
+      .expect("chunk should exist in chunk_by_ukey");
     let module_factories = runtime_requirements.contains(RuntimeGlobals::MODULE_FACTORIES);
+    // let require_function = runtime_requirements.contains(RuntimeGlobals::REQUIRE);
+    let intercept_module_execution =
+      runtime_requirements.contains(RuntimeGlobals::INTERCEPT_MODULE_EXECUTION);
+    // let module_used = runtime_requirements.contains(RuntimeGlobals::MODULE);
+    // let use_require = require_function || intercept_module_execution || module_used;
+    let mut header = ConcatSource::default();
 
-    let mut sources = ConcatSource::default();
-
-    sources.add(RawSource::from(
+    header.add(RawSource::from(
       "// The module cache\n var __webpack_module_cache__ = {};\n",
     ));
-    sources.add(RawSource::from(
+    header.add(RawSource::from(
       "function __webpack_require__(moduleId) {\n",
     ));
-    sources.add(self.render_require(chunk_ukey, compilation));
-    sources.add(RawSource::from("\n}\n"));
+    header.add(self.render_require(chunk_ukey, compilation));
+    header.add(RawSource::from("\n}\n"));
 
     if module_factories || runtime_requirements.contains(RuntimeGlobals::MODULE_FACTORIES_ADD_ONLY)
     {
-      sources.add(RawSource::from(
+      header.add(RawSource::from(
         "// expose the modules object (__webpack_modules__)\n __webpack_require__.m = __webpack_modules__;\n",
       ));
     }
 
     if runtime_requirements.contains(RuntimeGlobals::MODULE_CACHE) {
-      sources.add(RawSource::from(
+      header.add(RawSource::from(
         "// expose the module cache\n __webpack_require__.c = __webpack_module_cache__;\n",
       ));
     }
 
-    if runtime_requirements.contains(RuntimeGlobals::INTERCEPT_MODULE_EXECUTION) {
-      sources.add(RawSource::from(
+    if intercept_module_execution {
+      header.add(RawSource::from(
         "// expose the module execution interceptor\n __webpack_require__.i = [];\n",
       ));
     }
 
-    sources.boxed()
+    let mut startup = vec![];
+
+    if chunk.has_entry_module(&compilation.chunk_graph) {
+      let entries = compilation
+        .chunk_graph
+        .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey);
+      for (i, (module, entry)) in entries.iter().enumerate() {
+        let chunk_group = compilation
+          .chunk_group_by_ukey
+          .get(entry)
+          .expect("should have chunk group");
+        let chunk_ids = chunk_group
+          .chunks
+          .iter()
+          .filter(|c| *c != chunk_ukey)
+          .map(|chunk_ukey| {
+            let chunk = compilation
+              .chunk_by_ukey
+              .get(chunk_ukey)
+              .expect("Chunk not found");
+            chunk.expect_id().to_string()
+          })
+          .collect::<Vec<_>>();
+        let module_id = compilation
+          .module_graph
+          .module_graph_module_by_identifier(module)
+          .map(|module| module.id(&compilation.chunk_graph))
+          .expect("should have module id");
+        let mut module_id_expr = format!("'{module_id}'");
+        if runtime_requirements.contains(RuntimeGlobals::ENTRY_MODULE_ID) {
+          module_id_expr = format!("{} = {module_id_expr}", RuntimeGlobals::ENTRY_MODULE_ID);
+        }
+
+        if !chunk_ids.is_empty() {
+          startup.push(format!(
+            "{}{}(undefined, {} , function() {{ return __webpack_require__({module_id_expr}) }});",
+            if i + 1 == entries.len() {
+              "var __webpack_exports__ = "
+            } else {
+              ""
+            },
+            RuntimeGlobals::ON_CHUNKS_LOADED,
+            stringify_array(&chunk_ids)
+          ));
+        }
+        /* if use_require */
+        else {
+          startup.push(format!(
+            "{}__webpack_require__({module_id_expr});",
+            if i + 1 == entries.len() {
+              "var __webpack_exports__ = "
+            } else {
+              ""
+            },
+          ))
+        }
+        // else {
+        //   startup.push(format!("__webpack_modules__[{module_id_expr}]();"))
+        // }
+      }
+    }
+
+    if runtime_requirements.contains(RuntimeGlobals::ON_CHUNKS_LOADED) {
+      startup.push(format!(
+        "__webpack_exports__ = {}(__webpack_exports__);",
+        RuntimeGlobals::ON_CHUNKS_LOADED
+      ));
+    }
+
+    (header.boxed(), RawSource::from(startup.join("\n")).boxed())
   }
 
   pub async fn render_main(&self, args: &rspack_core::RenderManifestArgs<'_>) -> Result<BoxSource> {
@@ -180,18 +259,14 @@ impl JsPlugin {
       .get_tree_runtime_requirements(&args.chunk_ukey);
     let (module_source, mut chunk_init_fragments) =
       render_chunk_modules(compilation, &args.chunk_ukey)?;
+    let (header, startup) = self.render_bootstrap(&args.chunk_ukey, args.compilation);
     let mut sources = ConcatSource::default();
     sources.add(RawSource::from("var __webpack_modules__ = "));
     sources.add(module_source);
     sources.add(RawSource::from("\n"));
-    sources.add(self.render_bootstrap(&args.chunk_ukey, args.compilation));
+    sources.add(header);
     sources.add(render_runtime_modules(compilation, &args.chunk_ukey)?);
     if chunk.has_entry_module(&compilation.chunk_graph) {
-      // TODO: how do we handle multiple entry modules?
-      sources.add(generate_chunk_entry_code(compilation, &args.chunk_ukey));
-      if runtime_requirements.contains(RuntimeGlobals::RETURN_EXPORTS_FROM_RUNTIME) {
-        sources.add(RawSource::from("return __webpack_exports__;\n"));
-      }
       let last_entry_module = compilation
         .chunk_graph
         .get_chunk_entry_modules_with_chunk_group_iterable(&chunk.ukey)
@@ -207,9 +282,13 @@ impl JsPlugin {
             compilation,
             chunk: &chunk.ukey,
             module: *last_entry_module,
+            source: startup,
           })?
       {
         sources.add(source);
+      }
+      if runtime_requirements.contains(RuntimeGlobals::RETURN_EXPORTS_FROM_RUNTIME) {
+        sources.add(RawSource::from("return __webpack_exports__;\n"));
       }
     }
     let mut final_source = if compilation.options.output.iife {
@@ -281,7 +360,9 @@ impl JsPlugin {
     hasher: &mut Xxh3,
   ) {
     // sample hash use content
-    self.render_bootstrap(chunk_ukey, compilation).hash(hasher);
+    let (header, startup) = self.render_bootstrap(chunk_ukey, compilation);
+    header.hash(hasher);
+    startup.hash(hasher);
   }
 
   pub fn render_iife(&self, content: BoxSource) -> BoxSource {

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/constant_folding/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/constant_folding/expected/main.js
@@ -6,7 +6,8 @@ __webpack_require__("./development.js");
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/expected/main.js
@@ -257,7 +257,8 @@ var _default = 401;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/minify/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/minify/expected/main.js
@@ -1,1 +1,1 @@
-(self.webpackChunkwebpack=self.webpackChunkwebpack||[]).push([["main"],{"./index.js":function(n,e,a){n.exports=Math.random()}},function(n){n("./index.js")}]);
+(self.webpackChunkwebpack=self.webpackChunkwebpack||[]).push([["main"],{"./index.js":function(n,e,a){n.exports=Math.random()}},function(n){n(n.s="./index.js")}]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
@@ -10,7 +10,8 @@ __webpack_require__.el("./bug_only_single_quote.js").then(__webpack_require__.bi
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/main.js
@@ -12,7 +12,8 @@ img.src = imgSrc2;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/runtime.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/runtime.js
@@ -35,13 +35,15 @@ __webpack_require__.O = function (result, chunkIds, fn, priority) {
 	}
 	var notFulfilled = Infinity;
 	for (var i = 0; i < deferred.length; i++) {
-		var [chunkIds, fn, priority] = deferred[i];
+		var chunkIds = deferred[i][0],
+			fn = deferred[i][1],
+			priority = deferred[i][2];
 		var fulfilled = true;
 		for (var j = 0; j < chunkIds.length; j++) {
 			if (
 				(priority & (1 === 0) || notFulfilled >= priority) &&
 				Object.keys(__webpack_require__.O).every(function (key) {
-					__webpack_require__.O[key](chunkIds[j]);
+					return __webpack_require__.O[key](chunkIds[j]);
 				})
 			) {
 				chunkIds.splice(j--, 1);
@@ -72,17 +74,19 @@ __webpack_require__.o = function (obj, prop) {
 __webpack_require__.b = document.baseURI || self.location.href;
 var installedChunks = {"runtime": 0,};
 __webpack_require__.O.j = function (chunkId) {
-	installedChunks[chunkId] === 0;
+	return installedChunks[chunkId] === 0;
 };
 // install a JSONP callback for chunk loading
 var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
-	var [chunkIds, moreModules, runtime] = data;
+	var chunkIds = data[0],
+	moreModules = data[1],
+	runtime = data[2];
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId,
 		chunkId,
 		i = 0;
-	if (chunkIds.some(id => installedChunks[id] !== 0)) {
+	if (chunkIds.some(function(id) { return installedChunks[id] !== 0 })) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/main.js
@@ -12,7 +12,8 @@ img.src = imgSrc2;
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/runtime.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/runtime.js
@@ -35,13 +35,15 @@ __webpack_require__.O = function (result, chunkIds, fn, priority) {
 	}
 	var notFulfilled = Infinity;
 	for (var i = 0; i < deferred.length; i++) {
-		var [chunkIds, fn, priority] = deferred[i];
+		var chunkIds = deferred[i][0],
+			fn = deferred[i][1],
+			priority = deferred[i][2];
 		var fulfilled = true;
 		for (var j = 0; j < chunkIds.length; j++) {
 			if (
 				(priority & (1 === 0) || notFulfilled >= priority) &&
 				Object.keys(__webpack_require__.O).every(function (key) {
-					__webpack_require__.O[key](chunkIds[j]);
+					return __webpack_require__.O[key](chunkIds[j]);
 				})
 			) {
 				chunkIds.splice(j--, 1);
@@ -77,17 +79,19 @@ __webpack_require__.p = "/";
 __webpack_require__.b = document.baseURI || self.location.href;
 var installedChunks = {"runtime": 0,};
 __webpack_require__.O.j = function (chunkId) {
-	installedChunks[chunkId] === 0;
+	return installedChunks[chunkId] === 0;
 };
 // install a JSONP callback for chunk loading
 var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
-	var [chunkIds, moreModules, runtime] = data;
+	var chunkIds = data[0],
+	moreModules = data[1],
+	runtime = data[2];
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId,
 		chunkId,
 		i = 0;
-	if (chunkIds.some(id => installedChunks[id] !== 0)) {
+	if (chunkIds.some(function(id) { return installedChunks[id] !== 0 })) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
@@ -134,7 +134,8 @@ process.umask = function() {
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/simple/expected/main.js
@@ -5,7 +5,8 @@ console.log(__webpack_require__.c);
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_json/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack_plugin_json/tests/fixtures/simple/expected/main.js
@@ -14,7 +14,8 @@ module.exports = {
 ;},
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -85,6 +85,7 @@ impl Plugin for AssignLibraryPlugin {
     args: &RenderStartupArgs,
   ) -> PluginRenderStartupHookOutput {
     let mut source = ConcatSource::default();
+    source.add(args.source.clone());
     // TODO: respect entryOptions.library
     let library = &args.compilation.options.output.library;
     let is_copy = if let Some(library) = library {

--- a/crates/rspack_plugin_library/src/export_property_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_plugin.rs
@@ -1,0 +1,41 @@
+use rspack_core::{
+  rspack_sources::{ConcatSource, RawSource, SourceExt},
+  Plugin, PluginContext, PluginRenderStartupHookOutput, RenderStartupArgs,
+};
+
+use crate::utils::property_access;
+
+#[derive(Debug, Default)]
+pub struct ExportPropertyLibraryPlugin {}
+
+impl ExportPropertyLibraryPlugin {}
+
+impl Plugin for ExportPropertyLibraryPlugin {
+  fn name(&self) -> &'static str {
+    "ExportPropertyLibraryPlugin"
+  }
+
+  fn render_startup(
+    &self,
+    _ctx: PluginContext,
+    args: &RenderStartupArgs,
+  ) -> PluginRenderStartupHookOutput {
+    if let Some(export) = args
+      .compilation
+      .options
+      .output
+      .library
+      .as_ref()
+      .and_then(|lib| lib.export.as_ref())
+    {
+      let mut s = ConcatSource::default();
+      s.add(args.source.clone());
+      s.add(RawSource::from(format!(
+        "__webpack_exports__ = __webpack_exports__{};",
+        property_access(export)
+      )));
+      return Ok(Some(s.boxed()));
+    }
+    Ok(Some(args.source.clone()))
+  }
+}

--- a/crates/rspack_plugin_library/src/lib.rs
+++ b/crates/rspack_plugin_library/src/lib.rs
@@ -6,4 +6,6 @@ mod amd_library_plugin;
 pub use amd_library_plugin::AmdLibraryPlugin;
 mod module_library_plugin;
 pub use module_library_plugin::ModuleLibraryPlugin;
+mod export_property_plugin;
 mod utils;
+pub use export_property_plugin::ExportPropertyLibraryPlugin;

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -24,6 +24,7 @@ impl Plugin for ModuleLibraryPlugin {
     args: &RenderStartupArgs,
   ) -> PluginRenderStartupHookOutput {
     let mut source = ConcatSource::default();
+    source.add(args.source.clone());
     let mut exports = vec![];
     if let Some(ordered_exports) = args.compilation.exports_info_map.get(&args.module) {
       for info in ordered_exports {

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -9,11 +9,9 @@ use rspack_core::{
   PluginRenderChunkHookOutput, RenderChunkArgs, RenderStartupArgs, RuntimeGlobals,
 };
 use rspack_error::Result;
-use rspack_plugin_javascript::runtime::{
-  generate_chunk_entry_code, render_chunk_runtime_modules, render_runtime_modules,
-};
+use rspack_plugin_javascript::runtime::{render_chunk_runtime_modules, render_runtime_modules};
 
-use super::update_hash_for_entry_startup;
+use super::{generate_entry_startup, update_hash_for_entry_startup};
 #[derive(Debug)]
 pub struct ArrayPushCallbackChunkFormatPlugin {}
 
@@ -142,11 +140,13 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
           source.add(render_runtime_modules(args.compilation, args.chunk_ukey)?);
         }
         if has_entry {
-          source.add(generate_chunk_entry_code(args.compilation, args.chunk_ukey));
-          let last_entry_module = args
+          let entries = args
             .compilation
             .chunk_graph
-            .get_chunk_entry_modules_with_chunk_group_iterable(&chunk.ukey)
+            .get_chunk_entry_modules_with_chunk_group_iterable(args.chunk_ukey);
+          let start_up_source =
+            generate_entry_startup(args.compilation, args.chunk_ukey, entries, true);
+          let last_entry_module = entries
             .keys()
             .last()
             .expect("should have last entry module");
@@ -160,6 +160,7 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
                 compilation: args.compilation,
                 chunk: &chunk.ukey,
                 module: *last_entry_module,
+                source: start_up_source,
               })?
           {
             source.add(s);

--- a/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
+++ b/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
@@ -10,7 +10,7 @@ use crate::runtime_module::{
   GetChunkUpdateFilenameRuntimeModule, GetFullHashRuntimeModule, GetMainFilenameRuntimeModule,
   GetTrustedTypesPolicyRuntimeModule, GlobalRuntimeModule, HasOwnPropertyRuntimeModule,
   LoadChunkWithModuleRuntimeModule, LoadScriptRuntimeModule, NormalRuntimeModule,
-  PublicPathRuntimeModule,
+  OnChunkLoadedRuntimeModule, PublicPathRuntimeModule,
 };
 
 #[derive(Debug)]
@@ -130,6 +130,9 @@ impl Plugin for BasicRuntimeRequirementPlugin {
         }
         RuntimeGlobals::CREATE_SCRIPT_URL => {
           compilation.add_runtime_module(chunk, CreateScriptUrlRuntimeModule::default().boxed())
+        }
+        RuntimeGlobals::ON_CHUNKS_LOADED => {
+          compilation.add_runtime_module(chunk, OnChunkLoadedRuntimeModule::default().boxed());
         }
         RuntimeGlobals::DEFINE_PROPERTY_GETTERS => compilation
           .add_runtime_module(chunk, DefinePropertyGettersRuntimeModule::default().boxed()),

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -9,10 +9,12 @@ use rspack_core::{
   PluginRenderChunkHookOutput, RenderChunkArgs, RenderStartupArgs, RuntimeGlobals,
 };
 use rspack_error::Result;
-use rspack_plugin_javascript::runtime::{generate_chunk_entry_code, render_chunk_runtime_modules};
+use rspack_plugin_javascript::runtime::render_chunk_runtime_modules;
 
-use super::update_hash_for_entry_startup;
-use crate::get_runtime_chunk_path;
+use crate::{
+  generate_entry_startup, get_chunk_output_name, get_relative_path, get_runtime_chunk_output_name,
+  update_hash_for_entry_startup,
+};
 #[derive(Debug)]
 pub struct CommonJsChunkFormatPlugin {}
 
@@ -91,6 +93,7 @@ impl Plugin for CommonJsChunkFormatPlugin {
     args: &RenderChunkArgs,
   ) -> PluginRenderChunkHookOutput {
     let chunk = args.chunk();
+    let base_chunk_output_name = get_chunk_output_name(chunk, args.compilation);
     let mut sources = ConcatSource::default();
     sources.add(RawSource::from(format!(
       "exports.ids = ['{}'];\n",
@@ -114,20 +117,24 @@ impl Plugin for CommonJsChunkFormatPlugin {
     }
 
     if chunk.has_entry_module(&args.compilation.chunk_graph) {
+      let runtime_chunk_output_name = get_runtime_chunk_output_name(args)?;
       sources.add(RawSource::from(format!(
-        "\nvar {} = require('{}');\n",
+        "var {} = require('{}');\n",
         RuntimeGlobals::REQUIRE,
-        get_runtime_chunk_path(args)?
+        get_relative_path(&base_chunk_output_name, &runtime_chunk_output_name)
       )));
       sources.add(RawSource::from(format!(
-        "\n{}(exports)\n",
+        "{}(exports)\n",
         RuntimeGlobals::EXTERNAL_INSTALL_CHUNK,
       )));
-      sources.add(generate_chunk_entry_code(args.compilation, args.chunk_ukey));
-      let last_entry_module = args
+
+      let entries = args
         .compilation
         .chunk_graph
-        .get_chunk_entry_modules_with_chunk_group_iterable(&chunk.ukey)
+        .get_chunk_entry_modules_with_chunk_group_iterable(args.chunk_ukey);
+      let start_up_source =
+        generate_entry_startup(args.compilation, args.chunk_ukey, entries, false);
+      let last_entry_module = entries
         .keys()
         .last()
         .expect("should have last entry module");
@@ -141,6 +148,7 @@ impl Plugin for CommonJsChunkFormatPlugin {
             compilation: args.compilation,
             chunk: &chunk.ukey,
             module: *last_entry_module,
+            source: start_up_source,
           })?
       {
         sources.add(s);

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -8,7 +8,7 @@ use rspack_core::{
 use rspack_error::Result;
 use runtime_module::AsyncRuntimeModule;
 
-use crate::runtime_module::{EnsureChunkRuntimeModule, OnChunkLoadedRuntimeModule};
+use crate::runtime_module::EnsureChunkRuntimeModule;
 mod helpers;
 pub use helpers::*;
 mod lazy_compilation;
@@ -78,10 +78,6 @@ impl Plugin for RuntimePlugin {
 
     if runtime_requirements.contains(RuntimeGlobals::ASYNC_MODULE) {
       compilation.add_runtime_module(chunk, AsyncRuntimeModule::default().boxed());
-    }
-
-    if runtime_requirements.contains(RuntimeGlobals::ON_CHUNKS_LOADED) {
-      compilation.add_runtime_module(chunk, OnChunkLoadedRuntimeModule::default().boxed());
     }
 
     Ok(())

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -10,9 +10,12 @@ use rspack_core::{
 };
 use rspack_error::{internal_error, Result};
 use rspack_plugin_javascript::runtime::render_chunk_runtime_modules;
+use rustc_hash::FxHashSet as HashSet;
 
 use super::update_hash_for_entry_startup;
-use crate::get_runtime_chunk_path;
+use crate::{
+  get_all_chunks, get_chunk_output_name, get_relative_path, get_runtime_chunk_output_name,
+};
 #[derive(Debug)]
 pub struct ModuleChunkFormatPlugin {}
 
@@ -91,8 +94,9 @@ impl Plugin for ModuleChunkFormatPlugin {
     _ctx: PluginContext,
     args: &RenderChunkArgs,
   ) -> PluginRenderChunkHookOutput {
+    let compilation = args.compilation;
     let chunk = args.chunk();
-
+    let base_chunk_output_name = get_chunk_output_name(chunk, compilation);
     if matches!(chunk.kind, ChunkKind::HotUpdate) {
       return Err(internal_error!(
         "HMR is not implemented for module chunk format yet"
@@ -108,54 +112,97 @@ impl Plugin for ModuleChunkFormatPlugin {
     sources.add(args.module_source.clone());
     sources.add(RawSource::from(";\n"));
 
-    if !args
-      .compilation
+    if !compilation
       .chunk_graph
       .get_chunk_runtime_modules_in_order(args.chunk_ukey)
       .is_empty()
     {
       sources.add(RawSource::from("export const runtime = "));
-      sources.add(render_chunk_runtime_modules(
-        args.compilation,
-        args.chunk_ukey,
-      )?);
+      sources.add(render_chunk_runtime_modules(compilation, args.chunk_ukey)?);
       sources.add(RawSource::from(";\n"));
     }
 
-    let has_entry = chunk.has_entry_module(&args.compilation.chunk_graph);
-    if has_entry {
+    if chunk.has_entry_module(&compilation.chunk_graph) {
+      let runtime_chunk_output_name = get_runtime_chunk_output_name(args)?;
       sources.add(RawSource::from(format!(
         "import __webpack_require__ from '{}';\n",
-        get_runtime_chunk_path(args)?
+        get_relative_path(&base_chunk_output_name, &runtime_chunk_output_name)
       )));
 
-      //   let mut startup_source = ConcatSource::default();
-
-      //   startup_source.add(RawSource::from(
-      //     r#"
-      //   var __webpack_exec__ = function(moduleId) {
-      //     __webpack_require__(__webpack_require__.s = moduleId);
-      //   }
-      //   "#,
-      //   ));
-      let last_entry_module = args
-        .compilation
+      let entries = compilation
         .chunk_graph
-        .get_chunk_entry_modules_with_chunk_group_iterable(&chunk.ukey)
+        .get_chunk_entry_modules_with_chunk_group_iterable(args.chunk_ukey);
+
+      let mut startup_source = vec![];
+
+      startup_source.push(format!(
+        "var __webpack_exec__ = function(moduleId) {{ return __webpack_require__({} = moduleId); }}",
+        RuntimeGlobals::ENTRY_MODULE_ID
+      ));
+
+      let mut loaded_chunks = HashSet::default();
+      for (i, (module, entry)) in entries.iter().enumerate() {
+        let module_id = compilation
+          .module_graph
+          .module_graph_module_by_identifier(module)
+          .map(|module| module.id(&compilation.chunk_graph))
+          .expect("should have module id");
+        let runtime_chunk = compilation
+          .chunk_group_by_ukey
+          .get(entry)
+          .map(|e| e.get_runtime_chunk())
+          .expect("should have runtime chunk");
+        let chunks = get_all_chunks(
+          entry,
+          &runtime_chunk,
+          None,
+          &compilation.chunk_group_by_ukey,
+        );
+
+        for chunk_ukey in chunks.iter() {
+          if loaded_chunks.contains(chunk_ukey) {
+            continue;
+          }
+          loaded_chunks.insert(*chunk_ukey);
+          let index = loaded_chunks.len();
+          let chunk = compilation
+            .chunk_by_ukey
+            .get(chunk_ukey)
+            .expect("chunk should exist in chunk_by_ukey");
+          let other_chunk_output_name = get_chunk_output_name(chunk, compilation);
+          startup_source.push(format!(
+            "import * as __webpack_chunk_${index}__ from '{}';",
+            get_relative_path(&base_chunk_output_name, &other_chunk_output_name)
+          ));
+          startup_source.push(format!(
+            "{}(__webpack_chunk_${index}__);",
+            RuntimeGlobals::EXTERNAL_INSTALL_CHUNK
+          ));
+        }
+        startup_source.push(format!(
+          "{}__webpack_exec__('{module_id}');",
+          if i + 1 == entries.len() {
+            "var __webpack_exports__ = "
+          } else {
+            ""
+          }
+        ));
+      }
+
+      let last_entry_module = entries
         .keys()
         .last()
         .expect("should have last entry module");
-      if let Some(s) =
-        args
-          .compilation
-          .plugin_driver
-          .read()
-          .await
-          .render_startup(RenderStartupArgs {
-            compilation: args.compilation,
-            chunk: &chunk.ukey,
-            module: *last_entry_module,
-          })?
+      if let Some(s) = compilation
+        .plugin_driver
+        .read()
+        .await
+        .render_startup(RenderStartupArgs {
+          compilation,
+          chunk: &chunk.ukey,
+          module: *last_entry_module,
+          source: RawSource::from(startup_source.join("\n")).boxed(),
+        })?
       {
         sources.add(s);
       }

--- a/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
@@ -4,10 +4,11 @@ use rspack_core::{
   RUNTIME_MODULE_STAGE_ATTACH,
 };
 use rspack_identifier::Identifier;
+use rspack_plugin_javascript::runtime::stringify_chunks_to_array;
 use rustc_hash::FxHashSet as HashSet;
 
-use super::utils::{stringify_chunks, stringify_chunks_to_array};
 use crate::impl_runtime_module;
+use crate::runtime_module::stringify_chunks;
 #[derive(Debug, Default, Eq)]
 pub struct CssLoadingRuntimeModule {
   id: Identifier,

--- a/crates/rspack_plugin_runtime/src/runtime_module/export_webpack_require.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/export_webpack_require.rs
@@ -27,6 +27,10 @@ impl RuntimeModule for ExportWebpackRequireRuntimeModule {
   fn generate(&self, _compilation: &Compilation) -> BoxSource {
     RawSource::from("export default __webpack_require__;").boxed()
   }
+
+  fn should_isolate(&self) -> bool {
+    true
+  }
 }
 
 impl_runtime_module!(ExportWebpackRequireRuntimeModule);

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -59,6 +59,9 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
     let with_loading = self
       .runtime_requirements
       .contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+    let with_on_chunk_load = self
+      .runtime_requirements
+      .contains(RuntimeGlobals::ON_CHUNKS_LOADED);
 
     if with_loading {
       source.add(RawSource::from(
@@ -90,10 +93,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       )));
     }
 
-    if self
-      .runtime_requirements
-      .contains(RuntimeGlobals::ON_CHUNKS_LOADED)
-    {
+    if with_on_chunk_load {
       source.add(RawSource::from(include_str!(
         "runtime/jsonp_chunk_loading_with_on_chunk_load.js"
       )));
@@ -110,7 +110,14 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
       );
       source.add(RawSource::from(
         include_str!("runtime/jsonp_chunk_loading_with_callback.js")
-          .replace("$CHUNK_LOADING_GLOBAL_EXPR$", &chunk_loading_global_expr),
+          .replace("$CHUNK_LOADING_GLOBAL_EXPR$", &chunk_loading_global_expr)
+          .replace(
+            "$withOnChunkLoad$",
+            match with_on_chunk_load {
+              true => "return __webpack_require__.O(result);",
+              false => "",
+            },
+          ),
       ));
     }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_chunk_with_module.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_chunk_with_module.rs
@@ -5,10 +5,10 @@ use rspack_core::{
   Compilation, RuntimeModule,
 };
 use rspack_identifier::Identifier;
+use rspack_plugin_javascript::runtime::stringify_array;
 use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
-use super::utils::stringify_array;
 use crate::impl_runtime_module;
 
 #[derive(Debug, Eq)]

--- a/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
@@ -41,6 +41,7 @@ pub use module_chunk_loading::ModuleChunkLoadingRuntimeModule;
 pub use on_chunk_loaded::OnChunkLoadedRuntimeModule;
 pub use public_path::PublicPathRuntimeModule;
 pub use require_js_chunk_loading::RequireChunkLoadingRuntimeModule;
+pub use utils::*;
 mod create_script_url;
 mod get_trusted_types_policy;
 mod module_macro;

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -109,8 +109,8 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
     if with_on_chunk_load {
       source.add(RawSource::from(format!(
-        r#"{} = function(chunkId) {{
-            installedChunks[chunkId] === 0;
+        r#"{}.j = function(chunkId) {{
+            return installedChunks[chunkId] === 0;
         }}"#,
         RuntimeGlobals::ON_CHUNKS_LOADED
       )));

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -75,11 +75,20 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
     let with_loading = self
       .runtime_requirements
       .contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
+    let with_on_chunk_load = self
+      .runtime_requirements
+      .contains(RuntimeGlobals::ON_CHUNKS_LOADED);
 
     if with_loading || with_external_install_chunk {
-      source.add(RawSource::from(include_str!(
-        "runtime/require_chunk_loading.js"
-      )));
+      source.add(RawSource::from(
+        include_str!("runtime/require_chunk_loading.js").replace(
+          "$withOnChunkLoad$",
+          match with_on_chunk_load {
+            true => "__webpack_require__.O();",
+            false => "",
+          },
+        ),
+      ));
     }
 
     if with_loading {
@@ -109,10 +118,7 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
       )));
     }
 
-    if self
-      .runtime_requirements
-      .contains(RuntimeGlobals::ON_CHUNKS_LOADED)
-    {
+    if with_on_chunk_load {
       source.add(RawSource::from(include_str!(
         "runtime/require_chunk_loading_with_on_chunk_load.js"
       )));

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading.js
@@ -1,7 +1,7 @@
 var uniqueName = "webpack";
 // loadCssChunkData is unnecessary
 var loadingAttribute = "data-webpack-loading";
-var loadStylesheet = (chunkId, url, done, hmr) => {
+var loadStylesheet = function(chunkId, url, done, hmr) {
 	var link,
 		needAttach,
 		key = "chunk-" + chunkId;
@@ -37,7 +37,7 @@ var loadStylesheet = (chunkId, url, done, hmr) => {
 			link.crossOrigin = __CROSS_ORIGIN_LOADING_PLACEHOLDER__;
 		}
 	}
-	var onLinkComplete = (prev, event) => {
+	var onLinkComplete = function (prev, event) {
 		link.onerror = link.onload = null;
 		link.removeAttribute(loadingAttribute);
 		clearTimeout(timeout);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_callback.js
@@ -1,12 +1,14 @@
 // install a JSONP callback for chunk loading
 var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
-	var [chunkIds, moreModules, runtime] = data;
+	var chunkIds = data[0],
+	moreModules = data[1],
+	runtime = data[2];
 	// add "moreModules" to the modules object,
 	// then flag all "chunkIds" as loaded and fire callback
 	var moduleId,
 		chunkId,
 		i = 0;
-	if (chunkIds.some(id => installedChunks[id] !== 0)) {
+	if (chunkIds.some(function(id) { return installedChunks[id] !== 0 })) {
 		for (moduleId in moreModules) {
 			if (__webpack_require__.o(moreModules, moduleId)) {
 				__webpack_require__.m[moduleId] = moreModules[moduleId];
@@ -25,7 +27,7 @@ var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
 		}
 		installedChunks[chunkId] = 0;
 	}
-	return __webpack_require__.O(result);
+	$withOnChunkLoad$
 };
 
 var chunkLoadingGlobal = $CHUNK_LOADING_GLOBAL_EXPR$ = $CHUNK_LOADING_GLOBAL_EXPR$ || [];

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_on_chunk_load.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/jsonp_chunk_loading_with_on_chunk_load.js
@@ -1,3 +1,3 @@
 __webpack_require__.O.j = function (chunkId) {
-	installedChunks[chunkId] === 0;
+	return installedChunks[chunkId] === 0;
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/on_chunk_loaded.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/on_chunk_loaded.js
@@ -9,13 +9,15 @@ __webpack_require__.O = function (result, chunkIds, fn, priority) {
 	}
 	var notFulfilled = Infinity;
 	for (var i = 0; i < deferred.length; i++) {
-		var [chunkIds, fn, priority] = deferred[i];
+		var chunkIds = deferred[i][0],
+			fn = deferred[i][1],
+			priority = deferred[i][2];
 		var fulfilled = true;
 		for (var j = 0; j < chunkIds.length; j++) {
 			if (
 				(priority & (1 === 0) || notFulfilled >= priority) &&
 				Object.keys(__webpack_require__.O).every(function (key) {
-					__webpack_require__.O[key](chunkIds[j]);
+					return __webpack_require__.O[key](chunkIds[j]);
 				})
 			) {
 				chunkIds.splice(j--, 1);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/require_chunk_loading.js
@@ -12,4 +12,5 @@ var installChunk = function (chunk) {
 	}
 	if (runtime) runtime(__webpack_require__);
 	for (var i = 0; i < chunkIds.length; i++) installedChunks[chunkIds[i]] = 1;
+	$withOnChunkLoad$
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -63,27 +63,6 @@ pub fn stringify_chunks(chunks: &HashSet<String>, value: u8) -> String {
   )
 }
 
-pub fn stringify_chunks_to_array(chunks: &HashSet<String>) -> String {
-  let mut v = Vec::from_iter(chunks.iter());
-  v.sort_unstable();
-
-  format!(
-    r#"[{}]"#,
-    v.iter().fold(String::new(), |prev, cur| {
-      prev + format!(r#""{cur}","#).as_str()
-    })
-  )
-}
-
-pub fn stringify_array(vec: &[String]) -> String {
-  format!(
-    r#"[{}]"#,
-    vec.iter().fold(String::new(), |prev, cur| {
-      prev + format!(r#""{cur}","#).as_str()
-    })
-  )
-}
-
 pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
   if compilation
     .chunk_graph

--- a/crates/rspack_plugin_wasm/tests/fixtures/imports-multiple/expected/main.js
+++ b/crates/rspack_plugin_wasm/tests/fixtures/imports-multiple/expected/main.js
@@ -8,7 +8,8 @@
 },
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/crates/rspack_plugin_wasm/tests/fixtures/v128/expected/main.js
+++ b/crates/rspack_plugin_wasm/tests/fixtures/v128/expected/main.js
@@ -22,7 +22,8 @@ __webpack_require__.a(module, async function(__webpack_handle_async_dependencies
  module.exports = __webpack_require__.v(exports, module.id, "c61e7cc882ba31f8.module.wasm" );},
 
 },function(__webpack_require__) {
-var __webpack_exports__ = __webpack_require__('./index.js');
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
 
 }
 ]);

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`HashTestCases should print correct hash for package-path-change-0 1`] = `
 [
-  "runtime.36f773380322b3ba.js",
+  "runtime.42fc7bbb9c153e4d.js",
   "main.8ba66a6d562c9f41.js",
   "0.a419356ce1e112c6.js",
 ]
@@ -10,7 +10,7 @@ exports[`HashTestCases should print correct hash for package-path-change-0 1`] =
 
 exports[`HashTestCases should print correct hash for package-path-change-1 1`] = `
 [
-  "runtime.fa0be6df1472e68e.js",
+  "runtime.bb99b9f3a0c9d960.js",
   "main.b11af1dbcee032b1.js",
   "0.b681063969d05f1f.js",
 ]

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -146,7 +146,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
-  "hash": "7ab36b938110f17f",
+  "hash": "d4397e08714d855a",
   "modules": [
     {
       "assets": [],
@@ -222,7 +222,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for filename 2`] = `
-"Hash: 7ab36b938110f17f
+"Hash: d4397e08714d855a
              Asset       Size      Chunks             Chunk Names
       main.xxxx.js   1.39 KiB        main  [emitted]  main
 dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]  
@@ -612,14 +612,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 288,
+          "size": 392,
         },
         {
           "name": "e1~runtime.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1872,
+      "assetsSize": 1978,
       "chunks": [
         "e1",
         "e1~runtime",
@@ -630,14 +630,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 288,
+          "size": 392,
         },
         {
           "name": "e2~runtime.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1872,
+      "assetsSize": 1978,
       "chunks": [
         "e2",
         "e2~runtime",
@@ -651,14 +651,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 288,
+          "size": 392,
         },
         {
           "name": "e1~runtime.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1872,
+      "assetsSize": 1978,
       "chunks": [
         "e1",
         "e1~runtime",
@@ -669,14 +669,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 288,
+          "size": 392,
         },
         {
           "name": "e2~runtime.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1872,
+      "assetsSize": 1978,
       "chunks": [
         "e2",
         "e2~runtime",
@@ -757,14 +757,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e1.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -775,14 +775,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e2.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e2",
         "runtime~e2",
@@ -796,14 +796,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e1.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -814,14 +814,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e2.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e2",
         "runtime~e2",
@@ -889,14 +889,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 285,
+          "size": 389,
         },
         {
           "name": "runtime.js",
-          "size": 1581,
+          "size": 1583,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e1",
         "runtime",
@@ -907,14 +907,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 285,
+          "size": 389,
         },
         {
           "name": "runtime.js",
-          "size": 1581,
+          "size": 1583,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e2",
         "runtime",
@@ -928,14 +928,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 285,
+          "size": 389,
         },
         {
           "name": "runtime.js",
-          "size": 1581,
+          "size": 1583,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e1",
         "runtime",
@@ -946,14 +946,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 285,
+          "size": 389,
         },
         {
           "name": "runtime.js",
-          "size": 1581,
+          "size": 1583,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e2",
         "runtime",
@@ -1033,14 +1033,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e1.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -1051,14 +1051,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e2.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e2",
         "runtime~e2",
@@ -1072,14 +1072,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e1.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e1.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -1090,14 +1090,14 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
       "assets": [
         {
           "name": "e2.js",
-          "size": 282,
+          "size": 386,
         },
         {
           "name": "runtime~e2.js",
-          "size": 1584,
+          "size": 1586,
         },
       ],
-      "assetsSize": 1866,
+      "assetsSize": 1972,
       "chunks": [
         "e2",
         "runtime~e2",

--- a/packages/rspack/tests/configCases/output-module/single-runtime/chunk.js
+++ b/packages/rspack/tests/configCases/output-module/single-runtime/chunk.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack/tests/configCases/output-module/single-runtime/index.js
+++ b/packages/rspack/tests/configCases/output-module/single-runtime/index.js
@@ -1,0 +1,15 @@
+it("should execute as module", () => {
+	expect(
+		(function () {
+			return !this;
+		})()
+	).toBe(true);
+});
+
+it("should be able to load a chunk", async () => {
+	const module = await import("./chunk");
+	expect(module.default).toBe(42);
+});
+
+export const value = 1;
+export default 2;

--- a/packages/rspack/tests/configCases/output-module/single-runtime/webpack.config.js
+++ b/packages/rspack/tests/configCases/output-module/single-runtime/webpack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("../../../../dist").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js",
+		chunkFormat: "module",
+		chunkLoading: "import",
+		library: {
+			type: "module"
+		}
+	},
+	experiments: {
+		outputModule: true
+	},
+	optimization: {
+		runtimeChunk: true
+	}
+	// target: "node14"
+};

--- a/packages/rspack/tests/copyPlugin/build/main.js
+++ b/packages/rspack/tests/copyPlugin/build/main.js
@@ -23,5 +23,4 @@ function __webpack_require__(moduleId) {
 
 }
 var __webpack_exports__ = __webpack_require__('../helpers/enter.js');
-
 })();


### PR DESCRIPTION
## Related issue (if exists)

close https://github.com/web-infra-dev/rspack/issues/2775

<!--- Provide link of related issues -->

## Summary

- fix async script chunk loading, avoid loading module error
- fix chunk loaded runtime inject
- fix some runtime to es5

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d86865c</samp>

This pull request adds a new library plugin for exporting properties, improves the code generation and performance of the JavaScript and runtime plugins, and fixes the async script chunk loading issue. It also refactors some code, updates some imports, and adds a changeset file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d86865c</samp>

*  Add a new plugin for assigning the exports to a property of the global object (F8, [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-61cb590fb997493768811d139d6ee24b8f2977e7890beb02b4b679fb15a0c0efL9-R11))
*  Modify the `render_bootstrap` function in the `rspack_binding_options` crate to include the new plugin for the `umd`, `umd2`, `amd`, and `amd-require` library types ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ef5856a7fec8410383d58cc835932b263f5df692fd8d31fb1ea236182a162b00L370-R374), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ef5856a7fec8410383d58cc835932b263f5df692fd8d31fb1ea236182a162b00R380))
*  Add a new field, `source`, to the `RenderStartupArgs` struct in the `rspack_core` crate to pass the startup code generated by the previous plugins to the next plugins ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337R218), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL250-R262), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL209-R291), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-642bde562c4bac7d3a7e5f2a4036a9e7deac1c97428d86cdf4be20a2edad82adR167), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-cf0b5d37badeb43c872afa010841db383fe16a3ece6adc5462f371e8c237d907R151), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-4af6c3c9405524865903fa3308ef47dcde8e02e128b709df74433c29314ceb7bL118-R207))
*  Modify the `render_startup` function in the `plugin_driver.rs` file in the `rspack_core` crate to clone and pass the source code to each plugin and return the final source code ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL250-R262))
*  Add a new constant, `ENTRY_MODULE_ID`, to the `runtime_globals.rs` file in the `rspack_core` crate to store the module id of the entry module of a chunk ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-60776fe28d9b433ffea49e92438c2268de013c7ee653aa70ea05d910b9733187R199-R200))
*  Modify the `get_runtime_global` function in the `runtime_globals.rs` file in the `rspack_core` crate to handle the case of the `ENTRY_MODULE_ID` constant and return the corresponding code ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-60776fe28d9b433ffea49e92438c2268de013c7ee653aa70ea05d910b9733187R266))
*  Remove the `generate_chunk_entry_code` function from the `runtime.rs` file in the `rspack_plugin_javascript` crate, as it is replaced by the `generate_entry_startup` function in the `helpers.rs` file in the `rspack_plugin_runtime` crate ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-805767c722570267c13719882d913768d72e72229fe68ed197baf1daed8ae8b4L122-L146))
*  Split the `render_bootstrap` function in the `plugin.rs` file in the `rspack_plugin_javascript` crate into two parts, one that returns the header code and one that returns the startup code, and add a parameter, `chunk_ukey`, to the function ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL134-R164), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL283-R364))
*  Move the code for exposing the module execution interceptor to the header part of the `render_bootstrap` function in the `plugin.rs` file in the `rspack_plugin_javascript` crate, and add a condition to check if the `INTERCEPT_MODULE_EXECUTION` runtime requirement is present ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL160-R250))
*  Replace the call to the `generate_chunk_entry_code` function with a call to the `generate_entry_startup` function in the `render_chunk` function in the `plugin.rs` file in the `rspack_plugin_javascript` crate, and pass the startup code to the `render_startup` hook of the plugins ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL182-R268))
*  Add a condition to check if the `RETURN_EXPORTS_FROM_RUNTIME` runtime requirement is present in the `render_chunk` function in the `plugin.rs` file in the `rspack_plugin_javascript` crate, and move the code for returning the exports to the end of the function ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL209-R291))
*  Append the source code passed by the `RenderStartupArgs` struct to the output source in the `render_startup` function in the `assign_library_plugin.rs` and `module_library_plugin.rs` files in the `rspack_plugin_library` crate, so that the plugins can preserve the startup code generated by the previous plugins ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-979eac2d1174f1315fb43b75c93c8613baa58826742117730314ac01e9265f05R88), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-32658f3059223914bd10474ae269827489a13ca9c2f616e7597579f6b2041a8fR27))
*  Add the `OnChunkLoadedRuntimeModule` to the chunk if the `ON_CHUNKS_LOADED` runtime requirement is present in the `apply` function in the `basic_runtime_requirements.rs` file in the `rspack_plugin_runtime` crate ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-d1b082bd82f12dd11e47ebcf2e07ff8be00089f0bb5ce4b4ea7b0cf63496f0e0R134-R136))
*  Remove the block of code that adds the `OnChunkLoadedRuntimeModule` to the chunk from the `apply` function in the `lib.rs` file in the `rspack_plugin_runtime` crate, as it is handled by the `basic_runtime_requirements.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-192d01e2b37c4e7aef90ad97b7d98b5dad3f73d59837cf71f355d386d4d1d94eL83-L86))
*  Replace the call to the `get_runtime_chunk_path` function with a call to the `get_relative_path` function in the `render_chunk` function in the `common_js_chunk_format.rs` and `module_chunk_format.rs` files in the `rspack_plugin_runtime` crate, and add a new variable, `base_chunk_output_name`, to store the output name of the base chunk ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-cf0b5d37badeb43c872afa010841db383fe16a3ece6adc5462f371e8c237d907R96),  [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-4af6c3c9405524865903fa3308ef47dcde8e02e128b709df74433c29314ceb7bL94-R99), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-4af6c3c9405524865903fa3308ef47dcde8e02e128b709df74433c29314ceb7bL111-R115))
*  Rename the `get_runtime_chunk_path` function to `get_runtime_chunk_output_name` in the `helpers.rs` file in the `rspack_plugin_runtime` crate, and remove the `./` prefix from the output name ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-a61e18763b891db9fcd4659a22e1fabe30c87898e6c482ff9750883498f9b0caL96-R104))
*  Replace the call to the `render` method of the `chunk_filename` field of the output options with a call to the `get_chunk_output_name` function in the `get_runtime_chunk_output_name` function in the `helpers.rs` file in the `rspack_plugin_runtime` crate, and add the `get_chunk_output_name` function to the same file ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-a61e18763b891db9fcd4659a22e1fabe30c87898e6c482ff9750883498f9b0caL115-R250))
*  Change the type of the `exclude_chunk2` parameter from a reference to a `ChunkUkey` to an option of a reference to a `ChunkUkey` in the `get_all_chunks` function in the `helpers.rs` file in the `rspack_plugin_runtime` crate, and add a condition to check if the parameter is `Some` ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-a61e18763b891db9fcd4659a22e1fabe30c87898e6c482ff9750883498f9b0caL35-R38), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-a61e18763b891db9fcd4659a22e1fabe30c87898e6c482ff9750883498f9b0caL49-R52), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-a61e18763b891db9fcd4659a22e1fabe30c87898e6c482ff9750883498f9b0caL57-R71))
*  Move the `stringify_chunks_to_array` and `stringify_array` functions from the `utils.rs` file in the `rspack_plugin_runtime` crate to the `runtime.rs` file in the `rspack_plugin_javascript` crate, as they are more related to the JavaScript plugin than the runtime plugin ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-805767c722570267c13719882d913768d72e72229fe68ed197baf1daed8ae8b4R201-R221), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-a61e18763b891db9fcd4659a22e1fabe30c87898e6c482ff9750883498f9b0caL115-R250), [link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-91ea24cc6394b20e0af5920d78af923adede77760f1927826b3d8f97c260e3f4L7-R11))
*  Move the `stringify_chunks` function from the `utils.rs` file in the `rspack_plugin_runtime` crate to the `mod.rs` file in the same crate, as it is more related to the runtime plugin than the JavaScript plugin ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-91ea24cc6394b20e0af5920d78af923adede77760f1927826b3d8f97c260e3f4L7-R11))
*  Add a markdown file to the `.changeset` folder, which is used by the `changesets` tool to generate changelogs and version bumps for the packages in the repository ([link](https://github.com/web-infra-dev/rspack/pull/2966/files?diff=unified&w=0#diff-899dec93368ea9ff4ec95d8e8f45098e1e2ecc314f639b17a63db61649947dd5R1-R5))

</details>
