### PR TITLE
fix: add experiments.css schema

### DIFF
--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -341,7 +341,7 @@ module.exports = {
 					type: "boolean"
 				},
 				css: {
-					description: "Enable css support.",
+					description: "Enable native css support.",
 					type: "boolean"
 				}
 			}

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -339,6 +339,10 @@ module.exports = {
 				newSplitChunks: {
 					description: "Enable new SplitChunksPlugin",
 					type: "boolean"
+				},
+				css: {
+					description: "Enable css support.",
+					type: "boolean"
 				}
 			}
 		},


### PR DESCRIPTION
## Related issue (if exists)

Closed: #3182

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e82941f</samp>

Add `css` property to `rspack` config schema. This allows users to enable or disable css support in their `rspack` projects.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e82941f</samp>

* Add a new option `css` to enable css support in `rspack` ([link](https://github.com/web-infra-dev/rspack/pull/3183/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R342-R345))

</details>
