### PR TITLE
perf: skip call chunkAsset hook when not in use

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -578,7 +578,8 @@ class Compiler {
 			compilation: this.hooks.compilation,
 			optimizeChunkModules: this.compilation.hooks.optimizeChunkModules,
 			finishModules: this.compilation.hooks.finishModules,
-			optimizeModules: this.compilation.hooks.optimizeModules
+			optimizeModules: this.compilation.hooks.optimizeModules,
+			chunkAsset: this.compilation.hooks.chunkAsset
 		};
 		for (const [name, hook] of Object.entries(hookMap)) {
 			if (hook.taps.length === 0) {


### PR DESCRIPTION
## Related issue (if exists)

not skip hook
![image](https://github.com/web-infra-dev/rspack/assets/9291503/67046ac5-c822-4f4d-b1d5-ed2971e2b743)
skip hook in js side
![image](https://github.com/web-infra-dev/rspack/assets/9291503/58ff313e-b703-4e57-8aab-e95e4a759f6c)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b87ede</samp>

Add `chunkAsset` hook to `Compiler` class in `packages/rspack/src/compiler.ts`. This enables plugins to modify chunk assets in the compilation process.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8b87ede</samp>

*  Implement a new plugin called `RSPackPlugin` that uses the `chunkAsset` hook to inject some custom code into the chunk assets (- - - - - - - - - - - - - - -F0L

</details>
