### PR TITLE
fix: render exports for esm output at hmr

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -32,9 +32,7 @@ use crate::{
   build_chunk_graph::build_chunk_graph,
   cache::{use_code_splitting_cache, Cache, CodeSplittingCache},
   is_source_equal,
-  tree_shaking::{
-    optimizer, visitor::SymbolRef, webpack_ext::ExportInfo, BailoutFlag, OptimizeDependencyResult,
-  },
+  tree_shaking::{optimizer, visitor::SymbolRef, BailoutFlag, OptimizeDependencyResult},
   utils::fast_drop,
   AddQueue, AddTask, AddTaskResult, AdditionalChunkRuntimeRequirementsArgs, BoxModuleDependency,
   BuildQueue, BuildTask, BuildTaskResult, BundleEntries, Chunk, ChunkByUkey, ChunkGraph,
@@ -92,7 +90,6 @@ pub struct Compilation {
   pub used_symbol_ref: HashSet<SymbolRef>,
   /// Collecting all module that need to skip in tree-shaking ast modification phase
   pub bailout_module_identifiers: IdentifierMap<BailoutFlag>,
-  pub exports_info_map: IdentifierMap<Vec<ExportInfo>>,
   pub optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
 
   pub code_generation_results: CodeGenerationResults,
@@ -146,7 +143,6 @@ impl Compilation {
       named_chunk_groups: Default::default(),
       entry_module_identifiers: IdentifierSet::default(),
       used_symbol_ref: HashSet::default(),
-      exports_info_map: IdentifierMap::default(),
       optimize_analyze_result_map: IdentifierMap::default(),
       bailout_module_identifiers: IdentifierMap::default(),
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -16,10 +16,7 @@ use rustc_hash::FxHashSet as HashSet;
 use tokio::sync::RwLock;
 use tracing::instrument;
 
-use crate::{
-  cache::Cache, fast_set, tree_shaking::webpack_ext::ExportInfoExt, CompilerOptions, Plugin,
-  PluginDriver, SharedPluginDriver,
-};
+use crate::{cache::Cache, fast_set, CompilerOptions, Plugin, PluginDriver, SharedPluginDriver};
 
 #[derive(Debug)]
 pub struct Compiler<T>
@@ -175,14 +172,6 @@ where
         && self.options.optimization.side_effects.is_enable()
       {
         self.compilation.include_module_ids = analyze_result.include_module_ids;
-      }
-      for entry in &self.compilation.entry_module_identifiers {
-        if let Some(analyze_results) = analyze_result.analyze_results.get(entry) {
-          self
-            .compilation
-            .exports_info_map
-            .insert(*entry, analyze_results.ordered_exports());
-        }
       }
       self.compilation.optimize_analyze_result_map = analyze_result.analyze_results;
     }

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -2,7 +2,9 @@ use std::hash::Hash;
 
 use rspack_core::{
   rspack_sources::{ConcatSource, RawSource, SourceExt},
-  to_identifier, JsChunkHashArgs, Plugin, PluginContext, PluginJsChunkHashHookOutput,
+  to_identifier,
+  tree_shaking::webpack_ext::ExportInfoExt,
+  JsChunkHashArgs, Plugin, PluginContext, PluginJsChunkHashHookOutput,
   PluginRenderStartupHookOutput, RenderStartupArgs,
 };
 
@@ -26,8 +28,12 @@ impl Plugin for ModuleLibraryPlugin {
     let mut source = ConcatSource::default();
     source.add(args.source.clone());
     let mut exports = vec![];
-    if let Some(ordered_exports) = args.compilation.exports_info_map.get(&args.module) {
-      for info in ordered_exports {
+    if let Some(analyze_results) = args
+      .compilation
+      .optimize_analyze_result_map
+      .get(&args.module)
+    {
+      for info in analyze_results.ordered_exports() {
         let name = to_identifier(info.name.as_ref());
         let var_name = format!("__webpack_exports__{}", name);
         source.add(RawSource::from(format!(


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6db698</samp>

Refactored and simplified the export analysis and optimization code in `rspack_core`. Adapted the module library plugin in `rspack_plugin_library` to use the new API.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a6db698</samp>

*  Remove `ExportInfo` type and `webpack_ext` module from `tree_shaking` module, as they are no longer needed for export analysis ([link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L35-R35))
*  Replace `exports_info_map` field with `optimize_analyze_result_map` field in `Compilation` struct, to store the results of export analysis and optimization for each module ([link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L95), [link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L149), [link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L179-L186), [link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-32658f3059223914bd10474ae269827489a13ca9c2f616e7597579f6b2041a8fL29-R36))
*  Move `ExportInfoExt` trait from `compiler` module to `compilation` module, as it is only used by `Compilation` and its methods ([link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L19-R19), [link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-32658f3059223914bd10474ae269827489a13ca9c2f616e7597579f6b2041a8fL5-R7))
*  Call `ordered_exports` method on `analyze_results` field instead of `exports_info_map` field, to get the ordered list of exports for each module ([link](https://github.com/web-infra-dev/rspack/pull/3194/files?diff=unified&w=0#diff-32658f3059223914bd10474ae269827489a13ca9c2f616e7597579f6b2041a8fL29-R36))

</details>
