### PR TITLE
fix: add correct chunk group runtime for multiply entry single runtime

### DIFF
--- a/.changeset/seven-tigers-guess.md
+++ b/.changeset/seven-tigers-guess.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: add correct chunk group runtime for multiply entry single runtime

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -66,7 +66,9 @@ impl<'me> CodeSplitter<'me> {
 
       let mut entrypoint = ChunkGroup::new(
         ChunkGroupKind::Entrypoint,
-        HashSet::from_iter([Arc::from(name.to_string())]),
+        HashSet::from_iter([Arc::from(
+          options.runtime.clone().unwrap_or_else(|| name.to_string()),
+        )]),
         Some(name.to_string()),
       );
       if options.runtime.is_none() {
@@ -74,7 +76,6 @@ impl<'me> CodeSplitter<'me> {
       }
       entrypoint.set_entry_point_chunk(chunk.ukey);
       entrypoint.connect_chunk(chunk);
-      // compilation.chunk_graph.con
 
       compilation
         .named_chunk_groups

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -189,7 +189,7 @@ impl Stats<'_> {
       .chunk_group_by_ukey
       .get(ukey)
       .expect("compilation.chunk_group_by_ukey should have ukey from entrypoint");
-    let mut chunks: Vec<String> = cg
+    let chunks: Vec<String> = cg
       .chunks
       .iter()
       .map(|c| {
@@ -201,8 +201,7 @@ impl Stats<'_> {
       })
       .map(|c| c.expect_id().to_string())
       .collect();
-    chunks.sort_unstable();
-    let mut assets = cg.chunks.iter().fold(Vec::new(), |mut acc, c| {
+    let assets = cg.chunks.iter().fold(Vec::new(), |mut acc, c| {
       let chunk = self
         .compilation
         .chunk_by_ukey
@@ -222,7 +221,6 @@ impl Stats<'_> {
       }
       acc
     });
-    assets.sort_by_cached_key(|v| v.name.to_string());
     StatsChunkGroup {
       name: name.to_string(),
       chunks,

--- a/packages/rspack/tests/HotTestCases.template.ts
+++ b/packages/rspack/tests/HotTestCases.template.ts
@@ -329,7 +329,11 @@ export function describeCases(config: {
 									}
 									let promise = Promise.resolve();
 									const info = stats.toJson({});
-									if (config.target === "web") {
+									// here it is diffrent from webpack, because we add hotCases/chunk/multi-chunk-single-runtime
+									if (
+										config.target === "web" ||
+										config.target === "webworker"
+									) {
 										for (const file of info.entrypoints!.main.assets) {
 											if (file.name.endsWith(".js")) {
 												_require(`./${file.name}`);
@@ -344,7 +348,9 @@ export function describeCases(config: {
 											}
 										}
 									} else {
-										const assets = info.entrypoints!.main.assets;
+										const assets = info.entrypoints!.main.assets.filter(s =>
+											s.name.endsWith(".js")
+										);
 										const result = _require(
 											`./${assets[assets.length - 1].name}`
 										);

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -615,36 +615,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 392,
-        },
-        {
           "name": "e1~runtime.js",
           "size": 2060,
+        },
+        {
+          "name": "e1.js",
+          "size": 392,
         },
       ],
       "assetsSize": 2452,
       "chunks": [
-        "e1",
         "e1~runtime",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 392,
-        },
-        {
           "name": "e2~runtime.js",
           "size": 2060,
+        },
+        {
+          "name": "e2.js",
+          "size": 392,
         },
       ],
       "assetsSize": 2452,
       "chunks": [
-        "e2",
         "e2~runtime",
+        "e2",
       ],
       "name": "e2",
     },
@@ -654,36 +654,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 392,
-        },
-        {
           "name": "e1~runtime.js",
           "size": 2060,
+        },
+        {
+          "name": "e1.js",
+          "size": 392,
         },
       ],
       "assetsSize": 2452,
       "chunks": [
-        "e1",
         "e1~runtime",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 392,
-        },
-        {
           "name": "e2~runtime.js",
           "size": 2060,
+        },
+        {
+          "name": "e2.js",
+          "size": 392,
         },
       ],
       "assetsSize": 2452,
       "chunks": [
-        "e2",
         "e2~runtime",
+        "e2",
       ],
       "name": "e2",
     },
@@ -692,8 +692,8 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
 `;
 
 exports[`StatsTestCases should print correct stats for optimization-runtime-chunk 2`] = `
-"Entrypoint e1 = e1.js e1~runtime.js
-Entrypoint e2 = e2.js e2~runtime.js
+"Entrypoint e1 = e1~runtime.js e1.js
+Entrypoint e2 = e2~runtime.js e2.js
 chunk {e1} e1.js (e1) 27 bytes [entry]
 chunk {e1~runtime} e1~runtime.js (e1~runtime) 0 bytes [initial]
 chunk {e2} e2.js (e2) 27 bytes [entry]
@@ -760,36 +760,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e1.js",
           "size": 2060,
+        },
+        {
+          "name": "e1.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e1",
         "runtime~e1",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e2.js",
           "size": 2060,
+        },
+        {
+          "name": "e2.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e2",
         "runtime~e2",
+        "e2",
       ],
       "name": "e2",
     },
@@ -799,36 +799,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e1.js",
           "size": 2060,
+        },
+        {
+          "name": "e1.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e1",
         "runtime~e1",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e2.js",
           "size": 2060,
+        },
+        {
+          "name": "e2.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e2",
         "runtime~e2",
+        "e2",
       ],
       "name": "e2",
     },
@@ -837,8 +837,8 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
 `;
 
 exports[`StatsTestCases should print correct stats for optimization-runtime-chunk-multiple 2`] = `
-"Entrypoint e1 = e1.js runtime~e1.js
-Entrypoint e2 = e2.js runtime~e2.js
+"Entrypoint e1 = runtime~e1.js e1.js
+Entrypoint e2 = runtime~e2.js e2.js
 chunk {e1} e1.js (e1) 27 bytes [entry]
 chunk {e2} e2.js (e2) 27 bytes [entry]
 chunk {runtime~e1} runtime~e1.js (runtime~e1) 0 bytes [initial]
@@ -892,36 +892,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 389,
-        },
-        {
           "name": "runtime.js",
           "size": 2057,
+        },
+        {
+          "name": "e1.js",
+          "size": 389,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e1",
         "runtime",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 389,
-        },
-        {
           "name": "runtime.js",
           "size": 2057,
+        },
+        {
+          "name": "e2.js",
+          "size": 389,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e2",
         "runtime",
+        "e2",
       ],
       "name": "e2",
     },
@@ -931,36 +931,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 389,
-        },
-        {
           "name": "runtime.js",
           "size": 2057,
+        },
+        {
+          "name": "e1.js",
+          "size": 389,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e1",
         "runtime",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 389,
-        },
-        {
           "name": "runtime.js",
           "size": 2057,
+        },
+        {
+          "name": "e2.js",
+          "size": 389,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e2",
         "runtime",
+        "e2",
       ],
       "name": "e2",
     },
@@ -969,8 +969,8 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
 `;
 
 exports[`StatsTestCases should print correct stats for optimization-runtime-chunk-single 2`] = `
-"Entrypoint e1 = e1.js runtime.js
-Entrypoint e2 = e2.js runtime.js
+"Entrypoint e1 = runtime.js e1.js
+Entrypoint e2 = runtime.js e2.js
 chunk {e1} e1.js (e1) 27 bytes [entry]
 chunk {e2} e2.js (e2) 27 bytes [entry]
 chunk {runtime} runtime.js (runtime) 0 bytes [initial]"
@@ -1036,36 +1036,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e1.js",
           "size": 2060,
+        },
+        {
+          "name": "e1.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e1",
         "runtime~e1",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e2.js",
           "size": 2060,
+        },
+        {
+          "name": "e2.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e2",
         "runtime~e2",
+        "e2",
       ],
       "name": "e2",
     },
@@ -1075,36 +1075,36 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
     "e1": {
       "assets": [
         {
-          "name": "e1.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e1.js",
           "size": 2060,
+        },
+        {
+          "name": "e1.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e1",
         "runtime~e1",
+        "e1",
       ],
       "name": "e1",
     },
     "e2": {
       "assets": [
         {
-          "name": "e2.js",
-          "size": 386,
-        },
-        {
           "name": "runtime~e2.js",
           "size": 2060,
+        },
+        {
+          "name": "e2.js",
+          "size": 386,
         },
       ],
       "assetsSize": 2446,
       "chunks": [
-        "e2",
         "runtime~e2",
+        "e2",
       ],
       "name": "e2",
     },
@@ -1113,8 +1113,8 @@ exports[`StatsTestCases should print correct stats for optimization-runtime-chun
 `;
 
 exports[`StatsTestCases should print correct stats for optimization-runtime-chunk-true 2`] = `
-"Entrypoint e1 = e1.js runtime~e1.js
-Entrypoint e2 = e2.js runtime~e2.js
+"Entrypoint e1 = runtime~e1.js e1.js
+Entrypoint e2 = runtime~e2.js e2.js
 chunk {e1} e1.js (e1) 27 bytes [entry]
 chunk {e2} e2.js (e2) 27 bytes [entry]
 chunk {runtime~e1} runtime~e1.js (runtime~e1) 0 bytes [initial]

--- a/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/a/index.js
+++ b/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/a/index.js
@@ -1,0 +1,5 @@
+import file from '../file';
+
+it("should bundled in a", () => {
+  expect(typeof file).toBe('number');
+})

--- a/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/b/index.js
+++ b/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/b/index.js
@@ -1,0 +1,5 @@
+import file from '../file';
+
+it("should bundled in b", () => {
+  expect(typeof file).toBe('number');
+})

--- a/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/changed-file.js
+++ b/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/changed-file.js
@@ -1,0 +1,6 @@
+// TODO: remove this file after cache.
+const path = require('path');
+
+module.exports = [
+  path.resolve(__dirname, './file.js')
+]

--- a/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/file.js
+++ b/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/file.js
@@ -1,0 +1,9 @@
+module.exports = 1;
+---
+module.exports = 2;
+---
+module.exports = 3;
+---
+module.exports = 4;
+---
+module.exports = 5;

--- a/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/main/index.js
+++ b/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/main/index.js
@@ -1,0 +1,15 @@
+var value = require("../file");
+import('./async.js'); // make sure ensure chunk runtime added
+it("should accept a dependencies multiple times", (done) => {
+	expect(value).toBe(1);
+	module.hot.accept("../file", () => {
+		var oldValue = value;
+		value = require("../file");
+		expect(value).toBe(oldValue + 1);
+		if(value < 4)
+			NEXT(require("../../../update")(done));
+		else
+			done();
+	});
+	NEXT(require("../../../update")(done));
+});

--- a/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/webpack.config.js
+++ b/packages/rspack/tests/hotCases/chunk/multi-chunk-single-runtime/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  entry: { 
+    a: './a/index.js',
+    b: './b/index.js',
+    main: './main/index.js'
+  },
+  optimization: {
+    runtimeChunk: 'single'
+  }
+}


### PR DESCRIPTION
## Related issue (if exists)

close https://github.com/web-infra-dev/rspack/issues/3026
<!--- Provide link of related issues -->

## Summary

- also fix `stats.entrypoint.assets & chunks` order, the runtime chunk should at first

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7dea7c0</samp>

This pull request enhances the code splitting and hot module replacement features of rspack. It allows customizing the runtime chunk name and removes unused code in `code_splitter.rs`. It also adds a new test case for hot reloading with multiple chunks and a single runtime in `HotTestCases.template.ts` and related files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7dea7c0</samp>

*  Fix a bug where the chunk group runtime was not correctly set for multiple entrypoints with a single runtime ([link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-1eb889d854d55fc45adab995172ae1827d5f4ece2f3ea2f23e070514624ec696R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L69-R71), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-0ad5c3aef8114d4955ab4030815e4d048c5fab7533c9c3ddab214cc82ee4db67L1-R9))
*  Add a new test case `multi-chunk-single-runtime` to verify the bug fix and the hot reloading mechanism for this scenario ([link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-ee5a8bbc9554044e03d18450a40c46c88198c1b15c9c4f8e120dd3239f9f7a90R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-255b692420fe867a94022e448714a809b670e870d28db3b6157b934140b57887R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-44d773131c8d40f3117d4fa8e9a1605c011115d08fb32b38a28004467b273369R1-R6), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-b9121efec95856680eeac0ce7b14b9094a6dbd8229ec3153435614417c2ce401R1-R9), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-bcf830c1e7718e0991b0db3c902a9e28c753703d5f397f537984a422f25c9894R1-R15), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-6d18d304b63c9907e8d0c873112e0437768a1497759db0a30cba747f23bd98a5L332-R336), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-6d18d304b63c9907e8d0c873112e0437768a1497759db0a30cba747f23bd98a5L347-R353))
*  Remove unnecessary `mut` keywords and sorting of assets in the `stats.rs` file to improve code quality and performance ([link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L192-R192), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L204-R204), [link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-16aee29ffef703f493d3e45add4619f21709212d700fadbf55e8d479b2eedb37L225))
*  Remove a commented out line of code in the `code_splitter.rs` file that was probably left by mistake ([link](https://github.com/web-infra-dev/rspack/pull/3094/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L77))

</details>
