### PR TITLE
chore: console error info when ./x failed

### DIFF
--- a/x
+++ b/x
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 // ^ This cannot be `#!/usr/bin/env zx` because `zx` will create a temporary `.mjs` file to execute on if this is extensionless.
 
-import('./x.mjs').catch(() => process.exit(1)); // Using dynamic import because ESM cannot be extensionless.
+import('./x.mjs').catch((e) => {
+  console.error('error:', e);
+  process.exit(1)
+}); // Using dynamic import because ESM cannot be extensionless.
 
 // NOTE:
 // Add this directory to your $PATH for executing without dot slash (`./x`).


### PR DESCRIPTION
## Related issue (if exists)
silent failure will confuse users

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c6bfd8</samp>

Improve error handling and logging of `rspack` script. Add console.error to log dynamic import failures in `x`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c6bfd8</samp>

*  Log the error object when dynamic import fails in `x` ([link](https://github.com/web-infra-dev/rspack/pull/3175/files?diff=unified&w=0#diff-2d711642b726b04401627ca9fbac32f5c8530fb1903cc4db02258717921a4881L4-R7))

</details>
