### PR TITLE
feat(ts): resolve priority to be same with webpack

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -600,8 +600,7 @@ const getResolveDefaults = ({
 		if (targetProperties.electron) conditions.push("electron");
 		if (targetProperties.nwjs) conditions.push("nwjs");
 	}
-
-	const jsExtensions = [".tsx", ".ts", ".jsx", ".js", ".json", ".wasm"];
+	const jsExtensions = [".js", ".json", ".wasm", ".tsx", ".ts", ".jsx"];
 
 	const tp = targetProperties;
 	const browserField =

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -240,12 +240,12 @@ exports[`snapshots should have the correct base config 1`] = `
           "...",
         ],
         "extensions": [
-          ".tsx",
-          ".ts",
-          ".jsx",
           ".js",
           ".json",
           ".wasm",
+          ".tsx",
+          ".ts",
+          ".jsx",
         ],
         "mainFields": [
           "browser",
@@ -261,12 +261,12 @@ exports[`snapshots should have the correct base config 1`] = `
           "...",
         ],
         "extensions": [
-          ".tsx",
-          ".ts",
-          ".jsx",
           ".js",
           ".json",
           ".wasm",
+          ".tsx",
+          ".ts",
+          ".jsx",
         ],
         "mainFields": [
           "browser",
@@ -282,12 +282,12 @@ exports[`snapshots should have the correct base config 1`] = `
           "...",
         ],
         "extensions": [
-          ".tsx",
-          ".ts",
-          ".jsx",
           ".js",
           ".json",
           ".wasm",
+          ".tsx",
+          ".ts",
+          ".jsx",
         ],
         "mainFields": [
           "browser",
@@ -306,12 +306,12 @@ exports[`snapshots should have the correct base config 1`] = `
           "...",
         ],
         "extensions": [
-          ".tsx",
-          ".ts",
-          ".jsx",
           ".js",
           ".json",
           ".wasm",
+          ".tsx",
+          ".ts",
+          ".jsx",
         ],
         "mainFields": [
           "browser",


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/issues/3213

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4180d47</samp>

Changed the order of `jsExtensions` in `defaults.ts` to improve resolver performance.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4180d47</samp>

* Change the order of the `jsExtensions` array to match the webpack `resolve.extensions` array ([link](https://github.com/web-infra-dev/rspack/pull/3242/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL603-R604)). This improves the performance of the resolver by prioritizing the most common extensions and reducing file system lookups. The file affected is `packages/rspack/src/config/defaults.ts`.

</details>
