### PR TITLE
fix: rspack-dev-middleware should use node api

### DIFF
--- a/.changeset/tame-ladybugs-know.md
+++ b/.changeset/tame-ladybugs-know.md
@@ -1,0 +1,5 @@
+---
+"@rspack/dev-middleware": patch
+---
+
+fix: rspack-dev-middleware should use node api


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

The nuxt server is not use express, so has error when use express middleware. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 631ded8</samp>

Refactor `@rspack/dev-middleware` to use node api and fix response bug. Add changeset file for patch update.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 631ded8</samp>

*  Add a changeset file to document the patch update of `@rspack/dev-middleware` and the fix message for the changelog ([link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-da1b965c424040b325e32ad84d957c31477ea6ddbf9dc00de749e1b5416b3244R1-R5))
*  Refactor `middleware.ts` to use node types and methods instead of express types and methods ([link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L2-R4), [link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L19-R25), [link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L46-R45), [link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L62-R64))
  * Return a `RequestListener` from `createDevMiddleware` and handle the requests and responses using node api ([link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L19-R25))
  * Import `IncomingMessage`, `ServerResponse`, and `RequestListener` from `http` module instead of express ([link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L2-R4))
  * Remove the call to `next` and end the response with an empty body when the buffer is not found in `getRspackMemoryAssets` ([link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L46-R45))
  * Use `statusCode` and `end` instead of `status` and `send` in `getRspackMemoryAssets` ([link](https://github.com/web-infra-dev/rspack/pull/3233/files?diff=unified&w=0#diff-9749b0691bcfc29a326f4b7d6c27dd126e74ccd5ef6e0db0b378036a7e413b75L62-R64))

</details>
