### PR TITLE
chore: fix fix-issue-3873 crash 

### DIFF
--- a/examples/arco-pro/patches/mock.js
+++ b/examples/arco-pro/patches/mock.js
@@ -1,0 +1,11 @@
+export default {
+	setup() {},
+	mock() {
+		return {};
+	},
+	XHR: {
+		prototype: {
+			withCredentials: true
+		}
+	}
+};

--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -46,11 +46,11 @@ const config = {
 	resolve: {
 		alias: {
 			"@": path.resolve(__dirname, "src"),
-			// The default exported mock.js is a minified file with super deep binary
+			// The default exported mock.js contains a minified [parser](https://github.com/nuysoft/Mock/blob/refactoring/src/mock/regexp/parser.js) with super deep binary
 			// expression, which causes stack overflow for swc parser in debug mode.
 			// Alias to the unminified version mitigates this problem.
 			// See also <https://github.com/search?q=repo%3Aswc-project%2Fswc+parser+stack+overflow&type=issues>
-			"mockjs": require.resolve("mockjs/src/mock.js"),
+			mockjs: require.resolve("./patches/mock.js")
 		}
 	},
 	output: {

--- a/packages/rspack/tests/case.template.ts
+++ b/packages/rspack/tests/case.template.ts
@@ -78,6 +78,8 @@ export function describeCases(config: { name: string; casePath: string }) {
 											path: outputPath
 										}
 									};
+
+									fs.rmdirSync(outputPath, { recursive: true });
 									const stats = await util.promisify(rspack)(options);
 									const statsJson = stats!.toJson();
 									if (category.name === "errors") {


### PR DESCRIPTION
## Related issue (if exists)
since we don't clean dist folder it cause issue-3873 bundle dist/main.js recursively, which generates a complex dist/main.js cause swc stackoverflow
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3c9ff01</samp>

This pull request fixes a stack overflow error caused by mockjs when using swc in debug mode. It replaces mockjs with a custom mock module in the arco-pro example, and cleans up the output directory after each rspack test case.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3c9ff01</samp>

* Replace mockjs module with custom mock module to avoid stack overflow error when parsed by swc in debug mode ([link](https://github.com/web-infra-dev/rspack/pull/3196/files?diff=unified&w=0#diff-878b5d0d229dd54527487bee82e11b67639be2db9f3dec29959038cecac37784R1-R11),[link](https://github.com/web-infra-dev/rspack/pull/3196/files?diff=unified&w=0#diff-a15e1eaa368a715b66e785724260aac9f5f604803a4157926cddd5d588724c97L49-R53))
* Remove output directory recursively after each test case in `case.template.ts` to keep test environment clean and consistent ([link](https://github.com/web-infra-dev/rspack/pull/3196/files?diff=unified&w=0#diff-6c0bf465b39653e539e7adf0b2155d9f6f308e0c5eb316ec78059afa491b5348R81-R82))

</details>
