### PR TITLE
chore: make release profile the same for Cargo.toml and node_binding/Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,65 @@ exclude = [
 ] # Avoid including node binding, since feature unification will cause an linking issue. See: https://doc.rust-lang.org/cargo/reference/features.html#feature-unification
 members = ["crates/*"]
 
+  [workspace.dependencies]
+  anyhow             = { version = "1.0.70" }
+  async-recursion    = { version = "1.0.4" }
+  async-scoped       = { version = "0.7.1" }
+  async-trait        = { version = "0.1.68" }
+  better_scoped_tls  = { version = "0.1.0" }
+  bitflags           = { version = "1.3.2" }
+  colored            = { version = "2.0.0" }
+  dashmap            = { version = "5.4.0" }
+  derivative         = { version = "2.2.0" }
+  derive_builder     = { version = "0.11.2" }
+  futures            = { version = "0.3.28" }
+  futures-util       = "0.3.28"
+  glob               = { version = "0.3.1" }
+  hashlink           = { version = "0.8.1" }
+  indexmap           = { version = "1.9.3" }
+  insta              = { version = "1.29.0" }
+  itertools          = { version = "0.10.5" }
+  json               = { version = "0.12.4" }
+  linked_hash_set    = { version = "0.1.4" }
+  mimalloc-rust      = { version = "0.2" }
+  nodejs-resolver    = { version = "0.0.82" }
+  once_cell          = { version = "1.17.1" }
+  paste              = { version = "1.0" }
+  pathdiff           = { version = "0.2.1" }
+  preset_env_base    = { version = "0.4.2" }
+  rayon              = { version = "1.7.0" }
+  regex              = { version = "1.8.1" }
+  rspack_sources     = { version = "0.2.3" }
+  rustc-hash         = { version = "1.1.0" }
+  schemars           = { version = "0.8.12" }
+  serde              = { version = "1.0.160" }
+  serde_json         = { version = "1.0.96" }
+  similar            = { version = "2.2.1" }
+  sugar_path         = { version = "0.0.12" }
+  testing_macros     = { version = "0.2.9" }
+  tokio              = { version = "1.28.0" }
+  tracing            = { version = "0.1.38" }
+  tracing-subscriber = { version = "0.3.17" }
+  url                = { version = "2.3.1" }
+  ustr               = { version = "0.9.0" }
+  xxhash-rust        = { version = "0.8.6" }
+
+  # Pinned
+  napi                = { version = "=2.12.5" }
+  napi-build          = { version = "=2.0.1" }
+  napi-derive         = { version = "=2.12.3" }
+  napi-sys            = { version = "=2.2.3" }
+  swc_config          = { version = "=0.1.5" }
+  swc_core            = { version = "=0.75.35", default-features = false }
+  swc_css             = { version = "=0.153.7" }
+  swc_ecma_minifier   = { version = "=0.180.28", default-features = false }
+  swc_emotion         = { version = "=0.30.5" }
+  swc_error_reporters = { version = "=0.15.5" }
+  swc_html            = { version = "=0.123.26" }
+  swc_html_minifier   = { version = "=0.120.26" }
+  swc_node_comments   = { version = "=0.18.5" }
+  swc_plugin_import   = { version = "=0.1.5" }
+
 [profile.dev]
 debug       = 2
 incremental = true
@@ -11,66 +70,6 @@ incremental = true
 [profile.release]
 codegen-units = 1
 debug         = false
-incremental   = true
-lto           = false
+lto           = false # disabled by now, because it will significantly increase our compile time.
 opt-level     = 3
-
-
-[workspace.dependencies]
-anyhow             = { version = "1.0.70" }
-async-recursion    = { version = "1.0.4" }
-async-scoped       = { version = "0.7.1" }
-async-trait        = { version = "0.1.68" }
-better_scoped_tls  = { version = "0.1.0" }
-bitflags           = { version = "1.3.2" }
-colored            = { version = "2.0.0" }
-dashmap            = { version = "5.4.0" }
-derivative         = { version = "2.2.0" }
-derive_builder     = { version = "0.11.2" }
-futures            = { version = "0.3.28" }
-futures-util       = "0.3.28"
-glob               = { version = "0.3.1" }
-hashlink           = { version = "0.8.1" }
-indexmap           = { version = "1.9.3" }
-insta              = { version = "1.29.0" }
-itertools          = { version = "0.10.5" }
-json               = { version = "0.12.4" }
-linked_hash_set    = { version = "0.1.4" }
-mimalloc-rust      = { version = "0.2" }
-nodejs-resolver    = { version = "0.0.82" }
-once_cell          = { version = "1.17.1" }
-paste              = { version = "1.0" }
-pathdiff           = { version = "0.2.1" }
-preset_env_base    = { version = "0.4.2" }
-rayon              = { version = "1.7.0" }
-regex              = { version = "1.8.1" }
-rspack_sources     = { version = "0.2.3" }
-rustc-hash         = { version = "1.1.0" }
-schemars           = { version = "0.8.12" }
-serde              = { version = "1.0.160" }
-serde_json         = { version = "1.0.96" }
-similar            = { version = "2.2.1" }
-sugar_path         = { version = "0.0.12" }
-testing_macros     = { version = "0.2.9" }
-tokio              = { version = "1.28.0" }
-tracing            = { version = "0.1.38" }
-tracing-subscriber = { version = "0.3.17" }
-url                = { version = "2.3.1" }
-ustr               = { version = "0.9.0" }
-xxhash-rust        = { version = "0.8.6" }
-
-# Pinned
-napi                = { version = "=2.12.5" }
-napi-build          = { version = "=2.0.1" }
-napi-derive         = { version = "=2.12.3" }
-napi-sys            = { version = "=2.2.3" }
-swc_config          = { version = "=0.1.5" }
-swc_core            = { version = "=0.75.35", default-features = false }
-swc_css             = { version = "=0.153.7" }
-swc_ecma_minifier   = { version = "=0.180.28", default-features = false }
-swc_emotion         = { version = "=0.30.5" }
-swc_error_reporters = { version = "=0.15.5" }
-swc_html            = { version = "=0.123.26" }
-swc_html_minifier   = { version = "=0.120.26" }
-swc_node_comments   = { version = "=0.18.5" }
-swc_plugin_import   = { version = "=0.1.5" }
+strip         = true

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -55,6 +55,8 @@ napi-build = { version = "=2.0.1" }
 testing_macros = { version = "0.2.5" }
 
 [profile.release]
-# debug = true
-# Automatically strip symbols from the binary.
-# lto = true   # disabled by now, because it will significantly increase our compile time.
+codegen-units = 1
+debug         = false
+lto           = false # disabled by now, because it will significantly increase our compile time.
+opt-level     = 3
+strip         = true


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8acfd97</samp>

This pull request improves the performance and size of the node binding crate and tests the changes in the nightly workflow. It modifies the `Cargo.toml` files in the root and the `crates/node_binding` directory, the `.github/workflows/release-nightly.yml` file, and the `.github/actions/docker-build/action.yml` file. It also temporarily disables the npm publishing step in the nightly workflow.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8acfd97</samp>

*  Add a new trigger for the release-nightly workflow to run on push events to the same-cargo-toml branch ([link](https://github.com/web-infra-dev/rspack/pull/3004/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554R8-R10))
*  Comment out the release job in the release-nightly workflow to avoid publishing broken or unwanted packages while testing ([link](https://github.com/web-infra-dev/rspack/pull/3004/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L29-R89))
*  Specify the common dependencies for the workspace in the root `Cargo.toml` file and sort them alphabetically ([link](https://github.com/web-infra-dev/rspack/pull/3004/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R7-R65))
*  Improve the performance and size of the binaries by enabling codegen-units, strip, and opt-level, and disabling debug and incremental in the release profile of the root `Cargo.toml` file ([link](https://github.com/web-infra-dev/rspack/pull/3004/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R75))
*  Align the compiler options for the node binding crate with the root `Cargo.toml` file and comment out the debug option in the release profile of the `crates/node_binding/Cargo.toml` file ([link](https://github.com/web-infra-dev/rspack/pull/3004/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L58-R62))
*  List the node binding files after building them with pnpm in the docker-build action for debugging purposes ([link](https://github.com/web-infra-dev/rspack/pull/3004/files?diff=unified&w=0#diff-f1d084efa26a0f0f45c8ba872e6dc750a73daca60a47dfa42121b28eda7e32b3L42-R44))

</details>
