### PR TITLE
fix(create-rspack): fix compatible problem with node@14

### DIFF
--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -8,7 +8,7 @@ import {
 	RspackOptions,
 	MultiRspackOptions
 } from "@rspack/core";
-import path from "node:path";
+import path from "path";
 
 const defaultRoot = "dist";
 export class PreviewCommand implements RspackCommand {


### PR DESCRIPTION
## Related issue (if exists)
node:path is not supported in node@14
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->

