### PR TITLE
fix(rspack_plugin_javascript): remove empty whitespace from runtime

### DIFF
--- a/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
@@ -12,7 +12,7 @@ function __webpack_require__(moduleId) {
       }
       // Create a new module (and put it into the cache)
       var module = (__webpack_module_cache__[moduleId] = {
-       exports: {} 
+       exports: {}
       });
       // Execute the module function
       __webpack_modules__[moduleId](module, module.exports, __webpack_require__);

--- a/crates/rspack_plugin_html/tests/fixtures/variant/expected/output.html
+++ b/crates/rspack_plugin_html/tests/fixtures/variant/expected/output.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Rspack App</title>
-<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-+rvnKFBVF0WA40coHk0mfBA8+rK5eWjL0V9/K8pSggP7yfG/WBXmyz8Yo9lTwwVQ3YYxEhs/ZE4ig5W+VlkwhQ=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-EhlBY1oPqc7qxML0eaO4NDX5dvrtK8OiR6NKGfJsSHm6ThPAmD9eOpT044icXDES1RbnYtFqG/C1aLx9yJNE/Q=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-Z8PU3Ii4d2SPUxyN8IIBT+qeVhwEyS0gDBnVwfr1XrN7r20CMILhZ1GhnoENqrJIUHI9/6UVEdorpIqMuDavdQ==" /></head>
+<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-i8raEvyUBukSYamgRbYjxdSI5lDQujdCw8y/DRuVO13mPL9fsIk2lZQbwxJKpmC3X/qq/R5B7UFLlX6WqVRmiw=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-EhlBY1oPqc7qxML0eaO4NDX5dvrtK8OiR6NKGfJsSHm6ThPAmD9eOpT044icXDES1RbnYtFqG/C1aLx9yJNE/Q=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-Z8PU3Ii4d2SPUxyN8IIBT+qeVhwEyS0gDBnVwfr1XrN7r20CMILhZ1GhnoENqrJIUHI9/6UVEdorpIqMuDavdQ==" /></head>
 
 <body>
 

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -61,7 +61,7 @@ impl JsPlugin {
     }
 
     sources.add(RawSource::from(
-      r#" exports: {} 
+      r#" exports: {}
       });
       // Execute the module function
       "#,
@@ -246,7 +246,7 @@ impl JsPlugin {
         }
       } else if runtime_requirements.contains(RuntimeGlobals::STARTUP) {
         header.add(RawSource::from(format!(
-          r#"// the startup function 
+          r#"// the startup function
           // It's empty as no entry modules are in this chunk
             {} = function(){{}};
           "#,
@@ -255,7 +255,7 @@ impl JsPlugin {
       }
     } else if runtime_requirements.contains(RuntimeGlobals::STARTUP) {
       header.add(RawSource::from(format!(
-        r#"// the startup function 
+        r#"// the startup function
         // It's empty as some runtime module handles the default behavior
           {} = function(){{}};
         "#,

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/runtime.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/runtime.js
@@ -12,7 +12,7 @@ function __webpack_require__(moduleId) {
       }
       // Create a new module (and put it into the cache)
       var module = (__webpack_module_cache__[moduleId] = {
-       exports: {} 
+       exports: {}
       });
       // Execute the module function
       __webpack_modules__[moduleId](module, module.exports, __webpack_require__);

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/runtime.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/runtime.js
@@ -12,7 +12,7 @@ function __webpack_require__(moduleId) {
       }
       // Create a new module (and put it into the cache)
       var module = (__webpack_module_cache__[moduleId] = {
-       exports: {} 
+       exports: {}
       });
       // Execute the module function
       __webpack_modules__[moduleId](module, module.exports, __webpack_require__);

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`HashTestCases should print correct hash for package-path-change-0 1`] = `
 [
-  "runtime.b6213affe1a39ddf.js",
+  "runtime.c8619618c466366e.js",
   "main.6edd8022a70bcf.js",
   "0.acf446aa3893e384.js",
 ]
@@ -10,7 +10,7 @@ exports[`HashTestCases should print correct hash for package-path-change-0 1`] =
 
 exports[`HashTestCases should print correct hash for package-path-change-1 1`] = `
 [
-  "runtime.62c151d8d6666468.js",
+  "runtime.9afd7b04ab9cca9c.js",
   "main.7b25b592d62c77bb.js",
   "0.659bab60b9361e17.js",
 ]

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -620,10 +620,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "e1~runtime.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2452,
+      "assetsSize": 2451,
       "chunks": [
         "e1",
         "e1~runtime",
@@ -638,10 +638,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "e2~runtime.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2452,
+      "assetsSize": 2451,
       "chunks": [
         "e2",
         "e2~runtime",
@@ -659,10 +659,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "e1~runtime.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2452,
+      "assetsSize": 2451,
       "chunks": [
         "e1",
         "e1~runtime",
@@ -677,10 +677,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "e2~runtime.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2452,
+      "assetsSize": 2451,
       "chunks": [
         "e2",
         "e2~runtime",
@@ -765,10 +765,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e1.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -783,10 +783,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e2.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e2",
         "runtime~e2",
@@ -804,10 +804,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e1.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -822,10 +822,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e2.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e2",
         "runtime~e2",
@@ -897,10 +897,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime.js",
-          "size": 2057,
+          "size": 2056,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e1",
         "runtime",
@@ -915,10 +915,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime.js",
-          "size": 2057,
+          "size": 2056,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e2",
         "runtime",
@@ -936,10 +936,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime.js",
-          "size": 2057,
+          "size": 2056,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e1",
         "runtime",
@@ -954,10 +954,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime.js",
-          "size": 2057,
+          "size": 2056,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e2",
         "runtime",
@@ -1041,10 +1041,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e1.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -1059,10 +1059,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e2.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e2",
         "runtime~e2",
@@ -1080,10 +1080,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e1.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e1",
         "runtime~e1",
@@ -1098,10 +1098,10 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
         },
         {
           "name": "runtime~e2.js",
-          "size": 2060,
+          "size": 2059,
         },
       ],
-      "assetsSize": 2446,
+      "assetsSize": 2445,
       "chunks": [
         "e2",
         "runtime~e2",

--- a/packages/rspack/tests/copyPlugin/build/main.js
+++ b/packages/rspack/tests/copyPlugin/build/main.js
@@ -14,7 +14,7 @@ function __webpack_require__(moduleId) {
       }
       // Create a new module (and put it into the cache)
       var module = (__webpack_module_cache__[moduleId] = {
-       exports: {} 
+       exports: {}
       });
       // Execute the module function
       __webpack_modules__[moduleId](module, module.exports, __webpack_require__);


### PR DESCRIPTION
closes #2973

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 913f8e6</samp>

This pull request removes some trailing whitespace in various `runtime.js` files and updates the integrity hash of the `runtime.js` script in the `output.html` file. These changes improve the code style and security of the `rspack` crate and its plugins.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 913f8e6</samp>

*  Update integrity hash of `runtime.js` script in `output.html` file to ensure security ([link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-a425347dc58199533b4d09564eb1a2461abb7bb6a8ffd2da50595238e751e22eL6-R6))
*  Remove trailing whitespaces in `RawSource` strings in `plugin/mod.rs` file for code style consistency ([link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L64-R64), [link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L249-R249), [link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-a93a205fc4e29eb0c2740f223aeb1438194f2b7845f61948eef5b0fdc23e7501L258-R258))
*  Remove trailing whitespaces in `__webpack_require__` function in `runtime.js` files for code style consistency ([link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-b43592e25194affc62753cb616ade53935bb5dc078e83571340a6b875e63febfL15-R15), [link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-bdde075985805dcb63ab404a5872b66ec1b47142f89b2000ed9c113458582f54L15-R15), [link](https://github.com/web-infra-dev/rspack/pull/3083/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72L15-R15))

</details>
