### PR TITLE
fix: fix esbuild iife for minify plugin

### DIFF
--- a/packages/rspack-plugin-minify/src/index.js
+++ b/packages/rspack-plugin-minify/src/index.js
@@ -24,6 +24,7 @@ module.exports = class RspackMinifyPlugin {
 				target: this.options.target,
 				sourcefile,
 				sourcemap,
+				format: "iife",
 				minify: true,
 				minifyIdentifiers: true,
 				minifySyntax: true,


### PR DESCRIPTION
## Related issue (if exists)

## Summary
esbuild default generate helpers in global scope which may be conflict with other same name variable in other chunk, so we use iife format to avoid name conflict
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dfbb58</samp>

Added `format` option to rollup plugin output configuration in `rspack-plugin-minify`. This option enables generating bundles in `"iife"` format, which improves code minification and avoids global variable conflicts.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3dfbb58</samp>

*  Add `format` option to output configuration of rollup plugin ([link](https://github.com/web-infra-dev/rspack/pull/3107/files?diff=unified&w=0#diff-d3bc90b2ce9f62f99648e3cb197282df44cf0ed2a9d23fe4996f58c3b1cecb26R27))

</details>
