### PR TITLE
feat: add support for `Rule.loader` and `Rule.options`

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -278,6 +278,17 @@ const getRawModuleRule = (
 	rule: RuleSetRule,
 	options: ComposeJsUseOptions
 ): RawModuleRule => {
+	// Rule.loader is a shortcut to Rule.use: [ { loader } ].
+	// See: https://webpack.js.org/configuration/module/#ruleloader
+	if (rule.loader) {
+		rule.use = [
+			{
+				loader: rule.loader,
+				options: rule.options
+			}
+		];
+	}
+
 	return {
 		test: rule.test ? getRawRuleSetCondition(rule.test) : undefined,
 		include: rule.include ? getRawRuleSetCondition(rule.include) : undefined,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -322,6 +322,8 @@ export interface RuleSetRule {
 	};
 	oneOf?: RuleSetRule[];
 	type?: string;
+	loader?: RuleSetLoader;
+	options?: RuleSetLoaderOptions;
 	use?: RuleSetUse;
 	parser?: {
 		[k: string]: any;


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6afdcd2</samp>

Add support for `loader` and `options` properties in webpack module rules. This simplifies the user syntax and improves the type safety and readability of the configuration code. The changes affect the `RuleSetRule` interface in `packages/rspack/src/config/types.ts` and the `getRawModuleRule` function in `packages/rspack/src/config/adapter.ts`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6afdcd2</samp>

*  Add support for `loader` and `options` properties in webpack module rules ([link](https://github.com/web-infra-dev/rspack/pull/3246/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R281-R291), [link](https://github.com/web-infra-dev/rspack/pull/3246/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR325-R326))

</details>
