### PR TITLE
feat(new_split_chunks): support `reuseExistingChunk`

### DIFF
--- a/.changeset/strange-pans-raise.md
+++ b/.changeset/strange-pans-raise.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat(new_split_chunks): support `reuseExistingChunk`

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -427,6 +427,7 @@ export interface RawCacheGroupOptions {
   chunks?: string
   minChunks?: number
   name?: string
+  reuseExistingChunk?: boolean
 }
 export interface RawStatsOptions {
   colors: boolean

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -114,6 +114,7 @@ pub struct RawCacheGroupOptions {
   //   pub max_initial_size: usize,
   pub name: Option<String>,
   // used_exports: bool,
+  pub reuse_existing_chunk: Option<bool>,
 }
 
 use rspack_plugin_split_chunks_new as new_split_chunks_plugin;
@@ -161,6 +162,7 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
             &default_size_types,
             overall_min_size,
           ),
+          reuse_existing_chunk: v.reuse_existing_chunk.unwrap_or(true),
         }),
     );
 

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -14,6 +14,7 @@ pub struct CacheGroup {
   pub name: ChunkNameGetter,
   pub priority: f64,
   pub min_size: SplitChunkSizes,
+  pub reuse_existing_chunk: bool,
   /// number of referenced chunks
   pub min_chunks: u32,
 }

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(map_many_mut)]
+#![feature(let_chains)]
 
 pub(crate) mod cache_group;
 pub(crate) mod common;

--- a/crates/rspack_plugin_split_chunks_new/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/module_group.rs
@@ -21,6 +21,7 @@ pub(crate) struct ModuleGroup {
   pub modules: IdentifierSet,
   pub cache_group_index: usize,
   pub cache_group_priority: f64,
+  pub cache_group_reuse_existing_chunk: bool,
   /// If the `ModuleGroup` is going to create a chunk, which will be named using `chunk_name`
   /// A module
   pub chunk_name: Option<String>,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -32,7 +32,6 @@ impl SplitChunksPlugin {
     let mut module_group_map = self.prepare_module_group_map(compilation).await;
 
     self.ensure_min_size_fit(compilation, &mut module_group_map);
-    println!("module groups: {:#?}", module_group_map);
 
     while !module_group_map.is_empty() {
       let (_module_group_key, mut module_group) =
@@ -45,14 +44,6 @@ impl SplitChunksPlugin {
         &mut module_group,
         &mut is_reuse_existing_chunk,
         &mut is_reuse_existing_chunk_with_all_modules,
-      );
-      println!(
-        "{:?} get_corresponding_chunk {:?}",
-        module_group.chunk_name,
-        new_chunk
-          .as_ref(&compilation.chunk_by_ukey)
-          .chunk_reasons
-          .join("~")
       );
 
       if is_reuse_existing_chunk {

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{borrow::Cow, fmt::Debug};
 
 use async_scoped::TokioScope;
 use dashmap::DashMap;
@@ -32,27 +32,50 @@ impl SplitChunksPlugin {
     let mut module_group_map = self.prepare_module_group_map(compilation).await;
 
     self.ensure_min_size_fit(compilation, &mut module_group_map);
+    println!("module groups: {:#?}", module_group_map);
 
     while !module_group_map.is_empty() {
-      let (_module_group_key, module_group) = self.find_best_module_group(&mut module_group_map);
+      let (_module_group_key, mut module_group) =
+        self.find_best_module_group(&mut module_group_map);
 
-      let new_chunk = self.get_corresponding_chunk(compilation, &module_group);
+      let mut is_reuse_existing_chunk = false;
+      let mut is_reuse_existing_chunk_with_all_modules = false;
+      let new_chunk = self.get_corresponding_chunk(
+        compilation,
+        &mut module_group,
+        &mut is_reuse_existing_chunk,
+        &mut is_reuse_existing_chunk_with_all_modules,
+      );
+      println!(
+        "{:?} get_corresponding_chunk {:?}",
+        module_group.chunk_name,
+        new_chunk
+          .as_ref(&compilation.chunk_by_ukey)
+          .chunk_reasons
+          .join("~")
+      );
 
-      let original_chunks = &module_group.chunks;
+      if is_reuse_existing_chunk {
+        // The chunk is not new but created in code splitting. We need remove `new_chunk` since we would remove
+        // modules in this `Chunk/ModuleGroup` from other chunks. Other chunks is stored in `ModuleGroup.chunks`.
+        module_group.chunks.remove(&new_chunk);
+      }
+
+      let used_chunks = Cow::Borrowed(&module_group.chunks);
 
       self.move_modules_to_new_chunk_and_remove_from_old_chunks(
         &module_group,
         new_chunk,
-        original_chunks,
+        &used_chunks,
         compilation,
       );
 
-      self.split_from_original_chunks(&module_group, original_chunks, new_chunk, compilation);
+      self.split_from_original_chunks(&module_group, &used_chunks, new_chunk, compilation);
 
       self.remove_all_modules_from_other_module_groups(
         &module_group,
         &mut module_group_map,
-        original_chunks,
+        &used_chunks,
         compilation,
       )
     }
@@ -123,34 +146,123 @@ impl SplitChunksPlugin {
     });
   }
 
+  /// Affected by `splitChunks.cacheGroups.{cacheGroup}.reuseExistingChunk`
+  ///
+  /// If the current chunk contains modules already split out from the main bundle,
+  /// it will be reused instead of a new one being generated. This can affect the
+  /// resulting file name of the chunk.
+  fn find_the_best_reusable_chunk(
+    &self,
+    compilation: &mut Compilation,
+    module_group: &mut ModuleGroup,
+  ) -> Option<ChunkUkey> {
+    let candidates = module_group.chunks.par_iter().filter_map(|chunk| {
+      let chunk = chunk.as_ref(&compilation.chunk_by_ukey);
+
+      if compilation
+        .chunk_graph
+        .get_number_of_chunk_modules(&chunk.ukey)
+        != module_group.modules.len()
+      {
+        // Fast path for checking is the chunk reuseable for this `ModuleGroup`.
+        return None;
+      }
+
+      if module_group.chunks.len() > 1
+        && compilation
+          .chunk_graph
+          .get_number_of_entry_modules(&chunk.ukey)
+          > 0
+      {
+        // `module_group.chunks.len() > 1`: this ModuleGroup are related multiple chunks generated in code splitting.
+        // `get_number_of_entry_modules(&chunk.ukey) > 0`:  current chunk is an initial chunk.
+
+        // I(hyf0) don't see why breaking for this condition. But ChatGPT3.5 told me:
+
+        // The condition means that if there are multiple chunks in item and the current chunk is an
+        // entry chunk, then it cannot be reused. This is because entry chunks typically contain the core
+        // code of an application, while other chunks contain various parts of the application. If
+        // an entry chunk is used for other purposes, it may cause the application broken.
+        return None;
+      }
+
+      let is_all_module_in_chunk = module_group.modules.par_iter().all(|each_module| {
+        compilation
+          .chunk_graph
+          .is_module_in_chunk(each_module, chunk.ukey)
+      });
+      if !is_all_module_in_chunk {
+        return None;
+      }
+
+      Some(chunk)
+    });
+
+    /// Port https://github.com/webpack/webpack/blob/b471a6bfb71020f6d8f136ef10b7efb239ef5bbf/lib/optimize/SplitChunksPlugin.js#L1360-L1373
+    fn best_reuseable_chunk<'a>(first: &'a Chunk, second: &'a Chunk) -> &'a Chunk {
+      match (&first.name, &second.name) {
+        (None, None) => first,
+        (None, Some(_)) => second,
+        (Some(_), None) => first,
+        (Some(first_name), Some(second_name)) => match first_name.len().cmp(&second_name.len()) {
+          std::cmp::Ordering::Greater => second,
+          std::cmp::Ordering::Less => first,
+          std::cmp::Ordering::Equal => {
+            if matches!(second_name.cmp(first_name), std::cmp::Ordering::Less) {
+              second
+            } else {
+              first
+            }
+          }
+        },
+      }
+    }
+
+    let best_reuseable_chunk =
+      candidates.reduce_with(|best, each| best_reuseable_chunk(best, each));
+
+    best_reuseable_chunk.map(|c| c.ukey)
+  }
+
   fn get_corresponding_chunk(
     &self,
     compilation: &mut Compilation,
-    module_group: &ModuleGroup,
+    module_group: &mut ModuleGroup,
+    is_reuse_existing_chunk: &mut bool,
+    is_reuse_existing_chunk_with_all_modules: &mut bool,
   ) -> ChunkUkey {
     if let Some(chunk) = module_group
       .chunk_name
       .as_ref()
       .and_then(|chunk_name| compilation.named_chunks.get(chunk_name))
     {
+      *is_reuse_existing_chunk = true;
       return *chunk;
     }
 
-    let chunk = if let Some(chunk_name) = &module_group.chunk_name {
-      Compilation::add_named_chunk(
+    if let Some(reusable_chunk) = self.find_the_best_reusable_chunk(compilation, module_group) && module_group.cache_group_reuse_existing_chunk {
+      *is_reuse_existing_chunk = true;
+      *is_reuse_existing_chunk_with_all_modules = true;
+      return reusable_chunk;
+    } else if let Some(chunk_name) = &module_group.chunk_name {
+      let new_chunk = Compilation::add_named_chunk(
         chunk_name.clone(),
         &mut compilation.chunk_by_ukey,
         &mut compilation.named_chunks,
-      )
-    } else {
-      Compilation::add_chunk(&mut compilation.chunk_by_ukey)
-    };
-
-    chunk
-      .chunk_reasons
-      .push("Create by split chunks".to_string());
-    compilation.chunk_graph.add_chunk(chunk.ukey);
-    chunk.ukey
+      );
+      new_chunk
+        .chunk_reasons
+        .push("Create by split chunks".to_string());
+        compilation.chunk_graph.add_chunk(new_chunk.ukey);
+      new_chunk.ukey
+    }  else {
+      let new_chunk = Compilation::add_chunk(&mut compilation.chunk_by_ukey);
+      new_chunk
+        .chunk_reasons
+        .push("Create by split chunks".to_string());
+      compilation.chunk_graph.add_chunk(new_chunk.ukey);
+      new_chunk.ukey
+    }
   }
 
   fn remove_all_modules_from_other_module_groups(
@@ -342,6 +454,7 @@ impl SplitChunksPlugin {
                 modules: Default::default(),
                 cache_group_index,
                 cache_group_priority: cache_group.priority,
+                cache_group_reuse_existing_chunk: cache_group.reuse_existing_chunk,
                 sizes: Default::default(),
                 chunks: Default::default(),
                 chunk_name,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -142,6 +142,8 @@ impl SplitChunksPlugin {
   /// If the current chunk contains modules already split out from the main bundle,
   /// it will be reused instead of a new one being generated. This can affect the
   /// resulting file name of the chunk.
+  ///
+  /// the best means the reused chunks contains all modules in this ModuleGroup
   fn find_the_best_reusable_chunk(
     &self,
     compilation: &mut Compilation,
@@ -234,7 +236,7 @@ impl SplitChunksPlugin {
     if let Some(reusable_chunk) = self.find_the_best_reusable_chunk(compilation, module_group) && module_group.cache_group_reuse_existing_chunk {
       *is_reuse_existing_chunk = true;
       *is_reuse_existing_chunk_with_all_modules = true;
-      return reusable_chunk;
+      reusable_chunk
     } else if let Some(chunk_name) = &module_group.chunk_name {
       let new_chunk = Compilation::add_named_chunk(
         chunk_name.clone(),

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -474,7 +474,8 @@ function getRawSplitChunksOptions(
 							name: group.name,
 							priority: group.priority,
 							minChunks: group.minChunks,
-							chunks: group.chunks
+							chunks: group.chunks,
+							reuseExistingChunk: group.reuseExistingChunk
 						};
 						return [key, normalizedGroup];
 					})

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -1010,6 +1010,11 @@ module.exports = {
 							$ref: "#/definitions/OptimizationSplitChunksSizes"
 						}
 					]
+				},
+				reuseExistingChunk: {
+					description:
+						"If the current chunk contains modules already split out from the main bundle, it will be reused instead of a new one being generated. This can affect the resulting file name of the chunk.",
+					type: "boolean"
 				}
 			}
 		},

--- a/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/foo-2.js
+++ b/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/foo-2.js
@@ -1,0 +1,1 @@
+export default "foo-2.js";

--- a/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/foo.js
+++ b/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/foo.js
@@ -1,0 +1,2 @@
+import "./foo-2";
+export default "foo.js";

--- a/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/index.js
@@ -1,0 +1,11 @@
+() => import("./foo");
+
+import fs from "fs";
+import path from "path";
+
+export default "index.js";
+
+it("disable-reuse-existing-chunk-simple", () => {
+	expect(fs.existsSync(path.resolve(__dirname, "./splittedFoo.js"))).toBe(true);
+	expect(fs.existsSync(path.resolve(__dirname, "./foo_js.js"))).toBe(false);
+});

--- a/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/disable-reuse-existing-chunk-simple/webpack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	output: {
+		filename: "[name].js"
+	},
+	entry: "./index.js",
+	experiments: {
+		newSplitChunks: true
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 1,
+			cacheGroups: {
+				splittedFoo: {
+					name: "splittedFoo",
+					test: /(foo|foo-2)\.js/,
+					priority: 0,
+					reuseExistingChunk: false
+				}
+			}
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/foo-2.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/foo-2.js
@@ -1,0 +1,1 @@
+export default "foo-2.js";

--- a/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/foo.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/foo.js
@@ -1,0 +1,2 @@
+import "./foo-2";
+export default "foo.js";

--- a/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/index.js
@@ -1,0 +1,13 @@
+() => import("./foo");
+
+import fs from "fs";
+import path from "path";
+
+export default "index.js";
+
+it("reuse-existing-chunk-simple", () => {
+	expect(fs.existsSync(path.resolve(__dirname, "./splittedFoo.js"))).toBe(
+		false
+	);
+	expect(fs.existsSync(path.resolve(__dirname, "./foo_js.js"))).toBe(true);
+});

--- a/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-existing-chunk-simple/webpack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	entry: "./index.js",
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		newSplitChunks: true
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 1,
+			cacheGroups: {
+				splittedFoo: {
+					name: "splittedFoo",
+					test: /(foo|foo-2)\.js/,
+					priority: 0,
+					reuseExistingChunk: true
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

Related to #2991, but I need to add a test case for it in another PR to make sure solving the issue.

<!--- Provide link of related issues -->

## Summary

With `reuseExistingChunk: true`, Rspack would try to reuse chunks generated in CodeSplitting.

The test case `reuse-existing-chunk-simple` shows that the `splittedFoo` chunk is the same as `foo_js` chunk(generated in CodeSplitting), so we could just reuse the `foo_js` chunk instead of creating a new `splittedFoo` chunk.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5eff55d</samp>

This pull request adds a new option `reuseExistingChunk` to the split chunks plugin, which allows reusing existing chunks with the same modules instead of creating new ones. This option is enabled by default to improve performance and reduce bundle size. The pull request modifies the `rspack_plugin_split_chunks_new` crate and the `rspack` package to implement and expose the option. It also enables the `let_chains` feature in the `rspack_plugin_split_chunks_new` crate.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5eff55d</samp>

*  Add a new option `reuseExistingChunk` to the cache group configuration, which controls whether to reuse an existing chunk if it contains the same modules as the current chunk ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R117), [link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L477-R478), [link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R1013-R1017))
*  Pass the value of the `reuseExistingChunk` option to the `CacheGroup` and `ModuleGroup` structs, which represent the cache group and the module group in the plugin logic ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR17), [link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-9fe0bd2bb40e0e56daf84e7c76107d80d06b5b306b639db5194b24e5daaca8c7R24), [link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R450))
*  Enable the `let_chains` feature in the `rspack_plugin_split_chunks_new` crate, which allows using `let` expressions in the condition of an `if` or `while` statement ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812R2))
*  Import `std::borrow::Cow` to create a borrowed or owned reference to the chunks that the module group is related to ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L1-R1))
*  Modify the `get_corresponding_chunk` method in the `plugin.rs` file, which finds or creates a new chunk for a module group, to check if there is a reusable chunk and reuse it if the `reuseExistingChunk` option is true ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L37-R69), [link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L136-R258))
*  Add a new method `find_the_best_reusable_chunk` in the `plugin.rs` file, which searches for the best existing chunk that can be reused for a module group based on the chunk name and the modules ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L126-R225))
*  Set the default value of the `reuseExistingChunk` option to `true` when converting a `SplitChunksCacheGroup` to a `RawSplitChunksCacheGroup` ([link](https://github.com/web-infra-dev/rspack/pull/3000/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R165))

</details>
