### PR TITLE
ci: create issue in rspack-website when a pr is merged with "need documentation" label

### DIFF
--- a/.github/workflows/need-doc.yml
+++ b/.github/workflows/need-doc.yml
@@ -1,0 +1,33 @@
+# Create an issue in rspack-website when a PR with the "need documentation" label is merged
+
+name: Need Documentation
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  doc:
+    name: Need Documentation
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'need documentation') }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.RSPACK_WEBSITE_ACCESS_TOKEN }}
+          script: |
+            const title = "Document rspack change: " + context.payload.pull_request.title;
+            const body = "See pull request:\n* " + context.payload.pull_request.html_url;
+
+            console.log(title);
+            console.log(body);
+
+            const result = await github.rest.issues.create({
+              owner: 'web-infra-dev',
+              repo: 'rspack-website',
+              title: title,
+              body: body,
+            });
+
+            console.log(result);


### PR DESCRIPTION
…umentation" label

closes #3089

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b99d69</samp>

Added a workflow to create documentation issues for `rspack` changes. The workflow runs when a pull request with the `need documentation` label is closed and creates an issue in the `rspack-website` repository.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b99d69</samp>

* Add a new workflow file `need-doc.yml` that creates an issue in the `rspack-website` repository when a pull request with the label `need documentation` is closed in the `rspack` repository ([link](https://github.com/web-infra-dev/rspack/pull/3211/files?diff=unified&w=0#diff-ad70c9a962fa4429efda6e17ef5870152962e7f31ef99f32d5eaaf8a1a9cf1f8R1-R29))

</details>
