### PR TITLE
feat(chunkId): care about `Chunk#id_name_hints` and generate more stable chunk id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2366,6 +2366,7 @@ dependencies = [
 name = "rspack_ids"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "once_cell",
  "rayon",
  "regex",

--- a/crates/node_binding/Cargo.lock
+++ b/crates/node_binding/Cargo.lock
@@ -2008,6 +2008,7 @@ dependencies = [
 name = "rspack_ids"
 version = "0.1.0"
 dependencies = [
+ "dashmap",
  "once_cell",
  "rayon",
  "regex",

--- a/crates/rspack_ids/Cargo.toml
+++ b/crates/rspack_ids/Cargo.toml
@@ -8,6 +8,7 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+dashmap      = { workspace = true }
 once_cell    = { workspace = true }
 rayon        = { workspace = true }
 regex        = { workspace = true }

--- a/crates/rspack_ids/src/lib.rs
+++ b/crates/rspack_ids/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(iter_intersperse)]
 mod deterministic_module_ids_plugin;
 pub use deterministic_module_ids_plugin::*;
 mod named_module_ids_plugin;

--- a/crates/rspack_ids/src/stable_named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/stable_named_chunk_ids_plugin.rs
@@ -75,7 +75,7 @@ impl Plugin for StableNamedChunkIdsPlugin {
           }
 
           chunk.id = Some(name.clone());
-          chunk.ids = vec![name.clone()];
+          chunk.ids = vec![name];
         }
 
         if chunk.id.is_none() {
@@ -103,7 +103,7 @@ impl Plugin for StableNamedChunkIdsPlugin {
 
         let mut code_splitting_chunk_names = code_splitting_chunks
           .map(|c| {
-            c.id.as_ref().map(|id| id.as_str()).unwrap_or_else(|| {
+            c.id.as_deref().unwrap_or_else(|| {
               panic!(
                 "CodeSplitting chunks must have a name {:?}",
                 chunk.chunk_reasons.join("_")
@@ -122,7 +122,7 @@ impl Plugin for StableNamedChunkIdsPlugin {
             .iter()
             .map(|s| s.as_str())
             .chain(["splitting"])
-            .chain(code_splitting_chunk_names.iter().map(|s| *s))
+            .chain(code_splitting_chunk_names.iter().copied())
             .intersperse(&self.delimiter)
             .collect::<String>()
         } else {
@@ -130,7 +130,7 @@ impl Plugin for StableNamedChunkIdsPlugin {
             .id_name_hints
             .iter()
             .map(|s| s.as_str())
-            .chain(code_splitting_chunk_names.iter().map(|s| *s))
+            .chain(code_splitting_chunk_names.iter().copied())
             .intersperse(&self.delimiter)
             .collect::<String>()
         };

--- a/crates/rspack_ids/src/stable_named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/stable_named_chunk_ids_plugin.rs
@@ -1,3 +1,4 @@
+use dashmap::DashMap;
 use rspack_core::{ChunkUkey, Plugin};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -22,90 +23,127 @@ impl StableNamedChunkIdsPlugin {
 
 impl Plugin for StableNamedChunkIdsPlugin {
   fn chunk_ids(&mut self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
-    let context = self
-      .context
-      .clone()
-      .unwrap_or_else(|| compilation.options.context.to_string_lossy().to_string());
-
-    // If the chunk has a name, use it as the id
-
-    let mut used_ids: FxHashSet<String> = FxHashSet::default();
-
-    let dynamic_imported = compilation
+    use rayon::prelude::*;
+    // code_splitting_chunk means chunks generated in code splitting
+    let code_splitting_chunk_to_root_module = compilation
       .chunk_graph
       .split_point_module_identifier_to_chunk_ukey
       .iter()
       .map(|(k, v)| (v, k))
       .collect::<FxHashMap<_, _>>();
 
-    compilation.chunk_by_ukey.values_mut().for_each(|chunk| {
-      if let Some(name) = &chunk.name {
-        chunk.id = Some(name.clone());
-        chunk.ids = vec![name.clone()];
-      } else if let Some(m) = dynamic_imported.get(&chunk.ukey) {
-        let module = compilation
-          .module_graph
-          .module_by_identifier(m)
-          .expect("Module should exist");
-        let name = request_to_id(&get_short_module_name(module, &context));
-        if used_ids.contains(&name) {
-          panic!("Duplicate chunk id: {}", chunk.chunk_reasons.join("_"))
-        } else {
-          used_ids.insert(name.clone());
-        }
-        chunk.id = Some(name.clone());
-        chunk.ids = vec![name];
-      }
-    });
+    let context = self
+      .context
+      .clone()
+      .unwrap_or_else(|| compilation.options.context.to_string_lossy().to_string());
 
-    // Filter out chunks that don't have an id
-    let chunks = compilation
+    let mut used_code_splitting_chunk_name: FxHashSet<String> = FxHashSet::default();
+
+    let chunks_be_named = compilation
       .chunk_by_ukey
-      .values()
-      .filter(|chunk| chunk.id.is_none())
+      .values_mut()
+      .filter_map(|chunk| {
+        // If the chunk has a name already, use it as the id
+        if let Some(name) = &chunk.name {
+          // Initial chunk create in Code Splitting definitely has a name
+          chunk.id = Some(name.clone());
+          chunk.ids = vec![name.clone()];
+        } else if let Some(root_id) = code_splitting_chunk_to_root_module.get(&chunk.ukey) {
+          // Make sure all chunks create in code splitting must have a name
+          let root_module = compilation
+            .module_graph
+            .module_by_identifier(root_id)
+            .expect("Module should exist");
+          let root_module_name = request_to_id(&get_short_module_name(root_module, &context));
+
+          let name = chunk
+            .id_name_hints
+            .iter()
+            .map(|s| s.as_str())
+            .chain([root_module_name.as_str()])
+            .intersperse(self.delimiter.as_str())
+            .collect::<String>();
+
+          if used_code_splitting_chunk_name.contains(&name) {
+            // This is not likely to happen, any module could not be the root of multiple chunks
+            panic!(
+              "Duplicate root module name {}",
+              chunk.chunk_reasons.join("_")
+            )
+          } else {
+            used_code_splitting_chunk_name.insert(name.clone());
+          }
+        }
+
+        if chunk.id.is_none() {
+          None
+        } else {
+          Some(chunk.ukey)
+        }
+      })
       .collect::<Vec<_>>();
 
-    let mut name_to_chunks: FxHashMap<String, FxHashSet<ChunkUkey>> = Default::default();
+    let name_to_chunks: DashMap<String, FxHashSet<ChunkUkey>> = Default::default();
 
-    let mut unnamed_chunks = vec![];
+    let chunks_has_no_name = chunks_be_named
+      .into_par_iter()
+      .filter_map(|chunk| {
+        let chunk = chunk.as_ref(&compilation.chunk_by_ukey);
 
-    chunks.iter().cloned().for_each(|chunk| {
-      // If the chunk has no name, the chunk is mostly created by bundle splitting;
-      let mut chunk_names_in_same_group = chunk
-        .groups
-        .iter()
-        .map(|group| {
-          compilation
-            .chunk_group_by_ukey
-            .get(group)
-            .expect("Must have a ChunkGroup")
-        })
-        .flat_map(|group| group.chunks.iter())
-        .filter(|each_chunk| **each_chunk != chunk.ukey)
-        .map(|chunk| chunk.as_ref(&compilation.chunk_by_ukey))
-        .filter_map(|c| c.id.as_deref())
-        .collect::<Vec<_>>();
-      chunk_names_in_same_group.sort_unstable();
+        // filter out chunks generated in code splitting in the same `ChunkGroup`
+        let code_splitting_chunks = chunk
+          .groups
+          .iter()
+          .flat_map(|group| group.as_ref(&compilation.chunk_group_by_ukey).chunks.iter())
+          .filter(|chunk| code_splitting_chunk_to_root_module.contains_key(chunk))
+          .map(|c| c.as_ref(&compilation.chunk_by_ukey));
 
-      if chunk_names_in_same_group.len() == 1 {
-        // All modules of the chunk is from one group, to avoid conflict, we need to add a suffix
-        chunk_names_in_same_group.insert(0, "split");
-      }
+        let mut code_splitting_chunk_names = code_splitting_chunks
+          .map(|c| {
+            c.id
+              .as_ref()
+              .map(|id| id.as_str())
+              .expect("CodeSplitting chunks must have a name")
+          })
+          .collect::<Box<[&str]>>();
 
-      let name = shorten_long_string(
-        chunk_names_in_same_group.join(&self.delimiter),
-        &self.delimiter,
-      );
+        code_splitting_chunk_names.sort_unstable();
 
-      if name.is_empty() {
-        unnamed_chunks.push(chunk.ukey);
-      } else {
-        name_to_chunks.entry(name).or_default().insert(chunk.ukey);
-      }
-    });
+        let name = if code_splitting_chunk_names.len() == 1 {
+          // All modules of this chunk is from single code splitting chunk. To reduce naming conflicts,
+          // we need to add a prefix 'splitting'
+          chunk
+            .id_name_hints
+            .iter()
+            .map(|s| s.as_str())
+            .chain(["splitting"])
+            .chain(code_splitting_chunk_names.iter().map(|s| *s))
+            .intersperse(&self.delimiter)
+            .collect::<String>()
+        } else {
+          chunk
+            .id_name_hints
+            .iter()
+            .map(|s| s.as_str())
+            .chain(code_splitting_chunk_names.iter().map(|s| *s))
+            .intersperse(&self.delimiter)
+            .collect::<String>()
+        };
+
+        let name = shorten_long_string(name, &self.delimiter);
+
+        if name.is_empty() {
+          Some(chunk.ukey)
+        } else {
+          name_to_chunks.entry(name).or_default().insert(chunk.ukey);
+          None
+        }
+      })
+      .collect::<Vec<_>>();
 
     name_to_chunks.into_iter().for_each(|(name, chunks)| {
       if chunks.len() == 1 {
+        // The name has no conflicts to other chunks, we just use it as the chunk id
         let chunk = chunks.into_iter().next().expect("Must have a chunk");
         chunk.as_mut(&mut compilation.chunk_by_ukey).id = Some(name.clone());
         chunk.as_mut(&mut compilation.chunk_by_ukey).ids.push(name);
@@ -131,8 +169,8 @@ impl Plugin for StableNamedChunkIdsPlugin {
       }
     });
 
-    if !unnamed_chunks.is_empty() {
-      assign_ascending_chunk_ids(&unnamed_chunks, compilation)
+    if !chunks_has_no_name.is_empty() {
+      assign_ascending_chunk_ids(&chunks_has_no_name, compilation)
     }
 
     Ok(())


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0deb1b3</samp>

This pull request enhances the `StableNamedChunkIdsPlugin` module in the `rspack_ids` crate, which assigns stable and meaningful names and ids to webpack chunks. It uses a concurrent hash map to store and retrieve the chunk name-key mapping, adds support for code splitting chunks, and improves the naming logic for unnamed chunks. It also adds the `dashmap` and `iter_intersperse` dependencies to the `rspack_ids` crate.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0deb1b3</samp>

*  Add `dashmap` crate as a dependency and enable `iter_intersperse` feature for `rspack_ids` crate ([link](https://github.com/web-infra-dev/rspack/pull/3043/files?diff=unified&w=0#diff-5dbd9f82c3d8fbda2cd129d79b17aebf01af335eebc2113ee295f0fdc8f7caf9R11), [link](https://github.com/web-infra-dev/rspack/pull/3043/files?diff=unified&w=0#diff-47af638dbb0e62df408211713f9a035bcfe154a9fc3d5ddcd3dcfb2b17aa02daR1))
* Import `DashMap` type from `dashmap` crate in `stable_named_chunk_ids_plugin` module ([link](https://github.com/web-infra-dev/rspack/pull/3043/files?diff=unified&w=0#diff-7af246a1998512f1286a435ea99713f9f2cff084533758918fcfdf8c029b5dd7R1))
* Create reverse mapping from chunk keys to root module identifiers for code splitting chunks in `StableNamedChunkIdsPlugin` ([link](https://github.com/web-infra-dev/rspack/pull/3043/files?diff=unified&w=0#diff-7af246a1998512f1286a435ea99713f9f2cff084533758918fcfdf8c029b5dd7R26-R34))
* Assign names and ids to chunks based on code splitting dependencies, `id_name_hints`, and `intersperse` method in `StableNamedChunkIdsPlugin` ([link](https://github.com/web-infra-dev/rspack/pull/3043/files?diff=unified&w=0#diff-7af246a1998512f1286a435ea99713f9f2cff084533758918fcfdf8c029b5dd7L30-R146))
* Rename variable `unnamed_chunks` to `chunks_has_no_name` and pass it to `assign_ascending_chunk_ids` function ([link](https://github.com/web-infra-dev/rspack/pull/3043/files?diff=unified&w=0#diff-7af246a1998512f1286a435ea99713f9f2cff084533758918fcfdf8c029b5dd7L134-R173))

</details>
