### PR TITLE
chore(rspack-cli): run jest with --runInBand

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -12,7 +12,7 @@
     "build": "rimraf dist/ && tsc -b --force",
     "clean": "rimraf dist/ && tsc -b --clean",
     "dev": "tsc -b -w",
-    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --verbose --silent=false"
+    "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Related issue (if exists)

The flacky test may be caused by running tests in parallel.

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9881cc</samp>

Modified the `test` script in `packages/rspack-cli/package.json` to run jest tests serially. This fixes a memory issue with the GitHub Actions workflow.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9881cc</samp>

*  Modify the `test` script to use the `--runInBand` option for jest to avoid memory issues in GitHub Actions ([link](https://github.com/web-infra-dev/rspack/pull/3140/files?diff=unified&w=0#diff-339a67bf052f8e38b22471d780d60e45dc8680ad96596507b14ee2a34862eafcL15-R15))

</details>
