### PR TITLE
fix: getAssets error when source is null

### DIFF
--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -355,8 +355,9 @@ export class Compilation {
 		const assets = this.#inner.getAssets();
 
 		return assets.map(asset => {
-			// @ts-expect-error
-			const source = createSourceFromRaw(asset.source);
+			const source = asset.source
+				? createSourceFromRaw(asset.source)
+				: undefined;
 			return {
 				...asset,
 				source


### PR DESCRIPTION
## Related issue (if exists)

Closed https://github.com/web-infra-dev/rspack/issues/3147
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db1f4a0</samp>

Fix TypeScript error and refactor `createSourceFromRaw` usage in `compilation.ts`. This change improves the type safety and readability of the `Compilation` class.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at db1f4a0</samp>

* Fix TypeScript error by checking asset source property and assigning result of `createSourceFromRaw` to variable ([link](https://github.com/web-infra-dev/rspack/pull/3148/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L358-R360))
* Use `source` variable in `map` callback to create `Source` instances and add them to `compilation.assets` ([link](https://github.com/web-infra-dev/rspack/pull/3148/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L358-R360))

</details>
