### PR TITLE
feat(new_split_chunks): support `maxInitialRequests` and `maxAsyncRequests` internally

### DIFF
--- a/.changeset/orange-doors-pull.md
+++ b/.changeset/orange-doors-pull.md
@@ -1,0 +1,5 @@
+---
+"@rspack/binding": patch
+---
+
+feat(new_split_chunks): support `maxInitialRequests` and `maxAsyncRequests` internally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,6 +2708,7 @@ dependencies = [
  "rspack_identifier",
  "rspack_regex",
  "rustc-hash",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -191,6 +191,10 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
             min_chunks,
             min_size,
             reuse_existing_chunk: v.reuse_existing_chunk.unwrap_or(true),
+            // TODO(hyf0): the non-enforced default value should be 30
+            // I would set align default value with Webpack when the options is exposed to users
+            max_async_requests: u32::MAX,
+            max_initial_requests: u32::MAX,
           }
         }),
     );

--- a/crates/rspack_plugin_split_chunks_new/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks_new/Cargo.toml
@@ -19,3 +19,4 @@ derivative   = { workspace = true }
 futures-util = { workspace = true }
 rayon        = { workspace = true }
 rustc-hash   = { workspace = true }
+tracing      = { workspace = true }

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -29,4 +29,6 @@ pub struct CacheGroup {
   /// number of referenced chunks
   pub min_chunks: u32,
   pub id_hint: String,
+  pub max_initial_requests: u32,
+  pub max_async_requests: u32,
 }

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/max_request.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/max_request.rs
@@ -1,0 +1,68 @@
+use std::borrow::Cow;
+
+use rspack_core::{ChunkUkey, Compilation};
+use rustc_hash::FxHashSet;
+
+use crate::{CacheGroup, SplitChunksPlugin};
+
+impl SplitChunksPlugin {
+  /// Affected by `splitChunks.maxInitialRequests`/`splitChunks.cacheGroups.{cacheGroup}.maxInitialRequests`
+  /// Affected by `splitChunks.maxAsyncRequests`/`splitChunks.cacheGroups.{cacheGroup}.maxAsyncRequests`
+  pub(crate) fn ensure_max_request_fit(
+    &self,
+    compilation: &Compilation,
+    cache_group: &CacheGroup,
+    used_chunks: &mut Cow<FxHashSet<ChunkUkey>>,
+  ) {
+    let chunk_db = &compilation.chunk_by_ukey;
+    let chunk_group_db = &compilation.chunk_group_by_ukey;
+    let invalided_chunks = used_chunks
+      .iter()
+      .map(|c| c.as_ref(chunk_db))
+      .filter_map(|chunk| {
+        let allowed_max_request = if chunk.is_only_initial(chunk_group_db) {
+          cache_group.max_initial_requests
+        } else if chunk.can_be_initial(chunk_group_db) {
+          u32::max(
+            cache_group.max_initial_requests,
+            cache_group.max_async_requests,
+          )
+        } else {
+          cache_group.max_async_requests
+        };
+
+        // `Chunk`s in `used_chunks` are all code-splitting chunk.
+
+        // If a code-splitting chunk is not split by `SplitChunksPlugin`, the number of requests for
+        // the chunk is 1.
+
+        // If the code-splitting chunks is split by `SplitChunksPlugin`, to load the code-splitting chunk
+        // with correct semantics, we need to also load the chunks derive from the the code-splitting chunk.
+
+        // Chunks derive from the the code-splitting chunk is in the same ChunkGroup with the split chunk.
+
+        // So the number of requests is the length of `ChunkGroup#chunks` which belong to the split code-splitting
+        // chunk.
+
+        let actually_requests = chunk
+          .groups
+          .iter()
+          .map(|g| g.as_ref(chunk_group_db))
+          .map(|group| group.chunks.len())
+          .reduce(usize::max)
+          .map(|requests| requests as u32)
+          .unwrap_or_default();
+
+        if actually_requests >= allowed_max_request {
+          tracing::trace!("{{{:?}}} removed for actually_requests({actually_requests:?}) >= {allowed_max_request:?} ", chunk.chunk_reasons.join("~"));
+          Some(chunk.ukey)
+        } else {
+          None
+        }
+      })
+      .collect::<Vec<_>>();
+    invalided_chunks.into_iter().for_each(|c| {
+      used_chunks.to_mut().remove(&c);
+    })
+  }
+}

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
@@ -66,6 +66,7 @@ impl SplitChunksPlugin {
           .for_each(|violating_module| module_group.remove_module(violating_module));
 
         if module_group.modules.is_empty() {
+          tracing::trace!("{module_group_key} removed for minSize not fit");
           Some(module_group_key.clone())
         } else {
           None

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -162,7 +162,7 @@ impl SplitChunksPlugin {
         item.modules.iter().for_each(|module| {
           if each_module_group.modules.contains(module) {
             tracing::trace!("remove module({module}) from {key}");
-            let module: &Box<dyn Module> = compilation
+            let module = compilation
               .module_graph
               .module_by_identifier(module)
               .unwrap_or_else(|| panic!("Module({module}) not found"));

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -147,7 +147,7 @@ impl SplitChunksPlugin {
     compilation: &mut Compilation,
   ) {
     // remove all modules from other entries and update size
-    let keys_of_empty_group = module_group_map
+    let keys_of_invalid_group = module_group_map
       .iter_mut()
       .par_bridge()
       .filter(|(_key, each_module_group)| {
@@ -161,7 +161,8 @@ impl SplitChunksPlugin {
       .filter_map(|(key, each_module_group)| {
         item.modules.iter().for_each(|module| {
           if each_module_group.modules.contains(module) {
-            let module = compilation
+            tracing::trace!("remove module({module}) from {key}");
+            let module: &Box<dyn Module> = compilation
               .module_graph
               .module_by_identifier(module)
               .unwrap_or_else(|| panic!("Module({module}) not found"));
@@ -170,14 +171,42 @@ impl SplitChunksPlugin {
         });
 
         if each_module_group.modules.is_empty() {
-          Some(key.clone())
-        } else {
-          None
+          tracing::trace!(
+            "{key} is deleted for having empty modules",
+          );
+          return Some(key.clone());
         }
+
+        tracing::trace!("each_module_group: {each_module_group:#?}");
+        tracing::trace!("item.modules: {:#?}", item.modules);
+
+        // Since there are modules removed, make sure the rest of chunks are all used.
+        each_module_group.chunks.retain(|c| {
+          let is_used_chunk = each_module_group
+            .modules
+            .iter()
+            .any(|m| compilation.chunk_graph.is_module_in_chunk(m, *c));
+          is_used_chunk
+        });
+
+        let cache_group: &CacheGroup = &self.cache_groups[each_module_group.cache_group_index];
+
+        // There are some unused chunks, which is removed
+        if each_module_group.chunks.len() < cache_group.min_chunks as usize {
+          // `min_size` is not satisfied, remove this invalid `ModuleGroup`
+          tracing::trace!(
+            "{key} is deleted for each_module_group.chunks.len()({:?}) < cache_group.min_chunks({:?})",
+            each_module_group.chunks.len(),
+            cache_group.min_chunks
+          );
+          return Some(key.clone());
+        }
+
+        None
       })
       .collect::<Vec<_>>();
 
-    keys_of_empty_group.into_iter().for_each(|key| {
+    keys_of_invalid_group.into_iter().for_each(|key| {
       module_group_map.remove(&key);
     });
   }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- I will add tests on the PR that exposes `maxInitialRequests` and `maxAsyncRequests` option

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4624d05</samp>

This pull request adds support for limiting the number of requests per chunk and respecting the minimum number of chunks per module group for the `splitChunks` option of the `SplitChunksPlugin`. It modifies the `plugin`, `cache_group`, and `options` modules of the `rspack_plugin_split_chunks_new` and `rspack_binding_options` crates, and adds a new `max_request` module. It also updates the changelog and version for the `@rspack/binding` package.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4624d05</samp>

*  Add a markdown file to indicate a patch-level update for the `@rspack/binding` package ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-0b558caca3e3b7a355614a0f301954de345d7ca10911448e4af80adefe1ac0bbR1-R5))
*  Add `max_async_requests` and `max_initial_requests` fields to the `RawSplitChunks` struct in `raw_split_chunks.rs` and mark them as TODO for user exposure ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R194-R197))
*  Add `max_initial_requests` and `max_async_requests` fields to the `CacheGroup` struct in `cache_group.rs` and store the values from the raw configuration or the defaults ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR32-R33))
*  Implement the `ensure_max_request_fit` method in the `max_request.rs` module to remove chunks that exceed the request limits from the cache group ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-df5e22b8430b27c0d6936f0c0a74a3f449f5b84a3b60d7c84eacb5fb719e88b9R1-R67))
*  Import the `max_request.rs` module into the `plugin` module in `plugin/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-8ae45ec9606865dac58ced163f0e1e7efb9b21d0d014132b5a2de6587f1d4a4aR2))
*  Call the `ensure_max_request_fit` method and check the `min_chunks` requirement in the `apply` method of the `SplitChunksPlugin` struct in `plugin/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-8ae45ec9606865dac58ced163f0e1e7efb9b21d0d014132b5a2de6587f1d4a4aL65-R77))
*  Rename the variable `keys_of_empty_group` to `keys_of_invalid_group` and retain only the used chunks and valid module groups in the `remove_modules_from_other_entries_and_update_size` method of the `SplitChunksPlugin` struct in `plugin/module_group.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-491710d760a9177c165f505436fcb4f19f6f00caaeb2cd888f6377d881827d23L150-R150), [link](https://github.com/web-infra-dev/rspack/pull/3119/files?diff=unified&w=0#diff-491710d760a9177c165f505436fcb4f19f6f00caaeb2cd888f6377d881827d23L173-R197))

</details>
