### PR TITLE
ci: build and test x86_64-unknown-linux-gnu without docker

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -25,8 +25,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
-      tests: true
 
   release:
     name: Nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
-      tests: true
 
   release:
     name: Release

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,7 +19,6 @@ name: Reusable Release
 #     uses: ./.github/workflows/reusable-build.yml
 #     with:
 #       target: ${{ matrix.target }}
-#       docker: true
 
 on:
   workflow_call:
@@ -27,12 +26,9 @@ on:
       target:
         required: true
         type: string
-      docker:
-        required: true
-        type: boolean
       tests:
         description: "Run tests?"
-        default: false
+        default: true
         required: false
         type: boolean
 
@@ -48,17 +44,23 @@ jobs:
         id: run
         shell: bash
         run: |
-          if [[ "${{ contains(inputs.target, 'linux') }}" == "true" ]]; then
+          if [[ "${{ contains(inputs.target, 'linux') }}" == "true" ]]
+          then
             echo "host=ubuntu-latest" >> "$GITHUB_OUTPUT"
-            if [[ "${{ inputs.docker }}" == "true" ]]; then
-              echo "docker=true" >> "$GITHUB_OUTPUT"
-            fi
           fi
-          if [[ "${{ contains(inputs.target, 'windows') }}" == "true" ]]; then
+          if [[ "${{ contains(inputs.target, 'windows') }}" == "true" ]]
+          then
             echo "host=windows-latest" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{ contains(inputs.target, 'apple') }}" == "true" ]]; then
+          if [[ "${{ contains(inputs.target, 'apple') }}" == "true" ]]
+          then
             echo "host=macos-latest" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{ inputs.target }}" == "x86_64-unknown-linux-gnu" || "${{ inputs.target }}" == "x86_64-pc-windows-msvc" || "${{ inputs.target }}" == "x86_64-apple-darwin" ]]
+          then
+            echo "docker=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "docker=true" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -72,14 +74,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        if: ${{ needs.select.outputs.docker != 'true' }}
-        run: rustup show
-
-      - name: Setup Rust Target
-        if: ${{ needs.select.outputs.docker != 'true' }}
-        run: rustup target add ${{ inputs.target }}
-
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with:
@@ -89,14 +83,16 @@ jobs:
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache
 
-      # Linux
+      - name: Setup Rust Target
+        if: ${{ needs.select.outputs.docker != 'true' }}
+        run: |
+          rustup target add ${{ inputs.target }}
+          rustup show
 
-      - name: Build x86_64-unknown-linux-gnu in Docker
+      # Linux
+      - name: Build x86_64-unknown-linux-gnu
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
-        uses: ./.github/actions/docker-build
-        with:
-          image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
-          target: ${{ inputs.target }}
+        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
 
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
@@ -118,8 +114,7 @@ jobs:
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-          pre: |
-            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+          pre: export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
 
       # Windows
 
@@ -174,6 +169,9 @@ jobs:
       matrix:
         node: [14, 16]
     name: Test Node ${{ matrix.node }}
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+      PUPPETEER_SKIP_DOWNLOAD: true
     steps:
       - uses: actions/checkout@v3
 
@@ -187,7 +185,20 @@ jobs:
         shell: bash
         run: ls -lah crates/node_binding/*.node
 
+      - name: Setup Pnpm
+        uses: ./.github/actions/pnpm-cache
+        with:
+          node-version: ${{ matrix.node }}
+
       ### x86_64-unknown-linux-gnu
+      - name: Test x86_64-unknown-linux-gnu
+        if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
+        shell: bash
+        run: |
+          set -e
+          pnpm run build:js
+          pnpm run test:unit
+          pnpm run test:example
 
       - name: Test x86_64-unknown-linux-gnu
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
@@ -245,22 +256,11 @@ jobs:
 
       ### x86_64-apple-darwin
 
-      - name: Setup x86_64-apple-darwin
-        if: ${{ inputs.target == 'x86_64-apple-darwin' }}
-        uses: ./.github/actions/pnpm-cache
-        with:
-          node-version: ${{ matrix.node }}
-
       - name: Test x86_64-apple-darwin
         if: ${{ inputs.target == 'x86_64-apple-darwin' }}
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-          PUPPETEER_SKIP_DOWNLOAD: true
         shell: bash
         run: |
           set -e
-          corepack enable
-          pnpm install
           pnpm run build:js
           pnpm run test:unit
           pnpm run test:example
@@ -268,22 +268,11 @@ jobs:
 
       ### x86_64-pc-windows-msvc
 
-      - name: Setup x86_64-pc-windows-msvc
-        if: ${{ false && inputs.target == 'x86_64-pc-windows-msvc' }}
-        uses: ./.github/actions/pnpm-cache
-        with:
-          node-version: ${{ matrix.node }}
-
       - name: Test x86_64-pc-windows-msvc
         if: ${{ false && inputs.target == 'x86_64-pc-windows-msvc' }}
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-          PUPPETEER_SKIP_DOWNLOAD: true
         shell: bash
         run: |
           set -e
-          corepack enable
-          pnpm install
           pnpm run build:js
           pnpm run test:unit
           pnpm run test:example

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -56,7 +56,7 @@ jobs:
           then
             echo "host=macos-latest" >> "$GITHUB_OUTPUT"
           fi
-          if [[ "${{ inputs.target }}" == "x86_64-unknown-linux-gnu" || "${{ inputs.target }}" == "x86_64-pc-windows-msvc" || "${{ inputs.target }}" == "x86_64-apple-darwin" ]]
+          if [[ "${{ inputs.target }}" == "x86_64-unknown-linux-musl" || "${{ inputs.target }}" == "x86_64-pc-windows-msvc" || "${{ inputs.target }}" == "x86_64-apple-darwin" ]]
           then
             echo "docker=false" >> "$GITHUB_OUTPUT"
           else
@@ -90,9 +90,12 @@ jobs:
           rustup show
 
       # Linux
-      - name: Build x86_64-unknown-linux-gnu
+      - name: Build x86_64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
-        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+        uses: ./.github/actions/docker-build
+        with:
+          image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+          target: ${{ inputs.target }}
 
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
@@ -101,12 +104,9 @@ jobs:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
 
-      - name: Build x86_64-unknown-linux-musl in Docker
+      - name: Build x86_64-unknown-linux-musl
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
-        uses: ./.github/actions/docker-build
-        with:
-          target: ${{ inputs.target }}
-          image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' }}
@@ -193,15 +193,6 @@ jobs:
       ### x86_64-unknown-linux-gnu
       - name: Test x86_64-unknown-linux-gnu
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
-        shell: bash
-        run: |
-          set -e
-          pnpm run build:js
-          pnpm run test:unit
-          pnpm run test:example
-
-      - name: Test x86_64-unknown-linux-gnu
-        if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
         uses: ./.github/actions/docker-test
         with:
           node: ${{ matrix.node }}
@@ -228,11 +219,13 @@ jobs:
       ### x86_64-unknown-linux-musl
 
       - name: Test x86_64-unknown-linux-musl
-        if: ${{ false && inputs.target == 'x86_64-unknown-linux-musl' }}
-        uses: ./.github/actions/docker-test
-        with:
-          node: ${{ matrix.node }}
-          image: alpine
+        if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
+        shell: bash
+        run: |
+          set -e
+          pnpm run build:js
+          pnpm run test:unit
+          pnpm run test:example
 
       ### aarch64-unknown-linux-musl
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
         target:
-          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
           - x86_64-pc-windows-msvc
           - x86_64-apple-darwin
     uses: ./.github/workflows/reusable-build.yml
@@ -38,6 +38,7 @@ jobs:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
         target:
+          - x86_64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
     uses: ./.github/workflows/reusable-build.yml
     with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
-      tests: true
 
   build-pr:
     if: github.ref_name != 'main'
@@ -44,5 +42,3 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
-      tests: true


### PR DESCRIPTION
## Summary

The host target for GitHub ubuntu is already `x86_64-unknown-linux-gnu`, we don't need to build it inside docker. 

This is a pre-requesite for running e2e tests in `x86_64-unknown-linux-gnu`, because it is tedious to setup the environment for testing in docker.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e946cc2</samp>

Refactor and simplify the GitHub workflows for building, testing, and releasing the `rspack` project. Remove unused inputs and optimize the steps for different target platforms. Update the `.github/workflows/reusable-build.yml`, `.github/workflows/test.yml`, `.github/workflows/release-nightly.yml`, and `.github/workflows/release.yml` files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e946cc2</samp>

*  Remove `docker` and `tests` inputs from `release-nightly`, `release`, and `test` workflows, as they are not needed for their respective processes ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L28-L29), [link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34-L35), [link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L34-L35), [link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L47-L48))
*  Comment out `docker` input and set default value of `tests` input to `true` in `reusable-build` workflow, to enable tests by default for `release-nightly` workflow ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L22), [link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L30-R31))
*  Modify logic of selecting host and docker options based on target platform in `reusable-build` workflow, to avoid using docker for natively supported platforms and use docker for cross-compilation platforms ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L51-R64))
*  Replace docker-based build with native build for `x86_64-unknown-linux-gnu` target in `reusable-build` workflow, to speed up build process and avoid unnecessary docker overhead ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L92-R95))
*  Remove steps of installing Rust and setting up Rust target from `reusable-build` workflow, and move them to `release-nightly` workflow for non-docker-based builds, to avoid redundant steps for docker-based builds ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L75-L82))
*  Remove extra line break from docker-based build for `aarch64-unknown-linux-musl` target in `reusable-build` workflow, to improve readability of code ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L121-R117))
*  Add environment variables to skip browser download in `test` job of `reusable-build` workflow, to avoid downloading browsers that are not used by tests ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R172-R174))
*  Add step of setting up Pnpm and run example tests for `x86_64-unknown-linux-gnu` target in `test` job of `reusable-build` workflow, to enable testing of examples ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L190-R201))
*  Simplify test steps for `x86_64-apple-darwin` and `x86_64-pc-windows-msvc` targets in `test` job of `reusable-build` workflow, by removing redundant steps and environment variables ([link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L248-R263), [link](https://github.com/web-infra-dev/rspack/pull/3104/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L271-R275))

</details>
