### PR TITLE
chore: 🤖 add alias cargo test no fail fast

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,7 @@ CARGO_WORKSPACE_DIR = { value = "", relative = true }
 [alias]
 lint = "clippy --workspace --all-targets -- --deny warnings"
 # AKA `test-update`, handy cargo rst update without install `cargo-rst` binary
+t  = "test --no-fail-fast"
 tu = "run -p cargo-rst -- update"
 [target.'cfg(all())']
 rustflags = [


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82069b0</samp>

Add a new cargo alias `t` for running all tests in `.cargo/config.toml`. This improves the testing workflow and quality of the rspack project.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82069b0</samp>

* Add a new alias `t` for the cargo command `test --no-fail-fast` in the `.cargo/config.toml` file ([link](https://github.com/web-infra-dev/rspack/pull/3032/files?diff=unified&w=0#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268R8))

</details>
