### PR TITLE
chore(rust): bump sass-embedded and remove protobuf requirement

### DIFF
--- a/.github/workflows/bench-history.yaml
+++ b/.github/workflows/bench-history.yaml
@@ -19,10 +19,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Install protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install toolchain
         run: rustup show
 
@@ -31,7 +28,7 @@ jobs:
 
       - name: Run benchmark
         run: |
-          set -o pipefail 
+          set -o pipefail
           cargo bench --bench main -- --output-format bencher | tee output.txt
 
       - name: Run Hmr benchmark

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -37,11 +37,6 @@ jobs:
           submodules: false
           ref: ${{ steps.sha.outputs.result }}
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install toolchain
         run: rustup show
 

--- a/.github/workflows/bundle-stats.yaml.bak
+++ b/.github/workflows/bundle-stats.yaml.bak
@@ -16,10 +16,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Install protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v3
         with:
           node-version: "16"

--- a/.github/workflows/check-js.yaml.bak
+++ b/.github/workflows/check-js.yaml.bak
@@ -22,8 +22,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install protoc
-        uses: arduino/setup-protoc@v1
       - uses: actions/setup-node@v3
         with:
           node-version: "16"

--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -29,11 +29,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install toolchain
         run: rustup show
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -28,11 +28,6 @@ jobs:
         with:
           version: 0.10.1
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup target
         run: |
           rustup target add aarch64-apple-darwin

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -72,12 +72,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Protoc
-        if: ${{ needs.select.outputs.docker != 'true' }}
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install Rust
         if: ${{ needs.select.outputs.docker != 'true' }}
         run: rustup show
@@ -104,7 +98,6 @@ jobs:
         with:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           target: ${{ inputs.target }}
-          pre: sudo apt-get -y install protobuf-compiler
 
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
@@ -112,7 +105,6 @@ jobs:
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
-          pre: sudo apt-get -y install protobuf-compiler
 
       - name: Build x86_64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
@@ -120,7 +112,6 @@ jobs:
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-          pre: apk add --no-cache protoc
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' }}
@@ -130,7 +121,6 @@ jobs:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
-            apk add --no-cache protoc
 
       # Windows
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,15 +761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,12 +1429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "napi"
 version = "2.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,16 +1925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,28 +1974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,16 +1984,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -2174,15 +2117,6 @@ name = "relative-path"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf2521270932c3c7bed1a59151222bd7643c79310f2916f01925e1e16255698"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "ropey"
@@ -2951,16 +2885,15 @@ dependencies = [
 
 [[package]]
 name = "sass-embedded"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bc40eea43391e185d1760f78b7d254f8f8348da7ff7963e98c10ecd1ed0f15"
+checksum = "043fea16ac00f7132b50dce6094873fee0d328bd43c0f552faeb33d989d97b77"
 dependencies = [
  "atty",
  "crossbeam-channel",
  "dashmap",
  "parking_lot 0.12.1",
  "prost",
- "prost-build",
  "regex",
  "rustc-hash",
  "serde",
@@ -4410,20 +4343,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,17 +4838,6 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -539,15 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,12 +1164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
 name = "napi"
 version = "2.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,16 +1626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
-dependencies = [
- "proc-macro2",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,28 +1675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
-dependencies = [
- "bytes",
- "heck",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.107",
- "tempfile",
- "which",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1732,16 +1685,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
-dependencies = [
- "bytes",
- "prost",
 ]
 
 [[package]]
@@ -1875,15 +1818,6 @@ name = "relative-path"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3bf6b372449361333ac1f498b7edae4dd5e70dccd7c0c2a7c7bce8f05ede648"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "ropey"
@@ -2563,16 +2497,15 @@ checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "sass-embedded"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bc40eea43391e185d1760f78b7d254f8f8348da7ff7963e98c10ecd1ed0f15"
+checksum = "043fea16ac00f7132b50dce6094873fee0d328bd43c0f552faeb33d989d97b77"
 dependencies = [
  "atty",
  "crossbeam-channel",
  "dashmap",
  "parking_lot 0.12.1",
  "prost",
- "prost-build",
  "regex",
  "rustc-hash",
  "serde",
@@ -3951,20 +3884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
-dependencies = [
- "cfg-if",
- "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4419,17 +4338,6 @@ checksum = "48134de3d7598219ab9eaf6b91b15d8e50d31da76b8519fe4ecfcec2cf35104b"
 dependencies = [
  "indexmap",
  "url",
-]
-
-[[package]]
-name = "which"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
-dependencies = [
- "either",
- "libc",
- "once_cell",
 ]
 
 [[package]]

--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -15,7 +15,7 @@ regex = { workspace = true }
 rspack_core = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 rspack_loader_runner = { path = "../rspack_loader_runner" }
-sass-embedded = { version = "0.6.2", features = ["legacy", "serde"] }
+sass-embedded = { version = "0.7.1", features = ["legacy", "serde"] }
 serde = { workspace = true, features = ["derive"] }
 str_indices = "0.4.1"
 tokio = { workspace = true, features = [

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -517,7 +517,7 @@ impl Identifiable for SassLoader {
   }
 }
 
-fn sass_exception_to_error(e: Exception) -> Error {
+fn sass_exception_to_error(e: Box<Exception>) -> Error {
   if let Some(span) = e.span()
     && let Some(message) = e.sass_message()
     && let Some(e) = make_traceable_error("Sass Error", message, span) {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c3304a</samp>

This pull request removes unnecessary dependencies and steps from the GitHub workflows for Rust code, and updates the `rspack_loader_sass` crate to use the latest version of the `sass-embedded` crate. These changes aim to simplify, speed up, and improve the quality of the Rust code and benchmarks.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c3304a</samp>

* Remove unnecessary `Install protoc` steps from GitHub workflows ([link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-f823c74932582b496bd85b6c841c0bd830cf28a34348e3404e14ad3727dacff7L22-R22), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-7952962a8a59ebb5e00103ee4a339041d04de64d5454b3bdff0379b349d27a41L40-L44), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-5b78af515332e94dc01fd5e3712c1f9fe2328e02455fb99d45efb76dcd19fd78L32-L36), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-9f4438d00ff0b9f13896fd034278896ec94153fc2a5733b1852cbfce7ecaff77L31-L35), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L75-L80))
* Remove unnecessary `pre` commands to install `protobuf-compiler` or `protoc` from `reusable-build` workflow ([link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L107), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L115), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L123), [link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L133))
* Update `sass-embedded` dependency to version `0.7.1` in `rspack_loader_sass` crate ([link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-07e0029bdf6397999712f5ca814db9ce764467a6459da9f8a32dad5fa35c09e3L18-R18))
* Adapt to new API of `sass-embedded` crate by accepting a `Box<Exception>` in `sass_exception_to_error` function ([link](https://github.com/web-infra-dev/rspack/pull/3021/files?diff=unified&w=0#diff-f3a98482ba66e22cc9fbdc37dae0f882c5558175f3f93183da15ab498f4d725aL520-R520))

</details>
