### PR TITLE
chore: disable perfsee upload in ci environment

### DIFF
--- a/examples/perfsee/package.json
+++ b/examples/perfsee/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "rspack serve",
-    "build": "rspack build",
+    "build": "PERFSEE_NO_UPLOAD=true rspack build",
     "analyze": "PERFSEE_AUDIT=true rspack build"
   },
   "devDependencies": {


### PR DESCRIPTION
## Related issue (if exists)

## Summary
disable perfsee automatic upload asset in server
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91f9e8e</samp>

Delete `CI` environment variable in `perfsee` configuration. This prevents automatic uploading of performance assets when running perfsee in CI environments.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91f9e8e</samp>

*  Delete `CI` environment variable before running perfsee to avoid automatic asset upload in CI environments ([link](https://github.com/web-infra-dev/rspack/pull/3099/files?diff=unified&w=0#diff-e2e7a789bdb8a41b28fed266b59b4102472463006bf72f1ef4d00a4d3f7704e6R1))

</details>
