### PR TITLE
chore(gitattributes): make repo more rusty

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
-benchcases/** linguist-detectable=false
-fixtures/** linguist-detectable=false
-webpack-test/** linguist-detectable=false
+benchcases/**/*.js linguist-detectable=false
+webpack-examples/**/*.js linguist-detectable=false
+webpack-test/**/*.js linguist-detectable=false
+**/tests/**/*.js linguist-detectable=false
+
 * text=auto


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2017113</samp>

Modified `.gitattributes` to exclude JavaScript files from GitHub language statistics. This reflects the fact that the project is primarily a Python package and the JavaScript files are only auxiliary.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2017113</samp>

*  Exclude JavaScript files from GitHub language statistics ([link](https://github.com/web-infra-dev/rspack/pull/3215/files?diff=unified&w=0#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eL1-R4))

</details>
