### PR TITLE
fix: namespace access on var decl rhs

### DIFF
--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/a.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/a.js
@@ -1,0 +1,3 @@
+export const a = {
+	a: ''
+};

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/b.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/b.js
@@ -1,0 +1,3 @@
+export const b = {
+	b: ""
+};

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/enum-old.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/enum-old.js
@@ -1,0 +1,2 @@
+export {a} from './a'
+export {b} from './b'

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/enum.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/enum.js
@@ -1,0 +1,1 @@
+export * from './enum-old';

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/expected/main.js
@@ -1,0 +1,99 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
+"./a.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "a", {
+    enumerable: true,
+    get: function() {
+        return a;
+    }
+});
+const a = {
+    a: ''
+};
+},
+"./b.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "b", {
+    enumerable: true,
+    get: function() {
+        return b;
+    }
+});
+const b = {
+    b: ""
+};
+},
+"./enum-old.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: all[name]
+    });
+}
+_export(exports, {
+    a: function() {
+        return _a.a;
+    },
+    b: function() {
+        return _b.b;
+    }
+});
+var _a = __webpack_require__("./a.js");
+var _b = __webpack_require__("./b.js");
+},
+"./enum.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+__webpack_require__.es(__webpack_require__("./enum-old.js"), exports);
+},
+"./index.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+var _lib = __webpack_require__("./lib.js");
+console.log(_lib.getDocPermissionTextSendMe);
+},
+"./lib.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "getDocPermissionTextSendMe", {
+    enumerable: true,
+    get: function() {
+        return getDocPermissionTextSendMe;
+    }
+});
+var _enum = __webpack_require__.ir(__webpack_require__("./enum.js"));
+function Record() {}
+({
+    1: _enum.a.a
+});
+function getDocPermissionTextSendMe() {}
+class Doc extends Record({}) {
+    isSheet() {
+        return this.type === _enum.b.b;
+    }
+}
+Doc.fromJS = (data)=>new Doc(data);
+},
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__('./index.js'));
+
+}
+]);

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/index.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/index.js
@@ -1,0 +1,3 @@
+import { getDocPermissionTextSendMe } from "./lib";
+
+console.log(getDocPermissionTextSendMe);

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/lib.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/lib.js
@@ -1,0 +1,19 @@
+import * as ENUM from "./enum.js";
+
+function Record() {}
+
+export const code2CreateChatDocPermission = {
+	1: ENUM.a.a,
+};
+
+export function getDocPermissionTextSendMe() {}
+
+export class Doc extends Record({
+}) {
+	isSheet() {
+		return this.type === ENUM.b.b;
+	}
+}
+
+Doc.fromJS = (data) => new Doc(data);
+

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/test.config.json
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/test.config.json
@@ -1,0 +1,11 @@
+{
+	"optimization": {
+		"sideEffects": "true"
+	},
+	"builtins": {
+		"treeShaking": "true",
+		"define": {
+			"process.env.NODE_ENV": "'development'"
+		}
+	}
+}

--- a/crates/rspack_core/src/tree_shaking/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/mod.rs
@@ -42,7 +42,7 @@ static CARE_MODULE_ID_FROM_ENV: Lazy<Vec<String>> = Lazy::new(|| {
     Err(_) => vec![],
   }
 });
-pub static CARED_MODULE_ID: &[&str] = &[];
+pub static CARED_MODULE_ID: &[&str] = &["/Users/bytedance/Documents/bytedance/test/lib.js"];
 
 pub fn debug_care_module_id<T: AsRef<str>>(id: T) -> bool {
   if !ANALYZE_LOGGING {

--- a/crates/rspack_core/src/tree_shaking/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/mod.rs
@@ -42,7 +42,7 @@ static CARE_MODULE_ID_FROM_ENV: Lazy<Vec<String>> = Lazy::new(|| {
     Err(_) => vec![],
   }
 });
-pub static CARED_MODULE_ID: &[&str] = &["/Users/bytedance/Documents/bytedance/test/lib.js"];
+pub static CARED_MODULE_ID: &[&str] = &[];
 
 pub fn debug_care_module_id<T: AsRef<str>>(id: T) -> bool {
   if !ANALYZE_LOGGING {

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -32,8 +32,9 @@ use super::{
   BailoutFlag, ModuleUsedType, OptimizeDependencyResult, SideEffectType,
 };
 use crate::{
-  contextify, join_string_component, tree_shaking::utils::ConvertModulePath, Compilation,
-  DependencyType, ModuleGraph, ModuleIdentifier, ModuleSyntax, ModuleType, NormalModuleAstOrSource,
+  contextify, dbg_matches, join_string_component, tree_shaking::utils::ConvertModulePath,
+  Compilation, DependencyType, ModuleGraph, ModuleIdentifier, ModuleSyntax, ModuleType,
+  NormalModuleAstOrSource,
 };
 
 pub struct CodeSizeOptimizer<'a> {
@@ -1241,7 +1242,6 @@ async fn par_analyze_module(compilation: &mut Compilation) -> IdentifierMap<Opti
           {
             Some(ast) => JsModule::new(ast, *module_identifier).analyze(compilation),
             None => {
-              // FIXME: this could be none if you enable both hmr and tree-shaking, should investigate why
               return None;
             }
           }

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -32,9 +32,8 @@ use super::{
   BailoutFlag, ModuleUsedType, OptimizeDependencyResult, SideEffectType,
 };
 use crate::{
-  contextify, dbg_matches, join_string_component, tree_shaking::utils::ConvertModulePath,
-  Compilation, DependencyType, ModuleGraph, ModuleIdentifier, ModuleSyntax, ModuleType,
-  NormalModuleAstOrSource,
+  contextify, join_string_component, tree_shaking::utils::ConvertModulePath, Compilation,
+  DependencyType, ModuleGraph, ModuleIdentifier, ModuleSyntax, ModuleType, NormalModuleAstOrSource,
 };
 
 pub struct CodeSizeOptimizer<'a> {

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -28,7 +28,6 @@ use super::{
   utils::{get_dynamic_import_string_literal, get_require_literal},
   BailoutFlag,
 };
-use crate::tree_shaking::debug_care_module_id;
 use crate::{
   CompilerOptions, Dependency, DependencyType, FactoryMeta, ModuleGraph, ModuleIdentifier,
   ModuleSyntax,
@@ -453,9 +452,6 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         ref_list
           .iter()
           .flat_map(|ref_id| {
-            if debug_care_module_id(self.module_identifier.as_str()) {
-              dbg!(&ref_id);
-            }
             // Only used id imported from other module would generate a side effects.
             let id = match ref_id {
               IdOrMemExpr::Id(ref id) => id,
@@ -1071,15 +1067,6 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
       Decl::Class(_) | Decl::Fn(_) | Decl::Var(_) => {
         node.visit_children_with(self);
       }
-    }
-  }
-
-  fn visit_object_lit(&mut self, n: &ObjectLit) {
-    for prop in n.props.iter() {
-      // if debug_care_module_id(self.module_identifier.as_str()) {
-      //   dbg!(&prop);
-      // }
-      prop.visit_with(self);
     }
   }
 }

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -28,6 +28,7 @@ use super::{
   utils::{get_dynamic_import_string_literal, get_require_literal},
   BailoutFlag,
 };
+use crate::tree_shaking::debug_care_module_id;
 use crate::{
   CompilerOptions, Dependency, DependencyType, FactoryMeta, ModuleGraph, ModuleIdentifier,
   ModuleSyntax,
@@ -121,9 +122,6 @@ pub(crate) struct ModuleRefAnalyze<'a> {
   pub inherit_export_maps: IdentifierLinkedMap<HashMap<JsWord, SymbolRef>>,
   current_body_owner_symbol_ext: Option<SymbolExt>,
   pub(crate) maybe_lazy_reference_map: HashMap<SymbolExt, HashSet<IdOrMemExpr>>,
-  /// ```js
-  /// The method
-  /// ```
   pub(crate) immediate_evaluate_reference_map: HashMap<SymbolExt, HashSet<IdOrMemExpr>>,
   pub(crate) reachable_import_and_export: HashMap<JsWord, HashSet<SymbolRef>>,
   state: AnalyzeState,
@@ -423,7 +421,16 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
               let id = match ref_id {
                 IdOrMemExpr::Id(ref id) => id,
                 // TODO: inspect namespace access
-                IdOrMemExpr::MemberExpr { object, .. } => object,
+                IdOrMemExpr::MemberExpr { object, property } => match self.import_map.get(object) {
+                  Some(SymbolRef::Star(uri)) => {
+                    return HashSet::from_iter([SymbolRef::Indirect(IndirectTopLevelSymbol::new(
+                      uri.src(),
+                      self.module_identifier,
+                      IndirectType::Import(property.clone(), None),
+                    ))]);
+                  }
+                  _ => object,
+                },
               };
               // dbg!(&id);
               let ret = self.import_map.get(id);
@@ -446,11 +453,22 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         ref_list
           .iter()
           .flat_map(|ref_id| {
+            if debug_care_module_id(self.module_identifier.as_str()) {
+              dbg!(&ref_id);
+            }
             // Only used id imported from other module would generate a side effects.
             let id = match ref_id {
               IdOrMemExpr::Id(ref id) => id,
-              // TODO: inspect namespace access
-              IdOrMemExpr::MemberExpr { object, .. } => object,
+              IdOrMemExpr::MemberExpr { object, property } => match self.import_map.get(object) {
+                Some(SymbolRef::Star(uri)) => {
+                  return HashSet::from_iter([SymbolRef::Indirect(IndirectTopLevelSymbol::new(
+                    uri.src(),
+                    self.module_identifier,
+                    IndirectType::Import(property.clone(), None),
+                  ))]);
+                }
+                _ => object,
+              },
             };
             let ret = self.import_map.get(id);
             match ret {
@@ -706,7 +724,6 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
   }
 
   fn visit_assign_expr(&mut self, node: &AssignExpr) {
-    // TODO: assign should have body ext too
     let before_owner_extend_symbol = self.current_body_owner_symbol_ext.clone();
     let target = if before_owner_extend_symbol.is_none() {
       let target = first_ident_of_assign_lhs(node);
@@ -763,7 +780,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         let id: BetterId = obj.to_id().into();
         let mark = id.ctxt.outer();
 
-        if mark == self.top_level_mark {
+        if self.potential_top_mark.contains(&mark) {
           let member_expr = IdOrMemExpr::MemberExpr {
             object: id.clone(),
             property: prop.sym.clone(),
@@ -796,7 +813,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
 
         let id: BetterId = obj.to_id().into();
         let mark = id.ctxt.outer();
-        if mark == self.top_level_mark {
+        if self.potential_top_mark.contains(&mark) {
           let member_expr = IdOrMemExpr::MemberExpr {
             object: id.clone(),
             property: value.clone(),
@@ -1026,7 +1043,8 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         ele.init.visit_with(self);
         continue;
       };
-      if let Some(ref init) = ele.init && lhs.ctxt.outer() == self.top_level_mark {
+      if let Some(ref init) = ele.init && self.potential_top_mark.contains(&lhs.ctxt.outer()) {
+
         let mut symbol_ext = SymbolExt::new(lhs, SymbolFlag::VAR_DECL);
         match init {
             box Expr::Fn(_) => symbol_ext.flag.insert(SymbolFlag::FUNCTION_EXPR),
@@ -1053,6 +1071,15 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
       Decl::Class(_) | Decl::Fn(_) | Decl::Var(_) => {
         node.visit_children_with(self);
       }
+    }
+  }
+
+  fn visit_object_lit(&mut self, n: &ObjectLit) {
+    for prop in n.props.iter() {
+      // if debug_care_module_id(self.module_identifier.as_str()) {
+      //   dbg!(&prop);
+      // }
+      prop.visit_with(self);
     }
   }
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b9d2224</samp>

This pull request enhances the tree shaking feature of `rspack_core` by adding more debugging tools, fixing some bugs, and supporting more syntax cases. It modifies the files `optimizer.rs`, `visitor.rs`, `debug_helper.rs`, and `mod.rs` in the `tree_shaking` module.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b9d2224</samp>

*  Modify `dbg_matches` macro to print module identifier and values only when debug flag is on ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-bf255db28435fd0f45e761c7757369252f65adedd35a4d7eeed2e9578d2b67dbL11-R18))
*  Change `CARED_MODULE_ID` to include specific module path for debugging ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-f896c184cb1e8cd0b8945b2a03f3718a3073bc4f15843fec86bcefa7a8b1ca3bL45-R45))
*  Import and use `dbg_matches` macro in `optimizer.rs` to print optimization data ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL35-R37), [link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL1222-R1229))
*  Remove outdated comment about bug in `optimizer.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL1214))
*  Import and use `debug_care_module_id` function in `visitor.rs` to enable conditional debugging ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R31))
*  Remove incorrect comment about `visit_export_specifier` in `visitor.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L124-L126))
*  Handle namespace imports in `visit_import_specifier` and `visit_used_symbol` in `visitor.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L426-R433), [link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L449-R471))
*  Check potential top marks in `visit_member_expr`, `visit_prop_name_value`, and `visit_var_declarator` in `visitor.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L766-R783), [link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L799-R816), [link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1029-R1047))
*  Add `visit_object_lit` function to visit object properties in `visitor.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3176/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R1076-R1084))

</details>
