### PR TITLE
feat: data uri support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,17 +2690,12 @@ name = "rspack_plugin_schemes"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "derivative",
- "indexmap",
  "once_cell",
- "rayon",
  "regex",
  "rspack_base64",
  "rspack_core",
  "rspack_error",
- "rustc-hash",
  "urlencoding",
- "xxhash-rust",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,7 @@ dependencies = [
  "rspack_plugin_real_content_hash",
  "rspack_plugin_remove_empty_chunks",
  "rspack_plugin_runtime",
+ "rspack_plugin_schemes",
  "rspack_plugin_split_chunks",
  "rspack_plugin_split_chunks_new",
  "rspack_plugin_wasm",
@@ -2260,6 +2261,7 @@ dependencies = [
  "rspack_symbol",
  "rspack_util",
  "rustc-hash",
+ "serde",
  "serde_json",
  "string_cache",
  "sugar_path",
@@ -2599,6 +2601,7 @@ dependencies = [
  "rspack_symbol",
  "rspack_testing",
  "rustc-hash",
+ "serde_json",
  "sourcemap",
  "sugar_path",
  "swc_config",
@@ -2630,6 +2633,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_identifier",
+ "serde_json",
 ]
 
 [[package]]
@@ -2678,6 +2682,24 @@ dependencies = [
  "rspack_identifier",
  "rspack_plugin_javascript",
  "rustc-hash",
+ "xxhash-rust",
+]
+
+[[package]]
+name = "rspack_plugin_schemes"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "derivative",
+ "indexmap",
+ "once_cell",
+ "rayon",
+ "regex",
+ "rspack_base64",
+ "rspack_core",
+ "rspack_error",
+ "rustc-hash",
+ "urlencoding",
  "xxhash-rust",
 ]
 

--- a/crates/node_binding/src/js_values/normal_module_factory.rs
+++ b/crates/node_binding/src/js_values/normal_module_factory.rs
@@ -1,6 +1,4 @@
-use rspack_core::{
-  NormalModuleBeforeResolveArgs, NormalModuleFactoryResolveForSchemeArgs, ResourceData,
-};
+use rspack_core::{NormalModuleBeforeResolveArgs, ResourceData};
 
 #[napi(object)]
 pub struct SchemeAndJsResourceData {
@@ -37,11 +35,11 @@ impl From<ResourceData> for JsResourceData {
   }
 }
 
-impl From<NormalModuleFactoryResolveForSchemeArgs> for SchemeAndJsResourceData {
-  fn from(value: NormalModuleFactoryResolveForSchemeArgs) -> Self {
+impl From<ResourceData> for SchemeAndJsResourceData {
+  fn from(value: ResourceData) -> Self {
     Self {
-      resource_data: value.resource.into(),
-      scheme: value.scheme,
+      scheme: value.get_scheme().to_string(),
+      resource_data: value.into(),
     }
   }
 }

--- a/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
@@ -1,6 +1,6 @@
 exports.ids = ['main'];
 exports.modules = {
-"./child Lazy  recursive ^\.\/.*\.js$": function (module, exports, __webpack_require__) {
+"./child Lazy  recursive ^\\.\\/.*\\.js$": function (module, exports, __webpack_require__) {
 var map = {"./a.js": "./child/a.js","./b.js": "./child/b.js",};
 function webpackAsyncContext(req) {
 	if(!__webpack_require__.o(map, req)) {
@@ -26,9 +26,9 @@ module.exports = webpackAsyncContext;},
 const request = 'a';
 __webpack_require__.el("./child/a.js").then(__webpack_require__.bind(__webpack_require__, "./child/a.js")).then(__webpack_require__.ir).then(({ a  })=>console.log("Literal", a));
 __webpack_require__.el("./child/b.js").then(__webpack_require__.bind(__webpack_require__, "./child/b.js")).then(__webpack_require__.ir).then(({ b  })=>console.log("Template Literal", b));
-__webpack_require__('./child Lazy  recursive ^\.\/.*\.js$')(`./child/${request}.js`.replace("./child/", "./")).then(({ a  })=>console.log("context_module_tpl", a));
-__webpack_require__('./child Lazy  recursive ^\.\/.*\.js$')(('./child/' + request + '.js').replace("./child/", "./")).then(({ a  })=>console.log("context_module_bin", a));
-__webpack_require__('./child Lazy  recursive ^\.\/.*\.js$')("./child/".concat(request, ".js").replace("./child/", "./")).then(({ a  })=>console.log("context_module_concat", a));
+__webpack_require__("./child Lazy  recursive ^\\.\\/.*\\.js$")(`./child/${request}.js`.replace("./child/", "./")).then(({ a  })=>console.log("context_module_tpl", a));
+__webpack_require__("./child Lazy  recursive ^\\.\\/.*\\.js$")(('./child/' + request + '.js').replace("./child/", "./")).then(({ a  })=>console.log("context_module_bin", a));
+__webpack_require__("./child Lazy  recursive ^\\.\\/.*\\.js$")("./child/".concat(request, ".js").replace("./child/", "./")).then(({ a  })=>console.log("context_module_concat", a));
 },
 
 };

--- a/crates/rspack/tests/tree-shaking/context-module/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/context-module/expected/main.js
@@ -1,5 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./child Sync  recursive ^\.\/.*\.js$": function (module, exports, __webpack_require__) {
+"./child Sync  recursive ^\\.\\/.*\\.js$": function (module, exports, __webpack_require__) {
 var map = {"./child/index.js": "./child/child/index.js","./index.js": "./child/index.js",};
 function webpackContext(req) {
 var id = webpackContextResolve(req);
@@ -17,7 +17,7 @@ function webpackContextResolve(req) {
       return map[req];
     
 }
-webpackContext.id = './child Sync  recursive ^\.\/.*\.js$';
+webpackContext.id = '"./child Sync  recursive ^\\.\\/.*\\.js$"';
 
       webpackContext.keys = function webpackContextKeys() {
         return Object.keys(map);
@@ -53,7 +53,7 @@ const value = "dynamic";
 },
 "./index.js": function (module, exports, __webpack_require__) {
 let a = "index";
-__webpack_require__('./child Sync  recursive ^\.\/.*\.js$')(`./child/${a}.js`.replace("./child/", "./"));
+__webpack_require__("./child Sync  recursive ^\\.\\/.*\\.js$")(`./child/${a}.js`.replace("./child/", "./"));
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack_base64/src/lib.rs
+++ b/crates/rspack_base64/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod base64 {
-  use base64_simd::{Base64 as Raw, STANDARD};
+  use base64_simd::{Base64 as Raw, Error, STANDARD};
 
   pub struct Base64(Raw);
 
@@ -10,6 +10,10 @@ pub mod base64 {
 
     pub fn encode_to_string<D: AsRef<[u8]>>(&self, data: D) -> String {
       self.0.encode_to_string(data)
+    }
+
+    pub fn decode_to_vec<D: AsRef<[u8]>>(&self, data: D) -> Result<Vec<u8>, Error> {
+      self.0.decode_to_vec(data)
     }
   }
 

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -28,6 +28,7 @@ rspack_plugin_progress                  = { path = "../rspack_plugin_progress" }
 rspack_plugin_real_content_hash         = { path = "../rspack_plugin_real_content_hash" }
 rspack_plugin_remove_empty_chunks       = { path = "../rspack_plugin_remove_empty_chunks" }
 rspack_plugin_runtime                   = { path = "../rspack_plugin_runtime" }
+rspack_plugin_schemes                   = { path = "../rspack_plugin_schemes" }
 rspack_plugin_split_chunks              = { path = "../rspack_plugin_split_chunks" }
 rspack_plugin_split_chunks_new          = { path = "../rspack_plugin_split_chunks_new" }
 rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -119,6 +119,7 @@ impl RawOptionsApply for RawOptions {
     let dev_server: DevServerOptions = self.dev_server.into();
     let builtins = self.builtins.apply(plugins, loader_runner)?;
 
+    plugins.push(rspack_plugin_schemes::DataUriPlugin.boxed());
     plugins.push(
       rspack_plugin_asset::AssetPlugin::new(rspack_plugin_asset::AssetConfig {
         parse_options: module.parser.as_ref().and_then(|x| x.asset.clone()),

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -37,6 +37,7 @@ rspack_sources = { workspace = true }
 rspack_symbol = { path = "../rspack_symbol" }
 rspack_util = { path = "../rspack_util" }
 rustc-hash = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 string_cache = "0.8.7"
 sugar_path = { workspace = true }

--- a/crates/rspack_core/src/dependency/common_js_require_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/common_js_require_context_dependency.rs
@@ -1,4 +1,4 @@
-use rspack_error::Result;
+use rspack_error::{internal_error, Result};
 use swc_core::{
   common::DUMMY_SP,
   ecma::{
@@ -76,7 +76,8 @@ impl CodeGeneratable for CommonJsRequireContextDependency {
         .module_graph_module_by_dependency_id(&id)
         .map(|m| m.id(&compilation.chunk_graph))
       {
-        let module_id = serde_json::to_string(module_id).expect("invalid module_id");
+        let module_id =
+          serde_json::to_string(module_id).map_err(|e| internal_error!(e.to_string()))?;
         let context = normalize_context(&self.options.request);
         code_gen.visitors.push(
           create_javascript_visitor!(exact &self.ast_path, visit_mut_call_expr(n: &mut CallExpr) {

--- a/crates/rspack_core/src/dependency/common_js_require_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/common_js_require_context_dependency.rs
@@ -74,9 +74,9 @@ impl CodeGeneratable for CommonJsRequireContextDependency {
       if let Some(module_id) = compilation
         .module_graph
         .module_graph_module_by_dependency_id(&id)
-        .map(|m| m.id(&compilation.chunk_graph).to_string())
+        .map(|m| m.id(&compilation.chunk_graph))
       {
-        let module_id = format!("'{module_id}'");
+        let module_id = serde_json::to_string(module_id).expect("invalid module_id");
         let context = normalize_context(&self.options.request);
         code_gen.visitors.push(
           create_javascript_visitor!(exact &self.ast_path, visit_mut_call_expr(n: &mut CallExpr) {

--- a/crates/rspack_core/src/dependency/import_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/import_context_dependency.rs
@@ -1,4 +1,4 @@
-use rspack_error::Result;
+use rspack_error::{internal_error, Result};
 use swc_core::{
   common::DUMMY_SP,
   ecma::{
@@ -76,7 +76,8 @@ impl CodeGeneratable for ImportContextDependency {
         .module_graph_module_by_dependency_id(&id)
         .map(|m| m.id(&compilation.chunk_graph))
       {
-        let module_id = serde_json::to_string(module_id).expect("invalid module_id");
+        let module_id =
+          serde_json::to_string(module_id).map_err(|e| internal_error!(e.to_string()))?;
         let context = normalize_context(&self.options.request);
         code_gen.visitors.push(
           create_javascript_visitor!(exact &self.ast_path, visit_mut_call_expr(n: &mut CallExpr) {

--- a/crates/rspack_core/src/dependency/import_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/import_context_dependency.rs
@@ -74,9 +74,9 @@ impl CodeGeneratable for ImportContextDependency {
       if let Some(module_id) = compilation
         .module_graph
         .module_graph_module_by_dependency_id(&id)
-        .map(|m| m.id(&compilation.chunk_graph).to_string())
+        .map(|m| m.id(&compilation.chunk_graph))
       {
-        let module_id = format!("'{module_id}'");
+        let module_id = serde_json::to_string(module_id).expect("invalid module_id");
         let context = normalize_context(&self.options.request);
         code_gen.visitors.push(
           create_javascript_visitor!(exact &self.ast_path, visit_mut_call_expr(n: &mut CallExpr) {

--- a/crates/rspack_core/src/dependency/require_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/require_context_dependency.rs
@@ -1,4 +1,4 @@
-use rspack_error::Result;
+use rspack_error::{internal_error, Result};
 use swc_core::{
   common::DUMMY_SP,
   ecma::{
@@ -76,7 +76,8 @@ impl CodeGeneratable for RequireContextDependency {
         .module_graph_module_by_dependency_id(&id)
         .map(|m| m.id(&compilation.chunk_graph))
       {
-        let module_id = serde_json::to_string(module_id).expect("invalid module_id");
+        let module_id =
+          serde_json::to_string(module_id).map_err(|e| internal_error!(e.to_string()))?;
         code_gen.visitors.push(
           create_javascript_visitor!(exact &self.ast_path, visit_mut_call_expr(n: &mut CallExpr) {
             *n = CallExpr {

--- a/crates/rspack_core/src/dependency/require_context_dependency.rs
+++ b/crates/rspack_core/src/dependency/require_context_dependency.rs
@@ -74,9 +74,9 @@ impl CodeGeneratable for RequireContextDependency {
       if let Some(module_id) = compilation
         .module_graph
         .module_graph_module_by_dependency_id(&id)
-        .map(|m| m.id(&compilation.chunk_graph).to_string())
+        .map(|m| m.id(&compilation.chunk_graph))
       {
-        let module_id = format!("'{module_id}'");
+        let module_id = serde_json::to_string(module_id).expect("invalid module_id");
         code_gen.visitors.push(
           create_javascript_visitor!(exact &self.ast_path, visit_mut_call_expr(n: &mut CallExpr) {
             *n = CallExpr {

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -71,6 +71,7 @@ pub use ukey::*;
 
 pub mod tree_shaking;
 
+pub use rspack_loader_runner::{get_scheme, ResourceData, Scheme};
 pub use rspack_sources;
 
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -9,10 +9,10 @@ use crate::{
   AdditionalChunkRuntimeRequirementsArgs, AssetInfo, BoxLoader, BoxModule, ChunkAssetArgs,
   ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, ContentHashArgs, DoneArgs,
   FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
-  NormalModule, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext,
-  NormalModuleFactoryResolveForSchemeArgs, OptimizeChunksArgs, ParserAndGenerator, PluginContext,
-  ProcessAssetsArgs, RenderArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs,
-  RenderStartupArgs, Resolver, SourceType, ThisCompilationArgs,
+  NormalModule, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext, OptimizeChunksArgs,
+  ParserAndGenerator, PluginContext, ProcessAssetsArgs, RenderArgs, RenderChunkArgs,
+  RenderManifestArgs, RenderModuleContentArgs, RenderStartupArgs, Resolver, SourceType,
+  ThisCompilationArgs,
 };
 
 // use anyhow::{Context, Result};
@@ -112,7 +112,7 @@ pub trait Plugin: Debug + Send + Sync {
   async fn normal_module_factory_resolve_for_scheme(
     &self,
     _ctx: PluginContext,
-    _args: &NormalModuleFactoryResolveForSchemeArgs,
+    _args: &ResourceData,
   ) -> PluginNormalModuleFactoryResolveForSchemeOutput {
     Ok(None)
   }

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 use std::path::PathBuf;
 
 use rspack_error::{internal_error, Result};
-use rspack_loader_runner::ResourceData;
 use rspack_sources::BoxSource;
 use rustc_hash::FxHashSet as HashSet;
 use xxhash_rust::xxh3::Xxh3;
@@ -86,12 +85,6 @@ pub struct ModuleArgs {
   pub dependency_type: DependencyType,
   // lazy compilation visit module
   pub lazy_visit_modules: std::collections::HashSet<String>,
-}
-
-#[derive(Debug, Clone)]
-pub struct NormalModuleFactoryResolveForSchemeArgs {
-  pub resource: ResourceData,
-  pub scheme: String,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -13,9 +13,8 @@ use crate::{
   AdditionalChunkRuntimeRequirementsArgs, ApplyContext, BoxLoader, BoxedParserAndGeneratorBuilder,
   Chunk, ChunkAssetArgs, ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, Content,
   ContentHashArgs, DoneArgs, FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleType,
-  NormalModule, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext,
-  NormalModuleFactoryResolveForSchemeArgs, OptimizeChunksArgs, Plugin,
-  PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
+  NormalModule, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext, OptimizeChunksArgs,
+  Plugin, PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
   PluginChunkHashHookOutput, PluginCompilationHookOutput, PluginContext, PluginFactorizeHookOutput,
   PluginJsChunkHashHookOutput, PluginMakeHookOutput, PluginModuleHookOutput,
   PluginNormalModuleFactoryBeforeResolveOutput, PluginNormalModuleFactoryResolveForSchemeOutput,
@@ -349,7 +348,7 @@ impl PluginDriver {
 
   pub async fn normal_module_factory_resolve_for_scheme(
     &self,
-    args: NormalModuleFactoryResolveForSchemeArgs,
+    args: &ResourceData,
   ) -> PluginNormalModuleFactoryResolveForSchemeOutput {
     for plugin in &self.plugins {
       tracing::trace!("running resolve for scheme:{}", plugin.name());

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -353,7 +353,7 @@ impl PluginDriver {
     for plugin in &self.plugins {
       tracing::trace!("running resolve for scheme:{}", plugin.name());
       if let Some(data) = plugin
-        .normal_module_factory_resolve_for_scheme(PluginContext::new(), &args)
+        .normal_module_factory_resolve_for_scheme(PluginContext::new(), args)
         .await?
       {
         return Ok(Some(data));

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -135,22 +135,3 @@ pub fn stringify_map(map: &HashMap<String, String>) -> String {
     })
   )
 }
-
-pub fn stringify_value_vec_map(map: &HashMap<String, Vec<String>>) -> String {
-  format!(
-    r#"{{{}}}"#,
-    map.keys().sorted().fold(String::new(), |prev, cur| {
-      prev
-        + format!(
-          r#""{}": {},"#,
-          cur,
-          stringify_vec(map.get(cur).expect("get key from map"))
-        )
-        .as_str()
-    })
-  )
-}
-
-pub fn stringify_vec(vec: &[String]) -> String {
-  format!("[{}]", vec.iter().map(|s| format!("'{s}'")).join(",  "))
-}

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -9,7 +9,6 @@ version    = "0.1.0"
 
 [dev-dependencies]
 similar-asserts = "1.4.2"
-url             = { workspace = true }
 
 [dependencies]
 async-recursion = { workspace = true }
@@ -25,3 +24,4 @@ regex             = { workspace = true }
 rspack_error      = { path = "../rspack_error" }
 rspack_identifier = { path = "../rspack_identifier" }
 rspack_sources    = { workspace = true }
+url               = { workspace = true }

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -7,4 +7,4 @@ pub use content::Content;
 pub use loader::{DisplayWithSuffix, Loader};
 pub use plugin::LoaderRunnerPlugin;
 pub use rspack_identifier::{Identifiable, Identifier};
-pub use runner::{run_loaders, LoaderContext, ResourceData};
+pub use runner::{get_scheme, run_loaders, LoaderContext, ResourceData, Scheme};

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -24,13 +24,12 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
   let (result, _) = run_loaders(
     &[Arc::new(SassLoader::new(SassLoaderOptions::default()))
       as Arc<dyn Loader<LoaderRunnerContext>>],
-    &ResourceData {
-      resource: actual_path.to_string_lossy().to_string(),
-      resource_path: url.to_file_path().expect("bad url file path"),
-      resource_query: url.query().map(|q| q.to_owned()),
-      resource_fragment: url.fragment().map(|f| f.to_owned()),
-      resource_description: None,
-    },
+    &ResourceData::new(
+      actual_path.to_string_lossy().to_string(),
+      url.to_file_path().expect("bad url file path"),
+    )
+    .query_optional(url.query().map(|q| q.to_owned()))
+    .fragment_optional(url.fragment().map(|f| f.to_owned())),
     &[],
     CompilerContext {
       options: std::sync::Arc::new(CompilerOptions {

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -26,6 +26,7 @@ rspack_identifier = { path = "../rspack_identifier" }
 rspack_regex = { path = "../rspack_regex" }
 rspack_symbol = { path = "../rspack_symbol" }
 rustc-hash = { workspace = true }
+serde_json = { workspace = true }
 sourcemap = "6.2.3"
 sugar_path = { workspace = true }
 swc_config = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -189,7 +189,7 @@ impl JsPlugin {
             .module_graph_module_by_identifier(module)
             .map(|module| module.id(&compilation.chunk_graph))
             .expect("should have module id");
-          let mut module_id_expr = format!("'{module_id}'");
+          let mut module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");
           if runtime_requirements.contains(RuntimeGlobals::ENTRY_MODULE_ID) {
             module_id_expr = format!("{} = {module_id_expr}", RuntimeGlobals::ENTRY_MODULE_ID);
           }

--- a/crates/rspack_plugin_javascript/tests/fixtures/issuse_2960/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/issuse_2960/expected/main.js
@@ -1,5 +1,5 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./resources Sync  recursive ^\.\/pre_.*\.js$": function (module, exports, __webpack_require__) {
+"./resources Sync  recursive ^\\.\\/pre_.*\\.js$": function (module, exports, __webpack_require__) {
 var map = {"./pre_a.js": "./resources/pre_a.js","./pre_b.js": "./resources/pre_b.js","./pre_c.js": "./resources/pre_c.js",};
 function webpackContext(req) {
 var id = webpackContextResolve(req);
@@ -17,7 +17,7 @@ function webpackContextResolve(req) {
       return map[req];
     
 }
-webpackContext.id = './resources Sync  recursive ^\.\/pre_.*\.js$';
+webpackContext.id = '"./resources Sync  recursive ^\\.\\/pre_.*\\.js$"';
 
       webpackContext.keys = function webpackContextKeys() {
         return Object.keys(map);
@@ -26,7 +26,7 @@ webpackContext.id = './resources Sync  recursive ^\.\/pre_.*\.js$';
       module.exports = webpackContext;
       },
 "./index.js": function (module, exports, __webpack_require__) {
-__webpack_require__('./resources Sync  recursive ^\.\/pre_.*\.js$')(`./resources/pre_${i + 1}.js`.replace("./resources/", "./"));
+__webpack_require__("./resources Sync  recursive ^\\.\\/pre_.*\\.js$")(`./resources/pre_${i + 1}.js`.replace("./resources/", "./"));
 },
 "./resources/pre_a.js": function (module, exports, __webpack_require__) {
 console.log('a');

--- a/crates/rspack_plugin_library/Cargo.toml
+++ b/crates/rspack_plugin_library/Cargo.toml
@@ -10,3 +10,4 @@ version = "0.1.0"
 rspack_core       = { path = "../rspack_core" }
 rspack_error      = { path = "../rspack_error" }
 rspack_identifier = { path = "../rspack_identifier" }
+serde_json        = { workspace = true }

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -194,7 +194,8 @@ impl Plugin for UmdLibraryPlugin {
 }
 
 fn library_name(v: &[String], chunk: &Chunk, compilation: &Compilation) -> String {
-  let value = format!("'{}'", v.last().expect("should have last"));
+  let value =
+    serde_json::to_string(v.last().expect("should have last")).expect("invalid module_id");
   replace_keys(value, chunk, compilation)
 }
 

--- a/crates/rspack_plugin_library/src/utils.rs
+++ b/crates/rspack_plugin_library/src/utils.rs
@@ -5,7 +5,7 @@ use rspack_identifier::Identifiable;
 pub fn external_dep_array(modules: &[&ExternalModule]) -> String {
   let value = modules
     .iter()
-    .map(|m| format!("'{}'", m.request.as_str()))
+    .map(|m| serde_json::to_string(&m.request).expect("invalid json to_string"))
     .collect::<Vec<_>>()
     .join(", ");
   format!("[{value}]")

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+edition    = "2021"
+license    = "MIT"
+name       = "rspack_plugin_schemes"
+repository = "https://github.com/web-infra-dev/rspack"
+version    = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait   = { workspace = true }
+derivative    = { workspace = true }
+indexmap      = { workspace = true }
+once_cell     = { workspace = true }
+rayon         = { workspace = true }
+regex         = { workspace = true }
+rspack_base64 = { path = "../rspack_base64" }
+rspack_core   = { path = "../rspack_core" }
+rspack_error  = { path = "../rspack_error" }
+rustc-hash    = { workspace = true }
+urlencoding   = "2.1.2"
+xxhash-rust   = { workspace = true }

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -9,14 +9,9 @@ version    = "0.1.0"
 
 [dependencies]
 async-trait   = { workspace = true }
-derivative    = { workspace = true }
-indexmap      = { workspace = true }
 once_cell     = { workspace = true }
-rayon         = { workspace = true }
 regex         = { workspace = true }
 rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
-rustc-hash    = { workspace = true }
 urlencoding   = "2.1.2"
-xxhash-rust   = { workspace = true }

--- a/crates/rspack_plugin_schemes/LICENSE
+++ b/crates/rspack_plugin_schemes/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2022-present Bytedance, Inc. and its affiliates.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/rspack_plugin_schemes/src/data_uri.rs
+++ b/crates/rspack_plugin_schemes/src/data_uri.rs
@@ -1,0 +1,55 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rspack_core::{
+  Content, Plugin, PluginContext, PluginNormalModuleFactoryResolveForSchemeOutput,
+  PluginReadResourceOutput, ResourceData, Scheme,
+};
+use rspack_error::internal_error;
+
+static URI_REGEX: Lazy<Regex> = Lazy::new(|| {
+  Regex::new(r"^data:([^;,]+)?((?:;[^;,]+)*?)(?:;(base64))?,(.*)$").expect("Invalid Regex")
+});
+
+#[derive(Debug)]
+pub struct DataUriPlugin;
+
+#[async_trait::async_trait]
+impl Plugin for DataUriPlugin {
+  async fn normal_module_factory_resolve_for_scheme(
+    &self,
+    _ctx: PluginContext,
+    args: &ResourceData,
+  ) -> PluginNormalModuleFactoryResolveForSchemeOutput {
+    if let Some(captures) = URI_REGEX.captures(&args.resource)
+    && let Some(mimetype) = captures.get(1)
+    && let Some(parameters) = captures.get(2)
+    && let Some(encoding) = captures.get(3)
+    && let Some(encoded_content) = captures.get(4) {
+      let resource_data = args.clone();
+      return Ok(Some(resource_data
+        .mimetype(mimetype.as_str().to_owned())
+        .parameters(parameters.as_str().to_owned())
+        .encoding(encoding.as_str().to_owned())
+        .encoded_content(encoded_content.as_str().to_owned())
+      ))
+    }
+    Ok(None)
+  }
+
+  async fn read_resource(&self, resource_data: &ResourceData) -> PluginReadResourceOutput {
+    if resource_data.get_scheme() == &Scheme::Data && let Some(captures) = URI_REGEX.captures(&resource_data.resource) {
+      let body = captures.get(4).expect("should have data uri body").as_str();
+      let is_base64 = captures.get(3).is_some();
+      if is_base64 {
+        let base64 = rspack_base64::base64::Base64::new();
+        return Ok(Some(Content::Buffer(base64.decode_to_vec(body).map_err(|e| internal_error!(e.to_string()))?)))
+      }
+      if !body.is_ascii() {
+        return Ok(Some(Content::Buffer(urlencoding::decode_binary(body.as_bytes()).into_owned())))
+      } else {
+        return Ok(Some(Content::Buffer(body.bytes().collect())))
+      }
+    }
+    Ok(None)
+  }
+}

--- a/crates/rspack_plugin_schemes/src/lib.rs
+++ b/crates/rspack_plugin_schemes/src/lib.rs
@@ -1,0 +1,5 @@
+#![feature(let_chains)]
+
+mod data_uri;
+
+pub use data_uri::DataUriPlugin;

--- a/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/HashTestCases.test.ts.snap
@@ -18,7 +18,7 @@ exports[`HashTestCases should print correct hash for package-path-change-1 1`] =
 
 exports[`HashTestCases should print correct hash for provided-dependency-order 1`] = `
 [
-  "main.782d558c9d947378-782d55.js",
+  "main.7e4466459ed5d1d2-7e4466.js",
 ]
 `;
 

--- a/packages/rspack/tests/cases/schemes/data-imports/index.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.js
@@ -1,0 +1,5 @@
+import a from 'data:text/javascript,export default "a";';
+
+it("data imports", () => {
+	expect(a).toBe("a");
+});

--- a/packages/rspack/tests/copyPlugin/build/main.js
+++ b/packages/rspack/tests/copyPlugin/build/main.js
@@ -22,5 +22,5 @@ function __webpack_require__(moduleId) {
  return module.exports;
 
 }
-var __webpack_exports__ = __webpack_require__('../helpers/enter.js');
+var __webpack_exports__ = __webpack_require__("../helpers/enter.js");
 })()


### PR DESCRIPTION
## Related issue (if exists)

closes https://github.com/web-infra-dev/rspack/issues/2422
fixes part of https://github.com/web-infra-dev/rspack/issues/3150

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3becae9</samp>

This pull request refactors and simplifies the plugin API for resolving resources by scheme, using a new `ResourceData` struct and `serde_json` for serialization. It also adds support for different schemes, such as `data`, `file`, or custom ones, in the loader runner and the node binding plugin. It updates the dependencies and removes unused code where needed.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3becae9</samp>

*  Simplify and improve the plugin API by replacing `NormalModuleFactoryResolveForSchemeArgs` with `ResourceData` and removing unused imports ([link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6L40-R42), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L10-R11), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L167-R166), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL19-R22), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL137-R153), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L12-R15), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L115-R115), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337L5), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337L92-L97), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL16-R17), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL352-R351))
* Add support for data URI schemes in the loader runner by adding a new `DataUriPlugin` and registering it in the `options` module ([link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-581cd5f0a115c33c2a3636a9284ba84c19ba6a4a89cea66a90e85a966e291a2aR31), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41R122))
* Add serialization support for some types using `serde_json` and `base64_simd`, such as `ExternalRequest` and `ModuleId`, and remove unused utility functions for stringifying values ([link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-00d32632c3fba61f46cd68720a35e5aac67fe429aca93522472a9cccd0bfc75eL2-R2), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-00d32632c3fba61f46cd68720a35e5aac67fe429aca93522472a9cccd0bfc75eR14-R17), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-b15514bda6ea6c4fd02c5fe3c17a76a128bae9fc869d5245b0d2a109635e91f8R40), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d64b75f0221f54e5a13cc5f4b32d2ffb422b6b58415cf0444a065307d9a29a3L11-R11), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d64b75f0221f54e5a13cc5f4b32d2ffb422b6b58415cf0444a065307d9a29a3L180-R182), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d64b75f0221f54e5a13cc5f4b32d2ffb422b6b58415cf0444a065307d9a29a3L197-R197), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d64b75f0221f54e5a13cc5f4b32d2ffb422b6b58415cf0444a065307d9a29a3L264-R265), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d64b75f0221f54e5a13cc5f4b32d2ffb422b6b58415cf0444a065307d9a29a3L275-R276), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d65bac12415ffbc8988462b375681321ebbec5f4e296ebf3589415c5b275505L77-R79), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-030a867e867e35e2f3a18b220661f04500fe65a5e011ff09b9d95ce14caca708L77-R79), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6d45cf3a7f30de5838606a86eebc09f556e33f1ef5dca330155066af60c667bdL77-R79), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL1-R6), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL21-R24), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL96-R99), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-ba05d6e7007157284cbf958d29d0812bedcfceff315bbd95073e99f7f7a1c69eL227-R232), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-c948ed18412071ba1dac99f2e58e5abb97799e2275861a13d9c67c9e71c5d101L138-L156))
* Add new fields and methods to the `ResourceData` struct to handle different schemes and additional information, such as mimetype, parameters, encoding, and encoded content, and store the scheme in a `OnceCell` for lazy and thread-safe access ([link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-df66648edef24ca7ddd956da4a7b822f0a6de2da3ec1ee7fa9bc4fb5955a52c4L10-R10), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41L2-R2), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R9), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R22-R61), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41L32-R150), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R413), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R422), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R482), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R488-R491), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R655), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R661-R664))
* Refactor and optimize some parts of the `normal_module_factory` module, such as using the `get_scheme` function instead of parsing the URL, using the `matches!` macro instead of nested `match` expressions, using the `format!` macro instead of the `+` operator, and using the new methods of the `ResourceData` struct instead of the old struct literal syntax ([link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR10), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL125-R126), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL177-R174), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL199-R214), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL212-R235), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL247-R255), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL259-R279), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL281-R292), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL318-R331), [link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL344-R351))
* Propagate serialization errors from the `ContextModule` struct by changing the return type of some methods to `Result<BoxSource>` and using the `?` operator instead of unwrapping the result ([link](https://github.com/web-infra-dev/rspack/pull/3220/files?diff=unified&w=0#diff-0d64b75f0221f54e5a13cc5f4b32d2ffb422b6b58415cf0444a065307d9a29a3L358-R359))

</details>
