### PR TITLE
feat(rust): support __webpack_chunk_load__ module variable

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -24,6 +24,7 @@ pub const WEBPACK_HASH: &str = "__webpack_hash__";
 pub const WEBPACK_PUBLIC_PATH: &str = "__webpack_public_path__";
 pub const WEBPACK_MODULES: &str = "__webpack_modules__";
 pub const WEBPACK_RESOURCE_QUERY: &str = "__resourceQuery";
+pub const WEBPACK_CHUNK_LOAD: &str = "__webpack_chunk_load__";
 
 pub struct DependencyScanner<'a> {
   pub unresolved_ctxt: &'a SyntaxContext,
@@ -436,6 +437,13 @@ impl VisitAstPath for DependencyScanner<'_> {
                 as_parent_path(ast_path),
               )));
             }
+          }
+          WEBPACK_CHUNK_LOAD => {
+            self.add_presentational_dependency(Box::new(ConstDependency::new(
+              Expr::Ident(quote_ident!(RuntimeGlobals::ENSURE_CHUNK)),
+              Some(RuntimeGlobals::ENSURE_CHUNK),
+              as_parent_path(ast_path),
+            )));
           }
           _ => {}
         }

--- a/packages/rspack/tests/cases/module-variables/webpack_chunk_load/index.js
+++ b/packages/rspack/tests/cases/module-variables/webpack_chunk_load/index.js
@@ -1,0 +1,3 @@
+it("__webpack_chunk_load__", function () {
+	expect(__webpack_chunk_load__).not.toBeUndefined();
+});


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/issues/3070
## Summary

See details https://webpack.js.org/api/module-variables/#__webpack_chunk_load__-webpack-specific.
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a1b3da</samp>

This pull request enhances the rspack_plugin_javascript crate to handle webpack's chunk loading feature. It also adds a test case for the `__webpack_chunk_load__` module variable in the module-variables test suite.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a1b3da</samp>

*  Define and replace `__webpack_chunk_load__` module variable for async chunk loading ([link](https://github.com/web-infra-dev/rspack/pull/3080/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faR27), [link](https://github.com/web-infra-dev/rspack/pull/3080/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faR441-R447))
* Add test case for `__webpack_chunk_load__` module variable in `packages/rspack/tests/cases/module-variables/webpack_chunk_load/index.js` ([link](https://github.com/web-infra-dev/rspack/pull/3080/files?diff=unified&w=0#diff-9c50098f0ef76cbeb3809926b58056778e74fb3e5f356566b177157d79aaeffbR1-R3))

</details>
