### PR TITLE
feat(core): support webpack-manifest-plugin

### DIFF
--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -19,6 +19,6 @@
     "license-webpack-plugin": "^4.0.2",
     "webpack-bundle-analyzer": "4.7.0",
     "webpack-stats-plugin": "1.1.1",
-    "webpack-manifest-plugin": "5.0.0"
+    "rspack-manifest-plugin": "5.0.0-alpha0"
   }
 }

--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -18,6 +18,7 @@
     "generate-package-json-webpack-plugin": "^2.6.0",
     "license-webpack-plugin": "^4.0.2",
     "webpack-bundle-analyzer": "4.7.0",
-    "webpack-stats-plugin": "1.1.1"
+    "webpack-stats-plugin": "1.1.1",
+    "webpack-manifest-plugin": "5.0.0"
   }
 }

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -4,16 +4,18 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 const minifyPlugin = require("@rspack/plugin-minify");
-const manifestPlugin = require("webpack-manifest-plugin").WebpackManifestPlugin;
+const manifestPlugin = require("rspack-manifest-plugin").WebpackManifestPlugin;
 const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
 const licensePlugin = require("license-webpack-plugin");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	target: "node",
-	mode: "development",
 	stats: { errors: true, warnings: true },
 	entry: {
 		main: "./src/index.js"
+	},
+	output: {
+		filename: "[contenthash:8].js"
 	},
 	optimization: {
 		minimize: true,
@@ -39,8 +41,11 @@ const config = {
 		new HtmlPlugin({
 			template: "./index.ejs",
 			templateParameters: (compilation, assets, assetTags, options) => {
+				const cssFile = Object.keys(compilation.assets).filter(x =>
+					x.endsWith(".css")
+				)[0];
 				return {
-					inlineCss: compilation.assets["main.css"].source()
+					inlineCss: compilation.assets[cssFile].source()
 				};
 			}
 		}),
@@ -58,7 +63,24 @@ const config = {
 			outputFilename: `3rdpartylicenses.txt`
 		}),
 		new manifestPlugin({
-			fileName: "rspack-manifest.json"
+			fileName: "rspack-manifest.json",
+			generate: (seed, files, entries) => {
+				const manifestFiles = files.reduce((manifest, file) => {
+					manifest[file.name] = file.path;
+					return manifest;
+				}, seed);
+				const entrypointFiles = Object.keys(entries).reduce(
+					(previous, name) =>
+						previous.concat(
+							entries[name].filter(fileName => !fileName.endsWith(".map"))
+						),
+					[]
+				);
+				return {
+					files: manifestFiles,
+					entrypoints: entrypointFiles
+				};
+			}
 		})
 	]
 };

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -4,6 +4,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("@rspack/plugin-html").default;
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
 const minifyPlugin = require("@rspack/plugin-minify");
+const manifestPlugin = require("webpack-manifest-plugin").WebpackManifestPlugin;
 const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
 const licensePlugin = require("license-webpack-plugin");
 /** @type {import('@rspack/cli').Configuration} */
@@ -55,6 +56,9 @@ const config = {
 			},
 			perChunkOutput: true,
 			outputFilename: `3rdpartylicenses.txt`
+		}),
+		new manifestPlugin({
+			fileName: "rspack-manifest.json"
 		})
 	]
 };

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -627,7 +627,10 @@ export class Compilation {
 			return {
 				...chunk,
 				name: chunk.names.length > 0 ? chunk.names[0] : "",
-				modules: this.__internal__getAssociatedModules(chunk)
+				modules: this.__internal__getAssociatedModules(chunk),
+				isOnlyInitial: function () {
+					return this.initial;
+				}
 			};
 		});
 		return chunks;
@@ -783,6 +786,22 @@ export class Compilation {
 	static PROCESS_ASSETS_STAGE_REPORT = 5000;
 
 	__internal_getProcessAssetsHookByStage(stage: number) {
+		if (stage > Compilation.PROCESS_ASSETS_STAGE_REPORT) {
+			this.pushDiagnostic(
+				"warning",
+				"not supported process_assets_stage",
+				`custom stage for process_assets is not supported yet, so ${stage} is fallback to Compilation.PROCESS_ASSETS_STAGE_REPORT(${Compilation.PROCESS_ASSETS_STAGE_REPORT}) `
+			);
+			stage = Compilation.PROCESS_ASSETS_STAGE_REPORT;
+		}
+		if (stage < Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL) {
+			this.pushDiagnostic(
+				"warning",
+				"not supported process_assets_stage",
+				`custom stage for process_assets is not supported yet, so ${stage} is fallback to Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL(${Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL}) `
+			);
+			stage = Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL;
+		}
 		switch (stage) {
 			case Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL:
 				return this.hooks.processAssets.stageAdditional;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -411,8 +411,8 @@ importers:
       copy-webpack-plugin: 5.1.2
       generate-package-json-webpack-plugin: ^2.6.0
       license-webpack-plugin: ^4.0.2
+      rspack-manifest-plugin: 5.0.0-alpha0
       webpack-bundle-analyzer: 4.7.0
-      webpack-manifest-plugin: 5.0.0
       webpack-stats-plugin: 1.1.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
@@ -421,8 +421,8 @@ importers:
       copy-webpack-plugin: 5.1.2
       generate-package-json-webpack-plugin: 2.6.0
       license-webpack-plugin: 4.0.2
+      rspack-manifest-plugin: 5.0.0-alpha0
       webpack-bundle-analyzer: 4.7.0
-      webpack-manifest-plugin: 5.0.0
       webpack-stats-plugin: 1.1.1
 
   examples/polyfill:
@@ -19684,6 +19684,16 @@ packages:
       fsevents: 2.3.2
     dev: true
 
+  /rspack-manifest-plugin/5.0.0-alpha0:
+    resolution: {integrity: sha512-a84H6P/lK0x3kb0I8Qdiwxrnjt1oNW0j+7kwPMWcODJu8eYFBrTXa1t+14n18Jvg9RKIR6llCH16mYxf2d0s8A==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      webpack: ^5.75.0
+    dependencies:
+      tapable: 2.2.1
+      webpack-sources: 2.3.1
+    dev: true
+
   /run-async/2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -22831,16 +22841,6 @@ packages:
     dependencies:
       ansi-colors: 3.2.4
       uuid: 3.4.0
-    dev: true
-
-  /webpack-manifest-plugin/5.0.0:
-    resolution: {integrity: sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      webpack: ^5.47.0
-    dependencies:
-      tapable: 2.2.1
-      webpack-sources: 2.3.1
     dev: true
 
   /webpack-merge/5.8.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,6 +412,7 @@ importers:
       generate-package-json-webpack-plugin: ^2.6.0
       license-webpack-plugin: ^4.0.2
       webpack-bundle-analyzer: 4.7.0
+      webpack-manifest-plugin: 5.0.0
       webpack-stats-plugin: 1.1.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
@@ -421,6 +422,7 @@ importers:
       generate-package-json-webpack-plugin: 2.6.0
       license-webpack-plugin: 4.0.2
       webpack-bundle-analyzer: 4.7.0
+      webpack-manifest-plugin: 5.0.0
       webpack-stats-plugin: 1.1.1
 
   examples/polyfill:
@@ -20469,6 +20471,10 @@ packages:
     dev: true
     optional: true
 
+  /source-list-map/2.0.1:
+    resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
+    dev: true
+
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
@@ -22827,12 +22833,30 @@ packages:
       uuid: 3.4.0
     dev: true
 
+  /webpack-manifest-plugin/5.0.0:
+    resolution: {integrity: sha512-8RQfMAdc5Uw3QbCQ/CBV/AXqOR8mt03B6GJmRbhWopE8GzRfEpn+k0ZuWywxW+5QZsffhmFDY1J6ohqJo+eMuw==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      webpack: ^5.47.0
+    dependencies:
+      tapable: 2.2.1
+      webpack-sources: 2.3.1
+    dev: true
+
   /webpack-merge/5.8.0:
     resolution: {integrity: sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==}
     engines: {node: '>=10.0.0'}
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
+    dev: true
+
+  /webpack-sources/2.3.1:
+    resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      source-list-map: 2.0.1
+      source-map: 0.6.1
     dev: true
 
   /webpack-sources/3.2.3:


### PR DESCRIPTION
## Related issue (if exists)
related to #2196, support webpack-manifest-plugin, since we doesn't support custom stage and some community relys on custom stage, so we fallback unsupported stage to supported stage now and gives warning for it.

the forked repo and the changes is here https://github.com/hardfist/rspack-manifest-plugin/pull/1
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b7f270</samp>

Added support for generating asset manifest files with `webpack-manifest-plugin` in `rspack`. This improves compatibility with some webpack plugins and enables integration with other tools that need to know the output file names. Updated the `plugin-compat` example to demonstrate this feature.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b7f270</samp>

*  Add `webpack-manifest-plugin` dependency to `examples/plugin-compat/package.json` and `pnpm-lock.yaml` ([link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-7c79896436e137329e49b20866aa4502be0fe10e49a15ceb45974993392878c1L21-R22), [link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR415), [link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR425), [link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR22836-R22845))
* Import and configure `WebpackManifestPlugin` in `examples/plugin-compat/rspack.config.js` to generate `rspack-manifest.json` in output directory ([link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96R7), [link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-406f4d16e21e23ae6783e825f72f72378a25ff933d3fbc3db1d2029478f9ff96R59-R61))
* Implement `isOnlyInitial` method on `chunk` object in `packages/rspack/src/compilation.ts` for compatibility with plugins that filter or process initial chunks ([link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L630-R633))
* Validate and normalize `stage` parameter of `processAssets` method in `packages/rspack/src/compilation.ts` for compatibility with plugins that use custom stages for asset processing ([link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R789-R804))
* Add `source-list-map` and `webpack-sources` dependencies to `pnpm-lock.yaml` as transitive dependencies of `webpack-manifest-plugin` ([link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR20474-R20477), [link](https://github.com/web-infra-dev/rspack/pull/3163/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR22854-R22861))

</details>
