### PR TITLE
chore: enable emitCss for svelte

### DIFF
--- a/examples/svelte/rspack.config.js
+++ b/examples/svelte/rspack.config.js
@@ -32,8 +32,8 @@ const config = {
 							compilerOptions: {
 								dev: !prod
 							},
-							// TODO: checkout https://github.com/sveltejs/svelte-loader/blob/5373e5c9b005241e9974b13746f9f4ad05260d4a/index.js#L75
-							// emitCss: prod,
+
+							emitCss: prod,
 							hotReload: !prod,
 							preprocess: sveltePreprocess({ sourceMap: !prod, postcss: true })
 						}


### PR DESCRIPTION
## Related issue (if exists)
with the support of inline matchrequest, we finally support emitCss of svelte-loader
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18af1fa</samp>

Enable `emitCss` option for svelte-loader in `rspack.config.js`. This improves CSS handling and compatibility in production mode.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18af1fa</samp>

* Enable CSS extraction for svelte-loader in production mode ([link](https://github.com/web-infra-dev/rspack/pull/3136/files?diff=unified&w=0#diff-83384be12d0c7220d548c96dcb537258476885fff19d0fa9d0c8b529c4d9ccbbL35-R36))
* Remove outdated TODO comment about svelte-loader issue ([link](https://github.com/web-infra-dev/rspack/pull/3136/files?diff=unified&w=0#diff-83384be12d0c7220d548c96dcb537258476885fff19d0fa9d0c8b529c4d9ccbbL35-R36))

</details>
