### PR TITLE
fix: wasm loading runtime on node-18

### DIFF
--- a/crates/rspack_plugin_wasm/src/loading_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/loading_plugin.rs
@@ -34,10 +34,10 @@ impl Plugin for FetchCompileAsyncWasmPlugin {
       runtime_requirements.insert(RuntimeGlobals::PUBLIC_PATH);
       args.compilation.add_runtime_module(
         args.chunk,
-        AsyncWasmLoadingRuntimeModule::new(format!(
-          "fetch({} + $PATH)",
-          RuntimeGlobals::PUBLIC_PATH
-        ))
+        AsyncWasmLoadingRuntimeModule::new(
+          format!("fetch({} + $PATH)", RuntimeGlobals::PUBLIC_PATH),
+          true,
+        )
         .boxed(),
       );
     }
@@ -74,11 +74,14 @@ impl Plugin for ReadFileCompileAsyncWasmPlugin {
       runtime_requirements.insert(RuntimeGlobals::PUBLIC_PATH);
       args.compilation.add_runtime_module(
         args.chunk,
-        AsyncWasmLoadingRuntimeModule::new(if self.import {
-          include_str!("runtime/read_file_compile_async_wasm_with_import.js").to_string()
-        } else {
-          include_str!("runtime/read_file_compile_async_wasm.js").to_string()
-        })
+        AsyncWasmLoadingRuntimeModule::new(
+          if self.import {
+            include_str!("runtime/read_file_compile_async_wasm_with_import.js").to_string()
+          } else {
+            include_str!("runtime/read_file_compile_async_wasm.js").to_string()
+          },
+          false,
+        )
         .boxed(),
       );
     }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b63094</samp>

This pull request enhances the `rspack_plugin_wasm` crate to support streaming compilation of WebAssembly modules. It adds a new parameter and a new feature to the `AsyncWasmLoadingRuntimeModule` struct and updates its constructor and code generation. This feature can improve performance for modules fetched from the public path.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b63094</samp>

*  Add streaming support for WebAssembly modules fetched from public path ([link](https://github.com/web-infra-dev/rspack/pull/3197/files?diff=unified&w=0#diff-e4db69ffb1e38711241972a1c62fc3bf6fa820965e620ca574fbe63f04cb793bL37-R40), [link](https://github.com/web-infra-dev/rspack/pull/3197/files?diff=unified&w=0#diff-ecee3d6c9c086225440d9c2ba8af6ade6036af692a9f7d9b612ddf3edf4e3303L10-R18), [link](https://github.com/web-infra-dev/rspack/pull/3197/files?diff=unified&w=0#diff-ecee3d6c9c086225440d9c2ba8af6ade6036af692a9f7d9b612ddf3edf4e3303L27-R31), [link](https://github.com/web-infra-dev/rspack/pull/3197/files?diff=unified&w=0#diff-ecee3d6c9c086225440d9c2ba8af6ade6036af692a9f7d9b612ddf3edf4e3303R42-R64))
*  Disable streaming support for WebAssembly modules generated from files ([link](https://github.com/web-infra-dev/rspack/pull/3197/files?diff=unified&w=0#diff-e4db69ffb1e38711241972a1c62fc3bf6fa820965e620ca574fbe63f04cb793bL77-R84))

</details>
