### PR TITLE
fix: already split module should connect chunk group at multiply entry

### DIFF
--- a/.changeset/strange-points-worry.md
+++ b/.changeset/strange-points-worry.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: already split module should connect chunk group at multiply entry

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index_js.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index_js.js
@@ -1,0 +1,12 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["index_js"], {
+"./index.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+__webpack_require__("./shared.js");
+__webpack_require__.el("./index.js").then(__webpack_require__.bind(__webpack_require__, "./index.js")).then(__webpack_require__.ir);
+console.log('index1');
+},
+
+}]);

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -118,12 +118,17 @@ impl Chunk {
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> HashSet<ChunkUkey> {
-    let mut chunks = HashSet::default();
+    let mut chunks: std::collections::HashSet<
+      rspack_database::Ukey<Chunk>,
+      std::hash::BuildHasherDefault<rustc_hash::FxHasher>,
+    > = HashSet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_chunks(
       chunk_group_ukey: &ChunkGroupUkey,
       chunks: &mut HashSet<ChunkUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       let group = chunk_group_by_ukey
         .get(chunk_group_ukey)
@@ -134,12 +139,26 @@ impl Chunk {
       }
 
       for child_group_ukey in group.children.iter() {
-        add_chunks(child_group_ukey, chunks, chunk_group_by_ukey);
+        if !visit_chunk_groups.contains(child_group_ukey) {
+          visit_chunk_groups.insert(*child_group_ukey);
+          add_chunks(
+            child_group_ukey,
+            chunks,
+            chunk_group_by_ukey,
+            visit_chunk_groups,
+          );
+        }
       }
     }
 
     for group_ukey in &self.groups {
-      add_chunks(group_ukey, &mut chunks, chunk_group_by_ukey);
+      visit_chunk_groups.insert(*group_ukey);
+      add_chunks(
+        group_ukey,
+        &mut chunks,
+        chunk_group_by_ukey,
+        &mut visit_chunk_groups,
+      );
     }
 
     chunks
@@ -150,11 +169,13 @@ impl Chunk {
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> HashSet<ChunkUkey> {
     let mut chunks = HashSet::default();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_chunks(
       chunk_group_ukey: &ChunkGroupUkey,
       chunks: &mut HashSet<ChunkUkey>,
       chunk_group_by_ukey: &ChunkGroupByUkey,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       let group = chunk_group_by_ukey
         .get(chunk_group_ukey)
@@ -166,13 +187,26 @@ impl Chunk {
         }
 
         for child_group_ukey in group.children.iter() {
-          add_chunks(child_group_ukey, chunks, chunk_group_by_ukey);
+          if !visit_chunk_groups.contains(child_group_ukey) {
+            visit_chunk_groups.insert(*child_group_ukey);
+            add_chunks(
+              child_group_ukey,
+              chunks,
+              chunk_group_by_ukey,
+              visit_chunk_groups,
+            );
+          }
         }
       }
     }
 
     for group_ukey in &self.groups {
-      add_chunks(group_ukey, &mut chunks, chunk_group_by_ukey);
+      add_chunks(
+        group_ukey,
+        &mut chunks,
+        chunk_group_by_ukey,
+        &mut visit_chunk_groups,
+      );
     }
 
     chunks
@@ -199,6 +233,7 @@ impl Chunk {
       .cloned()
       .collect();
     let mut initial_queue = self.groups.clone();
+    let mut visit_chunk_groups = HashSet::default();
 
     fn add_to_queue(
       chunk_group_by_ukey: &ChunkGroupByUkey,
@@ -234,6 +269,7 @@ impl Chunk {
       chunks: &mut HashSet<ChunkUkey>,
       initial_chunks: &HashSet<ChunkUkey>,
       chunk_group_ukey: &ChunkGroupUkey,
+      visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
       if let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) {
         for chunk_ukey in chunk_group.chunks.iter() {
@@ -243,7 +279,16 @@ impl Chunk {
         }
 
         for group_ukey in chunk_group.children.iter() {
-          add_chunks(chunk_group_by_ukey, chunks, initial_chunks, group_ukey);
+          if !visit_chunk_groups.contains(group_ukey) {
+            visit_chunk_groups.insert(*group_ukey);
+            add_chunks(
+              chunk_group_by_ukey,
+              chunks,
+              initial_chunks,
+              group_ukey,
+              visit_chunk_groups,
+            );
+          }
         }
       }
     }
@@ -254,6 +299,7 @@ impl Chunk {
         &mut chunks,
         &initial_chunks,
         group_ukey,
+        &mut visit_chunk_groups,
       );
     }
 

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -58,6 +58,7 @@ pub fn get_all_chunks(
     entrypoint_ukey: &ChunkGroupUkey,
     exclude_chunk1: &ChunkUkey,
     exclude_chunk2: Option<&ChunkUkey>,
+    visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
   ) {
     if let Some(entrypoint) = chunk_group_by_ukey.get(entrypoint_ukey) {
       for chunk in &entrypoint.chunks {
@@ -72,8 +73,12 @@ pub fn get_all_chunks(
         chunks.insert(*chunk);
       }
 
-      for parent in entrypoint.ancestors(chunk_group_by_ukey) {
-        if let Some(chunk_group) = chunk_group_by_ukey.get(&parent) {
+      for parent in entrypoint.parents_iterable() {
+        if visit_chunk_groups.contains(parent) {
+          continue;
+        }
+        visit_chunk_groups.insert(*parent);
+        if let Some(chunk_group) = chunk_group_by_ukey.get(parent) {
           if chunk_group.is_initial() {
             add_chunks(
               chunk_group_by_ukey,
@@ -81,6 +86,7 @@ pub fn get_all_chunks(
               &chunk_group.ukey,
               exclude_chunk1,
               exclude_chunk2,
+              visit_chunk_groups,
             );
           }
         }
@@ -89,6 +95,7 @@ pub fn get_all_chunks(
   }
 
   let mut chunks: HashSet<ChunkUkey> = HashSet::default();
+  let mut visit_chunk_groups = HashSet::default();
 
   add_chunks(
     chunk_group_by_ukey,
@@ -96,6 +103,7 @@ pub fn get_all_chunks(
     entrypoint,
     exclude_chunk1,
     exclude_chunk2,
+    &mut visit_chunk_groups,
   );
 
   chunks

--- a/packages/rspack/tests/configCases/split-chunks-common/move-to-grandparent/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/move-to-grandparent/webpack.config.js
@@ -5,7 +5,8 @@ module.exports = {
 		misc: "./second"
 	},
 	output: {
-		filename: "[name].js"
+		filename: "[name].js",
+		chunkFilename: "async/[name].js" // avoid __webpack_require__.u fallback to default logic, it can run successfully
 	},
 	experiments: {
 		newSplitChunks: true


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ae1bf5</samp>

This pull request fixes a bug in the code splitting logic of `@rspack/core` and adds a test case to verify the fix. It also updates the package version and the changeset file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ae1bf5</samp>

*  Add a changeset file to document the patch version update and the fix for connecting chunk groups when a module is split by multiple entry points (`@rspack/core` package) ([link](https://github.com/web-infra-dev/rspack/pull/3057/files?diff=unified&w=0#diff-495e0521c73b67eb562a3440e4b6cbbae01c0a993179f2ca7007dab456167ad3R1-R5))
* Rename the `chunk` variable to `chunk_ukey` in the code splitter module to avoid confusion with the actual chunk object ([link](https://github.com/web-infra-dev/rspack/pull/3057/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L369-R369))
* Connect the chunk group of the split chunk with the chunk groups of the chunk that contains the split point module in the code splitter module to preserve the dependencies between the split chunks and enable the runtime to load them correctly ([link](https://github.com/web-infra-dev/rspack/pull/3057/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L375-R396))
* Modify the webpack configuration for the test case `split-chunks-common/move-to-grandparent` to specify the `chunkFilename` option and avoid errors when loading split chunks ([link](https://github.com/web-infra-dev/rspack/pull/3057/files?diff=unified&w=0#diff-2a4aebb063e9f9701fec4ae6546ab40bee496c87a2aff50ac037814dc33fc171L8-R9))

</details>
