### PR TITLE
feat: add compatible compilation.chunks

### DIFF
--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -16,6 +16,7 @@
     "@rspack/plugin-minify": "workspace:*",
     "copy-webpack-plugin": "5.1.2",
     "generate-package-json-webpack-plugin": "^2.6.0",
+    "license-webpack-plugin": "^4.0.2",
     "webpack-bundle-analyzer": "4.7.0",
     "webpack-stats-plugin": "1.1.1"
   }

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -4,8 +4,6 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 const minifyPlugin = require("@rspack/plugin-minify");
-const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
-const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin')
 const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin');
 const licensePlugin = require('license-webpack-plugin');
 /** @type {import('@rspack/cli').Configuration} */

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -5,6 +5,9 @@ const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 const minifyPlugin = require("@rspack/plugin-minify");
 const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
+const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin')
+const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin');
+const licensePlugin = require('license-webpack-plugin');
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	target: "node",
@@ -41,7 +44,15 @@ const config = {
 			stats: { all: true },
 			filename: "stats.json"
 		}),
-		new GeneratePackageJsonPlugin(basePackage, {})
+		new GeneratePackageJsonPlugin(basePackage, {}),
+		new licensePlugin.LicenseWebpackPlugin({
+			stats: {
+				warnings: false,
+				errors: false,
+			  },
+			perChunkOutput: true,
+			outputFilename: `3rdpartylicenses.txt`,
+		})
 	]
 };
 module.exports = config;

--- a/examples/plugin-compat/src/index.js
+++ b/examples/plugin-compat/src/index.js
@@ -1,3 +1,7 @@
 import { answer } from "./answer";
 import "./index.css";
+
+// Importing the below dependency to force to create the 3rdpartylicenses.txt file (license-webpack-plugin's output)
+import { plugin } from "copy-webpack-plugin";
+
 console.log({ answer });

--- a/examples/plugin-compat/src/index.js
+++ b/examples/plugin-compat/src/index.js
@@ -1,6 +1,5 @@
 import { answer } from "./answer";
 import "./index.css";
-
 // Importing the below dependency to force to create the 3rdpartylicenses.txt file (license-webpack-plugin's output)
 import { plugin } from "copy-webpack-plugin";
 

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -659,24 +659,28 @@ export class Compilation {
 	 * @internal
 	 */
 	__internal__getAssociatedModules(chunk: JsStatsChunk): any[] | undefined {
-		let modules = this.modules;
+		let modules = this.getModules();
+		let moduleMap: Map<string, JsModule> = new Map();
+		for (let module of modules) {
+			moduleMap.set(module.moduleIdentifier, module);
+		}
 		return chunk.modules?.flatMap(chunkModule => {
 			let jsModule = this.__internal__findJsModule(
 				chunkModule.issuer ?? chunkModule.identifier,
-				modules
+				moduleMap
 			);
 			return {
-				...jsModule,
-				dependencies: chunkModule.reasons?.flatMap(jsReason => {
-					let jsOriginModule = this.__internal__findJsModule(
-						jsReason.moduleIdentifier ?? "",
-						modules
-					);
-					return {
-						...jsReason,
-						originModule: jsOriginModule
-					};
-				})
+				...jsModule
+				// dependencies: chunkModule.reasons?.flatMap(jsReason => {
+				// 	let jsOriginModule = this.__internal__findJsModule(
+				// 		jsReason.moduleIdentifier ?? "",
+				// 		moduleMap
+				// 	);
+				// 	return {
+				// 		...jsReason,
+				// 		originModule: jsOriginModule
+				// 	};
+				// })
 			};
 		});
 	}
@@ -689,13 +693,10 @@ export class Compilation {
 	 * @internal
 	 */
 	__internal__findJsModule(
-		identifier: String,
-		modules: JsModule[]
+		identifier: string,
+		modules: Map<string, JsModule>
 	): JsModule | undefined {
-		let module = modules.find(module => {
-			return module.moduleIdentifier == identifier;
-		});
-		return module;
+		return modules.get(identifier);
 	}
 
 	getModules(): JsModule[] {

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -17,6 +17,7 @@ import {
 	JsCompatSource,
 	JsCompilation,
 	JsModule,
+	JsStatsChunk,
 	JsStatsError
 } from "@rspack/binding";
 
@@ -28,10 +29,10 @@ import {
 	RspackPluginInstance
 } from "./config";
 import { ContextModuleFactory } from "./ContextModuleFactory";
-import * as ErrorHelpers from "./ErrorHelpers";
 import ResolverFactory from "./ResolverFactory";
 import { ChunkGroup } from "./chunk_group";
 import { Compiler } from "./compiler";
+import ErrorHelpers from "./ErrorHelpers";
 import { LogType, Logger } from "./logging/Logger";
 import { NormalModule } from "./normalModule";
 import { NormalModuleFactory } from "./normalModuleFactory";
@@ -42,22 +43,7 @@ import {
 	createFakeCompilationDependencies,
 	createFakeProcessAssetsHook
 } from "./util/fake";
-import { Logger, LogType } from "./logging/Logger";
-import * as ErrorHelpers from "./ErrorHelpers";
-import { concatErrorMsgAndStack } from "./util";
-import { normalizeStatsPreset, Stats } from "./stats";
-import { NormalModuleFactory } from "./normalModuleFactory";
 import CacheFacade from "./lib/CacheFacade";
-
-const hashDigestLength = 8;
-const EMPTY_ASSET_INFO = {};
-import { Logger, LogType } from "./logging/Logger";
-import * as ErrorHelpers from "./ErrorHelpers";
-import { concatErrorMsgAndStack } from "./util";
-import { normalizeStatsPreset, Stats } from "./stats";
-import { NormalModuleFactory } from "./normalModuleFactory";
-import CacheFacade from "./lib/CacheFacade";
-import { JsStatsChunk } from "@rspack/binding";
 
 const hashDigestLength = 8;
 const EMPTY_ASSET_INFO = {};
@@ -151,10 +137,6 @@ export class Compilation {
 
 	get hash() {
 		return this.#inner.hash;
-	}
-
-	get chunks() {
-		return this.getChunks();
 	}
 
 	get fullHash() {

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -43,10 +43,6 @@ import {
 	createFakeCompilationDependencies,
 	createFakeProcessAssetsHook
 } from "./util/fake";
-import CacheFacade from "./lib/CacheFacade";
-
-const hashDigestLength = 8;
-const EMPTY_ASSET_INFO = {};
 
 export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
 export type Assets = Record<string, Source>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -404,6 +404,7 @@ importers:
       '@rspack/plugin-minify': workspace:*
       copy-webpack-plugin: 5.1.2
       generate-package-json-webpack-plugin: ^2.6.0
+      license-webpack-plugin: ^4.0.2
       webpack-bundle-analyzer: 4.7.0
       webpack-stats-plugin: 1.1.1
     devDependencies:
@@ -412,6 +413,7 @@ importers:
       '@rspack/plugin-minify': link:../../packages/rspack-plugin-minify
       copy-webpack-plugin: 5.1.2
       generate-package-json-webpack-plugin: 2.6.0
+      license-webpack-plugin: 4.0.2
       webpack-bundle-analyzer: 4.7.0
       webpack-stats-plugin: 1.1.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15911,6 +15911,19 @@ packages:
       type-check: 0.4.0
     dev: true
 
+  /license-webpack-plugin/4.0.2:
+    resolution: {integrity: sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==}
+    peerDependencies:
+      webpack: '*'
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+      webpack-sources:
+        optional: true
+    dependencies:
+      webpack-sources: 3.2.3
+    dev: true
+
   /license-webpack-plugin/4.0.2_webpack@5.80.0:
     resolution: {integrity: sha512-771TFWFD70G1wLTC4oU2Cw4qvtmNrIw+wRvBtn+okgHl7slJVi7zfNcdmqDL72BojM30VNJ2UHylr1o77U37Jw==}
     peerDependencies:


### PR DESCRIPTION
## Related issue (if exists)

Closed https://github.com/web-infra-dev/rspack/issues/2913

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


This pull request adds a getter method for the chunks property of the Compilation class in packages/rspack/src/compilation.ts. 

The integration is working well however the licenses file doesn't show all the included dependencies of the first-level included dependencies. 

The licenses file includes all first-level included dependencies but not for all second-level and the following. I guess to include all levels should be necessary also add compatible compilation.chunkGraph. 


</details>
