### PR TITLE
ci: remove manual symbol stripping from build steps

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -105,7 +105,6 @@ jobs:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           target: ${{ inputs.target }}
           pre: sudo apt-get -y install protobuf-compiler
-          post: strip crates/node_binding/*.node
 
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
@@ -114,7 +113,6 @@ jobs:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
           pre: sudo apt-get -y install protobuf-compiler
-          post: aarch64-unknown-linux-gnu-strip crates/node_binding/*.node
 
       - name: Build x86_64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
@@ -123,7 +121,6 @@ jobs:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           pre: apk add --no-cache protoc
-          post: strip crates/node_binding/*.node
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' }}
@@ -134,7 +131,6 @@ jobs:
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
             apk add --no-cache protoc
-          post: /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip crates/node_binding/*.node
 
       # Windows
 
@@ -160,7 +156,6 @@ jobs:
         if: ${{ inputs.target == 'x86_64-apple-darwin' }}
         run: |
           RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
-          strip -x crates/node_binding/*.node
 
       - name: Build aarch64-apple-darwin
         if: ${{ inputs.target == 'aarch64-apple-darwin' }}
@@ -171,7 +166,6 @@ jobs:
           SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
           export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
           RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
-          strip -x crates/node_binding/*.node
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Related issue (if exists)

The manual stripping step in unnecessary, I logged the binary size before and after the strip in https://github.com/web-infra-dev/rspack/actions/runs/4881379430, and found no change in size from the outputs.

According to @Brooooooklyn, there are targets that doesn't strip properly, but this is not the case for our supported targets. Even if stripping is buggy, the output size should be negligible because our binary size is at 40MBs.

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

copilot:summary

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

copilot:walkthrough

</details>
