### PR TITLE
refactor: remove dependency parent module identifier

### DIFF
--- a/.changeset/dry-dingos-study.md
+++ b/.changeset/dry-dingos-study.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+refactor: remove dependency parent module identifier

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -204,7 +204,13 @@ where
           .compilation
           .entry_dependencies
           .iter()
-          .flat_map(|(_, deps)| deps.clone())
+          .flat_map(|(_, deps)| {
+            deps
+              .clone()
+              .into_iter()
+              .map(|d| (d, None))
+              .collect::<Vec<_>>()
+          })
           .collect::<HashSet<_>>();
         SetupMakeParam::ForceBuildDeps(deps)
       };

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -122,7 +122,13 @@ where
       .compilation
       .entry_dependencies
       .iter()
-      .flat_map(|(_, deps)| deps.clone())
+      .flat_map(|(_, deps)| {
+        deps
+          .clone()
+          .into_iter()
+          .map(|d| (d, None))
+          .collect::<Vec<_>>()
+      })
       .collect::<HashSet<_>>();
     self.compile(SetupMakeParam::ForceBuildDeps(deps)).await?;
     self.cache.begin_idle();

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -137,14 +137,8 @@ pub struct AddTask {
 
 #[derive(Debug)]
 pub enum AddTaskResult {
-  ModuleReused {
-    module: Box<dyn Module>,
-    dependencies: Vec<DependencyId>,
-  },
-  ModuleAdded {
-    module: Box<dyn Module>,
-    dependencies: Vec<DependencyId>,
-  },
+  ModuleReused { module: Box<dyn Module> },
+  ModuleAdded { module: Box<dyn Module> },
 }
 
 impl AddTask {
@@ -165,7 +159,6 @@ impl AddTask {
 
       return Ok(TaskResult::Add(AddTaskResult::ModuleReused {
         module: self.module,
-        dependencies: self.dependencies,
       }));
     }
 
@@ -188,7 +181,6 @@ impl AddTask {
 
     Ok(TaskResult::Add(AddTaskResult::ModuleAdded {
       module: self.module,
-      dependencies: self.dependencies,
     }))
   }
 }
@@ -215,7 +207,6 @@ pub type AddQueue = WorkerQueue<AddTask>;
 
 pub struct BuildTask {
   pub module: Box<dyn Module>,
-  pub dependencies: Vec<DependencyId>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub compiler_options: Arc<CompilerOptions>,
   pub plugin_driver: SharedPluginDriver,
@@ -225,7 +216,6 @@ pub struct BuildTask {
 #[derive(Debug)]
 pub struct BuildTaskResult {
   pub module: Box<dyn Module>,
-  pub dependencies: Vec<DependencyId>,
   pub build_result: Box<BuildResult>,
   pub diagnostics: Vec<Diagnostic>,
 }
@@ -270,7 +260,6 @@ impl WorkerTask for BuildTask {
 
       TaskResult::Build(BuildTaskResult {
         module,
-        dependencies: self.dependencies,
         build_result: Box::new(build_result),
         diagnostics,
       })

--- a/crates/rspack_core/src/dependency/common_js_require_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/common_js_require_context_dependency.rs
@@ -9,14 +9,12 @@ use swc_core::{
 
 use crate::{
   create_javascript_visitor, normalize_context, CodeGeneratable, CodeGeneratableResult,
-  ContextOptions, Dependency, DependencyId, ErrorSpan, JsAstPath, ModuleDependency,
-  ModuleIdentifier, RuntimeGlobals,
+  ContextOptions, Dependency, DependencyId, ErrorSpan, JsAstPath, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CommonJsRequireContextDependency {
   pub id: Option<DependencyId>,
-  pub parent_module_identifier: Option<ModuleIdentifier>,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
   #[allow(unused)]
@@ -26,7 +24,6 @@ pub struct CommonJsRequireContextDependency {
 impl CommonJsRequireContextDependency {
   pub fn new(options: ContextOptions, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       options,
       span,
       ast_path,
@@ -48,14 +45,6 @@ impl Dependency for CommonJsRequireContextDependency {
 
   fn dependency_type(&self) -> &crate::DependencyType {
     &crate::DependencyType::CommonJSRequireContext
-  }
-
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 }
 

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -3,7 +3,7 @@ use swc_core::ecma::ast::Expr;
 
 use crate::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
-  Dependency, JsAstPath, ModuleIdentifier, RuntimeGlobals,
+  Dependency, JsAstPath, RuntimeGlobals,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -14,11 +14,7 @@ pub struct ConstDependency {
   pub ast_path: JsAstPath,
 }
 
-impl Dependency for ConstDependency {
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    None
-  }
-}
+impl Dependency for ConstDependency {}
 
 impl CodeGeneratable for ConstDependency {
   fn generate(

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -25,10 +25,6 @@ impl Dependency for ContextElementDependency {
     self.id = id;
   }
 
-  fn parent_module_identifier(&self) -> Option<&crate::ModuleIdentifier> {
-    None
-  }
-
   fn category(&self) -> &DependencyCategory {
     &self.category
   }

--- a/crates/rspack_core/src/dependency/dynamic_import.rs
+++ b/crates/rspack_core/src/dependency/dynamic_import.rs
@@ -10,13 +10,12 @@ use swc_core::{
 use crate::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableDeclMappings,
   CodeGeneratableResult, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  JsAstPath, ModuleDependency, ModuleDependencyExt, ModuleIdentifier, RuntimeGlobals,
+  JsAstPath, ModuleDependency, ModuleDependencyExt, RuntimeGlobals,
 };
 
 #[derive(Debug, Eq, Clone)]
 pub struct EsmDynamicImportDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   category: &'static DependencyCategory,
   dependency_type: &'static DependencyType,
@@ -32,8 +31,7 @@ pub struct EsmDynamicImportDependency {
 // Do not edit this, as it is used to uniquely identify the dependency.
 impl PartialEq for EsmDynamicImportDependency {
   fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
+    self.request == other.request
       && self.category == other.category
       && self.dependency_type == other.dependency_type
   }
@@ -42,7 +40,6 @@ impl PartialEq for EsmDynamicImportDependency {
 // Do not edit this, as it is used to uniquely identify the dependency.
 impl std::hash::Hash for EsmDynamicImportDependency {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
     self.request.hash(state);
     self.category.hash(state);
     self.dependency_type.hash(state);
@@ -57,7 +54,6 @@ impl EsmDynamicImportDependency {
     name: Option<String>,
   ) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       name,
       category: &DependencyCategory::Esm,
@@ -75,13 +71,6 @@ impl Dependency for EsmDynamicImportDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -1,6 +1,6 @@
 use crate::{
   CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier,
+  DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -16,10 +16,6 @@ impl EntryDependency {
 }
 
 impl Dependency for EntryDependency {
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    None
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }

--- a/crates/rspack_core/src/dependency/import_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/import_context_dependency.rs
@@ -9,14 +9,12 @@ use swc_core::{
 
 use crate::{
   create_javascript_visitor, normalize_context, CodeGeneratable, CodeGeneratableResult,
-  ContextOptions, Dependency, DependencyId, ErrorSpan, JsAstPath, ModuleDependency,
-  ModuleIdentifier, RuntimeGlobals,
+  ContextOptions, Dependency, DependencyId, ErrorSpan, JsAstPath, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ImportContextDependency {
   pub id: Option<DependencyId>,
-  pub parent_module_identifier: Option<ModuleIdentifier>,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
   #[allow(unused)]
@@ -26,7 +24,6 @@ pub struct ImportContextDependency {
 impl ImportContextDependency {
   pub fn new(options: ContextOptions, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       options,
       span,
       ast_path,
@@ -48,14 +45,6 @@ impl Dependency for ImportContextDependency {
 
   fn dependency_type(&self) -> &crate::DependencyType {
     &crate::DependencyType::ImportContext
-  }
-
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 }
 

--- a/crates/rspack_core/src/dependency/require_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/require_context_dependency.rs
@@ -9,13 +9,12 @@ use swc_core::{
 
 use crate::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableResult, ContextOptions, Dependency,
-  DependencyId, ErrorSpan, JsAstPath, ModuleDependency, ModuleIdentifier, RuntimeGlobals,
+  DependencyId, ErrorSpan, JsAstPath, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RequireContextDependency {
   pub id: Option<DependencyId>,
-  pub parent_module_identifier: Option<ModuleIdentifier>,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
   #[allow(unused)]
@@ -25,7 +24,6 @@ pub struct RequireContextDependency {
 impl RequireContextDependency {
   pub fn new(options: ContextOptions, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       options,
       span,
       ast_path,
@@ -47,14 +45,6 @@ impl Dependency for RequireContextDependency {
 
   fn dependency_type(&self) -> &crate::DependencyType {
     &crate::DependencyType::CommonJSRequireContext
-  }
-
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 }
 

--- a/crates/rspack_core/src/dependency/require_resolve_dependency.rs
+++ b/crates/rspack_core/src/dependency/require_resolve_dependency.rs
@@ -6,13 +6,12 @@ use swc_core::{
 
 use crate::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableResult, ContextOptions, Dependency,
-  DependencyId, ErrorSpan, JsAstPath, ModuleDependency, ModuleIdentifier,
+  DependencyId, ErrorSpan, JsAstPath, ModuleDependency,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RequireResolveDependency {
   pub id: Option<DependencyId>,
-  pub parent_module_identifier: Option<ModuleIdentifier>,
   pub request: String,
   pub weak: bool,
   span: ErrorSpan,
@@ -23,7 +22,6 @@ pub struct RequireResolveDependency {
 impl RequireResolveDependency {
   pub fn new(request: String, weak: bool, span: ErrorSpan, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       weak,
       span,
@@ -46,14 +44,6 @@ impl Dependency for RequireResolveDependency {
 
   fn dependency_type(&self) -> &crate::DependencyType {
     &crate::DependencyType::RequireResolve
-  }
-
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 }
 

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_error::Result;
 
 use crate::{
-  CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, ModuleIdentifier,
-  RuntimeGlobals,
+  CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -10,11 +9,7 @@ pub struct RuntimeRequirementsDependency {
   pub runtime_requirements: RuntimeGlobals,
 }
 
-impl Dependency for RuntimeRequirementsDependency {
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    None
-  }
-}
+impl Dependency for RuntimeRequirementsDependency {}
 
 impl CodeGeneratable for RuntimeRequirementsDependency {
   fn generate(

--- a/crates/rspack_core/src/dependency/static_exports_dependency.rs
+++ b/crates/rspack_core/src/dependency/static_exports_dependency.rs
@@ -1,6 +1,6 @@
 use crate::{
   CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier,
+  DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,9 +28,6 @@ impl Dependency for StaticExportsDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    None
   }
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Unknown

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -577,15 +577,7 @@ impl Module for NormalModule {
     // Other side effects should be set outside use_cache
     self.original_source = Some(original_source);
     self.ast_or_source = NormalModuleAstOrSource::new_built(ast_or_source, &diagnostics);
-    self.code_generation_dependencies = Some(
-      code_generation_dependencies
-        .into_iter()
-        .map(|mut d| {
-          d.set_parent_module_identifier(Some(self.identifier()));
-          d
-        })
-        .collect::<Vec<_>>(),
-    );
+    self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
 
     let mut hasher = Xxh3::new();

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -1,36 +1,19 @@
 use rspack_core::{
   CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier,
+  DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct CssComposeDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: String,
   span: Option<ErrorSpan>,
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for CssComposeDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier && self.request == other.request
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for CssComposeDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-  }
 }
 
 impl CssComposeDependency {
   pub fn new(request: String, span: Option<ErrorSpan>) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       request,
       span,
     }
@@ -43,13 +26,6 @@ impl Dependency for CssComposeDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -1,43 +1,25 @@
 use rspack_core::{
   create_css_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, CssAstPath,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
-  ModuleIdentifier,
 };
 use swc_core::{
   common::util::take::Take,
   css::ast::{AtRulePrelude, Rule},
 };
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct CssImportDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: String,
   span: Option<ErrorSpan>,
   #[allow(unused)]
   ast_path: CssAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for CssImportDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier && self.request == other.request
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for CssImportDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-  }
-}
-
 impl CssImportDependency {
   pub fn new(request: String, span: Option<ErrorSpan>, ast_path: CssAstPath) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       request,
       span,
       ast_path,
@@ -51,13 +33,6 @@ impl Dependency for CssImportDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -5,35 +5,18 @@ use rspack_core::{
 };
 use swc_core::css::ast::UrlValue;
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct CssUrlDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: String,
   span: Option<ErrorSpan>,
   #[allow(unused)]
   ast_path: CssAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for CssUrlDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier && self.request == other.request
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for CssUrlDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-  }
-}
-
 impl CssUrlDependency {
   pub fn new(request: String, span: Option<ErrorSpan>, ast_path: CssAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       span,
       ast_path,
@@ -75,13 +58,6 @@ impl Dependency for CssUrlDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require.rs
@@ -1,17 +1,16 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier,
+  ModuleDependency,
 };
 use swc_core::ecma::{
   ast::*,
   atoms::{Atom, JsWord},
 };
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct CommonJSRequireDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   // user_request: String,
   category: &'static DependencyCategory,
@@ -21,31 +20,10 @@ pub struct CommonJSRequireDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for CommonJSRequireDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for CommonJSRequireDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl CommonJSRequireDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       request,
       // user_request,
       category: &DependencyCategory::CommonJS,
@@ -62,13 +40,6 @@ impl Dependency for CommonJSRequireDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/export.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/export.rs
@@ -1,17 +1,16 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier,
+  ModuleDependency,
 };
 use rspack_core::{CodeGeneratableDeclMappings, ModuleDependencyExt};
 use swc_core::ecma::ast::ModuleDecl;
 use swc_core::ecma::atoms::Atom;
 use swc_core::ecma::atoms::JsWord;
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct EsmExportDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   category: &'static DependencyCategory,
   dependency_type: &'static DependencyType,
@@ -21,30 +20,9 @@ pub struct EsmExportDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for EsmExportDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for EsmExportDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl EsmExportDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::EsmExport,
@@ -61,13 +39,6 @@ impl Dependency for EsmExportDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import.rs
@@ -1,14 +1,13 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableDeclMappings,
   CodeGeneratableResult, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  JsAstPath, ModuleDependency, ModuleDependencyExt, ModuleIdentifier,
+  JsAstPath, ModuleDependency, ModuleDependencyExt,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct EsmImportDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   // user_request: String,
   category: &'static DependencyCategory,
@@ -19,30 +18,9 @@ pub struct EsmImportDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for EsmImportDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for EsmImportDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl EsmImportDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       // user_request,
       category: &DependencyCategory::Esm,
@@ -60,13 +38,6 @@ impl Dependency for EsmImportDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,14 +1,13 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct ImportMetaModuleHotAcceptDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   // user_request: String,
   category: &'static DependencyCategory,
@@ -19,30 +18,9 @@ pub struct ImportMetaModuleHotAcceptDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for ImportMetaModuleHotAcceptDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for ImportMetaModuleHotAcceptDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl ImportMetaModuleHotAcceptDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::ImportMetaHotAccept,
@@ -59,13 +37,6 @@ impl Dependency for ImportMetaModuleHotAcceptDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,14 +1,13 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct ImportMetaModuleHotDeclineDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   // user_request: String,
   category: &'static DependencyCategory,
@@ -19,30 +18,9 @@ pub struct ImportMetaModuleHotDeclineDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for ImportMetaModuleHotDeclineDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for ImportMetaModuleHotDeclineDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl ImportMetaModuleHotDeclineDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
-      parent_module_identifier: None,
       request,
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::ImportMetaHotDecline,
@@ -59,13 +37,6 @@ impl Dependency for ImportMetaModuleHotDeclineDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,14 +1,13 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct ModuleHotAcceptDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   // user_request: String,
   category: &'static DependencyCategory,
@@ -19,31 +18,10 @@ pub struct ModuleHotAcceptDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for ModuleHotAcceptDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for ModuleHotAcceptDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl ModuleHotAcceptDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       request,
       category: &DependencyCategory::CommonJS,
       dependency_type: &DependencyType::ModuleHotAccept,
@@ -59,13 +37,6 @@ impl Dependency for ModuleHotAcceptDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,14 +1,13 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct ModuleHotDeclineDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   // user_request: String,
   category: &'static DependencyCategory,
@@ -19,31 +18,10 @@ pub struct ModuleHotDeclineDependency {
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for ModuleHotDeclineDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier
-      && self.request == other.request
-      && self.category == other.category
-      && self.dependency_type == other.dependency_type
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for ModuleHotDeclineDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category.hash(state);
-    self.dependency_type.hash(state);
-  }
-}
-
 impl ModuleHotDeclineDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       request,
       category: &DependencyCategory::CommonJS,
       dependency_type: &DependencyType::ModuleHotDecline,
@@ -59,13 +37,6 @@ impl Dependency for ModuleHotDeclineDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,44 +1,25 @@
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency, ModuleIdentifier, RuntimeGlobals,
+  ModuleDependency, RuntimeGlobals,
 };
 use swc_core::common::Spanned;
 use swc_core::ecma::utils::{member_expr, quote_ident, quote_str};
 use swc_core::ecma::{ast::*, atoms::JsWord};
 
-#[derive(Debug, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct URLDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   request: JsWord,
   span: Option<ErrorSpan>,
   #[allow(unused)]
   ast_path: JsAstPath,
 }
 
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl PartialEq for URLDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.parent_module_identifier == other.parent_module_identifier && self.request == other.request
-  }
-}
-
-// Do not edit this, as it is used to uniquely identify the dependency.
-impl std::hash::Hash for URLDependency {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.parent_module_identifier.hash(state);
-    self.request.hash(state);
-    self.category().hash(state);
-    self.dependency_type().hash(state);
-  }
-}
-
 impl URLDependency {
   pub fn new(request: JsWord, span: Option<ErrorSpan>, ast_path: JsAstPath) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       request,
       span,
       ast_path,
@@ -52,13 +33,6 @@ impl Dependency for URLDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, module_identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = module_identifier;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin.rs
@@ -444,7 +444,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>> {
     let ParseContext {
       source,
-      module_identifier,
       module_type,
       resource_data,
       compiler_options,
@@ -498,13 +497,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     Ok(
       ParseResult {
         ast_or_source: AstOrSource::Ast(ModuleAst::JavaScript(ast)),
-        dependencies: dependencies
-          .into_iter()
-          .map(|mut d| {
-            d.set_parent_module_identifier(Some(module_identifier));
-            d
-          })
-          .collect(),
+        dependencies,
         presentational_dependencies,
       }
       .with_diagnostic(diagnostics),

--- a/crates/rspack_plugin_wasm/src/dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency.rs
@@ -1,9 +1,6 @@
-use core::hash::Hash;
-use std::hash::Hasher;
-
 use rspack_core::{
   CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier,
+  DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 use crate::WasmNode;
@@ -11,7 +8,6 @@ use crate::WasmNode;
 #[derive(Debug, Clone)]
 pub struct WasmImportDependency {
   id: Option<DependencyId>,
-  parent_module_identifier: Option<ModuleIdentifier>,
   name: String,
   request: String,
   // only_direct_import: bool,
@@ -25,7 +21,6 @@ impl WasmImportDependency {
   pub fn new(request: String, name: String, desc: WasmNode) -> Self {
     Self {
       id: None,
-      parent_module_identifier: None,
       name,
       request,
       desc,
@@ -44,13 +39,6 @@ impl Dependency for WasmImportDependency {
   }
   fn set_id(&mut self, id: Option<DependencyId>) {
     self.id = id;
-  }
-  fn parent_module_identifier(&self) -> Option<&ModuleIdentifier> {
-    self.parent_module_identifier.as_ref()
-  }
-
-  fn set_parent_module_identifier(&mut self, identifier: Option<ModuleIdentifier>) {
-    self.parent_module_identifier = identifier;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -83,17 +71,4 @@ impl CodeGeneratable for WasmImportDependency {
   ) -> rspack_error::Result<CodeGeneratableResult> {
     todo!()
   }
-}
-
-impl PartialEq for WasmImportDependency {
-  fn eq(&self, other: &Self) -> bool {
-    self.id == other.id
-      && self.parent_module_identifier == other.parent_module_identifier
-      && self.name == other.name
-      && self.request == other.request
-  }
-}
-impl Eq for WasmImportDependency {}
-impl Hash for WasmImportDependency {
-  fn hash<H: Hasher>(&self, _state: &mut H) {}
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- remove the dependency parent module identifier, because already has the dependency id and can search for it
- add `make_failed_module` to avoid dependencies passing through & refactor some logic of rebuild to implement the first work.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c13d60d</samp>

This pull request refactors the dependency system in the `rspack_core` package to simplify the dependency representation and the compilation logic. It removes the `parent_module_identifier` field and methods from various dependency structs, and uses the module graph to store and track the parent modules of dependencies. It also introduces a new type `BuildDependency`, which is a tuple of `(DependencyId, Option<ModuleIdentifier>)`, and uses it to handle dependencies that need to be rebuilt. It updates the `compile` method of the `Compilation` struct and the related methods of the `Compiler` and `Hmr` structs to accept and process `BuildDependency` values. It also adds a `.changeset` file to document the changes for the `changesets` tool.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c13d60d</samp>

*  Refactor the dependency system in the `rspack_core` package to store the parent module identifier of each dependency in the module graph, instead of in the dependency itself ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-d2876b00cdba018d97b59f61c8c9d9d4715eabff83376251770063c829f331e2R1-R5))
  * Change the `SetupMakeParam::ForceBuildDeps` variant to take a `HashSet<BuildDependency>` instead of a `HashSet<DependencyId>`, where `BuildDependency` is a new type alias for a tuple of `(DependencyId, Option<ModuleIdentifier>)` ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L58-R66))
  * Add two new fields to the `Compilation` struct: `make_failed_module` and `make_failed_dependencies`, which are `HashSet`s of `ModuleIdentifier` and `BuildDependency`, respectively, and are used to store the modules and dependencies that failed to build during the compilation ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L70-R76), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R132))
  * Modify the `compile` method of the `Compilation` struct to use the new fields and parameters, and to handle the module creation and error handling for each dependency that needs to be rebuilt ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L384-R391), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L419-R426), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L449-R457), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L458-R498), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L616-R625), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L642-R654), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L663), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L669-R673), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R747))
  * Modify the `handle_hmr` method of the `Hmr` struct to convert the `deps` variable into a `HashSet<BuildDependency>` and pass it to the `compile` method of the `Compilation` struct ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L207-R213))
  * Modify the `build` method of the `Compiler` struct to convert the `deps` variable into a `HashSet<BuildDependency>` and pass it to the `compile` method of the `Compilation` struct ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L125-R131))
  * Remove the `dependencies` field from the `AddTaskResult`, `FactorizeTask`, `BuildTask`, and `BuildTaskResult` structs, and the `ModuleReused` and `ModuleAdded` variants, in the `queue.rs` file, since they are no longer needed ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L140-R141), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L168), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L191), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L218), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L228), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L273))
  * Remove the `parent_module_identifier` field and methods from the `CommonJsRequireContextDependency`, `EsmDynamicImportDependency`, and `ImportContextDependency` structs, and the `parent_module_identifier` method from the `ConstDependency`, `ContextElementDependency`, and `EntryDependency` structs, in the `dependency` module, since they are no longer needed ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-0d65bac12415ffbc8988462b375681321ebbec5f4e296ebf3589415c5b275505L12-R12), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-0d65bac12415ffbc8988462b375681321ebbec5f4e296ebf3589415c5b275505L19), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-0d65bac12415ffbc8988462b375681321ebbec5f4e296ebf3589415c5b275505L29), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-0d65bac12415ffbc8988462b375681321ebbec5f4e296ebf3589415c5b275505L52-L59), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-e3da5840d5c20629ef67cf9766fd51c83ee1846a072484b2cd32b5e399df4671L6-R6), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-e3da5840d5c20629ef67cf9766fd51c83ee1846a072484b2cd32b5e399df4671L17-R17), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-a56822bd4be1ed20cbeec3be04a6a93f6c8ea13d50d25b46fb7db1cfcc1a1e9fL28-L31), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL13-R13), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL19), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL35-R34), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL45), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL60), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL79-R75), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-02a9fa9489da92eb7183cd9b7b6323cec5e5825389c78c06a64c65da624b9dd8L3-R3), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-02a9fa9489da92eb7183cd9b7b6323cec5e5825389c78c06a64c65da624b9dd8L19-L22), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-030a867e867e35e2f3a18b220661f04500fe65a5e011ff09b9d95ce14caca708L12-R12), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-030a867e867e35e2f3a18b220661f04500fe65a5e011ff09b9d95ce14caca708L19), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-030a867e867e35e2f3a18b220661f04500fe65a5e011ff09b9d95ce14caca708L29), [link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-030a867e867e35e2f3a18b220661f04500fe65a5e011ff09b9d95ce14caca708L52-L59))
  * Remove the `DynEq` and `DynHash` imports from the `mod.rs` file in the `dependency` module, since they are no longer required by the `Dependency` and `ModuleDependency` traits ([link](https://github.com/web-infra-dev/rspack/pull/3024/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8L31-R31))

</details>
