### PR TITLE
fix: circular dependencies rebuild panic

### DIFF
--- a/.changeset/cuddly-fans-glow.md
+++ b/.changeset/cuddly-fans-glow.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+fix: circular dependencies rebuild panic

--- a/packages/rspack/tests/hotCases/runtime/hmr-circular/a.js
+++ b/packages/rspack/tests/hotCases/runtime/hmr-circular/a.js
@@ -1,0 +1,2 @@
+import "./b";
+export default "a.js";

--- a/packages/rspack/tests/hotCases/runtime/hmr-circular/b.js
+++ b/packages/rspack/tests/hotCases/runtime/hmr-circular/b.js
@@ -1,0 +1,2 @@
+import "./a";
+export default "b.js";

--- a/packages/rspack/tests/hotCases/runtime/hmr-circular/changed-file.js
+++ b/packages/rspack/tests/hotCases/runtime/hmr-circular/changed-file.js
@@ -1,0 +1,4 @@
+// TODO: remove this file after cache.
+const path = require("path");
+
+module.exports = [path.resolve(__dirname, "./entry.js")];

--- a/packages/rspack/tests/hotCases/runtime/hmr-circular/entry.js
+++ b/packages/rspack/tests/hotCases/runtime/hmr-circular/entry.js
@@ -1,0 +1,4 @@
+import './a';
+export default "entry.js"
+---
+export default "new_entry.js"

--- a/packages/rspack/tests/hotCases/runtime/hmr-circular/index.js
+++ b/packages/rspack/tests/hotCases/runtime/hmr-circular/index.js
@@ -1,0 +1,10 @@
+import entry from "./entry";
+
+it("should not throw error when hmr remove circular dependencies", done => {
+	expect(entry).toBe("entry.js");
+	module.hot.accept("./entry", () => {
+		expect(entry).toBe("new_entry.js");
+		done();
+	});
+	NEXT(require("../../update")(done));
+});


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 637cc9c</samp>

Improve HMR performance with parallelism and hash map optimization. Use `rayon` to parallelize module processing and only hash and chunk modules in the `crates/rspack_core/src/compiler/hmr.rs` file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 637cc9c</samp>

* Improve HMR performance by using parallel iterators from rayon crate ([link](https://github.com/web-infra-dev/rspack/pull/3001/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763R7))
* Refactor module hash and chunk id map creation to iterate over chunk graph modules instead of module graph modules, avoiding unnecessary computations and lookups ([link](https://github.com/web-infra-dev/rspack/pull/3001/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L58-R75))

</details>
