### PR TITLE
feat(new_split_chunks): support `splitChunks.{cacheGroup}.minSize`

### DIFF
--- a/.changeset/witty-months-look.md
+++ b/.changeset/witty-months-look.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat(new_split_chunks): support `splitChunks.{cacheGroup}.minSize`

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -378,6 +378,7 @@ export interface RawCacheGroupOptions {
   /** What kind of chunks should be selected. */
   chunks?: string
   minChunks?: number
+  minSize?: number
   name?: string
   reuseExistingChunk?: boolean
 }

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -104,7 +104,7 @@ pub struct RawCacheGroupOptions {
   //   pub max_initial_requests: usize,
   pub min_chunks: Option<u32>,
   // hide_path_info: bool,
-  //   pub min_size: usize,
+  pub min_size: Option<f64>,
   //   pub min_size_reduction: usize,
   //   pub enforce_size_threshold: usize,
   //   pub min_remaining_size: usize,
@@ -160,7 +160,7 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
           min_chunks: v.min_chunks.unwrap_or(1),
           min_size: new_split_chunks_plugin::SplitChunkSizes::with_initial_value(
             &default_size_types,
-            overall_min_size,
+            v.min_size.unwrap_or(overall_min_size),
           ),
           reuse_existing_chunk: v.reuse_existing_chunk.unwrap_or(true),
         }),

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -475,7 +475,8 @@ function getRawSplitChunksOptions(
 							priority: group.priority,
 							minChunks: group.minChunks,
 							chunks: group.chunks,
-							reuseExistingChunk: group.reuseExistingChunk
+							reuseExistingChunk: group.reuseExistingChunk,
+							minSize: group.minSize
 						};
 						return [key, normalizedGroup];
 					})

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -953,6 +953,14 @@ module.exports = {
 							instanceof: "RegExp"
 						}
 					]
+				},
+				minSize: {
+					description: "Minimal size for the created chunks.",
+					oneOf: [
+						{
+							$ref: "#/definitions/OptimizationSplitChunksSizes"
+						}
+					]
 				}
 			}
 		},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -590,6 +590,7 @@ export interface OptimizationSplitChunksCacheGroup {
 	priority?: number;
 	reuseExistingChunk?: boolean;
 	test?: RegExp;
+	minSize?: number;
 }
 export type OptimizationSplitChunksSizes = number;
 export type OptimizationRuntimeChunk =

--- a/packages/rspack/tests/configCases/split-chunks-common/move-entry/a.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/move-entry/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/configCases/split-chunks-common/move-entry/index.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/move-entry/index.js
@@ -1,0 +1,3 @@
+it("should not be moved", function () {
+	expect(new Error().stack).not.toMatch(/webpackBootstrap/);
+});

--- a/packages/rspack/tests/configCases/split-chunks-common/move-entry/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/move-entry/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["./commons.js", "./main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks-common/move-entry/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/move-entry/webpack.config.js
@@ -1,0 +1,25 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index?0",
+		second: "./index?1"
+	},
+	target: "web",
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		newSplitChunks: true
+	},
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				commons: {
+					chunks: "initial",
+					minSize: 0,
+					name: "commons"
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

Related #2918

<!--- Provide link of related issues -->

## Summary

- Support `splitChunks.{cacheGroup}.minSize`
- Migrate `test/configCases/split-chunks-common/move-entry` of Webpack 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4fe2bca</samp>

Added support for `minSize` option for split chunks optimization in `rspack`. This option allows specifying a minimum size for chunks to be split or merged. Updated the Rust and TypeScript code, the JSON schema, and the TypeScript interface for the option. Added a new test case `move-entry` to verify the option.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4fe2bca</samp>

* Change the type of `min_size` field in `RawSplitChunksCacheGroup` and `SplitChunksCacheGroup` structs to allow fractional and optional values ([link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L107-R107), [link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L163-R163))
* Add the `minSize` field to the TypeScript and JSON schema definitions for the `OptimizationSplitChunksCacheGroup` object ([link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L478-R479), [link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R956-R963), [link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR593))
* Add a new test case `move-entry` to check the behavior of the `minSize` option for split chunks ([link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-247519f06c7959064693e6cfb0efca2fda5651e7920307bac25eef21803dfca6R1), [link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-e0c9dc2cf3fda755bfc158c25b5599e2c29d47265c8b8e69cfe9fe78330b1035R1-R3), [link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-1c49d80f3b3fb9eb09ab6b97dde6791cbda5d0086ccb35325c799137db81ac2cR1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3015/files?diff=unified&w=0#diff-340f6b5faa455050b59f0369c313962ab590a4a8754898169f0fc2ab0282ed13R1-R25))

</details>
