### PR TITLE
chore: enable status check for test-pr

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,16 +2,6 @@ name: Test PR
 on:
   merge_group:
   pull_request:
-    paths:
-      - "crates/**"
-      - "packages/**"
-      - "examples/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - "rust-toolchain.toml"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
     branches:
       - "**"
       - "!release-**"


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46e8a00</samp>

Removed `paths` filter from `test` job in `.github/workflows/test-pr.yml`. This ensures that the tests are always run on any pull request to the `rspack` repository.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46e8a00</samp>

* Remove the `paths` filter from the `test` job in the workflow `.github/workflows/test-pr.yml` ([link](https://github.com/web-infra-dev/rspack/pull/3044/files?diff=unified&w=0#diff-553365cb26b1fc82e9fae16796d827431ccea4d72e0c1420cfed527de0e23fddL5-L14)). This ensures that the tests are always run on the latest code on any pull request.

</details>
