### PR TITLE
perf(split_chunks): use `intersection` instead of `union`

### DIFF
--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -270,7 +270,7 @@ impl SplitChunksPlugin {
       .iter_mut()
       .par_bridge()
       .filter(|(_key, each_module_group)| {
-        // Fast path: check wether has overlap on chunks
+        // Fast path: check whether has overlap on chunks
         each_module_group
           .chunks
           .intersection(used_chunks)


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

The fast path doesn't work before. In any 
 case,`each_module_group.chunks.union(used_chunks).next().is_some()` would be `true`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41fdedd</samp>

Refactor module removal logic in `split_chunks_new` plugin. Improve performance and readability of `plugin.rs`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41fdedd</samp>

* Refactor the logic of removing modules from existing module groups that overlap with the new split chunk ([link](https://github.com/web-infra-dev/rspack/pull/3033/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519L272-R295))

</details>
