### PR TITLE
feat(core): support custom dependency type internally

### DIFF
--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -17,6 +17,7 @@ mod require_context_dependency;
 mod require_resolve_dependency;
 use std::{
   any::Any,
+  borrow::Cow,
   fmt::{Debug, Display},
   hash::Hash,
 };
@@ -32,7 +33,7 @@ use crate::{AsAny, ContextMode, ContextOptions, ErrorSpan, ModuleGraph, ModuleId
 
 // Used to describe dependencies' types, see webpack's `type` getter in `Dependency`
 // Note: This is almost the same with the old `ResolveKind`
-#[derive(Default, Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Default, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum DependencyType {
   #[default]
   Unknown,
@@ -77,6 +78,7 @@ pub enum DependencyType {
   WasmExportImported,
   /// static exports
   StaticExports,
+  Custom(Cow<'static, str>),
 }
 
 impl Display for DependencyType {
@@ -104,6 +106,7 @@ impl Display for DependencyType {
       DependencyType::WasmImport => write!(f, "wasm import"),
       DependencyType::WasmExportImported => write!(f, "wasm export imported"),
       DependencyType::StaticExports => write!(f, "static exports"),
+      DependencyType::Custom(ty) => write!(f, "custom {ty}"),
     }
   }
 }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -483,7 +483,7 @@ impl NormalModuleFactory {
       .read()
       .await
       .module(ModuleArgs {
-        dependency_type: *data.dependency.dependency_type(),
+        dependency_type: data.dependency.dependency_type().clone(),
         indentfiler: normal_module.identifier(),
         lazy_visit_modules: self.context.lazy_visit_modules.clone(),
       })

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -45,7 +45,7 @@ pub async fn resolve(
     .get(ResolveOptionsWithDependencyType {
       resolve_options: args.resolve_options,
       resolve_to_context: args.resolve_to_context,
-      dependency_type: *args.dependency_type,
+      dependency_type: args.dependency_type.clone(),
       dependency_category: *args.dependency_category,
     });
   let result = resolver.resolve(base_dir, args.specifier);


### PR DESCRIPTION
## Related issue (if exists)

#3051 

<!--- Provide link of related issues -->

## Summary

- In most cases `Cow<'static, str>` would be `&'static str` behind, so `clone` would be not a problem.
- This also makes Rspack could support custom dependency type from the js side in the future.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22eff06</samp>

Added custom dependency types to `rspack_core` and refactored dependency and module logic. Changed `dependency_type` arguments to use `clone` instead of dereferencing to avoid copying.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22eff06</samp>

*  Add `Custom` variant to `DependencyType` enum and use `borrow::Cow` for string values ([link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8R20), [link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8L35-R36), [link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8R81))
*  Update `dependency_type` field and arguments to use `clone` instead of dereferencing, since `DependencyType` is no longer `Copy` ([link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8R109), [link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL486-R486), [link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-e3cb84e19ccc823fb214fdbb9dcd1afe8de633c34762f11d11a2c22a1fff2238L48-R48))
*  Move `normal_module_factory.rs` to `dependency/mod.rs` and refactor dependency logic to separate module ([link](https://github.com/web-infra-dev/rspack/pull/3068/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL486-R486))

</details>
