### PR TITLE
ci: create issue in rspack-website when a pr is merged with "need doc…

### DIFF
--- a/.github/workflows/need-doc.yml
+++ b/.github/workflows/need-doc.yml
@@ -1,0 +1,34 @@
+name: Need Documentation
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  doc:
+    runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'need documentation') }}
+    # if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'need documentation') }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const title = 'Document rspack change: ' + github.event.pull_request.title;
+
+            const body = 'See pull request:\n  * ' + github.event.pull_request.url;
+
+            console.log(title);
+            console.log(body);
+
+            const result = await github.rest.issues.get({
+              owner: 'web-infra-dev',
+              repo: 'rspack-website',
+              issue_number: 296
+            });
+            console.log(result);
+            # github.rest.issues.create({
+              # owner: 'web-infra-dev',
+              # repo: 'rspack-website',
+              # title: title ,
+            # });


### PR DESCRIPTION
…umentation" label

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a5e025</samp>

Add a new GitHub workflow to create documentation issues for `rspack` changes. The workflow runs when a pull request is closed with the `need documentation` label and creates an issue in the `rspack-website` repository.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a5e025</samp>

* Add a new workflow file to automate the documentation process for changes that require website updates ([link](https://github.com/web-infra-dev/rspack/pull/3207/files?diff=unified&w=0#diff-ad70c9a962fa4429efda6e17ef5870152962e7f31ef99f32d5eaaf8a1a9cf1f8R1-R37))

</details>
