### PR TITLE
chore: fix node16 tests

### DIFF
--- a/packages/rspack/tests/case.template.ts
+++ b/packages/rspack/tests/case.template.ts
@@ -78,8 +78,9 @@ export function describeCases(config: { name: string; casePath: string }) {
 											path: outputPath
 										}
 									};
-
-									fs.rmdirSync(outputPath, { recursive: true });
+									if (fs.existsSync(outputPath)) {
+										fs.rmdirSync(outputPath, { recursive: true });
+									}
 									const stats = await util.promisify(rspack)(options);
 									const statsJson = stats!.toJson();
 									if (category.name === "errors") {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 775c826</samp>

Improve error handling in `rspack` bundler test case. Add a check for output path existence before deleting it in `case.template.ts`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 775c826</samp>

* Add a check for output path existence before deleting it in a test case ([link](https://github.com/web-infra-dev/rspack/pull/3200/files?diff=unified&w=0#diff-6c0bf465b39653e539e7adf0b2155d9f6f308e0c5eb316ec78059afa491b5348L81-R83))

</details>
