### PR TITLE
fix: provided dependency generated code not stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "either",
+ "indexmap",
  "linked_hash_set",
  "once_cell",
  "paste",

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 either = "1"
+indexmap = { workspace = true }
 linked_hash_set = { workspace = true }
 once_cell = { workspace = true }
 paste = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
@@ -1,5 +1,4 @@
-use std::collections::HashSet;
-
+use indexmap::IndexSet;
 use rspack_core::Provide;
 use swc_core::common::util::take::Take;
 use swc_core::common::Span;
@@ -18,7 +17,8 @@ static MODULE_DOT: &str = r#"_dot_"#;
 pub struct ProvideBuiltin<'a> {
   opts: &'a Provide,
   unresolved_mark: Mark,
-  current_import_provide: HashSet<String>,
+  // the order should be stable to ensure the generated code is stable
+  current_import_provide: IndexSet<String>,
 }
 
 impl<'a> ProvideBuiltin<'a> {
@@ -26,7 +26,7 @@ impl<'a> ProvideBuiltin<'a> {
     ProvideBuiltin {
       opts,
       unresolved_mark,
-      current_import_provide: HashSet::new(),
+      current_import_provide: IndexSet::new(),
     }
   }
 

--- a/packages/rspack/tests/HashTestCases.test.ts
+++ b/packages/rspack/tests/HashTestCases.test.ts
@@ -19,7 +19,6 @@ describe("HashTestCases", () => {
 	tests.forEach(testName => {
 		it("should print correct hash for " + testName, async () => {
 			const testPath = path.resolve(base, testName);
-			console.log(testPath);
 			const configPath = path.resolve(testPath, "webpack.config.js");
 			const testConfigPath = path.resolve(testPath, "test.config.js");
 			let config;

--- a/packages/rspack/tests/HashTestCases.test.ts
+++ b/packages/rspack/tests/HashTestCases.test.ts
@@ -18,13 +18,21 @@ const tests = fs.readdirSync(base).filter(testName => {
 describe("HashTestCases", () => {
 	tests.forEach(testName => {
 		it("should print correct hash for " + testName, async () => {
-			const configPath = path.resolve(base, testName, "webpack.config.js");
-			const testConfigPath = path.resolve(base, testName, "test.config.js");
+			const testPath = path.resolve(base, testName);
+			console.log(testPath);
+			const configPath = path.resolve(testPath, "webpack.config.js");
+			const testConfigPath = path.resolve(testPath, "test.config.js");
 			let config;
 			if (fs.existsSync(configPath)) {
 				config = require(configPath);
 			} else {
 				throw new Error("HashTestCases must have a webpack.config.js");
+			}
+			if (!Array.isArray(config) && typeof config === "object") {
+				config.context ??= testPath;
+				config.entry ??= "./index";
+				config.output ??= {};
+				config.output.path ??= path.resolve(testPath, "dist");
 			}
 			let testConfig;
 			if (fs.existsSync(testConfigPath)) {

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -18,7 +18,7 @@ exports[`HashTestCases should print correct hash for package-path-change-1 1`] =
 
 exports[`HashTestCases should print correct hash for provided-dependency-order 1`] = `
 [
-  "main.50aba011803329b0-50aba0.js",
+  "main.782d558c9d947378-782d55.js",
 ]
 `;
 

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -16,4 +16,10 @@ exports[`HashTestCases should print correct hash for package-path-change-1 1`] =
 ]
 `;
 
+exports[`HashTestCases should print correct hash for provided-dependency-order 1`] = `
+[
+  "main.50aba011803329b0-50aba0.js",
+]
+`;
+
 exports[`HashTestCases should print correct hash for real-content-hash 1`] = `undefined`;

--- a/packages/rspack/tests/hashCases/provided-dependency-order/index.js
+++ b/packages/rspack/tests/hashCases/provided-dependency-order/index.js
@@ -1,0 +1,1 @@
+console.log(Buffer, process.env);

--- a/packages/rspack/tests/hashCases/provided-dependency-order/webpack.config.js
+++ b/packages/rspack/tests/hashCases/provided-dependency-order/webpack.config.js
@@ -1,0 +1,15 @@
+const NodePolyfillPlugin = require("@rspack/plugin-node-polyfill");
+
+/** @type {import("../../../").Configuration} */
+module.exports = {
+	mode: "production",
+	devtool: false,
+	output: {
+		filename: "[name].[contenthash]-[contenthash:6].js"
+	},
+	optimization: {
+		realContentHash: true
+	},
+	stats: "normal",
+	plugins: [new NodePolyfillPlugin()]
+};

--- a/packages/rspack/tests/hashCases/provided-dependency-order/webpack.config.js
+++ b/packages/rspack/tests/hashCases/provided-dependency-order/webpack.config.js
@@ -2,7 +2,7 @@ const NodePolyfillPlugin = require("@rspack/plugin-node-polyfill");
 
 /** @type {import("../../../").Configuration} */
 module.exports = {
-	mode: "production",
+	mode: "development",
 	devtool: false,
 	output: {
 		filename: "[name].[contenthash]-[contenthash:6].js"
@@ -10,6 +10,5 @@ module.exports = {
 	optimization: {
 		realContentHash: true
 	},
-	stats: "normal",
 	plugins: [new NodePolyfillPlugin()]
 };


### PR DESCRIPTION
## Related issue (if exists)

closes #3202

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 818f498</samp>

This pull request implements the feature of preserving the order of provided dependencies in the `rspack_plugin_javascript` crate. It also adds a test case to verify the content hash stability of the generated code.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 818f498</samp>

*  Add indexmap crate as a dependency to `rspack_plugin_javascript` ([link](https://github.com/web-infra-dev/rspack/pull/3204/files?diff=unified&w=0#diff-de9d76de11eb9821c20e5ee2f57fa780188d579d23b4699e25f0fc2f62150f64R16))
*  Replace `HashSet` with `IndexSet` in `provide.rs` to preserve the order of provided dependencies ([link](https://github.com/web-infra-dev/rspack/pull/3204/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL1-R1), [link](https://github.com/web-infra-dev/rspack/pull/3204/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL21-R21), [link](https://github.com/web-infra-dev/rspack/pull/3204/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL29-R29))
*  Add a test case for the provided dependency order feature in `rspack` ([link](https://github.com/web-infra-dev/rspack/pull/3204/files?diff=unified&w=0#diff-dda2259fee47c679d8fa1e0f0c75f468327a61613d8851b8e78a3ad6e8b5d564R1), [link](https://github.com/web-infra-dev/rspack/pull/3204/files?diff=unified&w=0#diff-ca9160e0d94470a41515b0260b011c90e0d01643b95001019e3d664825b0cc5cR1-R15))

</details>
