### PR TITLE
ci: remove unnecessary `test` option from reusable-build

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -25,7 +25,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      tests: true
 
   release:
     name: Nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      tests: true
 
   release:
     name: Release

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,11 +26,6 @@ on:
       target:
         required: true
         type: string
-      tests:
-        description: "Run tests?"
-        default: false
-        required: false
-        type: boolean
 
 jobs:
   select:
@@ -153,7 +148,7 @@ jobs:
   e2e:
     name: E2E Testing
     needs: [select, build]
-    if: inputs.tests && inputs.target == 'x86_64-unknown-linux-gnu'
+    if: inputs.target == 'x86_64-unknown-linux-gnu'
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.33.0-jammy
@@ -179,7 +174,6 @@ jobs:
 
   test:
     needs: [select, build]
-    if: inputs.tests
     runs-on: ${{ needs.select.outputs.host }}
     # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      tests: true
 
   build-pr:
     if: github.ref_name != 'main'
@@ -43,4 +42,3 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      tests: true


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d448fd5</samp>

This pull request removes the `tests` input from four GitHub workflows that build and release the `rspack` binary. This makes the workflows simpler and more efficient, as the tests are already run by other workflows on every push and pull request.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d448fd5</samp>

*  Remove `tests` input from workflows that trigger releases or run tests ([link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L28), [link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L34), [link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L34))
*  Remove `tests` input from `reusable-build.yml` workflow and its callers, since it is unused ([link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L29-L33), [link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L46))
*  Make `E2E Testing` job always run for `x86_64-unknown-linux-gnu` target in `reusable-build.yml` workflow, to ensure end-to-end tests are run for the main Linux target ([link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L156-R151))
*  Make `Upload Artifacts` step always run for every build in `reusable-build.yml` workflow, to upload the built binary and test server to GitHub artifact ([link](https://github.com/web-infra-dev/rspack/pull/3245/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L182))

</details>
