### PR TITLE
feat(plugin-node-polyfill): add process & buffer to node-polyfill

### DIFF
--- a/examples/node-polyfill/index.html
+++ b/examples/node-polyfill/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/node-polyfill/package.json
+++ b/examples/node-polyfill/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "example-node-polyfill",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*",
+    "@rspack/plugin-node-polyfill": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/node-polyfill/rspack.config.js
+++ b/examples/node-polyfill/rspack.config.js
@@ -1,0 +1,17 @@
+const polyfillPlugin = require("@rspack/plugin-node-polyfill");
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	context: __dirname,
+	entry: {
+		main: "./src/index.js"
+	},
+	builtins: {
+		html: [
+			{
+				template: "./index.html"
+			}
+		]
+	},
+	plugins: [new polyfillPlugin()]
+};
+module.exports = config;

--- a/examples/node-polyfill/src/index.js
+++ b/examples/node-polyfill/src/index.js
@@ -1,0 +1,4 @@
+const util = require("util");
+console.log("procss:", process.version);
+console.log("buffer", Buffer.from("abcd"));
+console.log("util:", util.format("%s:%s", "foo", "bar"));

--- a/packages/rspack-plugin-node-polyfill/src/index.js
+++ b/packages/rspack-plugin-node-polyfill/src/index.js
@@ -32,9 +32,22 @@ const PolyfilledBuiltinModules = {
 };
 module.exports = class PolyfillBuiltinsPlugin {
 	apply(compiler) {
-		compiler.options.resolve.alias = {
+		const provide = {
+			Buffer: [require.resolve("buffer/"), "Buffer"],
+			console: [require.resolve("console-browserify")],
+			process: [require.resolve("process/browser")]
+		};
+
+		compiler.options.builtins = {
+			...compiler.options.builtins,
+			provide: {
+				...compiler.options.builtins?.provide,
+				...provide
+			}
+		};
+		compiler.options.resolve.fallback = {
 			...PolyfilledBuiltinModules,
-			...compiler.options.resolve.alias
+			...compiler.options.resolve.fallback
 		};
 	}
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,14 @@ importers:
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
 
+  examples/node-polyfill:
+    specifiers:
+      '@rspack/cli': workspace:*
+      '@rspack/plugin-node-polyfill': workspace:*
+    devDependencies:
+      '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/plugin-node-polyfill': link:../../packages/rspack-plugin-node-polyfill
+
   examples/perfsee:
     specifiers:
       '@perfsee/webpack': 1.6.0


### PR DESCRIPTION
## Related issue (if exists)
related to #2994, port the rest of https://github.com/Richienb/node-polyfill-webpack-plugin/blob/main/index.js#L30-L33
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 497e86a</samp>

This pull request adds a new example project called `node-polyfill` that demonstrates how to use the `@rspack/plugin-node-polyfill` package to bundle and serve a web application that uses node built-in modules. It also updates the plugin code to use the `resolve.fallback` option instead of the `resolve.alias` option for webpack 5 compatibility.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 497e86a</samp>

*  Add a node-polyfill example project that demonstrates how to use node built-in modules in the browser ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-b8638db6d7d0042a2fe83085ad14049f9e5655b1e8633ffc1759e4607dfee93cR1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-c269b09807155d650a5719fe42a2e6e930d560df1c5672379ebd399246e2c5a4L1-R18), [link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-ad5ff484e95ed1d9b26e1c6502c2e053c88e14fb483c4a87005b635f93842cd1R1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-fa5d65ba643d691c74a8b7a7712366e14e1fce9eb6822e7a3d59f9b46fd3e00aR1-R4), [link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR390-R397))
  * Create a basic HTML template for the project in `examples/node-polyfill/index.html` ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-b8638db6d7d0042a2fe83085ad14049f9e5655b1e8633ffc1759e4607dfee93cR1-R12))
  * Initialize a package.json file for the project in `examples/node-polyfill/package.json` with the relevant metadata and devDependencies ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-c269b09807155d650a5719fe42a2e6e930d560df1c5672379ebd399246e2c5a4L1-R18))
  * Configure the rspack CLI options for the project in `examples/node-polyfill/rspack.config.js`, using the `@rspack/plugin-node-polyfill` plugin and the `builtins` option ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-ad5ff484e95ed1d9b26e1c6502c2e053c88e14fb483c4a87005b635f93842cd1R1-R17))
  * Write a sample JavaScript code that requires node modules in `examples/node-polyfill/src/index.js` and logs some information to the console ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-fa5d65ba643d691c74a8b7a7712366e14e1fce9eb6822e7a3d59f9b46fd3e00aR1-R4))
  * Update the pnpm-lock.yaml file with the entry for the project and its dependencies ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR390-R397))
*  Update the `@rspack/plugin-node-polyfill` plugin to use the `resolve.fallback` and `provide` options for webpack 5 compatibility and global variable injection ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-437889559491286bfcc191e0157f6bcb92e5c6864370cfe4304f318938a8a830L35-R50))
  * Replace the `resolve.alias` option with the `resolve.fallback` option in the `PolyfillBuiltinsPlugin` class in `packages/rspack-plugin-node-polyfill/src/index.js` ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-437889559491286bfcc191e0157f6bcb92e5c6864370cfe4304f318938a8a830L35-R50))
  * Add a `provide` option to the `builtins` option in the same file, which specifies the modules that should be exposed as global variables in the browser, such as `buffer`, `console`, and `process` ([link](https://github.com/web-infra-dev/rspack/pull/3154/files?diff=unified&w=0#diff-437889559491286bfcc191e0157f6bcb92e5c6864370cfe4304f318938a8a830L35-R50))

</details>
