### PR TITLE
chore: take bump check temporarily

### DIFF
--- a/scripts/check_changeset.js
+++ b/scripts/check_changeset.js
@@ -59,4 +59,5 @@ async function checkBump() {
 }
 
 await checkVersion();
-//await checkBump();
+// checkBump sometimes is hang forever so we take it down before it is fixed
+//await checkBump(); 

--- a/scripts/check_changeset.js
+++ b/scripts/check_changeset.js
@@ -59,4 +59,4 @@ async function checkBump() {
 }
 
 await checkVersion();
-await checkBump();
+//await checkBump();


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4d6a3a6</samp>

Commented out `checkBump` function in `scripts/check_changeset.js` to skip version checking for testing. This is a temporary change for a feature branch.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d6a3a6</samp>

*  Disable the version bump check for testing purposes ([link](https://github.com/web-infra-dev/rspack/pull/3064/files?diff=unified&w=0#diff-00c04a208565587d9af0e9a2155712fe21371025c86f238c64e42179ab5d1f87L62-R62)). This change affects the `scripts/check_changeset.js` file, which runs a script to validate the changeset files before committing them. The `checkBump` function call was commented out to allow testing the changeset functionality without following the semantic versioning rules.

</details>
