### PR TITLE
feat(chunkIds): support `optimization.chunkIds: 'deterministic'`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2438,6 +2438,7 @@ name = "rspack_ids"
 version = "0.1.0"
 dependencies = [
  "dashmap",
+ "itertools",
  "once_cell",
  "rayon",
  "regex",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -792,6 +792,7 @@ export interface RawNodeOption {
 export interface RawOptimizationOptions {
   splitChunks?: RawSplitChunksOptions
   moduleIds: string
+  chunkIds: string
   removeAvailableModules: boolean
   removeEmptyChunks: boolean
   sideEffects: string

--- a/crates/rspack_binding_options/src/options/raw_optimization.rs
+++ b/crates/rspack_binding_options/src/options/raw_optimization.rs
@@ -2,7 +2,10 @@ use better_scoped_tls::scoped_tls;
 use napi_derive::napi;
 use rspack_core::{Optimization, PluginExt, SideEffectOption};
 use rspack_error::internal_error;
-use rspack_ids::{DeterministicModuleIdsPlugin, NamedModuleIdsPlugin};
+use rspack_ids::{
+  DeterministicChunkIdsPlugin, DeterministicModuleIdsPlugin, NamedChunkIdsPlugin,
+  NamedModuleIdsPlugin,
+};
 use rspack_plugin_split_chunks::SplitChunksPlugin;
 use serde::Deserialize;
 
@@ -17,6 +20,7 @@ scoped_tls!(pub(crate) static IS_ENABLE_NEW_SPLIT_CHUNKS: bool);
 pub struct RawOptimizationOptions {
   pub split_chunks: Option<RawSplitChunksOptions>,
   pub module_ids: String,
+  pub chunk_ids: String,
   pub remove_available_modules: bool,
   pub remove_empty_chunks: bool,
   pub side_effects: String,
@@ -42,6 +46,16 @@ impl RawOptionsApply for RawOptimizationOptions {
 
       plugins.push(split_chunks_plugin);
     }
+    let chunk_ids_plugin = match self.chunk_ids.as_ref() {
+      "named" => NamedChunkIdsPlugin::new(None, None).boxed(),
+      "deterministic" => DeterministicChunkIdsPlugin::default().boxed(),
+      _ => {
+        return Err(internal_error!(
+          "'chunk_ids' should be 'named' or 'deterministic'."
+        ))
+      }
+    };
+    plugins.push(chunk_ids_plugin);
     let module_ids_plugin = match self.module_ids.as_ref() {
       "named" => NamedModuleIdsPlugin::default().boxed(),
       "deterministic" => DeterministicModuleIdsPlugin::default().boxed(),

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{cmp::Ordering, fmt::Debug, sync::Arc};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -31,6 +31,21 @@ pub fn get_runtime_key(runtime: RuntimeSpec) -> String {
   let mut runtime: Vec<Arc<str>> = Vec::from_iter(runtime.into_iter());
   runtime.sort_unstable();
   runtime.join("\n")
+}
+
+pub fn compare_runtime(a: &RuntimeSpec, b: &RuntimeSpec) -> Ordering {
+  if a == b {
+    return Ordering::Equal;
+  }
+  let a_key = get_runtime_key(a.clone());
+  let b_key = get_runtime_key(b.clone());
+  if a_key < b_key {
+    return Ordering::Less;
+  }
+  if a_key > b_key {
+    return Ordering::Greater;
+  }
+  Ordering::Equal
 }
 
 #[derive(Default, Clone, Debug)]

--- a/crates/rspack_ids/Cargo.toml
+++ b/crates/rspack_ids/Cargo.toml
@@ -9,6 +9,7 @@ version    = "0.1.0"
 
 [dependencies]
 dashmap      = { workspace = true }
+itertools    = { workspace = true }
 once_cell    = { workspace = true }
 rayon        = { workspace = true }
 regex        = { workspace = true }

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -1,0 +1,78 @@
+use std::collections::HashMap;
+
+use rspack_core::Plugin;
+
+use crate::id_helpers::{
+  assign_deterministic_ids, compare_chunks_natural, get_full_chunk_name, get_used_chunk_ids,
+};
+
+#[derive(Debug, Default)]
+pub struct DeterministicChunkIdsPlugin {
+  pub delimiter: String,
+  pub context: Option<String>,
+}
+
+impl DeterministicChunkIdsPlugin {
+  pub fn new(delimiter: Option<String>, context: Option<String>) -> Self {
+    Self {
+      delimiter: delimiter.unwrap_or_else(|| "~".to_string()),
+      context,
+    }
+  }
+}
+
+impl Plugin for DeterministicChunkIdsPlugin {
+  fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+    let mut used_ids = get_used_chunk_ids(compilation);
+    let used_ids_len = used_ids.len();
+
+    let chunk_graph = &mut compilation.chunk_graph;
+    let module_graph = &compilation.module_graph;
+    let context = self
+      .context
+      .clone()
+      .unwrap_or_else(|| compilation.options.context.as_str().to_string());
+
+    let max_length = 3;
+    let expand_factor = 10;
+    let salt = 10;
+
+    let chunks = compilation
+      .chunk_by_ukey
+      .values()
+      .filter(|chunk| chunk.id.is_none())
+      .collect::<Vec<_>>();
+    let mut chunk_key_to_id = HashMap::with_capacity(chunks.len());
+
+    assign_deterministic_ids(
+      chunks,
+      |chunk| get_full_chunk_name(chunk, chunk_graph, module_graph, &context),
+      |a, b| compare_chunks_natural(chunk_graph, module_graph, a, b),
+      |chunk, id| {
+        let size = used_ids.len();
+        used_ids.insert(id.clone());
+        if used_ids.len() == size {
+          return false;
+        }
+
+        chunk_key_to_id.insert(chunk.ukey, id);
+        true
+      },
+      &[usize::pow(10, max_length)],
+      expand_factor,
+      used_ids_len,
+      salt,
+    );
+
+    chunk_key_to_id.into_iter().for_each(|(chunk_ukey, id)| {
+      let chunk = compilation
+        .chunk_by_ukey
+        .get_mut(&chunk_ukey)
+        .expect("Chunk should exists");
+      chunk.id = Some(id.clone());
+      chunk.ids = vec![id];
+    });
+
+    Ok(())
+  }
+}

--- a/crates/rspack_ids/src/lib.rs
+++ b/crates/rspack_ids/src/lib.rs
@@ -8,3 +8,5 @@ mod named_chunk_ids_plugin;
 pub use named_chunk_ids_plugin::*;
 mod stable_named_chunk_ids_plugin;
 pub use stable_named_chunk_ids_plugin::StableNamedChunkIdsPlugin;
+mod deterministic_chunk_ids_plugin;
+pub use deterministic_chunk_ids_plugin::DeterministicChunkIdsPlugin;

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -66,6 +66,10 @@ fn default_optimization_module_ids() -> String {
   "named".to_string()
 }
 
+fn default_optimization_chunk_ids() -> String {
+  "named".to_string()
+}
+
 fn default_optimization_side_effects() -> String {
   "false".to_string()
 }
@@ -117,6 +121,8 @@ pub struct Optimization {
   pub remove_empty_chunks: bool,
   #[serde(default = "default_optimization_module_ids")]
   pub module_ids: String,
+  #[serde(default = "default_optimization_chunk_ids")]
+  pub chunk_ids: String,
   #[serde(default = "default_optimization_side_effects")]
   pub side_effects: String,
 }
@@ -595,6 +601,11 @@ impl TestConfig {
       plugins.push(rspack_ids::NamedModuleIdsPlugin::default().boxed());
     } else {
       plugins.push(rspack_ids::DeterministicModuleIdsPlugin::default().boxed());
+    }
+    if self.optimization.chunk_ids == "named" {
+      plugins.push(rspack_ids::NamedChunkIdsPlugin::new(None, None).boxed());
+    } else {
+      plugins.push(rspack_ids::DeterministicChunkIdsPlugin::default().boxed());
     }
     plugins.push(rspack_ids::StableNamedChunkIdsPlugin::new(None, None).boxed());
     // Notice the plugin need to be placed after SplitChunksPlugin

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -663,6 +663,7 @@ function getRawOptimization(
 ): RawOptions["optimization"] {
 	assert(
 		!isNil(optimization.moduleIds) &&
+			!isNil(optimization.chunkIds) &&
 			!isNil(optimization.removeAvailableModules) &&
 			!isNil(optimization.removeEmptyChunks) &&
 			!isNil(optimization.sideEffects) &&
@@ -670,6 +671,7 @@ function getRawOptimization(
 		"optimization.moduleIds, optimization.removeAvailableModules, optimization.removeEmptyChunks, optimization.sideEffects, optimization.realContentHash should not be nil after defaults"
 	);
 	return {
+		chunkIds: optimization.chunkIds,
 		splitChunks: toRawSplitChunksOptions(optimization.splitChunks),
 		moduleIds: optimization.moduleIds,
 		removeAvailableModules: optimization.removeAvailableModules,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -662,6 +662,7 @@ const applyOptimizationDefaults = (
 		if (production) return "deterministic";
 		return "named";
 	});
+	F(optimization, "chunkIds", (): "named" | "deterministic" => "named");
 	F(optimization, "sideEffects", () => (production ? true : "flag"));
 	D(optimization, "runtimeChunk", false);
 	D(optimization, "realContentHash", production);

--- a/packages/rspack/src/config/zod/optimization/index.ts
+++ b/packages/rspack/src/config/zod/optimization/index.ts
@@ -9,6 +9,7 @@ const rspackPluginInstance = z.object({
 export function optimization() {
 	return z.strictObject({
 		moduleIds: z.enum(["named", "deterministic"]).optional(),
+		chunkIds: z.enum(["named", "deterministic"]).optional(),
 		minimize: z.boolean().optional(),
 		minimizer: z.literal("...").or(rspackPluginInstance).array().optional(),
 		splitChunks: splitChunks().optional(),

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -213,6 +213,7 @@ exports[`snapshots should have the correct base config 1`] = `
     "global": "warn",
   },
   "optimization": {
+    "chunkIds": "named",
     "minimize": false,
     "minimizer": [],
     "moduleIds": "named",


### PR DESCRIPTION
## Related issue (if exists)

Fix https://github.com/web-infra-dev/rspack/issues/2393

## Summary

Support optimizations.chunkIds deterministic

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0e652b</samp>

This pull request adds a new feature to the `@rspack/binding` and `@rspack/core` packages that allows users to control how chunk ids are generated and assigned by webpack. It introduces a new option, `optimization.chunkIds`, that can be either `"named"` or `"deterministic"`. The `"named"` option uses the existing `StableNamedChunkIdsPlugin` to create chunk ids based on the chunk name. The `"deterministic"` option uses a new `DeterministicChunkIdsPlugin` to create chunk ids based on the chunk name, runtime spec, and modules. The `"deterministic"` option improves the caching and performance of the output chunks. The pull request also updates the `rspack_testing` crate to support the new option and modifies the snapshot tests to reflect the changes.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a0e652b</samp>

*  Add support for `optimization.chunkIds` deterministic option ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-7ce4eba4b3c6612dcfd13ad00f93da708b29d98056e218bb4ee7082ab602f6d8R1-R6))
*  Define and implement `DeterministicChunkIdsPlugin` to assign chunk ids based on chunk name, runtime spec, and modules ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-d630354350430a281469a8966d1bf85381ce831cb819343195281de6300f81c9R1-R78), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-2dcfe8eaf72bc177273f6778c7161384120c9297f5b5899340d55cea77e3a9ecR413-R436), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-2dcfe8eaf72bc177273f6778c7161384120c9297f5b5899340d55cea77e3a9ecR494-R546), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-47af638dbb0e62df408211713f9a035bcfe154a9fc3d5ddcd3dcfb2b17aa02daR10-R11))
*  Add `chunk_ids` field to `RawOptimization` struct and `TestConfig` struct to hold the value of `chunkIds` option ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062R24), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-8b7ae8eae42b4d9202dbd35407c3338295c42d2b3b863c1a9c179c23502c86c2R110-R111))
*  Add logic to create and push the appropriate chunk ids plugin to the `plugins` vector based on the `chunk_ids` field value ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062R49-R58), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-8b7ae8eae42b4d9202dbd35407c3338295c42d2b3b863c1a9c179c23502c86c2R540-R544), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R470))
*  Add `get_chunk_modules_iterable` method to `ChunkGraph` struct to return an iterator over the modules of a chunk ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-1e0eaa9697d538fa03d275db44b65e1238a0f197f6ca3748b790e8f4e48af81cR182-R194))
*  Add `compare_runtime` function to `runtime.rs` file to compare two runtime specs and return an `Ordering` value ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-7ee3386f1d14753555fdc96b4060cafd0ab57a4c1bb907dc04f54b486d43e482L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-7ee3386f1d14753555fdc96b4060cafd0ab57a4c1bb907dc04f54b486d43e482R36-R50))
*  Add `itertools` crate as a dependency to `rspack_ids` crate and use its iterator methods to compare and assign chunk ids ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-5dbd9f82c3d8fbda2cd129d79b17aebf01af335eebc2113ee295f0fdc8f7caf9R11), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-2dcfe8eaf72bc177273f6778c7161384120c9297f5b5899340d55cea77e3a9ecR494-R546))
*  Add `Default` trait to `StableNamedChunkIdsPlugin` struct to allow creating it with the default delimiter value ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-2dcfe8eaf72bc177273f6778c7161384120c9297f5b5899340d55cea77e3a9ecL8-R15), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-7af246a1998512f1286a435ea99713f9f2cff084533758918fcfdf8c029b5dd7L8-R8))
*  Add logic to apply the default value for the `optimization.chunkIds` option in the `applyOptimizationDefaults` function, depending on the `production` flag ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccR539-R542))
*  Add `chunkIds` field to `Optimization` interface and `getRawOptimization` function to configure the chunk ids plugin ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L459-R463), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR571))
*  Update snapshot tests to reflect the change of the chunk ids assigned to the chunks, which are now numeric instead of named, due to the `chunkIds` option being `"deterministic"` by default in production mode ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9L125-R127), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9L174-R178), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L29-R29), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L53-R53), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L59-R59), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L95-R95), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L107-R107), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L134-R134), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L149-R154), [link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-efab451098bbc17c77d3613b9c0dc8bf2931290243f5c161e85b15091a5800e2L180-R185))
*  Remove the line that adds the `StableNamedChunkIdsPlugin` to the `plugins` vector in the `rspack_binding_options` crate, as it is no longer needed ([link](https://github.com/web-infra-dev/rspack/pull/3053/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L203-L204))

</details>
