### PR TITLE
chore: fine grained tracing

### DIFF
--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -6,7 +6,7 @@ use mimalloc_rust::GlobalMiMalloc;
 use rspack_core::Compiler;
 use rspack_fs::AsyncNativeFileSystem;
 use rspack_testing::apply_from_fixture;
-// #[cfg(feature = "tracing")]
+#[cfg(feature = "tracing")]
 use rspack_tracing::{enable_tracing_by_env, enable_tracing_by_env_with_chrome_layer};
 use termcolorful::println_string_with_fg_color;
 
@@ -35,6 +35,7 @@ impl FromStr for Layer {
 
 #[tokio::main]
 async fn main() {
+  #[cfg(feature = "tracing")]
   let layer = std::env::var("layer")
     .ok()
     .and_then(|var| Layer::from_str(&var).ok())
@@ -51,11 +52,16 @@ async fn main() {
   ];
   for p in path_list {
     println_string_with_fg_color(p, termcolorful::Color::Red);
-    run(p, layer).await;
+    run(
+      p,
+      #[cfg(feature = "tracing")]
+      layer,
+    )
+    .await;
   }
 }
 
-async fn run(relative_path: &str, layer: Layer) {
+async fn run(relative_path: &str, #[cfg(feature = "tracing")] layer: Layer) {
   #[cfg(feature = "tracing")]
   let guard = match layer {
     Layer::Logger => enable_tracing_by_env(),

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -1,24 +1,48 @@
 mod termcolorful;
+use std::str::FromStr;
 use std::{path::PathBuf, time::Instant};
 
 use mimalloc_rust::GlobalMiMalloc;
 use rspack_core::Compiler;
 use rspack_fs::AsyncNativeFileSystem;
 use rspack_testing::apply_from_fixture;
-#[cfg(feature = "tracing")]
-use rspack_tracing::enable_tracing_by_env_with_chrome_layer;
+// #[cfg(feature = "tracing")]
+use rspack_tracing::{enable_tracing_by_env, enable_tracing_by_env_with_chrome_layer};
 use termcolorful::println_string_with_fg_color;
 
 #[cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))]
 #[global_allocator]
 static GLOBAL: GlobalMiMalloc = GlobalMiMalloc;
 
+#[derive(Default, Clone, Copy)]
+enum Layer {
+  #[default]
+  Logger,
+  Chrome,
+}
+
+impl FromStr for Layer {
+  type Err = ();
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    Ok(match s {
+      "chrome" => Self::Chrome,
+      "logger" => Self::Logger,
+      _ => unimplemented!("Unknown layer {s}, please use one of `chrome`, `logger` "),
+    })
+  }
+}
+
 #[tokio::main]
 async fn main() {
+  let layer = std::env::var("layer")
+    .ok()
+    .and_then(|var| Layer::from_str(&var).ok())
+    .unwrap_or_default();
   let path_list = vec![
     // "examples/cjs-tree-shaking-basic",
     // "examples/basic",
-    "smoke-examples/basic",
+    "smoke-example/basic",
     // "examples/export-star-chain",
     // "examples/bbb",
     /* "examples/named-export-decl-with-src-eval",
@@ -27,13 +51,16 @@ async fn main() {
   ];
   for p in path_list {
     println_string_with_fg_color(p, termcolorful::Color::Red);
-    run(p).await;
+    run(p, layer).await;
   }
 }
 
-async fn run(relative_path: &str) {
+async fn run(relative_path: &str, layer: Layer) {
   #[cfg(feature = "tracing")]
-  let guard = enable_tracing_by_env_with_chrome_layer();
+  let guard = match layer {
+    Layer::Logger => enable_tracing_by_env(),
+    Layer::Chrome => enable_tracing_by_env_with_chrome_layer(),
+  };
   let manifest_dir = PathBuf::from(env!("CARGO_WORKSPACE_DIR"));
   // let bundle_dir = manifest_dir.join("tests/fixtures/postcss/pxtorem");
   let bundle_dir: PathBuf = manifest_dir.join(relative_path);

--- a/crates/rspack_tracing/src/lib.rs
+++ b/crates/rspack_tracing/src/lib.rs
@@ -22,8 +22,6 @@ impl<S> Filter<S> for FilterEvent {
 pub fn enable_tracing_by_env() -> Option<FlushGuard> {
   let trace_var = std::env::var("TRACE");
   let is_enable_tracing = trace_var.is_ok();
-  // Sometimes developer may want to trace the upstream lib events,
-  // by default, we only trace the event emitted by rspack
   if is_enable_tracing && !IS_TRACING_ENABLED.swap(true, std::sync::atomic::Ordering::SeqCst) {
     use tracing_subscriber::{fmt, prelude::*};
     let layers = generate_common_layers(trace_var);
@@ -48,8 +46,8 @@ fn generate_common_layers(
   trace_var: Result<String, std::env::VarError>,
 ) -> Vec<Box<dyn Layer<tracing_subscriber::Registry> + Send + Sync>> {
   let default_level = trace_var
-    .ok()
     .as_ref()
+    .ok()
     .and_then(|var| Level::from_str(var).ok());
 
   let mut layers = vec![];
@@ -67,7 +65,15 @@ fn generate_common_layers(
         .boxed(),
     );
   } else {
-    layers.push(EnvFilter::from_env("TRACE").boxed());
+    // SAFETY: we know that trace_var is `Ok(StrinG)` now,
+    // for the second unwrap, if we can't parse the directive, then the tracing result would be
+    // unexpected, then panic is reasonable
+    let res = EnvFilter::builder()
+      .with_regex(true)
+      .parse(trace_var.unwrap())
+      .unwrap();
+
+    layers.push(res.boxed());
   }
   layers
 }
@@ -75,8 +81,6 @@ fn generate_common_layers(
 pub fn enable_tracing_by_env_with_chrome_layer() -> Option<FlushGuard> {
   let trace_var = std::env::var("TRACE");
   let is_enable_tracing = trace_var.is_ok();
-  // Sometimes developer may want to trace the upstream lib events,
-  // by default, we only trace the event emitted by rspack
   if is_enable_tracing && !IS_TRACING_ENABLED.swap(true, std::sync::atomic::Ordering::SeqCst) {
     use tracing_chrome::ChromeLayerBuilder;
     use tracing_subscriber::prelude::*;

--- a/result.logrcc
+++ b/result.logrcc
@@ -1,0 +1,9 @@
+   Compiling rspack_tracing v0.1.0 (/home/victor/Documents/rspack/rspack/crates/rspack_tracing)
+error[E0425]: cannot find value `access_log` in this scope
+  --> crates/rspack_tracing/src/lib.rs:51:24
+   |
+51 |           .with_filter(access_log.with_filter(filter_fn(|metadata| true))),
+   |                        ^^^^^^^^^^ not found in this scope
+
+For more information about this error, try `rustc --explain E0425`.
+error: could not compile `rspack_tracing` (lib) due to previous error

--- a/result.logrcc
+++ b/result.logrcc
@@ -1,9 +1,0 @@
-   Compiling rspack_tracing v0.1.0 (/home/victor/Documents/rspack/rspack/crates/rspack_tracing)
-error[E0425]: cannot find value `access_log` in this scope
-  --> crates/rspack_tracing/src/lib.rs:51:24
-   |
-51 |           .with_filter(access_log.with_filter(filter_fn(|metadata| true))),
-   |                        ^^^^^^^^^^ not found in this scope
-
-For more information about this error, try `rustc --explain E0425`.
-error: could not compile `rspack_tracing` (lib) due to previous error


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/issues/2989, not sure if we could close that.
<!--- Provide link of related issues -->

## Summary
1. Before we could only use `TRACE`, `INFO`, etc, to enable tracing . The method we used before has a pitfall, we can't did some fine-grained event filter, for example, only emit the event in  function `rspack_core::compiler::compilation:xxxx`. This might be a problem when you are trying to debug a big project which might have thousands of modules, the tracing file would be too long to read.
2. After this pull request, we could use the same syntax supported by Tokio tracing https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives. when you want to trace all debug event in rspack emitted by `rspack*` crate, you could use 
```
TRACE=info cargo rb bench -F tracing &| sed -e 's/\x1b\[[0-9;]*m//g' > result.log   
``` 
or for javascript 
```
TRACE=info npx rspack build
```
If you only care about event in mod `rspack_core::compiler::compilation` you could use 
```
TRACE=rspack_core::compiler::compilation cargo rb bench -F tracing &| sed -e 's/\x1b\[[0-9;]*m//g' > result.log   
``` 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 50acdb1</samp>

This pull request improves the tracing functionality for the `bench` and `rspack_tracing` crates. It allows the `bench` crate to select different tracing output formats by setting an environment variable. It also simplifies the tracing configuration and output in the `rspack_tracing` crate by using the `EnvFilter` layer.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 50acdb1</samp>

*  Add `Layer` enum to control tracing output format ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL16-R45))
*  Import `FromStr` trait to implement `Layer` enum ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cR2))
*  Modify `run` function to take `layer` parameter and pass it to tracing initialization functions ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL30-R63))
*  Return `Option<FlushGuard>` from tracing initialization functions to flush output when out of scope ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-c2b93321ef9dc870495ddd3cd7f6d7c3d0a3ed27951770b0f63ead8cf27dbad3L20-R21), [link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-c2b93321ef9dc870495ddd3cd7f6d7c3d0a3ed27951770b0f63ead8cf27dbad3L34-R36))
*  Simplify tracing enabling condition by checking only `TRACE` environment variable ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-c2b93321ef9dc870495ddd3cd7f6d7c3d0a3ed27951770b0f63ead8cf27dbad3L20-R21))
*  Use `EnvFilter` layer to allow user to specify target and level filters by environment variable ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-c2b93321ef9dc870495ddd3cd7f6d7c3d0a3ed27951770b0f63ead8cf27dbad3L34-R36))
*  Remove `#[cfg(feature = "tracing")]` attribute and always enable tracing feature ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL8-R10))
*  Fix typo in `smoke-example/basic` path ([link](https://github.com/web-infra-dev/rspack/pull/3002/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL16-R45))

</details>
