### PR TITLE
chore: fix toml indentation

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,5 +1,5 @@
 # https://taplo.tamasfe.dev/configuration/formatter-options.html
 [formatting]
 align_entries = true
-indent_tables = true
+column_width  = 120
 reorder_keys  = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,64 +2,64 @@
 members  = ["crates/*"]
 resolver = "2"          # See https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 
-  [workspace.dependencies]
-  anyhow             = { version = "1.0.70" }
-  async-recursion    = { version = "1.0.4" }
-  async-scoped       = { version = "0.7.1" }
-  async-trait        = { version = "0.1.68" }
-  better_scoped_tls  = { version = "0.1.0" }
-  bitflags           = { version = "1.3.2" }
-  colored            = { version = "2.0.0" }
-  dashmap            = { version = "5.4.0" }
-  derivative         = { version = "2.2.0" }
-  derive_builder     = { version = "0.11.2" }
-  futures            = { version = "0.3.28" }
-  futures-util       = "0.3.28"
-  glob               = { version = "0.3.1" }
-  hashlink           = { version = "0.8.1" }
-  indexmap           = { version = "1.9.3" }
-  insta              = { version = "1.29.0" }
-  itertools          = { version = "0.10.5" }
-  json               = { version = "0.12.4" }
-  linked_hash_set    = { version = "0.1.4" }
-  mimalloc-rust      = { version = "0.2" }
-  nodejs-resolver    = { version = "0.0.83" }
-  once_cell          = { version = "1.17.1" }
-  paste              = { version = "1.0" }
-  pathdiff           = { version = "0.2.1" }
-  preset_env_base    = { version = "0.4.2" }
-  rayon              = { version = "1.7.0" }
-  regex              = { version = "1.8.1" }
-  rspack_sources     = { version = "0.2.4" }
-  rustc-hash         = { version = "1.1.0" }
-  schemars           = { version = "0.8.12" }
-  serde              = { version = "1.0.160" }
-  serde_json         = { version = "1.0.96" }
-  similar            = { version = "2.2.1" }
-  sugar_path         = { version = "0.0.12" }
-  testing_macros     = { version = "0.2.9" }
-  tokio              = { version = "1.28.0" }
-  tracing            = { version = "0.1.37" }
-  tracing-subscriber = { version = "0.3.17" }
-  url                = { version = "2.3.1" }
-  ustr               = { version = "0.9.0" }
-  xxhash-rust        = { version = "0.8.6" }
+[workspace.dependencies]
+anyhow             = { version = "1.0.70" }
+async-recursion    = { version = "1.0.4" }
+async-scoped       = { version = "0.7.1" }
+async-trait        = { version = "0.1.68" }
+better_scoped_tls  = { version = "0.1.0" }
+bitflags           = { version = "1.3.2" }
+colored            = { version = "2.0.0" }
+dashmap            = { version = "5.4.0" }
+derivative         = { version = "2.2.0" }
+derive_builder     = { version = "0.11.2" }
+futures            = { version = "0.3.28" }
+futures-util       = "0.3.28"
+glob               = { version = "0.3.1" }
+hashlink           = { version = "0.8.1" }
+indexmap           = { version = "1.9.3" }
+insta              = { version = "1.29.0" }
+itertools          = { version = "0.10.5" }
+json               = { version = "0.12.4" }
+linked_hash_set    = { version = "0.1.4" }
+mimalloc-rust      = { version = "0.2" }
+nodejs-resolver    = { version = "0.0.83" }
+once_cell          = { version = "1.17.1" }
+paste              = { version = "1.0" }
+pathdiff           = { version = "0.2.1" }
+preset_env_base    = { version = "0.4.2" }
+rayon              = { version = "1.7.0" }
+regex              = { version = "1.8.1" }
+rspack_sources     = { version = "0.2.4" }
+rustc-hash         = { version = "1.1.0" }
+schemars           = { version = "0.8.12" }
+serde              = { version = "1.0.160" }
+serde_json         = { version = "1.0.96" }
+similar            = { version = "2.2.1" }
+sugar_path         = { version = "0.0.12" }
+testing_macros     = { version = "0.2.9" }
+tokio              = { version = "1.28.0" }
+tracing            = { version = "0.1.37" }
+tracing-subscriber = { version = "0.3.17" }
+url                = { version = "2.3.1" }
+ustr               = { version = "0.9.0" }
+xxhash-rust        = { version = "0.8.6" }
 
-  # Pinned
-  napi                = { version = "=2.12.5" }
-  napi-build          = { version = "=2.0.1" }
-  napi-derive         = { version = "=2.12.3" }
-  napi-sys            = { version = "=2.2.3" }
-  swc_config          = { version = "=0.1.5" }
-  swc_core            = { version = "=0.75.35", default-features = false }
-  swc_css             = { version = "=0.153.7" }
-  swc_ecma_minifier   = { version = "=0.180.28", default-features = false }
-  swc_emotion         = { version = "=0.30.5" }
-  swc_error_reporters = { version = "=0.15.5" }
-  swc_html            = { version = "=0.123.26" }
-  swc_html_minifier   = { version = "=0.120.26" }
-  swc_node_comments   = { version = "=0.18.5" }
-  swc_plugin_import   = { version = "=0.1.5" }
+# Pinned
+napi                = { version = "=2.12.5" }
+napi-build          = { version = "=2.0.1" }
+napi-derive         = { version = "=2.12.3" }
+napi-sys            = { version = "=2.2.3" }
+swc_config          = { version = "=0.1.5" }
+swc_core            = { version = "=0.75.35", default-features = false }
+swc_css             = { version = "=0.153.7" }
+swc_ecma_minifier   = { version = "=0.180.28", default-features = false }
+swc_emotion         = { version = "=0.30.5" }
+swc_error_reporters = { version = "=0.15.5" }
+swc_html            = { version = "=0.123.26" }
+swc_html_minifier   = { version = "=0.120.26" }
+swc_node_comments   = { version = "=0.18.5" }
+swc_plugin_import   = { version = "=0.1.5" }
 
 [profile.dev]
 debug       = 2

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -8,16 +8,10 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_core = { path = "../rspack_core" }
-rspack_fs = { path = "../rspack_fs", features = ["async"] }
+rspack_core    = { path = "../rspack_core" }
+rspack_fs      = { path = "../rspack_fs", features = ["async"] }
 rspack_testing = { path = "../rspack_testing" }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+tokio          = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 
 [target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 mimalloc-rust  = { workspace = true }

--- a/crates/rspack_ast_viewer/Cargo.toml
+++ b/crates/rspack_ast_viewer/Cargo.toml
@@ -10,14 +10,8 @@ name = "rspack-ast-viewer"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = { workspace = true }
-argh = "0.1.10"
-regex = { workspace = true }
-swc_core = { workspace = true, features = [
-  "ecma_ast",
-  "ecma_parser",
-  "css_ast",
-  "css_parser",
-  "common",
-] }
+anyhow              = { workspace = true }
+argh                = "0.1.10"
+regex               = { workspace = true }
+swc_core            = { workspace = true, features = ["ecma_ast", "ecma_parser", "css_ast", "css_parser", "common"] }
 swc_error_reporters = { workspace = true }

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -6,56 +6,43 @@ repository = "https://github.com/web-infra-dev/rspack"
 version    = "0.1.0"
 
 [dependencies]
-anyhow = { workspace = true, features = ["backtrace"] }
-async-trait = { workspace = true }
-better_scoped_tls = { workspace = true }
-derivative = { workspace = true }
-glob = "0.3.1"
-indexmap = { workspace = true }
-napi = { workspace = true, features = [
-  "async",
-  "tokio_rt",
-  "serde-json",
-  "anyhow",
-] }
-napi-derive = { workspace = true }
-rspack_binding_macros = { path = "../rspack_binding_macros" }
-rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
-rspack_identifier = { path = "../rspack_identifier" }
-rspack_ids = { path = "../rspack_ids" }
-rspack_loader_sass = { path = "../rspack_loader_sass" }
-rspack_napi_shared = { path = "../rspack_napi_shared" }
-rspack_plugin_asset = { path = "../rspack_plugin_asset" }
-rspack_plugin_banner = { path = "../rspack_plugin_banner" }
-rspack_plugin_copy = { path = "../rspack_plugin_copy" }
-rspack_plugin_css = { path = "../rspack_plugin_css" }
+anyhow                                  = { workspace = true, features = ["backtrace"] }
+async-trait                             = { workspace = true }
+better_scoped_tls                       = { workspace = true }
+derivative                              = { workspace = true }
+glob                                    = "0.3.1"
+indexmap                                = { workspace = true }
+napi                                    = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
+napi-derive                             = { workspace = true }
+rspack_binding_macros                   = { path = "../rspack_binding_macros" }
+rspack_core                             = { path = "../rspack_core" }
+rspack_error                            = { path = "../rspack_error" }
+rspack_identifier                       = { path = "../rspack_identifier" }
+rspack_ids                              = { path = "../rspack_ids" }
+rspack_loader_sass                      = { path = "../rspack_loader_sass" }
+rspack_napi_shared                      = { path = "../rspack_napi_shared" }
+rspack_plugin_asset                     = { path = "../rspack_plugin_asset" }
+rspack_plugin_banner                    = { path = "../rspack_plugin_banner" }
+rspack_plugin_copy                      = { path = "../rspack_plugin_copy" }
+rspack_plugin_css                       = { path = "../rspack_plugin_css" }
 rspack_plugin_dev_friendly_split_chunks = { path = "../rspack_plugin_dev_friendly_split_chunks" }
-rspack_plugin_devtool = { path = "../rspack_plugin_devtool" }
-rspack_plugin_externals = { path = "../rspack_plugin_externals" }
-rspack_plugin_html = { path = "../rspack_plugin_html" }
-rspack_plugin_javascript = { path = "../rspack_plugin_javascript" }
-rspack_plugin_json = { path = "../rspack_plugin_json" }
-rspack_plugin_library = { path = "../rspack_plugin_library" }
-rspack_plugin_progress = { path = "../rspack_plugin_progress" }
-rspack_plugin_real_content_hash = { path = "../rspack_plugin_real_content_hash" }
-rspack_plugin_remove_empty_chunks = { path = "../rspack_plugin_remove_empty_chunks" }
-rspack_plugin_runtime = { path = "../rspack_plugin_runtime" }
-rspack_plugin_split_chunks = { path = "../rspack_plugin_split_chunks" }
-rspack_plugin_split_chunks_new = { path = "../rspack_plugin_split_chunks_new" }
-rspack_plugin_wasm = { path = "../rspack_plugin_wasm" }
-rspack_regex = { path = "../rspack_regex" }
-serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true }
-swc_core = { workspace = true, default-features = false, features = [
-  "ecma_transforms_react",
-] }
-swc_plugin_import = { workspace = true }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
-tracing = { workspace = true }
+rspack_plugin_devtool                   = { path = "../rspack_plugin_devtool" }
+rspack_plugin_externals                 = { path = "../rspack_plugin_externals" }
+rspack_plugin_html                      = { path = "../rspack_plugin_html" }
+rspack_plugin_javascript                = { path = "../rspack_plugin_javascript" }
+rspack_plugin_json                      = { path = "../rspack_plugin_json" }
+rspack_plugin_library                   = { path = "../rspack_plugin_library" }
+rspack_plugin_progress                  = { path = "../rspack_plugin_progress" }
+rspack_plugin_real_content_hash         = { path = "../rspack_plugin_real_content_hash" }
+rspack_plugin_remove_empty_chunks       = { path = "../rspack_plugin_remove_empty_chunks" }
+rspack_plugin_runtime                   = { path = "../rspack_plugin_runtime" }
+rspack_plugin_split_chunks              = { path = "../rspack_plugin_split_chunks" }
+rspack_plugin_split_chunks_new          = { path = "../rspack_plugin_split_chunks_new" }
+rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }
+rspack_regex                            = { path = "../rspack_regex" }
+serde                                   = { workspace = true, features = ["derive"] }
+serde_json                              = { workspace = true }
+swc_core                                = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
+swc_plugin_import                       = { workspace = true }
+tokio                                   = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
+tracing                                 = { workspace = true }

--- a/crates/rspack_build/Cargo.toml
+++ b/crates/rspack_build/Cargo.toml
@@ -6,17 +6,11 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
-rspack_fs = { path = "../rspack_fs", features = ["async"] }
+rspack_core    = { path = "../rspack_core" }
+rspack_error   = { path = "../rspack_error" }
+rspack_fs      = { path = "../rspack_fs", features = ["async"] }
 rspack_testing = { path = "../rspack_testing" }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+tokio          = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 
 [target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
 mimalloc-rust = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -69,13 +69,7 @@ swc_emotion = { workspace = true }
 swc_error_reporters = { workspace = true }
 swc_node_comments = { workspace = true }
 swc_plugin_import = { workspace = true }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 tracing = { workspace = true }
 url = { workspace = true }
 ustr = { workspace = true }

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -20,14 +20,8 @@ termcolor          = "1.2"
 insta = { workspace = true }
 # rspack = { path = "../rspack" }
 rspack_binding_options = { path = "../rspack_binding_options" }
-rspack_core = { path = "../rspack_core" }
-rspack_fs = { path = "../rspack_fs", features = ["async"] }
-rspack_testing = { path = "../rspack_testing" }
-rspack_tracing = { path = "../rspack_tracing" }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+rspack_core            = { path = "../rspack_core" }
+rspack_fs              = { path = "../rspack_fs", features = ["async"] }
+rspack_testing         = { path = "../rspack_testing" }
+rspack_tracing         = { path = "../rspack_tracing" }
+tokio                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }

--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -13,12 +13,10 @@ async   = ["rspack_fs/async"]
 default = ["async"]
 
 [dependencies]
-futures = { workspace = true }
-napi = { workspace = true, features = ["napi4", "tokio_rt"] }
-napi-derive = { workspace = true }
-rspack_fs = { path = "../rspack_fs", default-features = false, features = [
-  "rspack-error",
-] }
+futures            = { workspace = true }
+napi               = { workspace = true, features = ["napi4", "tokio_rt"] }
+napi-derive        = { workspace = true }
+rspack_fs          = { path = "../rspack_fs", default-features = false, features = ["rspack-error"] }
 rspack_napi_shared = { path = "../rspack_napi_shared" }
 
 [build-dependencies]

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -13,18 +13,11 @@ url             = { workspace = true }
 
 [dependencies]
 async-recursion = { workspace = true }
-async-trait = { workspace = true }
-bitflags = { workspace = true }
-derivative = { workspace = true }
-rustc-hash = { workspace = true }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-  "fs",
-] }
+async-trait     = { workspace = true }
+bitflags        = { workspace = true }
+derivative      = { workspace = true }
+rustc-hash      = { workspace = true }
+tokio           = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot", "fs"] }
 
 nodejs-resolver   = { workspace = true }
 once_cell         = { workspace = true }

--- a/crates/rspack_loader_sass/Cargo.toml
+++ b/crates/rspack_loader_sass/Cargo.toml
@@ -8,23 +8,17 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = { workspace = true }
-itertools = { workspace = true }
-once_cell = { workspace = true }
-regex = { workspace = true }
-rspack_core = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
+async-trait          = { workspace = true }
+itertools            = { workspace = true }
+once_cell            = { workspace = true }
+regex                = { workspace = true }
+rspack_core          = { path = "../rspack_core" }
+rspack_error         = { path = "../rspack_error" }
 rspack_loader_runner = { path = "../rspack_loader_runner" }
-sass-embedded = { version = "0.7.1", features = ["legacy", "serde"] }
-serde = { workspace = true, features = ["derive"] }
-str_indices = "0.4.1"
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+sass-embedded        = { version = "0.7.1", features = ["legacy", "serde"] }
+serde                = { workspace = true, features = ["derive"] }
+str_indices          = "0.4.1"
+tokio                = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 
 [dev-dependencies]
 indexmap       = { workspace = true }

--- a/crates/rspack_napi_shared/Cargo.toml
+++ b/crates/rspack_napi_shared/Cargo.toml
@@ -8,18 +8,6 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-napi = { workspace = true, features = [
-  "async",
-  "tokio_rt",
-  "serde-json",
-  "napi4",
-  "anyhow",
-] }
+napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "napi4", "anyhow"] }
 rspack_error = { path = "../rspack_error" }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+tokio        = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }

--- a/crates/rspack_testing/Cargo.toml
+++ b/crates/rspack_testing/Cargo.toml
@@ -33,16 +33,10 @@ rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }
 rspack_regex                            = { path = "../rspack_regex" }
 rspack_tracing                          = { path = "../rspack_tracing" }
 
-cargo-rst = { path = "../cargo-rst" }
-schemars = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-swc_core = { workspace = true }
+cargo-rst      = { path = "../cargo-rst" }
+schemars       = { workspace = true }
+serde          = { workspace = true }
+serde_json     = { workspace = true }
+swc_core       = { workspace = true }
 testing_macros = { workspace = true, features = [] }
-tokio = { workspace = true, features = [
-  "rt",
-  "rt-multi-thread",
-  "macros",
-  "test-util",
-  "parking_lot",
-] }
+tokio          = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 348fad2</samp>

This pull request updates the formatting and alignment of the TOML files in the repository using the Taplo tool and the `.taplo.toml` file. It also adds the `column_width` option and removes the `indent_tables` option from the `.taplo.toml` file to improve the readability and consistency of the TOML files. The changes affect the `Cargo.toml` files of the `rspack` crates and the `.taplo.toml` file itself.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 348fad2</samp>

*  Add `column_width` option to the TOML formatting configuration ([link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-b7c76183b83d02658dcf830b3f4b13d8369829b257c1378ce6ccf59f6060bfbaL4-R4))
*  Remove `indent_tables` option from the TOML formatting configuration ([link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L5-R62))
*  Align the dependencies in the `Cargo.toml` files of the `rspack` crates by adding spaces between the keys and the values ([link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dL11-R14), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-e13c02fd10abbf352ff0e22210f7411eeea97c2d4bdf6b853d3650b77dba5bb8L13-R16), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL9-R48), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-f07f423257fb3c175025f7a9fd07aecd985e708ed2c9ebbf0295378d9627ec56L9-R13), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-b15514bda6ea6c4fd02c5fe3c17a76a128bae9fc869d5245b0d2a109635e91f8L72-R72), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-ecfe3e3156d8717f286e00893af607ada528d4b16217e90ab94e2cb090acb42dL23-R27), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-08124f063931b3b92fe188cbceb79203848876ed427408872b48bf9cc7f2279bL16-R19), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-4168cbe766389af33fc1d0840ddf230a49d5e3d77b4cfa9bcfcae55d293238dcL16-R20), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-07e0029bdf6397999712f5ca814db9ce764467a6459da9f8a32dad5fa35c09e3L11-R21), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-eb08bce575574bcf4b4c0c72632a3d2ccb286f75147074f3f2d55cf3a6054c58L11-R13), [link](https://github.com/web-infra-dev/rspack/pull/3114/files?diff=unified&w=0#diff-a6ce0ec143b8a4fb832dc10908a6dc9d2a9f065cfcd1f3f95a67361992ce05e1L36-R42))

</details>
