### PR TITLE
fix(core): fix require(`./xxx/xx.js`) failed

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require.rs
@@ -118,7 +118,16 @@ impl CodeGeneratable for CommonJSRequireDependency {
               {
                 str.value = JsWord::from(&*module_id);
                 str.raw = Some(Atom::from(format!("\"{module_id}\"")));
-              };
+              }else if let Some(ExprOrSpread{
+                spread:None,
+                expr: box Expr::Tpl(tpl)
+              }) = n.args.first_mut() && tpl.exprs.is_empty() {
+
+                let s = tpl.quasis.first_mut().expect("should have one quasis");
+                s.raw = Atom::from(module_id.as_str());
+
+
+              }
             }
           }),
         );

--- a/packages/rspack/tests/cases/context/issue-3014/answer.js
+++ b/packages/rspack/tests/cases/context/issue-3014/answer.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/packages/rspack/tests/cases/context/issue-3014/index.js
+++ b/packages/rspack/tests/cases/context/issue-3014/index.js
@@ -1,0 +1,4 @@
+it("issue-3014", function () {
+	let answer = require(`./answer`);
+	expect(answer).toBe(42);
+});


### PR DESCRIPTION
## Related issue (if exists)
fixes https://github.com/web-infra-dev/rspack/issues/3011
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b14c42</samp>

This pull request enhances the JavaScript dependency scanner and resolver for `rspack` by supporting template literals as require arguments and optimizing the output code.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b14c42</samp>

*  Handle template literals with no expressions as arguments of require calls ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-e30cf4d1f2a5adaf4b5efbc50db2897a0fb69775de346910bd3dddd218a0eedaL121-R130), [link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faR66-R76), [link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL72-R84))
  - Replace template literals with string literals in the output code ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-e30cf4d1f2a5adaf4b5efbc50db2897a0fb69775de346910bd3dddd218a0eedaL121-R130))
  - Add dependencies for template literals with no expressions to the dependency graph ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faR66-R76))
  - Return early after adding dependencies to avoid scanning the rest of the expression ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL72-R84))
*  Skip scanning template literals with no expressions for context modules ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL468-R479))
  - Check if a template literal has any expressions before trying to find a context module pattern ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL468-R479))
  - Avoid false positives and errors when scanning a template literal with no expressions, which is not a context module ([link](https://github.com/web-infra-dev/rspack/pull/3014/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL468-R479))

</details>
