### PR TITLE
feat: support inline match resource

### DIFF
--- a/.changeset/tender-poets-look.md
+++ b/.changeset/tender-poets-look.md
@@ -1,0 +1,6 @@
+---
+"@rspack/binding": patch
+"@rspack/core": patch
+---
+
+feat: support inline match resource

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -326,6 +326,8 @@ pub struct NormalModule {
   module_type: ModuleType,
   /// Affiliated parser and generator to the module type
   parser_and_generator: Box<dyn ParserAndGenerator>,
+  /// Resource matched with inline match resource, (`!=!` syntax)
+  match_resource: Option<ResourceData>,
   /// Resource data (path, query, fragment etc.)
   resource_data: ResourceData,
   /// Loaders for the module
@@ -389,6 +391,7 @@ impl NormalModule {
     parser_and_generator: Box<dyn ParserAndGenerator>,
     parser_options: Option<AssetParserOptions>,
     generator_options: Option<AssetGeneratorOptions>,
+    match_resource: Option<ResourceData>,
     resource_data: ResourceData,
     resolve_options: Option<Resolve>,
     loaders: Vec<BoxLoader>,
@@ -404,6 +407,7 @@ impl NormalModule {
       parser_and_generator,
       parser_options,
       generator_options,
+      match_resource,
       resource_data,
       resolve_options,
       loaders,
@@ -416,6 +420,10 @@ impl NormalModule {
       code_generation_dependencies: None,
       presentational_dependencies: None,
     }
+  }
+
+  pub fn match_resource(&self) -> Option<&ResourceData> {
+    self.match_resource.as_ref()
   }
 
   pub fn resource_resolved_data(&self) -> &ResourceData {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -3,19 +3,22 @@ use std::{
   sync::Arc,
 };
 
+use once_cell::sync::Lazy;
+use regex::Regex;
 use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_identifier::Identifiable;
-use sugar_path::AsPath;
+use sugar_path::{AsPath, SugarPath};
 use swc_core::common::Span;
 
 use crate::{
-  cache::Cache, module_rule_matcher, resolve, AssetGeneratorOptions, AssetParserOptions, BoxLoader,
-  CompilerOptions, Dependency, DependencyCategory, DependencyType, FactorizeArgs, FactoryMeta,
-  MissingModule, ModuleArgs, ModuleDependency, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
-  ModuleFactoryResult, ModuleIdentifier, ModuleRule, ModuleRuleEnforce, ModuleType, NormalModule,
+  cache::Cache, module_rule_matcher, parse_resource, resolve, stringify_loaders_and_resource,
+  AssetGeneratorOptions, AssetParserOptions, BoxLoader, CompilerOptions, Dependency,
+  DependencyCategory, DependencyType, FactorizeArgs, FactoryMeta, MissingModule, ModuleArgs,
+  ModuleDependency, ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
+  ModuleIdentifier, ModuleRule, ModuleRuleEnforce, ModuleType, NormalModule,
   NormalModuleFactoryResolveForSchemeArgs, RawModule, Resolve, ResolveArgs, ResolveError,
   ResolveOptionsWithDependencyType, ResolveResult, ResolverFactory, ResourceData,
-  SharedPluginDriver,
+  ResourceParsedData, SharedPluginDriver,
 };
 
 #[derive(Debug)]
@@ -35,6 +38,9 @@ impl ModuleFactory for NormalModuleFactory {
     Ok(self.factorize(data).await?)
   }
 }
+
+static MATCH_RESOURCE_REGEX: Lazy<Regex> =
+  Lazy::new(|| Regex::new("^([^!]+)!=!").expect("Failed to initialize `MATCH_RESOURCE_REGEX`"));
 
 impl NormalModuleFactory {
   pub fn new(
@@ -64,44 +70,33 @@ impl NormalModuleFactory {
     } else {
       PathBuf::from(self.context.options.context.as_path())
     };
-    let specifier = data.dependency.request();
-    if should_skip_resolve(specifier) {
+    let mut request_without_match_resource = data.dependency.request();
+    if should_skip_resolve(request_without_match_resource) {
       return Ok(None);
     }
 
     let mut file_dependencies = Default::default();
     let mut missing_dependencies = Default::default();
 
-    let mut resolve_args = ResolveArgs {
-      importer,
-      context: data.context,
-      specifier,
-      dependency_type: data.dependency.dependency_type(),
-      dependency_category: data.dependency.category(),
-      span: data.dependency.span().cloned(),
-      resolve_options: data.resolve_options,
-      resolve_to_context: false,
-      file_dependencies: &mut file_dependencies,
-      missing_dependencies: &mut missing_dependencies,
-    };
-
-    let scheme = url::Url::parse(specifier)
+    let scheme = url::Url::parse(request_without_match_resource)
       .map(|url| url.scheme().to_string())
       .ok();
     let plugin_driver = &self.plugin_driver;
+
+    let mut match_resource_data: Option<ResourceData> = None;
     let mut inline_loaders: Vec<BoxLoader> = vec![];
     let mut no_pre_auto_loaders = false;
     let mut no_auto_loaders = false;
     let mut no_pre_post_auto_loaders = false;
 
     // with scheme, windows absolute path is considered scheme by `url`
-    let resource_data = if let Some(scheme) = scheme && !Path::is_absolute(Path::new(specifier)) {
+    let resource_data = if let Some(scheme) = scheme && !Path::is_absolute(Path::new(request_without_match_resource)) {
       let data = plugin_driver
         .read()
         .await
         .normal_module_factory_resolve_for_scheme(NormalModuleFactoryResolveForSchemeArgs {
           resource: ResourceData {
-            resource: specifier.to_string(),
+            resource: request_without_match_resource.to_string(),
             resource_description: None,
             resource_fragment: None,
             resource_query: None,
@@ -113,13 +108,13 @@ impl NormalModuleFactory {
       match data {
         Ok(Some(data)) => data,
         Ok(None) => {
-          let ident = format!("{}{specifier}", importer_with_context.display());
+          let ident = format!("{}{request_without_match_resource}", importer_with_context.display());
           let module_identifier = ModuleIdentifier::from(format!("missing|{ident}"));
 
           let missing_module = MissingModule::new(
             module_identifier,
             format!("{ident} (missing)"),
-            format!("Failed to resolve {specifier}"),
+            format!("Failed to resolve {request_without_match_resource}"),
           )
           .boxed();
           self.context.module_type = Some(*missing_module.module_type());
@@ -133,7 +128,74 @@ impl NormalModuleFactory {
       }
     } else {
       {
-        let mut request = specifier.chars();
+        let plugin_driver = self.plugin_driver.read().await;
+        let importer = importer.map(|i| {i.display().to_string()});
+        let context = {
+          if let Some(context) = &data.context {
+            context.as_path()
+          } else if let Some(i) = importer.as_ref() {
+            {
+              // TODO: delete this fn after use `normalModule.context` rather than `importer`
+              if let Some(index) = i.find('?') {
+                Path::new(&i[0..index])
+              } else {
+                Path::new(i)
+              }
+            }
+            .parent()
+            .ok_or_else(|| internal_error!("parent() failed for {:?}", importer))?
+          } else {
+            &plugin_driver.options.context
+          }
+        };
+        request_without_match_resource = {
+          let match_resource_match = MATCH_RESOURCE_REGEX.captures(request_without_match_resource);
+          if let Some(m) = match_resource_match {
+            let mut match_resource: String = m.get(1).expect("Should have match resource").as_str().to_owned();
+            let mut chars = match_resource.chars();
+            let first_char = chars.next();
+            let second_char = chars.next();
+
+            if matches!(first_char, Some('.')) {
+              if matches!(second_char, Some('/')) || (matches!(second_char, Some('.')) && matches!(chars.next(), Some('/'))) {
+                // if matchResources startsWith ../ or ./
+                match_resource = context.join(match_resource).absolutize().to_string_lossy().to_string();
+              }
+            }
+
+            let ResourceParsedData {
+              path,
+              query,
+              fragment
+            } = parse_resource(&*match_resource).expect("Should parse resource");
+            match_resource_data = Some(ResourceData {
+              resource: match_resource,
+              resource_path: path,
+              resource_query: query,
+              resource_fragment: fragment,
+              resource_description: None
+            });
+
+            // e.g. ./index.js!=!
+            let whole_matched = m.get(0).expect("Whole matched").as_str();
+
+            match request_without_match_resource.char_indices().nth(whole_matched.len()) {
+              Some((pos, _)) => {
+                &request_without_match_resource[pos..]
+              },
+              None => {
+                let dependency = data.dependency;
+                unreachable!("Invalid dependency: {dependency:?}")
+              }
+            }
+          } else {
+            request_without_match_resource
+          }
+        };
+
+        dbg!(&match_resource_data);
+
+        let mut request = request_without_match_resource.chars();
         let first_char = request.next();
         let second_char = request.next();
         // See: https://webpack.js.org/concepts/loaders/#inline
@@ -142,7 +204,7 @@ impl NormalModuleFactory {
         no_pre_post_auto_loaders = matches!(first_char, Some('!')) && matches!(second_char, Some('!'));
 
         let mut raw_elements = {
-          let s = match specifier.char_indices().nth({
+          let s = match request_without_match_resource.char_indices().nth({
             if no_pre_auto_loaders || no_pre_post_auto_loaders {
               2
             } else if no_auto_loaders {
@@ -152,7 +214,7 @@ impl NormalModuleFactory {
             }
           }) {
             Some((pos, _)) => {
-              &specifier[pos..]
+              &request_without_match_resource[pos..]
             },
             None=> {
               let dependency = data.dependency;
@@ -161,41 +223,21 @@ impl NormalModuleFactory {
           };
           s.split('!').filter(|item| !item.is_empty()).collect::<Vec<_>>()
         };
-        resolve_args.specifier = raw_elements.pop().ok_or_else(|| {
-          let s = resolve_args.specifier;
-          internal_error!("Invalid request: {s}")
+        request_without_match_resource = raw_elements.pop().ok_or_else(|| {
+          internal_error!("Invalid request: {request_without_match_resource}")
         })?;
 
         let loader_resolver = self.resolver_factory.get(ResolveOptionsWithDependencyType {
-          resolve_options: resolve_args.resolve_options.clone(),
+          resolve_options: data.resolve_options.clone(),
           resolve_to_context: false,
           dependency_type: DependencyType::CjsRequire,
           dependency_category: DependencyCategory::CommonJS,
         });
 
-        let plugin_driver = self.plugin_driver.read().await;
         for element in raw_elements {
-          let importer = resolve_args.importer.map(|i| i.display().to_string());
           let res = plugin_driver.resolve_loader(
             &self.context.options,
-            {
-              if let Some(context) = &resolve_args.context {
-                context.as_path()
-              } else if let Some(i) = importer.as_ref() {
-                {
-                  // TODO: delete this fn after use `normalModule.context` rather than `importer`
-                  if let Some(index) = i.find('?') {
-                    Path::new(&i[0..index])
-                  } else {
-                    Path::new(i)
-                  }
-                }
-                .parent()
-                .ok_or_else(|| internal_error!("parent() failed for {:?}", importer))?
-              } else {
-                &plugin_driver.options.context
-              }
-            },
+            context,
             &loader_resolver,
             element
             )
@@ -205,6 +247,19 @@ impl NormalModuleFactory {
           inline_loaders.push(res);
         }
       }
+
+      let resolve_args = ResolveArgs {
+        importer,
+        context: data.context,
+        specifier: request_without_match_resource,
+        dependency_type: data.dependency.dependency_type(),
+        dependency_category: data.dependency.category(),
+        span: data.dependency.span().cloned(),
+        resolve_options: data.resolve_options,
+        resolve_to_context: false,
+        file_dependencies: &mut file_dependencies,
+        missing_dependencies: &mut missing_dependencies,
+      };
 
       // default resolve
       let resource_data = self
@@ -224,7 +279,7 @@ impl NormalModuleFactory {
           }
         }
         Ok(ResolveResult::Ignored) => {
-          let ident = format!("{}/{}", importer_with_context.display(), specifier);
+          let ident = format!("{}/{}", importer_with_context.display(), request_without_match_resource);
           let module_identifier = ModuleIdentifier::from(format!("ignored|{ident}"));
 
           let raw_module = RawModule::new(
@@ -241,7 +296,7 @@ impl NormalModuleFactory {
           ));
         }
         Err(ResolveError(runtime_error, internal_error)) => {
-          let ident = format!("{}{specifier}", importer_with_context.display());
+          let ident = format!("{}{request_without_match_resource}", importer_with_context.display());
           let module_identifier = ModuleIdentifier::from(format!("missing|{ident}"));
 
           let missing_module = MissingModule::new(
@@ -259,19 +314,29 @@ impl NormalModuleFactory {
     };
     //TODO: with contextScheme
     let resolved_module_rules = self
-      .calculate_module_rules(&resource_data, data.dependency.category())
+      .calculate_module_rules(
+        if let Some(match_resource_data) = match_resource_data.as_ref() {
+          match_resource_data
+        } else {
+          &resource_data
+        },
+        data.dependency.category(),
+      )
       .await?;
 
-    let user_request = if !inline_loaders.is_empty() {
-      let s = inline_loaders
-        .iter()
-        .map(|i| i.identifier().as_str())
-        .collect::<Vec<_>>()
-        .join("!");
-      format!("{s}!{}", resource_data.resource)
-    } else {
-      resource_data.resource.clone()
+    let user_request = {
+      let suffix = stringify_loaders_and_resource(&inline_loaders, &resource_data.resource);
+      if let Some(ResourceData { resource, .. }) = match_resource_data.as_ref() {
+        let mut resource = resource.to_owned();
+        resource += "!=!";
+        resource += &*suffix;
+        resource
+      } else {
+        suffix.into_owned()
+      }
     };
+
+    dbg!(&user_request);
 
     // TODO: move loader resolver to rust
     let loaders: Vec<BoxLoader> = {
@@ -304,8 +369,13 @@ impl NormalModuleFactory {
       );
 
       all_loaders.extend(post_loaders);
-      all_loaders.extend(inline_loaders);
-      all_loaders.extend(normal_loaders);
+      if match_resource_data.is_some() {
+        all_loaders.extend(normal_loaders);
+        all_loaders.extend(inline_loaders);
+      } else {
+        all_loaders.extend(inline_loaders);
+        all_loaders.extend(normal_loaders);
+      }
       all_loaders.extend(pre_loaders);
 
       all_loaders
@@ -356,6 +426,7 @@ impl NormalModuleFactory {
       resolved_parser_and_generator,
       resolved_parser_options,
       resolved_generator_options,
+      match_resource_data,
       resource_data,
       resolved_resolve_options,
       loaders,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -193,7 +193,7 @@ impl NormalModuleFactory {
           }
         };
 
-        dbg!(&match_resource_data);
+        // dbg!(&match_resource_data);
 
         let mut request = request_without_match_resource.chars();
         let first_char = request.next();
@@ -336,7 +336,7 @@ impl NormalModuleFactory {
       }
     };
 
-    dbg!(&user_request);
+    // dbg!(&user_request);
 
     // TODO: move loader resolver to rust
     let loaders: Vec<BoxLoader> = {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -156,18 +156,16 @@ impl NormalModuleFactory {
             let first_char = chars.next();
             let second_char = chars.next();
 
-            if matches!(first_char, Some('.')) {
-              if matches!(second_char, Some('/')) || (matches!(second_char, Some('.')) && matches!(chars.next(), Some('/'))) {
-                // if matchResources startsWith ../ or ./
-                match_resource = context.join(match_resource).absolutize().to_string_lossy().to_string();
-              }
+            if matches!(first_char, Some('.')) && (matches!(second_char, Some('/')) || (matches!(second_char, Some('.')) && matches!(chars.next(), Some('/')))) {
+              // if matchResources startsWith ../ or ./
+              match_resource = context.join(match_resource).absolutize().to_string_lossy().to_string();
             }
 
             let ResourceParsedData {
               path,
               query,
               fragment
-            } = parse_resource(&*match_resource).expect("Should parse resource");
+            } = parse_resource(&match_resource).expect("Should parse resource");
             match_resource_data = Some(ResourceData {
               resource: match_resource,
               resource_path: path,

--- a/crates/rspack_core/src/utils/identifier.rs
+++ b/crates/rspack_core/src/utils/identifier.rs
@@ -1,8 +1,13 @@
-use std::{borrow::Cow, path::Path};
+use std::{
+  borrow::Cow,
+  path::{Path, PathBuf},
+};
 
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rspack_util::identifier::absolute_to_request;
+
+use crate::BoxLoader;
 
 pub fn contextify(context: impl AsRef<Path>, request: &str) -> String {
   let context = context.as_ref();
@@ -19,4 +24,41 @@ static IDENTIFIER_REGEXP: Lazy<Regex> =
 #[inline]
 pub fn to_identifier(v: &str) -> Cow<'_, str> {
   IDENTIFIER_REGEXP.replace_all(v, "_")
+}
+
+static PATH_QUERY_FRAGMENT_REGEXP: Lazy<Regex> = Lazy::new(|| {
+  Regex::new("^((?:\0.|[^?#\0])*)(\\?(?:\0.|[^#\0])*)?(#.*)?$")
+    .expect("Failed to initialize `PATH_QUERY_FRAGMENT_REGEXP`")
+});
+
+pub struct ResourceParsedData {
+  pub path: PathBuf,
+  pub query: Option<String>,
+  pub fragment: Option<String>,
+}
+
+pub fn parse_resource(resource: &str) -> Option<ResourceParsedData> {
+  let groups = PATH_QUERY_FRAGMENT_REGEXP.captures(resource)?;
+
+  Some(ResourceParsedData {
+    path: groups.get(1)?.as_str().into(),
+    query: groups.get(2).map(|q| q.as_str().to_owned()),
+    fragment: groups.get(3).map(|q| q.as_str().to_owned()),
+  })
+}
+
+pub fn stringify_loaders_and_resource<'a>(
+  loaders: &'a [BoxLoader],
+  resource: &'a str,
+) -> Cow<'a, str> {
+  if !loaders.is_empty() {
+    let s = loaders
+      .iter()
+      .map(|i| i.identifier().as_str())
+      .collect::<Vec<_>>()
+      .join("!");
+    Cow::Owned(format!("{s}!{}", resource))
+  } else {
+    Cow::Borrowed(resource)
+  }
 }

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/.gitignore
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/b.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/b.js
@@ -1,0 +1,1 @@
+module.exports = ["b"];

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/c.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/c.js
@@ -1,0 +1,1 @@
+module.exports = ["c"];

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/index.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/index.js
@@ -1,0 +1,17 @@
+it("should apply inline loaders before matchResource", function () {
+	var foo = require("c.js!=!loader1!./b.js");
+
+	expect(foo).toEqual(["b", "1", "2"]);
+});
+
+it("should apply config loaders before inline loaders", function () {
+	var foo = require("loader1!./c.js");
+
+	expect(foo).toEqual(["c", "2", "1"]);
+});
+
+it("should not apply config loaders when matchResource is used", function () {
+	var foo = require("d.js!=!loader1!./c.js");
+
+	expect(foo).toEqual(["c", "1", "3"]);
+});

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/node_modules/loader1.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/node_modules/loader1.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("1");';
+};

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/node_modules/loader2.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/node_modules/loader2.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("2");';
+};

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/node_modules/loader3.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/node_modules/loader3.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("3");';
+};

--- a/packages/rspack/tests/configCases/loader/issue-webpack-9053/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/issue-webpack-9053/webpack.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /c\.js$/,
+				use: ["loader2"]
+			},
+			{
+				test: /d\.js$/,
+				use: ["loader3"]
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

closes https://github.com/web-infra-dev/rspack/issues/2646

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 081df2d</samp>

This pull request adds support for the inline match resource syntax (`!=!`) in the module requests and resolves, which allows specifying a different resource to match the module rules and load the module content. It also adds a new test case (`issue-webpack-9053`) to verify the functionality and behavior of this feature. It modifies the files `normal_module_factory.rs`, `normal_module.rs`, and `identifier.rs` in the `rspack_core` crate, and adds new files in the `rspack` package.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 081df2d</samp>

*  Add support for inline match resource syntax (`!=!`) in module requests ([link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL6-R21), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR42-R44), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL67-R74), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL136-R198), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL262-R340), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL307-R378), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR429), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90R329-R330), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90R394), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90R410), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90R425-R428), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-1e29ce8ab6ee7abb5a44dd36bd91c5376542e960b51a7f7657b389233149c291R28-R64))
*  Update the logic to resolve and stringify module requests with match resource data, using the `request_without_match_resource` variable instead of the `specifier` variable ([link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL75-R86), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL98-R93), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL104-R99), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL116-R111), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL122-R117), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL145-R207), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL155-R217), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL164-R231), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL176-R240), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR251-R263), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL227-R282), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL244-R299))
*  Add a new test case `issue-webpack-9053` to verify the behavior of the match resource syntax and the loaders syntax in different scenarios ([link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-b59f128f8d3d6d2af0bd3aa2027b25310f0e0d950fba1e1d8b55c9a2af36e430L1-L-1), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-98c924793553a2f6536b3c67dd12b54d160e9f8574d35ca8168c4af9e6718e4bR1), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-b21722ef9df26248f796f9c22bbb48185d80ecaa06cb3609dc35f30bf7fb355dR1), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-3e38359eb6462c4da70354ad739ef6984fd6c584a112e2a0fef76b9cfd56a6baR1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-481c6116e457cf6d4b71abadc52ba21d5c71006ed350e131eb97f63097b4347eR1-R14))
*  Update and reformat the imports in `normal_module_factory.rs` and `identifier.rs` files ([link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL6-R21), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-1e29ce8ab6ee7abb5a44dd36bd91c5376542e960b51a7f7657b389233149c291L1-R4), [link](https://github.com/web-infra-dev/rspack/pull/3017/files?diff=unified&w=0#diff-1e29ce8ab6ee7abb5a44dd36bd91c5376542e960b51a7f7657b389233149c291R10-R11))

</details>
