### PR TITLE
fix: call devServer.invalidate() panic

### DIFF
--- a/.changeset/honest-turtles-decide.md
+++ b/.changeset/honest-turtles-decide.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+fix: call devServer.invalidate() panic

--- a/packages/rspack/src/watching.ts
+++ b/packages/rspack/src/watching.ts
@@ -238,7 +238,10 @@ class Watching {
 		this.compiler.hooks.watchRun.callAsync(this.compiler, err => {
 			if (err) return this._done(err, null);
 
-			const isRebuild = this.compiler.options.devServer && !this.#initial;
+			const canRebuild =
+				this.compiler.options.devServer &&
+				!this.#initial &&
+				(modifiedFiles?.size || deleteFiles?.size);
 
 			const onBuild = (err?: Error) => {
 				if (err) return this._done(err, null);
@@ -246,7 +249,7 @@ class Watching {
 				this._done(null, this.compiler.compilation);
 			};
 
-			if (isRebuild) {
+			if (canRebuild) {
 				this.compiler.rebuild(modifiedFiles, deleteFiles, onBuild as any);
 			} else {
 				this.compiler.build(onBuild);


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->
Fixes: #2341 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Rspack rebuild need both `modifiedFiles` and `deleteFiles` are exists, but will panic when triggered manually by the user.
This bug doesn't exist in webpack because it only has a `compile` method and doesn't care about `modifiedFiles`

Currently, rspack rebuild performs two more steps of `incremental rebuild` and `calc hmr chunk` than build. And there doesn't seem to be a need for `calc hmr chunk` when manually triggered by the user, so just use the build is enough.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bfba87</samp>

Improve file watching and rebuilding logic for `rspack`. Use a new variable `canRebuild` to avoid unnecessary rebuilds and enable rebuilds without `devServer`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bfba87</samp>

*  Introduce a new variable `canRebuild` to check if there are any file changes that trigger a rebuild ([link](https://github.com/web-infra-dev/rspack/pull/3105/files?diff=unified&w=0#diff-4d50b60f1736e09ee8e9cd235bba1d9bab8e99412926b998e107443fbc7bc8f4L241-R242))
*  Update the condition for calling the `rebuild` method of the compiler to use `canRebuild` instead of `isRebuild` ([link](https://github.com/web-infra-dev/rspack/pull/3105/files?diff=unified&w=0#diff-4d50b60f1736e09ee8e9cd235bba1d9bab8e99412926b998e107443fbc7bc8f4L249-R250))

</details>
