### PR TITLE
feat: support `optimization.removeEmptyChunks` config

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -604,6 +604,7 @@ export interface RawOptimizationOptions {
   splitChunks?: RawSplitChunksOptions
   moduleIds: string
   removeAvailableModules: boolean
+  removeEmptyChunks: boolean
   sideEffects: string
   realContentHash: boolean
 }

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -203,7 +203,9 @@ impl RawOptionsApply for RawOptions {
     plugins.push(rspack_ids::StableNamedChunkIdsPlugin::new(None, None).boxed());
 
     // Notice the plugin need to be placed after SplitChunksPlugin
-    plugins.push(rspack_plugin_remove_empty_chunks::RemoveEmptyChunksPlugin.boxed());
+    if optimization.remove_empty_chunks {
+      plugins.push(rspack_plugin_remove_empty_chunks::RemoveEmptyChunksPlugin.boxed());
+    }
 
     Ok(Self::Options {
       entry,

--- a/crates/rspack_binding_options/src/options/raw_optimization.rs
+++ b/crates/rspack_binding_options/src/options/raw_optimization.rs
@@ -19,6 +19,7 @@ pub struct RawOptimizationOptions {
   pub split_chunks: Option<RawSplitChunksOptions>,
   pub module_ids: String,
   pub remove_available_modules: bool,
+  pub remove_empty_chunks: bool,
   pub side_effects: String,
   pub real_content_hash: bool,
 }
@@ -57,6 +58,7 @@ impl RawOptionsApply for RawOptimizationOptions {
     }
     Ok(Optimization {
       remove_available_modules: self.remove_available_modules,
+      remove_empty_chunks: self.remove_empty_chunks,
       side_effects: SideEffectOption::from(self.side_effects.as_str()),
     })
   }

--- a/crates/rspack_core/src/options/optimizations.rs
+++ b/crates/rspack_core/src/options/optimizations.rs
@@ -47,5 +47,6 @@ impl SideEffectOption {
 #[derive(Debug)]
 pub struct Optimization {
   pub remove_available_modules: bool,
+  pub remove_empty_chunks: bool,
   pub side_effects: SideEffectOption,
 }

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -74,6 +74,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
         node: Default::default(),
         optimization: rspack_core::Optimization {
           remove_available_modules: false,
+          remove_empty_chunks: true,
           side_effects: SideEffectOption::False,
         },
       }),

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -101,6 +101,8 @@ pub struct Optimization {
   // True by default to reduce code in snapshots.
   #[serde(default = "true_by_default")]
   pub remove_available_modules: bool,
+  #[serde(default = "true_by_default")]
+  pub remove_empty_chunks: bool,
   #[serde(default = "default_optimization_module_ids")]
   pub module_ids: String,
   #[serde(default = "default_optimization_side_effects")]
@@ -453,6 +455,7 @@ impl TestConfig {
       }),
       optimization: c::Optimization {
         remove_available_modules: self.optimization.remove_available_modules,
+        remove_empty_chunks: self.optimization.remove_empty_chunks,
         side_effects: c::SideEffectOption::from(self.optimization.side_effects.as_str()),
       },
     };

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -457,9 +457,10 @@ function getRawOptimization(
 	assert(
 		!isNil(optimization.moduleIds) &&
 			!isNil(optimization.removeAvailableModules) &&
+			!isNil(optimization.removeEmptyChunks) &&
 			!isNil(optimization.sideEffects) &&
 			!isNil(optimization.realContentHash),
-		"optimization.moduleIds, optimization.removeAvailableModules, optimization.sideEffects, optimization.realContentHash should not be nil after defaults"
+		"optimization.moduleIds, optimization.removeAvailableModules, optimization.removeEmptyChunks, optimization.sideEffects, optimization.realContentHash should not be nil after defaults"
 	);
 	return {
 		splitChunks: optimization.splitChunks
@@ -467,6 +468,7 @@ function getRawOptimization(
 			: undefined,
 		moduleIds: optimization.moduleIds,
 		removeAvailableModules: optimization.removeAvailableModules,
+		removeEmptyChunks: optimization.removeEmptyChunks,
 		sideEffects: String(optimization.sideEffects),
 		realContentHash: optimization.realContentHash
 	};

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -532,6 +532,7 @@ const applyOptimizationDefaults = (
 	{ production, development }: { production: boolean; development: boolean }
 ) => {
 	D(optimization, "removeAvailableModules", true);
+	D(optimization, "removeEmptyChunks", true);
 	F(optimization, "moduleIds", () => {
 		if (production) return "deterministic";
 		return "named";

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -849,6 +849,10 @@ module.exports = {
 						"Removes modules from chunks when these modules are already included in all parents.",
 					type: "boolean"
 				},
+				removeEmptyChunks: {
+					description: "Remove chunks which are empty.",
+					type: "boolean"
+				},
 				runtimeChunk: {
 					$ref: "#/definitions/OptimizationRuntimeChunk"
 				},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -573,6 +573,10 @@ export interface Optimization {
 	splitChunks?: OptimizationSplitChunksOptions | false;
 	runtimeChunk?: OptimizationRuntimeChunk;
 	removeAvailableModules?: boolean;
+	/**
+	 * Remove chunks which are empty.
+	 */
+	removeEmptyChunks?: boolean;
 	sideEffects?: "flag" | boolean;
 	realContentHash?: boolean;
 }

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -167,6 +167,7 @@ exports[`snapshots should have the correct base config 1`] = `
     "moduleIds": "named",
     "realContentHash": false,
     "removeAvailableModules": true,
+    "removeEmptyChunks": true,
     "runtimeChunk": false,
     "sideEffects": "flag",
     "splitChunks": {


### PR DESCRIPTION

The `optimization.removeEmptyChunks` config is documented but not implemented, this PR adds the implementation.

https://www.rspack.dev/config/optimization.html#optimizationremoveemptychunks

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c942bb</samp>

This pull request adds a new optimization option, `remove_empty_chunks`, to the `rspack` tool and its related crates. This option allows the user to control whether empty chunks are removed from the output bundle or not. It updates the configuration file parser, schema, adapter, and defaults, as well as the core and testing crates, and the sass loader test fixture.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0c942bb</samp>

*  Add `remove_empty_chunks` option to control whether empty chunks are removed by the plugin ([link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062R22), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-977596e157975dc4197eb665b26946ed33ed5fe3f497c0ddf25ec0a92558b062R61), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-c731bb105a4e32d3172a4f8937933d0e441484fd002c4d8eb05280cc8bfa49b9R50), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L460-R463), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R471), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccR535), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R852-R855), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR576-R579))
*  Push `RemoveEmptyChunksPlugin` to `plugins` array only if `remove_empty_chunks` is true in `options/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41L206-R208))
*  Set `remove_empty_chunks` to true in test fixture for `rspack_loader_sass` in `fixtures.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-540f3da2174ff9bebb32ec9123aed3f974b53dc3af899dfe9ef4edd0585dbcffR77))
*  Add `remove_empty_chunks` to `TestConfig` and `RawOptimization` structs for `rspack_testing` in `test_config.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-8b7ae8eae42b4d9202dbd35407c3338295c42d2b3b863c1a9c179c23502c86c2R104-R105), [link](https://github.com/web-infra-dev/rspack/pull/3076/files?diff=unified&w=0#diff-8b7ae8eae42b4d9202dbd35407c3338295c42d2b3b863c1a9c179c23502c86c2R458))

</details>
