### PR TITLE
refactor(rust): add more restriction clippy rules

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,9 +6,23 @@ CARGO_WORKSPACE_DIR = { value = "", relative = true }
 lint = "clippy --workspace --all-targets -- --deny warnings"
 # AKA `test-update`, handy cargo rst update without install `cargo-rst` binary
 tu = "run -p cargo-rst -- update"
+
 [target.'cfg(all())']
 rustflags = [
-  "-Dclippy::unwrap_in_result", # https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_in_result
+  # CLIPPY LINT SETTINGS
+  # This is a workaround to configure lints for the entire workspace, pending the ability to configure this via TOML.
+  # See: `https://github.com/rust-lang/cargo/issues/5034`
+  #      `https://github.com/EmbarkStudios/rust-ecosystem/issues/22#issuecomment-947011395`
+  "-Wclippy::all", # all lints that are on by default (correctness, suspicious, style, complexity, perf)
+
+  # restriction
   "-Wclippy::dbg_macro",
-  "-Wclippy::unwrap_used",      # https://rust-lang.github.io/rust-clippy/master/#unwrap_used
+  "-Wclippy::unwrap_in_result",
+  "-Wclippy::unwrap_used",
+  "-Wclippy::empty_drop",
+  "-Wclippy::exit",
+  "-Wclippy::empty_structs_with_brackets",
+  "-Wclippy::rc_buffer",
+  "-Wclippy::rc_mutex",
+  "-Wclippy::same_name_method",
 ]

--- a/crates/cargo-rst/src/record.rs
+++ b/crates/cargo-rst/src/record.rs
@@ -47,10 +47,10 @@ impl Record {
 
     p.push(record_path);
 
-    fs::write(p, self.serialize()).expect("TODO:");
+    fs::write(p, self.to_json()).expect("TODO:");
   }
 
-  pub fn serialize(&self) -> String {
+  pub fn to_json(&self) -> String {
     serde_json::to_string_pretty(self).expect("TODO:")
   }
 }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -174,6 +174,7 @@ impl Rspack {
     Ok(Self { id, disabled_hooks })
   }
 
+  #[allow(clippy::unwrap_in_result, clippy::unwrap_used)]
   #[napi(
     catch_unwind,
     js_name = "unsafe_set_disabled_hooks",

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -443,6 +443,7 @@ impl JsHooksAdapter {
     })
   }
 
+  #[allow(clippy::unwrap_used)]
   fn is_hook_disabled(&self, hook: &Hook) -> bool {
     self.disabled_hooks.read().unwrap().contains(hook)
   }

--- a/crates/rspack_error/src/emitter.rs
+++ b/crates/rspack_error/src/emitter.rs
@@ -34,7 +34,7 @@ pub trait DiagnosticDisplay {
 }
 
 #[derive(Default)]
-pub struct StdioDiagnosticDisplay {}
+pub struct StdioDiagnosticDisplay;
 
 impl DiagnosticDisplay for StdioDiagnosticDisplay {
   type Output = crate::Result<()>;

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -7,7 +7,7 @@ use crate::id_helpers::{
 };
 
 #[derive(Debug, Default)]
-pub struct DeterministicModuleIdsPlugin {}
+pub struct DeterministicModuleIdsPlugin;
 
 impl Plugin for DeterministicModuleIdsPlugin {
   fn module_ids(&mut self, compilation: &mut Compilation) -> Result<()> {

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -7,7 +7,7 @@ use crate::id_helpers::{
 };
 
 #[derive(Debug, Default)]
-pub struct NamedModuleIdsPlugin {}
+pub struct NamedModuleIdsPlugin;
 
 impl Plugin for NamedModuleIdsPlugin {
   fn name(&self) -> &'static str {

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -317,7 +317,7 @@ pub(crate) mod test {
     }
   }
 
-  pub(crate) struct Custom {}
+  pub(crate) struct Custom;
 
   #[async_trait::async_trait]
   impl Loader<()> for Custom {
@@ -335,7 +335,7 @@ pub(crate) mod test {
     }
   }
 
-  pub(crate) struct Custom2 {}
+  pub(crate) struct Custom2;
 
   #[async_trait::async_trait]
   impl Loader<()> for Custom2 {
@@ -353,7 +353,7 @@ pub(crate) mod test {
     }
   }
 
-  pub(crate) struct Composed {}
+  pub(crate) struct Composed;
 
   #[async_trait::async_trait]
   impl Loader<()> for Composed {
@@ -371,7 +371,7 @@ pub(crate) mod test {
     }
   }
 
-  pub(crate) struct Builtin {}
+  pub(crate) struct Builtin;
 
   #[async_trait::async_trait]
   impl Loader<()> for Builtin {
@@ -391,8 +391,8 @@ pub(crate) mod test {
 
   #[test]
   fn should_extract_and_compose_loader_info_correctly() {
-    let c1 = Arc::new(Custom {}) as Arc<dyn Loader<()>>;
-    let c2 = Arc::new(Custom2 {}) as Arc<dyn Loader<()>>;
+    let c1 = Arc::new(Custom) as Arc<dyn Loader<()>>;
+    let c2 = Arc::new(Custom2) as Arc<dyn Loader<()>>;
     let l: Vec<LoaderItem<()>> = vec![c1.into(), c2.into()];
     let item = l[0].data.try_as_normal().unwrap();
     assert_eq!(item.path, "/rspack/custom-loader-1/index.js".into());
@@ -407,7 +407,7 @@ pub(crate) mod test {
 
   #[test]
   fn should_extract_composed_loader_correctly() {
-    let c1 = Arc::new(Composed {}) as Arc<dyn Loader<()>>;
+    let c1 = Arc::new(Composed) as Arc<dyn Loader<()>>;
     let ident = c1.identifier();
     let l: LoaderItem<()> = c1.into();
     let items = l.data.try_as_composed().unwrap();
@@ -427,13 +427,13 @@ pub(crate) mod test {
 
   #[test]
   fn should_handle_builtin_loader_correctly() {
-    let c1 = Arc::new(Builtin {}) as Arc<dyn Loader<()>>;
+    let c1 = Arc::new(Builtin) as Arc<dyn Loader<()>>;
     let ident1 = c1.identifier();
     let l: LoaderItem<()> = c1.into();
     let item = l.data.try_as_normal().unwrap();
     assert!(item.meta.contains(LoaderItemDataMeta::BUILTIN));
 
-    let c2 = Arc::new(Composed {}) as Arc<dyn Loader<()>>;
+    let c2 = Arc::new(Composed) as Arc<dyn Loader<()>>;
     let ident2 = c2.identifier();
     let l = vec![l, c2.into()];
     let ll = LoaderItemList(&l[..]);

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -304,7 +304,7 @@ mod test {
     DisplayWithSuffix,
   };
 
-  struct TestContentPlugin {}
+  struct TestContentPlugin;
 
   #[async_trait::async_trait]
   impl LoaderRunnerPlugin for TestContentPlugin {
@@ -323,7 +323,7 @@ mod test {
       static IDENTS: RefCell<Vec<String>> = RefCell::default();
     }
 
-    struct Pitching {}
+    struct Pitching;
 
     impl Identifiable for Pitching {
       fn identifier(&self) -> Identifier {
@@ -350,13 +350,13 @@ mod test {
         Ok(())
       }
     }
-    let c1 = Arc::new(Custom {}) as Arc<dyn Loader<()>>;
+    let c1 = Arc::new(Custom) as Arc<dyn Loader<()>>;
     let i1 = c1.identifier();
-    let c2 = Arc::new(Custom2 {}) as Arc<dyn Loader<()>>;
+    let c2 = Arc::new(Custom2) as Arc<dyn Loader<()>>;
     let i2 = c2.identifier();
-    let c3 = Arc::new(Composed {}) as Arc<dyn Loader<()>>;
+    let c3 = Arc::new(Composed) as Arc<dyn Loader<()>>;
     let i3 = c3.identifier();
-    let p1 = Arc::new(Pitching {}) as Arc<dyn Loader<()>>;
+    let p1 = Arc::new(Pitching) as Arc<dyn Loader<()>>;
     let i0 = p1.identifier();
 
     let rs = ResourceData {
@@ -367,14 +367,9 @@ mod test {
       resource_path: Default::default(),
     };
 
-    run_loaders(
-      &[c1, p1, c2, c3],
-      &rs,
-      &[Box::new(TestContentPlugin {})],
-      (),
-    )
-    .await
-    .unwrap();
+    run_loaders(&[c1, p1, c2, c3], &rs, &[Box::new(TestContentPlugin)], ())
+      .await
+      .unwrap();
 
     IDENTS.with(|i| {
       let i = i.borrow();
@@ -398,7 +393,7 @@ mod test {
       static IDENTS: RefCell<Vec<String>> = RefCell::default();
     }
 
-    struct Pitching {}
+    struct Pitching;
 
     impl Identifiable for Pitching {
       fn identifier(&self) -> Identifier {
@@ -414,7 +409,7 @@ mod test {
       }
     }
 
-    struct Pitching2 {}
+    struct Pitching2;
 
     impl Identifiable for Pitching2 {
       fn identifier(&self) -> Identifier {
@@ -430,7 +425,7 @@ mod test {
       }
     }
 
-    struct Normal {}
+    struct Normal;
 
     impl Identifiable for Normal {
       fn identifier(&self) -> Identifier {
@@ -446,7 +441,7 @@ mod test {
       }
     }
 
-    struct Normal2 {}
+    struct Normal2;
 
     impl Identifiable for Normal2 {
       fn identifier(&self) -> Identifier {
@@ -462,7 +457,7 @@ mod test {
       }
     }
 
-    struct PitchNormalBase {}
+    struct PitchNormalBase;
 
     impl Identifiable for PitchNormalBase {
       fn identifier(&self) -> Identifier {
@@ -483,7 +478,7 @@ mod test {
       }
     }
 
-    struct PitchNormal {}
+    struct PitchNormal;
 
     impl Identifiable for PitchNormal {
       fn identifier(&self) -> Identifier {
@@ -505,7 +500,7 @@ mod test {
       }
     }
 
-    struct PitchNormal2 {}
+    struct PitchNormal2;
 
     impl Identifiable for PitchNormal2 {
       fn identifier(&self) -> Identifier {
@@ -527,10 +522,10 @@ mod test {
       }
     }
 
-    let c1 = Arc::new(Normal {}) as Arc<dyn Loader<()>>;
-    let c2 = Arc::new(Normal2 {}) as Arc<dyn Loader<()>>;
-    let p1 = Arc::new(Pitching {}) as Arc<dyn Loader<()>>;
-    let p2 = Arc::new(Pitching2 {}) as Arc<dyn Loader<()>>;
+    let c1 = Arc::new(Normal) as Arc<dyn Loader<()>>;
+    let c2 = Arc::new(Normal2) as Arc<dyn Loader<()>>;
+    let p1 = Arc::new(Pitching) as Arc<dyn Loader<()>>;
+    let p2 = Arc::new(Pitching2) as Arc<dyn Loader<()>>;
 
     let rs = ResourceData {
       resource: "/rspack/main.js?abc=123#efg".to_owned(),
@@ -540,22 +535,17 @@ mod test {
       resource_path: Default::default(),
     };
 
-    run_loaders::<()>(
-      &[p1, p2, c1, c2],
-      &rs,
-      &[Box::new(TestContentPlugin {})],
-      (),
-    )
-    .await
-    .unwrap();
+    run_loaders::<()>(&[p1, p2, c1, c2], &rs, &[Box::new(TestContentPlugin)], ())
+      .await
+      .unwrap();
     IDENTS.with(|i| assert_eq!(*i.borrow(), &["pitch1", "pitch2", "normal2", "normal1"]));
     IDENTS.with(|i| i.borrow_mut().clear());
 
-    let p1 = Arc::new(PitchNormalBase {}) as Arc<dyn Loader<()>>;
-    let p2 = Arc::new(PitchNormal {}) as Arc<dyn Loader<()>>;
-    let p3 = Arc::new(PitchNormal2 {}) as Arc<dyn Loader<()>>;
+    let p1 = Arc::new(PitchNormalBase) as Arc<dyn Loader<()>>;
+    let p2 = Arc::new(PitchNormal) as Arc<dyn Loader<()>>;
+    let p3 = Arc::new(PitchNormal2) as Arc<dyn Loader<()>>;
 
-    run_loaders::<()>(&[p1, p2, p3], &rs, &[Box::new(TestContentPlugin {})], ())
+    run_loaders::<()>(&[p1, p2, p3], &rs, &[Box::new(TestContentPlugin)], ())
       .await
       .unwrap();
     IDENTS.with(|i| {

--- a/crates/rspack_plugin_css/src/lib.rs
+++ b/crates/rspack_plugin_css/src/lib.rs
@@ -28,7 +28,7 @@ use swc_core::css::{ast::Stylesheet, parser::parser::Parser};
 static SWC_COMPILER: Lazy<Arc<SwcCssCompiler>> = Lazy::new(|| Arc::new(SwcCssCompiler::new()));
 
 #[derive(Default)]
-pub struct SwcCssCompiler {}
+pub struct SwcCssCompiler;
 
 impl SwcCssCompiler {
   pub fn new() -> Self {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/export.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/export.rs
@@ -1,2 +1,2 @@
 // TODO
-pub struct CommonJsExportDependency {}
+pub struct CommonJsExportDependency;

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -37,7 +37,7 @@ use crate::visitors::{run_after_pass, run_before_pass, scan_dependencies};
 use crate::JsMinifyOptions;
 
 #[derive(Debug)]
-pub struct JsPlugin {}
+pub struct JsPlugin;
 
 impl JsPlugin {
   pub fn new() -> Self {
@@ -349,7 +349,7 @@ impl JsPlugin {
   }
 
   #[inline]
-  pub async fn render_chunk(
+  pub async fn render_chunk_impl(
     &self,
     args: &rspack_core::RenderManifestArgs<'_>,
   ) -> Result<BoxSource> {
@@ -375,7 +375,7 @@ impl JsPlugin {
   }
 
   #[inline]
-  pub async fn chunk_hash(
+  pub async fn get_chunk_hash(
     &self,
     chunk_ukey: &ChunkUkey,
     compilation: &Compilation,
@@ -422,7 +422,7 @@ impl Default for JsPlugin {
 }
 
 #[derive(Debug)]
-pub struct JavaScriptParserAndGenerator {}
+pub struct JavaScriptParserAndGenerator;
 
 impl JavaScriptParserAndGenerator {
   fn new() -> Self {
@@ -633,7 +633,7 @@ impl Plugin for JsPlugin {
   ) -> PluginChunkHashHookOutput {
     let mut hasher = Xxh3::default();
     self
-      .chunk_hash(&args.chunk_ukey, args.compilation, &mut hasher)
+      .get_chunk_hash(&args.chunk_ukey, args.compilation, &mut hasher)
       .await?;
     if args
       .chunk()
@@ -661,7 +661,7 @@ impl Plugin for JsPlugin {
     }
 
     self
-      .chunk_hash(&args.chunk_ukey, args.compilation, &mut hasher)
+      .get_chunk_hash(&args.chunk_ukey, args.compilation, &mut hasher)
       .await?;
 
     let mut ordered_modules = compilation.chunk_graph.get_chunk_modules_by_source_type(
@@ -715,11 +715,11 @@ impl Plugin for JsPlugin {
     let compilation = args.compilation;
     let chunk = args.chunk();
     let source = if matches!(chunk.kind, ChunkKind::HotUpdate) {
-      self.render_chunk(&args).await?
+      self.render_chunk_impl(&args).await?
     } else if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
       self.render_main(&args).await?
     } else {
-      self.render_chunk(&args).await?
+      self.render_chunk_impl(&args).await?
     };
 
     let filename_template = get_js_chunk_filename_template(

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -86,7 +86,7 @@ static RUNTIME_CODE: &str = r#"
 function $RefreshReg$(type, id) {
   __webpack_modules__.$ReactRefreshRuntime$.register(type, __webpack_module__.id+ "_" + id);
 }
-Promise.resolve().then(function(){ 
+Promise.resolve().then(function(){
   __webpack_modules__.$ReactRefreshRuntime$.refresh(__webpack_module__.id, module.hot);
 })
 "#;
@@ -97,7 +97,7 @@ static RUNTIME_CODE_AST: Lazy<Script> = Lazy::new(|| {
     .expect_script()
 });
 
-pub struct ReactHmrFolder {}
+pub struct ReactHmrFolder;
 
 impl Fold for ReactHmrFolder {
   fn fold_program(&mut self, mut program: Program) -> Program {

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -13,7 +13,7 @@ use rspack_error::{
 mod utils;
 
 #[derive(Debug)]
-struct JsonParserAndGenerator {}
+struct JsonParserAndGenerator;
 
 impl ParserAndGenerator for JsonParserAndGenerator {
   fn source_types(&self) -> &[SourceType] {
@@ -127,7 +127,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
 }
 
 #[derive(Debug)]
-pub struct JsonPlugin {}
+pub struct JsonPlugin;
 
 impl Plugin for JsonPlugin {
   fn name(&self) -> &'static str {

--- a/crates/rspack_plugin_library/src/export_property_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
 use crate::utils::property_access;
 
 #[derive(Debug, Default)]
-pub struct ExportPropertyLibraryPlugin {}
+pub struct ExportPropertyLibraryPlugin;
 
 impl ExportPropertyLibraryPlugin {}
 

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
 use crate::utils::property_access;
 
 #[derive(Debug, Default)]
-pub struct ModuleLibraryPlugin {}
+pub struct ModuleLibraryPlugin;
 
 impl ModuleLibraryPlugin {}
 

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -12,8 +12,9 @@ use rspack_error::Result;
 use rspack_plugin_javascript::runtime::{render_chunk_runtime_modules, render_runtime_modules};
 
 use super::{generate_entry_startup, update_hash_for_entry_startup};
+
 #[derive(Debug)]
-pub struct ArrayPushCallbackChunkFormatPlugin {}
+pub struct ArrayPushCallbackChunkFormatPlugin;
 
 #[async_trait]
 impl Plugin for ArrayPushCallbackChunkFormatPlugin {

--- a/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
+++ b/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
@@ -14,9 +14,7 @@ use crate::runtime_module::{
 };
 
 #[derive(Debug)]
-pub struct BasicRuntimeRequirementPlugin {}
-
-impl BasicRuntimeRequirementPlugin {}
+pub struct BasicRuntimeRequirementPlugin;
 
 #[async_trait]
 impl Plugin for BasicRuntimeRequirementPlugin {

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -15,8 +15,9 @@ use crate::{
   generate_entry_startup, get_chunk_output_name, get_relative_path, get_runtime_chunk_output_name,
   update_hash_for_entry_startup,
 };
+
 #[derive(Debug)]
-pub struct CommonJsChunkFormatPlugin {}
+pub struct CommonJsChunkFormatPlugin;
 
 #[async_trait]
 impl Plugin for CommonJsChunkFormatPlugin {

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use crate::runtime_module::RequireChunkLoadingRuntimeModule;
 
 #[derive(Debug)]
-pub struct CommonJsChunkLoadingPlugin {}
+pub struct CommonJsChunkLoadingPlugin;
 
 #[async_trait]
 impl Plugin for CommonJsChunkLoadingPlugin {

--- a/crates/rspack_plugin_runtime/src/css_modules.rs
+++ b/crates/rspack_plugin_runtime/src/css_modules.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use crate::runtime_module::CssLoadingRuntimeModule;
 
 #[derive(Debug)]
-pub struct CssModulesPlugin {}
+pub struct CssModulesPlugin;
 
 #[async_trait]
 impl Plugin for CssModulesPlugin {

--- a/crates/rspack_plugin_runtime/src/hot_module_replacement.rs
+++ b/crates/rspack_plugin_runtime/src/hot_module_replacement.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use crate::runtime_module::HotModuleReplacementRuntimeModule;
 
 #[derive(Debug)]
-pub struct HotModuleReplacementPlugin {}
+pub struct HotModuleReplacementPlugin;
 
 #[async_trait]
 impl Plugin for HotModuleReplacementPlugin {

--- a/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use crate::runtime_module::ImportScriptsChunkLoadingRuntimeModule;
 
 #[derive(Debug)]
-pub struct ImportScriptsChunkLoadingPlugin {}
+pub struct ImportScriptsChunkLoadingPlugin;
 
 #[async_trait]
 impl Plugin for ImportScriptsChunkLoadingPlugin {

--- a/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use crate::runtime_module::JsonpChunkLoadingRuntimeModule;
 
 #[derive(Debug)]
-pub struct JsonpChunkLoadingPlugin {}
+pub struct JsonpChunkLoadingPlugin;
 
 #[async_trait]
 impl Plugin for JsonpChunkLoadingPlugin {

--- a/crates/rspack_plugin_runtime/src/lazy_compilation.rs
+++ b/crates/rspack_plugin_runtime/src/lazy_compilation.rs
@@ -79,7 +79,7 @@ impl PartialEq for LazyCompilationProxyModule {
 impl Eq for LazyCompilationProxyModule {}
 
 #[derive(Debug)]
-pub struct LazyCompilationPlugin {}
+pub struct LazyCompilationPlugin;
 
 #[async_trait]
 impl Plugin for LazyCompilationPlugin {

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -36,10 +36,9 @@ pub use import_scripts_chunk_loading::ImportScriptsChunkLoadingPlugin;
 mod runtime_module;
 mod startup_chunk_dependencies;
 pub use startup_chunk_dependencies::StartupChunkDependenciesPlugin;
-#[derive(Debug)]
-pub struct RuntimePlugin {}
 
-impl RuntimePlugin {}
+#[derive(Debug)]
+pub struct RuntimePlugin;
 
 #[async_trait]
 impl Plugin for RuntimePlugin {

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -16,8 +16,9 @@ use super::update_hash_for_entry_startup;
 use crate::{
   get_all_chunks, get_chunk_output_name, get_relative_path, get_runtime_chunk_output_name,
 };
+
 #[derive(Debug)]
-pub struct ModuleChunkFormatPlugin {}
+pub struct ModuleChunkFormatPlugin;
 
 #[async_trait]
 impl Plugin for ModuleChunkFormatPlugin {

--- a/crates/rspack_plugin_runtime/src/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_loading.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use crate::runtime_module::{ExportWebpackRequireRuntimeModule, ModuleChunkLoadingRuntimeModule};
 
 #[derive(Debug)]
-pub struct ModuleChunkLoadingPlugin {}
+pub struct ModuleChunkLoadingPlugin;
 
 #[async_trait]
 impl Plugin for ModuleChunkLoadingPlugin {

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -10,7 +10,7 @@ use rspack_plugin_asset::ModuleIdToFileName;
 
 use crate::AsyncWasmParserAndGenerator;
 
-pub struct EnableWasmLoadingPlugin {}
+pub struct EnableWasmLoadingPlugin;
 
 #[derive(Debug, Default)]
 pub struct AsyncWasmPlugin {

--- a/crates/rspack_tracing/src/lib.rs
+++ b/crates/rspack_tracing/src/lib.rs
@@ -9,7 +9,8 @@ use tracing_subscriber::{EnvFilter, Layer};
 
 static IS_TRACING_ENABLED: AtomicBool = AtomicBool::new(false);
 // skip event because it's not useful for performance analysis
-struct FilterEvent {}
+struct FilterEvent;
+
 impl<S> Filter<S> for FilterEvent {
   fn enabled(
     &self,


### PR DESCRIPTION
## Related issue (if exists)

relates to #2855

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b69ed33</samp>

This pull request refactors and cleans up some code in the rspack plugin system, mainly by renaming and removing some methods and structs, simplifying some struct definitions, and removing empty braces from structs that do not have any fields. It also adds some comments and clippy lints to the `.cargo/config.toml` file, and suppresses some clippy lints in the node binding crate.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b69ed33</samp>

*  Add comment and clippy lints to `.cargo/config.toml` for code quality and consistency ([link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268L9-R28))
*  Rename `serialize` method to `to_json` in `Record` struct to clarify its purpose ([link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-a172f54316e22ec24175a43647ec3a4fe873fae20a11a691330f491883a3b0b2L50-R53))
*  Suppress clippy lints for `unwrap` usage in `init` and `load` functions of `NodeBinding` and `Plugins` structs, as they are expected to panic on failure ([link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaR177), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R446))
*  Remove empty braces from structs that implement `Default` or have no fields, to make them more idiomatic and consistent, in files `emitter.rs`, `deterministic_module_ids_plugin.rs`, `named_module_ids_plugin.rs`, `lib.rs`, `export.rs`, `plugin.rs`, `react.rs`, `module_library_plugin.rs`, `array_push_callback_chunk_format.rs`, `basic_runtime_requirements.rs`, `common_js_chunk_format.rs`, `common_js_chunk_loading.rs`, `css_modules.rs`, `hot_module_replacement.rs`, and `import_scripts_chunk_loading.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-b9d97124e6a133aa19f66951633d18dab82be0967559d987a59253d6424952fdL37-R37), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-dd2e5a1227a8507ac3c088d106d849afbc2e64eef12375804abf0aeedf30cef5L10-R10), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-8b6878a772ebf77827ad4005719aa0e5e7c94348f81d1fe67dce1f5867131c30L10-R10), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-db4ae8ef13237bee509d3125b0f615da21d6c0e8dbf5ee7f5411842a9b674677L38-R38), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-06589b21409c48283eca2fdff8a7fd8bf49d2e8fe3b9f2fb6b83ed7602b09542L2-R2), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL39-R39), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL303-R303), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL107-R107), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-2f5104bd5419764ef84b345b76adbee5aca8ffe25ff36c515b66de2aaebcc1f1L16-R16), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-2f5104bd5419764ef84b345b76adbee5aca8ffe25ff36c515b66de2aaebcc1f1L130-R130), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-32658f3059223914bd10474ae269827489a13ca9c2f616e7597579f6b2041a8fL12-R12), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-642bde562c4bac7d3a7e5f2a4036a9e7deac1c97428d86cdf4be20a2edad82adL17-R19), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-d1b082bd82f12dd11e47ebcf2e07ff8be00089f0bb5ce4b4ea7b0cf63496f0e0L17-R18), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-cf0b5d37badeb43c872afa010841db383fe16a3ece6adc5462f371e8c237d907L16-R18), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-b03d091422aa9802562b85e0d6721c813516655d22012a04035ef9523bb4f7eaL11-R11), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-59116873710be9e35dd1cce51860ffeb169e18c82f08be5ce1c069ea6411068fL11-R11), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-5fe1f81c8630195634bdc03699da6a8f1ee4792f6b1b7ed90c232d8539d91443L11-R11), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-b4f2d8b855e55b46791b6cd1804187181dcf4d9dc02bf4b2ac05f62e894197eeL11-R11))
*  Rename `render_chunk` and `chunk_hash` methods to `render_chunk_impl` and `get_chunk_hash` in `JsPlugin` struct to avoid name collision and follow naming convention, and update their calls accordingly ([link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL232-R232), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL258-R258), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL514-R514), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL542-R542), [link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ce793c32e1baad830eb21ecb7be37f3b8179bf0ee41646eee0f51ddc3dbdf83bL596-R600))
*  Remove trailing space from `HMR_FOOTER` static string in `react.rs` to improve code style and formatting ([link](https://github.com/web-infra-dev/rspack/pull/2974/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL91-R91))

</details>
