### PR TITLE
feat(new_split_chunks): support `id_hint` internally

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -149,6 +149,7 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
         .unwrap_or_default()
         .into_iter()
         .map(|(key, v)| new_split_chunks_plugin::CacheGroup {
+          id_hint: key.clone(),
           key,
           name: v
             .name

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -28,4 +28,5 @@ pub struct CacheGroup {
   pub reuse_existing_chunk: bool,
   /// number of referenced chunks
   pub min_chunks: u32,
+  pub id_hint: String,
 }

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -37,6 +37,8 @@ impl SplitChunksPlugin {
       let (_module_group_key, mut module_group) =
         self.find_best_module_group(&mut module_group_map);
 
+      let cache_group = &self.cache_groups[module_group.cache_group_index];
+
       let mut is_reuse_existing_chunk = false;
       let mut is_reuse_existing_chunk_with_all_modules = false;
       let new_chunk = self.get_corresponding_chunk(
@@ -45,6 +47,16 @@ impl SplitChunksPlugin {
         &mut is_reuse_existing_chunk,
         &mut is_reuse_existing_chunk_with_all_modules,
       );
+
+      let new_chunk_mut = new_chunk.as_mut(&mut compilation.chunk_by_ukey);
+
+      new_chunk_mut
+        .chunk_reasons
+        .push(["(cache group: ", cache_group.key.as_str(), ")"].join(""));
+
+      new_chunk_mut
+        .id_name_hints
+        .insert(cache_group.id_hint.clone());
 
       if is_reuse_existing_chunk {
         // The chunk is not new but created in code splitting. We need remove `new_chunk` since we would remove


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- No actual effects. Because the named chunk id plugin hasn't started using `Chunk#id_name_hints` field.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41ee682</samp>

This pull request enhances the `rspack_plugin_split_chunks_new` plugin by adding cache group information to the generated chunks. It also adds an `id_hint` option to the cache group configuration, which can be used to influence the chunk names.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41ee682</samp>

*  Add `id_hint` field to cache group options and structs ([link](https://github.com/web-infra-dev/rspack/pull/3041/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R152), [link](https://github.com/web-infra-dev/rspack/pull/3041/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR31))
*  Retrieve cache group for each module group in plugin logic ([link](https://github.com/web-infra-dev/rspack/pull/3041/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R40-R41))
*  Set chunk reason and id name hint based on cache group information for each module group chunk ([link](https://github.com/web-infra-dev/rspack/pull/3041/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R51-R60))

</details>
