### PR TITLE
feat: add afterCompile hook

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -175,6 +175,7 @@ export interface JsHooks {
   optimizeModules: (...args: any[]) => any
   optimizeChunkModule: (...args: any[]) => any
   beforeCompile: (...args: any[]) => any
+  afterCompile: (...args: any[]) => any
   finishModules: (...args: any[]) => any
   beforeResolve: (...args: any[]) => any
   contextModuleBeforeResolve: (...args: any[]) => any

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -18,6 +18,7 @@ pub enum Hook {
   AfterEmit,
   OptimizeChunkModules,
   BeforeCompile,
+  AfterCompile,
   FinishModules,
   OptimizeModules,
   /// webpack `compilation.hooks.chunkAsset`
@@ -42,6 +43,7 @@ impl From<String> for Hook {
       "afterEmit" => Hook::AfterEmit,
       "optimizeChunkModules" => Hook::OptimizeChunkModules,
       "beforeCompile" => Hook::BeforeCompile,
+      "afterCompile" => Hook::AfterCompile,
       "finishModules" => Hook::FinishModules,
       "optimizeModules" => Hook::OptimizeModules,
       "chunkAsset" => Hook::ChunkAsset,

--- a/crates/node_binding/src/js_values/hooks.rs
+++ b/crates/node_binding/src/js_values/hooks.rs
@@ -18,6 +18,7 @@ pub struct JsHooks {
   pub optimize_modules: JsFunction,
   pub optimize_chunk_module: JsFunction,
   pub before_compile: JsFunction,
+  pub after_compile: JsFunction,
   pub finish_modules: JsFunction,
   pub before_resolve: JsFunction,
   pub context_module_before_resolve: JsFunction,

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -37,6 +37,7 @@ pub struct JsHooksAdapter {
   pub optimize_modules_tsfn: ThreadsafeFunction<JsCompilation, ()>,
   pub optimize_chunk_modules_tsfn: ThreadsafeFunction<JsCompilation, ()>,
   pub before_compile_tsfn: ThreadsafeFunction<(), ()>,
+  pub after_compile_tsfn: ThreadsafeFunction<JsCompilation, ()>,
   pub finish_modules_tsfn: ThreadsafeFunction<JsCompilation, ()>,
   pub chunk_asset_tsfn: ThreadsafeFunction<JsChunkAssetArgs, ()>,
   pub before_resolve: ThreadsafeFunction<BeforeResolveData, Option<bool>>,
@@ -377,6 +378,28 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call before compile: {err}",))?
   }
 
+  async fn after_compile(
+    &mut self,
+    compilation: &mut rspack_core::Compilation,
+  ) -> rspack_error::Result<()> {
+    if self.is_hook_disabled(&Hook::AfterCompile) {
+      return Ok(());
+    }
+
+    let compilation = JsCompilation::from_compilation(unsafe {
+      std::mem::transmute::<&'_ mut rspack_core::Compilation, &'static mut rspack_core::Compilation>(
+        compilation,
+      )
+    });
+
+    self
+      .after_compile_tsfn
+      .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
+      .into_rspack_result()?
+      .await
+      .map_err(|err| internal_error!("Failed to call after compile: {err}"))?
+  }
+
   async fn finish_modules(
     &mut self,
     compilation: &mut rspack_core::Compilation,
@@ -448,6 +471,7 @@ impl JsHooksAdapter {
       context_module_before_resolve,
       normal_module_factory_resolve_for_scheme,
       before_compile,
+      after_compile,
       finish_modules,
       chunk_asset,
     } = js_hooks;
@@ -481,6 +505,8 @@ impl JsHooksAdapter {
       js_fn_into_theadsafe_fn!(optimize_chunk_module, env);
     let before_compile_tsfn: ThreadsafeFunction<(), ()> =
       js_fn_into_theadsafe_fn!(before_compile, env);
+    let after_compile_tsfn: ThreadsafeFunction<JsCompilation, ()> =
+      js_fn_into_theadsafe_fn!(after_compile, env);
     let finish_modules_tsfn: ThreadsafeFunction<JsCompilation, ()> =
       js_fn_into_theadsafe_fn!(finish_modules, env);
     let context_module_before_resolve: ThreadsafeFunction<BeforeResolveData, Option<bool>> =
@@ -512,6 +538,7 @@ impl JsHooksAdapter {
       optimize_modules_tsfn,
       optimize_chunk_modules_tsfn,
       before_compile_tsfn,
+      after_compile_tsfn,
       before_resolve,
       context_module_before_resolve,
       normal_module_factory_resolve_for_scheme,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -177,6 +177,13 @@ where
     }
     self.compilation.seal(self.plugin_driver.clone()).await?;
 
+    self
+      .plugin_driver
+      .write()
+      .await
+      .after_compile(&mut self.compilation)
+      .await?;
+
     // Consume plugin driver diagnostic
     let plugin_driver_diagnostics = self.plugin_driver.read().await.take_diagnostic();
     self

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -311,6 +311,10 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
+  async fn after_compile(&mut self, _compilation: &mut Compilation) -> Result<()> {
+    Ok(())
+  }
+
   async fn finish_modules(&mut self, _modules: &mut Compilation) -> Result<()> {
     Ok(())
   }

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -176,6 +176,17 @@ impl PluginDriver {
 
     Ok(())
   }
+
+  pub async fn after_compile(
+    &mut self,
+    compilation: &mut Compilation,
+  ) -> PluginCompilationHookOutput {
+    for plugin in &mut self.plugins {
+      plugin.after_compile(compilation).await?;
+    }
+
+    Ok(())
+  }
   /// Executed while initializing the compilation, right before emitting the compilation event. This hook is not copied to child compilers.
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#thiscompilation


### PR DESCRIPTION
## Related issue (if exists)

https://github.com/web-infra-dev/rspack/issues/3158

## Summary

Adds the afterCompile hook needed for ProgressPlugin.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13aa843</samp>

This pull request adds a new hook `afterCompile` to the compiler and the plugin system. The hook allows plugins to run custom code after the compilation is done and before the output is emitted. The pull request modifies several files in the `crates` and `packages` directories to implement and support this new hook.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13aa843</samp>

*  Add a new hook `afterCompile` to the plugin system that allows plugins to perform custom logic after the compilation is done and before the output is emitted ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R21), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R46), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR21), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R40), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R381-R402), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R474), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R508-R509), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R541), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209R180-R186), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R314-R317), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR179-R189), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR134), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR230), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR280), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR555), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR607-R611))
  * Define a new variant `Hook::AfterCompile` in `crates/node_binding/src/hook.rs` and handle its conversion from a string ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R21), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R46))
  * Add a new field `after_compile` to the `Hooks` struct in `crates/node_binding/src/js_values/hooks.rs` that holds the JavaScript function for the hook ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR21))
  * Add a new field `after_compile_tsfn` to the `Plugin` struct in `crates/node_binding/src/plugins/mod.rs` that wraps the JavaScript function in a `ThreadsafeFunction` ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R40))
  * Add a new method `after_compile` to the `Plugin` struct in `crates/node_binding/src/plugins/mod.rs` that calls the `after_compile_tsfn` with the current `Compilation` object ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R381-R402))
  * Export the `after_compile` method from the `Plugin` struct in `crates/node_binding/src/plugins/mod.rs` and create a `ThreadsafeFunction` from the `after_compile` JavaScript function in the `init` and `new` methods ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R474), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R508-R509), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R541))
  * Call the `after_compile` method of the `plugin_driver` in the `compile` method of the `Compiler` struct in `crates/rspack_core/src/compiler/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209R180-R186))
  * Add a default implementation of the `after_compile` method to the `Plugin` trait in `crates/rspack_core/src/plugin/api.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R314-R317))
  * Add a new method `after_compile` to the `PluginDriver` struct in `crates/rspack_core/src/plugin/plugin_driver.rs` that iterates over the plugins and calls their `after_compile` methods ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR179-R189))
  * Add a new property `afterCompile` to the `Compiler` class in `packages/rspack/src/compiler.ts` that is an instance of the `tapable.AsyncSeriesHook` class ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR134))
  * Initialize the `afterCompile` property of the `Compiler` class in `packages/rspack/src/compiler.ts` and pass it to the Rust `Compiler` struct in the `createCompiler` function ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR230), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR280))
  * Return the `afterCompile` property from the `getHooks` method of the `Compiler` class in `packages/rspack/src/compiler.ts` and add a private method `#afterCompile` that invokes the hook and updates the list of disabled hooks ([link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR555), [link](https://github.com/web-infra-dev/rspack/pull/3235/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR607-R611))

</details>
