### PR TITLE
fix: 🐛 cross compile

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -20,7 +20,7 @@ async function build() {
 		}
 
 		if (process.env.USE_ZIG) {
-			args.push("--zig");
+			args.push("--cross-compile");
 		}
 
 		if (process.env.RUST_TARGET) {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43e0d59</samp>

Enable cross-compilation of node bindings using Zig. Modify `build.js` to use `--cross-compile` flag instead of `--zig` flag when `USE_ZIG` is set.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43e0d59</samp>

*  Enable cross-compilation of node bindings using Zig compiler ([link](https://github.com/web-infra-dev/rspack/pull/3059/files?diff=unified&w=0#diff-68d7ac20da498f25961f5cc517c798d1caba8badf994621b9d764ec4578673d0L23-R23))

</details>
