### PR TITLE
chore(rspack): add github-actions-reporter to jest

### DIFF
--- a/packages/rspack-cli/jest.config.js
+++ b/packages/rspack-cli/jest.config.js
@@ -1,8 +1,16 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+const config = {
 	preset: "ts-jest",
 	testEnvironment: "node",
 	testTimeout: process.env.CI ? 120000 : 30000,
 	testMatch: ["<rootDir>/tests/**/*.test.ts", "<rootDir>/tests/**/*.test.js"],
 	watchPathIgnorePatterns: ["<rootDir>/tests/.*/dist"]
 };
+
+if (process.env.CI) {
+	config.reporters = [["github-actions", { silent: false }], "summary"];
+} else {
+	config.reporters = ["default"];
+}
+
+module.exports = config;

--- a/packages/rspack-dev-server/jest.config.js
+++ b/packages/rspack-dev-server/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+const config = {
 	preset: "ts-jest",
 	testEnvironmentOptions: {
 		url: "http://localhost/"
@@ -8,3 +8,11 @@ module.exports = {
 	cache: false,
 	testTimeout: process.env.CI ? 120000 : 30000
 };
+
+if (process.env.CI) {
+	config.reporters = [["github-actions", { silent: false }], "summary"];
+} else {
+	config.reporters = ["default"];
+}
+
+module.exports = config;

--- a/packages/rspack/jest.config.js
+++ b/packages/rspack/jest.config.js
@@ -1,5 +1,5 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-module.exports = {
+const config = {
 	testEnvironment: "node",
 	testMatch: [
 		"<rootDir>/tests/*.test.ts",
@@ -21,3 +21,11 @@ module.exports = {
 		"^.+\\.jsx?$": "babel-jest"
 	}
 };
+
+if (process.env.CI) {
+	config.reporters = [["github-actions", { silent: false }], "summary"];
+} else {
+	config.reporters = ["default"];
+}
+
+module.exports = config;


### PR DESCRIPTION
## Summary

See https://jestjs.io/docs/configuration#github-actions-reporter

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b776c46</samp>

Updated jest configuration files for `rspack-cli`, `rspack-dev-server`, and `rspack` packages to support TypeScript testing and improve coverage reporting. Added conditional reporters for GitHub Actions and local development in `rspack-cli`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b776c46</samp>

*  Replace `module.exports` assignment with `config` variable declaration in jest configuration files to allow conditional modification based on `CI` environment variable ([link](https://github.com/web-infra-dev/rspack/pull/3081/files?diff=unified&w=0#diff-12f3b852c110f777477bdd2eb94fe43ae4c124c32ae20d75cd55a2e7a540c508L2-R2), [link](https://github.com/web-infra-dev/rspack/pull/3081/files?diff=unified&w=0#diff-3cc73048bda75c7cdbd469770510da75d2851fda2ad2378f2df7fe8c2be49168L2-R2), [link](https://github.com/web-infra-dev/rspack/pull/3081/files?diff=unified&w=0#diff-024f31f19f0ada07a91f77563c854995109bc81d6daf39b39e6c97f708ecf16eL2-R2))
*  Set `reporters` property of jest configuration object depending on `CI` environment variable in `packages/rspack-cli/jest.config.js`, `packages/rspack-dev-server/jest.config.js`, and `packages/rspack/jest.config.js` to use different test result formats for GitHub Actions and local development ([link](https://github.com/web-infra-dev/rspack/pull/3081/files?diff=unified&w=0#diff-12f3b852c110f777477bdd2eb94fe43ae4c124c32ae20d75cd55a2e7a540c508R9-R16), [link](https://github.com/web-infra-dev/rspack/pull/3081/files?diff=unified&w=0#diff-3cc73048bda75c7cdbd469770510da75d2851fda2ad2378f2df7fe8c2be49168R11-R18), [link](https://github.com/web-infra-dev/rspack/pull/3081/files?diff=unified&w=0#diff-024f31f19f0ada07a91f77563c854995109bc81d6daf39b39e6c97f708ecf16eR24-R31))

</details>
