### PR TITLE
feat: add scheme, mimetype, and resourceFragment rule condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2244,6 +2244,7 @@ dependencies = [
  "hashlink",
  "indexmap",
  "itertools",
+ "mime_guess",
  "nodejs-resolver",
  "once_cell",
  "paste",
@@ -2440,12 +2441,16 @@ dependencies = [
  "anyhow",
  "async-trait",
  "mime_guess",
+ "once_cell",
  "rayon",
+ "regex",
  "rspack_base64",
  "rspack_core",
  "rspack_error",
  "rspack_testing",
- "sugar_path",
+ "rspack_util",
+ "serde_json",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ itertools          = { version = "0.10.5" }
 json               = { version = "0.12.4" }
 linked_hash_set    = { version = "0.1.4" }
 mimalloc-rust      = { version = "0.2" }
+mime_guess         = { version = "2.0.4" }
 nodejs-resolver    = { version = "0.0.84" }
 once_cell          = { version = "1.17.1" }
 paste              = { version = "1.0" }
@@ -43,6 +44,7 @@ tokio              = { version = "1.28.0" }
 tracing            = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17" }
 url                = { version = "2.3.1" }
+urlencoding        = { version = "2.1.2" }
 ustr               = { version = "0.9.0" }
 xxhash-rust        = { version = "0.8.6" }
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -226,6 +226,16 @@ export interface JsModule {
   moduleIdentifier: string
 }
 
+export interface JsResolveForSchemeInput {
+  resourceData: JsResourceData
+  scheme: string
+}
+
+export interface JsResolveForSchemeResult {
+  resourceData: JsResourceData
+  stop: boolean
+}
+
 export interface JsResourceData {
   /** Resource with absolute path, query and fragment */
   resource: string
@@ -337,8 +347,6 @@ export interface NodeFS {
 
 export interface PathData {
   filename?: string
-  query?: string
-  fragment?: string
   hash?: string
   contentHash?: string
   runtime?: string
@@ -587,6 +595,7 @@ export interface RawModuleRule {
   resource?: RawRuleSetCondition
   /** A condition matcher against the resource query. */
   resourceQuery?: RawRuleSetCondition
+  resourceFragment?: RawRuleSetCondition
   descriptionData?: Record<string, RawRuleSetCondition>
   sideEffects?: boolean
   use?: Array<RawModuleRuleUse>
@@ -596,6 +605,8 @@ export interface RawModuleRule {
   resolve?: RawResolveOptions
   issuer?: RawRuleSetCondition
   dependency?: RawRuleSetCondition
+  scheme?: RawRuleSetCondition
+  mimetype?: RawRuleSetCondition
   oneOf?: Array<RawModuleRule>
   /** Specifies the category of the loader. No value means normal loader. */
   enforce?: 'pre' | 'post'
@@ -840,11 +851,6 @@ export interface RawStyleConfig {
 
 export interface RawTrustedTypes {
   policyName?: string
-}
-
-export interface SchemeAndJsResourceData {
-  resourceData: JsResourceData
-  scheme: string
 }
 
 export interface ThreadsafeNodeFS {

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -22,6 +22,7 @@ pub enum Hook {
   OptimizeModules,
   /// webpack `compilation.hooks.chunkAsset`
   ChunkAsset,
+  NormalModuleFactoryResolveForScheme,
 }
 
 impl From<String> for Hook {
@@ -45,6 +46,7 @@ impl From<String> for Hook {
       "finishModules" => Hook::FinishModules,
       "optimizeModules" => Hook::OptimizeModules,
       "chunkAsset" => Hook::ChunkAsset,
+      "normalModuleFactoryResolveForScheme" => Hook::NormalModuleFactoryResolveForScheme,
       hook_name => panic!("{hook_name} is an invalid hook name"),
     }
   }

--- a/crates/node_binding/src/js_values/normal_module_factory.rs
+++ b/crates/node_binding/src/js_values/normal_module_factory.rs
@@ -1,9 +1,15 @@
 use rspack_core::{NormalModuleBeforeResolveArgs, ResourceData};
 
 #[napi(object)]
-pub struct SchemeAndJsResourceData {
+pub struct JsResolveForSchemeInput {
   pub resource_data: JsResourceData,
   pub scheme: String,
+}
+
+#[napi(object)]
+pub struct JsResolveForSchemeResult {
+  pub resource_data: JsResourceData,
+  pub stop: bool,
 }
 
 #[napi(object)]
@@ -35,7 +41,7 @@ impl From<ResourceData> for JsResourceData {
   }
 }
 
-impl From<ResourceData> for SchemeAndJsResourceData {
+impl From<ResourceData> for JsResolveForSchemeInput {
   fn from(value: ResourceData) -> Self {
     Self {
       scheme: value.get_scheme().to_string(),

--- a/crates/node_binding/src/js_values/path_data.rs
+++ b/crates/node_binding/src/js_values/path_data.rs
@@ -1,12 +1,8 @@
-use std::path::Path;
-
 use super::JsAssetInfo;
 
 #[napi(object)]
 pub struct PathData {
   pub filename: Option<String>,
-  pub query: Option<String>,
-  pub fragment: Option<String>,
   pub hash: Option<String>,
   pub content_hash: Option<String>,
   pub runtime: Option<String>,
@@ -17,9 +13,7 @@ pub struct PathData {
 impl PathData {
   pub fn as_core_path_data(&self) -> rspack_core::PathData {
     rspack_core::PathData {
-      filename: self.filename.as_deref().map(Path::new),
-      query: self.query.as_deref(),
-      fragment: self.fragment.as_deref(),
+      filename: self.filename.as_deref(),
       chunk: None,
       module: None,
       hash: self.hash.as_deref(),

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -223,6 +223,7 @@ pub struct RawModuleRule {
   pub resource: Option<RawRuleSetCondition>,
   /// A condition matcher against the resource query.
   pub resource_query: Option<RawRuleSetCondition>,
+  pub resource_fragment: Option<RawRuleSetCondition>,
   pub description_data: Option<HashMap<String, RawRuleSetCondition>>,
   pub side_effects: Option<bool>,
   pub r#use: Option<Vec<RawModuleRuleUse>>,
@@ -234,6 +235,8 @@ pub struct RawModuleRule {
   pub resolve: Option<RawResolveOptions>,
   pub issuer: Option<RawRuleSetCondition>,
   pub dependency: Option<RawRuleSetCondition>,
+  pub scheme: Option<RawRuleSetCondition>,
+  pub mimetype: Option<RawRuleSetCondition>,
   pub one_of: Option<Vec<RawModuleRule>>,
   /// Specifies the category of the loader. No value means normal loader.
   #[napi(ts_type = "'pre' | 'post'")]
@@ -384,6 +387,10 @@ impl RawOptionsApply for RawModuleRule {
       include: self.include.map(|raw| raw.try_into()).transpose()?,
       exclude: self.exclude.map(|raw| raw.try_into()).transpose()?,
       resource_query: self.resource_query.map(|raw| raw.try_into()).transpose()?,
+      resource_fragment: self
+        .resource_fragment
+        .map(|raw| raw.try_into())
+        .transpose()?,
       resource: self.resource.map(|raw| raw.try_into()).transpose()?,
       description_data,
       r#use: uses,
@@ -394,6 +401,8 @@ impl RawOptionsApply for RawModuleRule {
       side_effects: self.side_effects,
       issuer: self.issuer.map(|raw| raw.try_into()).transpose()?,
       dependency: self.dependency.map(|raw| raw.try_into()).transpose()?,
+      scheme: self.scheme.map(|raw| raw.try_into()).transpose()?,
+      mimetype: self.mimetype.map(|raw| raw.try_into()).transpose()?,
       one_of,
       enforce,
     })

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -20,6 +20,7 @@ glob-match = "0.2.1"
 hashlink = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
+mime_guess = { workspace = true }
 nodejs-resolver = { workspace = true }
 once_cell = { workspace = true }
 paste = { workspace = true }

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use async_recursion::async_recursion;
+use derivative::Derivative;
 use futures::future::BoxFuture;
 use rspack_error::Result;
 use rspack_regex::RspackRegex;
@@ -119,7 +120,8 @@ where
   Ok(true)
 }
 
-#[derive(Default)]
+#[derive(Derivative, Default)]
+#[derivative(Debug)]
 pub struct ModuleRule {
   /// A condition matcher matching an absolute path.
   pub test: Option<RuleSetCondition>,
@@ -129,12 +131,16 @@ pub struct ModuleRule {
   pub resource: Option<RuleSetCondition>,
   /// A condition matcher against the resource query.
   pub resource_query: Option<RuleSetCondition>,
+  pub resource_fragment: Option<RuleSetCondition>,
   pub dependency: Option<RuleSetCondition>,
   pub issuer: Option<RuleSetCondition>,
+  pub scheme: Option<RuleSetCondition>,
+  pub mimetype: Option<RuleSetCondition>,
   pub description_data: Option<DescriptionData>,
   pub side_effects: Option<bool>,
   /// The `ModuleType` to use for the matched resource.
   pub r#type: Option<ModuleType>,
+  #[derivative(Debug(format_with = "fmt_use"))]
   pub r#use: Vec<BoxLoader>,
   pub parser: Option<AssetParserOptions>,
   pub generator: Option<AssetGeneratorOptions>,
@@ -143,35 +149,19 @@ pub struct ModuleRule {
   pub enforce: ModuleRuleEnforce,
 }
 
-impl Debug for ModuleRule {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    f.debug_struct("ModuleRule")
-      .field("test", &self.test)
-      .field("include", &self.include)
-      .field("exclude", &self.exclude)
-      .field("resource", &self.resource)
-      .field("resource_query", &self.resource_query)
-      .field("dependency", &self.dependency)
-      .field("issuer", &self.issuer)
-      .field("description_data", &self.description_data)
-      .field("side_effects", &self.side_effects)
-      .field("r#type", &self.r#type)
-      .field(
-        "r#use",
-        &self
-          .r#use
-          .iter()
-          .map(|l| l.identifier().to_string())
-          .collect::<Vec<_>>()
-          .join("!"),
-      )
-      .field("parser", &self.parser)
-      .field("generator", &self.generator)
-      .field("resolve", &self.resolve)
-      .field("one_of", &self.one_of)
-      .field("enforce", &self.enforce)
-      .finish()
-  }
+fn fmt_use(
+  r#use: &[BoxLoader],
+  f: &mut std::fmt::Formatter,
+) -> std::result::Result<(), std::fmt::Error> {
+  write!(
+    f,
+    "{}",
+    r#use
+      .iter()
+      .map(|l| l.identifier().to_string())
+      .collect::<Vec<_>>()
+      .join("!")
+  )
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -24,7 +24,7 @@ pub type PluginProcessAssetsHookOutput = Result<()>;
 pub type PluginReadResourceOutput = Result<Option<Content>>;
 pub type PluginFactorizeHookOutput = Result<Option<ModuleFactoryResult>>;
 pub type PluginModuleHookOutput = Result<Option<BoxModule>>;
-pub type PluginNormalModuleFactoryResolveForSchemeOutput = Result<Option<ResourceData>>;
+pub type PluginNormalModuleFactoryResolveForSchemeOutput = Result<(ResourceData, bool)>;
 pub type PluginNormalModuleFactoryBeforeResolveOutput = Result<Option<bool>>;
 pub type PluginContentHashHookOutput = Result<Option<(SourceType, String)>>;
 pub type PluginChunkHashHookOutput = Result<Option<u64>>;
@@ -112,9 +112,9 @@ pub trait Plugin: Debug + Send + Sync {
   async fn normal_module_factory_resolve_for_scheme(
     &self,
     _ctx: PluginContext,
-    _args: &ResourceData,
+    args: ResourceData,
   ) -> PluginNormalModuleFactoryResolveForSchemeOutput {
-    Ok(None)
+    Ok((args, false))
   }
 
   async fn content_hash(

--- a/crates/rspack_core/src/utils/identifier.rs
+++ b/crates/rspack_core/src/utils/identifier.rs
@@ -31,6 +31,7 @@ static PATH_QUERY_FRAGMENT_REGEXP: Lazy<Regex> = Lazy::new(|| {
     .expect("Failed to initialize `PATH_QUERY_FRAGMENT_REGEXP`")
 });
 
+#[derive(Debug)]
 pub struct ResourceParsedData {
   pub path: PathBuf,
   pub query: Option<String>,

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 mod content;
 mod loader;
 mod plugin;

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -21,7 +21,7 @@ use crate::{
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Scheme {
-  Normal,
+  None,
   Data,
   File,
   Custom(String),
@@ -31,6 +31,7 @@ pub enum Scheme {
 impl From<&str> for Scheme {
   fn from(value: &str) -> Self {
     match value {
+      "" => Self::None,
       "data" => Self::Data,
       "file" => Self::File,
       v => Self::Custom(v.to_string()),
@@ -44,7 +45,7 @@ impl fmt::Display for Scheme {
       f,
       "{}",
       match self {
-        Self::Normal => "",
+        Self::None => "",
         Self::Data => "data",
         Self::File => "file",
         Self::Custom(v) => v,
@@ -56,7 +57,7 @@ impl fmt::Display for Scheme {
 pub fn get_scheme(specifier: &str) -> Scheme {
   url::Url::parse(specifier)
     .map(|url| Scheme::from(url.scheme()))
-    .unwrap_or(Scheme::Normal)
+    .unwrap_or(Scheme::None)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_plugin_asset/Cargo.toml
+++ b/crates/rspack_plugin_asset/Cargo.toml
@@ -13,9 +13,13 @@ rspack_testing = { path = "../rspack_testing" }
 [dependencies]
 anyhow        = { workspace = true }
 async-trait   = { workspace = true }
-mime_guess    = "2.0.4"
+mime_guess    = { workspace = true }
+once_cell     = { workspace = true }
 rayon         = { workspace = true }
+regex         = { workspace = true }
 rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
-sugar_path    = { workspace = true }
+rspack_util   = { path = "../rspack_util" }
+serde_json    = { workspace = true }
+urlencoding   = { workspace = true }

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -191,7 +191,7 @@ impl CopyPlugin {
       let template_str = compilation.get_asset_path(
         &Filename::from(filename.to_string_lossy().to_string()),
         PathData::default()
-          .filename(&source_filename)
+          .filename(&source_filename.to_string_lossy())
           .content_hash(&content_hash)
           .hash(&content_hash),
       );

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -71,7 +71,6 @@ impl CodeGeneratable for CssImportDependency {
           .take()
           .into_iter()
           .filter(|rule| match rule {
-            // FIXME(ahabhgk): @import "data:..."
             Rule::AtRule(at_rule) => !matches!(at_rule.prelude, Some(box AtRulePrelude::ImportPrelude(_))),
             _ => true,
           })

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -51,7 +51,9 @@ impl swc_core::css::modules::TransformConfig for ModulesTransformConfig<'_> {
     self
       .local_name_ident
       .render(LocalIdentNameRenderOptions {
-        path_data: PathData::default().filename(self.filename).hash(&hash),
+        path_data: PathData::default()
+          .filename(&self.filename.to_string_lossy())
+          .hash(&hash),
         local: Some(local),
       })
       .into()

--- a/crates/rspack_plugin_css/src/visitors/mod.rs
+++ b/crates/rspack_plugin_css/src/visitors/mod.rs
@@ -63,8 +63,6 @@ impl VisitAstPath for Analyzer<'_> {
     n: &'ast ImportPrelude,
     ast_path: &mut AstNodePath<AstParentNodeRef<'r>>,
   ) {
-    n.visit_children_with_path(self, ast_path);
-
     let specifier = match &*n.href {
       ImportHref::Url(u) => u.value.as_ref().map(|box s| match s {
         UrlValue::Str(s) => s.value.to_string(),
@@ -72,7 +70,7 @@ impl VisitAstPath for Analyzer<'_> {
       }),
       ImportHref::Str(s) => Some(s.value.to_string()),
     };
-    if let Some(specifier) = specifier && !is_url_requestable(&specifier) {
+    if let Some(specifier) = specifier {
       let specifier = replace_module_request_prefix(specifier, self.diagnostics);
       self.deps.push(Box::new(CssImportDependency::new(
         specifier,
@@ -93,7 +91,7 @@ impl VisitAstPath for Analyzer<'_> {
       UrlValue::Str(s) => s.value.to_string(),
       UrlValue::Raw(r) => r.value.to_string(),
     });
-    if let Some(specifier) = specifier && !is_url_requestable(&specifier) {
+    if let Some(specifier) = specifier {
       let specifier = replace_module_request_prefix(specifier, self.diagnostics);
       let dep = Box::new(CssUrlDependency::new(
         specifier,
@@ -104,9 +102,4 @@ impl VisitAstPath for Analyzer<'_> {
       self.code_generation_dependencies.push(dep);
     }
   }
-}
-
-// TODO(ahabhgk): dataurl should be resolved by DataUriPlugin
-fn is_url_requestable(url: &str) -> bool {
-  url.starts_with("data:")
 }

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -184,7 +184,7 @@ impl Plugin for DevtoolPlugin {
                   source_map_filename_config,
                   PathData::default()
                     .chunk(chunk)
-                    .filename(Path::new(&filename))
+                    .filename(&filename)
                     .content_hash_optional(chunk.content_hash.get(source_type).map(|i| i.as_str())),
                 );
                 break;

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -15,7 +15,6 @@ use rspack_core::{
   CompilationAsset, Filename, PathData, Plugin,
 };
 use serde::Deserialize;
-use sugar_path::SugarPath;
 use swc_html::visit::VisitMutWith;
 
 use crate::{
@@ -182,9 +181,7 @@ impl Plugin for HtmlPlugin {
     let html_file_name = Filename::from(config.filename.clone());
     let (output_path, asset_info) = compilation.get_path_with_info(
       &html_file_name,
-      PathData::default()
-        .filename(&Path::new(&url).relative(&compilation.options.context))
-        .content_hash(&hash),
+      PathData::default().filename(&url).content_hash(&hash),
     );
     compilation.emit_asset(
       output_path,

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -14,4 +14,4 @@ regex         = { workspace = true }
 rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
-urlencoding   = "2.1.2"
+urlencoding   = { workspace = true }

--- a/crates/rspack_plugin_schemes/src/data_uri.rs
+++ b/crates/rspack_plugin_schemes/src/data_uri.rs
@@ -18,22 +18,39 @@ impl Plugin for DataUriPlugin {
   async fn normal_module_factory_resolve_for_scheme(
     &self,
     _ctx: PluginContext,
-    args: &ResourceData,
+    resource_data: ResourceData,
   ) -> PluginNormalModuleFactoryResolveForSchemeOutput {
-    if let Some(captures) = URI_REGEX.captures(&args.resource)
-    && let Some(mimetype) = captures.get(1)
-    && let Some(parameters) = captures.get(2)
-    && let Some(encoding) = captures.get(3)
-    && let Some(encoded_content) = captures.get(4) {
-      let resource_data = args.clone();
-      return Ok(Some(resource_data
-        .mimetype(mimetype.as_str().to_owned())
-        .parameters(parameters.as_str().to_owned())
-        .encoding(encoding.as_str().to_owned())
-        .encoded_content(encoded_content.as_str().to_owned())
-      ))
+    if let Some(captures) = URI_REGEX.captures(&resource_data.resource) {
+      let mimetype = captures
+        .get(1)
+        .map(|i| i.as_str())
+        .unwrap_or_default()
+        .to_owned();
+      let parameters = captures
+        .get(2)
+        .map(|i| i.as_str())
+        .unwrap_or_default()
+        .to_owned();
+      let encoding = captures
+        .get(3)
+        .map(|i| i.as_str())
+        .unwrap_or_default()
+        .to_owned();
+      let encoded_content = captures
+        .get(4)
+        .map(|i| i.as_str())
+        .unwrap_or_default()
+        .to_owned();
+      return Ok((
+        resource_data
+          .mimetype(mimetype)
+          .parameters(parameters)
+          .encoding(encoding)
+          .encoded_content(encoded_content),
+        false,
+      ));
     }
-    Ok(None)
+    Ok((resource_data, false))
   }
 
   async fn read_resource(&self, resource_data: &ResourceData) -> PluginReadResourceOutput {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -12,7 +12,6 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_identifier::Identifier;
-use sugar_path::SugarPath;
 use wasmparser::{Import, Parser, Payload};
 
 use crate::dependency::WasmImportDependency;
@@ -280,16 +279,10 @@ fn render_wasm_name(
   wasm_filename_template: &Filename,
   hash: String,
 ) -> (String, AssetInfo) {
-  let context = &compilation.options.context;
   compilation.get_asset_path_with_info(
     wasm_filename_template,
     PathData::default()
-      .filename(
-        &normal_module
-          .resource_resolved_data()
-          .resource_path
-          .relative(context),
-      )
+      .filename(&normal_module.resource_resolved_data().resource)
       .content_hash(&hash)
       .hash(&hash),
   )

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -633,12 +633,16 @@ class Compiler {
 	}
 
 	async #normalModuleFactoryResolveForScheme(
-		resourceData: binding.SchemeAndJsResourceData
-	) {
-		await this.compilation.normalModuleFactory?.hooks.resolveForScheme
-			.for(resourceData.scheme)
-			.promise(resourceData.resourceData);
-		return resourceData.resourceData;
+		input: binding.JsResolveForSchemeInput
+	): Promise<binding.JsResolveForSchemeResult> {
+		let stop =
+			await this.compilation.normalModuleFactory?.hooks.resolveForScheme
+				.for(input.scheme)
+				.promise(input.resourceData);
+		return {
+			resourceData: input.resourceData,
+			stop: stop === true
+		};
 	}
 
 	async #optimize_chunk_modules() {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -298,6 +298,11 @@ const getRawModuleRule = (
 		resourceQuery: rule.resourceQuery
 			? getRawRuleSetCondition(rule.resourceQuery)
 			: undefined,
+		resourceFragment: rule.resourceFragment
+			? getRawRuleSetCondition(rule.resourceFragment)
+			: undefined,
+		scheme: rule.scheme ? getRawRuleSetCondition(rule.scheme) : undefined,
+		mimetype: rule.mimetype ? getRawRuleSetCondition(rule.mimetype) : undefined,
 		sideEffects: rule.sideEffects,
 		use: createRawModuleRuleUses(rule.use ?? [], options),
 		type: rule.type,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -191,7 +191,15 @@ const applyModuleDefaults = (
 		};
 		const rules: RuleSetRules = [
 			{
+				mimetype: "application/node",
+				type: "javascript/auto"
+			},
+			{
 				test: /\.json$/i,
+				type: "json"
+			},
+			{
+				mimetype: "application/json",
 				type: "json"
 			},
 			{
@@ -217,6 +225,12 @@ const applyModuleDefaults = (
 				...commonjs
 			},
 			{
+				mimetype: {
+					or: ["text/javascript", "application/javascript"]
+				},
+				...esm
+			},
+			{
 				test: /\.jsx$/i,
 				type: "jsx"
 			},
@@ -229,6 +243,31 @@ const applyModuleDefaults = (
 				type: "tsx"
 			}
 		];
+
+		if (asyncWebAssembly) {
+			const wasm = {
+				type: "webassembly/async",
+				rules: [
+					{
+						descriptionData: {
+							type: "module"
+						},
+						resolve: {
+							fullySpecified: true
+						}
+					}
+				]
+			};
+			rules.push({
+				test: /\.wasm$/i,
+				...wasm
+			});
+			rules.push({
+				mimetype: "application/wasm",
+				...wasm
+			});
+		}
+
 		if (css) {
 			const cssRule = {
 				type: "css",
@@ -255,34 +294,23 @@ const applyModuleDefaults = (
 					}
 				]
 			});
-		}
-
-		if (asyncWebAssembly) {
-			const wasm = {
-				type: "webassembly/async",
-				rules: [
-					{
-						descriptionData: {
-							type: "module"
-						},
-						resolve: {
-							fullySpecified: true
-						}
-					}
-				]
-			};
 			rules.push({
-				test: /\.wasm$/i,
-				...wasm
+				mimetype: "text/css+module",
+				...cssModulesRule
+			});
+			rules.push({
+				mimetype: "text/css",
+				...cssRule
 			});
 		}
+
 		rules.push({
 			dependency: "url",
 			oneOf: [
-				// {
-				// 	scheme: /^data$/,
-				// 	type: "asset/inline"
-				// },
+				{
+					scheme: /^data$/,
+					type: "asset/inline"
+				},
 				{
 					type: "asset/resource"
 				}

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -1700,6 +1700,22 @@ module.exports = {
 						}
 					]
 				},
+				mimetype: {
+					description: "Match module mimetype when load from Data URI.",
+					oneOf: [
+						{
+							$ref: "#/definitions/RuleSetConditionOrConditions"
+						}
+					]
+				},
+				scheme: {
+					description: "Match module scheme.",
+					oneOf: [
+						{
+							$ref: "#/definitions/RuleSetConditionOrConditions"
+						}
+					]
+				},
 				rules: {
 					description:
 						"Match and execute these rules when this rule is matched.",

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -317,6 +317,8 @@ export interface RuleSetRule {
 	resource?: RuleSetCondition;
 	resourceFragment?: RuleSetCondition;
 	resourceQuery?: RuleSetCondition;
+	scheme?: RuleSetCondition;
+	mimetype?: RuleSetCondition;
 	descriptionData?: {
 		[k: string]: RuleSetCondition;
 	};

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -282,6 +282,20 @@ describe("snapshots", () => {
 		+         ],
 		+         "test": /\\.wasm$/i,
 		+         "type": "webassembly/async",
+		+       },
+		+       Object {
+		+         "mimetype": "application/wasm",
+		+         "rules": Array [
+		+           Object {
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "type": "webassembly/async",
 	`)
 	);
 
@@ -312,6 +326,20 @@ describe("snapshots", () => {
 			+           },
 			+         ],
 			+         "test": /\\.wasm$/i,
+			+         "type": "webassembly/async",
+			+       },
+			+       Object {
+			+         "mimetype": "application/wasm",
+			+         "rules": Array [
+			+           Object {
+			+             "descriptionData": Object {
+			+               "type": "module",
+			+             },
+			+             "resolve": Object {
+			+               "fullySpecified": true,
+			+             },
+			+           },
+			+         ],
 			+         "type": "webassembly/async",
 		`)
 	);
@@ -1056,6 +1084,21 @@ describe("snapshots", () => {
 			-           },
 			-         ],
 			-         "test": /\\.css$/i,
+			-       },
+			-       Object {
+			-         "mimetype": "text/css+module",
+			-         "resolve": Object {
+			-           "fullySpecified": true,
+			-         },
+			-         "type": "css/module",
+			-       },
+			-       Object {
+			-         "mimetype": "text/css",
+			-         "resolve": Object {
+			-           "fullySpecified": true,
+			-           "preferRelative": true,
+			-         },
+			-         "type": "css",
 		`)
 	);
 });

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -67,7 +67,15 @@ exports[`snapshots should have the correct base config 1`] = `
   "module": {
     "defaultRules": [
       {
+        "mimetype": "application/node",
+        "type": "javascript/auto",
+      },
+      {
         "test": /\\\\\\.json\\$/i,
+        "type": "json",
+      },
+      {
+        "mimetype": "application/json",
         "type": "json",
       },
       {
@@ -107,6 +115,22 @@ exports[`snapshots should have the correct base config 1`] = `
         "type": "javascript/dynamic",
       },
       {
+        "mimetype": {
+          "or": [
+            "text/javascript",
+            "application/javascript",
+          ],
+        },
+        "resolve": {
+          "byDependency": {
+            "esm": {
+              "fullySpecified": true,
+            },
+          },
+        },
+        "type": "javascript/esm",
+      },
+      {
         "test": /\\\\\\.jsx\\$/i,
         "type": "jsx",
       },
@@ -138,8 +162,27 @@ exports[`snapshots should have the correct base config 1`] = `
         "test": /\\\\\\.css\\$/i,
       },
       {
+        "mimetype": "text/css+module",
+        "resolve": {
+          "fullySpecified": true,
+        },
+        "type": "css/module",
+      },
+      {
+        "mimetype": "text/css",
+        "resolve": {
+          "fullySpecified": true,
+          "preferRelative": true,
+        },
+        "type": "css",
+      },
+      {
         "dependency": "url",
         "oneOf": [
+          {
+            "scheme": /\\^data\\$/,
+            "type": "asset/inline",
+          },
           {
             "type": "asset/resource",
           },

--- a/packages/rspack/tests/cases/schemes/data-imports/a.css
+++ b/packages/rspack/tests/cases/schemes/data-imports/a.css
@@ -1,0 +1,1 @@
+.a { color: palegreen; };;;

--- a/packages/rspack/tests/cases/schemes/data-imports/index.css
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.css
@@ -1,0 +1,8 @@
+@import url("data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ=="); /* .b{color: green} */
+@import url("./a.css");
+
+.class {
+  a: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+  b: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+  c: url('data:image/svg;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==');
+}

--- a/packages/rspack/tests/cases/schemes/data-imports/index.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.js
@@ -1,5 +1,33 @@
 import a from 'data:text/javascript,export default "a";';
+import "data:text/css,.red{color: red;}";
+import "./index.css";
+import inlineSvg from 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+import fs from "node:fs";
+import path from "node:path";
 
 it("data imports", () => {
 	expect(a).toBe("a");
+	expect(fs.readFileSync(path.resolve(__dirname, "main.css"), "utf-8"))
+		.toBe(`.red {
+  color: red;
+}
+
+.b {
+  color: green;
+}
+
+.a {
+  color: palegreen;
+}
+;;;
+
+
+.class {
+  a: url("2c6053f86393fdda.svg");
+  b: url("2c6053f86393fdda.svg");
+  c: url("2c6053f86393fdda");
+}`);
+	expect(inlineSvg).toBe(
+		'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+	);
 });

--- a/packages/rspack/tests/cases/schemes/data-imports/webpack.config.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/webpack.config.js
@@ -1,0 +1,20 @@
+/** @type {import('webpack').Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				dependency: "url",
+				scheme: /^data$/,
+				type: "asset/resource"
+			},
+			{
+				issuer: /\.js/,
+				mimetype: /^image\/svg/,
+				type: "asset/inline"
+			}
+		]
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

fixes #3150 

- refactor resolveForScheme hook
- add more module rule condition: scheme, mimetype, resourceFragment
- refactor Filename::render, now query and fragment is parsed from filename

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d60263</samp>

This pull request adds a new hook to the `rspack` compiler that allows plugins to customize the resolution of resources with different schemes, such as `data`, `file`, or `http`. It also updates the `node_binding` crate to support the new hook in the Node.js integration, and adds or modifies several plugins to handle different types of asset modules. Additionally, it improves the code quality and readability of some structs and methods in the `rspack_core`, `rspack_binding_options`, and `rspack_loader_runner` crates.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d60263</samp>

*  Add new fields `resource_fragment`, `scheme`, and `mimetype` to the `ModuleRule` and `RawModuleRule` structs to allow specifying condition matchers for the resource fragment, the scheme, and the mimetype in the module rules ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R226), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R238-R239), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R390-R393), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R404-R405), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-06c579a7786ea5f17871a0f626ca314d0a41ffb8ba25152ce1d7661e6d1f3d8eL132-R143), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL17-R22), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbR72-R104))
*  Add a new hook `normal_module_factory_resolve_for_scheme` to the `Hook` enum and the `Plugin` trait to allow plugins to customize the resolution of resources with different schemes ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R25), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R49), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L45-R45), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L166-R186), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L491-R500), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L27-R27), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L115-R117), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL351-R364))
*  Change the output type of the `normal_module_factory_resolve_for_scheme` hook to include a flag to indicate whether to stop the resolution process ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6R10-R15), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L18-R18), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L45-R45), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L166-R186), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L491-R500), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL136-R146), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L27-R27), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L115-R117), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL351-R364))
*  Rename the `Scheme::Normal` variant to `Scheme::None` and handle the empty string case in the `Scheme` enum ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41L24-R24), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41R34), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41L47-R48), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-6881ac83dd99ca4e4abfba3497ced1b7d020af702f48bed9eb1e5a82ddfc4a41L59-R60), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL136-R146))
*  Use the `mime_guess` crate to guess the mime type of resources based on their file extensions ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R27), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-b15514bda6ea6c4fd02c5fe3c17a76a128bae9fc869d5245b0d2a109635e91f8R23), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edR132-R186))
*  Use the `urlencoding` crate to encode and decode binary data as URL-safe strings ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R47), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-2bc96ba9cc965e76b0b1373c82571f2c0c0b745d7c445f23820de906bdb3f9eaL16-R25), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edR132-R186), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL253-R312))
*  Use the `let_chains` feature to write `if let` and `match` expressions in a chain ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-df66648edef24ca7ddd956da4a7b822f0a6de2da3ec1ee7fa9bc4fb5955a52c4R1-R2), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL1-R5))
*  Use the `serde_json` crate to serialize the encoded source as a JSON string in the `AssetParserAndGenerator` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-2bc96ba9cc965e76b0b1373c82571f2c0c0b745d7c445f23820de906bdb3f9eaL16-R25), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL276-R344))
*  Simplify the `JsPathData` struct by removing the `query` and `fragment` fields and updating the methods accordingly ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-c6ab97b9afad25f2ecae0a9768466ae0a622515a958f0ce2145fa3f9aad123ebL8-L9), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-c6ab97b9afad25f2ecae0a9768466ae0a622515a958f0ce2145fa3f9aad123ebL20-R16))
*  Simplify the `Debug` implementation for the `ModuleRule` struct by using the `derivative` crate and a custom `format_with` attribute for the `r#use` field ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-06c579a7786ea5f17871a0f626ca314d0a41ffb8ba25152ce1d7661e6d1f3d8eL146-R164))
*  Implement the logic for parsing and generating the asset modules based on the resource data and the encoding option in the `AssetParserAndGenerator` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edR132-R186), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL253-R312), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL264-R320), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL276-R344), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL299-R351))
*  Implement the logic for running the `normal_module_factory_resolve_for_scheme` hook for each plugin and returning the final resolved data and the flag in the `PluginDriver` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL351-R364))
*  Implement the logic for calling the `normal_module_factory_resolve_for_scheme` hook from the Rust and JavaScript sides using the `napi` crate in the `JsPlugin` and `JsHooks` structs ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L18-R18), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L45-R45), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L166-R186), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L491-R500))
*  Implement the logic for converting the `resource_fragment`, `scheme`, and `mimetype` fields from the `RawModuleRule` struct to the `ModuleRule` struct in the `try_into` method ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R390-R393), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R404-R405))
*  Implement the logic for matching the condition matchers for the resource fragment, the scheme, and the mimetype in the `try_match` method of the `ModuleRule` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbR72-R104))
*  Implement the logic for templating the output filename based on the resource data and handling the `data` scheme in the `mut` function of the `Filename` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-75d001733998d80ed823bf765b9791ff28b8612900dd4a1686a54aa25f3155c5L235-R270))
*  Handle the `data` scheme in the `parse` method of the `ImportDependency` struct by using the `parse_resource` function ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-b3b8aa96b3ec7c43ff2acf93f2b613cee489aca779a6bece14aac5e1cf0b5f88L74))
*  Handle the `data` scheme in the `copy` method of the `CopyPlugin` struct by skipping the asset path generation and the asset info insertion ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-60327d77238d48f4c8ce2d4c1415530ee60e71ac5c2b879b608209b83189e5edL299-R351))
*  Fix a type mismatch error in the `copy` method of the `CopyPlugin` struct by using the `to_string_lossy` method for the `source_filename` ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-cde7edc635e72d8f64c982c4e78298d248e671f6f022318cc20440f6091b70baL194-R194))
*  Derive the `Debug` implementation for the `ModuleIdentifier` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-1e29ce8ab6ee7abb5a44dd36bd91c5376542e960b51a7f7657b389233149c291R34))
*  Rename the struct `SchemeAndJsResourceData` to `JsResolveForSchemeInput` to make the name more descriptive and consistent with the new hook name ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6L4-R4), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-fa2967504ea279fce218f9c974f3b934a620b4e2c64a99ed07dc8de452327be6L38-R44), [link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L18-R18))
*  Remove the unused import of `std::path::Path` in the `path_data.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-c6ab97b9afad25f2ecae0a9768466ae0a622515a958f0ce2145fa3f9aad123ebL1-L2))
*  Remove the unused import of `PluginNormalModuleFactoryResolveForSchemeOutput` in the `plugin_driver.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL20-R24))
*  Remove a redundant comment in the `parse` method of the `ImportDependency` struct ([link](https://github.com/web-infra-dev/rspack/pull/3238/files?diff=unified&w=0#diff-b3b8aa96b3ec7c43ff2acf93f2b613cee489aca779a6bece14aac5e1cf0b5f88L74))

</details>
