### PR TITLE
feat(new_split_chunks): support `splitChunks.{cacheGroup}.enforce`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -394,6 +394,7 @@ export interface RawCacheGroupOptions {
   minSize?: number
   name?: string
   reuseExistingChunk?: boolean
+  enforce?: boolean
 }
 
 export interface RawCacheOptions {

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -166,9 +166,9 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
             }
           });
 
-          let min_chunks =
-            v.min_chunks
-              .unwrap_or_else(|| if enforce { 1 } else { overall_min_chunks });
+          let min_chunks = v
+            .min_chunks
+            .unwrap_or(if enforce { 1 } else { overall_min_chunks });
 
           new_split_chunks_plugin::CacheGroup {
             id_hint: key.clone(),

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -116,12 +116,15 @@ pub struct RawCacheGroupOptions {
   pub name: Option<String>,
   // used_exports: bool,
   pub reuse_existing_chunk: Option<bool>,
+  pub enforce: Option<bool>,
 }
 
 use rspack_plugin_split_chunks_new as new_split_chunks_plugin;
 
 impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
   fn from(raw_opts: RawSplitChunksOptions) -> Self {
+    use new_split_chunks_plugin::SplitChunkSizes;
+
     let mut cache_groups = vec![];
 
     let overall_chunk_filter = raw_opts
@@ -136,6 +139,8 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
 
     let overall_min_size = raw_opts.min_size.unwrap_or(20000.0);
 
+    let overall_min_chunks = raw_opts.min_chunks.unwrap_or(1);
+
     let overall_name_getter = raw_opts
       .name
       .map(new_split_chunks_plugin::create_chunk_name_getter_by_const_name)
@@ -143,35 +148,50 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
 
     let default_size_types = [SourceType::JavaScript, SourceType::Unknown];
 
+    let create_sizes = |size: f64| SplitChunkSizes::with_initial_value(&default_size_types, size);
+
     cache_groups.extend(
       raw_opts
         .cache_groups
         .unwrap_or_default()
         .into_iter()
-        .map(|(key, v)| new_split_chunks_plugin::CacheGroup {
-          id_hint: key.clone(),
-          key,
-          name: v
-            .name
-            .map(new_split_chunks_plugin::create_chunk_name_getter_by_const_name)
-            .unwrap_or_else(|| overall_name_getter.clone()),
-          priority: v.priority.unwrap_or(-20) as f64,
-          test: new_split_chunks_plugin::create_module_filter(v.test.clone()),
-          chunk_filter: v
-            .chunks
-            .map(|chunks| match chunks.as_str() {
-              "initial" => new_split_chunks_plugin::create_initial_chunk_filter(),
-              "async" => new_split_chunks_plugin::create_async_chunk_filter(),
-              "all" => new_split_chunks_plugin::create_all_chunk_filter(),
-              _ => panic!("Invalid chunk type: {chunks}"),
-            })
-            .unwrap_or_else(|| overall_chunk_filter.clone()),
-          min_chunks: v.min_chunks.unwrap_or(1),
-          min_size: new_split_chunks_plugin::SplitChunkSizes::with_initial_value(
-            &default_size_types,
-            v.min_size.unwrap_or(overall_min_size),
-          ),
-          reuse_existing_chunk: v.reuse_existing_chunk.unwrap_or(true),
+        .map(|(key, v)| {
+          let enforce = v.enforce.unwrap_or_default();
+
+          let min_size = v.min_size.map(create_sizes).unwrap_or_else(|| {
+            if enforce {
+              SplitChunkSizes::empty()
+            } else {
+              create_sizes(overall_min_size)
+            }
+          });
+
+          let min_chunks =
+            v.min_chunks
+              .unwrap_or_else(|| if enforce { 1 } else { overall_min_chunks });
+
+          new_split_chunks_plugin::CacheGroup {
+            id_hint: key.clone(),
+            key,
+            name: v
+              .name
+              .map(new_split_chunks_plugin::create_chunk_name_getter_by_const_name)
+              .unwrap_or_else(|| overall_name_getter.clone()),
+            priority: v.priority.unwrap_or(-20) as f64,
+            test: new_split_chunks_plugin::create_module_filter(v.test.clone()),
+            chunk_filter: v
+              .chunks
+              .map(|chunks| match chunks.as_str() {
+                "initial" => new_split_chunks_plugin::create_initial_chunk_filter(),
+                "async" => new_split_chunks_plugin::create_async_chunk_filter(),
+                "all" => new_split_chunks_plugin::create_all_chunk_filter(),
+                _ => panic!("Invalid chunk type: {chunks}"),
+              })
+              .unwrap_or_else(|| overall_chunk_filter.clone()),
+            min_chunks,
+            min_size,
+            reuse_existing_chunk: v.reuse_existing_chunk.unwrap_or(true),
+          }
         }),
     );
 

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -59,6 +59,10 @@ pub fn create_module_filter(re: Option<String>) -> ModuleFilter {
 pub struct SplitChunkSizes(FxHashMap<SourceType, f64>);
 
 impl SplitChunkSizes {
+  pub fn empty() -> Self {
+    Self(Default::default())
+  }
+
   pub fn with_initial_value(default_size_types: &[SourceType], initial_bytes: f64) -> Self {
     Self(
       default_size_types

--- a/crates/rspack_plugin_split_chunks_new/src/plugin.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin.rs
@@ -90,6 +90,10 @@ impl SplitChunksPlugin {
       .par_iter_mut()
       .filter_map(|(module_group_key, module_group)| {
         let cache_group = &self.cache_groups[module_group.cache_group_index];
+        // Fast path
+        if cache_group.min_size.is_empty() {
+          return None;
+        }
 
         // Find out what `SourceType`'s size is not fit the min_size
         let violating_source_types: Box<[SourceType]> = module_group

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -964,6 +964,11 @@ module.exports = {
 						"Try to reuse existing chunk (with name) when it has matching modules.",
 					type: "boolean"
 				},
+				enforce: {
+					description:
+						"ignore splitChunks.minSize, splitChunks.minChunks, splitChunks.maxAsyncRequests and splitChunks.maxInitialRequests options and always create chunks for this cache group.",
+					type: "boolean"
+				},
 				test: {
 					description: "Assign modules to a cache group by module name.",
 					anyOf: [

--- a/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/b.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/c.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/index.js
@@ -1,0 +1,4 @@
+import "./b";
+import "./c";
+
+it("should compile fine", () => {});

--- a/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["common.js", "main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/reuse-chunk-name/webpack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: "web",
+	optimization: {
+		splitChunks: {
+			chunks: "all",
+			cacheGroups: {
+				b: {
+					test: /b\.js/,
+					name: "common",
+					enforce: true
+				},
+				c: {
+					test: /c\.js/,
+					name: "common",
+					enforce: true
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

See https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkscachegroupscachegroupenforce

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 374b901</samp>

This pull request adds support for the `enforce` and `min_size` options for cache groups in the split chunks plugin, which allow creating chunks for specific modules regardless of the global split chunks options. It also adds a new test case `reuse-chunk-name` to verify the behavior of the plugin when two cache groups have the same name and enforce chunks. The changes affect the `rspack_binding_options`, `rspack_plugin_split_chunks_new`, and `rspack` crates, as well as the configuration schema and the test files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 374b901</samp>

*  Add a new `enforce` option to the cache group configuration for the split chunks plugin ([link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R119), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R963-R967))
* Import and use the `SplitChunkSizes` type from the `new_split_chunks_plugin` module ([link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R126-R127), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9R62-R65))
* Refactor the logic of mapping the raw cache group options to the `CacheGroup` struct ([link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R142-R143), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R151-R152), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L151-R194))
* Add a new condition to the `select_cache_group` function to implement the `enforce` logic ([link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-1fd1e5597d8b55dc4d44db0f1921d1dfe136ebbc9326ca34e1328f6890060519R93-R96))
* Add a new test case `reuse-chunk-name` to test the behavior of the split chunks plugin when two cache groups have the same name and enforce the creation of chunks ([link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-aa279dc8933207ceac13026793a769a9883a2d1ef139eb5d96578554a616b9b4R1), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-5c64740c8ea68e099f7e51acd9cba08c0ceb0e4d97e82c0fb90280973953612dR1), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-c52692ee4c34065a6d5f9ab40b5321f4073abb2f2c8913cf633435c67ff127c0R1-R4), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-125122a22947b35f0994d9164dba73fdd6e6223939d408256e5c91d253158af1R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3086/files?diff=unified&w=0#diff-e2de1617650a3e9cdcee26a3034bf9bb00300b8b619655d296b39092e66fe33dR1-R24))

</details>
