### PR TITLE
chore: clean up Cargo.toml for node_binding and rspack_binding_options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,11 @@ members  = ["crates/*"]
 resolver = "2"          # See https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 
 [workspace.dependencies]
-anyhow             = { version = "1.0.70" }
+anyhow             = { version = "1.0.70", features = ["backtrace"] }
 async-recursion    = { version = "1.0.4" }
 async-scoped       = { version = "0.7.1" }
 async-trait        = { version = "0.1.68" }
+backtrace          = "0.3"
 better_scoped_tls  = { version = "0.1.0" }
 bitflags           = { version = "1.3.2" }
 colored            = { version = "2.0.0" }
@@ -14,7 +15,7 @@ dashmap            = { version = "5.4.0" }
 derivative         = { version = "2.2.0" }
 derive_builder     = { version = "0.11.2" }
 futures            = { version = "0.3.28" }
-futures-util       = "0.3.28"
+futures-util       = { version = "0.3.28" }
 glob               = { version = "0.3.1" }
 hashlink           = { version = "0.8.1" }
 indexmap           = { version = "1.9.3" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -6,8 +6,6 @@ publish    = false
 repository = "https://github.com/web-infra-dev/rspack"
 version    = "0.1.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib"]
 
@@ -21,28 +19,27 @@ rspack_identifier      = { path = "../rspack_identifier" }
 rspack_napi_shared     = { path = "../rspack_napi_shared" }
 rspack_tracing         = { path = "../rspack_tracing" }
 
-anyhow      = { version = "1.0.65", features = ["backtrace"] }
-async-trait = "0.1.53"
-backtrace   = "0.3"
-dashmap     = "5.4.0"
-futures     = "0.3"
-once_cell   = "1"
-tokio       = { version = "1.28.0", features = ["rt", "rt-multi-thread", "macros"] }
-tracing     = "0.1.34"
+anyhow      = { workspace = true }
+async-trait = { workspace = true }
+backtrace   = { workspace = true }
+dashmap     = { workspace = true }
+futures     = { workspace = true }
+once_cell   = { workspace = true }
+tokio       = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
+tracing     = { workspace = true }
 
-# Pinned
-napi        = { version = "=2.12.5" }
-napi-derive = { version = "=2.12.3" }
-napi-sys    = { version = "=2.2.3" }
+napi        = { workspace = true }
+napi-derive = { workspace = true }
+napi-sys    = { workspace = true }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
-mimalloc-rust = { version = "0.2" }
+mimalloc-rust = { workspace = true }
 
 [target.'cfg(all(target_os = "linux", not(all(target_env = "musl", target_arch = "aarch64"))))'.dependencies]
-mimalloc-rust = { version = "0.2", features = ["local-dynamic-tls"] }
+mimalloc-rust = { workspace = true, features = ["local-dynamic-tls"] }
 
 [build-dependencies]
-napi-build = { version = "=2.0.1" }
+napi-build = { workspace = true }
 
 [dev-dependencies]
-testing_macros = { version = "0.2.5" }
+testing_macros = { workspace = true }

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -6,14 +6,6 @@ repository = "https://github.com/web-infra-dev/rspack"
 version    = "0.1.0"
 
 [dependencies]
-anyhow                                  = { workspace = true, features = ["backtrace"] }
-async-trait                             = { workspace = true }
-better_scoped_tls                       = { workspace = true }
-derivative                              = { workspace = true }
-glob                                    = "0.3.1"
-indexmap                                = { workspace = true }
-napi                                    = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
-napi-derive                             = { workspace = true }
 rspack_binding_macros                   = { path = "../rspack_binding_macros" }
 rspack_core                             = { path = "../rspack_core" }
 rspack_error                            = { path = "../rspack_error" }
@@ -40,9 +32,18 @@ rspack_plugin_split_chunks              = { path = "../rspack_plugin_split_chunk
 rspack_plugin_split_chunks_new          = { path = "../rspack_plugin_split_chunks_new" }
 rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }
 rspack_regex                            = { path = "../rspack_regex" }
-serde                                   = { workspace = true, features = ["derive"] }
-serde_json                              = { workspace = true }
-swc_core                                = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-swc_plugin_import                       = { workspace = true }
-tokio                                   = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
-tracing                                 = { workspace = true }
+
+anyhow            = { workspace = true, features = ["backtrace"] }
+async-trait       = { workspace = true }
+better_scoped_tls = { workspace = true }
+derivative        = { workspace = true }
+glob              = { workspace = true }
+indexmap          = { workspace = true }
+napi              = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
+napi-derive       = { workspace = true }
+serde             = { workspace = true, features = ["derive"] }
+serde_json        = { workspace = true }
+swc_core          = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
+swc_plugin_import = { workspace = true }
+tokio             = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
+tracing           = { workspace = true }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e8542d7</samp>

This pull request contains minor improvements to the `Cargo.toml` files of three crates in the `rspack` project. It reverts, removes, or reorganizes some dependencies and comments to enhance the code quality and avoid potential issues.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e8542d7</samp>

* Enable backtrace feature for `anyhow` dependency in workspace, and add `backtrace` dependency ([link](https://github.com/web-infra-dev/rspack/pull/3139/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L6-R10))
* Remove redundant comment line in `node_binding` crate ([link](https://github.com/web-infra-dev/rspack/pull/3139/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L9-L10))
* Use `workspace = true` syntax for dependencies in `node_binding` and `rspack_binding_options` crates, to avoid duplication and inconsistency ([link](https://github.com/web-infra-dev/rspack/pull/3139/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L24-R45), [link](https://github.com/web-infra-dev/rspack/pull/3139/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL9-L16))
* Reorder dependencies alphabetically in `rspack_binding_options` crate, to follow Rust style guide and common practice ([link](https://github.com/web-infra-dev/rspack/pull/3139/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aL43-R49))
* Revert mistaken change in workspace `Cargo.toml` ([link](https://github.com/web-infra-dev/rspack/pull/3139/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17-R18))

</details>
