### PR TITLE
feat(resolve): support custom exports fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,9 +1493,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.83"
+version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5554f7a1fd80140d05b025491e6a80295c349fc2b4c37be2a62a69b0b519c97a"
+checksum = "b2510e8ad37a58f71f24d7d477e7804c40f6ad3fba89ee68ebc4369b3767beb6"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ itertools          = { version = "0.10.5" }
 json               = { version = "0.12.4" }
 linked_hash_set    = { version = "0.1.4" }
 mimalloc-rust      = { version = "0.2" }
-nodejs-resolver    = { version = "0.0.83" }
+nodejs-resolver    = { version = "0.0.84" }
 once_cell          = { version = "1.17.1" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -768,6 +768,7 @@ export interface RawResolveOptions {
   modules?: Array<string>
   byDependency?: Record<string, RawResolveOptions>
   fullySpecified?: boolean
+  exportsFields?: Array<string>
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_options/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_options/src/options/raw_resolve.rs
@@ -28,6 +28,7 @@ pub struct RawResolveOptions {
   pub modules: Option<Vec<String>>,
   pub by_dependency: Option<HashMap<String, RawResolveOptions>>,
   pub fully_specified: Option<bool>,
+  pub exports_fields: Option<Vec<String>>,
 }
 
 fn normalize_alias(alias: Option<RawAliasOption>) -> anyhow::Result<Option<Alias>> {
@@ -90,6 +91,9 @@ impl TryFrom<RawResolveOptions> for Resolve {
           .collect::<Result<ByDependency, Self::Error>>()
       })
       .transpose()?;
+    let exports_field = value
+      .exports_fields
+      .map(|v| v.into_iter().map(|s| vec![s]).collect());
 
     Ok(Resolve {
       modules,
@@ -105,6 +109,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
       fallback,
       by_dependency,
       fully_specified,
+      exports_field,
     })
   }
 }

--- a/crates/rspack_core/src/compiler/resolver.rs
+++ b/crates/rspack_core/src/compiler/resolver.rs
@@ -63,13 +63,12 @@ impl ResolverFactory {
         Some(o) => base_options.merge(o.clone()),
         None => base_options,
       };
-      let resolver = Arc::new(Resolver(nodejs_resolver::Resolver::new(
-        merged_options.to_inner_options(
-          self.cache.clone(),
-          options.resolve_to_context,
-          options.dependency_category,
-        ),
-      )));
+      let normalized = merged_options.to_inner_options(
+        self.cache.clone(),
+        options.resolve_to_context,
+        options.dependency_category,
+      );
+      let resolver = Arc::new(Resolver(nodejs_resolver::Resolver::new(normalized)));
       self.resolvers.insert(options, resolver.clone());
       resolver
     }

--- a/crates/rspack_core/src/options/resolve.rs
+++ b/crates/rspack_core/src/options/resolve.rs
@@ -45,6 +45,9 @@ pub struct Resolve {
   /// extensions or main files are not resolved for it.
   /// Default is `false`.
   pub fully_specified: Option<bool>,
+  /// A list of exports fields in descriptions files
+  /// Default is `[["exports"]]`.
+  pub exports_field: Option<Vec<Vec<String>>>,
   pub by_dependency: Option<ByDependency>,
 }
 
@@ -86,6 +89,9 @@ impl Resolve {
       .unwrap_or_else(|| vec!["node_modules".to_string()]);
     let fallback = options.fallback.unwrap_or_default();
     let fully_specified = options.fully_specified.unwrap_or_default();
+    let exports_field = options
+      .exports_field
+      .unwrap_or_else(|| vec![vec!["exports".to_string()]]);
     nodejs_resolver::Options {
       fallback,
       modules,
@@ -103,6 +109,7 @@ impl Resolve {
       tsconfig,
       resolve_to_context,
       fully_specified,
+      exports_field,
     }
   }
 
@@ -204,7 +211,7 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
     pre.merge(now)
   });
   let tsconfig = overwrite(base.tsconfig, other.tsconfig, |_, value| value);
-
+  let exports_field = overwrite(base.exports_field, other.exports_field, |_, value| value);
   Resolve {
     fallback,
     modules,
@@ -219,6 +226,7 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
     tsconfig,
     by_dependency,
     fully_specified,
+    exports_field,
   }
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -621,6 +621,7 @@ const getResolveDefaults = ({
 		extensions: [],
 		browserField,
 		mainFields: ["main"].filter(Boolean),
+		exportsFields: ["exports"],
 		byDependency: {
 			wasm: esmDeps(),
 			esm: esmDeps(),

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -1435,6 +1435,16 @@ module.exports = {
 				tsConfigPath: {
 					description: "Path to tsconfig.json",
 					type: "string"
+				},
+				exportsFields: {
+					description:
+						"Fields in the description file (usually package.json) which are used to redirect requests inside the module.",
+					type: "array",
+					items: {
+						description:
+							"Field name from the description file (package.json) which are used to find the default entry point.",
+						type: "string"
+					}
 				}
 			}
 		},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -285,6 +285,7 @@ export interface ResolveOptions {
 	preferRelative?: boolean;
 	tsConfigPath?: string;
 	fullySpecified?: boolean;
+	exportsFields?: string[];
 	byDependency?: {
 		[k: string]: ResolveOptions;
 	};

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -323,6 +323,9 @@ exports[`snapshots should have the correct base config 1`] = `
       "production",
       "browser",
     ],
+    "exportsFields": [
+      "exports",
+    ],
     "extensions": [],
     "mainFields": [
       "main",

--- a/packages/rspack/tests/configCases/resolve/conditions/test.config.js
+++ b/packages/rspack/tests/configCases/resolve/conditions/test.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-	entry: {
-		main: ["./index.js"]
-	},
-	resolve: {
-		conditionNames: ["pack"]
-	}
-};

--- a/packages/rspack/tests/configCases/resolve/exports-fields/.gitignore
+++ b/packages/rspack/tests/configCases/resolve/exports-fields/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/resolve/exports-fields/index.js
+++ b/packages/rspack/tests/configCases/resolve/exports-fields/index.js
@@ -1,0 +1,4 @@
+it("should resolve both alternatives", () => {
+	const b = require("exports-field");
+	expect(b).toBe("b");
+});

--- a/packages/rspack/tests/configCases/resolve/exports-fields/node_modules/exports-field/b.js
+++ b/packages/rspack/tests/configCases/resolve/exports-fields/node_modules/exports-field/b.js
@@ -1,0 +1,1 @@
+module.exports = 'b'

--- a/packages/rspack/tests/configCases/resolve/exports-fields/node_modules/exports-field/package.json
+++ b/packages/rspack/tests/configCases/resolve/exports-fields/node_modules/exports-field/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-field",
+  "version": "1.0.0",
+  "b": "./b.js"
+}

--- a/packages/rspack/tests/configCases/resolve/exports-fields/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve/exports-fields/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	entry: "./index.js",
+	resolve: {
+		exportsFields: ["a", "b"]
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9e42b02</samp>

Added support for custom exports fields in module resolution options for both Rust and webpack. Updated nodejs-resolver dependency and added a new test case for exports-fields. Removed an unused test file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9e42b02</samp>

*  Update nodejs-resolver dependency to version 0.0.84 ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L27-R27))
*  Add export_fields field to RawResolveOptions struct and map it to exports_field field in ResolveOptions struct ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-d0ff551abe7f965b57ac363f3b8e70ef24bc589ce21b7ebcb16c119ffd7e82c7R31), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-d0ff551abe7f965b57ac363f3b8e70ef24bc589ce21b7ebcb16c119ffd7e82c7R94), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-d0ff551abe7f965b57ac363f3b8e70ef24bc589ce21b7ebcb16c119ffd7e82c7R110))
*  Add exports_field field to ResolveOptions struct and assign it a default value of `[["exports"]]` ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R48-R50), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R92-R94))
*  Pass exports_field field to Resolve::new function and merge it with base and other options ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R112), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0L207-R214), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R229))
*  Add exportsFields field to webpack configuration and validate it with resolve schema ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccR624), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R1438-R1447), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR288))
*  Add exports-fields test case to test resolving modules with different exports fields ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-be6aa16d9628b6ac4ad689d657ebce0bbbe28ae64a99e136c2d5c66cc54ac8cbL1-L-1), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-7404ef9d5f36c6202791be0264cd261b300c3631de4047cf0a978473a4b70d14R1-R4), [link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-9220eea7b6bdbacc6721bcb10b367582ce2e1c0ea8f1245fc5d6ceb9025e3cb1R1-R6))
*  Delete test.config.js file from resolve/conditions test case ([link](https://github.com/web-infra-dev/rspack/pull/3186/files?diff=unified&w=0#diff-bd77a816875e296d45f87a9f262c945b4e91fab32502893868a15d6e43628e36))

</details>
