### PR TITLE
feat: normal module factory after resolve hooks

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -85,6 +85,14 @@ export class Rspack {
   unsafe_drop(): void
 }
 
+export interface AfterResolveData {
+  request: string
+  context?: string
+  fileDependencies: Array<string>
+  contextDependencies: Array<string>
+  missingDependencies: Array<string>
+}
+
 export interface BeforeResolveData {
   request: string
   context?: string
@@ -177,6 +185,7 @@ export interface JsHooks {
   beforeCompile: (...args: any[]) => any
   finishModules: (...args: any[]) => any
   beforeResolve: (...args: any[]) => any
+  afterResolve: (...args: any[]) => any
   contextModuleBeforeResolve: (...args: any[]) => any
   normalModuleFactoryResolveForScheme: (...args: any[]) => any
   chunkAsset: (...args: any[]) => any

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -24,6 +24,7 @@ pub enum Hook {
   ChunkAsset,
   NormalModuleFactoryResolveForScheme,
   AfterResolve,
+  BeforeResolve,
 }
 
 impl From<String> for Hook {
@@ -49,6 +50,7 @@ impl From<String> for Hook {
       "chunkAsset" => Hook::ChunkAsset,
       "normalModuleFactoryResolveForScheme" => Hook::NormalModuleFactoryResolveForScheme,
       "afterResolve" => Hook::AfterResolve,
+      "beforeResolve" => Hook::BeforeResolve,
       hook_name => panic!("{hook_name} is an invalid hook name"),
     }
   }

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -23,6 +23,7 @@ pub enum Hook {
   /// webpack `compilation.hooks.chunkAsset`
   ChunkAsset,
   NormalModuleFactoryResolveForScheme,
+  AfterResolve,
 }
 
 impl From<String> for Hook {
@@ -47,6 +48,7 @@ impl From<String> for Hook {
       "optimizeModules" => Hook::OptimizeModules,
       "chunkAsset" => Hook::ChunkAsset,
       "normalModuleFactoryResolveForScheme" => Hook::NormalModuleFactoryResolveForScheme,
+      "afterResolve" => Hook::AfterResolve,
       hook_name => panic!("{hook_name} is an invalid hook name"),
     }
   }

--- a/crates/node_binding/src/js_values/hooks.rs
+++ b/crates/node_binding/src/js_values/hooks.rs
@@ -20,6 +20,7 @@ pub struct JsHooks {
   pub before_compile: JsFunction,
   pub finish_modules: JsFunction,
   pub before_resolve: JsFunction,
+  pub after_resolve: JsFunction,
   pub context_module_before_resolve: JsFunction,
   pub normal_module_factory_resolve_for_scheme: JsFunction,
   pub chunk_asset: JsFunction,

--- a/crates/node_binding/src/js_values/normal_module_factory.rs
+++ b/crates/node_binding/src/js_values/normal_module_factory.rs
@@ -1,4 +1,7 @@
-use rspack_core::{NormalModuleBeforeResolveArgs, ResourceData};
+use rspack_core::{
+  NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
+  NormalModuleFactoryResolveForSchemeArgs, ResourceData,
+};
 
 #[napi(object)]
 pub struct JsResolveForSchemeInput {
@@ -16,6 +19,15 @@ pub struct JsResolveForSchemeResult {
 pub struct BeforeResolveData {
   pub request: String,
   pub context: Option<String>,
+}
+
+#[napi(object)]
+pub struct AfterResolveData {
+  pub request: String,
+  pub context: Option<String>,
+  pub file_dependencies: Vec<String>,
+  pub context_dependencies: Vec<String>,
+  pub missing_dependencies: Vec<String>,
 }
 
 #[napi(object)]
@@ -55,6 +67,30 @@ impl From<NormalModuleBeforeResolveArgs<'_>> for BeforeResolveData {
     Self {
       context: value.context.to_owned(),
       request: value.request.to_string(),
+    }
+  }
+}
+
+impl From<NormalModuleAfterResolveArgs<'_>> for AfterResolveData {
+  fn from(value: NormalModuleAfterResolveArgs) -> Self {
+    Self {
+      context: value.context.to_owned(),
+      request: value.request.to_string(),
+      file_dependencies: value
+        .file_dependencies
+        .clone()
+        .into_iter()
+        .map(|item| item.to_string_lossy().to_string()),
+      context_dependencies: value
+        .context_dependencies
+        .clone()
+        .into_iter()
+        .map(|item| item.to_string_lossy().to_string()),
+      missing_dependencies: value
+        .context_dependencies
+        .clone()
+        .into_iter()
+        .map(|item| item.to_string_lossy().to_string()),
     }
   }
 }

--- a/crates/node_binding/src/js_values/normal_module_factory.rs
+++ b/crates/node_binding/src/js_values/normal_module_factory.rs
@@ -80,17 +80,20 @@ impl From<NormalModuleAfterResolveArgs<'_>> for AfterResolveData {
         .file_dependencies
         .clone()
         .into_iter()
-        .map(|item| item.to_string_lossy().to_string()),
+        .map(|item| item.to_string_lossy().to_string())
+        .collect::<Vec<_>>(),
       context_dependencies: value
         .context_dependencies
         .clone()
         .into_iter()
-        .map(|item| item.to_string_lossy().to_string()),
+        .map(|item| item.to_string_lossy().to_string())
+        .collect::<Vec<_>>(),
       missing_dependencies: value
         .context_dependencies
         .clone()
         .into_iter()
-        .map(|item| item.to_string_lossy().to_string()),
+        .map(|item| item.to_string_lossy().to_string())
+        .collect::<Vec<_>>(),
     }
   }
 }

--- a/crates/node_binding/src/js_values/normal_module_factory.rs
+++ b/crates/node_binding/src/js_values/normal_module_factory.rs
@@ -1,7 +1,4 @@
-use rspack_core::{
-  NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
-  NormalModuleFactoryResolveForSchemeArgs, ResourceData,
-};
+use rspack_core::{NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs, ResourceData};
 
 #[napi(object)]
 pub struct JsResolveForSchemeInput {

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -147,7 +147,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
     if self.is_hook_disabled(&Hook::BeforeResolve) {
       return Ok(None);
     }
-    let res = self
+    self
       .before_resolve
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
@@ -163,13 +163,12 @@ impl rspack_core::Plugin for JsHooksAdapter {
     if self.is_hook_disabled(&Hook::AfterResolve) {
       return Ok(None);
     }
-    let res = self
+    self
       .after_resolve
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?;
-    res
+      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
   }
   async fn context_module_before_resolve(
     &self,

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -7,8 +7,10 @@ pub use loader::JsLoaderResolver;
 use napi::{Env, Result};
 use rspack_binding_macros::js_fn_into_theadsafe_fn;
 use rspack_core::{
-  ChunkAssetArgs, NormalModuleBeforeResolveArgs, PluginNormalModuleFactoryBeforeResolveOutput,
-  PluginNormalModuleFactoryResolveForSchemeOutput, ResourceData,
+  ChunkAssetArgs, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
+  NormalModuleFactoryResolveForSchemeArgs, PluginNormalModuleFactoryAfterResolveOutput,
+  PluginNormalModuleFactoryBeforeResolveOutput, PluginNormalModuleFactoryResolveForSchemeOutput,
+  ResourceData,
 };
 use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
@@ -40,7 +42,7 @@ pub struct JsHooksAdapter {
   pub finish_modules_tsfn: ThreadsafeFunction<JsCompilation, ()>,
   pub chunk_asset_tsfn: ThreadsafeFunction<JsChunkAssetArgs, ()>,
   pub before_resolve: ThreadsafeFunction<BeforeResolveData, Option<bool>>,
-  pub before_resolve: ThreadsafeFunction<AfterResolveData, Option<bool>>,
+  pub after_resolve: ThreadsafeFunction<AfterResolveData, Option<bool>>,
   pub context_module_before_resolve: ThreadsafeFunction<BeforeResolveData, Option<bool>>,
   pub normal_module_factory_resolve_for_scheme:
     ThreadsafeFunction<JsResolveForSchemeInput, JsResolveForSchemeResult>,
@@ -150,13 +152,13 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
   }
 
-  async fn before_resolve(
+  async fn after_resolve(
     &self,
     _ctx: rspack_core::PluginContext,
-    args: &NormalModuleBeforeResolveArgs,
-  ) -> PluginNormalModuleFactoryBeforeResolveOutput {
+    args: &NormalModuleAfterResolveArgs,
+  ) -> PluginNormalModuleFactoryAfterResolveOutput {
     let res = self
-      .before_resolve
+      .after_resolve
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
@@ -468,6 +470,7 @@ impl JsHooksAdapter {
       optimize_modules,
       optimize_chunk_module,
       before_resolve,
+      after_resolve,
       context_module_before_resolve,
       normal_module_factory_resolve_for_scheme,
       before_compile,
@@ -510,6 +513,8 @@ impl JsHooksAdapter {
       js_fn_into_theadsafe_fn!(context_module_before_resolve, env);
     let before_resolve: ThreadsafeFunction<BeforeResolveData, Option<bool>> =
       js_fn_into_theadsafe_fn!(before_resolve, env);
+    let after_resolve: ThreadsafeFunction<AfterResolveData, Option<bool>> =
+      js_fn_into_theadsafe_fn!(after_resolve, env);
     let normal_module_factory_resolve_for_scheme: ThreadsafeFunction<
       JsResolveForSchemeInput,
       JsResolveForSchemeResult,
@@ -540,6 +545,7 @@ impl JsHooksAdapter {
       normal_module_factory_resolve_for_scheme,
       finish_modules_tsfn,
       chunk_asset_tsfn,
+      after_resolve,
     })
   }
 

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -8,9 +8,8 @@ use napi::{Env, Result};
 use rspack_binding_macros::js_fn_into_theadsafe_fn;
 use rspack_core::{
   ChunkAssetArgs, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
-  NormalModuleFactoryResolveForSchemeArgs, PluginNormalModuleFactoryAfterResolveOutput,
-  PluginNormalModuleFactoryBeforeResolveOutput, PluginNormalModuleFactoryResolveForSchemeOutput,
-  ResourceData,
+  PluginNormalModuleFactoryAfterResolveOutput, PluginNormalModuleFactoryBeforeResolveOutput,
+  PluginNormalModuleFactoryResolveForSchemeOutput, ResourceData,
 };
 use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -144,7 +144,10 @@ impl rspack_core::Plugin for JsHooksAdapter {
     _ctx: rspack_core::PluginContext,
     args: &NormalModuleBeforeResolveArgs,
   ) -> PluginNormalModuleFactoryBeforeResolveOutput {
-    self
+    if self.is_hook_disabled(&Hook::BeforeResolve) {
+      return Ok(None);
+    }
+    let res = self
       .before_resolve
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
@@ -157,6 +160,9 @@ impl rspack_core::Plugin for JsHooksAdapter {
     _ctx: rspack_core::PluginContext,
     args: &NormalModuleAfterResolveArgs,
   ) -> PluginNormalModuleFactoryAfterResolveOutput {
+    if self.is_hook_disabled(&Hook::AfterResolve) {
+      return Ok(None);
+    }
     let res = self
       .after_resolve
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -16,7 +16,8 @@ use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunc
 use rspack_napi_shared::NapiResultExt;
 
 use crate::js_values::{
-  AfterResolveData, BeforeResolveData, JsChunkAssetArgs, JsResourceData, SchemeAndJsResourceData,
+  AfterResolveData, BeforeResolveData, JsChunkAssetArgs, JsResolveForSchemeInput,
+  JsResolveForSchemeResult,
 };
 use crate::{DisabledHooks, Hook, JsCompilation, JsHooks};
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -40,9 +40,12 @@ impl ModuleFactory for NormalModuleFactory {
     if let Ok(Some(before_resolve_data)) = self.before_resolve(&data).await {
       return Ok(before_resolve_data);
     }
-    let factory_result = self.factorize(&mut data).await?;
-    let context = data.context;
-    Ok(factory_result)
+    let (factory_result, diagnostics) = self.factorize(&mut data).await?.split_into_parts();
+    if let Ok(Some(after_resolve_data)) = self.after_resolve(&data, &factory_result).await {
+      return Ok(after_resolve_data);
+    }
+
+    Ok(factory_result.with_diagnostic(diagnostics))
   }
 }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -34,12 +34,14 @@ pub struct NormalModuleFactory {
 impl ModuleFactory for NormalModuleFactory {
   async fn create(
     mut self,
-    data: ModuleFactoryCreateData,
+    mut data: ModuleFactoryCreateData,
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>> {
     if let Ok(Some(before_resolve_data)) = self.before_resolve(&data).await {
       return Ok(before_resolve_data);
     }
-    Ok(self.factorize(data).await?)
+    let factory_result = self.factorize(&mut data).await?;
+    let context = data.context;
+    Ok(factory_result)
   }
 }
 
@@ -107,7 +109,7 @@ impl NormalModuleFactory {
 
   pub async fn factorize_normal_module(
     &mut self,
-    data: ModuleFactoryCreateData,
+    data: &mut ModuleFactoryCreateData,
   ) -> Result<Option<TWithDiagnosticArray<ModuleFactoryResult>>> {
     let importer = self.context.original_resource_path.as_ref();
     let importer_with_context = if let Some(importer) = importer {
@@ -210,8 +212,7 @@ impl NormalModuleFactory {
             {
               Some((pos, _)) => &request_without_match_resource[pos..],
               None => {
-                let dependency = data.dependency;
-                unreachable!("Invalid dependency: {dependency:?}")
+                unreachable!("Invalid dependency: {:?}", &data.dependency)
               }
             }
           } else {
@@ -273,12 +274,14 @@ impl NormalModuleFactory {
 
       let resolve_args = ResolveArgs {
         importer,
-        context: data.context,
+        context: data.context.clone(),
         specifier: request_without_match_resource,
         dependency_type: data.dependency.dependency_type(),
         dependency_category: data.dependency.category(),
         span: data.dependency.span().cloned(),
-        resolve_options: data.resolve_options,
+        // take the options is safe here, because it
+        // is not used in after_resolve hooks
+        resolve_options: data.resolve_options.take(),
         resolve_to_context: false,
         optional,
         file_dependencies: &mut file_dependencies,
@@ -564,7 +567,7 @@ impl NormalModuleFactory {
 
   pub async fn factorize(
     &mut self,
-    data: ModuleFactoryCreateData,
+    data: &mut ModuleFactoryCreateData,
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>> {
     let result = self
       .plugin_driver

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -17,9 +17,8 @@ use crate::{
   DependencyCategory, DependencyType, FactorizeArgs, FactoryMeta, MissingModule, ModuleArgs,
   ModuleDependency, ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
   ModuleIdentifier, ModuleRule, ModuleRuleEnforce, ModuleType, NormalModule,
-  NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
-  NormalModuleFactoryResolveForSchemeArgs, RawModule, Resolve, ResolveArgs, ResolveError,
-  ResolveOptionsWithDependencyType, ResolveResult, ResolverFactory, ResourceData,
+  NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs, RawModule, Resolve, ResolveArgs,
+  ResolveError, ResolveOptionsWithDependencyType, ResolveResult, ResolverFactory, ResourceData,
   ResourceParsedData, SharedPluginDriver,
 };
 
@@ -294,7 +293,7 @@ impl NormalModuleFactory {
           }) {
             Some((pos, _)) => &request_without_match_resource[pos..],
             None => {
-              let dependency = data.dependency;
+              let dependency = &data.dependency;
               unreachable!("Invalid dependency: {dependency:?}")
             }
           };

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -7,13 +7,12 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   AdditionalChunkRuntimeRequirementsArgs, AssetInfo, BoxLoader, BoxModule, ChunkAssetArgs,
-  ChunkHashArgs, ChunkUkey, Compilation, CompilationArgs, CompilerOptions, ContentHashArgs,
-  DoneArgs, FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
+  ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, ContentHashArgs, DoneArgs,
+  FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
   NormalModule, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
-  NormalModuleFactoryContext, NormalModuleFactoryResolveForSchemeArgs, OptimizeChunksArgs,
-  ParserAndGenerator, PluginContext, ProcessAssetsArgs, RenderArgs, RenderChunkArgs,
-  RenderManifestArgs, RenderModuleContentArgs, RenderStartupArgs, Resolver, SourceType,
-  ThisCompilationArgs,
+  NormalModuleFactoryContext, OptimizeChunksArgs, ParserAndGenerator, PluginContext,
+  ProcessAssetsArgs, RenderArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs,
+  RenderStartupArgs, Resolver, SourceType, ThisCompilationArgs,
 };
 
 // use anyhow::{Context, Result};

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -7,9 +7,10 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   AdditionalChunkRuntimeRequirementsArgs, AssetInfo, BoxLoader, BoxModule, ChunkAssetArgs,
-  ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, ContentHashArgs, DoneArgs,
-  FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
-  NormalModule, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext, OptimizeChunksArgs,
+  ChunkHashArgs, ChunkUkey, Compilation, CompilationArgs, CompilerOptions, ContentHashArgs,
+  DoneArgs, FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
+  NormalModule, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
+  NormalModuleFactoryContext, NormalModuleFactoryResolveForSchemeArgs, OptimizeChunksArgs,
   ParserAndGenerator, PluginContext, ProcessAssetsArgs, RenderArgs, RenderChunkArgs,
   RenderManifestArgs, RenderModuleContentArgs, RenderStartupArgs, Resolver, SourceType,
   ThisCompilationArgs,
@@ -26,6 +27,7 @@ pub type PluginFactorizeHookOutput = Result<Option<ModuleFactoryResult>>;
 pub type PluginModuleHookOutput = Result<Option<BoxModule>>;
 pub type PluginNormalModuleFactoryResolveForSchemeOutput = Result<(ResourceData, bool)>;
 pub type PluginNormalModuleFactoryBeforeResolveOutput = Result<Option<bool>>;
+pub type PluginNormalModuleFactoryAfterResolveOutput = Result<Option<bool>>;
 pub type PluginContentHashHookOutput = Result<Option<(SourceType, String)>>;
 pub type PluginChunkHashHookOutput = Result<Option<u64>>;
 pub type PluginRenderManifestHookOutput = Result<Vec<RenderManifestEntry>>;
@@ -94,6 +96,14 @@ pub trait Plugin: Debug + Send + Sync {
     _ctx: PluginContext,
     _args: &NormalModuleBeforeResolveArgs,
   ) -> PluginNormalModuleFactoryBeforeResolveOutput {
+    Ok(None)
+  }
+
+  async fn after_resolve(
+    &self,
+    _ctx: PluginContext,
+    _args: &NormalModuleAfterResolveArgs,
+  ) -> PluginNormalModuleFactoryAfterResolveOutput {
     Ok(None)
   }
 

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -92,6 +92,14 @@ pub struct NormalModuleBeforeResolveArgs<'a> {
   pub request: &'a str,
   pub context: &'a Option<String>,
 }
+#[derive(Debug, Clone)]
+pub struct NormalModuleAfterResolveArgs<'a> {
+  pub request: &'a str,
+  pub context: &'a Option<String>,
+  pub file_dependencies: &'a HashSet<PathBuf>,
+  pub context_dependencies: &'a HashSet<PathBuf>,
+  pub missing_dependencies: &'a HashSet<PathBuf>,
+}
 
 #[derive(Debug)]
 pub struct ResolveArgs<'a> {

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -14,7 +14,7 @@ use crate::{
   Chunk, ChunkAssetArgs, ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, Content,
   ContentHashArgs, DoneArgs, FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleType,
   NormalModule, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
-  NormalModuleFactoryContext, NormalModuleFactoryResolveForSchemeArgs, OptimizeChunksArgs, Plugin,
+  NormalModuleFactoryContext, OptimizeChunksArgs, Plugin,
   PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
   PluginChunkHashHookOutput, PluginCompilationHookOutput, PluginContext, PluginFactorizeHookOutput,
   PluginJsChunkHashHookOutput, PluginMakeHookOutput, PluginModuleHookOutput,

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -13,11 +13,13 @@ use crate::{
   AdditionalChunkRuntimeRequirementsArgs, ApplyContext, BoxLoader, BoxedParserAndGeneratorBuilder,
   Chunk, ChunkAssetArgs, ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, Content,
   ContentHashArgs, DoneArgs, FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleType,
-  NormalModule, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext, OptimizeChunksArgs,
-  Plugin, PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
+  NormalModule, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
+  NormalModuleFactoryContext, NormalModuleFactoryResolveForSchemeArgs, OptimizeChunksArgs, Plugin,
+  PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
   PluginChunkHashHookOutput, PluginCompilationHookOutput, PluginContext, PluginFactorizeHookOutput,
   PluginJsChunkHashHookOutput, PluginMakeHookOutput, PluginModuleHookOutput,
-  PluginNormalModuleFactoryBeforeResolveOutput, PluginProcessAssetsOutput,
+  PluginNormalModuleFactoryAfterResolveOutput, PluginNormalModuleFactoryBeforeResolveOutput,
+  PluginNormalModuleFactoryResolveForSchemeOutput, PluginProcessAssetsOutput,
   PluginRenderChunkHookOutput, PluginRenderHookOutput, PluginRenderManifestHookOutput,
   PluginRenderModuleContentOutput, PluginRenderStartupHookOutput, PluginThisCompilationHookOutput,
   ProcessAssetsArgs, RenderArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs,
@@ -329,6 +331,18 @@ impl PluginDriver {
     Ok(None)
   }
 
+  pub async fn after_resolve(
+    &self,
+    args: NormalModuleAfterResolveArgs<'_>,
+  ) -> PluginNormalModuleFactoryAfterResolveOutput {
+    for plugin in &self.plugins {
+      tracing::trace!("running resolve for scheme:{}", plugin.name());
+      if let Some(data) = plugin.after_resolve(PluginContext::new(), &args).await? {
+        return Ok(Some(data));
+      }
+    }
+    Ok(None)
+  }
   pub async fn context_module_before_resolve(
     &self,
     args: NormalModuleBeforeResolveArgs<'_>,

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -19,11 +19,11 @@ use crate::{
   PluginChunkHashHookOutput, PluginCompilationHookOutput, PluginContext, PluginFactorizeHookOutput,
   PluginJsChunkHashHookOutput, PluginMakeHookOutput, PluginModuleHookOutput,
   PluginNormalModuleFactoryAfterResolveOutput, PluginNormalModuleFactoryBeforeResolveOutput,
-  PluginNormalModuleFactoryResolveForSchemeOutput, PluginProcessAssetsOutput,
-  PluginRenderChunkHookOutput, PluginRenderHookOutput, PluginRenderManifestHookOutput,
-  PluginRenderModuleContentOutput, PluginRenderStartupHookOutput, PluginThisCompilationHookOutput,
-  ProcessAssetsArgs, RenderArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs,
-  RenderStartupArgs, Resolver, ResolverFactory, SourceType, Stats, ThisCompilationArgs,
+  PluginProcessAssetsOutput, PluginRenderChunkHookOutput, PluginRenderHookOutput,
+  PluginRenderManifestHookOutput, PluginRenderModuleContentOutput, PluginRenderStartupHookOutput,
+  PluginThisCompilationHookOutput, ProcessAssetsArgs, RenderArgs, RenderChunkArgs,
+  RenderManifestArgs, RenderModuleContentArgs, RenderStartupArgs, Resolver, ResolverFactory,
+  SourceType, Stats, ThisCompilationArgs,
 };
 
 pub struct PluginDriver {

--- a/examples/basic/src/main.css
+++ b/examples/basic/src/main.css
@@ -1,0 +1,2 @@
+  clip-path: url("#test")
+}

--- a/examples/basic/src/main.css
+++ b/examples/basic/src/main.css
@@ -1,2 +1,0 @@
-  clip-path: url("#test")
-}

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -580,7 +580,7 @@ class Compiler {
 			optimizeChunkModules: this.compilation.hooks.optimizeChunkModules,
 			finishModules: this.compilation.hooks.finishModules,
 			optimizeModules: this.compilation.hooks.optimizeModules,
-			chunkAsset: this.compilation.hooks.chunkAsset
+			chunkAsset: this.compilation.hooks.chunkAsset,
 			beforeResolve: this.compilation.normalModuleFactory?.hooks.beforeResolve,
 			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve
 		};

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -326,6 +326,7 @@ class Compiler {
 						this.#normalModuleFactoryResolveForScheme.bind(this),
 					chunkAsset: this.#chunkAsset.bind(this),
 					beforeResolve: this.#beforeResolve.bind(this),
+					afterResolve: this.#afterResolve.bind(this),
 					contextModuleBeforeResolve:
 						this.#contextModuleBeforeResolve.bind(this)
 				},
@@ -580,9 +581,11 @@ class Compiler {
 			finishModules: this.compilation.hooks.finishModules,
 			optimizeModules: this.compilation.hooks.optimizeModules,
 			chunkAsset: this.compilation.hooks.chunkAsset
+			beforeResolve: this.compilation.normalModuleFactory?.hooks.beforeResolve,
+			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve
 		};
 		for (const [name, hook] of Object.entries(hookMap)) {
-			if (hook.taps.length === 0) {
+			if (hook?.taps.length === 0) {
 				disabledHooks.push(name);
 			}
 		}
@@ -613,15 +616,30 @@ class Compiler {
 		this.#updateDisabledHooks();
 	}
 
-	async #beforeResolve(resourceData: binding.BeforeResolveData) {
+	async #beforeResolve(resolveData: binding.BeforeResolveData) {
 		let res =
-			await this.compilation.normalModuleFactory?.hooks.beforeResolve.promise(
-				resourceData
+			await this.compilation.normalModuleFactory?.hooks.beforeResolve.promise({
+				request: resolveData.request,
+				context: resolveData.context,
+				fileDependencies: [],
+				missingDependencies: [],
+				contextDependencies: []
+			});
+
+		this.#updateDisabledHooks();
+		return res;
+	}
+
+	async #afterResolve(resolveData: binding.AfterResolveData) {
+		let res =
+			await this.compilation.normalModuleFactory?.hooks.afterResolve.promise(
+				resolveData
 			);
 
 		this.#updateDisabledHooks();
 		return res;
 	}
+
 	async #contextModuleBeforeResolve(resourceData: binding.BeforeResolveData) {
 		let res =
 			await this.compilation.contextModuleFactory?.hooks.beforeResolve.promise(

--- a/packages/rspack/src/normalModuleFactory.ts
+++ b/packages/rspack/src/normalModuleFactory.ts
@@ -14,6 +14,10 @@ type ResourceDataWithData = ResourceData & { data?: Record<string, any> };
 type ResolveData = {
 	context?: string;
 	request: string;
+	fileDependencies: string[];
+	missingDependencies: string[];
+	contextDependencies: string[];
+
 	// assertions: Record<string, any> | undefined;
 	// dependencies: ModuleDependency[];
 };
@@ -25,6 +29,7 @@ export class NormalModuleFactory {
 			AsyncSeriesBailHook<[ResourceDataWithData], true | void>
 		>;
 		beforeResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
+		afterResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
 	};
 	constructor() {
 		this.hooks = {
@@ -41,9 +46,9 @@ export class NormalModuleFactory {
 			// /** @type {AsyncSeriesBailHook<[ResolveData], Module>} */
 			// factorize: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			beforeResolve: new AsyncSeriesBailHook(["resolveData"])
+			beforeResolve: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			// afterResolve: new AsyncSeriesBailHook(["resolveData"]),
+			afterResolve: new AsyncSeriesBailHook(["resolveData"])
 			// /** @type {AsyncSeriesBailHook<[ResolveData["createData"], ResolveData], Module | void>} */
 			// createModule: new AsyncSeriesBailHook(["createData", "resolveData"]),
 			// /** @type {SyncWaterfallHook<[Module, ResolveData["createData"], ResolveData], Module>} */


### PR DESCRIPTION
## Related issue (if exists)
1. closed https://github.com/web-infra-dev/rspack/issues/2619
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ca7003</samp>

This pull request adds support for the `afterResolve` hook in rspack, a Rust and Node.js bundler. The hook allows customizing the resolved module before it is processed further by the bundler. The pull request implements the hook in both the Rust and Node.js layers, and defines the types and structures needed to pass the hook arguments between them. It also fixes some minor errors and adds some imports and fields to the relevant files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3ca7003</samp>

*  Implement the `afterResolve` hook in Rust and expose it to the Node.js binding layer ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R25), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R49), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L10-R11), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R45), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R155-R168), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R469), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R512-R513), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R544), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL19-R22), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL107-R159), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL296-R351), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL582-R632), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L12-R16), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R30), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R102-R109), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337R102-R109), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL16-R26), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR334-R345), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR377), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR685), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-54fd5319d3a879176a1575a0b73dd717d2df3b967b25539ff9a96429296af4acR17-R20), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-54fd5319d3a879176a1575a0b73dd717d2df3b967b25539ff9a96429296af4acR32), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-54fd5319d3a879176a1575a0b73dd717d2df3b967b25539ff9a96429296af4acL44-R51))
  * Define a new variant `AfterResolve` to the enum `Hook` in `./crates/node_binding/src/hook.rs` and enable parsing the string `"afterResolve"` into it ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R25), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R49))
  * Define a new struct `NormalModuleAfterResolveArgs` in `./crates/rspack_core/src/plugin/args.rs` that represents the arguments for the `afterResolve` hook ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337R102-R109))
  * Define a new type alias `PluginNormalModuleFactoryAfterResolveOutput` in `./crates/rspack_core/src/plugin/api.rs` that represents the output type for the `afterResolve` method of the `Plugin` trait ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R30))
  * Define a new struct `AfterResolveData` in `./crates/node_binding/src/js_values/normal_module_factory.rs` that can be converted from and to a JavaScript object that represents the `afterResolve` hook arguments ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6R19-R27), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6R67-R93))
  * Define a new field `after_resolve` to the `JsHooks` struct in `./crates/node_binding/src/js_values/hooks.rs` that stores a `JsFunction` that represents the `afterResolve` hook in JavaScript ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR23))
  * Define a new field `after_resolve` to the `JsPlugin` struct in `./crates/node_binding/src/plugins/mod.rs` that stores a `ThreadsafeFunction<AfterResolveData, Option<bool>>` that represents the `afterResolve` hook in JavaScript ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R45))
  * Define a new `async fn after_resolve` method to the `Plugin` trait in `./crates/rspack_core/src/plugin/api.rs` that takes a `PluginContext` and a `NormalModuleAfterResolveArgs` as arguments, and returns a `PluginNormalModuleFactoryAfterResolveOutput` ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R102-R109))
  * Implement the `after_resolve` method of the `Plugin` trait for the `JsPlugin` struct in `./crates/node_binding/src/plugins/mod.rs` that calls the `afterResolve` hook from Rust to JavaScript through the `ThreadsafeFunction` mechanism ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R155-R168))
  * Implement the `after_resolve` method of the `Plugin` trait for the `NormalModuleFactory` struct in `./crates/rspack_core/src/normal_module_factory.rs` that calls the `afterResolve` hook from Rust to JavaScript through the `PluginDriver` mechanism, and handles the possible return value of the hook ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL107-R159))
  * Implement the `after_resolve` method of the `PluginDriver` struct in `./crates/rspack_core/src/plugin/plugin_driver.rs` that iterates over the registered plugins to call their `after_resolve` methods ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR334-R345))
  * Define the `afterResolve` hook of the `NormalModuleFactory` class in `./packages/rspack/src/normalModuleFactory.ts` that is an instance of the `AsyncSeriesBailHook` class that takes a `ResolveData` object as an argument, and returns a `boolean` or `void` value ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-54fd5319d3a879176a1575a0b73dd717d2df3b967b25539ff9a96429296af4acR32))
  * Define the `afterResolve` hook in the `Compiler` class in `./packages/rspack/src/compiler.ts` that calls the `afterResolve` hook of the `normalModuleFactory` property of the `compilation` property of the `Compiler` class ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR685))
  * Pass the `afterResolve` hook function from JavaScript to Rust through the `JsHooks` struct ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR23), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R469), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R512-R513), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R544), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR377))
  * Pass the `afterResolve` hook arguments from Rust to JavaScript through the `ThreadsafeFunction` mechanism ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6L2-R3), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6R19-R27), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6R67-R93), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R155-R168), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL107-R159))
  * Call the `after_resolve` hook after the `factorize` method of the `NormalModuleFactory` struct in `./crates/rspack_core/src/normal_module_factory.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL36-R44), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL582-R632))
  * Fix syntax errors in the `unreachable!` macro calls in the `factorize_normal_module` method of the `NormalModuleFactory` struct in `./crates/rspack_core/src/normal_module_factory.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL230-R280), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL263-R312))
  * Avoid borrowing and ownership issues with the `data` argument in the `factorize` and `factorize_normal_module` methods of the `NormalModuleFactory` struct in `./crates/rspack_core/src/normal_module_factory.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL36-R44), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL296-R351), [link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL582-R632))
  * Include the `beforeResolve` and `afterResolve` hooks in the logic that determines which hooks are disabled based on their taps length in the `#updateDisabledHooks` method of the `Compiler` class in `./packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3060/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL625-R631))

</details>
