### PR TITLE
ci: run e2e tests in ubuntu-latest

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -150,6 +150,33 @@ jobs:
           path: crates/node_binding/*.node
           if-no-files-found: error
 
+  e2e:
+    name: E2E Testing
+    needs: [select, build]
+    if: inputs.tests && inputs.target == 'x86_64-unknown-linux-gnu'
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.33.0-jammy
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download bindings
+        uses: actions/download-artifact@v3
+        with:
+          name: bindings-${{ inputs.target }}
+          path: crates/node_binding/
+
+      - name: Setup Pnpm
+        uses: ./.github/actions/pnpm-cache
+        with:
+          node-version: 16
+
+      - name: Run e2e
+        shell: bash
+        run: |
+          pnpm run build:js
+          pnpm run test:e2e
+
   test:
     needs: [select, build]
     if: inputs.tests

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/playground"
   },
   "devDependencies": {
-    "playwright-chromium": "1.32.1",
+    "playwright-chromium": "1.33.0",
     "fs-extra": "11.1.1",
     "@types/fs-extra": "11.0.1",
     "jest-environment-node": "29.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,7 +670,7 @@ importers:
       '@types/fs-extra': 11.0.1
       fs-extra: 11.1.1
       jest-environment-node: 29.5.0
-      playwright-chromium: 1.32.1
+      playwright-chromium: 1.33.0
       ws: 8.8.1
     devDependencies:
       '@rspack/core': link:../rspack
@@ -678,7 +678,7 @@ importers:
       '@types/fs-extra': 11.0.1
       fs-extra: 11.1.1
       jest-environment-node: 29.5.0
-      playwright-chromium: 1.32.1
+      playwright-chromium: 1.33.0
       ws: 8.8.1
 
   packages/playground/fixtures/cross-origin-loading:
@@ -18144,17 +18144,17 @@ packages:
     dependencies:
       find-up: 4.1.0
 
-  /playwright-chromium/1.32.1:
-    resolution: {integrity: sha512-TADlQ5xJ4iHIHLKQw361PrleUMHJIRlrw+yDadd3IWS0TCHL+CpMjGhSV9OZbKdsi0oZxjDudwd8B2d6lzjfmw==}
+  /playwright-chromium/1.33.0:
+    resolution: {integrity: sha512-aG2IqRp7Q6vRltZFT+N2stWwDUH2fEUTOTv8RxSKMK5QmIQQoNL9nJvNMIJ3yLuin8+coaa3mhJXjjUheo0+/A==}
     engines: {node: '>=14'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      playwright-core: 1.32.1
+      playwright-core: 1.33.0
     dev: true
 
-  /playwright-core/1.32.1:
-    resolution: {integrity: sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==}
+  /playwright-core/1.33.0:
+    resolution: {integrity: sha512-aizyPE1Cj62vAECdph1iaMILpT0WUDCq3E6rW6I+dleSbBoGbktvJtzS6VHkZ4DKNEOG9qJpiom/ZxO+S15LAw==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fc4f1a</samp>

This pull request adds end-to-end tests for the rspack project using Playwright and updates the playwright-chromium dependency to version 1.33.0 in the `pnpm-lock.yaml` and `packages/playground/package.json` files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3fc4f1a</samp>

* Add a new job to run e2e tests using Playwright for the rspack project ([link](https://github.com/web-infra-dev/rspack/pull/3122/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R153-R179))
  - Specify bash as the shell for the run e2e step ([link](https://github.com/web-infra-dev/rspack/pull/3122/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R228))
* Update the version of `playwright-chromium` used by the playground project and the e2e tests ([link](https://github.com/web-infra-dev/rspack/pull/3122/files?diff=unified&w=0#diff-c69ea5b1e7366dd726b3ca612a4e14fc26221b7fde2af205ff52b9f09cc3daf8L14-R14), [link](https://github.com/web-infra-dev/rspack/pull/3122/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL673-R673), [link](https://github.com/web-infra-dev/rspack/pull/3122/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL681-R681), [link](https://github.com/web-infra-dev/rspack/pull/3122/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18147-R18157))

</details>
