### PR TITLE
chore(rust): clean up dependencies via `cargo-machete`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,6 @@ version = "0.1.0"
 dependencies = [
  "mimalloc-rust",
  "rspack_core",
- "rspack_error",
  "rspack_fs",
  "rspack_testing",
  "rspack_tracing",
@@ -2130,26 +2129,18 @@ dependencies = [
 name = "rspack"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "async-trait",
  "criterion",
- "dashmap",
  "insta",
  "mimalloc-rust",
- "once_cell",
  "rspack_binding_options",
  "rspack_core",
- "rspack_error",
  "rspack_fs",
- "rspack_symbol",
  "rspack_testing",
  "rspack_tracing",
  "serde",
  "serde_json",
  "testing_macros",
  "tokio",
- "tracing",
- "tracing-subscriber",
  "ustr",
  "xshell",
 ]
@@ -2183,21 +2174,16 @@ dependencies = [
  "anyhow",
  "async-trait",
  "better_scoped_tls",
- "cfg-if",
- "dashmap",
  "derivative",
  "glob",
  "indexmap",
  "napi",
  "napi-derive",
- "once_cell",
- "regex",
  "rspack_binding_macros",
  "rspack_core",
  "rspack_error",
  "rspack_identifier",
  "rspack_ids",
- "rspack_loader_runner",
  "rspack_loader_sass",
  "rspack_napi_shared",
  "rspack_plugin_asset",
@@ -2222,7 +2208,6 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_core",
- "swc_emotion",
  "swc_plugin_import",
  "tokio",
  "tracing",
@@ -2247,7 +2232,6 @@ dependencies = [
  "anyhow",
  "anymap",
  "async-recursion",
- "async-scoped",
  "async-trait",
  "bitflags 1.3.2",
  "dashmap",
@@ -2276,7 +2260,6 @@ dependencies = [
  "rspack_symbol",
  "rspack_util",
  "rustc-hash",
- "serde",
  "serde_json",
  "string_cache",
  "sugar_path",
@@ -2339,7 +2322,6 @@ dependencies = [
  "napi",
  "napi-build",
  "napi-derive",
- "rspack_error",
  "rspack_fs",
  "rspack_napi_shared",
 ]
@@ -2349,7 +2331,6 @@ name = "rspack_futures"
 version = "0.1.0"
 dependencies = [
  "async-scoped",
- "tokio",
 ]
 
 [[package]]
@@ -2391,8 +2372,6 @@ dependencies = [
  "rustc-hash",
  "similar-asserts",
  "tokio",
- "tracing",
- "tracing-subscriber",
  "url",
 ]
 
@@ -2413,8 +2392,6 @@ dependencies = [
  "serde",
  "str_indices",
  "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2441,19 +2418,14 @@ dependencies = [
  "napi-derive",
  "napi-sys",
  "once_cell",
- "regex",
  "rspack_binding_macros",
  "rspack_binding_options",
  "rspack_core",
  "rspack_error",
- "rspack_fs",
  "rspack_fs_node",
  "rspack_identifier",
  "rspack_napi_shared",
- "rspack_plugin_html",
  "rspack_tracing",
- "serde",
- "serde_json",
  "testing_macros",
  "tokio",
  "tracing",
@@ -2465,19 +2437,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "dashmap",
  "mime_guess",
- "once_cell",
  "rayon",
  "rspack_base64",
  "rspack_core",
  "rspack_error",
- "rspack_identifier",
  "rspack_testing",
- "serde_json",
  "sugar_path",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2497,19 +2463,16 @@ dependencies = [
 name = "rspack_plugin_copy"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "dashmap",
  "glob",
  "lazy_static",
  "pathdiff",
- "rayon",
  "regex",
  "rspack_core",
  "rspack_error",
  "rspack_futures",
  "rspack_testing",
- "serde_json",
  "sugar_path",
  "testing_macros",
  "tokio",
@@ -2523,9 +2486,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "better_scoped_tls",
  "bitflags 1.3.2",
- "dashmap",
  "data-encoding",
  "heck",
  "hrx-parser",
@@ -2546,7 +2507,6 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "swc_core",
- "tokio",
  "tracing",
  "xxhash-rust",
 ]
@@ -2580,7 +2540,6 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
- "tracing",
 ]
 
 [[package]]
@@ -2592,10 +2551,7 @@ dependencies = [
  "regex",
  "rspack_core",
  "rspack_error",
- "rspack_identifier",
  "rspack_regex",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -2606,13 +2562,11 @@ dependencies = [
  "async-trait",
  "dojang",
  "itertools",
- "once_cell",
  "rayon",
  "rspack_base64",
  "rspack_core",
  "rspack_error",
  "rspack_testing",
- "rustc-hash",
  "schemars",
  "serde",
  "serde_json",
@@ -2629,8 +2583,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
- "better_scoped_tls",
  "bitflags 1.3.2",
  "dashmap",
  "either",
@@ -2647,7 +2599,6 @@ dependencies = [
  "rspack_symbol",
  "rspack_testing",
  "rustc-hash",
- "serde",
  "sourcemap",
  "sugar_path",
  "swc_config",
@@ -2657,7 +2608,6 @@ dependencies = [
  "swc_node_comments",
  "swc_plugin_import",
  "tokio",
- "tracing",
  "url",
  "xxhash-rust",
 ]
@@ -2666,13 +2616,11 @@ dependencies = [
 name = "rspack_plugin_json"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "json",
  "ropey",
  "rspack_core",
  "rspack_error",
  "rspack_testing",
- "tracing",
 ]
 
 [[package]]
@@ -2682,8 +2630,6 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_identifier",
- "rspack_util",
- "rustc-hash",
 ]
 
 [[package]]
@@ -2707,7 +2653,6 @@ dependencies = [
  "rayon",
  "regex",
  "rspack_core",
- "rspack_error",
  "rustc-hash",
  "xxhash-rust",
 ]
@@ -2718,7 +2663,6 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "rspack_core",
- "tracing",
 ]
 
 [[package]]
@@ -2760,14 +2704,10 @@ dependencies = [
  "derivative",
  "futures-util",
  "rayon",
- "regex",
  "rspack_core",
  "rspack_identifier",
  "rspack_regex",
- "rspack_util",
  "rustc-hash",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2782,11 +2722,8 @@ dependencies = [
  "rspack_identifier",
  "rspack_plugin_runtime",
  "rspack_testing",
- "rspack_util",
- "rustc-hash",
  "serde_json",
  "sugar_path",
- "tracing",
  "wasmparser",
 ]
 
@@ -2833,10 +2770,6 @@ name = "rspack_testing"
 version = "0.1.0"
 dependencies = [
  "cargo-rst",
- "colored",
- "derive_builder",
- "glob",
- "rayon",
  "rspack_binding_options",
  "rspack_core",
  "rspack_fs",
@@ -2850,7 +2783,6 @@ dependencies = [
  "rspack_plugin_html",
  "rspack_plugin_javascript",
  "rspack_plugin_json",
- "rspack_plugin_progress",
  "rspack_plugin_remove_empty_chunks",
  "rspack_plugin_runtime",
  "rspack_plugin_wasm",
@@ -2859,7 +2791,6 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "similar",
  "swc_core",
  "testing_macros",
  "tokio",

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -9,7 +9,6 @@ version    = "0.1.0"
 
 [dependencies]
 rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
 rspack_fs = { path = "../rspack_fs", features = ["async"] }
 rspack_testing = { path = "../rspack_testing" }
 tokio = { workspace = true, features = [

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -16,11 +16,9 @@ rspack_binding_macros  = { path = "../rspack_binding_macros" }
 rspack_binding_options = { path = "../rspack_binding_options" }
 rspack_core            = { path = "../rspack_core" }
 rspack_error           = { path = "../rspack_error" }
-rspack_fs              = { path = "../rspack_fs", features = ["async"] }
 rspack_fs_node         = { path = "../rspack_fs_node" }
 rspack_identifier      = { path = "../rspack_identifier" }
 rspack_napi_shared     = { path = "../rspack_napi_shared" }
-rspack_plugin_html     = { path = "../rspack_plugin_html" }
 rspack_tracing         = { path = "../rspack_tracing" }
 
 anyhow      = { version = "1.0.65", features = ["backtrace"] }
@@ -29,9 +27,6 @@ backtrace   = "0.3"
 dashmap     = "5.4.0"
 futures     = "0.3"
 once_cell   = "1"
-regex       = "1.6.0"
-serde       = { version = "1", features = ["derive"] }
-serde_json  = "1"
 tokio       = { version = "1.28.0", features = ["rt", "rt-multi-thread", "macros"] }
 tracing     = "0.1.34"
 

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -9,18 +9,10 @@ version    = "0.1.0"
 
 
 [dependencies]
-dashmap       = { workspace = true }
-rspack_core   = { path = "../rspack_core" }
-rspack_error  = { path = "../rspack_error" }
-rspack_fs     = { path = "../rspack_fs", features = ["async", "rspack-error"] }
-rspack_symbol = { path = "../rspack_symbol" }
+rspack_core = { path = "../rspack_core" }
+rspack_fs   = { path = "../rspack_fs", features = ["async", "rspack-error"] }
 
-anyhow             = { workspace = true }
-async-trait        = { workspace = true }
-once_cell          = { workspace = true }
-tokio              = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
-tracing            = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 rspack_binding_options = { path = "../rspack_binding_options" }

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -9,8 +9,6 @@ version    = "0.1.0"
 anyhow = { workspace = true, features = ["backtrace"] }
 async-trait = { workspace = true }
 better_scoped_tls = { workspace = true }
-cfg-if = "1.0.0"
-dashmap = { workspace = true }
 derivative = { workspace = true }
 glob = "0.3.1"
 indexmap = { workspace = true }
@@ -21,14 +19,11 @@ napi = { workspace = true, features = [
   "anyhow",
 ] }
 napi-derive = { workspace = true }
-once_cell = { workspace = true }
-regex = { workspace = true }
 rspack_binding_macros = { path = "../rspack_binding_macros" }
 rspack_core = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 rspack_identifier = { path = "../rspack_identifier" }
 rspack_ids = { path = "../rspack_ids" }
-rspack_loader_runner = { path = "../rspack_loader_runner" }
 rspack_loader_sass = { path = "../rspack_loader_sass" }
 rspack_napi_shared = { path = "../rspack_napi_shared" }
 rspack_plugin_asset = { path = "../rspack_plugin_asset" }
@@ -55,7 +50,6 @@ serde_json = { workspace = true }
 swc_core = { workspace = true, default-features = false, features = [
   "ecma_transforms_react",
 ] }
-swc_emotion = { workspace = true }
 swc_plugin_import = { workspace = true }
 tokio = { workspace = true, features = [
   "rt",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -9,7 +9,6 @@ version    = "0.1.0"
 anyhow = { workspace = true }
 anymap = "1.0.0-beta.2"
 async-recursion = { workspace = true }
-async-scoped = { workspace = true, features = ["use-tokio"] }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }
@@ -38,7 +37,6 @@ rspack_sources = { workspace = true }
 rspack_symbol = { path = "../rspack_symbol" }
 rspack_util = { path = "../rspack_util" }
 rustc-hash = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 string_cache = "0.8.7"
 sugar_path = { workspace = true }

--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -16,7 +16,6 @@ default = ["async"]
 futures = { workspace = true }
 napi = { workspace = true, features = ["napi4", "tokio_rt"] }
 napi-derive = { workspace = true }
-rspack_error = { path = "../rspack_error" }
 rspack_fs = { path = "../rspack_fs", default-features = false, features = [
   "rspack-error",
 ] }

--- a/crates/rspack_futures/Cargo.toml
+++ b/crates/rspack_futures/Cargo.toml
@@ -8,4 +8,3 @@ version    = "0.1.0"
 
 [dependencies]
 async-scoped = { workspace = true, features = ["use-tokio"] }
-tokio        = { workspace = true, features = ["rt"] }

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -26,11 +26,9 @@ tokio = { workspace = true, features = [
   "fs",
 ] }
 
-nodejs-resolver    = { workspace = true }
-once_cell          = { workspace = true }
-regex              = { workspace = true }
-rspack_error       = { path = "../rspack_error" }
-rspack_identifier  = { path = "../rspack_identifier" }
-rspack_sources     = { workspace = true }
-tracing            = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+nodejs-resolver   = { workspace = true }
+once_cell         = { workspace = true }
+regex             = { workspace = true }
+rspack_error      = { path = "../rspack_error" }
+rspack_identifier = { path = "../rspack_identifier" }
+rspack_sources    = { workspace = true }

--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -25,8 +25,6 @@ tokio = { workspace = true, features = [
   "test-util",
   "parking_lot",
 ] }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [dev-dependencies]
 indexmap       = { workspace = true }

--- a/crates/rspack_plugin_asset/Cargo.toml
+++ b/crates/rspack_plugin_asset/Cargo.toml
@@ -11,23 +11,11 @@ version    = "0.1.0"
 rspack_testing = { path = "../rspack_testing" }
 
 [dependencies]
-anyhow = { workspace = true }
-async-trait = { workspace = true }
-dashmap = { workspace = true }
-mime_guess = "2.0.4"
-once_cell = { workspace = true }
-rayon = { workspace = true }
+anyhow        = { workspace = true }
+async-trait   = { workspace = true }
+mime_guess    = "2.0.4"
+rayon         = { workspace = true }
 rspack_base64 = { path = "../rspack_base64" }
-rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
-rspack_identifier = { path = "../rspack_identifier" }
-serde_json = { workspace = true }
-sugar_path = { workspace = true }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
-tracing = { workspace = true }
+rspack_core   = { path = "../rspack_core" }
+rspack_error  = { path = "../rspack_error" }
+sugar_path    = { workspace = true }

--- a/crates/rspack_plugin_copy/Cargo.toml
+++ b/crates/rspack_plugin_copy/Cargo.toml
@@ -12,18 +12,15 @@ rspack_testing = { path = "../rspack_testing" }
 testing_macros = { workspace = true }
 
 [dependencies]
-anyhow         = { workspace = true }
 async-trait    = { workspace = true }
 dashmap        = { workspace = true }
 glob           = { workspace = true }
 lazy_static    = "1.4.0"
 pathdiff       = { workspace = true }
-rayon          = { workspace = true }
 regex          = { workspace = true }
 rspack_core    = { path = "../rspack_core" }
 rspack_error   = { path = "../rspack_error" }
 rspack_futures = { path = "../rspack_futures" }
-serde_json     = { workspace = true }
 sugar_path     = { workspace = true }
 tokio          = { workspace = true, features = ["fs"] }
 tracing        = { workspace = true }

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -8,9 +8,7 @@ version    = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-better_scoped_tls = { workspace = true }
 bitflags = { workspace = true }
-dashmap = { workspace = true }
 data-encoding = "2.3.3"
 heck = "0.4.1"
 indexmap = { workspace = true }
@@ -38,13 +36,6 @@ swc_core = { workspace = true, features = [
   "css_modules",
   "css_prefixer",
   "css_minifier",
-] }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
 ] }
 tracing = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -20,4 +20,3 @@ rspack_error  = { path = "../rspack_error" }
 rspack_util   = { path = "../rspack_util" }
 rustc-hash    = { workspace = true }
 serde_json    = { workspace = true }
-tracing       = { workspace = true }

--- a/crates/rspack_plugin_externals/Cargo.toml
+++ b/crates/rspack_plugin_externals/Cargo.toml
@@ -8,12 +8,9 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait        = { workspace = true }
-once_cell          = { workspace = true }
-regex              = { workspace = true }
-rspack_core        = { path = "../rspack_core" }
-rspack_error       = { path = "../rspack_error" }
-rspack_identifier  = { path = "../rspack_identifier" }
-rspack_regex       = { path = "../rspack_regex" }
-tracing            = { workspace = true }
-tracing-subscriber = { workspace = true, features = ["env-filter"] }
+async-trait  = { workspace = true }
+once_cell    = { workspace = true }
+regex        = { workspace = true }
+rspack_core  = { path = "../rspack_core" }
+rspack_error = { path = "../rspack_error" }
+rspack_regex = { path = "../rspack_regex" }

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -17,12 +17,10 @@ anyhow            = { workspace = true }
 async-trait       = { workspace = true }
 dojang            = "0.1.6"
 itertools         = { workspace = true }
-once_cell         = { workspace = true }
 rayon             = { workspace = true }
 rspack_base64     = { path = "../rspack_base64" }
 rspack_core       = { path = "../rspack_core" }
 rspack_error      = { path = "../rspack_error" }
-rustc-hash        = { workspace = true }
 schemars          = { workspace = true, optional = true }
 serde             = { workspace = true, features = ["derive"] }
 serde_json        = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -11,8 +11,6 @@ rspack_testing = { path = "../rspack_testing" }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-base64 = "0.13"
-better_scoped_tls = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }
 either = "1"
@@ -28,7 +26,6 @@ rspack_identifier = { path = "../rspack_identifier" }
 rspack_regex = { path = "../rspack_regex" }
 rspack_symbol = { path = "../rspack_symbol" }
 rustc-hash = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 sourcemap = "6.2.3"
 sugar_path = { workspace = true }
 swc_config = { workspace = true }
@@ -50,6 +47,5 @@ swc_emotion = { workspace = true }
 swc_node_comments = { workspace = true }
 swc_plugin_import = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
-tracing = { workspace = true }
 url = "2.3.1"
 xxhash-rust = { workspace = true, features = ["xxh3", "xxh32"] }

--- a/crates/rspack_plugin_json/Cargo.toml
+++ b/crates/rspack_plugin_json/Cargo.toml
@@ -11,9 +11,7 @@ version    = "0.1.0"
 rspack_testing = { path = "../rspack_testing" }
 
 [dependencies]
-anyhow       = { workspace = true }
 json         = { workspace = true }
 ropey        = "1.6.0"
 rspack_core  = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
-tracing      = { workspace = true }

--- a/crates/rspack_plugin_library/Cargo.toml
+++ b/crates/rspack_plugin_library/Cargo.toml
@@ -10,5 +10,3 @@ version = "0.1.0"
 rspack_core       = { path = "../rspack_core" }
 rspack_error      = { path = "../rspack_error" }
 rspack_identifier = { path = "../rspack_identifier" }
-rspack_util       = { path = "../rspack_util" }
-rustc-hash        = { workspace = true }

--- a/crates/rspack_plugin_real_content_hash/Cargo.toml
+++ b/crates/rspack_plugin_real_content_hash/Cargo.toml
@@ -8,13 +8,12 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait  = { workspace = true }
-derivative   = { workspace = true }
-indexmap     = { workspace = true }
-once_cell    = { workspace = true }
-rayon        = { workspace = true }
-regex        = { workspace = true }
-rspack_core  = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
-rustc-hash   = { workspace = true }
-xxhash-rust  = { workspace = true }
+async-trait = { workspace = true }
+derivative  = { workspace = true }
+indexmap    = { workspace = true }
+once_cell   = { workspace = true }
+rayon       = { workspace = true }
+regex       = { workspace = true }
+rspack_core = { path = "../rspack_core" }
+rustc-hash  = { workspace = true }
+xxhash-rust = { workspace = true }

--- a/crates/rspack_plugin_remove_empty_chunks/Cargo.toml
+++ b/crates/rspack_plugin_remove_empty_chunks/Cargo.toml
@@ -10,4 +10,3 @@ version    = "0.1.0"
 [dependencies]
 async-trait = { workspace = true }
 rspack_core = { path = "../rspack_core" }
-tracing     = { workspace = true }

--- a/crates/rspack_plugin_split_chunks_new/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks_new/Cargo.toml
@@ -8,17 +8,14 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-scoped      = { workspace = true, features = ["use-tokio"] }
-async-trait       = { workspace = true }
-dashmap           = { workspace = true }
-derivative        = { workspace = true }
-futures-util      = { workspace = true }
-rayon             = { workspace = true }
-regex             = { workspace = true }
 rspack_core       = { path = "../rspack_core" }
 rspack_identifier = { path = "../rspack_identifier" }
 rspack_regex      = { path = "../rspack_regex" }
-rspack_util       = { path = "../rspack_util" }
-rustc-hash        = { workspace = true }
-tokio             = { workspace = true }
-tracing           = { workspace = true }
+
+async-scoped = { workspace = true, features = ["use-tokio"] }
+async-trait  = { workspace = true }
+dashmap      = { workspace = true }
+derivative   = { workspace = true }
+futures-util = { workspace = true }
+rayon        = { workspace = true }
+rustc-hash   = { workspace = true }

--- a/crates/rspack_plugin_wasm/Cargo.toml
+++ b/crates/rspack_plugin_wasm/Cargo.toml
@@ -15,13 +15,9 @@ rspack_core           = { path = "../rspack_core" }
 rspack_error          = { path = "../rspack_error" }
 rspack_identifier     = { path = "../rspack_identifier" }
 rspack_plugin_runtime = { path = "../rspack_plugin_runtime" }
-rspack_util           = { path = "../rspack_util" }
-rustc-hash            = { workspace = true }
 serde_json            = { workspace = true }
 sugar_path            = { workspace = true }
-tracing               = { workspace = true }
 wasmparser            = "0.102.0"
-
 
 [dev-dependencies]
 rspack_testing = { path = "../rspack_testing" }

--- a/crates/rspack_testing/Cargo.toml
+++ b/crates/rspack_testing/Cargo.toml
@@ -27,7 +27,6 @@ rspack_plugin_externals                 = { path = "../rspack_plugin_externals" 
 rspack_plugin_html                      = { path = "../rspack_plugin_html", features = ["testing"] }
 rspack_plugin_javascript                = { path = "../rspack_plugin_javascript" }
 rspack_plugin_json                      = { path = "../rspack_plugin_json" }
-rspack_plugin_progress                  = { path = "../rspack_plugin_progress" }
 rspack_plugin_remove_empty_chunks       = { path = "../rspack_plugin_remove_empty_chunks" }
 rspack_plugin_runtime                   = { path = "../rspack_plugin_runtime" }
 rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }
@@ -35,14 +34,9 @@ rspack_regex                            = { path = "../rspack_regex" }
 rspack_tracing                          = { path = "../rspack_tracing" }
 
 cargo-rst = { path = "../cargo-rst" }
-colored = { workspace = true }
-derive_builder = { workspace = true }
-glob = { workspace = true }
-rayon = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-similar = { workspace = true }
 swc_core = { workspace = true }
 testing_macros = { workspace = true, features = [] }
 tokio = { workspace = true, features = [


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ac0f6b</samp>

Removed unused dependencies from the `crates/bench/Cargo.toml` file of the `rspack` project. This improves the performance and simplicity of the benchmarking code and reduces the size of the benchmarking binary. The changes affect various `rspack` crates that were previously listed as dependencies for the benchmarking crate.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1ac0f6b</samp>

*  Remove unused dependencies from various `Cargo.toml` files ([link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dL12), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L19-R21), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L32-L34), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL12-L13), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL24-L25), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL31), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL58), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-b15514bda6ea6c4fd02c5fe3c17a76a128bae9fc869d5245b0d2a109635e91f8L12), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-b15514bda6ea6c4fd02c5fe3c17a76a128bae9fc869d5245b0d2a109635e91f8L41), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-08124f063931b3b92fe188cbceb79203848876ed427408872b48bf9cc7f2279bL19), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-d96cbb7a8364e37a9fa5896f37d9d9710cc4635281d30977e5404f26a03369fcL11), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-4168cbe766389af33fc1d0840ddf230a49d5e3d77b4cfa9bcfcae55d293238dcL29-R34), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-07e0029bdf6397999712f5ca814db9ce764467a6459da9f8a32dad5fa35c09e3L28-L29), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-2bc96ba9cc965e76b0b1373c82571f2c0c0b745d7c445f23820de906bdb3f9eaL14-R21), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-806d507d54de72a8417a3b58c9d2d4ea2a62aeee1ce6e3c083b551e5fb4bd718L15), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-806d507d54de72a8417a3b58c9d2d4ea2a62aeee1ce6e3c083b551e5fb4bd718L21-R23), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-22ff3c7952d58482e6da78428a34f37611d34217325ddd16ed8d9d7dd8f7fbacL11-R11), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-22ff3c7952d58482e6da78428a34f37611d34217325ddd16ed8d9d7dd8f7fbacL42-L48), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-89b005f88e42f4b935f93a00e82910f409c6fdf1bdb21f1b6b1d2390b4f93d36L23), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-ed087a840a1db14f5b45b64e94c9dce74a20fcdc95163b527e6658d170c92916L11-R16), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-ff5d3405535927b7df3b3d04126df21b25ff5576d92e57440a7c91b0b112810cL20-R23), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-de9d76de11eb9821c20e5ee2f57fa780188d579d23b4699e25f0fc2f62150f64L14-L15), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-de9d76de11eb9821c20e5ee2f57fa780188d579d23b4699e25f0fc2f62150f64L31), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-de9d76de11eb9821c20e5ee2f57fa780188d579d23b4699e25f0fc2f62150f64L53), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-5aa63bdb00e3bacfca3cf48f9285df027b477d940f4ea52a44f05a00ce0b81d5L14-R17), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-39b127f958340f9e24c7b30ddd2bfde51e37e57fecbec27331580c1f3d23dc5eL13-L14), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-c69aa565d20d62522739e30e6463cdba0947663bc457d5892f9c3e3babbfb67fL11-R19), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-c2219d8eea77fe1199514704ff4e9def71896b8ed06df2d57d31323c2beba5f0L13), [link](https://github.com/web-infra-dev/rspack/pull/3106/files?diff=unified&w=0#diff-f51d8e1dc90c204d99678ea03628f395c2f28efb9acf6c590d8f6a2046782d02L12-R15))

</details>
