### PR TITLE
chore: add node shims example

### DIFF
--- a/examples/node-globals-shim/index.html
+++ b/examples/node-globals-shim/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/node-globals-shim/package.json
+++ b/examples/node-globals-shim/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/node-globals-shim/rspack.config.js
+++ b/examples/node-globals-shim/rspack.config.js
@@ -1,0 +1,19 @@
+const path = require("path");
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	context: __dirname,
+	entry: {
+		main: "./src/index.js"
+	},
+	builtins: {
+		html: [
+			{
+				template: "./index.html"
+			}
+		],
+		provide: {
+			process: path.resolve(__dirname, "./src/process-shim.js")
+		}
+	}
+};
+module.exports = config;

--- a/examples/node-globals-shim/src/answer.js
+++ b/examples/node-globals-shim/src/answer.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/examples/node-globals-shim/src/index.js
+++ b/examples/node-globals-shim/src/index.js
@@ -1,0 +1,8 @@
+import "./util";
+import { answer } from "./answer";
+function render() {
+	document.getElementById(
+		"root"
+	).innerHTML = `the answer to the universe is ${answer}`;
+}
+render();

--- a/examples/node-globals-shim/src/process-shim.js
+++ b/examples/node-globals-shim/src/process-shim.js
@@ -1,0 +1,1 @@
+var process = {};

--- a/examples/node-globals-shim/src/util.js
+++ b/examples/node-globals-shim/src/util.js
@@ -1,0 +1,1 @@
+console.log("process:", process);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -327,6 +327,12 @@ importers:
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
 
+  examples/node-globals-shim:
+    specifiers:
+      '@rspack/cli': workspace:*
+    devDependencies:
+      '@rspack/cli': link:../../packages/rspack-cli
+
   examples/perfsee:
     specifiers:
       '@perfsee/webpack': 1.6.0


### PR DESCRIPTION
## Related issue (if exists)
it's a common question that users import node globals like `process` and `Buffer` like https://github.com/web-infra-dev/rspack/issues/2994, so we provide an example about how to provide custom shims to avoid runtime error on browser.

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8959d13</samp>

This pull request adds a new example project that shows how to use the `rspack` CLI tool to bundle and serve JavaScript modules that use Node.js globals in the browser. It creates a simple app that renders a message with the answer to life, the universe, and everything.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8959d13</samp>

*  Add an example project that uses the rspack CLI tool to bundle and serve JavaScript modules ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-50de4493920ca38b93467b9a71fba198b56ca6f7e317cf261d7d5284df1528c6R1-R12), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-e4658eda260aaa3196a45e26481c3612b75e956de3ba414c6a05308bc6bfb962L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-11b3544f4c7ab7870cb564f05cdf4099931805a109124b2fe4325d5b39acd81cR1-R19), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-8a612d2100f34b2e6fde6428a53c3299de1bc832a9503c894ce948ca53bcf3abR1), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-490841a381b5568687560b9f1494715f10c2d21a165695f771fa732b1282e0f4R1-R8), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-0579b64ea5376a1a043cfabae4339cf5a5f810a190043d214ad210011718db91R1), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-b9058a6e2083cd836f7fc7d7aa8fca515ab362ad58c89653f0bdfeee1a5799f7R1))
  * Create a basic HTML template for the project in `index.html` and inject it into the output bundle with the html plugin ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-50de4493920ca38b93467b9a71fba198b56ca6f7e317cf261d7d5284df1528c6R1-R12), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-11b3544f4c7ab7870cb564f05cdf4099931805a109124b2fe4325d5b39acd81cR1-R19))
  * Define the project metadata, scripts, and dev dependency in `package.json` and reference the rspack CLI tool as a workspace package ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-e4658eda260aaa3196a45e26481c3612b75e956de3ba414c6a05308bc6bfb962L1-R17))
  * Configure the context, entry, and builtins options for the rspack CLI tool in `rspack.config.js` and use the provide plugin to shim the process global variable with a custom module ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-11b3544f4c7ab7870cb564f05cdf4099931805a109124b2fe4325d5b39acd81cR1-R19), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-0579b64ea5376a1a043cfabae4339cf5a5f810a190043d214ad210011718db91R1))
  * Implement the app logic in `src/index.js` and import the util and answer modules ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-490841a381b5568687560b9f1494715f10c2d21a165695f771fa732b1282e0f4R1-R8), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-b9058a6e2083cd836f7fc7d7aa8fca515ab362ad58c89653f0bdfeee1a5799f7R1), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-8a612d2100f34b2e6fde6428a53c3299de1bc832a9503c894ce948ca53bcf3abR1))
  * Define a constant named answer with the value 42 in `src/answer.js` and export it ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-8a612d2100f34b2e6fde6428a53c3299de1bc832a9503c894ce948ca53bcf3abR1))
  * Log the process variable to the console in `src/util.js` and demonstrate how the provide plugin works ([link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-b9058a6e2083cd836f7fc7d7aa8fca515ab362ad58c89653f0bdfeee1a5799f7R1), [link](https://github.com/web-infra-dev/rspack/pull/2997/files?diff=unified&w=0#diff-0579b64ea5376a1a043cfabae4339cf5a5f810a190043d214ad210011718db91R1))

</details>
