### PR TITLE
ci: run x86_64-unknown-linux-gnu tests without docker

### DIFF
--- a/.github/actions/docker-test/action.yml
+++ b/.github/actions/docker-test/action.yml
@@ -40,8 +40,4 @@ runs:
 
           corepack enable
           pnpm install
-          pnpm run build:js
-          pnpm run test:unit
-          pnpm run test:example
-          # e2e is disabled because this does not run on some targets
-          # pnpm run test:e2e
+          pnpm run test:ci

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -25,7 +25,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
       tests: true
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
       tests: true
 
   release:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -19,7 +19,6 @@ name: Reusable Release
 #     uses: ./.github/workflows/reusable-build.yml
 #     with:
 #       target: ${{ matrix.target }}
-#       docker: true
 
 on:
   workflow_call:
@@ -27,9 +26,6 @@ on:
       target:
         required: true
         type: string
-      docker:
-        required: true
-        type: boolean
       tests:
         description: "Run tests?"
         default: false
@@ -42,7 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       host: ${{ steps.run.outputs.host }}
-      docker: ${{ steps.run.outputs.docker }}
     steps:
       - name: Choose Target for ${{ inputs.target }}
         id: run
@@ -50,9 +45,6 @@ jobs:
         run: |
           if [[ "${{ contains(inputs.target, 'linux') }}" == "true" ]]; then
             echo "host=ubuntu-latest" >> "$GITHUB_OUTPUT"
-            if [[ "${{ inputs.docker }}" == "true" ]]; then
-              echo "docker=true" >> "$GITHUB_OUTPUT"
-            fi
           fi
           if [[ "${{ contains(inputs.target, 'windows') }}" == "true" ]]; then
             echo "host=windows-latest" >> "$GITHUB_OUTPUT"
@@ -72,12 +64,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        if: ${{ needs.select.outputs.docker != 'true' }}
-        run: rustup show
-
       - name: Setup Rust Target
-        if: ${{ needs.select.outputs.docker != 'true' }}
         run: rustup target add ${{ inputs.target }}
 
       - name: Rust Cache
@@ -174,6 +161,9 @@ jobs:
       matrix:
         node: [14, 16]
     name: Test Node ${{ matrix.node }}
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
+      PUPPETEER_SKIP_DOWNLOAD: true
     steps:
       - uses: actions/checkout@v3
 
@@ -187,13 +177,28 @@ jobs:
         shell: bash
         run: ls -lah crates/node_binding/*.node
 
+      - name: Setup Pnpm
+        uses: ./.github/actions/pnpm-cache
+        with:
+          node-version: ${{ matrix.node }}
+
+      ### x86_64-apple-darwin
+
+      - name: Test x86_64-apple-darwin
+        if: ${{ inputs.target == 'x86_64-apple-darwin' }}
+        run: pnpm run test:ci
+
+      ### x86_64-pc-windows-msvc
+
+      - name: Test x86_64-pc-windows-msvc
+        if: ${{ false && inputs.target == 'x86_64-pc-windows-msvc' }}
+        run: pnpm run test:ci
+
       ### x86_64-unknown-linux-gnu
 
       - name: Test x86_64-unknown-linux-gnu
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
-        uses: ./.github/actions/docker-test
-        with:
-          node: ${{ matrix.node }}
+        run: pnpm run test:ci
 
       ### aarch64-unknown-linux-gnu
 
@@ -242,49 +247,3 @@ jobs:
         with:
           node: ${{ matrix.node }}
           options: --platform linux/arm64
-
-      ### x86_64-apple-darwin
-
-      - name: Setup x86_64-apple-darwin
-        if: ${{ inputs.target == 'x86_64-apple-darwin' }}
-        uses: ./.github/actions/pnpm-cache
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Test x86_64-apple-darwin
-        if: ${{ inputs.target == 'x86_64-apple-darwin' }}
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-          PUPPETEER_SKIP_DOWNLOAD: true
-        shell: bash
-        run: |
-          set -e
-          corepack enable
-          pnpm install
-          pnpm run build:js
-          pnpm run test:unit
-          pnpm run test:example
-          # pnpm run test:e2e
-
-      ### x86_64-pc-windows-msvc
-
-      - name: Setup x86_64-pc-windows-msvc
-        if: ${{ false && inputs.target == 'x86_64-pc-windows-msvc' }}
-        uses: ./.github/actions/pnpm-cache
-        with:
-          node-version: ${{ matrix.node }}
-
-      - name: Test x86_64-pc-windows-msvc
-        if: ${{ false && inputs.target == 'x86_64-pc-windows-msvc' }}
-        env:
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true
-          PUPPETEER_SKIP_DOWNLOAD: true
-        shell: bash
-        run: |
-          set -e
-          corepack enable
-          pnpm install
-          pnpm run build:js
-          pnpm run test:unit
-          pnpm run test:example
-          # pnpm run test:e2e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
       tests: true
 
   build-pr:
@@ -44,5 +43,4 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      docker: true
       tests: true

--- a/package.json
+++ b/package.json
@@ -28,9 +28,10 @@
     "changeset": "changeset",
     "prepare": "is-ci || husky install",
     "pnpm:devPreinstall": "is-ci || node ./scripts/doctor.js",
-    "test:example": "NODE_OPTIONS=--max_old_space_size=8192 pnpm --filter \"example-*\" build",
-    "test:unit": "NODE_OPTIONS=--max_old_space_size=8192 pnpm --filter \"@rspack/*\" test",
-    "test:e2e": "NODE_OPTIONS=--max_old_space_size=8192 pnpm --filter \"@rspack-e2e/*\" test"
+    "test:example": "pnpm --filter \"example-*\" build",
+    "test:unit": "pnpm --filter \"@rspack/*\" test",
+    "test:e2e": "pnpm --filter \"@rspack-e2e/*\" test",
+    "test:ci": "NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:example && pnpm run test:unit"
   },
   "lint-staged": {
     "*.rs": "rustfmt --edition 2021",


### PR DESCRIPTION
## Summary

As it turns out, we can run the `x86_64-unknown-linux-gnu` build directly on the `ubuntu-latest` without docker. This is a prerequisite for running e2e tests, given it's tedious to setup docker for e2e testing.

This may also fix the flacky tests.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a65d51c</samp>

This pull request improves the CI workflows and test scripts for the `rspack` project. It refactors the reusable-build and docker-test actions, updates the test, release, and release-nightly workflows, and adds a `test:ci` script to the `package.json` file. These changes reduce duplication, increase performance, and ensure consistency.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a65d51c</samp>

*  Simplify test script in docker-test action by using `test:ci` script from `package.json` ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-16fa8792c589ad765a257180228958a9294395331c5674be4eccfbb8454cf4beL43-R43))
* Remove unused `docker` input and output from reusable-build action and dependent workflows ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L28), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L22), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L30-L32), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L45), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L53-L55), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L34), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L47))
* Move Rust setup and test steps from reusable-build action to docker-test action, as they are only relevant for docker-based tests ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L75-R67), [link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L190-R201))
* Add environment variables to reusable-build action to avoid downloading unnecessary browsers for tests ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R164-R166))
* Remove test steps for non-docker targets from reusable-build action, as they are now tested by test workflow using pnpm-cache action ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L245-L290))
* Add `test:ci` script to `package.json` to combine build and test commands ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R34))
* Add `improve-ci` branch to test workflow trigger, to check changes on pull request ([link](https://github.com/web-infra-dev/rspack/pull/3117/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R14))

</details>
