### PR TITLE
chore: placeholder options for stats nestedModules

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -35,8 +35,8 @@ export class JsCompilation {
 
 export class JsStats {
   getAssets(): JsStatsGetAssets
-  getModules(reasons: boolean, moduleAssets: boolean): Array<JsStatsModule>
-  getChunks(chunkModules: boolean, chunksRelations: boolean, reasons: boolean, moduleAssets: boolean): Array<JsStatsChunk>
+  getModules(reasons: boolean, moduleAssets: boolean, nestedModules: boolean): Array<JsStatsModule>
+  getChunks(chunkModules: boolean, chunksRelations: boolean, reasons: boolean, moduleAssets: boolean, nestedModules: boolean): Array<JsStatsChunk>
   getEntrypoints(): Array<JsStatsChunkGroup>
   getNamedChunkGroups(): Array<JsStatsChunkGroup>
   getErrors(): Array<JsStatsError>

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -268,10 +268,15 @@ impl JsStats {
   }
 
   #[napi]
-  pub fn get_modules(&self, reasons: bool, module_assets: bool) -> Vec<JsStatsModule> {
+  pub fn get_modules(
+    &self,
+    reasons: bool,
+    module_assets: bool,
+    nested_modules: bool,
+  ) -> Vec<JsStatsModule> {
     self
       .inner
-      .get_modules(reasons, module_assets)
+      .get_modules(reasons, module_assets, nested_modules)
       .expect("Failed to get modules")
       .into_iter()
       .map(Into::into)
@@ -285,10 +290,17 @@ impl JsStats {
     chunks_relations: bool,
     reasons: bool,
     module_assets: bool,
+    nested_modules: bool,
   ) -> Vec<JsStatsChunk> {
     self
       .inner
-      .get_chunks(chunk_modules, chunks_relations, reasons, module_assets)
+      .get_chunks(
+        chunk_modules,
+        chunks_relations,
+        reasons,
+        module_assets,
+        nested_modules,
+      )
       .expect("Failed to get chunks")
       .into_iter()
       .map(Into::into)

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -261,6 +261,10 @@ export class Compilation {
 			!context.forToString
 		);
 		options.moduleAssets = optionOrLocalFallback(options.moduleAssets, true);
+		options.nestedModules = optionOrLocalFallback(
+			options.nestedModules,
+			!context.forToString
+		);
 
 		return options;
 	}

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -1875,6 +1875,11 @@ module.exports = {
 				builtAt: {
 					description: "Add built at time information.",
 					type: "boolean"
+				},
+				nestedModules: {
+					description:
+						"Add information about modules nested in other modules (like with module concatenation).",
+					type: "boolean"
 				}
 			}
 		},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -563,6 +563,7 @@ export interface StatsOptions {
 	timings?: boolean;
 	builtAt?: boolean;
 	moduleAssets?: boolean;
+	nestedModules?: boolean;
 }
 
 ///// Optimization /////

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -93,13 +93,15 @@ export class Stats {
 				options.chunkModules!,
 				options.chunkRelations!,
 				options.reasons!,
-				options.moduleAssets!
+				options.moduleAssets!,
+				options.nestedModules!
 			);
 		}
 		if (options.modules) {
 			obj.modules = this.#inner.getModules(
 				options.reasons!,
-				options.moduleAssets!
+				options.moduleAssets!,
+				options.nestedModules!
 			);
 		}
 		if (options.entrypoints) {


### PR DESCRIPTION
## Related issue (if exists)

closes #2610 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a53dc3</samp>

Added a new `nestedModules` option to the stats output of rspack and its core and node binding crates. This option allows users to see information about modules that are concatenated into other modules by webpack, which can help with bundle optimization and analysis. Modified the `Stats`, `Compilation`, and `StatsModule` classes and interfaces and the `StatsOptions` schema and interface to support this option.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a53dc3</samp>

*  Add a new option `nestedModules` to the `StatsOptions` interface (F4L564), schema (F3L1876), and class (F5L94, F5L100) in the rspack package to control whether to include information about modules nested in other modules in the stats output

</details>
