### PR TITLE
feat(types): support string or object in copy.patterns array 

### DIFF
--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -90,11 +90,12 @@ export type PluginImportConfig = {
 };
 
 export type CopyConfig = {
-	patterns:
-		| string[]
+	patterns: (
+		| string
 		| ({
 				from: string;
-		  } & Partial<RawPattern>)[];
+		  } & Partial<RawPattern>)
+	)[];
 };
 
 export type BannerCondition = string | RegExp;


### PR DESCRIPTION
## Related issue (if exists)

#3217 

support below config:

```
module.exports = {
  builtins: {
    copy: {
      patterns: [
        {
          from: 'file.txt',
        },
       "path/to/source",
      ],
    },
  },
};
```


<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18567ce</samp>

Improved the `CopyConfig` type in `builtins.ts` to accept mixed arrays of strings and objects for the `patterns` property. This enables users to customize the copy behavior for different files or directories more easily.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18567ce</samp>

*  Allow `patterns` to be a mixed array of strings and objects in `CopyConfig` type ([link](https://github.com/web-infra-dev/rspack/pull/3218/files?diff=unified&w=0#diff-908957625f9952a51b579835fc42cf2a8d717ac0ffa1ce16aa4ac24bf6362885L93-R98))

</details>
