### PR TITLE
fix: use custom tokio runtime to customize stack size of tokio worker threads

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -20,6 +20,7 @@ use rspack_napi_shared::NAPI_ENV;
 mod hook;
 mod js_values;
 mod plugins;
+mod tokio_runtime;
 mod utils;
 
 use hook::*;

--- a/crates/node_binding/src/tokio_runtime.rs
+++ b/crates/node_binding/src/tokio_runtime.rs
@@ -10,7 +10,7 @@ fn init_tokio_runtime() -> tokio::runtime::Runtime {
     // 6mb+
     .thread_stack_size(6777216)
     .build()
-    .unwrap()
+    .expect("should initial tokio runtime without error")
 }
 
 pub fn tokio_rt() -> &'static tokio::runtime::Runtime {

--- a/crates/node_binding/src/tokio_runtime.rs
+++ b/crates/node_binding/src/tokio_runtime.rs
@@ -1,0 +1,18 @@
+use once_cell::sync::Lazy;
+
+/// TODO(hyf0): we might need a way to cleanup this resource
+static TOKIO_RT: Lazy<tokio::runtime::Runtime> = Lazy::new(init_tokio_runtime);
+
+fn init_tokio_runtime() -> tokio::runtime::Runtime {
+  //
+  tokio::runtime::Builder::new_multi_thread()
+    // See https://github.com/web-infra-dev/rspack/pull/183
+    // 6mb+
+    .thread_stack_size(6777216)
+    .build()
+    .unwrap()
+}
+
+pub fn tokio_rt() -> &'static tokio::runtime::Runtime {
+  &TOKIO_RT
+}

--- a/crates/node_binding/src/utils.rs
+++ b/crates/node_binding/src/utils.rs
@@ -12,6 +12,8 @@ use rspack_napi_shared::threadsafe_function::{
   ThreadSafeContext, ThreadsafeFunction, ThreadsafeFunctionCallMode,
 };
 
+use crate::tokio_runtime::tokio_rt;
+
 static CUSTOM_TRACE_SUBSCRIBER: OnceCell<bool> = OnceCell::new();
 
 /// Try to resolve the string value of a given named property
@@ -140,7 +142,7 @@ where
     Ok(())
   })?;
 
-  napi::bindgen_prelude::spawn(async move {
+  tokio_rt().spawn(async move {
     let fut = CatchUnwindFuture::create(fut);
     let res = fut.await;
     match res {


### PR DESCRIPTION

## Related issue (if exists)

Fix #183 again.

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac3c9ed</samp>

This pull request adds a global tokio runtime for the node binding crate, which allows spawning async tasks that use the server pack library more efficiently and reliably. It also modifies the `spawn` function in `utils.rs` to use the global runtime instead of the default one.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac3c9ed</samp>

* Create and use a global tokio runtime for the node binding crate ([link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaR23), [link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-a18668940300b4d822452c8fa75b644567f231d10e65c2e0655f3b3382bcc30fR1-R18), [link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-ef2e1d1bc508a9809f30c6b58257b123729b118a076296895590fa4ed94442a3R15-R16), [link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-ef2e1d1bc508a9809f30c6b58257b123729b118a076296895590fa4ed94442a3L143-R145))
  - Import the `tokio_runtime` module in `lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaR23))
  - Define the `init_tokio_runtime` and `tokio_rt` functions in `tokio_runtime.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-a18668940300b4d822452c8fa75b644567f231d10e65c2e0655f3b3382bcc30fR1-R18))
  - Add a dependency on the `tokio_runtime` module in `utils.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-ef2e1d1bc508a9809f30c6b58257b123729b118a076296895590fa4ed94442a3R15-R16))
  - Replace the `napi::bindgen_prelude::spawn` function with the `tokio_rt().spawn` function in the `spawn` function in `utils.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3199/files?diff=unified&w=0#diff-ef2e1d1bc508a9809f30c6b58257b123729b118a076296895590fa4ed94442a3L143-R145))

</details>
