### PR TITLE
feat(minify-plugin): support minify-css for minify-plugin

### DIFF
--- a/.changeset/few-mugs-remember.md
+++ b/.changeset/few-mugs-remember.md
@@ -1,0 +1,5 @@
+---
+"@rspack/plugin-minify": patch
+---
+
+support minify css

--- a/examples/extract-license/index.html
+++ b/examples/extract-license/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/extract-license/package.json
+++ b/examples/extract-license/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-extract-license",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/extract-license/rspack.config.js
+++ b/examples/extract-license/rspack.config.js
@@ -1,0 +1,18 @@
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	context: __dirname,
+	entry: {
+		main: "./src/index.js"
+	},
+	builtins: {
+		html: [
+			{
+				template: "./index.html"
+			}
+		],
+		minifyOptions: {
+			extractComments: true
+		}
+	}
+};
+module.exports = config;

--- a/examples/extract-license/src/index.js
+++ b/examples/extract-license/src/index.js
@@ -1,0 +1,13 @@
+/**
+ * @preserve Copyright 2009 SomeThirdParty.
+ * Here is the full license text and copyright
+ * notice for this file. Note that the notice can span several
+ * lines and is only terminated by the closing star and slash:
+ */
+
+/**
+ * Utility functions for the foo package.
+ * @license Apache-2.0
+ */
+const add = require("lodash").add;
+console.log("result:", add(10, 32));

--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/plugin-html": "workspace:*",
+    "@rspack/plugin-minify": "workspace:*",
     "copy-webpack-plugin": "5.1.2",
     "generate-package-json-webpack-plugin": "^2.6.0",
     "webpack-bundle-analyzer": "4.7.0",

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -3,7 +3,8 @@ const BundleAnalyzerPlugin =
 const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
-const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin')
+const minifyPlugin = require("@rspack/plugin-minify");
+const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	target: "node",
@@ -12,8 +13,15 @@ const config = {
 	entry: {
 		main: "./src/index.js"
 	},
-	builtins: {
-		minify: false
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new minifyPlugin({
+				minifier: "terser",
+				target: "es6",
+				css: true
+			})
+		]
 	},
 	plugins: [
 		new BundleAnalyzerPlugin({
@@ -38,13 +46,11 @@ const config = {
 };
 module.exports = config;
 
-
-
 var basePackage = {
-  "name": "my-nodejs-module",
-  "version": "1.0.0",
-  "main": "./bundle.js",
-  "engines": {
-    "node": ">= 14"
-  }
-}
+	name: "my-nodejs-module",
+	version: "1.0.0",
+	main: "./bundle.js",
+	engines: {
+		node: ">= 14"
+	}
+};

--- a/examples/plugin-compat/src/index.css
+++ b/examples/plugin-compat/src/index.css
@@ -1,0 +1,3 @@
+body {
+	color: red;
+}

--- a/examples/plugin-compat/src/index.js
+++ b/examples/plugin-compat/src/index.js
@@ -1,3 +1,3 @@
 import { answer } from "./answer";
-
+import "./index.css";
 console.log({ answer });

--- a/packages/rspack-plugin-minify/src/index.js
+++ b/packages/rspack-plugin-minify/src/index.js
@@ -1,4 +1,6 @@
 const isJsFile = /\.[cm]?js(?:\?.*)?$/i;
+const isCssFile = /\.css(?:\?.*)?$/i;
+
 const esbuild = require("esbuild");
 const terser = require("terser");
 const { RawSource, SourceMapSource } = require("webpack-sources");
@@ -8,14 +10,17 @@ module.exports = class RspackMinifyPlugin {
 	 * @param {{minifier: 'esbuild' | 'terser'}} options
 	 */
 	constructor(options) {
-		this.options = options || {
+		this.options = {
 			minifier: "esbuild",
-			target: "es6"
+			target: "es6",
+			css: false,
+			...options
 		};
 	}
-	async transform(code, { sourcemap, sourcefile }) {
-		if (this.options.minifier === "esbuild") {
+	async transform(code, { sourcemap, sourcefile, css }) {
+		if (this.options.minifier === "esbuild" || css) {
 			return await esbuild.transform(code, {
+				loader: css ? "css" : "js",
 				target: this.options.target,
 				sourcefile,
 				sourcemap,
@@ -55,7 +60,10 @@ module.exports = class RspackMinifyPlugin {
 					} = compilation.compiler;
 					const sourcemap = !!devtool;
 					const assets = compilation.getAssets().filter(asset => {
-						return isJsFile.test(asset.name);
+						return (
+							isJsFile.test(asset.name) ||
+							(this.options.css && isCssFile.test(asset.name))
+						);
 					});
 
 					await Promise.all(
@@ -64,6 +72,7 @@ module.exports = class RspackMinifyPlugin {
 							const sourceAsString = source.toString();
 							const result = await this.transform(sourceAsString, {
 								sourcemap,
+								css: isCssFile.test(asset.name),
 								sourcefile: asset.name
 							});
 							compilation.updateAsset(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,12 @@ importers:
       eslint-loader: 4.0.2_eslint@7.32.0
       eslint-rspack-plugin: 4.0.0-alpha_eslint@7.32.0
 
+  examples/extract-license:
+    specifiers:
+      '@rspack/cli': workspace:*
+    devDependencies:
+      '@rspack/cli': link:../../packages/rspack-cli
+
   examples/library:
     specifiers:
       '@rspack/cli': workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,7 @@ importers:
     specifiers:
       '@rspack/cli': workspace:*
       '@rspack/plugin-html': workspace:*
+      '@rspack/plugin-minify': workspace:*
       copy-webpack-plugin: 5.1.2
       generate-package-json-webpack-plugin: ^2.6.0
       webpack-bundle-analyzer: 4.7.0
@@ -416,6 +417,7 @@ importers:
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
       '@rspack/plugin-html': link:../../packages/rspack-plugin-html
+      '@rspack/plugin-minify': link:../../packages/rspack-plugin-minify
       copy-webpack-plugin: 5.1.2
       generate-package-json-webpack-plugin: 2.6.0
       webpack-bundle-analyzer: 4.7.0


### PR DESCRIPTION
## Related issue (if exists)
closes #3087 
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2c8f022</samp>

This pull request adds a new feature and a new example to the `@rspack/plugin-minify` package, which enables the plugin to minify CSS files and extract comments from the minified code. It also updates the `plugin-compat` example to use the `@rspack/plugin-minify` package and demonstrate its functionality. It also fixes some formatting issues and updates the `pnpm-lock.yaml` file and the `.changeset` folder accordingly.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2c8f022</samp>

*  Add a markdown file to the `.changeset` folder to indicate a patch update for the `@rspack/plugin-minify` package and describe the change ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-d79c753fa0fe38512bf294e521e35c6f9d8cf8dc9c1ff97433097bc021de077eR1-R5))
*  Add a new example folder called `extract-license` to demonstrate how to use the `@rspack/plugin-minify` package to extract comments from the minified code and generate a license file ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-c3cc45cb32c88d491bc5a0c457d0cad9bfc61f4cbe1783b6f6babcd3b580f880R1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-a08ead0906ba340f80b00858ee9d9423cdd911ddfcbc5661bd9ad59a32a941b2L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-febaf742e4dcaa4492e1c03b7c9af73dfc3380b34266be9cc1e8a589a7383371R1-R18), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-2a35fde83f7f0bcffd9f8cae1e59362aa82fd21b6ea405b764b9e8665a2f55d8R1-R13))
*  Update the `plugin-compat` example to use the `@rspack/plugin-minify` package as a custom minimizer and to bundle and minify a CSS file ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-7c79896436e137329e49b20866aa4502be0fe10e49a15ceb45974993392878c1R16), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96L6-R7), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96L15-R24), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-f605d0d562a1d7c96aad6043e046a9a10c87a10045922a8e51fcc325b250d863R1-R3), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-9b2a86e4af94015d0ef19e3dac0ee61c7824764edb0d167e2eb11b914781b08dL2-R2))
*  Fix the formatting of the `basePackage` variable in the `plugin-compat` example ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96L41-R56))
*  Add a regular expression constant and a default value for the `css` option to the `src/index.js` file for the `@rspack/plugin-minify` package ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-d3bc90b2ce9f62f99648e3cb197282df44cf0ed2a9d23fe4996f58c3b1cecb26R2-R3), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-d3bc90b2ce9f62f99648e3cb197282df44cf0ed2a9d23fe4996f58c3b1cecb26L11-R23))
*  Update the filter function and the transform method of the `MinifyPlugin` class in the `src/index.js` file for the `@rspack/plugin-minify` package to support minifying CSS files ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-d3bc90b2ce9f62f99648e3cb197282df44cf0ed2a9d23fe4996f58c3b1cecb26L58-R66), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-d3bc90b2ce9f62f99648e3cb197282df44cf0ed2a9d23fe4996f58c3b1cecb26R75))
*  Add sections for the `examples/extract-license` and the `@rspack/plugin-minify` packages to the `pnpm-lock.yaml` file to lock the dependencies and versions ([link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR306-R311), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR412), [link](https://github.com/web-infra-dev/rspack/pull/3093/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR420))

</details>
