### PR TITLE
chore: add stale bot, which only adds the "stale" label and never closes issues or PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+# It is considered harmful to close issues or PRs, so our stale bot will never close an issue or PR.
+# To remove the stale label, just leave a new comment.
+# Adapted from https://github.com/NixOS/nixpkgs/blob/master/.github/STALE-BOT.md
+
+# Configuration for probot-stale - https://github.com/probot/stale
+staleLabel: "stale"
+daysUntilStale: 30
+daysUntilClose: false
+markComment: false
+closeComment: false
+# exemptLabels:
+  # - ""


### PR DESCRIPTION
## Related issue (if exists)

* https://github.com/web-infra-dev/rspack/issues/2472

## Summary

It is considered harmful to close issues or PRs, so our stale bot will never close an issue or PR.
To remove the stale label, just leave a new comment.
Adapted from https://github.com/NixOS/nixpkgs/blob/master/.github/STALE-BOT.md

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 060e7f6</samp>

Add probot-stale bot configuration to label inactive issues and PRs as stale. This helps to keep the repository clean and active, and to avoid losing track of relevant or useful contributions.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 060e7f6</samp>

* Add a configuration file for the probot-stale bot to label inactive issues and PRs as stale ([link](https://github.com/web-infra-dev/rspack/pull/3065/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aR1-R12))

</details>
