### PR TITLE
feat: allow to pass `false` to `splitChunks.name` and `splitChunks.{cacheGroup}.name`

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -473,7 +473,7 @@ function getRawSplitChunksOptions(
 	sc: OptimizationSplitChunksOptions
 ): RawOptions["optimization"]["splitChunks"] {
 	return {
-		name: sc.name,
+		name: sc.name === false ? undefined : sc.name,
 		cacheGroups: sc.cacheGroups
 			? Object.fromEntries(
 					Object.entries(sc.cacheGroups).map(([key, group]) => {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -479,7 +479,7 @@ function getRawSplitChunksOptions(
 					Object.entries(sc.cacheGroups).map(([key, group]) => {
 						let normalizedGroup: RawCacheGroupOptions = {
 							test: group.test ? group.test.source : undefined,
-							name: group.name,
+							name: group.name === false ? undefined : group.name,
 							priority: group.priority,
 							minChunks: group.minChunks,
 							chunks: group.chunks,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -588,7 +588,7 @@ export interface OptimizationSplitChunksOptions {
 export interface OptimizationSplitChunksCacheGroup {
 	chunks?: "initial" | "async" | "all";
 	minChunks?: number;
-	name?: string;
+	name?: string | false;
 	priority?: number;
 	reuseExistingChunk?: boolean;
 	test?: RegExp;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -583,7 +583,7 @@ export interface OptimizationSplitChunksOptions {
 	minSize?: OptimizationSplitChunksSizes;
 	enforceSizeThreshold?: OptimizationSplitChunksSizes;
 	minRemainingSize?: OptimizationSplitChunksSizes;
-	name?: string;
+	name?: string | false;
 }
 export interface OptimizationSplitChunksCacheGroup {
 	chunks?: "initial" | "async" | "all";


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58937c4</samp>

This pull request fixes a bug and improves the type definition for the `splitChunks` option of webpack in the `rspack` package. It allows setting the `name` option to `false` to disable naming the chunks, and handles this value correctly in the config adapter.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 58937c4</samp>

* Fix a bug where setting `name` to `false` in `splitChunks` causes an error in webpack ([link](https://github.com/web-infra-dev/rspack/pull/3029/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L470-R470))
* Update the type definition of `OptimizationSplitChunksOptions` to allow `name` to be `false` ([link](https://github.com/web-infra-dev/rspack/pull/3029/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL586-R586))

</details>
