### PR TITLE
chore: fix arco-pro example crashing in debug mode

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -13,7 +13,7 @@ const config = {
 		historyApiFallback: true
 	},
 	mode: prod ? "production" : "development",
-	devtool: prod ? false : "source-map",
+	devtool: false,
 	builtins: {
 		progress: {},
 		treeShaking: true,
@@ -43,7 +43,16 @@ const config = {
 			}
 		]
 	},
-	resolve: { alias: { "@": path.resolve(__dirname, "src") } },
+	resolve: {
+		alias: {
+			"@": path.resolve(__dirname, "src"),
+			// The default exported mock.js is a minified file with super deep binary
+			// expression, which causes stack overflow for swc parser in debug mode.
+			// Alias to the unminified version mitigates this problem.
+			// See also <https://github.com/search?q=repo%3Aswc-project%2Fswc+parser+stack+overflow&type=issues>
+			"mockjs": require.resolve("mockjs/src/mock.js"),
+		}
+	},
 	output: {
 		publicPath: "/",
 		filename: "[name].[contenthash].js"


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba2c5dc</samp>

This pull request improves the web app performance and fixes a transpiler error by modifying the `rspack.config.js` file in the arco-pro example. It disables source maps and aliases the `mockjs` module.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba2c5dc</samp>

*  Disable source map generation for production and development modes to reduce bundle size and improve performance ([link](https://github.com/web-infra-dev/rspack/pull/3192/files?diff=unified&w=0#diff-a15e1eaa368a715b66e785724260aac9f5f604803a4157926cddd5d588724c97L16-R16))
*  Add alias for mockjs module to avoid stack overflow error when using swc transpiler in debug mode ([link](https://github.com/web-infra-dev/rspack/pull/3192/files?diff=unified&w=0#diff-a15e1eaa368a715b66e785724260aac9f5f604803a4157926cddd5d588724c97L46-R55))

</details>
