### PR TITLE
refactor: 💡 angular support

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
-    "build:rspack": "rspack",
+    "build:ng": "ng build",
+    "build": "node scripts/build.js",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
   },

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rspack-ng",
+  "name": "example-angular",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/examples/angular/scripts/build.js
+++ b/examples/angular/scripts/build.js
@@ -1,0 +1,34 @@
+const { spawn, spawnSync } = require("node:child_process");
+const ls = spawn("node", ["-v"]);
+
+ls.stdout.on("data", (data) => {
+	let res = data.toString().trim();
+	const [a, _] = res.split(".");
+	if (a >= "v16") {
+		build()
+			.then(console.log)
+			.catch((err) => {
+				console.error(err);
+				process.exit(-1);
+			});
+	} else {
+		console.log("The Angular CLI requires a minimum of v16.13")
+		// Working around angular not support node14, but we need to test node v14 in CI
+		process.exit(0);
+	}
+});
+
+ls.stderr.on("data", (data) => {
+	throw new Error(`${data}`);
+});
+
+function build() {
+	return new Promise((resolve, reject) => {
+		try {
+			spawnSync("npx", ["rspack", "build"], { stdio: "inherit" });
+			resolve();
+		} catch (err) {
+			reject(err);
+		}
+	});
+}

--- a/packages/rspack-dev-server/tests/normalizeOptions.test.ts
+++ b/packages/rspack-dev-server/tests/normalizeOptions.test.ts
@@ -2,7 +2,6 @@ import { RspackOptions, rspack } from "@rspack/core";
 import { RspackDevServer, Configuration } from "@rspack/dev-server";
 import { createCompiler } from "@rspack/core";
 import serializer from "jest-serializer-path";
-//@ts-ignore
 expect.addSnapshotSerializer(serializer);
 
 // The aims of use a cutstom value rather than
@@ -114,7 +113,6 @@ async function match(config: RspackOptions) {
 	// it will break ci
 	//@ts-ignore
 	delete server.options.port;
-	//@ts-ignore
 	expect(server.options).toMatchSnapshot();
 	await server.stop();
 }
@@ -151,7 +149,6 @@ async function matchAdditionEntries(
 			return [key, replaced];
 		})
 	);
-	//@ts-ignore
 	expect(value).toMatchSnapshot();
 	await server.stop();
 }

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -36,6 +36,7 @@ import { NormalModuleFactory } from "./normalModuleFactory";
 import { WatchFileSystem } from "./util/fs";
 import { getScheme } from "./util/scheme";
 import Watching from "./watching";
+import { NormalModule } from "./normalModule";
 
 class EntryPlugin {
 	constructor(

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -78,54 +78,6 @@ class HotModuleReplacementPlugin {
 	apply() {}
 }
 
-const compilationHooksMap = new WeakMap();
-export class NormalModule {
-	static getCompilationHooks(compilation: Compilation) {
-		if (!(compilation instanceof Compilation)) {
-			throw new TypeError(
-				"The 'compilation' argument must be an instance of Compilation"
-			);
-		}
-		let hooks = compilationHooksMap.get(compilation);
-		if (hooks === undefined) {
-			hooks = {
-				// loader: new SyncHook(["loaderContext", "module"]),
-				loader: new SyncHook(["loaderContext"])
-				// beforeLoaders: new SyncHook(["loaders", "module", "loaderContext"]),
-				// beforeParse: new SyncHook(["module"]),
-				// beforeSnapshot: new SyncHook(["module"]),
-				// TODO webpack 6 deprecate
-				// readResourceForScheme: new tapable.HookMap(scheme => {
-				// 	const hook = hooks.readResource.for(scheme);
-				// 	return createFakeHook(
-				// 		/** @type {AsyncSeriesBailHook<[string, NormalModule], string | Buffer>} */ ({
-				// 			tap: (options, fn) =>
-				// 				hook.tap(options, loaderContext =>
-				// 					fn(loaderContext.resource, loaderContext._module)
-				// 				),
-				// 			tapAsync: (options, fn) =>
-				// 				hook.tapAsync(options, (loaderContext, callback) =>
-				// 					fn(loaderContext.resource, loaderContext._module, callback)
-				// 				),
-				// 			tapPromise: (options, fn) =>
-				// 				hook.tapPromise(options, loaderContext =>
-				// 					fn(loaderContext.resource, loaderContext._module)
-				// 				)
-				// 		})
-				// 	);
-				// }),
-				// readResource: new tapable.HookMap(
-				// 	() => new tapable.AsyncSeriesBailHook(["loaderContext"])
-				// )
-				// needBuild: new tapable.AsyncSeriesBailHook(["module", "context"])
-			};
-			compilationHooksMap.set(compilation, hooks);
-		}
-		return hooks;
-	}
-	apply() {}
-}
-
 class Compiler {
 	#_instance?: binding.Rspack;
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -16,7 +16,8 @@ import {
 	SourceMapSource
 } from "webpack-sources";
 
-import { Compiler, NormalModule } from "../compiler";
+import { Compiler } from "../compiler";
+import { NormalModule } from "../normalModule";
 import { Compilation } from "../compilation";
 import {
 	LoaderContext,
@@ -518,9 +519,16 @@ export async function runLoader(
 	};
 
 	let compilation: Compilation | undefined = compiler.compilation;
+	let step = 0;
 	while (compilation) {
 		NormalModule.getCompilationHooks(compilation).loader.call(loaderContext);
 		compilation = compilation.compiler.parentCompilation;
+		step++;
+		if (step > 1000) {
+			throw Error(
+				"Too much nested child compiler, exceeded max limitation 1000"
+			);
+		}
 	}
 
 	return new Promise((resolve, reject) => {

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -526,7 +526,7 @@ export async function runLoader(
 		step++;
 		if (step > 1000) {
 			throw Error(
-				"Too much nested child compiler, exceeded max limitation 1000"
+				"Too many nested child compiler, exceeded max limitation 1000"
 			);
 		}
 	}

--- a/packages/rspack/src/normalModule.ts
+++ b/packages/rspack/src/normalModule.ts
@@ -1,4 +1,4 @@
-import { AsyncSeriesBailHook, Hook, HookMap, SyncHook } from "tapable";
+import { AsyncSeriesBailHook, HookMap, SyncHook } from "tapable";
 import util from "util";
 import { Compilation, LoaderContext } from ".";
 
@@ -64,7 +64,9 @@ export class NormalModule {
 		let hooks = compilationHooksMap.get(compilation);
 		if (hooks === undefined) {
 			hooks = {
-				loader: new SyncHook(["loaderContext"]),
+				// TODO: figure out why tsc complain about this
+				// @ts-ignore
+				loader: new SyncHook(["loaderContext", "module"]),
 				// beforeLoaders: new SyncHook(["loaders", "module", "loaderContext"]),
 				// beforeParse: new SyncHook(["module"]),
 				// beforeSnapshot: new SyncHook(["module"]),

--- a/packages/rspack/src/normalModule.ts
+++ b/packages/rspack/src/normalModule.ts
@@ -1,4 +1,4 @@
-import { AsyncSeriesBailHook, Hook, HookMap } from "tapable";
+import { AsyncSeriesBailHook, Hook, HookMap, SyncHook } from "tapable";
 import util from "util";
 import { Compilation, LoaderContext } from ".";
 
@@ -64,7 +64,7 @@ export class NormalModule {
 		let hooks = compilationHooksMap.get(compilation);
 		if (hooks === undefined) {
 			hooks = {
-				// loader: new SyncHook(["loaderContext", "module"]),
+				loader: new SyncHook(["loaderContext"]),
 				// beforeLoaders: new SyncHook(["loaders", "module", "loaderContext"]),
 				// beforeParse: new SyncHook(["module"]),
 				// beforeSnapshot: new SyncHook(["module"]),


### PR DESCRIPTION
## Related issue (if exists)
address NIT in https://github.com/web-infra-dev/rspack/pull/3009
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e467dc8</samp>

This pull request improves the code quality and functionality of the rspack package, which is a tool for bundling and running web applications. It removes some redundant code, refactors some modules, and adds a new hook for customizing the loader context. The main files affected are `normalizeOptions.test.ts`, `loader-runner/index.ts`, `normalModule.ts`, and `compiler.ts`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e467dc8</samp>

*  Remove unnecessary TypeScript ignore comments from `normalizeOptions.test.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-97e9d413e3df8cf0ca4b0b2efbabe4b908db209ed172c6481432a7d1d4127da6L5), [link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-97e9d413e3df8cf0ca4b0b2efbabe4b908db209ed172c6481432a7d1d4127da6L117), [link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-97e9d413e3df8cf0ca4b0b2efbabe4b908db209ed172c6481432a7d1d4127da6L154))
*  Move `NormalModule` class from `compiler.ts` to a separate file `normalModule.ts` for better modularity and readability ([link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL81-L128), [link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-132b353a7923506ed74a05672aec330c46a4d68f89259d860d60fdf8ce91a513L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-132b353a7923506ed74a05672aec330c46a4d68f89259d860d60fdf8ce91a513L67-R67))
*  Update import statement for `NormalModule` in `loader-runner/index.ts` to reflect the new file location ([link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L19-R20))
*  Add safety check for nested child compiler level in `runLoader` function in `loader-runner/index.ts` to prevent potential infinite loops or memory leaks ([link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L521-R531))
*  Enable `loader` hook in `NormalModule` class to allow loader runner to access and modify loader context for each module ([link](https://github.com/web-infra-dev/rspack/pull/3055/files?diff=unified&w=0#diff-132b353a7923506ed74a05672aec330c46a4d68f89259d860d60fdf8ce91a513L67-R67))

</details>
