### PR TITLE
chore(examples): remove unused eslint-loader from examples/eslint

### DIFF
--- a/examples/eslint/package.json
+++ b/examples/eslint/package.json
@@ -11,9 +11,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "eslint-rspack-plugin": "4.0.0-alpha",
-    "eslint": "7",
-    "eslint-loader": "4.0.2"
+    "eslint-rspack-plugin": "^4.0.0-alpha",
+    "eslint": "8"
   },
   "sideEffects": false,
   "keywords": [],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,14 +286,12 @@ importers:
   examples/eslint:
     specifiers:
       '@rspack/cli': workspace:*
-      eslint: '7'
-      eslint-loader: 4.0.2
-      eslint-rspack-plugin: 4.0.0-alpha
+      eslint: '8'
+      eslint-rspack-plugin: ^4.0.0-alpha
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
-      eslint: 7.32.0
-      eslint-loader: 4.0.2_eslint@7.32.0
-      eslint-rspack-plugin: 4.0.0-alpha_eslint@7.32.0
+      eslint: 8.40.0
+      eslint-rspack-plugin: 4.0.0-alpha_eslint@8.40.0
 
   examples/extract-license:
     specifiers:
@@ -1738,12 +1736,6 @@ packages:
 
   /@assemblyscript/loader/0.10.1:
     resolution: {integrity: sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==}
-    dev: true
-
-  /@babel/code-frame/7.12.11:
-    resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-    dependencies:
-      '@babel/highlight': 7.18.6
     dev: true
 
   /@babel/code-frame/7.18.6:
@@ -5811,21 +5803,41 @@ packages:
     dev: true
     optional: true
 
-  /@eslint/eslintrc/0.4.3:
-    resolution: {integrity: sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /@eslint-community/eslint-utils/4.4.0_eslint@8.40.0:
+    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+    dependencies:
+      eslint: 8.40.0
+      eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@eslint-community/regexpp/4.5.1:
+    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+    dev: true
+
+  /@eslint/eslintrc/2.0.3:
+    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 7.3.1
+      espree: 9.5.2
       globals: 13.20.0
-      ignore: 4.0.6
+      ignore: 5.2.0
       import-fresh: 3.3.0
-      js-yaml: 3.14.1
+      js-yaml: 4.1.0
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@eslint/js/8.40.0:
+    resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
   /@eyhn/msgpack-stream/2.8.4:
@@ -5837,8 +5849,8 @@ packages:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
     dev: true
 
-  /@humanwhocodes/config-array/0.5.0:
-    resolution: {integrity: sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==}
+  /@humanwhocodes/config-array/0.11.8:
+    resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -5846,6 +5858,11 @@ packages:
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@humanwhocodes/module-importer/1.0.1:
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
     dev: true
 
   /@humanwhocodes/object-schema/1.2.1:
@@ -5917,7 +5934,7 @@ packages:
       '@jest/reporters': 29.0.3
       '@jest/test-result': 29.0.3
       '@jest/transform': 29.4.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 18.15.11
       ansi-escapes: 4.3.2
       chalk: 4.1.2
@@ -5934,7 +5951,7 @@ packages:
       jest-runner: 29.0.3
       jest-runtime: 29.0.3
       jest-snapshot: 29.0.3
-      jest-util: 29.4.3
+      jest-util: 29.5.0
       jest-validate: 29.0.3
       jest-watcher: 29.0.3
       micromatch: 4.0.5
@@ -5951,7 +5968,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/fake-timers': 29.0.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 18.15.11
       jest-mock: 29.0.3
     dev: true
@@ -5987,7 +6004,7 @@ packages:
     resolution: {integrity: sha512-tmbUIo03x0TdtcZCESQ0oQSakPCpo7+s6+9mU19dd71MptkP4zCwoeZqna23//pgbhtT1Wq02VmA9Z9cNtvtCQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@sinonjs/fake-timers': 9.1.2
       '@types/node': 18.15.11
       jest-message-util: 29.0.3
@@ -6125,6 +6142,7 @@ packages:
       '@types/node': 18.15.11
       '@types/yargs': 17.0.12
       chalk: 4.1.2
+    dev: true
 
   /@jest/types/29.5.0:
     resolution: {integrity: sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==}
@@ -6136,7 +6154,6 @@ packages:
       '@types/node': 18.15.11
       '@types/yargs': 17.0.12
       chalk: 4.1.2
-    dev: true
 
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
@@ -9238,14 +9255,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.8.0
-
-  /acorn-jsx/5.3.2_acorn@7.4.1:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    dependencies:
-      acorn: 7.4.1
-    dev: true
 
   /acorn-jsx/5.3.2_acorn@8.8.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -12469,23 +12478,7 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /eslint-loader/4.0.2_eslint@7.32.0:
-    resolution: {integrity: sha512-EDpXor6lsjtTzZpLUn7KmXs02+nIjGcgees9BYjNkWra3jVq5vVa8IoCKgzT2M7dNNeoMBtaSG83Bd40N3poLw==}
-    engines: {node: '>= 10.13.0'}
-    deprecated: This loader has been deprecated. Please use eslint-webpack-plugin
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      eslint: 7.32.0
-      find-cache-dir: 3.3.2
-      fs-extra: 8.1.0
-      loader-utils: 2.0.4
-      object-hash: 2.2.0
-      schema-utils: 2.7.1
-    dev: true
-
-  /eslint-rspack-plugin/4.0.0-alpha_eslint@7.32.0:
+  /eslint-rspack-plugin/4.0.0-alpha_eslint@8.40.0:
     resolution: {integrity: sha512-lpnH2SjvWPWOxrU2+wslp0q9VjFSKfbrpHX/WwS+Tp+NAvJ6CRgzuvOwYwC65DweOkJb+Q/quq/3qQGBudVIFg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -12493,11 +12486,11 @@ packages:
       webpack: ^5.0.0
     dependencies:
       '@types/eslint': 8.37.0
-      eslint: 7.32.0
+      eslint: 8.40.0
       jest-worker: 29.5.0
       micromatch: 4.0.5
       normalize-path: 3.0.0
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
     dev: true
 
   /eslint-scope/5.1.1:
@@ -12507,79 +12500,75 @@ packages:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
-  /eslint-utils/2.1.0:
-    resolution: {integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==}
-    engines: {node: '>=6'}
+  /eslint-scope/7.2.0:
+    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      eslint-visitor-keys: 1.3.0
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
     dev: true
 
-  /eslint-visitor-keys/1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
+  /eslint-visitor-keys/3.4.1:
+    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint-visitor-keys/2.1.0:
-    resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==}
-    engines: {node: '>=10'}
-    dev: true
-
-  /eslint/7.32.0:
-    resolution: {integrity: sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /eslint/8.40.0:
+    resolution: {integrity: sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.12.11
-      '@eslint/eslintrc': 0.4.3
-      '@humanwhocodes/config-array': 0.5.0
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.40.0
+      '@eslint-community/regexpp': 4.5.1
+      '@eslint/eslintrc': 2.0.3
+      '@eslint/js': 8.40.0
+      '@humanwhocodes/config-array': 0.11.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
       debug: 4.3.4
       doctrine: 3.0.0
-      enquirer: 2.3.6
       escape-string-regexp: 4.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-      eslint-visitor-keys: 2.1.0
-      espree: 7.3.1
+      eslint-scope: 7.2.0
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
+      find-up: 5.0.0
+      glob-parent: 6.0.2
       globals: 13.20.0
-      ignore: 4.0.6
+      grapheme-splitter: 1.0.4
+      ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.14.1
+      is-path-inside: 3.0.3
+      js-sdsl: 4.4.0
+      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
       optionator: 0.9.1
-      progress: 2.0.3
-      regexpp: 3.2.0
-      semver: 7.3.8
       strip-ansi: 6.0.1
       strip-json-comments: 3.1.1
-      table: 6.8.1
       text-table: 0.2.0
-      v8-compile-cache: 2.3.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /espree/7.3.1:
-    resolution: {integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /espree/9.5.2:
+    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2_acorn@7.4.1
-      eslint-visitor-keys: 1.3.0
+      acorn: 8.8.0
+      acorn-jsx: 5.3.2_acorn@8.8.0
+      eslint-visitor-keys: 3.4.1
     dev: true
 
   /esprima/4.0.1:
@@ -13402,10 +13391,6 @@ packages:
       es-abstract: 1.20.4
       functions-have-names: 1.2.3
 
-  /functional-red-black-tree/1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
-    dev: true
-
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
@@ -14180,11 +14165,6 @@ packages:
 
   /ignore/3.3.10:
     resolution: {integrity: sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==}
-    dev: true
-
-  /ignore/4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
     dev: true
 
   /ignore/5.2.0:
@@ -15027,13 +15007,13 @@ packages:
     dependencies:
       '@jest/core': 29.0.3
       '@jest/test-result': 29.0.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
       jest-config: 29.0.3
-      jest-util: 29.4.3
+      jest-util: 29.5.0
       jest-validate: 29.0.3
       prompts: 2.4.2
       yargs: 17.6.2
@@ -15057,7 +15037,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@jest/test-sequencer': 29.0.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       babel-jest: 29.4.3_@babel+core@7.21.0
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -15070,7 +15050,7 @@ packages:
       jest-regex-util: 29.4.3
       jest-resolve: 29.0.3
       jest-runner: 29.0.3
-      jest-util: 29.4.3
+      jest-util: 29.5.0
       jest-validate: 29.0.3
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -15095,7 +15075,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@jest/test-sequencer': 29.0.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 18.15.11
       babel-jest: 29.4.3_@babel+core@7.21.0
       chalk: 4.1.2
@@ -15109,7 +15089,7 @@ packages:
       jest-regex-util: 29.4.3
       jest-resolve: 29.0.3
       jest-runner: 29.0.3
-      jest-util: 29.4.3
+      jest-util: 29.5.0
       jest-validate: 29.0.3
       micromatch: 4.0.5
       parse-json: 5.2.0
@@ -15154,7 +15134,7 @@ packages:
     dependencies:
       '@jest/environment': 29.0.3
       '@jest/fake-timers': 29.0.3
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 18.15.11
       jest-mock: 29.0.3
       jest-util: 29.5.0
@@ -15219,7 +15199,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@babel/code-frame': 7.18.6
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
       graceful-fs: 4.2.10
@@ -15248,7 +15228,7 @@ packages:
     resolution: {integrity: sha512-ort9pYowltbcrCVR43wdlqfAiFJXBx8l4uJDsD8U72LgBcetvEp+Qxj1W9ZYgMRoeAo+ov5cnAGF2B6+Oth+ww==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 18.15.11
     dev: true
 
@@ -15407,7 +15387,7 @@ packages:
     resolution: {integrity: sha512-ToSGORAz4SSSoqxDSylWX8JzkOQR7zoBtNRsA7e+1WUX5F8jrOwaNpuh1YfJHJKDHXLHmObv5eOjejUd+/Ws+Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
-      '@jest/types': 29.4.3
+      '@jest/types': 29.5.0
       '@types/node': 18.15.11
       chalk: 4.1.2
       ci-info: 3.3.2
@@ -15502,6 +15482,10 @@ packages:
   /jiti/1.18.2:
     resolution: {integrity: sha512-QAdOptna2NYiSSpv0O/BwoHBSmz4YhpzJHyi+fnMRTXFjp7B8i/YG5Z8IfusxB1ufjcD2Sre1F3R+nX3fvy7gg==}
     hasBin: true
+    dev: true
+
+  /js-sdsl/4.4.0:
+    resolution: {integrity: sha512-FfVSdx6pJ41Oa+CF7RDaFmTnCaFhua+SNYQX74riGOpl96x+2jQCqEfQ2bnXu/5DPCqlRuiqyvTJM0Qjz26IVg==}
     dev: true
 
   /js-stringify/1.0.2:
@@ -17478,11 +17462,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  /object-hash/2.2.0:
-    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
-    engines: {node: '>= 6'}
-    dev: true
-
   /object-hash/3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
@@ -19415,11 +19394,6 @@ packages:
       define-properties: 1.1.4
       functions-have-names: 1.2.3
 
-  /regexpp/3.2.0:
-    resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
-    engines: {node: '>=8'}
-    dev: true
-
   /regexpu-core/5.2.2:
     resolution: {integrity: sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==}
     engines: {node: '>=4'}
@@ -19990,7 +19964,6 @@ packages:
       '@types/json-schema': 7.0.11
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
-    dev: true
 
   /schema-utils/4.0.0:
     resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==}
@@ -21434,7 +21407,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       jest-worker: 27.5.1
-      schema-utils: 3.1.1
+      schema-utils: 3.1.2
       serialize-javascript: 6.0.0
       terser: 5.16.1
       webpack: 5.74.0
@@ -22311,10 +22284,6 @@ packages:
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-    dev: true
-
-  /v8-compile-cache/2.3.0:
-    resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
 
   /v8-to-istanbul/9.0.1:


### PR DESCRIPTION
## Summary

eslint-loader is deprecated by the way.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65a51d1</samp>

This pull request updates the code quality tools and configuration for the `examples/eslint` project. It upgrades `eslint` and `eslint-rspack-plugin` to the latest versions, fixes some dependency issues in the lockfile, and applies the new linting rules to the code.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65a51d1</samp>

*  Update `eslint` and `eslint-rspack-plugin` dependencies to latest versions in `examples/eslint/package.json` ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-5a19f7a0bcfc2cc5976ae1e22a8068e803a50a9b3309bb121fea3bacc518aea8L14-R15),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-5a19f7a0bcfc2cc5976ae1e22a8068e803a50a9b3309bb121fea3bacc518aea8L22-R21))
*  Sync `eslint` and `eslint-rspack-plugin` dependencies in `pnpm-lock.yaml` with `examples/eslint/package.json` ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL289-R294),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12496-R12493))
*  Remove unused dependencies from `pnpm-lock.yaml`, such as `@babel/code-frame`, `acorn-jsx`, `functional-red-black-tree`, `ignore`, `object-hash`, `regexpp`, and `v8-compile-cache` ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1743-L1748),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9242-L9249),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13405-L13408),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL14185-L14189),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL17481-L17485),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL19418-L19422),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL22316-L22319))
*  Add new dependencies to `pnpm-lock.yaml`, such as `@eslint-community/eslint-utils`, `@eslint-community/regexpp`, `@eslint/js`, and `js-sdsl`, which are required by `eslint` version 8 ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5838-R5842),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5840-R5853),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5863-R5867),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15487-R15490))
*  Update existing dependencies in `pnpm-lock.yaml` to match the new versions of `eslint` and `eslint-rspack-plugin`, such as `@eslint/eslintrc`, `@humanwhocodes/config-array`, `espree`, and `schema-utils` ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5814-R5831),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5863-R5867),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12510-R12527),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12540-R12551),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12564-R12571),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL19993),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL21437-R21410))
*  Update `@jest/types` and `jest-util` dependencies in `pnpm-lock.yaml` to version 29.5.0, which is a minor update with some bug fixes and enhancements ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5920-R5937),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5937-R5954),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5954-R5971),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5990-R6007),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15030-R15010),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15036-R15016),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15060-R15040),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15073-R15053),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15098-R15078),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15112-R15092),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15157-R15137),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15222-R15202),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15251-R15231),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL15410-R15390))
*  Fix `dev` property in `pnpm-lock.yaml` for `@jest/fake-timers` and `@jest/source-map` dependencies, to correctly reflect their usage as development or production dependencies ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6145),[link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6139))
*  Remove `eslint-loader` and `eslint` dependencies from `pnpm-lock.yaml` for `examples/eslint` project, as they are no longer used ([link](https://github.com/web-infra-dev/rspack/pull/3123/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12472-R12481))

</details>
