### PR TITLE
feat: add build meta exports type

### DIFF
--- a/.changeset/nasty-schools-draw.md
+++ b/.changeset/nasty-schools-draw.md
@@ -1,0 +1,5 @@
+---
+"@rspack/core": patch
+---
+
+feat: add build meta exports type

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -34,11 +34,32 @@ pub struct BuildInfo {
 }
 
 #[derive(Debug, Default, Clone)]
+pub enum BuildMetaExportsType {
+  #[default]
+  Default,
+  Namespace,
+  Flagged,
+  Dynamic,
+}
+
+#[derive(Debug, Default, Clone)]
+pub enum BuildMetaDefaultObject {
+  #[default]
+  False,
+  Redirect,
+  RedirectWarn,
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct BuildMeta {
+  pub strict: bool,
   pub strict_harmony_module: bool,
   pub is_async: bool,
-  // TODO webpack exportsType
   pub esm: bool,
+  pub exports_type: BuildMetaExportsType,
+  pub default_object: BuildMetaDefaultObject,
+  pub module_argument: &'static str,
+  pub exports_argument: &'static str,
 }
 
 // webpack build info

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -591,8 +591,6 @@ impl Module for NormalModule {
     build_info.build_dependencies = loader_result.build_dependencies;
     build_info.asset_filenames = loader_result.asset_filenames;
 
-    // TODO: match package.json type files
-    build_meta.strict_harmony_module = matches!(self.module_type, ModuleType::JsEsm);
     Ok(
       BuildResult {
         build_info,

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -9,11 +9,12 @@ use async_trait::async_trait;
 use rayon::prelude::*;
 use rspack_core::{
   rspack_sources::{RawSource, SourceExt},
-  AssetInfo, AssetParserDataUrlOption, AssetParserOptions, AstOrSource,
-  CodeGenerationDataAssetInfo, CodeGenerationDataFilename, CodeGenerationDataUrl,
-  FilenameRenderOptions, GenerateContext, GenerationResult, Module, ParseContext,
-  ParserAndGenerator, PathData, Plugin, PluginContext, PluginRenderManifestHookOutput,
-  RenderManifestArgs, RenderManifestEntry, RuntimeGlobals, SourceType,
+  AssetInfo, AssetParserDataUrlOption, AssetParserOptions, AstOrSource, BuildMetaDefaultObject,
+  BuildMetaExportsType, CodeGenerationDataAssetInfo, CodeGenerationDataFilename,
+  CodeGenerationDataUrl, FilenameRenderOptions, GenerateContext, GenerationResult, Module,
+  ParseContext, ParserAndGenerator, PathData, Plugin, PluginContext,
+  PluginRenderManifestHookOutput, RenderManifestArgs, RenderManifestEntry, RuntimeGlobals,
+  SourceType,
 };
 use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result};
 use sugar_path::SugarPath;
@@ -190,9 +191,14 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     parse_context: rspack_core::ParseContext,
   ) -> Result<rspack_error::TWithDiagnosticArray<rspack_core::ParseResult>> {
     let ParseContext {
-      source, build_info, ..
+      source,
+      build_meta,
+      build_info,
+      ..
     } = parse_context;
     build_info.strict = true;
+    build_meta.exports_type = BuildMetaExportsType::Default;
+    build_meta.default_object = BuildMetaDefaultObject::False;
     let size = source.size();
 
     self.parsed_asset_config = match &self.data_url {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -10,8 +10,8 @@ use rspack_core::{
   rspack_sources::{
     MapOptions, RawSource, Source, SourceExt, SourceMap, SourceMapSource, SourceMapSourceOptions,
   },
-  GenerateContext, GenerationResult, Module, ModuleType, ParseContext, ParseResult,
-  ParserAndGenerator, SourceType,
+  BuildMetaExportsType, GenerateContext, GenerationResult, Module, ModuleType, ParseContext,
+  ParseResult, ParserAndGenerator, SourceType,
 };
 use rspack_core::{AstOrSource, ModuleAst, ModuleDependency};
 use rspack_error::{
@@ -102,9 +102,13 @@ impl ParserAndGenerator for CssParserAndGenerator {
       module_type,
       resource_data,
       compiler_options,
+      build_info,
+      build_meta,
       code_generation_dependencies,
       ..
     } = parse_context;
+    build_info.strict = true;
+    build_meta.exports_type = BuildMetaExportsType::Namespace;
     let cm: Arc<swc_core::common::SourceMap> = Default::default();
     let content = source.source().to_string();
     let css_modules = matches!(module_type, ModuleType::CssModule);

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -72,7 +72,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       compiler_options,
       syntax,
       build_info,
-      build_meta,
       module_type,
       &source,
     )?;
@@ -84,6 +83,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         resource_data,
         compiler_options,
         module_type,
+        build_info,
+        build_meta,
       )
     });
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection.rs
@@ -1,0 +1,49 @@
+use rspack_core::{BuildInfo, BuildMeta, BuildMetaExportsType, Dependency, ModuleType};
+use swc_core::ecma::ast::{ModuleItem, Program};
+use swc_core::ecma::visit::{noop_visit_type, Visit};
+
+// Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/HarmonyDetectionParserPlugin.js
+pub struct HarmonyDetectionScanner<'a> {
+  pub build_info: &'a mut BuildInfo,
+  pub build_meta: &'a mut BuildMeta,
+  pub module_type: &'a ModuleType,
+  pub presentational_dependencies: &'a mut Vec<Box<dyn Dependency>>,
+}
+
+impl<'a> HarmonyDetectionScanner<'a> {
+  pub fn new(
+    build_info: &'a mut BuildInfo,
+    build_meta: &'a mut BuildMeta,
+    module_type: &'a ModuleType,
+    presentational_dependencies: &'a mut Vec<Box<dyn Dependency>>,
+  ) -> Self {
+    Self {
+      build_info,
+      build_meta,
+      module_type,
+      presentational_dependencies,
+    }
+  }
+}
+
+impl Visit for HarmonyDetectionScanner<'_> {
+  noop_visit_type!();
+
+  fn visit_program(&mut self, program: &'_ Program) {
+    let strict_harmony_module = self.module_type.is_js_esm();
+
+    let is_harmony = matches!(program, Program::Module(module) if module.body.iter().any(|s| matches!(s, ModuleItem::ModuleDecl(_))));
+
+    if is_harmony || strict_harmony_module {
+      self.build_meta.esm = true;
+      self.build_meta.exports_type = BuildMetaExportsType::Namespace;
+      self.build_info.strict = true;
+      self.build_meta.exports_argument = "__webpack_exports__";
+    }
+
+    if strict_harmony_module {
+      self.build_meta.strict_harmony_module = true;
+      self.build_meta.module_argument = "__webpack_module__";
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -24,9 +24,7 @@ use swc_core::ecma::transforms::optimization::simplify::dce::{dce, Config};
 pub mod relay;
 mod swc_visitor;
 mod tree_shaking;
-use rspack_core::{
-  ast::javascript::Ast, BuildMeta, CompilerOptions, GenerateContext, ResourceData,
-};
+use rspack_core::{ast::javascript::Ast, CompilerOptions, GenerateContext, ResourceData};
 use rspack_error::{Error, Result};
 use swc_core::base::config::ModuleConfig;
 use swc_core::common::{chain, comments::Comments};
@@ -60,7 +58,6 @@ pub fn run_before_pass(
   options: &CompilerOptions,
   syntax: Syntax,
   build_info: &mut BuildInfo,
-  build_meta: &mut BuildMeta,
   module_type: &ModuleType,
   source: &str,
 ) -> Result<()> {
@@ -83,7 +80,7 @@ pub fn run_before_pass(
     }
 
     let mut pass = chain!(
-      strict_mode(build_info, build_meta),
+      strict_mode(build_info),
       swc_visitor::resolver(unresolved_mark, top_level_mark, syntax.typescript()),
       //      swc_visitor::lint(
       //        &ast,

--- a/crates/rspack_plugin_javascript/src/visitors/strict.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/strict.rs
@@ -1,33 +1,22 @@
-use rspack_core::{BuildInfo, BuildMeta};
-use swc_core::ecma::ast::{Expr, ExprStmt, Lit, ModuleItem, Stmt, Str};
+use rspack_core::BuildInfo;
+use swc_core::ecma::ast::{Expr, ExprStmt, Lit, Stmt, Str};
 use swc_core::ecma::visit::{as_folder, noop_visit_mut_type, Fold, VisitMut};
 
-pub fn strict_mode<'a>(
-  build_info: &'a mut BuildInfo,
-  build_meta: &'a mut BuildMeta,
-) -> impl Fold + 'a {
-  as_folder(StrictModeVisitor {
-    build_info,
-    build_meta,
-  })
+pub fn strict_mode(build_info: &mut BuildInfo) -> impl Fold + '_ {
+  as_folder(StrictModeVisitor { build_info })
 }
 
 struct StrictModeVisitor<'a> {
   build_info: &'a mut BuildInfo,
-  build_meta: &'a mut BuildMeta,
 }
 
 impl<'a> VisitMut for StrictModeVisitor<'a> {
   noop_visit_mut_type!();
 
-  fn visit_mut_module_item(&mut self, module_item: &mut ModuleItem) {
-    if matches!(module_item, ModuleItem::ModuleDecl(_)) {
-      self.build_info.strict = true;
-      self.build_meta.esm = true;
-    }
-  }
-
   fn visit_mut_stmt(&mut self, stmt: &mut Stmt) {
+    if self.build_info.strict {
+      return;
+    }
     if let Stmt::Expr(ExprStmt { box expr, .. }) = stmt && let Expr::Lit(Lit::Str(Str { ref value, .. })) = expr && value == "use strict" {
        self.build_info.strict = true;
       }

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -3,7 +3,8 @@ use json::Error::{
 };
 use rspack_core::{
   rspack_sources::{RawSource, Source, SourceExt},
-  GenerateContext, Module, ParserAndGenerator, Plugin, SourceType,
+  BuildMetaDefaultObject, BuildMetaExportsType, GenerateContext, Module, ParserAndGenerator,
+  Plugin, SourceType,
 };
 use rspack_error::{
   internal_error, DiagnosticKind, Error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
@@ -32,9 +33,13 @@ impl ParserAndGenerator for JsonParserAndGenerator {
       source: box_source,
       resource_data,
       build_info,
+      build_meta,
       ..
     } = parse_context;
     build_info.strict = true;
+    build_meta.exports_type = BuildMetaExportsType::Default;
+    // TODO default_object is not align with webpack
+    build_meta.default_object = BuildMetaDefaultObject::RedirectWarn;
     let source = box_source.source();
 
     let parse_result = json::parse(&source).map_err(|e| {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -8,9 +8,9 @@ use rspack_core::rspack_sources::{RawSource, Source, SourceExt};
 use rspack_core::DependencyType::WasmImport;
 // use rspack_core::StaticExportsDependency;
 use rspack_core::{
-  AstOrSource, Context, Dependency, Filename, FilenameRenderOptions, GenerateContext,
-  GenerationResult, Module, ModuleDependency, ModuleIdentifier, NormalModule, ParseContext,
-  ParseResult, ParserAndGenerator, RuntimeGlobals, SourceType,
+  AstOrSource, BuildMetaExportsType, Context, Dependency, Filename, FilenameRenderOptions,
+  GenerateContext, GenerationResult, Module, ModuleDependency, ModuleIdentifier, NormalModule,
+  ParseContext, ParseResult, ParserAndGenerator, RuntimeGlobals, SourceType,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_identifier::Identifier;
@@ -35,6 +35,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
   fn parse(&mut self, parse_context: ParseContext) -> Result<TWithDiagnosticArray<ParseResult>> {
     parse_context.build_info.strict = true;
     parse_context.build_meta.is_async = true;
+    parse_context.build_meta.exports_type = BuildMetaExportsType::Namespace;
 
     let source = parse_context.source;
 


### PR DESCRIPTION
## Related issue (if exists)

releated of https://github.com/web-infra-dev/rspack/issues/2886

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08c068f</samp>

This pull request adds support for different export formats and interop options for various module types in the `rspack` bundler. It introduces new metadata types and fields in the `rspack_core` crate and updates the plugins for JavaScript, CSS, JSON, and WebAssembly to use them. It also refactors and simplifies some of the code in the `rspack_plugin_javascript` crate, and adds a new visitor to detect harmony features. It updates the `.changeset` file to document the new feature.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08c068f</samp>

*  Add a markdown file to the `.changeset` directory to indicate a patch-level update for the `@rspack/core` package and a feature description for the changelog ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-6cf6c1257f9d8ba59a6a896b208919a8a2669ec8b1e5fe303e28760a35fa86b4R1-R5))
*  Add new fields to the `BuildMeta` struct and define new enums `BuildMetaExportsType` and `BuildMetaDefaultObject` to store and control the export and interop modes of the modules ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0L36-R72))
*  Add logic to the `ExternalModule` struct to set the `build_meta.exports_type`, `build_info.strict`, and `build_meta.is_async` fields based on the `external_type` field ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL180-R194))
*  Remove logic from the `NormalModule` struct to set the `build_meta.strict_harmony_module` field based on the `module_type` field ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L594-L595))
*  Add logic to the `AssetParserAndGenerator` struct to set the `build_meta.exports_type` and `build_meta.default_object` fields to `Default` and `False` respectively for the asset modules ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL193-R201))
*  Add logic to the `CssParserAndGenerator` struct to set the `build_meta.exports_type` field to `Namespace` for the CSS modules ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-92a05fddd0f140eaa90842ec788a05f79b66772dfa918770d7ee71b3f0bc50eaL105-R111))
*  Add logic to the `JsonParserAndGenerator` struct to set the `build_meta.exports_type` and `build_meta.default_object` fields to `Default` and `RedirectWarn` respectively for the JSON modules ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-2f5104bd5419764ef84b345b76adbee5aca8ffe25ff36c515b66de2aaebcc1f1L35-R42))
*  Add logic to the `WasmParserAndGenerator` struct to set the `build_meta.exports_type` field to `Namespace` for the WebAssembly modules ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-a4dcb46189b4987eea542ab16a9887f25b0b440b28f17523a39ac03899b88b5bR38))
*  Add the `HarmonyDetectionScanner` visitor to scan the AST of the modules and set the `build_meta` fields related to ECMAScript module declarations ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-694a038bb4e1d339cfc61bdfd123e0861ed2c5ba74063998f61509f6d56aa3b1R1-R49), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1R3), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L10-R12), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L16-R20), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1R31-R32), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1R84-R89))
*  Remove the `build_meta` parameter and argument from the `strict_mode` function and the `StrictModeVisitor` struct and constructor, and remove the `visit_mut_module_item` method from the `StrictModeVisitor` struct, as the logic for setting the `build_meta` fields was moved to the `HarmonyDetectionScanner` visitor ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L27-R27), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L63), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L86-R83), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-b8fb2da49e5f92ffd820a3778184722aa373c1fc8ea4ce67b3e98e0b832e8368L1-R10), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-b8fb2da49e5f92ffd820a3778184722aa373c1fc8ea4ce67b3e98e0b832e8368L23-R19))
*  Add the `build_info` and `build_meta` parameters and arguments to the `CodeGenerationVisitor` visitor and the `DependencyScanner` visitor to pass the metadata for the modules ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-36bed5f19c83dd2f89f91be1eeda3550ab3255889870eabb6286c6f669e2c6c4R86-R87), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1R31-R32))
*  Add a condition to the `visit_mut_stmt` method of the `StrictModeVisitor` struct to check if the `build_info.strict` field is already true and return early ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-b8fb2da49e5f92ffd820a3778184722aa373c1fc8ea4ce67b3e98e0b832e8368L23-R19))
*  Add new imports to various files to use the new types and fields related to the `build_meta` struct ([link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL9-R12), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL12-R17), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-92a05fddd0f140eaa90842ec788a05f79b66772dfa918770d7ee71b3f0bc50eaL13-R14), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-36bed5f19c83dd2f89f91be1eeda3550ab3255889870eabb6286c6f669e2c6c4L75), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L10-R12), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-2f5104bd5419764ef84b345b76adbee5aca8ffe25ff36c515b66de2aaebcc1f1L6-R7), [link](https://github.com/web-infra-dev/rspack/pull/3121/files?diff=unified&w=0#diff-a4dcb46189b4987eea542ab16a9887f25b0b440b28f17523a39ac03899b88b5bL11-R13))

</details>
