### PR TITLE
fix(react-hmr): inject the runtime global function

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -83,7 +83,7 @@ impl Visit for ReactRefreshUsageFinder {
 // __webpack_require__.$ReactRefreshRuntime$ is injected by the react-refresh additional entry
 static HMR_HEADER: &str = r#"var RefreshRuntime = __webpack_modules__.$ReactRefreshRuntime$;
 var $RefreshReg$ = function (type, id) {
-  RefreshRuntime.register(type, __webpack_module__.id + "_" + id);
+  RefreshRuntime.register(type, __webpack_module__.id+ "_" + id);
 }
 var $RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;"#;
 

--- a/packages/rspack-dev-client/src/reactRefresh.ts
+++ b/packages/rspack-dev-client/src/reactRefresh.ts
@@ -18,6 +18,11 @@ function refresh(moduleId, webpackHot) {
 	}
 }
 
+// Injected global react refresh runtime
+
+// @ts-ignored
+globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+
 // @ts-ignored
 __webpack_modules__.$ReactRefreshRuntime$ = {
 	refresh,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98a3bf1</samp>

Improved the support for React HMR (hot module replacement) with rspack by simplifying the code generation logic in `rspack_plugin_javascript` and injecting the necessary global function in `rspack-dev-client`. This fixed a runtime error with react-refresh.


<details open=true>
  <summary><h2>Walkthrough</h2></summary>


<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 98a3bf1</samp>

*  Inject global `$RefreshSig$` function into client code to support react-refresh transform ([link](https://github.com/web-infra-dev/rspack/pull/2977/files?diff=unified&w=0#diff-854689d2363c434ac2e6497b60d6517bcbedf5affba872017f9dd1d32687c8f4L21-R26))
* Simplify HMR runtime code generation by merging header and footer constants and using map operation ([link](https://github.com/web-infra-dev/rspack/pull/2977/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL84-R99), [link](https://github.com/web-infra-dev/rspack/pull/2977/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL118-R117), [link](https://github.com/web-infra-dev/rspack/pull/2977/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL128-L131))
* Remove unused import of `Stmt` from `swc_core::ecma::ast` ([link](https://github.com/web-infra-dev/rspack/pull/2977/files?diff=unified&w=0#diff-ad84e1dabffffec60f49e9f526da2eff4742091382b567627ba28513a3893a2cL6-R6))

</details>
