### PR TITLE
refactor(split_chunks_new): asyncify `prepare_module_group_map`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,9 +2835,11 @@ dependencies = [
 name = "rspack_plugin_split_chunks_new"
 version = "0.1.0"
 dependencies = [
+ "async-scoped",
  "async-trait",
  "dashmap",
  "derivative",
+ "futures-util",
  "rayon",
  "regex",
  "rspack_core",
@@ -2845,6 +2847,7 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash",
+ "tokio",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dashmap            = { version = "5.4.0" }
 derivative         = { version = "2.2.0" }
 derive_builder     = { version = "0.11.2" }
 futures            = { version = "0.3.28" }
+futures-util       = "0.3.28"
 glob               = { version = "0.3.1" }
 hashlink           = { version = "0.8.1" }
 indexmap           = { version = "1.9.3" }

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2430,9 +2430,11 @@ dependencies = [
 name = "rspack_plugin_split_chunks_new"
 version = "0.1.0"
 dependencies = [
+ "async-scoped",
  "async-trait",
  "dashmap",
  "derivative",
+ "futures-util",
  "rayon",
  "regex",
  "rspack_core",
@@ -2440,6 +2442,7 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -137,7 +137,7 @@ export interface RawMinification {
   passes: number
   dropConsole: boolean
   pureFuncs: Array<string>
-  extractComments?: string 
+  extractComments?: string
 }
 export interface RawPresetEnv {
   targets: Array<string>

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -142,7 +142,9 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
         .unwrap_or_default()
         .into_iter()
         .map(|(k, v)| new_split_chunks_plugin::CacheGroup {
-          name: v.name.unwrap_or(k),
+          name: new_split_chunks_plugin::create_chunk_name_getter_by_const_name(
+            v.name.unwrap_or(k),
+          ),
           priority: v.priority.unwrap_or(-20) as f64,
           test: new_split_chunks_plugin::create_module_filter(v.test.clone()),
           chunk_filter: v

--- a/crates/rspack_plugin_split_chunks_new/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks_new/Cargo.toml
@@ -8,9 +8,11 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-scoped      = { workspace = true, features = ["use-tokio"] }
 async-trait       = { workspace = true }
 dashmap           = { workspace = true }
 derivative        = { workspace = true }
+futures-util      = { workspace = true }
 rayon             = { workspace = true }
 regex             = { workspace = true }
 rspack_core       = { path = "../rspack_core" }
@@ -18,4 +20,5 @@ rspack_identifier = { path = "../rspack_identifier" }
 rspack_regex      = { path = "../rspack_regex" }
 rspack_util       = { path = "../rspack_util" }
 rustc-hash        = { workspace = true }
+tokio             = { workspace = true }
 tracing           = { workspace = true }

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -1,6 +1,6 @@
 use derivative::Derivative;
 
-use crate::common::{ChunkFilter, ModuleFilter, SplitChunkSizes};
+use crate::common::{ChunkFilter, ChunkNameGetter, ModuleFilter, SplitChunkSizes};
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -10,7 +10,8 @@ pub struct CacheGroup {
   #[derivative(Debug = "ignore")]
   pub test: ModuleFilter,
   /// `name` is used to create chunk
-  pub name: String,
+  #[derivative(Debug = "ignore")]
+  pub name: ChunkNameGetter,
   pub priority: f64,
   pub min_size: SplitChunkSizes,
   /// number of referenced chunks

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -1,8 +1,11 @@
 use std::{
+  future::{self, Future},
   ops::{Deref, DerefMut},
+  pin::Pin,
   sync::Arc,
 };
 
+use futures_util::FutureExt;
 use rspack_core::{Chunk, ChunkGroupByUkey, Module, SourceType};
 use rustc_hash::FxHashMap;
 
@@ -85,4 +88,12 @@ impl DerefMut for SplitChunkSizes {
   fn deref_mut(&mut self) -> &mut Self::Target {
     &mut self.0
   }
+}
+
+type PinFutureBox<T> = Pin<Box<dyn Future<Output = T> + Send>>;
+
+pub type ChunkNameGetter = Box<dyn Fn(&dyn Module) -> PinFutureBox<Option<String>> + Send + Sync>;
+
+pub fn create_chunk_name_getter_by_const_name(name: String) -> ChunkNameGetter {
+  Box::new(move |_module| future::ready(Some(name.clone())).boxed())
 }

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -9,8 +9,9 @@ pub use crate::{
   cache_group::CacheGroup,
   common::{
     create_all_chunk_filter, create_async_chunk_filter, create_chunk_filter_from_str,
-    create_default_module_filter, create_initial_chunk_filter, create_module_filter,
-    create_module_filter_from_regex, create_module_filter_from_rspack_regex, SplitChunkSizes,
+    create_chunk_name_getter_by_const_name, create_default_module_filter,
+    create_initial_chunk_filter, create_module_filter, create_module_filter_from_regex,
+    create_module_filter_from_rspack_regex, SplitChunkSizes,
   },
   plugin::{PluginOptions, SplitChunksPlugin},
 };

--- a/crates/rspack_plugin_split_chunks_new/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/module_group.rs
@@ -23,7 +23,7 @@ pub(crate) struct ModuleGroup {
   pub cache_group_priority: f64,
   /// If the `ModuleGroup` is going to create a chunk, which will be named using `chunk_name`
   /// A module
-  pub chunk_name: String,
+  pub chunk_name: Option<String>,
   pub sizes: SplitChunkSizes,
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[derivative(Debug = "ignore")]

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -374,7 +374,7 @@ impl Plugin for SplitChunksPlugin {
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {
-    use std::time::Instant;
+    // use std::time::Instant;
     // let start = Instant::now();
     self.inner_impl(args.compilation).await;
     // let duration = start.elapsed();

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use async_scoped::TokioScope;
 use dashmap::DashMap;
 use rayon::prelude::*;
 use rspack_core::{Chunk, ChunkUkey, Compilation, Module, Plugin, SourceType};
@@ -27,8 +28,8 @@ impl SplitChunksPlugin {
     }
   }
 
-  fn inner_impl(&self, compilation: &mut Compilation) {
-    let mut module_group_map = self.prepare_module_group_map(compilation);
+  async fn inner_impl(&self, compilation: &mut Compilation) {
+    let mut module_group_map = self.prepare_module_group_map(compilation).await;
 
     self.ensure_min_size_fit(compilation, &mut module_group_map);
 
@@ -127,21 +128,29 @@ impl SplitChunksPlugin {
     compilation: &mut Compilation,
     module_group: &ModuleGroup,
   ) -> ChunkUkey {
-    if let Some(chunk) = compilation.named_chunks.get(&module_group.chunk_name) {
-      *chunk
-    } else {
-      let chunk = Compilation::add_named_chunk(
-        module_group.chunk_name.clone(),
+    if let Some(chunk) = module_group
+      .chunk_name
+      .as_ref()
+      .and_then(|chunk_name| compilation.named_chunks.get(chunk_name))
+    {
+      return *chunk;
+    }
+
+    let chunk = if let Some(chunk_name) = &module_group.chunk_name {
+      Compilation::add_named_chunk(
+        chunk_name.clone(),
         &mut compilation.chunk_by_ukey,
         &mut compilation.named_chunks,
-      );
+      )
+    } else {
+      Compilation::add_chunk(&mut compilation.chunk_by_ukey)
+    };
 
-      chunk
-        .chunk_reasons
-        .push("Create by split chunks".to_string());
-      compilation.chunk_graph.add_chunk(chunk.ukey);
-      chunk.ukey
-    }
+    chunk
+      .chunk_reasons
+      .push("Create by split chunks".to_string());
+    compilation.chunk_graph.add_chunk(chunk.ukey);
+    chunk.ukey
   }
 
   fn remove_all_modules_from_other_module_groups(
@@ -252,7 +261,7 @@ impl SplitChunksPlugin {
     (best_entry_key, best_module_group)
   }
 
-  fn prepare_module_group_map(&self, compilation: &mut Compilation) -> ModuleGroupMap {
+  async fn prepare_module_group_map(&self, compilation: &mut Compilation) -> ModuleGroupMap {
     let chunk_db = &compilation.chunk_by_ukey;
     let chunk_group_db = &compilation.chunk_group_by_ukey;
 
@@ -265,24 +274,25 @@ impl SplitChunksPlugin {
       selected_chunks: Box<[&'a Chunk]>,
     }
 
-    let matched_items = compilation
-      .module_graph
-      .modules()
-      .values()
-      .par_bridge()
-      .flat_map(|module| {
+    let module_group_map: DashMap<String, ModuleGroup> = DashMap::default();
+
+    async_scoped::Scope::scope_and_block(|scope: &mut TokioScope<'_, _>| {
+      for module in compilation.module_graph.modules().values() {
+        let module = &**module;
+
         let belong_to_chunks = compilation
           .chunk_graph
           .get_module_chunks((*module).identifier());
 
-        // A module may match multiple CacheGroups
-        self.cache_groups.par_iter().enumerate().filter_map(
-          move |(cache_group_index, cache_group)| {
+        let module_group_map = &module_group_map;
+
+        for (cache_group_index, cache_group) in self.cache_groups.iter().enumerate() {
+          scope.spawn(async move {
             // Filter by `splitChunks.cacheGroups.{cacheGroup}.test`
             let is_match_the_test: bool = (cache_group.test)(module);
 
             if !is_match_the_test {
-              return None;
+              return;
             }
 
             let selected_chunks = belong_to_chunks
@@ -294,45 +304,57 @@ impl SplitChunksPlugin {
 
             // Filter by `splitChunks.cacheGroups.{cacheGroup}.minChunks`
             if selected_chunks.len() < cache_group.min_chunks as usize {
-              return None;
+              return;
             }
 
-            Some(MatchedItem {
-              module: &**module,
-              cache_group,
-              cache_group_index,
-              selected_chunks,
-            })
-          },
-        )
-      });
+            merge_matched_item_into_module_group_map(
+              MatchedItem {
+                module,
+                cache_group,
+                cache_group_index,
+                selected_chunks,
+              },
+              module_group_map,
+            )
+            .await;
 
-    let module_group_map: DashMap<String, ModuleGroup> = DashMap::default();
+            async fn merge_matched_item_into_module_group_map(
+              matched_item: MatchedItem<'_>,
+              module_group_map: &DashMap<String, ModuleGroup>,
+            ) {
+              let MatchedItem {
+                module,
+                cache_group_index,
+                cache_group,
+                selected_chunks,
+              } = matched_item;
 
-    matched_items.for_each(|matched_item| {
-      let MatchedItem {
-        module,
-        cache_group_index,
-        cache_group,
-        selected_chunks,
-      } = matched_item;
+              // Merge the `Module` of `MatchedItem` into the `ModuleGroup` which has the same `key`/`cache_group.name`
+              let chunk_name: Option<String> = (cache_group.name)(module).await;
 
-      // Merge the `Module` of `MatchedItem` into the `ModuleGroup` which has the same `key`/`cache_group.name`
-      let key = ["name: ", &cache_group.name].join("");
+              let key: String = if let Some(cache_group_name) = &chunk_name {
+                ["name: ", cache_group_name].join("")
+              } else {
+                ["index: ", &cache_group_index.to_string()].join("")
+              };
 
-      let mut module_group = module_group_map.entry(key).or_insert_with(|| ModuleGroup {
-        modules: Default::default(),
-        cache_group_index,
-        cache_group_priority: cache_group.priority,
-        sizes: Default::default(),
-        chunks: Default::default(),
-        chunk_name: cache_group.name.clone(),
-      });
+              let mut module_group = module_group_map.entry(key).or_insert_with(|| ModuleGroup {
+                modules: Default::default(),
+                cache_group_index,
+                cache_group_priority: cache_group.priority,
+                sizes: Default::default(),
+                chunks: Default::default(),
+                chunk_name,
+              });
 
-      module_group.add_module(module);
-      module_group
-        .chunks
-        .extend(selected_chunks.iter().map(|c| c.ukey))
+              module_group.add_module(module);
+              module_group
+                .chunks
+                .extend(selected_chunks.iter().map(|c| c.ukey))
+            }
+          });
+        }
+      }
     });
 
     module_group_map.into_iter().collect()
@@ -352,7 +374,11 @@ impl Plugin for SplitChunksPlugin {
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {
-    self.inner_impl(args.compilation);
+    use std::time::Instant;
+    // let start = Instant::now();
+    self.inner_impl(args.compilation).await;
+    // let duration = start.elapsed();
+    // println!("SplitChunksPlugin is: {:?}", duration);
     Ok(())
   }
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- No behaviors change
- Make name an async function
- Preparation for calling `name` function provided by the JS side

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ceb67d6</samp>

This pull request adds async and parallel processing to the `rspack_plugin_split_chunks_new` crate, which implements a plugin for splitting modules into chunks based on cache groups. It also updates the cache group and module group structs to use functions for generating chunk names instead of fixed strings, and handles unnamed and dynamic chunk names in the plugin logic. It adds new dependencies and imports to support these features.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ceb67d6</samp>

*  Add `futures-util` crate as a dependency for working with async code ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R32), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-bb77f4a776a00a1377e31ab5f38a079c93e6767ba399c09227c2def2a2067056L11-R15))
*  Add `async-scoped` and `tokio` crates as dependencies for enabling async and parallel processing of modules and cache groups in `rspack_plugin_split_chunks_new` crate ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-bb77f4a776a00a1377e31ab5f38a079c93e6767ba399c09227c2def2a2067056L11-R15), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-bb77f4a776a00a1377e31ab5f38a079c93e6767ba399c09227c2def2a2067056R23))
*  Define `ChunkNameGetter` type and function for dynamically generating chunk names based on modules in `common.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9R92-R99))
*  Modify `CacheGroup` struct to use `ChunkNameGetter` instead of `String` for `name` field in `raw_split_chunks.rs` and `cache_group.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L145-R147), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebL13-R14))
*  Modify `ModuleGroup` struct to use `Option<String>` instead of `String` for `chunk_name` field in `module_group.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-9fe0bd2bb40e0e56daf84e7c76107d80d06b5b306b639db5194b24e5daaca8c7L26-R26))
*  Modify `SplitChunksPlugin` struct to use async functions and tasks for processing modules and cache groups in `plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L30-R32), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L255-R264), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L268-R295), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L297-R357), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L355-R381))
*  Modify `create_chunk` method of `SplitChunksPlugin` to handle module groups without chunk names in `plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L130-R153))
*  Import `ChunkNameGetter` and related types and functions from `common` module in `cache_group.rs` and `lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebL3-R3), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L2-R8), [link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812L12-R14))
*  Import `TokioScope` from `async_scoped` crate in `plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/2975/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R3))

</details>
