### PR TITLE
chore: 🤖 fix cargo test crash

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,7 +31,7 @@ rustflags = [
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>
 # To be able to run unit tests on macOS, support compilation to 'x86_64-apple-darwin'.
 [target.'cfg(target_vendor = "apple")']
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains"]
 
 # To be able to run unit tests on Linux, support compilation to 'x86_64-unknown-linux-gnu'.
 [target.'cfg(target_os = "linux")']


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3db846</samp>

Fix crashes on macOS when running unit tests with rspack. Add `-no_fixup_chains` flag to linker arguments in `.cargo/config.toml`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3db846</samp>

*  Add linker flag to prevent fixup chains on macOS ([link](https://github.com/web-infra-dev/rspack/pull/3178/files?diff=unified&w=0#diff-9a4f3e4537ebb7474452d131b0d969d89a51286f4269aac5ef268e712be17268L34-R34))

</details>
