### PR TITLE
refactor(new_split_chunks): use `RspackRegex`

### DIFF
--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -34,7 +34,7 @@ pub fn create_chunk_filter_from_str(chunks: &str) -> ChunkFilter {
 
 pub type ModuleFilter = Arc<dyn Fn(&dyn Module) -> bool + Send + Sync>;
 
-pub fn create_default_module_filter() -> ModuleFilter {
+fn create_default_module_filter() -> ModuleFilter {
   Arc::new(|_| true)
 }
 
@@ -46,18 +46,11 @@ pub fn create_module_filter_from_rspack_regex(re: rspack_regex::RspackRegex) -> 
   })
 }
 
-pub fn create_module_filter_from_regex(re: regex::Regex) -> ModuleFilter {
-  Arc::new(move |module| {
-    module
-      .name_for_condition()
-      .map_or(false, |name| re.is_match(&name))
-  })
-}
-
 pub fn create_module_filter(re: Option<String>) -> ModuleFilter {
   re.map(|test| {
-    let re = regex::Regex::new(&test).unwrap_or_else(|_| panic!("Invalid regex: {}", &test));
-    create_module_filter_from_regex(re)
+    let re =
+      rspack_regex::RspackRegex::new(&test).unwrap_or_else(|_| panic!("Invalid regex: {}", &test));
+    create_module_filter_from_rspack_regex(re)
   })
   .unwrap_or_else(create_default_module_filter)
 }

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -10,9 +10,9 @@ pub use crate::{
   cache_group::CacheGroup,
   common::{
     create_all_chunk_filter, create_async_chunk_filter, create_chunk_filter_from_str,
-    create_chunk_name_getter_by_const_name, create_default_module_filter,
-    create_empty_chunk_name_getter, create_initial_chunk_filter, create_module_filter,
-    create_module_filter_from_regex, create_module_filter_from_rspack_regex, SplitChunkSizes,
+    create_chunk_name_getter_by_const_name, create_empty_chunk_name_getter,
+    create_initial_chunk_filter, create_module_filter, create_module_filter_from_rspack_regex,
+    SplitChunkSizes,
   },
   plugin::{PluginOptions, SplitChunksPlugin},
 };


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 196cc25</samp>

Refactored the module filter creation logic in `rspack_plugin_split_chunks_new` to use a custom regex engine and hide internal details. Removed unused functions and added a new function to create module filters from regex strings.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 196cc25</samp>

*  Make `create_default_module_filter` function private ([link](https://github.com/web-infra-dev/rspack/pull/3040/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L37-R37)) and remove `create_module_filter_from_regex` function ([link](https://github.com/web-infra-dev/rspack/pull/3040/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L49-R53)) in `common.rs`, as part of refactoring to use a custom regex engine for module filtering
* Update re-exports in `lib.rs` to remove the unused functions and add the new function for module filtering ([link](https://github.com/web-infra-dev/rspack/pull/3040/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812L13-R15))

</details>
