### PR TITLE
fix: context module elimated

### DIFF
--- a/crates/rspack/tests/tree-shaking/context-module-elimated/child/child/index.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/child/child/index.js
@@ -1,0 +1,1 @@
+export const value = "dynamic";

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/child/index.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/child/index.js
@@ -1,0 +1,1 @@
+export const value = "dynamic";

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/expected/main.js
@@ -1,59 +1,10 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./child Sync  recursive ^\.\/.*\.js$": function (module, exports, __webpack_require__) {
-var map = {"./child/index.js": "./child/child/index.js","./index.js": "./child/index.js",};
-function webpackContext(req) {
-var id = webpackContextResolve(req);
-
-return __webpack_require__(id);
-
-}
-function webpackContextResolve(req) {
-
-      if(!__webpack_require__.o(map, req)) {
-        var e = new Error("Cannot find module '" + req + "'");
-        e.code = 'MODULE_NOT_FOUND';
-        throw e;
-      }
-      return map[req];
-    
-}
-webpackContext.id = './child Sync  recursive ^\.\/.*\.js$';
-
-      webpackContext.keys = function webpackContextKeys() {
-        return Object.keys(map);
-      };
-      webpackContext.resolve = webpackContextResolve;
-      module.exports = webpackContext;
-      },
-"./child/child/index.js": function (module, exports, __webpack_require__) {
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-Object.defineProperty(exports, "value", {
-    enumerable: true,
-    get: function() {
-        return value;
-    }
-});
-const value = "dynamic";
-},
-"./child/index.js": function (module, exports, __webpack_require__) {
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-Object.defineProperty(exports, "value", {
-    enumerable: true,
-    get: function() {
-        return value;
-    }
-});
-const value = "dynamic";
-},
 "./index.js": function (module, exports, __webpack_require__) {
-let a = "index";
-__webpack_require__('./child Sync  recursive ^\.\/.*\.js$')(`./child/${a}.js`.replace("./child/", "./"));
+"use strict";
+;
+function test() {
+    a;
+}
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/expected/main.js
@@ -1,0 +1,64 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
+"./child Sync  recursive ^\.\/.*\.js$": function (module, exports, __webpack_require__) {
+var map = {"./child/index.js": "./child/child/index.js","./index.js": "./child/index.js",};
+function webpackContext(req) {
+var id = webpackContextResolve(req);
+
+return __webpack_require__(id);
+
+}
+function webpackContextResolve(req) {
+
+      if(!__webpack_require__.o(map, req)) {
+        var e = new Error("Cannot find module '" + req + "'");
+        e.code = 'MODULE_NOT_FOUND';
+        throw e;
+      }
+      return map[req];
+    
+}
+webpackContext.id = './child Sync  recursive ^\.\/.*\.js$';
+
+      webpackContext.keys = function webpackContextKeys() {
+        return Object.keys(map);
+      };
+      webpackContext.resolve = webpackContextResolve;
+      module.exports = webpackContext;
+      },
+"./child/child/index.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "value", {
+    enumerable: true,
+    get: function() {
+        return value;
+    }
+});
+const value = "dynamic";
+},
+"./child/index.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "value", {
+    enumerable: true,
+    get: function() {
+        return value;
+    }
+});
+const value = "dynamic";
+},
+"./index.js": function (module, exports, __webpack_require__) {
+let a = "index";
+__webpack_require__('./child Sync  recursive ^\.\/.*\.js$')(`./child/${a}.js`.replace("./child/", "./"));
+},
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
+
+}
+]);

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/index.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/index.js
@@ -1,0 +1,2 @@
+let a = "index";
+require(`./child/${a}.js`);

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/index.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/index.js
@@ -1,2 +1,4 @@
-let a = "index";
-require(`./child/${a}.js`);
+import {a} from './lib.js'
+function test() {
+	a
+}

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/lib.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/lib.js
@@ -1,0 +1,2 @@
+export const a = "";
+require(`./child/${a}.js`);

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/package.json
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/package.json
@@ -1,0 +1,3 @@
+{
+  "sideEffects": false
+}

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/test.config.json
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/test.config.json
@@ -3,7 +3,7 @@
     "sideEffects": "true"
   },
   "builtins": {
-    "treeShaking": "true",
+    "treeShaking": "module",
     "define": {
       "process.env.NODE_ENV": "'development'"
     }

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/test.config.json
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/test.config.json
@@ -1,0 +1,11 @@
+{
+  "optimization": {
+    "sideEffects": "true"
+  },
+  "builtins": {
+    "treeShaking": "true",
+    "define": {
+      "process.env.NODE_ENV": "'development'"
+    }
+  }
+}

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -383,7 +383,6 @@ impl<'a> CodeSizeOptimizer<'a> {
             .entry_module_identifiers
             .contains(&module_identifier)
         {
-          dbg!(&module_identifier);
           continue;
         } else {
         }

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -479,7 +479,7 @@ impl<'a> CodeSizeOptimizer<'a> {
             continue;
           }
 
-          // we need to pushed dependencies of context module instead of only its self, context module doesn't have ast,
+          // we need to push either dependencies of context module instead of only its self, context module doesn't have ast,
           // which imply it will be treated as a external module in analyze phase
           if matches!(
             dependency.dependency_type(),
@@ -487,7 +487,7 @@ impl<'a> CodeSizeOptimizer<'a> {
               | DependencyType::RequireContext
               | DependencyType::ImportContext
           ) {
-            let deps_of_context_module = self
+            let deps_module_id_of_context_module = self
               .compilation
               .module_graph
               .dependencies_by_module_identifier(module_identifier)
@@ -504,7 +504,7 @@ impl<'a> CodeSizeOptimizer<'a> {
                   .collect::<Vec<_>>()
               })
               .unwrap_or_default();
-            q.extend(deps_of_context_module);
+            q.extend(deps_module_id_of_context_module);
           }
           q.push_back(*module_identifier);
         }

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -346,15 +346,8 @@ impl<'a> CodeSizeOptimizer<'a> {
       // pruning
       let mut visited_symbol_node_index: HashSet<NodeIndex> = HashSet::default();
       let mut visited = IdentifierSet::default();
-      let context_entry_modules = self.bailout_modules.iter().filter_map(|(k, v)| {
-        if v.contains(BailoutFlag::CONTEXT_MODULE) {
-          Some(*k)
-        } else {
-          None
-        }
-      });
       let mut q = VecDeque::from_iter(
-        self.compilation.entry_modules(), // .chain(context_entry_modules),
+        self.compilation.entry_modules(), //
       );
       while let Some(module_identifier) = q.pop_front() {
         if visited.contains(&module_identifier) {
@@ -498,7 +491,7 @@ impl<'a> CodeSizeOptimizer<'a> {
                       .compilation
                       .module_graph
                       .module_identifier_by_dependency_id(dep)
-                      .map(|ident| *ident)
+                      .cloned()
                   })
                   .collect::<Vec<_>>()
               })

--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -254,7 +254,7 @@ pub fn run_after_pass(
             &compilation.include_module_ids,
             compilation.options.clone()
           ),
-          builtin_tree_shaking.is_true() && need_tree_shaking
+          builtin_tree_shaking.enable() && need_tree_shaking
         ),
         Optional::new(
           Repeat::new(dce(Config::default(), unresolved_mark)),


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc8830d</samp>

This pull request improves the tree-shaking optimization for context modules in `rspack_core` and adds a new test case for it in `rspack_plugin_javascript`. It also fixes a minor inconsistency in the `mut` function and a typo in `optimizer.rs`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc8830d</samp>

*  Fix a bug that causes context entry modules to be included in the bundle even if they are not reachable from the entry modules by removing them from the initial queue of reachable modules in `optimize` function ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL357-R357))
*  Improve the tree-shaking optimization for context modules by analyzing their actual dependencies instead of treating them as external modules in `optimize` function ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL477-R509))
*  Add a test case for tree-shaking context modules that are dynamically required or imported based on a variable in `crates/rspack/tests/tree-shaking/context-module-elimated` folder ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-3061e4a3b1fd4b0c68e36c9f2c97ebaf42017be95519123b16d260acb4a4b55cR1), [link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-7d1a36c91af7b7001210c74be2bfc3018746d76339a26a4b12055023575ba2ecR1), [link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-a6df6c6d891b10583025a558b1cbe0fe6d1fef91eb9e5d0f61316581af71f8abL1-R14), [link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-6893de06c9e3ba51aaac3949c645dd149134d0249521918c93036ec0f7b22bfbR1-R4), [link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-ae08b26663652f7b5ec8340cd95b44d0ee443875cdbb66ab76df32c230ea396eR1-R2), [link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-3d836cd34915acf17a543d52d552dd962e3edbe91db7bd0b4cb2b6d9e23178c6R1-R3), [link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-19bccde4461b9d37f33f121cfe155a7b3dea142085991af7032ac9155093e58fR1-R11))
*  Use the `enable` method instead of the `is_true` method for the `builtin_tree_shaking` option in `mut` function for consistency and clarity ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L257-R257))
*  Fix a typo in the `optimize` function to use the correct variable name `module_identifier` instead of `module_ident` for consistency and readability ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL429-R427))
*  Add a debug statement to the `optimize` function to print the current module identifier being processed by the queue for debugging purposes ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eR386))
*  Remove an empty line from the `optimize` function for formatting and style ([link](https://github.com/web-infra-dev/rspack/pull/3151/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL467))

</details>
