### PR TITLE
chore: add web-worker example

### DIFF
--- a/examples/web-worker/index.html
+++ b/examples/web-worker/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/web-worker/package.json
+++ b/examples/web-worker/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/web-worker/rspack.config.js
+++ b/examples/web-worker/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	mode: "development",
+	context: __dirname,
+	entry: {
+		main: "./src/index.js"
+	},
+	builtins: {
+		html: [
+			{
+				template: "./index.html"
+			}
+		]
+	}
+};
+module.exports = config;

--- a/examples/web-worker/src/answer.js
+++ b/examples/web-worker/src/answer.js
@@ -1,0 +1,5 @@
+self.onmessage = ({ data: { question } }) => {
+	self.postMessage({
+		answer: 42
+	});
+};

--- a/examples/web-worker/src/index.js
+++ b/examples/web-worker/src/index.js
@@ -1,0 +1,8 @@
+const worker = new Worker(new URL("./answer.js", import.meta.url));
+worker.postMessage({
+	question:
+		"The Answer to the Ultimate Question of Life, The Universe, and Everything."
+});
+worker.onmessage = ({ data: { answer } }) => {
+	console.log(answer);
+};


### PR DESCRIPTION
## Related issue (if exists)
add basic web-worker example, not supporting bundle worker yet
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c311d15</samp>

This pull request adds a new web-worker example to the rspack project. The example demonstrates how to use the rspack CLI and the html builtin plugin to create and communicate with a web worker in a simple app.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c311d15</samp>

*  Add a web-worker example app that uses the rspack CLI to serve and bundle the app ([link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-bac3d2658625c82479af7ca58cce2de02cbb2e9dbf8def98e20438a2d5fcf1ccR1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-410c66614fc058ce4cb66f8e0c3a099dcb5bac2b42508dc86931c3796bd053b3L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-3a9993da4ffeefbece8b27e6920321c6a69576e5a6a9d8fc5942eb54ee3b2666R1-R16), [link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-0f868b47dd5ce95becdf25e28496e6e6cdac2d16c04c6a665cce5559731887ddR1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-567a7a958046b34aa10ede8e232adee53e55d0008fae74857459632e655f7873R1-R8))
  * Create a basic HTML template for the app in `index.html` and inject the app script using the html builtin plugin ([link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-bac3d2658625c82479af7ca58cce2de02cbb2e9dbf8def98e20438a2d5fcf1ccR1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-3a9993da4ffeefbece8b27e6920321c6a69576e5a6a9d8fc5942eb54ee3b2666R1-R16))
  * Define the app entry point in `src/index.js` and create a web worker instance using the `answer.js` file as the source ([link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-567a7a958046b34aa10ede8e232adee53e55d0008fae74857459632e655f7873R1-R8))
  * Define a web worker script in `src/answer.js` that listens for messages from the main thread and responds with the answer 42 ([link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-0f868b47dd5ce95becdf25e28496e6e6cdac2d16c04c6a665cce5559731887ddR1-R5))
  * Add a `package.json` file that specifies the app metadata, scripts, devDependencies, sideEffects, and other fields ([link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-410c66614fc058ce4cb66f8e0c3a099dcb5bac2b42508dc86931c3796bd053b3L1-R17))
  * Add a `rspack.config.js` file that sets the mode, context, entry, and builtins options for the rspack CLI ([link](https://github.com/web-infra-dev/rspack/pull/3012/files?diff=unified&w=0#diff-3a9993da4ffeefbece8b27e6920321c6a69576e5a6a9d8fc5942eb54ee3b2666R1-R16))

</details>
