### PR TITLE
chore: fix arco-pro crash again

### DIFF
--- a/examples/arco-pro/patches/mock.js
+++ b/examples/arco-pro/patches/mock.js
@@ -1,0 +1,11 @@
+export default {
+	setup() {},
+	mock() {
+		return {};
+	},
+	XHR: {
+		prototype: {
+			withCredentials: true
+		}
+	}
+};

--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -46,11 +46,11 @@ const config = {
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "src"),
-			// The default exported mock.js is a minified file with super deep binary
+			// The default exported mock.js contains a minified [parser](https://github.com/nuysoft/Mock/blob/refactoring/src/mock/regexp/parser.js) with super deep binary
 			// expression, which causes stack overflow for swc parser in debug mode.
 			// Alias to the unminified version mitigates this problem.
 			// See also <https://github.com/search?q=repo%3Aswc-project%2Fswc+parser+stack+overflow&type=issues>
-			"mockjs": require.resolve("mockjs/src/mock.js"),
+			mockjs: require.resolve("./patches/mock.js")
 		}
 	},
 	output: {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7374eac</samp>

This pull request adds a `mock.js` module and updates the `rspack.config.js` file to mock the mockjs library and avoid a swc parser error. This allows rspack to transpile and bundle the code for the arco-pro example.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7374eac</samp>

*  Add a mock module to mock the behavior of mockjs ([link](https://github.com/web-infra-dev/rspack/pull/3195/files?diff=unified&w=0#diff-878b5d0d229dd54527487bee82e11b67639be2db9f3dec29959038cecac37784R1-R11))
*  Replace the default mockjs module with the mock module in the alias configuration ([link](https://github.com/web-infra-dev/rspack/pull/3195/files?diff=unified&w=0#diff-a15e1eaa368a715b66e785724260aac9f5f604803a4157926cddd5d588724c97L49-R53))

</details>
