### PR TITLE
feat(realContentHash): multi contenthash in filename

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap"
+version = "1.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
+
+[[package]]
 name = "argh"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2245,7 @@ name = "rspack_core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "anymap",
  "async-recursion",
  "async-scoped",
  "async-trait",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -113,7 +113,7 @@ export interface JsAssetInfo {
    * the value(s) of the module hash used for this asset
    * the value(s) of the content hash used for this asset
    */
-  contentHash?: string
+  contentHash: Array<string>
   /**
    * when asset was created from a source file (potentially transformed), the original filename relative to compilation context
    * size in bytes, only set after asset has been emitted

--- a/crates/node_binding/src/js_values/asset.rs
+++ b/crates/node_binding/src/js_values/asset.rs
@@ -25,7 +25,7 @@ pub struct JsAssetInfo {
   /// the value(s) of the module hash used for this asset
   // pub module_hash:
   /// the value(s) of the content hash used for this asset
-  pub content_hash: Option<String>,
+  pub content_hash: Vec<String>,
   /// when asset was created from a source file (potentially transformed), the original filename relative to compilation context
   // pub source_filename:
   /// size in bytes, only set after asset has been emitted
@@ -47,7 +47,7 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
       development: i.development,
       hot_module_replacement: i.hot_module_replacement,
       related: i.related.into(),
-      content_hash: i.content_hash,
+      content_hash: i.content_hash.into_iter().collect(),
     }
   }
 }
@@ -74,7 +74,7 @@ impl From<rspack_core::AssetInfo> for JsAssetInfo {
       development: info.development,
       hot_module_replacement: info.hot_module_replacement,
       related: info.related.into(),
-      content_hash: info.content_hash,
+      content_hash: info.content_hash.into_iter().collect(),
     }
   }
 }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -7,6 +7,7 @@ version    = "0.1.0"
 
 [dependencies]
 anyhow = { workspace = true }
+anymap = "1.0.0-beta.2"
 async-recursion = { workspace = true }
 async-scoped = { workspace = true, features = ["use-tokio"] }
 async-trait = { workspace = true }

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -309,7 +309,7 @@ impl Chunk {
   // pub fn get_all_referenced_async_entry_points() -> HashSet<ChunkUkey> {}
 
   pub fn get_render_hash(&self) -> String {
-    format!("{:x}", self.hash.finish())
+    format!("{:016x}", self.hash.finish())
   }
 
   pub fn expect_id(&self) -> &str {

--- a/crates/rspack_core/src/code_generation_results.rs
+++ b/crates/rspack_core/src/code_generation_results.rs
@@ -1,14 +1,16 @@
 use std::collections::hash_map::Entry;
 use std::hash::{Hash, Hasher};
+use std::ops::{Deref, DerefMut};
 
+use anymap::CloneAny;
 use rspack_error::{internal_error, Result};
 use rspack_identifier::IdentifierMap;
 use rustc_hash::FxHashMap as HashMap;
 use xxhash_rust::xxh3::Xxh3;
 
 use crate::{
-  AstOrSource, ChunkInitFragments, ModuleIdentifier, RuntimeGlobals, RuntimeSpec, RuntimeSpecMap,
-  SourceType,
+  AssetInfo, AstOrSource, ChunkInitFragments, ModuleIdentifier, RuntimeGlobals, RuntimeSpec,
+  RuntimeSpecMap, SourceType,
 };
 
 #[derive(Debug, Clone)]
@@ -22,11 +24,75 @@ impl From<AstOrSource> for GenerationResult {
   }
 }
 
+#[derive(Clone, Debug)]
+pub struct CodeGenerationDataUrl {
+  inner: String,
+}
+
+impl CodeGenerationDataUrl {
+  pub fn new(inner: String) -> Self {
+    Self { inner }
+  }
+
+  pub fn inner(&self) -> &str {
+    &self.inner
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct CodeGenerationDataFilename {
+  inner: String,
+}
+
+impl CodeGenerationDataFilename {
+  pub fn new(inner: String) -> Self {
+    Self { inner }
+  }
+
+  pub fn inner(&self) -> &str {
+    &self.inner
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct CodeGenerationDataAssetInfo {
+  inner: AssetInfo,
+}
+
+impl CodeGenerationDataAssetInfo {
+  pub fn new(inner: AssetInfo) -> Self {
+    Self { inner }
+  }
+
+  pub fn inner(&self) -> &AssetInfo {
+    &self.inner
+  }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct CodeGenerationData {
+  inner: anymap::Map<dyn CloneAny + Send + Sync>,
+}
+
+impl Deref for CodeGenerationData {
+  type Target = anymap::Map<dyn CloneAny + Send + Sync>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.inner
+  }
+}
+
+impl DerefMut for CodeGenerationData {
+  fn deref_mut(&mut self) -> &mut Self::Target {
+    &mut self.inner
+  }
+}
+
 #[derive(Debug, Default, Clone)]
 pub struct CodeGenerationResult {
   inner: HashMap<SourceType, GenerationResult>,
   /// [definition in webpack](https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/Module.js#L75)
-  pub data: HashMap<String, String>,
+  pub data: CodeGenerationData,
   pub chunk_init_fragments: ChunkInitFragments,
   pub runtime_requirements: RuntimeGlobals,
   pub hash: u64,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1514,7 +1514,7 @@ impl AssetInfo {
     self
   }
 
-  pub fn with_content_hashs(mut self, v: HashSet<String>) -> Self {
+  pub fn with_content_hashes(mut self, v: HashSet<String>) -> Self {
     self.content_hash = v;
     self
   }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1476,7 +1476,7 @@ pub struct AssetInfo {
   /// the value(s) of the module hash used for this asset
   // pub module_hash:
   /// the value(s) of the content hash used for this asset
-  pub content_hash: Option<String>,
+  pub content_hash: HashSet<String>,
   /// when asset was created from a source file (potentially transformed), the original filename relative to compilation context
   // pub source_filename:
   /// size in bytes, only set after asset has been emitted
@@ -1512,9 +1512,13 @@ impl AssetInfo {
     self
   }
 
-  pub fn with_content_hash(mut self, v: Option<String>) -> Self {
+  pub fn with_content_hashs(mut self, v: HashSet<String>) -> Self {
     self.content_hash = v;
     self
+  }
+
+  pub fn set_content_hash(&mut self, v: String) {
+    self.content_hash.insert(v);
   }
 }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1318,7 +1318,9 @@ impl Compilation {
     )?;
     tracing::trace!("calculate runtime chunks content hash");
 
-    self.hash = format!("{:x}", compilation_hasher.finish());
+    // TODO(ahabhgk): refactor, upper-level wrapper for format!("{:016x}")
+    // 016 for length = 16
+    self.hash = format!("{:016x}", compilation_hasher.finish());
     tracing::trace!("compilation hash");
     Ok(())
   }

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -358,7 +358,7 @@ where
             module.hash(&mut hot_update_chunk.hash);
           }
         }
-        let hash = format!("{:x}", hot_update_chunk.hash.finish());
+        let hash = format!("{:016x}", hot_update_chunk.hash.finish());
         hot_update_chunk
           .content_hash
           .insert(crate::SourceType::JavaScript, hash.clone());

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -6,9 +6,9 @@ use rspack_identifier::{Identifiable, Identifier};
 
 use crate::{
   rspack_sources::{BoxSource, RawSource, Source, SourceExt},
-  to_identifier, AstOrSource, BuildContext, BuildResult, ChunkInitFragments, CodeGenerationResult,
-  Compilation, Context, ExternalType, GenerationResult, InitFragment, InitFragmentStage,
-  LibIdentOptions, Module, ModuleType, RuntimeGlobals, SourceType,
+  to_identifier, AstOrSource, BuildContext, BuildResult, ChunkInitFragments, CodeGenerationDataUrl,
+  CodeGenerationResult, Compilation, Context, ExternalType, GenerationResult, InitFragment,
+  InitFragmentStage, LibIdentOptions, Module, ModuleType, RuntimeGlobals, SourceType,
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -194,7 +194,9 @@ impl Module for ExternalModule {
             .boxed(),
           )),
         );
-        cgr.data.insert("url".to_owned(), self.request.clone());
+        cgr
+          .data
+          .insert(CodeGenerationDataUrl::new(self.request.clone()));
       }
       "css-import" => {
         cgr.add(

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -377,15 +377,15 @@ mod test {
     e1.hash(&mut state1);
     e2.hash(&mut state2);
 
-    let hash1 = format!("{:x}", state1.finish());
-    let hash2 = format!("{:x}", state2.finish());
+    let hash1 = format!("{:016x}", state1.finish());
+    let hash2 = format!("{:016x}", state2.finish());
     assert_eq!(hash1, hash2);
 
     let e3: Box<dyn Module> = ExternalModule("e3").boxed();
     let mut state3 = xxhash_rust::xxh3::Xxh3::default();
     e3.hash(&mut state3);
 
-    let hash3 = format!("{:x}", state3.finish());
+    let hash3 = format!("{:016x}", state3.finish());
     assert_ne!(hash1, hash3);
   }
 

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use sugar_path::SugarPath;
 
-use crate::{Chunk, ChunkGroupByUkey, ChunkKind, Compilation, SourceType};
+use crate::{AssetInfo, Chunk, ChunkGroupByUkey, ChunkKind, Compilation, SourceType};
 
 #[derive(Debug)]
 pub struct OutputOptions {
@@ -132,41 +132,54 @@ impl Filename {
     chunk: &Chunk,
     extension: &str,
     source_type: &SourceType,
+    asset_info: Option<&mut AssetInfo>,
   ) -> String {
     let hash = Some(chunk.get_render_hash());
-    self.render(FilenameRenderOptions {
-      // See https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/TemplatedPathPlugin.js#L214
-      name: chunk.name_for_filename_template(),
-      extension: Some(extension.to_owned()),
-      id: chunk.id.clone(),
-      contenthash: chunk.content_hash.get(source_type).cloned(),
-      chunkhash: hash.clone(),
-      hash,
-      ..Default::default()
-    })
+    self.render(
+      FilenameRenderOptions {
+        // See https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/TemplatedPathPlugin.js#L214
+        name: chunk.name_for_filename_template(),
+        extension: Some(extension.to_owned()),
+        id: chunk.id.clone(),
+        contenthash: chunk.content_hash.get(source_type).cloned(),
+        chunkhash: hash.clone(),
+        hash,
+        ..Default::default()
+      },
+      asset_info,
+    )
   }
+
   pub fn render_with_chunk_and_file(
     &self,
     chunk: &Chunk,
     file: &str,
     extension: &str,
     source_type: &SourceType,
+    asset_info: Option<&mut AssetInfo>,
   ) -> String {
     let hash = Some(chunk.get_render_hash());
-    self.render(FilenameRenderOptions {
-      // See https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/TemplatedPathPlugin.js#L214
-      file: Some(file.to_owned()),
-      name: chunk.name_for_filename_template(),
-      extension: Some(extension.to_owned()),
-      id: chunk.id.clone(),
-      contenthash: chunk.content_hash.get(source_type).cloned(),
-      chunkhash: hash.clone(),
-      hash,
-      ..Default::default()
-    })
+    self.render(
+      FilenameRenderOptions {
+        // See https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/TemplatedPathPlugin.js#L214
+        file: Some(file.to_owned()),
+        name: chunk.name_for_filename_template(),
+        extension: Some(extension.to_owned()),
+        id: chunk.id.clone(),
+        contenthash: chunk.content_hash.get(source_type).cloned(),
+        chunkhash: hash.clone(),
+        hash,
+        ..Default::default()
+      },
+      asset_info,
+    )
   }
 
-  pub fn render(&self, options: FilenameRenderOptions) -> String {
+  pub fn render(
+    &self,
+    options: FilenameRenderOptions,
+    mut asset_info: Option<&mut AssetInfo>,
+  ) -> String {
     let mut filename = self.template.clone();
     if let Some(file) = options.file {
       filename = filename.replace(FILE_PLACEHOLDER, &file);
@@ -196,7 +209,11 @@ impl Filename {
             .and_then(|m| m.as_str().parse().ok())
             .unwrap_or(hash_len)
             .min(hash_len);
-          &contenthash[..hash_len.min(contenthash.len())]
+          let contenthash = &contenthash[..hash_len.min(contenthash.len())];
+          if let Some(asset_info) = asset_info.as_mut() {
+            asset_info.set_content_hash(contenthash.to_owned());
+          }
+          contenthash
         })
         .into_owned();
     }

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -3,12 +3,11 @@ use std::fmt::Debug;
 use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_loader_runner::ResourceData;
 use rspack_sources::BoxSource;
-use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  AssetGeneratorOptions, AssetParserOptions, AstOrSource, BuildInfo, BuildMeta, Compilation,
-  CompilerOptions, Dependency, GenerationResult, Module, ModuleDependency, ModuleIdentifier,
-  ModuleType, RuntimeGlobals, SourceType,
+  AssetGeneratorOptions, AssetParserOptions, AstOrSource, BuildInfo, BuildMeta, CodeGenerationData,
+  Compilation, CompilerOptions, Dependency, GenerationResult, Module, ModuleDependency,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, SourceType,
 };
 
 #[derive(Debug)]
@@ -37,7 +36,7 @@ pub struct GenerateContext<'a> {
   pub compilation: &'a Compilation,
   pub module_generator_options: Option<&'a AssetGeneratorOptions>,
   pub runtime_requirements: &'a mut RuntimeGlobals,
-  pub data: &'a mut HashMap<String, String>,
+  pub data: &'a mut CodeGenerationData,
   pub requested_source_type: SourceType,
 }
 

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -206,6 +206,7 @@ impl CopyPlugin {
           query: None,
           ..Default::default()
         },
+        None,
       );
 
       LOGGER.log(&format!(

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  create_css_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Compilation,
-  CssAstPath, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency, ModuleIdentifier, PublicPath,
+  create_css_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
+  CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, CssAstPath, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier,
+  PublicPath,
 };
 use swc_core::css::ast::UrlValue;
 
@@ -36,9 +37,10 @@ impl CssUrlDependency {
       .module_generation_result_map
       .get(identifier);
     if let Some(code_gen_result) = code_gen_result {
-      if let Some(url) = code_gen_result.data.get("url") {
-        Some(url.to_string())
-      } else if let Some(filename) = code_gen_result.data.get("filename") {
+      if let Some(url) = code_gen_result.data.get::<CodeGenerationDataUrl>() {
+        Some(url.inner().to_string())
+      } else if let Some(filename) = code_gen_result.data.get::<CodeGenerationDataFilename>() {
+        let filename = filename.inner();
         let public_path = match &compilation.options.output.public_path {
           PublicPath::String(p) => p,
           PublicPath::Auto => AUTO_PUBLIC_PATH_PLACEHOLDER,

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -160,6 +160,7 @@ impl Plugin for CssPlugin {
       .collect::<Vec<ConcatSource>>();
 
     let source = ConcatSource::new(sources);
+    let mut asset_info = AssetInfo::default();
 
     let filename_template = get_css_chunk_filename_template(
       chunk,
@@ -167,7 +168,8 @@ impl Plugin for CssPlugin {
       &args.compilation.chunk_group_by_ukey,
     );
 
-    let output_path = filename_template.render_with_chunk(chunk, ".css", &SourceType::Css);
+    let output_path =
+      filename_template.render_with_chunk(chunk, ".css", &SourceType::Css, Some(&mut asset_info));
 
     let content = source.source();
     let auto_public_path_matches: Vec<_> = AUTO_PUBLIC_PATH_PLACEHOLDER_REGEX
@@ -197,7 +199,7 @@ impl Plugin for CssPlugin {
       source.boxed(),
       output_path,
       path_data,
-      AssetInfo::default().with_content_hash(chunk.content_hash.get(&SourceType::Css).cloned()),
+      asset_info,
     )])
   }
 

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -83,7 +83,7 @@ impl Plugin for CssPlugin {
         }
       });
 
-    Ok(Some((SourceType::Css, format!("{:x}", hasher.finish()))))
+    Ok(Some((SourceType::Css, format!("{:016x}", hasher.finish()))))
   }
 
   async fn render_manifest(

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -42,7 +42,7 @@ pub struct LocalIdentName(Filename);
 
 impl LocalIdentName {
   pub fn render(&self, options: LocalIdentNameRenderOptions) -> String {
-    let mut s = self.0.render(options.filename_options);
+    let mut s = self.0.render(options.filename_options, None);
     if let Some(local) = options.local {
       s = s.replace("[local]", &local);
     }

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -168,12 +168,13 @@ impl Plugin for DevtoolPlugin {
         args.compilation.emit_asset(filename, asset);
       } else {
         let mut source_map_filename = filename.to_owned() + ".map";
+        // TODO(ahabhgk): refactor
         // https://webpack.docschina.org/configuration/output/#outputsourcemapfilename
         if args.compilation.options.devtool.source_map() {
           let source_map_filename_config = &args.compilation.options.output.source_map_filename;
           for chunk in args.compilation.chunk_by_ukey.values() {
             for file in &chunk.files {
-              if *file.to_string() == filename {
+              if file == &filename {
                 let extension = if is_css { ".css" } else { ".js" };
                 let source_type = if is_css {
                   &SourceType::Css
@@ -185,6 +186,7 @@ impl Plugin for DevtoolPlugin {
                   &filename,
                   extension,
                   source_type,
+                  None,
                 );
                 break;
               }

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -13,7 +13,7 @@ use rayon::prelude::{IntoParallelRefMutIterator, ParallelIterator};
 use rspack_core::{
   parse_to_url,
   rspack_sources::{RawSource, SourceExt},
-  CompilationAsset, Filename, FilenameRenderOptions, Plugin,
+  AssetInfo, CompilationAsset, Filename, FilenameRenderOptions, Plugin,
 };
 use serde::Deserialize;
 use sugar_path::SugarPath;
@@ -180,31 +180,35 @@ impl Plugin for HtmlPlugin {
 
     let source = parser.codegen(&mut current_ast)?;
     let hash = hash_for_ast_or_source(&source);
+    let mut asset_info = AssetInfo::default();
     let html_file_name = Filename::from(config.filename.clone());
-    let html_file_name = html_file_name.render(FilenameRenderOptions {
-      name: Path::new(&url)
-        .file_stem()
-        .map(|s| s.to_string_lossy().to_string()),
-      path: Some(
-        Path::new(&url)
-          .relative(&compilation.options.context)
-          .to_string_lossy()
-          .to_string(),
-      ),
-      extension: Path::new(&url)
-        .extension()
-        .and_then(OsStr::to_str)
-        .map(|str| format!("{}{}", ".", str)),
-      id: None,
-      contenthash: Some(hash.clone()),
-      chunkhash: Some(hash.clone()),
-      hash: Some(hash),
-      query: Some("".to_string()),
-      ..Default::default()
-    });
+    let html_file_name = html_file_name.render(
+      FilenameRenderOptions {
+        name: Path::new(&url)
+          .file_stem()
+          .map(|s| s.to_string_lossy().to_string()),
+        path: Some(
+          Path::new(&url)
+            .relative(&compilation.options.context)
+            .to_string_lossy()
+            .to_string(),
+        ),
+        extension: Path::new(&url)
+          .extension()
+          .and_then(OsStr::to_str)
+          .map(|str| format!("{}{}", ".", str)),
+        id: None,
+        contenthash: Some(hash.clone()),
+        chunkhash: Some(hash.clone()),
+        hash: Some(hash),
+        query: Some("".to_string()),
+        ..Default::default()
+      },
+      Some(&mut asset_info),
+    );
     compilation.emit_asset(
       html_file_name,
-      CompilationAsset::from(RawSource::from(source).boxed()),
+      CompilationAsset::new(Some(RawSource::from(source).boxed()), asset_info),
     );
 
     if let Some(favicon) = &self.config.favicon {

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -232,5 +232,5 @@ impl Plugin for HtmlPlugin {
 fn hash_for_ast_or_source(ast_or_source: &str) -> String {
   let mut hasher = DefaultHasher::new();
   ast_or_source.hash(&mut hasher);
-  format!("{:x}", hasher.finish())
+  format!("{:016x}", hasher.finish())
 }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -143,7 +143,7 @@ impl Plugin for JsPlugin {
 
     Ok(Some((
       SourceType::JavaScript,
-      format!("{:x}", hasher.finish()),
+      format!("{:016x}", hasher.finish()),
     )))
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -162,13 +162,18 @@ impl Plugin for JsPlugin {
       self.render_chunk_impl(&args).await?
     };
 
+    let mut asset_info = AssetInfo::default();
     let filename_template = get_js_chunk_filename_template(
       chunk,
       &compilation.options.output,
       &compilation.chunk_group_by_ukey,
     );
-
-    let output_path = filename_template.render_with_chunk(chunk, ".js", &SourceType::JavaScript);
+    let output_path = filename_template.render_with_chunk(
+      chunk,
+      ".js",
+      &SourceType::JavaScript,
+      Some(&mut asset_info),
+    );
 
     let path_options = PathData {
       chunk_ukey: args.chunk_ukey,
@@ -177,8 +182,7 @@ impl Plugin for JsPlugin {
       source,
       output_path,
       path_options,
-      AssetInfo::default()
-        .with_content_hash(chunk.content_hash.get(&SourceType::JavaScript).cloned()),
+      asset_info,
     )])
   }
 

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -81,7 +81,7 @@ impl Plugin for AmdLibraryPlugin {
       )));
     } else if let Some(name) = name {
       let normalize_name =
-        Filename::from(name).render_with_chunk(chunk, ".js", &SourceType::JavaScript);
+        Filename::from(name).render_with_chunk(chunk, ".js", &SourceType::JavaScript, None);
       source.add(RawSource::from(format!(
         "define('{normalize_name}', {external_deps_array}, {fn_start}"
       )));

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -51,7 +51,12 @@ impl AssignLibraryPlugin {
             root
               .iter()
               .map(|v| {
-                Filename::from(v.clone()).render_with_chunk(chunk, ".js", &SourceType::JavaScript)
+                Filename::from(v.clone()).render_with_chunk(
+                  chunk,
+                  ".js",
+                  &SourceType::JavaScript,
+                  None,
+                )
               })
               .collect::<Vec<_>>(),
           );

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -195,7 +195,7 @@ fn library_name(v: &[String], chunk: &Chunk) -> String {
 }
 
 fn replace_keys(v: String, chunk: &Chunk) -> String {
-  Filename::from(v).render_with_chunk(chunk, ".js", &SourceType::JavaScript)
+  Filename::from(v).render_with_chunk(chunk, ".js", &SourceType::JavaScript, None)
 }
 
 fn externals_require_array(_t: &str, externals: &[&ExternalModule]) -> String {

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -146,7 +146,7 @@ impl RealContentHashPlugin {
               .to_owned()
           })
           .collect();
-        Ok((new_source.clone(), old_info.with_content_hashs(new_hashes)))
+        Ok((new_source.clone(), old_info.with_content_hashes(new_hashes)))
       })?;
       if let Some(new_name) = new_name {
         compilation.rename_asset(&name, new_name);

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -243,11 +243,8 @@ pub fn get_relative_path(base_chunk_output_name: &str, other_chunk_output_name: 
 
 pub fn get_chunk_output_name(chunk: &Chunk, compilation: &Compilation) -> String {
   let hash: Option<String> = Some(chunk.get_render_hash());
-  compilation
-    .options
-    .output
-    .chunk_filename
-    .render(FilenameRenderOptions {
+  compilation.options.output.chunk_filename.render(
+    FilenameRenderOptions {
       name: chunk.name_for_filename_template(),
       extension: Some(".js".to_string()),
       id: chunk.id.clone(),
@@ -255,5 +252,7 @@ pub fn get_chunk_output_name(chunk: &Chunk, compilation: &Compilation) -> String
       chunkhash: hash.clone(),
       hash,
       ..Default::default()
-    })
+    },
+    None,
+  )
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -91,15 +91,18 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
                 _ => unreachable!(),
               };
               let hash = Some(chunk.get_render_hash());
-              let filename = filename_template.render(FilenameRenderOptions {
-                name: chunk.name_for_filename_template(),
-                extension: Some(format!(".{}", self.content_type)),
-                id: chunk.id.clone(),
-                contenthash: chunk.content_hash.get(&self.source_type).cloned(),
-                chunkhash: hash.clone(),
-                hash,
-                ..Default::default()
-              });
+              let filename = filename_template.render(
+                FilenameRenderOptions {
+                  name: chunk.name_for_filename_template(),
+                  extension: Some(format!(".{}", self.content_type)),
+                  id: chunk.id.clone(),
+                  contenthash: chunk.content_hash.get(&self.source_type).cloned(),
+                  chunkhash: hash.clone(),
+                  hash,
+                  ..Default::default()
+                },
+                None,
+              );
               chunks_map.insert(chunk.expect_id().to_string(), format!("\"{filename}\""));
             }
           }

--- a/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/public_path.rs
@@ -48,7 +48,7 @@ impl RuntimeModule for PublicPathRuntimeModule {
           &compilation.options.output,
           &compilation.chunk_group_by_ukey,
         );
-        let filename = filename.render_with_chunk(chunk, ".js", &SourceType::JavaScript);
+        let filename = filename.render_with_chunk(chunk, ".js", &SourceType::JavaScript, None);
         RawSource::from(auto_public_path_template(
           &filename,
           &compilation.options.output,

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -126,7 +126,7 @@ pub fn get_output_dir(chunk: &Chunk, compilation: &Compilation, enforce_relative
     &compilation.options.output,
     &compilation.chunk_group_by_ukey,
   );
-  let output_dir = filename.render_with_chunk(chunk, ".js", &SourceType::JavaScript);
+  let output_dir = filename.render_with_chunk(chunk, ".js", &SourceType::JavaScript, None);
   get_undo_path(
     output_dir.as_str(),
     compilation.options.output.path.display().to_string(),

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -283,28 +283,31 @@ fn render_wasm_name(
   wasm_filename_template: &Filename,
   hash: String,
 ) -> String {
-  wasm_filename_template.render(FilenameRenderOptions {
-    name: normal_module.and_then(|m| {
-      let p = Path::new(&m.resource_resolved_data().resource_path);
-      p.file_stem().map(|s| s.to_string_lossy().to_string())
-    }),
-    path: normal_module.map(|m| {
-      Path::new(&m.resource_resolved_data().resource_path)
-        .relative(ctx)
-        .to_string_lossy()
-        .to_string()
-    }),
-    extension: normal_module.and_then(|m| {
-      Path::new(&m.resource_resolved_data().resource_path)
-        .extension()
-        .and_then(OsStr::to_str)
-        .map(|str| format!("{}{}", ".", str))
-    }),
-    contenthash: Some(hash.clone()),
-    chunkhash: Some(hash.clone()),
-    hash: Some(hash),
-    ..Default::default()
-  })
+  wasm_filename_template.render(
+    FilenameRenderOptions {
+      name: normal_module.and_then(|m| {
+        let p = Path::new(&m.resource_resolved_data().resource_path);
+        p.file_stem().map(|s| s.to_string_lossy().to_string())
+      }),
+      path: normal_module.map(|m| {
+        Path::new(&m.resource_resolved_data().resource_path)
+          .relative(ctx)
+          .to_string_lossy()
+          .to_string()
+      }),
+      extension: normal_module.and_then(|m| {
+        Path::new(&m.resource_resolved_data().resource_path)
+          .extension()
+          .and_then(OsStr::to_str)
+          .map(|str| format!("{}{}", ".", str))
+      }),
+      contenthash: Some(hash.clone()),
+      chunkhash: Some(hash.clone()),
+      hash: Some(hash),
+      ..Default::default()
+    },
+    None,
+  )
 }
 
 fn render_import_stmt(import_var: &str, module_id: &str) -> String {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -318,5 +318,5 @@ fn render_import_stmt(import_var: &str, module_id: &str) -> String {
 fn hash_for_ast_or_source(ast_or_source: &AstOrSource) -> String {
   let mut hasher = DefaultHasher::new();
   ast_or_source.hash(&mut hasher);
-  format!("{:x}", hasher.finish())
+  format!("{:016x}", hasher.finish())
 }

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -79,6 +79,7 @@ impl Plugin for AsyncWasmPlugin {
           .transpose()?
           .map(|source| {
             let options = &compilation.options;
+            let mut asset_info = AssetInfo::default();
             let wasm_filename = self
               .module_id_to_filename_without_ext
               .get(&m.identifier())
@@ -92,11 +93,10 @@ impl Plugin for AsyncWasmPlugin {
                 options
                   .output
                   .webassembly_module_filename
-                  .render_with_chunk(chunk, ".wasm", &SourceType::Wasm)
+                  .render_with_chunk(chunk, ".wasm", &SourceType::Wasm, Some(&mut asset_info))
               }),
               path_options,
-              AssetInfo::default()
-                .with_content_hash(chunk.content_hash.get(&SourceType::Wasm).cloned()),
+              asset_info,
             )
           });
 

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -302,9 +302,7 @@ export class Compilation {
 			filename,
 			compatNewSourceOrFunction,
 			typeof assetInfoUpdateOrFunction === "function"
-				? jsAssetInfo => {
-						return assetInfoUpdateOrFunction(jsAssetInfo);
-				  }
+				? jsAssetInfo => toJsAssetInfo(assetInfoUpdateOrFunction(jsAssetInfo))
 				: toJsAssetInfo(assetInfoUpdateOrFunction)
 		);
 	}

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -331,15 +331,14 @@ export class Compilation {
 	 * @returns {void}
 	 */
 	emitAsset(filename: string, source: Source, assetInfo?: AssetInfo) {
-		const info = Object.assign(
-			{
-				minimized: false,
-				development: false,
-				hotModuleReplacement: false,
-				related: {}
-			},
-			assetInfo
-		);
+		const info = {
+			minimized: false,
+			development: false,
+			hotModuleReplacement: false,
+			related: {},
+			contentHash: [] as string[],
+			...assetInfo
+		};
 		this.#inner.emitAsset(filename, createRawFromSource(source), info);
 	}
 

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -1,4 +1,5 @@
-import { JsStatsError } from "@rspack/binding";
+import { JsAssetInfo, JsStatsError } from "@rspack/binding";
+import { AssetInfo } from "../compilation";
 
 export function mapValues(
 	record: Record<string, string>,
@@ -73,4 +74,15 @@ export function asArray<T>(item: readonly T[]): readonly T[];
 export function asArray<T>(item: T): T[];
 export function asArray<T>(item: T | T[]): T[] {
 	return Array.isArray(item) ? item : [item];
+}
+
+export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
+	return {
+		minimized: false,
+		development: false,
+		hotModuleReplacement: false,
+		related: {},
+		contentHash: [],
+		...info
+	};
 }

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`HashTestCases should print correct hash for package-path-change-0 1`] = `
 [
-  "runtime.b6213affe1a39ddf.js",
+  "runtime.c8619618c466366e.js",
   "main.006edd8022a70bcf.js",
   "0.acf446aa3893e384.js",
 ]

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`HashTestCases should print correct hash for package-path-change-0 1`] = `
 [
-  "runtime.c8619618c466366e.js",
-  "main.6edd8022a70bcf.js",
+  "runtime.b6213affe1a39ddf.js",
+  "main.006edd8022a70bcf.js",
   "0.acf446aa3893e384.js",
 ]
 `;

--- a/packages/rspack/tests/hashCases/real-content-hash/webpack.config.js
+++ b/packages/rspack/tests/hashCases/real-content-hash/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = [
 		devtool: false,
 		output: {
 			path: path.resolve(__dirname, "./dist/a-normal"),
-			filename: "[contenthash]-[contenthash:6].js",
+			filename: "[name].[contenthash]-[contenthash:6].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
 	},
@@ -44,7 +44,7 @@ module.exports = [
 		devtool: false,
 		output: {
 			path: path.resolve(__dirname, "./dist/b-normal"),
-			filename: "[contenthash]-[contenthash:6].js",
+			filename: "[name].[contenthash]-[contenthash:6].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
 	},
@@ -55,8 +55,7 @@ module.exports = [
 		devtool: "source-map",
 		output: {
 			path: path.resolve(__dirname, "./dist/a-source-map"),
-			// filename: "[contenthash]-[contenthash:6].js",
-			filename: "[contenthash].js",
+			filename: "[name].[contenthash]-[contenthash:6].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
 	},
@@ -67,8 +66,7 @@ module.exports = [
 		devtool: "source-map",
 		output: {
 			path: path.resolve(__dirname, "./dist/b-source-map"),
-			// filename: "[contenthash]-[contenthash:6].js",
-			filename: "[contenthash].js",
+			filename: "[name].[contenthash]-[contenthash:6].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
 	}

--- a/packages/rspack/tests/hashCases/real-content-hash/webpack.config.js
+++ b/packages/rspack/tests/hashCases/real-content-hash/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = [
 		devtool: false,
 		output: {
 			path: path.resolve(__dirname, "./dist/a-normal"),
-			filename: "[contenthash].js",
+			filename: "[contenthash]-[contenthash:6].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
 	},
@@ -44,7 +44,7 @@ module.exports = [
 		devtool: false,
 		output: {
 			path: path.resolve(__dirname, "./dist/b-normal"),
-			filename: "[contenthash].js",
+			filename: "[contenthash]-[contenthash:6].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
 	},
@@ -55,6 +55,7 @@ module.exports = [
 		devtool: "source-map",
 		output: {
 			path: path.resolve(__dirname, "./dist/a-source-map"),
+			// filename: "[contenthash]-[contenthash:6].js",
 			filename: "[contenthash].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}
@@ -66,6 +67,7 @@ module.exports = [
 		devtool: "source-map",
 		output: {
 			path: path.resolve(__dirname, "./dist/b-source-map"),
+			// filename: "[contenthash]-[contenthash:6].js",
 			filename: "[contenthash].js",
 			assetModuleFilename: "[contenthash][ext]"
 		}


### PR DESCRIPTION
## Related issue (if exists)

Support realContentHash for `output.filename = '[contenthash]-[contenthash:6].js'`

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 43e381d</samp>

This pull request adds support for multiple content hashes for different source types of assets, and refactors the code generation logic and data structures to use more specific and consistent types. It also improves the performance and readability of some modules and crates, and updates the `Filename` struct to take an optional `asset_info` parameter to pass and update the `AssetInfo` struct. The pull request affects the `rspack_core`, `rspack_plugin_asset`, `rspack_plugin_css`, `rspack_plugin_devtool`, `rspack_plugin_html`, `rspack_plugin_javascript`, `rspack_plugin_copy`, and `rspack_plugin_library` crates, and modifies several files in the `crates` directory.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 43e381d</samp>

*  Change the `content_hash` field of the `AssetInfo` struct from `Option<String>` to `Vec<String>` or `HashSet<String>` to allow multiple content hashes for different source types ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67L28-R28), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67L50-R50), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67L77-R77), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1479-R1481), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1515-R1524), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL250-R274), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL305-R309), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL439-R454), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749R163), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L200-R202), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcL183-R211))
*  Add the `anymap` crate as a dependency to the `rspack_core` crate and use the `CloneAny` trait and the `Map` type to store different types of data in a map ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-b15514bda6ea6c4fd02c5fe3c17a76a128bae9fc869d5245b0d2a109635e91f8R10), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-267e8e26f47f1406aa368886decc1b5eb8e4b3d532e279c727824a5a1e7f1808L3-R5))
*  Add the `CodeGenerationDataUrl`, `CodeGenerationDataFilename`, and `CodeGenerationDataAssetInfo` structs to represent different types of data that can be generated by a module, and wrap them in a `CodeGenerationData` struct that uses an `anymap::Map` ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-267e8e26f47f1406aa368886decc1b5eb8e4b3d532e279c727824a5a1e7f1808L25-R95), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL9-R11),  [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-33ba6bc03cdf35cb7df7d676b2c3cbfa15bd9919596e495b1abd5fdbf24ea157L6-R10), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL12-R20), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL299-R300), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL305-R309), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-1c15f5a8a8d9172d23b16378c2921ade100be73e843e6d9eb2064b7e8bee3c93L2-R5), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-1c15f5a8a8d9172d23b16378c2921ade100be73e843e6d9eb2064b7e8bee3c93L39-R43))
*  Change the `get_render_hash` method of the `Chunk` struct and other functions to use a fixed length of 16 hexadecimal digits for the hash value, to match the webpack convention ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-86272f0bc7b7b8e6b0ab182b026116a2d16fac8ee7e4de45c4a473aaa33517abL312-R312), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1321-R1323), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L361-R361), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0L380-R381), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0L388-R388), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L86-R86),  [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcL231-R235))
*  Change the `render` and `render_with_chunk` methods of the `Filename` struct to take an optional `asset_info` parameter, which is a mutable reference to an `AssetInfo` struct that can be updated with the content hash information, and update the `asset_info` parameter with the content hash value, if it is given ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-75d001733998d80ed823bf765b9791ff28b8612900dd4a1686a54aa25f3155c5L135-R152), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-75d001733998d80ed823bf765b9791ff28b8612900dd4a1686a54aa25f3155c5L154-R182), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-75d001733998d80ed823bf765b9791ff28b8612900dd4a1686a54aa25f3155c5L199-R216), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L45-R45), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcL183-R211), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-cb100885778a02cf058ed143db3d44a406d7751a96f61993055827e493082287R165), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-cb100885778a02cf058ed143db3d44a406d7751a96f61993055827e493082287L170-R177))
*  Remove the unused imports and structs from the `code_generation_results.rs`, `normal_module.rs`, and `external_module.rs` modules ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-267e8e26f47f1406aa368886decc1b5eb8e4b3d532e279c727824a5a1e7f1808L10-R13), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L24-R24), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L35-R35), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL197-R199))
*  Simplify the creation of the `CodeGenerationResult` struct in the `normal_module.rs` module by using the `data` and `runtime_requirements` fields of the `generate_context` struct directly, instead of using local variables ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L609-L610), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L618-R617), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L628-L631))
*  Change the `data` field of the `CodeGenerationResult` struct to use the `CodeGenerationDataUrl` and `CodeGenerationDataFilename` structs instead of strings for the `url` and `filename` keys, and access their inner values using the `inner` method, in the `rspack_plugin_asset` and `rspack_plugin_css` crates ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL299-R300), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL439-R454), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-1c15f5a8a8d9172d23b16378c2921ade100be73e843e6d9eb2064b7e8bee3c93L39-R43))
*  Change the `emit_asset` method of the `Compilation` struct to use the `CompilationAsset::new` constructor that takes an `AssetInfo` struct as a parameter, instead of using the `From` implementation that creates a default `AssetInfo` struct, in the `rspack_plugin_html` crate ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcL183-R211))
*  Pass a `None` value for the `asset_info` parameter to the `render_with_chunk` method of the `Filename` struct, as it is not needed for the `rspack_plugin_copy` and `rspack_plugin_devtool` crates ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-cde7edc635e72d8f64c982c4e78298d248e671f6f022318cc20440f6091b70baR209), [link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9R189))
*  Change the `file` variable to use the `PartialEq` implementation of the `String` type instead of converting it to a string using the `to_string` method, to avoid unnecessary allocation and comparison, in the `rspack_plugin_devtool` crate ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9L176-R177))
*  Add a comment to indicate a possible refactoring of the code to avoid duplication of logic, in the `rspack_plugin_devtool` crate ([link](https://github.com/web-infra-dev/rspack/pull/3095/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9R171))

</details>
