### PR TITLE
fix(magic_comment): support '()'

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -115,7 +115,7 @@ impl DependencyScanner<'_> {
   fn try_extract_webpack_chunk_name(&self, first_arg_span_of_import_call: &Span) -> Option<String> {
     use swc_core::common::comments::CommentKind;
     static WEBPACK_CHUNK_NAME_CAPTURE_RE: Lazy<regex::Regex> = Lazy::new(|| {
-      regex::Regex::new(r#"webpackChunkName\s*:\s*("(?P<_1>(\./)?([\w0-9_\-\[\]]+/)*?[\w0-9_\-\[\]]+)"|'(?P<_2>(\./)?([\w0-9_\-\[\]]+/)*?[\w0-9_\-\[\]]+)'|`(?P<_3>(\./)?([\w0-9_\-\[\]]+/)*?[\w0-9_\-\[\]]+)`)"#)
+      regex::Regex::new(r#"webpackChunkName\s*:\s*("(?P<_1>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)"|'(?P<_2>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)'|`(?P<_3>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)`)"#)
         .expect("invalid regex")
     });
     self

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
@@ -6,6 +6,7 @@ __webpack_require__.el("./single_quote.js").then(__webpack_require__.bind(__webp
 __webpack_require__.el("./other.js").then(__webpack_require__.bind(__webpack_require__, "./other.js")).then(__webpack_require__.ir);
 __webpack_require__.el("./user/1.js").then(__webpack_require__.bind(__webpack_require__, "./user/1.js")).then(__webpack_require__.ir);
 __webpack_require__.el("./user/page/2.js").then(__webpack_require__.bind(__webpack_require__, "./user/page/2.js")).then(__webpack_require__.ir);
+__webpack_require__.el("./user/page/3.js").then(__webpack_require__.bind(__webpack_require__, "./user/page/3.js")).then(__webpack_require__.ir);
 __webpack_require__.el("./bug_only_single_quote.js").then(__webpack_require__.bind(__webpack_require__, "./bug_only_single_quote.js")).then(__webpack_require__.ir);
 },
 

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/user/(id)/page.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/user/(id)/page.js
@@ -1,0 +1,6 @@
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["user/(id)/page"], {
+"./user/page/3.js": function (module, exports, __webpack_require__) {
+console.log('user (id)/page3');
+},
+
+}]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/index.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/index.js
@@ -5,6 +5,8 @@ import(/* webpackChunkName: './sub/single' */ './single_quote')
 import(/* webpackChunkName: `./sub/other` */ './other')
 import(/* webpackChunkName: "./user/[id]" */ './user/1')
 import(/* webpackChunkName: `user/[id]/page`*/ './user/page/2')
+import(/* webpackChunkName: `user/(id)/page`*/ './user/page/3')
+
 import(/* 'bug_' */ './bug_only_single_quote.js')
 
 

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/user/page/3.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/user/page/3.js
@@ -1,0 +1,1 @@
+console.log('user (id)/page3')


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->
https://github.com/web-infra-dev/rspack/issues/3157
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 65308d1</samp>

Allow parentheses in webpack chunk names for dynamic imports. Add a test case and update the expected output for the rspack plugin that handles JavaScript magic comments.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 65308d1</samp>

* Allow parentheses in webpack chunk names for dynamic imports ([link](https://github.com/web-infra-dev/rspack/pull/3179/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL118-R118))
* Add a test case for the new feature ([link](https://github.com/web-infra-dev/rspack/pull/3179/files?diff=unified&w=0#diff-90a6cb45918dbd03fa7560798ab4eb28dc019f4cab94e02900ab977feff506e5R8-R9), [link](https://github.com/web-infra-dev/rspack/pull/3179/files?diff=unified&w=0#diff-3e021a3ae36a950ede35e74e40927692aea3710080af06f23baf5a9c1911d0f3R1), [link](https://github.com/web-infra-dev/rspack/pull/3179/files?diff=unified&w=0#diff-896ce47440c79b9f60c65faac7b527f1186a7faf40e9a1c4bf9afdbab32bcc55R9))

</details>
