### PR TITLE
chore(examples/plugin-compat): disable verbose log && add inline css

### DIFF
--- a/examples/plugin-compat/index.ejs
+++ b/examples/plugin-compat/index.ejs
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html class="dark">
+	<head>
+		<meta charset="utf-8" />
+		<% if (inlineCss) { %>
+		<style>
+			<%= inlineCss %>
+		</style>
+		<% } %>
+	</head>
+	<body>
+		<div id="__plugin"></div>
+	</body>
+</html>

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -4,13 +4,13 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 const minifyPlugin = require("@rspack/plugin-minify");
-const GeneratePackageJsonPlugin = require('generate-package-json-webpack-plugin');
-const licensePlugin = require('license-webpack-plugin');
+const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
+const licensePlugin = require("license-webpack-plugin");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	target: "node",
 	mode: "development",
-	stats: { all: true },
+	stats: { errors: true, warnings: true },
 	entry: {
 		main: "./src/index.js"
 	},
@@ -36,7 +36,12 @@ const config = {
 			}
 		]),
 		new HtmlPlugin({
-			template: "./index.html"
+			template: "./index.ejs",
+			templateParameters: (compilation, assets, assetTags, options) => {
+				return {
+					inlineCss: compilation.assets["main.css"].source()
+				};
+			}
 		}),
 		new StatsWriterPlugin({
 			stats: { all: true },
@@ -46,10 +51,10 @@ const config = {
 		new licensePlugin.LicenseWebpackPlugin({
 			stats: {
 				warnings: false,
-				errors: false,
-			  },
+				errors: false
+			},
 			perChunkOutput: true,
-			outputFilename: `3rdpartylicenses.txt`,
+			outputFilename: `3rdpartylicenses.txt`
 		})
 	]
 };


### PR DESCRIPTION
## Related issue (if exists)
related to https://github.com/web-infra-dev/rspack/discussions/3126

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b8f2ffd</samp>

This pull request improves the plugin compatibility of Rspack by using a custom template file with inline CSS for the HtmlPlugin. It also fixes a syntax error and reduces the console output in the Rspack configuration file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b8f2ffd</samp>

*  Add a new template file `index.ejs` for the HtmlPlugin to use and pass the inline CSS from the `main.css` asset to it ([link](https://github.com/web-infra-dev/rspack/pull/3138/files?diff=unified&w=0#diff-e363477560d6e8eef92fc13dc6e9f9e01d4e271771476129df66b66ec2922f18R1-R14), [link](https://github.com/web-infra-dev/rspack/pull/3138/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96L39-R44))
*  Reduce the console output of the Rspack by only showing errors and warnings in the stats ([link](https://github.com/web-infra-dev/rspack/pull/3138/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96L7-R13))
*  Fix a syntax error in the licensePlugin configuration by removing the trailing commas ([link](https://github.com/web-infra-dev/rspack/pull/3138/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96L49-R57))

</details>
