### PR TITLE
fix(license-plugin): add support for license-plugin in case of perChunkOutput as false

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -457,6 +457,10 @@ class Compiler {
 			return finalCallback(null, entries, compilation);
 		});
 	}
+	isChild() {
+		const isRoot = this.root === this;
+		return !isRoot;
+	}
 	getInfrastructureLogger(name: string | Function) {
 		if (!name) {
 			throw new TypeError(


### PR DESCRIPTION
Appearing the build error in case of set [perChunkOutput](https://github.com/web-infra-dev/rspack/blob/98b6c6b8b98235f27d8462f07df0b1709da83be0/examples/plugin-compat/rspack.config.js#LL62C25-L62C25
) as false: 

```
Error: napi error: GenericFailure - TypeError: compilation.compiler.isChild is not a function
...
:28)
   0: _napi_register_module_v1
   1: <unknown>
   2: <unknown>
```
	
The Rspack isn't supporting the LicenseWebpackPlugin when the perChunkOutput property has value false.

```javascript
               new licensePlugin.LicenseWebpackPlugin({
			stats: {
				warnings: false,
				errors: false
			},
			perChunkOutput: true,
			outputFilename: `3rdpartylicenses.txt`
		}),
```
