### PR TITLE
docs: pnpm install command fix based on engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,10 @@ Install Node.js dependencies via [pnpm](https://pnpm.io/).
 corepack enable
 
 # or install pnpm directly
-npm install -g pnpm@7
+npm install -g pnpm@7.32.0
 
 # Install dependencies
-pnpm run init
+pnpm install
 ```
 
 ### Setup Other Dependencies


### PR DESCRIPTION
## Summary

Just a small fix on [CONTRIBUTING.md](https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md) as currently pnpm@7.32.0 is forced by engine definition in package.json.