### PR TITLE
fix(plugin-node-polyfill): remove console polyfill

### DIFF
--- a/examples/node-polyfill/src/index.js
+++ b/examples/node-polyfill/src/index.js
@@ -1,4 +1,6 @@
 const util = require("util");
+const logger = require("./logger");
 console.log("procss:", process.version);
 console.log("buffer", Buffer.from("abcd"));
 console.log("util:", util.format("%s:%s", "foo", "bar"));
+logger("log", "logger");

--- a/examples/node-polyfill/src/logger.js
+++ b/examples/node-polyfill/src/logger.js
@@ -1,0 +1,3 @@
+module.exports = function logger(method, ...args) {
+	console[method](...args);
+};

--- a/packages/rspack-plugin-node-polyfill/src/index.js
+++ b/packages/rspack-plugin-node-polyfill/src/index.js
@@ -34,7 +34,6 @@ module.exports = class PolyfillBuiltinsPlugin {
 	apply(compiler) {
 		const provide = {
 			Buffer: [require.resolve("buffer/"), "Buffer"],
-			console: [require.resolve("console-browserify")],
 			process: [require.resolve("process/browser")]
 		};
 


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/issues/3187
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 624056b</samp>

This pull request updates the `rspack-plugin-node-polyfill` plugin to remove the `console` alias and fixes a bug related to console-browserify. It also adds a new `logger` module and uses it in the `examples/node-polyfill` code to demonstrate the plugin functionality.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 624056b</samp>

*  Removed `console` alias from `rspack-plugin-node-polyfill` plugin to fix compatibility issues with browser console ([link](https://github.com/web-infra-dev/rspack/pull/3191/files?diff=unified&w=0#diff-437889559491286bfcc191e0157f6bcb92e5c6864370cfe4304f318938a8a830L37))
*  Added `logger` module to demonstrate custom module usage with `rspack-plugin-node-polyfill` plugin in `examples/node-polyfill` folder ([link](https://github.com/web-infra-dev/rspack/pull/3191/files?diff=unified&w=0#diff-3bf23f9ac0337b024f37a8827cb43921f39bc64c228c1211d1197af47cef6a18R1-R3), [link](https://github.com/web-infra-dev/rspack/pull/3191/files?diff=unified&w=0#diff-fa5d65ba643d691c74a8b7a7712366e14e1fce9eb6822e7a3d59f9b46fd3e00aL2-R6))
*  Used `logger` module in `index.js` to log messages to the console ([link](https://github.com/web-infra-dev/rspack/pull/3191/files?diff=unified&w=0#diff-fa5d65ba643d691c74a8b7a7712366e14e1fce9eb6822e7a3d59f9b46fd3e00aL2-R6))

</details>
