### PR TITLE
fix: ci clippy

### DIFF
--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -401,7 +401,7 @@ impl<'a> CodeSizeOptimizer<'a> {
         if let Some(symbol_ref_list) = module_visited_symbol_ref.get(&module_identifier) {
           for symbol_ref in symbol_ref_list {
             update_reachable_dependency(
-              &symbol_ref,
+              symbol_ref,
               &mut reachable_dependency_identifier,
               symbol_graph,
               &self.bailout_modules,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a49038</samp>

Refactor tree shaking optimizer module in `rspack_core` crate. Fix compile error by removing unnecessary reference in `update_reachable_dependency` function call.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a49038</samp>

*  Refactor the `update_reachable_dependency` function to take ownership of the `symbol_ref` argument and avoid cloning it ([link](https://github.com/web-infra-dev/rspack/pull/3208/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL404-R404),                           

</details>
