### PR TITLE
chore: 🤖 refactor before resolve

### DIFF
--- a/crates/node_binding/src/js_values/normal_module_factory.rs
+++ b/crates/node_binding/src/js_values/normal_module_factory.rs
@@ -46,11 +46,11 @@ impl From<NormalModuleFactoryResolveForSchemeArgs> for SchemeAndJsResourceData {
   }
 }
 
-impl From<NormalModuleBeforeResolveArgs> for BeforeResolveData {
+impl From<NormalModuleBeforeResolveArgs<'_>> for BeforeResolveData {
   fn from(value: NormalModuleBeforeResolveArgs) -> Self {
     Self {
-      context: value.context,
-      request: value.request,
+      context: value.context.to_owned(),
+      request: value.request.to_string(),
     }
   }
 }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -60,8 +60,8 @@ impl ContextModuleFactory {
       .read()
       .await
       .context_module_before_resolve(NormalModuleBeforeResolveArgs {
-        request: data.dependency.request().to_owned(),
-        context: data.context.clone(),
+        request: data.dependency.request(),
+        context: &data.context,
       })
       .await
     {

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -22,28 +22,8 @@ impl ModuleFactory for ContextModuleFactory {
     mut self,
     data: ModuleFactoryCreateData,
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>> {
-    if let Ok(Some(false)) = self
-      .plugin_driver
-      .read()
-      .await
-      .context_module_before_resolve(NormalModuleBeforeResolveArgs {
-        request: data.dependency.request(),
-        context: &data.context,
-      })
-      .await
-    {
-      let specifier = data.dependency.request();
-      let ident = format!("{}{specifier}", data.context.expect("should have context"));
-
-      let module_identifier = ModuleIdentifier::from(format!("missing|{ident}"));
-
-      let missing_module = MissingModule::new(
-        module_identifier,
-        format!("{ident} (missing)"),
-        format!("Failed to resolve {specifier}"),
-      )
-      .boxed();
-      return Ok(ModuleFactoryResult::new(missing_module).with_empty_diagnostic());
+    if let Ok(Some(before_resolve_result)) = self.before_resolve(&data).await {
+      return Ok(before_resolve_result);
     }
     Ok(self.resolve(data).await?)
   }
@@ -55,6 +35,41 @@ impl ContextModuleFactory {
       plugin_driver,
       cache,
     }
+  }
+
+  pub async fn before_resolve(
+    &mut self,
+    data: &ModuleFactoryCreateData,
+  ) -> Result<Option<TWithDiagnosticArray<ModuleFactoryResult>>> {
+    if let Ok(Some(false)) = self
+      .plugin_driver
+      .read()
+      .await
+      .context_module_before_resolve(NormalModuleBeforeResolveArgs {
+        request: data.dependency.request(),
+        context: &data.context,
+      })
+      .await
+    {
+      let specifier = data.dependency.request();
+      let ident = format!(
+        "{}{specifier}",
+        data.context.as_ref().expect("should have context")
+      );
+
+      let module_identifier = ModuleIdentifier::from(format!("missing|{ident}"));
+
+      let missing_module = MissingModule::new(
+        module_identifier,
+        format!("{ident} (missing)"),
+        format!("Failed to resolve {specifier}"),
+      )
+      .boxed();
+      return Ok(Some(
+        ModuleFactoryResult::new(missing_module).with_empty_diagnostic(),
+      ));
+    }
+    Ok(None)
   }
 
   pub async fn resolve(

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -95,9 +95,9 @@ pub struct NormalModuleFactoryResolveForSchemeArgs {
 }
 
 #[derive(Debug, Clone)]
-pub struct NormalModuleBeforeResolveArgs {
-  pub request: String,
-  pub context: Option<String>,
+pub struct NormalModuleBeforeResolveArgs<'a> {
+  pub request: &'a str,
+  pub context: &'a Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -310,7 +310,7 @@ impl PluginDriver {
 
   pub async fn before_resolve(
     &self,
-    args: NormalModuleBeforeResolveArgs,
+    args: NormalModuleBeforeResolveArgs<'_>,
   ) -> PluginNormalModuleFactoryBeforeResolveOutput {
     for plugin in &self.plugins {
       tracing::trace!("running resolve for scheme:{}", plugin.name());
@@ -323,7 +323,7 @@ impl PluginDriver {
 
   pub async fn context_module_before_resolve(
     &self,
-    args: NormalModuleBeforeResolveArgs,
+    args: NormalModuleBeforeResolveArgs<'_>,
   ) -> PluginNormalModuleFactoryBeforeResolveOutput {
     for plugin in &self.plugins {
       tracing::trace!("running resolve for scheme:{}", plugin.name());

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -417,14 +417,22 @@ class Compiler {
 	}
 
 	async #beforeResolve(resourceData: binding.BeforeResolveData) {
-		return await this.compilation.normalModuleFactory?.hooks.beforeResolve.promise(
-			resourceData
-		);
+		let res =
+			await this.compilation.normalModuleFactory?.hooks.beforeResolve.promise(
+				resourceData
+			);
+
+		this.#updateDisabledHooks();
+		return res;
 	}
 	async #contextModuleBeforeResolve(resourceData: binding.BeforeResolveData) {
-		return await this.compilation.contextModuleFactory?.hooks.beforeResolve.promise(
-			resourceData
-		);
+		let res =
+			await this.compilation.contextModuleFactory?.hooks.beforeResolve.promise(
+				resourceData
+			);
+
+		this.#updateDisabledHooks();
+		return res;
 	}
 
 	async #normalModuleFactoryResolveForScheme(

--- a/packages/rspack/src/normalModuleFactory.ts
+++ b/packages/rspack/src/normalModuleFactory.ts
@@ -25,6 +25,7 @@ export class NormalModuleFactory {
 			AsyncSeriesBailHook<[ResourceDataWithData], true | void>
 		>;
 		beforeResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
+		afterResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
 	};
 	constructor() {
 		this.hooks = {
@@ -41,9 +42,9 @@ export class NormalModuleFactory {
 			// /** @type {AsyncSeriesBailHook<[ResolveData], Module>} */
 			// factorize: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			beforeResolve: new AsyncSeriesBailHook(["resolveData"])
+			beforeResolve: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			// afterResolve: new AsyncSeriesBailHook(["resolveData"]),
+			afterResolve: new AsyncSeriesBailHook(["resolveData"])
 			// /** @type {AsyncSeriesBailHook<[ResolveData["createData"], ResolveData], Module | void>} */
 			// createModule: new AsyncSeriesBailHook(["createData", "resolveData"]),
 			// /** @type {SyncWaterfallHook<[Module, ResolveData["createData"], ResolveData], Module>} */

--- a/packages/rspack/src/normalModuleFactory.ts
+++ b/packages/rspack/src/normalModuleFactory.ts
@@ -25,7 +25,6 @@ export class NormalModuleFactory {
 			AsyncSeriesBailHook<[ResourceDataWithData], true | void>
 		>;
 		beforeResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
-		afterResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
 	};
 	constructor() {
 		this.hooks = {
@@ -42,9 +41,9 @@ export class NormalModuleFactory {
 			// /** @type {AsyncSeriesBailHook<[ResolveData], Module>} */
 			// factorize: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			beforeResolve: new AsyncSeriesBailHook(["resolveData"]),
+			beforeResolve: new AsyncSeriesBailHook(["resolveData"])
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			afterResolve: new AsyncSeriesBailHook(["resolveData"])
+			// afterResolve: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData["createData"], ResolveData], Module | void>} */
 			// createModule: new AsyncSeriesBailHook(["createData", "resolveData"]),
 			// /** @type {SyncWaterfallHook<[Module, ResolveData["createData"], ResolveData], Module>} */


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5eaae0f</samp>

This pull request improves the performance and flexibility of the `NormalModuleFactory` and `ContextModuleFactory` classes by reducing unnecessary cloning and allowing plugins to abort or customize module resolution. It changes the signatures and implementations of some hooks and methods in `rspack_core` and `node_binding` crates, and adds a new hook in `rspack` package.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5eaae0f</samp>

*  Reduce memory allocation and cloning by using references and lifetimes for `NormalModuleBeforeResolveArgs` ([link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6L49-R53), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-18c60b97bd3384589d0fba20abd98f1368309f53b65bcf6bcd24e2118dce265fL63-R64), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337L98-R100), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL313-R313), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL326-R326))
*  Add `afterResolve` hook to `NormalModuleFactory` in TypeScript to allow plugins to modify or reject resolved modules ([link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-54fd5319d3a879176a1575a0b73dd717d2df3b967b25539ff9a96429296af4acR28), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-54fd5319d3a879176a1575a0b73dd717d2df3b967b25539ff9a96429296af4acL44-R47))
*  Return `MissingModule` if `before_resolve` hook returns `false` in Rust to prevent the resolution of certain modules ([link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR38-R72), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL88-R123), [link](https://github.com/web-infra-dev/rspack/pull/3036/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR143))

</details>
