### PR TITLE
feat(packages/rspack): support statsPrinter and statsFactory hook

### DIFF
--- a/examples/basic/build.js
+++ b/examples/basic/build.js
@@ -1,0 +1,13 @@
+const { rspack } = require('../../packages/rspack')
+const config = require('./rspack.config')
+
+// call rspack
+const compiler = rspack(config)
+// compiler.run
+compiler.run((err, stats) => {
+  let  statsString = stats.toString();
+	console.log('statsString', statsString)
+  if (err) {
+    console.log(err)
+  }
+})

--- a/packages/rspack/src/stats.ts
+++ b/packages/rspack/src/stats.ts
@@ -143,6 +143,10 @@ export class Stats {
 		const options = this.compilation.createStatsOptions(opts, {
 			forToString: true
 		});
+		// call hooks
+		this.compilation.createStatsFactory(options);
+		this.compilation.createStatsPrinter(options);
+		// TODO:  add plugin for Stats
 		const useColors = optionsOrFallback(options.colors, false);
 		const obj: any = this.toJson(options, true);
 		return Stats.jsonToString(obj, useColors);
@@ -262,7 +266,6 @@ export class Stats {
 		};
 
 		if (obj.hash) {
-			colors.normal("Hash: ");
 			colors.bold(obj.hash);
 			newline();
 		}

--- a/packages/rspack/src/stats/StatsFactory.js
+++ b/packages/rspack/src/stats/StatsFactory.js
@@ -1,0 +1,292 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { HookMap, SyncBailHook, SyncWaterfallHook } = require("tapable");
+const { concatComparators, keepOriginalOrder } = require("../util/comparators");
+const smartGrouping = require("../util/smartGrouping");
+
+/** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../compilation")} Compilation */
+/** @typedef {import("../Module")} Module */
+/** @typedef {import("../WebpackError")} WebpackError */
+/** @typedef {import("../util/runtime").RuntimeSpec} RuntimeSpec */
+
+/** @typedef {import("../util/smartGrouping").GroupConfig<any, object>} GroupConfig */
+
+/**
+ * @typedef {Object} KnownStatsFactoryContext
+ * @property {string} type
+ * @property {function(string): string=} makePathsRelative
+ * @property {Compilation=} compilation
+ * @property {Set<Module>=} rootModules
+ * @property {Map<string,Chunk[]>=} compilationFileToChunks
+ * @property {Map<string,Chunk[]>=} compilationAuxiliaryFileToChunks
+ * @property {RuntimeSpec=} runtime
+ * @property {function(Compilation): WebpackError[]=} cachedGetErrors
+ * @property {function(Compilation): WebpackError[]=} cachedGetWarnings
+ */
+
+/** @typedef {KnownStatsFactoryContext & Record<string, any>} StatsFactoryContext */
+
+class StatsFactory {
+	constructor() {
+		this.hooks = Object.freeze({
+			/** @type {HookMap<SyncBailHook<[Object, any, StatsFactoryContext]>>} */
+			extract: new HookMap(
+				() => new SyncBailHook(["object", "data", "context"])
+			),
+			/** @type {HookMap<SyncBailHook<[any, StatsFactoryContext, number, number]>>} */
+			filter: new HookMap(
+				() => new SyncBailHook(["item", "context", "index", "unfilteredIndex"])
+			),
+			/** @type {HookMap<SyncBailHook<[(function(any, any): number)[], StatsFactoryContext]>>} */
+			sort: new HookMap(() => new SyncBailHook(["comparators", "context"])),
+			/** @type {HookMap<SyncBailHook<[any, StatsFactoryContext, number, number]>>} */
+			filterSorted: new HookMap(
+				() => new SyncBailHook(["item", "context", "index", "unfilteredIndex"])
+			),
+			/** @type {HookMap<SyncBailHook<[GroupConfig[], StatsFactoryContext]>>} */
+			groupResults: new HookMap(
+				() => new SyncBailHook(["groupConfigs", "context"])
+			),
+			/** @type {HookMap<SyncBailHook<[(function(any, any): number)[], StatsFactoryContext]>>} */
+			sortResults: new HookMap(
+				() => new SyncBailHook(["comparators", "context"])
+			),
+			/** @type {HookMap<SyncBailHook<[any, StatsFactoryContext, number, number]>>} */
+			filterResults: new HookMap(
+				() => new SyncBailHook(["item", "context", "index", "unfilteredIndex"])
+			),
+			/** @type {HookMap<SyncBailHook<[any[], StatsFactoryContext]>>} */
+			merge: new HookMap(() => new SyncBailHook(["items", "context"])),
+			/** @type {HookMap<SyncBailHook<[any[], StatsFactoryContext]>>} */
+			result: new HookMap(() => new SyncWaterfallHook(["result", "context"])),
+			/** @type {HookMap<SyncBailHook<[any, StatsFactoryContext]>>} */
+			getItemName: new HookMap(() => new SyncBailHook(["item", "context"])),
+			/** @type {HookMap<SyncBailHook<[any, StatsFactoryContext]>>} */
+			getItemFactory: new HookMap(() => new SyncBailHook(["item", "context"]))
+		});
+		const hooks = this.hooks;
+		this._caches =
+			/** @type {Record<keyof typeof hooks, Map<string, SyncBailHook<[any[], StatsFactoryContext]>[]>>} */ ({});
+		for (const key of Object.keys(hooks)) {
+			this._caches[key] = new Map();
+		}
+		this._inCreate = false;
+	}
+
+	_getAllLevelHooks(hookMap, cache, type) {
+		const cacheEntry = cache.get(type);
+		if (cacheEntry !== undefined) {
+			return cacheEntry;
+		}
+		const hooks = [];
+		const typeParts = type.split(".");
+		for (let i = 0; i < typeParts.length; i++) {
+			const hook = hookMap.get(typeParts.slice(i).join("."));
+			if (hook) {
+				hooks.push(hook);
+			}
+		}
+		cache.set(type, hooks);
+		return hooks;
+	}
+
+	_forEachLevel(hookMap, cache, type, fn) {
+		for (const hook of this._getAllLevelHooks(hookMap, cache, type)) {
+			const result = fn(hook);
+			if (result !== undefined) return result;
+		}
+	}
+
+	_forEachLevelWaterfall(hookMap, cache, type, data, fn) {
+		for (const hook of this._getAllLevelHooks(hookMap, cache, type)) {
+			data = fn(hook, data);
+		}
+		return data;
+	}
+
+	_forEachLevelFilter(hookMap, cache, type, items, fn, forceClone) {
+		const hooks = this._getAllLevelHooks(hookMap, cache, type);
+		if (hooks.length === 0) return forceClone ? items.slice() : items;
+		let i = 0;
+		return items.filter((item, idx) => {
+			for (const hook of hooks) {
+				const r = fn(hook, item, idx, i);
+				if (r !== undefined) {
+					if (r) i++;
+					return r;
+				}
+			}
+			i++;
+			return true;
+		});
+	}
+
+	/**
+	 * @param {string} type type
+	 * @param {any} data factory data
+	 * @param {Omit<StatsFactoryContext, "type">} baseContext context used as base
+	 * @returns {any} created object
+	 */
+	create(type, data, baseContext) {
+		if (this._inCreate) {
+			return this._create(type, data, baseContext);
+		} else {
+			try {
+				this._inCreate = true;
+				return this._create(type, data, baseContext);
+			} finally {
+				for (const key of Object.keys(this._caches)) this._caches[key].clear();
+				this._inCreate = false;
+			}
+		}
+	}
+
+	_create(type, data, baseContext) {
+		const context = {
+			...baseContext,
+			type,
+			[type]: data
+		};
+		if (Array.isArray(data)) {
+			// run filter on unsorted items
+			const items = this._forEachLevelFilter(
+				this.hooks.filter,
+				this._caches.filter,
+				type,
+				data,
+				(h, r, idx, i) => h.call(r, context, idx, i),
+				true
+			);
+
+			// sort items
+			const comparators = [];
+			this._forEachLevel(this.hooks.sort, this._caches.sort, type, h =>
+				h.call(comparators, context)
+			);
+			if (comparators.length > 0) {
+				items.sort(
+					// @ts-expect-error number of arguments is correct
+					concatComparators(...comparators, keepOriginalOrder(items))
+				);
+			}
+
+			// run filter on sorted items
+			const items2 = this._forEachLevelFilter(
+				this.hooks.filterSorted,
+				this._caches.filterSorted,
+				type,
+				items,
+				(h, r, idx, i) => h.call(r, context, idx, i),
+				false
+			);
+
+			// for each item
+			let resultItems = items2.map((item, i) => {
+				const itemContext = {
+					...context,
+					_index: i
+				};
+
+				// run getItemName
+				const itemName = this._forEachLevel(
+					this.hooks.getItemName,
+					this._caches.getItemName,
+					`${type}[]`,
+					h => h.call(item, itemContext)
+				);
+				if (itemName) itemContext[itemName] = item;
+				const innerType = itemName ? `${type}[].${itemName}` : `${type}[]`;
+
+				// run getItemFactory
+				const itemFactory =
+					this._forEachLevel(
+						this.hooks.getItemFactory,
+						this._caches.getItemFactory,
+						innerType,
+						h => h.call(item, itemContext)
+					) || this;
+
+				// run item factory
+				return itemFactory.create(innerType, item, itemContext);
+			});
+
+			// sort result items
+			const comparators2 = [];
+			this._forEachLevel(
+				this.hooks.sortResults,
+				this._caches.sortResults,
+				type,
+				h => h.call(comparators2, context)
+			);
+			if (comparators2.length > 0) {
+				resultItems.sort(
+					// @ts-expect-error number of arguments is correct
+					concatComparators(...comparators2, keepOriginalOrder(resultItems))
+				);
+			}
+
+			// group result items
+			const groupConfigs = [];
+			this._forEachLevel(
+				this.hooks.groupResults,
+				this._caches.groupResults,
+				type,
+				h => h.call(groupConfigs, context)
+			);
+			if (groupConfigs.length > 0) {
+				resultItems = smartGrouping(resultItems, groupConfigs);
+			}
+
+			// run filter on sorted result items
+			const finalResultItems = this._forEachLevelFilter(
+				this.hooks.filterResults,
+				this._caches.filterResults,
+				type,
+				resultItems,
+				(h, r, idx, i) => h.call(r, context, idx, i),
+				false
+			);
+
+			// run merge on mapped items
+			let result = this._forEachLevel(
+				this.hooks.merge,
+				this._caches.merge,
+				type,
+				h => h.call(finalResultItems, context)
+			);
+			if (result === undefined) result = finalResultItems;
+
+			// run result on merged items
+			return this._forEachLevelWaterfall(
+				this.hooks.result,
+				this._caches.result,
+				type,
+				result,
+				(h, r) => h.call(r, context)
+			);
+		} else {
+			const object = {};
+
+			// run extract on value
+			this._forEachLevel(this.hooks.extract, this._caches.extract, type, h =>
+				h.call(object, data, context)
+			);
+
+			// run result on extracted object
+			return this._forEachLevelWaterfall(
+				this.hooks.result,
+				this._caches.result,
+				type,
+				object,
+				(h, r) => h.call(r, context)
+			);
+		}
+	}
+}
+module.exports = StatsFactory;

--- a/packages/rspack/src/stats/StatsPrinter.js
+++ b/packages/rspack/src/stats/StatsPrinter.js
@@ -1,0 +1,249 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+const { HookMap, SyncWaterfallHook, SyncBailHook } = require("tapable");
+
+/** @template T @typedef {import("tapable").AsArray<T>} AsArray<T> */
+/** @typedef {import("tapable").Hook} Hook */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsAsset} StatsAsset */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsChunk} StatsChunk */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsChunkGroup} StatsChunkGroup */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsCompilation} StatsCompilation */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsModule} StatsModule */
+/** @typedef {import("./DefaultStatsFactoryPlugin").StatsModuleReason} StatsModuleReason */
+
+/**
+ * @typedef {Object} PrintedElement
+ * @property {string} element
+ * @property {string} content
+ */
+
+/**
+ * @typedef {Object} KnownStatsPrinterContext
+ * @property {string=} type
+ * @property {StatsCompilation=} compilation
+ * @property {StatsChunkGroup=} chunkGroup
+ * @property {StatsAsset=} asset
+ * @property {StatsModule=} module
+ * @property {StatsChunk=} chunk
+ * @property {StatsModuleReason=} moduleReason
+ * @property {(str: string) => string=} bold
+ * @property {(str: string) => string=} yellow
+ * @property {(str: string) => string=} red
+ * @property {(str: string) => string=} green
+ * @property {(str: string) => string=} magenta
+ * @property {(str: string) => string=} cyan
+ * @property {(file: string, oversize?: boolean) => string=} formatFilename
+ * @property {(id: string) => string=} formatModuleId
+ * @property {(id: string, direction?: "parent"|"child"|"sibling") => string=} formatChunkId
+ * @property {(size: number) => string=} formatSize
+ * @property {(dateTime: number) => string=} formatDateTime
+ * @property {(flag: string) => string=} formatFlag
+ * @property {(time: number, boldQuantity?: boolean) => string=} formatTime
+ * @property {string=} chunkGroupKind
+ */
+
+/** @typedef {KnownStatsPrinterContext & Record<string, any>} StatsPrinterContext */
+
+class StatsPrinter {
+	constructor() {
+		this.hooks = Object.freeze({
+			/** @type {HookMap<SyncBailHook<[string[], StatsPrinterContext], true>>} */
+			sortElements: new HookMap(
+				() => new SyncBailHook(["elements", "context"])
+			),
+			/** @type {HookMap<SyncBailHook<[PrintedElement[], StatsPrinterContext], string>>} */
+			printElements: new HookMap(
+				() => new SyncBailHook(["printedElements", "context"])
+			),
+			/** @type {HookMap<SyncBailHook<[any[], StatsPrinterContext], true>>} */
+			sortItems: new HookMap(() => new SyncBailHook(["items", "context"])),
+			/** @type {HookMap<SyncBailHook<[any, StatsPrinterContext], string>>} */
+			getItemName: new HookMap(() => new SyncBailHook(["item", "context"])),
+			/** @type {HookMap<SyncBailHook<[string[], StatsPrinterContext], string>>} */
+			printItems: new HookMap(
+				() => new SyncBailHook(["printedItems", "context"])
+			),
+			/** @type {HookMap<SyncBailHook<[{}, StatsPrinterContext], string>>} */
+			print: new HookMap(() => new SyncBailHook(["object", "context"])),
+			/** @type {HookMap<SyncWaterfallHook<[string, StatsPrinterContext]>>} */
+			result: new HookMap(() => new SyncWaterfallHook(["result", "context"]))
+		});
+		/** @type {Map<HookMap<Hook>, Map<string, Hook[]>>} */
+		this._levelHookCache = new Map();
+		this._inPrint = false;
+	}
+
+	/**
+	 * get all level hooks
+	 * @private
+	 * @template {Hook} T
+	 * @param {HookMap<T>} hookMap HookMap
+	 * @param {string} type type
+	 * @returns {T[]} hooks
+	 */
+	_getAllLevelHooks(hookMap, type) {
+		let cache = /** @type {Map<string, T[]>} */ (
+			this._levelHookCache.get(hookMap)
+		);
+		if (cache === undefined) {
+			cache = new Map();
+			this._levelHookCache.set(hookMap, cache);
+		}
+		const cacheEntry = cache.get(type);
+		if (cacheEntry !== undefined) {
+			return cacheEntry;
+		}
+		/** @type {T[]} */
+		const hooks = [];
+		const typeParts = type.split(".");
+		for (let i = 0; i < typeParts.length; i++) {
+			const hook = hookMap.get(typeParts.slice(i).join("."));
+			if (hook) {
+				hooks.push(hook);
+			}
+		}
+		cache.set(type, hooks);
+		return hooks;
+	}
+
+	/**
+	 * Run `fn` for each level
+	 * @private
+	 * @template T
+	 * @template R
+	 * @param {HookMap<SyncBailHook<T, R>>} hookMap HookMap
+	 * @param {string} type type
+	 * @param {(hook: SyncBailHook<T, R>) => R} fn function
+	 * @returns {R} result of `fn`
+	 */
+	_forEachLevel(hookMap, type, fn) {
+		for (const hook of this._getAllLevelHooks(hookMap, type)) {
+			const result = fn(hook);
+			if (result !== undefined) return result;
+		}
+	}
+
+	/**
+	 * Run `fn` for each level
+	 * @private
+	 * @template T
+	 * @param {HookMap<SyncWaterfallHook<T>>} hookMap HookMap
+	 * @param {string} type type
+	 * @param {AsArray<T>[0]} data data
+	 * @param {(hook: SyncWaterfallHook<T>, data: AsArray<T>[0]) => AsArray<T>[0]} fn function
+	 * @returns {AsArray<T>[0]} result of `fn`
+	 */
+	_forEachLevelWaterfall(hookMap, type, data, fn) {
+		for (const hook of this._getAllLevelHooks(hookMap, type)) {
+			data = fn(hook, data);
+		}
+		return data;
+	}
+
+	/**
+	 * @param {string} type The type
+	 * @param {Object} object Object to print
+	 * @param {Object=} baseContext The base context
+	 * @returns {string} printed result
+	 */
+	print(type, object, baseContext) {
+		if (this._inPrint) {
+			return this._print(type, object, baseContext);
+		} else {
+			try {
+				this._inPrint = true;
+				return this._print(type, object, baseContext);
+			} finally {
+				this._levelHookCache.clear();
+				this._inPrint = false;
+			}
+		}
+	}
+
+	/**
+	 * @private
+	 * @param {string} type type
+	 * @param {Object} object object
+	 * @param {Object=} baseContext context
+	 * @returns {string} printed result
+	 */
+	_print(type, object, baseContext) {
+		const context = {
+			...baseContext,
+			type,
+			[type]: object
+		};
+
+		let printResult = this._forEachLevel(this.hooks.print, type, hook =>
+			hook.call(object, context)
+		);
+		if (printResult === undefined) {
+			if (Array.isArray(object)) {
+				const sortedItems = object.slice();
+				this._forEachLevel(this.hooks.sortItems, type, h =>
+					h.call(sortedItems, context)
+				);
+				const printedItems = sortedItems.map((item, i) => {
+					const itemContext = {
+						...context,
+						_index: i
+					};
+					const itemName = this._forEachLevel(
+						this.hooks.getItemName,
+						`${type}[]`,
+						h => h.call(item, itemContext)
+					);
+					if (itemName) itemContext[itemName] = item;
+					return this.print(
+						itemName ? `${type}[].${itemName}` : `${type}[]`,
+						item,
+						itemContext
+					);
+				});
+				printResult = this._forEachLevel(this.hooks.printItems, type, h =>
+					h.call(printedItems, context)
+				);
+				if (printResult === undefined) {
+					const result = printedItems.filter(Boolean);
+					if (result.length > 0) printResult = result.join("\n");
+				}
+			} else if (object !== null && typeof object === "object") {
+				const elements = Object.keys(object).filter(
+					key => object[key] !== undefined
+				);
+				this._forEachLevel(this.hooks.sortElements, type, h =>
+					h.call(elements, context)
+				);
+				const printedElements = elements.map(element => {
+					const content = this.print(`${type}.${element}`, object[element], {
+						...context,
+						_parent: object,
+						_element: element,
+						[element]: object[element]
+					});
+					return { element, content };
+				});
+				printResult = this._forEachLevel(this.hooks.printElements, type, h =>
+					h.call(printedElements, context)
+				);
+				if (printResult === undefined) {
+					const result = printedElements.map(e => e.content).filter(Boolean);
+					if (result.length > 0) printResult = result.join("\n");
+				}
+			}
+		}
+
+		return this._forEachLevelWaterfall(
+			this.hooks.result,
+			type,
+			printResult,
+			(h, r) => h.call(r, context)
+		);
+	}
+}
+module.exports = StatsPrinter;

--- a/packages/rspack/src/util/comparators.js
+++ b/packages/rspack/src/util/comparators.js
@@ -1,0 +1,432 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/** @typedef {import("../Chunk")} Chunk */
+/** @typedef {import("../ChunkGraph")} ChunkGraph */
+/** @typedef {import("../ChunkGroup")} ChunkGroup */
+/** @typedef {import("../Dependency").DependencyLocation} DependencyLocation */
+/** @typedef {import("../Module")} Module */
+/** @typedef {import("../ModuleGraph")} ModuleGraph */
+
+/** @template T @typedef {function(T, T): -1|0|1} Comparator */
+/** @template TArg @template T @typedef {function(TArg, T, T): -1|0|1} RawParameterizedComparator */
+/** @template TArg @template T @typedef {function(TArg): Comparator<T>} ParameterizedComparator */
+
+/**
+ * @template T
+ * @param {RawParameterizedComparator<any, T>} fn comparator with argument
+ * @returns {ParameterizedComparator<any, T>} comparator
+ */
+const createCachedParameterizedComparator = fn => {
+	/** @type {WeakMap<object, Comparator<T>>} */
+	const map = new WeakMap();
+	return arg => {
+		const cachedResult = map.get(arg);
+		if (cachedResult !== undefined) return cachedResult;
+		/**
+		 * @param {T} a first item
+		 * @param {T} b second item
+		 * @returns {-1|0|1} compare result
+		 */
+		const result = (a, b) => {
+			return fn(arg, a, b);
+		};
+		map.set(arg, result);
+		return result;
+	};
+};
+
+/**
+ * @param {Chunk} a chunk
+ * @param {Chunk} b chunk
+ * @returns {-1|0|1} compare result
+ */
+exports.compareChunksById = (a, b) => {
+	return compareIds(a.id, b.id);
+};
+
+/**
+ * @param {Module} a module
+ * @param {Module} b module
+ * @returns {-1|0|1} compare result
+ */
+exports.compareModulesByIdentifier = (a, b) => {
+	return compareIds(a.identifier(), b.identifier());
+};
+
+/**
+ * @param {ChunkGraph} chunkGraph the chunk graph
+ * @param {Module} a module
+ * @param {Module} b module
+ * @returns {-1|0|1} compare result
+ */
+const compareModulesById = (chunkGraph, a, b) => {
+	return compareIds(chunkGraph.getModuleId(a), chunkGraph.getModuleId(b));
+};
+/** @type {ParameterizedComparator<ChunkGraph, Module>} */
+exports.compareModulesById =
+	createCachedParameterizedComparator(compareModulesById);
+
+/**
+ * @param {number} a number
+ * @param {number} b number
+ * @returns {-1|0|1} compare result
+ */
+const compareNumbers = (a, b) => {
+	if (typeof a !== typeof b) {
+		return typeof a < typeof b ? -1 : 1;
+	}
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+};
+exports.compareNumbers = compareNumbers;
+
+/**
+ * @param {string} a string
+ * @param {string} b string
+ * @returns {-1|0|1} compare result
+ */
+const compareStringsNumeric = (a, b) => {
+	const partsA = a.split(/(\d+)/);
+	const partsB = b.split(/(\d+)/);
+	const len = Math.min(partsA.length, partsB.length);
+	for (let i = 0; i < len; i++) {
+		const pA = partsA[i];
+		const pB = partsB[i];
+		if (i % 2 === 0) {
+			if (pA.length > pB.length) {
+				if (pA.slice(0, pB.length) > pB) return 1;
+				return -1;
+			} else if (pB.length > pA.length) {
+				if (pB.slice(0, pA.length) > pA) return -1;
+				return 1;
+			} else {
+				if (pA < pB) return -1;
+				if (pA > pB) return 1;
+			}
+		} else {
+			const nA = +pA;
+			const nB = +pB;
+			if (nA < nB) return -1;
+			if (nA > nB) return 1;
+		}
+	}
+	if (partsB.length < partsA.length) return 1;
+	if (partsB.length > partsA.length) return -1;
+	return 0;
+};
+exports.compareStringsNumeric = compareStringsNumeric;
+
+/**
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {Module} a module
+ * @param {Module} b module
+ * @returns {-1|0|1} compare result
+ */
+const compareModulesByPostOrderIndexOrIdentifier = (moduleGraph, a, b) => {
+	const cmp = compareNumbers(
+		moduleGraph.getPostOrderIndex(a),
+		moduleGraph.getPostOrderIndex(b)
+	);
+	if (cmp !== 0) return cmp;
+	return compareIds(a.identifier(), b.identifier());
+};
+/** @type {ParameterizedComparator<ModuleGraph, Module>} */
+exports.compareModulesByPostOrderIndexOrIdentifier =
+	createCachedParameterizedComparator(
+		compareModulesByPostOrderIndexOrIdentifier
+	);
+
+/**
+ * @param {ModuleGraph} moduleGraph the module graph
+ * @param {Module} a module
+ * @param {Module} b module
+ * @returns {-1|0|1} compare result
+ */
+const compareModulesByPreOrderIndexOrIdentifier = (moduleGraph, a, b) => {
+	const cmp = compareNumbers(
+		moduleGraph.getPreOrderIndex(a),
+		moduleGraph.getPreOrderIndex(b)
+	);
+	if (cmp !== 0) return cmp;
+	return compareIds(a.identifier(), b.identifier());
+};
+/** @type {ParameterizedComparator<ModuleGraph, Module>} */
+exports.compareModulesByPreOrderIndexOrIdentifier =
+	createCachedParameterizedComparator(
+		compareModulesByPreOrderIndexOrIdentifier
+	);
+
+/**
+ * @param {ChunkGraph} chunkGraph the chunk graph
+ * @param {Module} a module
+ * @param {Module} b module
+ * @returns {-1|0|1} compare result
+ */
+const compareModulesByIdOrIdentifier = (chunkGraph, a, b) => {
+	const cmp = compareIds(chunkGraph.getModuleId(a), chunkGraph.getModuleId(b));
+	if (cmp !== 0) return cmp;
+	return compareIds(a.identifier(), b.identifier());
+};
+/** @type {ParameterizedComparator<ChunkGraph, Module>} */
+exports.compareModulesByIdOrIdentifier = createCachedParameterizedComparator(
+	compareModulesByIdOrIdentifier
+);
+
+/**
+ * @param {ChunkGraph} chunkGraph the chunk graph
+ * @param {Chunk} a chunk
+ * @param {Chunk} b chunk
+ * @returns {-1|0|1} compare result
+ */
+const compareChunks = (chunkGraph, a, b) => {
+	return chunkGraph.compareChunks(a, b);
+};
+/** @type {ParameterizedComparator<ChunkGraph, Chunk>} */
+exports.compareChunks = createCachedParameterizedComparator(compareChunks);
+
+/**
+ * @param {string|number} a first id
+ * @param {string|number} b second id
+ * @returns {-1|0|1} compare result
+ */
+const compareIds = (a, b) => {
+	if (typeof a !== typeof b) {
+		return typeof a < typeof b ? -1 : 1;
+	}
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+};
+
+exports.compareIds = compareIds;
+
+/**
+ * @param {string} a first string
+ * @param {string} b second string
+ * @returns {-1|0|1} compare result
+ */
+const compareStrings = (a, b) => {
+	if (a < b) return -1;
+	if (a > b) return 1;
+	return 0;
+};
+
+exports.compareStrings = compareStrings;
+
+/**
+ * @param {ChunkGroup} a first chunk group
+ * @param {ChunkGroup} b second chunk group
+ * @returns {-1|0|1} compare result
+ */
+const compareChunkGroupsByIndex = (a, b) => {
+	return a.index < b.index ? -1 : 1;
+};
+
+exports.compareChunkGroupsByIndex = compareChunkGroupsByIndex;
+
+/**
+ * @template K1 {Object}
+ * @template K2
+ * @template T
+ */
+class TwoKeyWeakMap {
+	constructor() {
+		/** @private @type {WeakMap<any, WeakMap<any, T>>} */
+		this._map = new WeakMap();
+	}
+
+	/**
+	 * @param {K1} key1 first key
+	 * @param {K2} key2 second key
+	 * @returns {T | undefined} value
+	 */
+	get(key1, key2) {
+		const childMap = this._map.get(key1);
+		if (childMap === undefined) {
+			return undefined;
+		}
+		return childMap.get(key2);
+	}
+
+	/**
+	 * @param {K1} key1 first key
+	 * @param {K2} key2 second key
+	 * @param {T | undefined} value new value
+	 * @returns {void}
+	 */
+	set(key1, key2, value) {
+		let childMap = this._map.get(key1);
+		if (childMap === undefined) {
+			childMap = new WeakMap();
+			this._map.set(key1, childMap);
+		}
+		childMap.set(key2, value);
+	}
+}
+
+/** @type {TwoKeyWeakMap<Comparator<any>, Comparator<any>, Comparator<any>>}} */
+const concatComparatorsCache = new TwoKeyWeakMap();
+
+/**
+ * @template T
+ * @param {Comparator<T>} c1 comparator
+ * @param {Comparator<T>} c2 comparator
+ * @param {Comparator<T>[]} cRest comparators
+ * @returns {Comparator<T>} comparator
+ */
+const concatComparators = (c1, c2, ...cRest) => {
+	if (cRest.length > 0) {
+		const [c3, ...cRest2] = cRest;
+		return concatComparators(c1, concatComparators(c2, c3, ...cRest2));
+	}
+	const cacheEntry = /** @type {Comparator<T>} */ (
+		concatComparatorsCache.get(c1, c2)
+	);
+	if (cacheEntry !== undefined) return cacheEntry;
+	/**
+	 * @param {T} a first value
+	 * @param {T} b second value
+	 * @returns {-1|0|1} compare result
+	 */
+	const result = (a, b) => {
+		const res = c1(a, b);
+		if (res !== 0) return res;
+		return c2(a, b);
+	};
+	concatComparatorsCache.set(c1, c2, result);
+	return result;
+};
+exports.concatComparators = concatComparators;
+
+/** @template A, B @typedef {(input: A) => B} Selector */
+
+/** @type {TwoKeyWeakMap<Selector<any, any>, Comparator<any>, Comparator<any>>}} */
+const compareSelectCache = new TwoKeyWeakMap();
+
+/**
+ * @template T
+ * @template R
+ * @param {Selector<T, R>} getter getter for value
+ * @param {Comparator<R>} comparator comparator
+ * @returns {Comparator<T>} comparator
+ */
+const compareSelect = (getter, comparator) => {
+	const cacheEntry = compareSelectCache.get(getter, comparator);
+	if (cacheEntry !== undefined) return cacheEntry;
+	/**
+	 * @param {T} a first value
+	 * @param {T} b second value
+	 * @returns {-1|0|1} compare result
+	 */
+	const result = (a, b) => {
+		const aValue = getter(a);
+		const bValue = getter(b);
+		if (aValue !== undefined && aValue !== null) {
+			if (bValue !== undefined && bValue !== null) {
+				return comparator(aValue, bValue);
+			}
+			return -1;
+		} else {
+			if (bValue !== undefined && bValue !== null) {
+				return 1;
+			}
+			return 0;
+		}
+	};
+	compareSelectCache.set(getter, comparator, result);
+	return result;
+};
+exports.compareSelect = compareSelect;
+
+/** @type {WeakMap<Comparator<any>, Comparator<Iterable<any>>>} */
+const compareIteratorsCache = new WeakMap();
+
+/**
+ * @template T
+ * @param {Comparator<T>} elementComparator comparator for elements
+ * @returns {Comparator<Iterable<T>>} comparator for iterables of elements
+ */
+const compareIterables = elementComparator => {
+	const cacheEntry = compareIteratorsCache.get(elementComparator);
+	if (cacheEntry !== undefined) return cacheEntry;
+	/**
+	 * @param {Iterable<T>} a first value
+	 * @param {Iterable<T>} b second value
+	 * @returns {-1|0|1} compare result
+	 */
+	const result = (a, b) => {
+		const aI = a[Symbol.iterator]();
+		const bI = b[Symbol.iterator]();
+		// eslint-disable-next-line no-constant-condition
+		while (true) {
+			const aItem = aI.next();
+			const bItem = bI.next();
+			if (aItem.done) {
+				return bItem.done ? 0 : -1;
+			} else if (bItem.done) {
+				return 1;
+			}
+			const res = elementComparator(aItem.value, bItem.value);
+			if (res !== 0) return res;
+		}
+	};
+	compareIteratorsCache.set(elementComparator, result);
+	return result;
+};
+exports.compareIterables = compareIterables;
+
+// TODO this is no longer needed when minimum node.js version is >= 12
+// since these versions ship with a stable sort function
+/**
+ * @template T
+ * @param {Iterable<T>} iterable original ordered list
+ * @returns {Comparator<T>} comparator
+ */
+exports.keepOriginalOrder = iterable => {
+	/** @type {Map<T, number>} */
+	const map = new Map();
+	let i = 0;
+	for (const item of iterable) {
+		map.set(item, i++);
+	}
+	return (a, b) => compareNumbers(map.get(a), map.get(b));
+};
+
+/**
+ * Compare two locations
+ * @param {DependencyLocation} a A location node
+ * @param {DependencyLocation} b A location node
+ * @returns {-1|0|1} sorting comparator value
+ */
+exports.compareLocations = (a, b) => {
+	let isObjectA = typeof a === "object" && a !== null;
+	let isObjectB = typeof b === "object" && b !== null;
+	if (!isObjectA || !isObjectB) {
+		if (isObjectA) return 1;
+		if (isObjectB) return -1;
+		return 0;
+	}
+	if ("start" in a && "start" in b) {
+		const ap = a.start;
+		const bp = b.start;
+		if (ap.line < bp.line) return -1;
+		if (ap.line > bp.line) return 1;
+		if (ap.column < bp.column) return -1;
+		if (ap.column > bp.column) return 1;
+	}
+	if ("name" in a && "name" in b) {
+		if (a.name < b.name) return -1;
+		if (a.name > b.name) return 1;
+	}
+	if ("index" in a && "index" in b) {
+		if (a.index < b.index) return -1;
+		if (a.index > b.index) return 1;
+	}
+	return 0;
+};

--- a/packages/rspack/src/util/smartGrouping.js
+++ b/packages/rspack/src/util/smartGrouping.js
@@ -1,0 +1,170 @@
+/*
+	MIT License http://www.opensource.org/licenses/mit-license.php
+	Author Tobias Koppers @sokra
+*/
+
+"use strict";
+
+/**
+ * @typedef {Object} GroupOptions
+ * @property {boolean=} groupChildren
+ * @property {boolean=} force
+ * @property {number=} targetGroupCount
+ */
+
+/**
+ * @template T
+ * @template R
+ * @typedef {Object} GroupConfig
+ * @property {function(T): string[]} getKeys
+ * @property {function(string, (R | T)[], T[]): R} createGroup
+ * @property {function(string, T[]): GroupOptions=} getOptions
+ */
+
+/**
+ * @template T
+ * @typedef {Object} ItemWithGroups
+ * @property {T} item
+ * @property {Set<string>} groups
+ */
+
+/**
+ * @template T
+ * @template R
+ * @param {T[]} items the list of items
+ * @param {GroupConfig<T, R>[]} groupConfigs configuration
+ * @returns {(R | T)[]} grouped items
+ */
+const smartGrouping = (items, groupConfigs) => {
+	/** @type {Set<ItemWithGroups<T>>} */
+	const itemsWithGroups = new Set();
+	/** @type {Map<string, [GroupConfig<T, R>, string]>} */
+	const groupConfigMap = new Map();
+	for (const item of items) {
+		const groups = new Set();
+		for (let i = 0; i < groupConfigs.length; i++) {
+			const groupConfig = groupConfigs[i];
+			const keys = groupConfig.getKeys(item);
+			if (keys) {
+				for (const group of keys) {
+					const fullGroup = `${i}:${group}`;
+					if (!groupConfigMap.has(fullGroup)) {
+						groupConfigMap.set(fullGroup, [groupConfig, group]);
+					}
+					groups.add(fullGroup);
+				}
+			}
+		}
+		itemsWithGroups.add({
+			item,
+			groups
+		});
+	}
+	const alreadyGrouped = new Set();
+	/**
+	 * @param {Set<ItemWithGroups<T>>} itemsWithGroups input items with groups
+	 * @returns {(T | R)[]} groups items
+	 */
+	const runGrouping = itemsWithGroups => {
+		const totalSize = itemsWithGroups.size;
+		/** @type {Map<string, Set<ItemWithGroups<T>>>} */
+		const groupMap = new Map();
+		for (const entry of itemsWithGroups) {
+			for (const group of entry.groups) {
+				if (alreadyGrouped.has(group)) continue;
+				const list = groupMap.get(group);
+				if (list === undefined) {
+					groupMap.set(group, new Set([entry]));
+				} else {
+					list.add(entry);
+				}
+			}
+		}
+		/** @type {Set<string>} */
+		const usedGroups = new Set();
+		/** @type {(T | R)[]} */
+		const results = [];
+		for (;;) {
+			let bestGroup = undefined;
+			let bestGroupSize = -1;
+			let bestGroupItems = undefined;
+			let bestGroupOptions = undefined;
+			for (const [group, items] of groupMap) {
+				if (items.size === 0) continue;
+				const [groupConfig, groupKey] = groupConfigMap.get(group);
+				const options =
+					groupConfig.getOptions &&
+					groupConfig.getOptions(
+						groupKey,
+						Array.from(items, ({ item }) => item)
+					);
+				const force = options && options.force;
+				if (!force) {
+					if (bestGroupOptions && bestGroupOptions.force) continue;
+					if (usedGroups.has(group)) continue;
+					if (items.size <= 1 || totalSize - items.size <= 1) {
+						continue;
+					}
+				}
+				const targetGroupCount = (options && options.targetGroupCount) || 4;
+				let sizeValue = force
+					? items.size
+					: Math.min(
+							items.size,
+							(totalSize * 2) / targetGroupCount +
+								itemsWithGroups.size -
+								items.size
+					  );
+				if (
+					sizeValue > bestGroupSize ||
+					(force && (!bestGroupOptions || !bestGroupOptions.force))
+				) {
+					bestGroup = group;
+					bestGroupSize = sizeValue;
+					bestGroupItems = items;
+					bestGroupOptions = options;
+				}
+			}
+			if (bestGroup === undefined) {
+				break;
+			}
+			const items = new Set(bestGroupItems);
+			const options = bestGroupOptions;
+
+			const groupChildren = !options || options.groupChildren !== false;
+
+			for (const item of items) {
+				itemsWithGroups.delete(item);
+				// Remove all groups that items have from the map to not select them again
+				for (const group of item.groups) {
+					const list = groupMap.get(group);
+					if (list !== undefined) list.delete(item);
+					if (groupChildren) {
+						usedGroups.add(group);
+					}
+				}
+			}
+			groupMap.delete(bestGroup);
+
+			const idx = bestGroup.indexOf(":");
+			const configKey = bestGroup.slice(0, idx);
+			const key = bestGroup.slice(idx + 1);
+			const groupConfig = groupConfigs[+configKey];
+
+			const allItems = Array.from(items, ({ item }) => item);
+
+			alreadyGrouped.add(bestGroup);
+			const children = groupChildren ? runGrouping(items) : allItems;
+			alreadyGrouped.delete(bestGroup);
+
+			results.push(groupConfig.createGroup(key, children, allItems));
+		}
+		for (const { item } of itemsWithGroups) {
+			results.push(item);
+		}
+		return results;
+	};
+	return runGrouping(itemsWithGroups);
+};
+
+module.exports = smartGrouping;

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -143,7 +143,7 @@ describe("Stats", () => {
 		}
 	`);
 		expect(stats?.toString(statsOptions)).toMatchInlineSnapshot(`
-		"Hash: a8535b55b7de03c8
+		"a8535b55b7de03c8
 		PublicPath: auto
 		  Asset       Size  Chunks             Chunk Names
 		main.js  215 bytes    main  [emitted]  main
@@ -174,7 +174,7 @@ describe("Stats", () => {
 			entry: "./fixtures/abc"
 		});
 		expect(stats?.toString({ timings: false })).toMatchInlineSnapshot(`
-		"Hash: 54a4e1c6f704eccd
+		"54a4e1c6f704eccd
 		PublicPath: auto
 		  Asset       Size  Chunks             Chunk Names
 		main.js  419 bytes    main  [emitted]  main

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -222,7 +222,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for filename 2`] = `
-"Hash: 382c54c013a30aa4
+"382c54c013a30aa4
              Asset       Size      Chunks             Chunk Names
       main.xxxx.js   1.39 KiB        main  [emitted]  main
 dynamic_js.xxxx.js  218 bytes  dynamic_js  [emitted]  
@@ -365,7 +365,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for hot+production 2`] = `
-"Hash: b50ba9ed7df3e351
+"b50ba9ed7df3e351
     Asset      Size  Chunks             Chunk Names
 bundle.js  8.89 KiB    main  [emitted]  main
 Entrypoint main = bundle.js
@@ -1415,7 +1415,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-overflow 2`] = `
-"Hash: 96843041aec37d26
+"96843041aec37d26
 PublicPath: auto
     Asset       Size  Chunks             Chunk Names
 bundle.js  365 bytes    main  [emitted]  main
@@ -1634,7 +1634,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-unexpected-exports-in-pkg 2`] = `
-"Hash: 35d11ac4c0a84831
+"35d11ac4c0a84831
     Asset       Size  Chunks             Chunk Names
 bundle.js  974 bytes    main  [emitted]  main
 Entrypoint main = bundle.js
@@ -1778,7 +1778,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for simple 2`] = `
-"Hash: c1603650c938e434
+"c1603650c938e434
     Asset       Size  Chunks             Chunk Names
 bundle.js  319 bytes    main  [emitted]  main
 Entrypoint main = bundle.js


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/issues/3090

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82da589</samp>

This pull request adds statistics generation and printing features to the `rspack` module. It introduces new classes, hooks, and utilities to allow customization of the statistics. It also adds an example file to demonstrate how to use the `rspack` module.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82da589</samp>

*  Add `examples/basic/build.js` file to demonstrate how to use `rspack` module ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-9bae34ae0f4ea45e132d1108ffc19fd219da31c7f9516f73fe0c2a9d03bfb8d1R1-R13))
*  Import and expose `StatsFactory` and `StatsPrinter` classes in `compilation.ts` file ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R40-R41))
*  Add `statsFactory` and `statsPrinter` hooks to `Compilation` class to allow plugins to customize statistics creation and printing ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R86-R87), [link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L118-R124))
*  Add `createStatsFactory` and `createStatsPrinter` methods to `Compilation` class to create and return statistics instances and call hooks ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L268-R284))
*  Add `StatsFactory` class in `stats/StatsFactory.js` file to create statistics objects from compilation data using hooks ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-d77da689d6cda84f9c979523e11775731c88b3817a7b788e43069dd23db8048bR1-R292))
*  Add `StatsPrinter` class in `stats/StatsPrinter.js` file to print statistics objects to a string using hooks ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-7b9184dbd72da4ad1df15d7bf6b4fb50b760c65183fe24737e93e50d9e496d9bR1-R249))
*  Add `smartGrouping` function in `util/smartGrouping.js` file to group items based on configurable keys and options ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-06b5f6ee368d224a7cca9d63f33315c56ea53a89bc46813609e9d01d663f9f4fR1-R170))
*  Use `createStatsFactory` and `createStatsPrinter` methods in `Stats` class and add TODO comment for plugin ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-dabb493b406bdc4bd957c1580c51c7003d0aef67411624e6664c7b1c50b67705R146-R149))
*  Remove hash printing from `Stats` class as it is handled by `StatsPrinter` class ([link](https://github.com/web-infra-dev/rspack/pull/3177/files?diff=unified&w=0#diff-dabb493b406bdc4bd957c1580c51c7003d0aef67411624e6664c7b1c50b67705L265))

</details>
