### PR TITLE
chore: add test commands to x.mjs

### DIFF
--- a/x.mjs
+++ b/x.mjs
@@ -48,9 +48,57 @@ cleanCommand
 const buildCommand = program.command("build").alias("b").description("build");
 
 // x build binding
-buildCommand.command("binding").action(async function () {
-  await $`pnpm --filter @rspack/binding build:debug`;
-});
+buildCommand
+  .command("binding")
+  .description("build rust binding")
+  .action(async function () {
+    await $`pnpm --filter @rspack/binding build:debug`;
+  });
+
+// x build js
+buildCommand
+  .command("js")
+  .description("build js packages")
+  .action(async function () {
+    await $`pnpm --filter "@rspack/*" build`;
+  });
+
+// x test
+const testCommand = program.command("test").alias("t").description("test");
+
+// x test rust
+testCommand
+  .command("rust")
+  .description("run cargo tests")
+  .action(async function () {
+    await $`cargo test`;
+  });
+
+// x test example
+testCommand
+  .command("example")
+  .description("build examples")
+  .action(async function () {
+    await $`pnpm --filter "example-*" build`;
+  });
+
+// x test unit
+testCommand
+  .command("unit")
+  .description("run all unit tests")
+  .action(async function () {
+    await $`./x build js`;
+    await $`pnpm --filter "@rspack/*" test`;
+  });
+
+// x test ci
+testCommand
+  .command("ci")
+  .description("run tests for ci")
+  .action(async function () {
+    await $`./x test example`;
+    await $`./x test unit`;
+  });
 
 let argv = process.argv.slice(2); // remove the `node` and script call
 if (argv[0] && /x.mjs/.test(argv[0])) {


### PR DESCRIPTION
## Related issue (if exists)

https://github.com/web-infra-dev/rspack/issues/2915

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ebe2089</samp>

Add more subcommands to `x` script for building and testing rspack. The new subcommands are `build`, `test`, `clean`, and `watch`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ebe2089</samp>

* Added subcommands to the `x` script for building and testing the rspack project ([link](https://github.com/web-infra-dev/rspack/pull/3082/files?diff=unified&w=0#diff-866d8c4b601772273677680d6cedcec91a98ae1b64b2cda04eff6dab131dfcf1L51-R102))

</details>
