### PR TITLE
fix(emotion): should use source code for computing hash

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -48,8 +48,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       module_type,
       compiler_options.builtins.decorator.is_some(),
     );
+    let source = source.source();
     let (mut ast, diagnostics) = match crate::ast::parse(
-      source.source().to_string(),
+      source.to_string(),
       syntax,
       &resource_data.resource_path.to_string_lossy(),
       module_type,
@@ -73,7 +74,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       build_info,
       build_meta,
       module_type,
-      &source.source(),
+      &source,
     )?;
 
     let (dependencies, presentational_dependencies) = ast.visit(|program, context| {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -73,7 +73,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       build_info,
       build_meta,
       module_type,
-      &*source.source(),
+      &source.source(),
     )?;
 
     let (dependencies, presentational_dependencies) = ast.visit(|program, context| {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -73,6 +73,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       build_info,
       build_meta,
       module_type,
+      &*source.source(),
     )?;
 
     let (dependencies, presentational_dependencies) = ast.visit(|program, context| {

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -61,12 +61,12 @@ pub fn run_before_pass(
   build_info: &mut BuildInfo,
   build_meta: &mut BuildMeta,
   module_type: &ModuleType,
+  source: &str,
 ) -> Result<()> {
   let es_version = match options.target.es_version {
     rspack_core::TargetEsVersion::Esx(es_version) => Some(es_version),
     _ => None,
   };
-  let hash = build_info.hash;
   let cm = ast.get_context().source_map.clone();
   // TODO: should use react-loader to get exclude/include
   let should_transform_by_react = module_type.is_jsx_like();
@@ -120,7 +120,7 @@ pub fn run_before_pass(
           swc_emotion::emotion(
             emotion_options.clone(),
             &resource_data.resource_path,
-            xxh32(&hash.to_be_bytes(), 0),
+            xxh32(source.as_bytes(), 0),
             cm.clone(),
             comments,
           )

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -53,7 +53,6 @@ macro_rules! either {
 }
 
 /// return (ast, top_level_mark, unresolved_mark, globals)
-/// too-many-arguments
 #[allow(clippy::too_many_arguments)]
 pub fn run_before_pass(
   resource_data: &ResourceData,

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -53,6 +53,8 @@ macro_rules! either {
 }
 
 /// return (ast, top_level_mark, unresolved_mark, globals)
+/// too-many-arguments
+#[allow(clippy::too_many_arguments)]
 pub fn run_before_pass(
   resource_data: &ResourceData,
   ast: &mut Ast,


### PR DESCRIPTION
## Related issue (if exists)

Fixes https://github.com/web-infra-dev/rspack/issues/2922

<!--- Provide link of related issues -->

## Summary

The PR fixes the hash collision problem of emotion. The `build_info.hash` Rspack give to emotion plugin is empty for every module, so it's easily generate the same hash value for different modules.

This PR fixes the problem by passing the hash value computed by the source code of each module to emotion plugin.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae439ab</samp>

This pull request improves the emotion style generation for JavaScript files by using the source code as the basis for class names. It modifies the `parse_and_generate` function and the `emotion` visitor in `visitors/mod.rs`, and passes the source code as an argument in `parser_and_generator/mod.rs`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae439ab</samp>

*  Pass source code as a string to `parse_and_generate` function to generate unique class names for emotion styles ([link](https://github.com/web-infra-dev/rspack/pull/3100/files?diff=unified&w=0#diff-36bed5f19c83dd2f89f91be1eeda3550ab3255889870eabb6286c6f669e2c6c4R76), [link](https://github.com/web-infra-dev/rspack/pull/3100/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861R64), [link](https://github.com/web-infra-dev/rspack/pull/3100/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L123-R123))
* Remove unused `hash` variable and argument from `parse_and_generate` function and `emotion` visitor ([link](https://github.com/web-infra-dev/rspack/pull/3100/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L69), [link](https://github.com/web-infra-dev/rspack/pull/3100/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L123-R123))
* Update `emotion` visitor in `crates/rspack_plugin_javascript/src/visitors/mod.rs` to use source code hash instead of build info hash for class names ([link](https://github.com/web-infra-dev/rspack/pull/3100/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L123-R123))

</details>
