### PR TITLE
chore: 🤖 recover check on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,6 @@
   "eslint.enable": false,
   "cSpell.allowCompoundWords": true,
   "cSpell.caseSensitive": true,
-  "rust-analyzer.checkOnSave": false,
   "json.schemas": [
     {
       "fileMatch": [


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 34c8f6c</samp>

This pull request updates the VS Code settings for the Rust project in `web-infra-dev/rspack`. It removes an unnecessary check on save option and adds a newline at the end of the settings file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 34c8f6c</samp>

* Enable rust-analyzer check on save feature for Rust code quality and consistency ([link](https://github.com/web-infra-dev/rspack/pull/3013/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L20))
* Add newline at the end of the file to comply with common practice and avoid potential issues ([link](https://github.com/web-infra-dev/rspack/pull/3013/files?diff=unified&w=0#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L50-R49))

</details>
