### PR TITLE
ci: automatically create Tuesday's release PR

### DIFF
--- a/.github/workflows/check-rs.yaml
+++ b/.github/workflows/check-rs.yaml
@@ -7,6 +7,8 @@ on:
     tags-ignore:
       - "**"
   pull_request:
+    branches-ignore:
+      - 'release-**'
     paths: # Only run when changes are made to rust code or root Cargo
       - "crates/**"
       - "examples/**"

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -3,8 +3,8 @@ name: Release Nightly
 on:
   workflow_dispatch:
   schedule:
-    # 00:07 AM Beijing Time, offset an odd number to avoid cron jobs firing off at the same time
-    - cron: "7 16 * * *"
+    # 08:00 AM Beijing Time. Except Tuesday, which is for full release
+    - cron: "0 0 * * 0,1,3,4,5,6"
 
 jobs:
   build:
@@ -33,11 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Checkout Repo
+      - name: Checkout Main Branch
         uses: actions/checkout@v3
-        with:
-          # This makes Actions fetch only one branch to release
-          fetch-depth: 1
 
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -13,6 +13,9 @@ on:
           - alpha
           - beta
           - latest
+  schedule:
+    # 08:00 AM Beijing Time on every Tuesday
+    - cron: "0 0 * * 2"
 
 jobs:
   release:
@@ -20,18 +23,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@master
+      - name: Checkout Main Branch
+        uses: actions/checkout@v3
         with:
-          # getting release note text need to get commit history
-          fetch-depth: 100
+          fetch-depth: 0 # Checkout full history for getting the correct changeset
+
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache
+
       - name: Create Release Pull Request
         uses: web-infra-dev/actions@v2
         with:
-          # this expects you to have a script called release which does a build for your packages and calls changeset publish
-          version: ${{ github.event.inputs.version }}
+          version: ${{ inputs.version || 'latest' }}
           versionNumber: "auto"
           type: "pull request"
           tools: "changeset"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         type: choice
         description: "Release Version(canary, alpha, beta, latest)"
         required: true
-        default: "canary"
+        default: "latest"
         options:
           - canary
           - alpha
@@ -66,11 +66,26 @@ jobs:
       - name: Link optional dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Release
+      - name: Release Nightly
+        uses: web-infra-dev/actions@v2
+        with:
+          version: "canary"
+          npmTag: "nightly"
+          type: "release"
+          branch: ""
+          tools: "changeset"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          ONLY_RELEASE_TAG: true
+
+      - name: Release Full
         uses: web-infra-dev/actions@v2
         with:
           # this expects you to have a script called release which does a build for your packages and calls changeset publish
-          version: ${{ github.event.inputs.version }}
+          version: ${{ inputs.version }}
           type: "release"
           branch: ${{ github.ref_name }}
           tools: "changeset"


### PR DESCRIPTION
## Summary

Stop nightly on Tuesdays, so we can sync full and nightly with the same commit on Tuesday.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 068e3aa</samp>

This pull request updates and improves the GitHub workflows for releasing and checking the packages. It changes the schedule and steps of the `release-nightly` workflow, automates the creation of the release pull request, publishes both full and nightly releases to npm, and skips the `check-rs` workflow on release branches.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 068e3aa</samp>

* Ignore release branches in `check-rs` workflow to avoid redundant checks ([link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-5b78af515332e94dc01fd5e3712c1f9fe2328e02455fb99d45efb76dcd19fd78R10-R11))
* Automate release pull request creation every Tuesday using `release-pull-request` workflow ([link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-16a64a20883492ca4054e74874bd1b1b2e551bb2d4729678a263a8df16b44efdR16-R18))
* Update `actions/checkout` and `web-infra-dev/actions` usage in `release-pull-request` workflow and pass `version` input ([link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-16a64a20883492ca4054e74874bd1b1b2e551bb2d4729678a263a8df16b44efdL23-R37))
* Adjust nightly release schedule and checkout process in `release-nightly` workflow ([link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L6-R7), [link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L37-R38))
* Change default release version to `latest` and add nightly release step in `release` workflow ([link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L10-R10), [link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L70-R74), [link](https://github.com/web-infra-dev/rspack/pull/3248/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R84-R98))

</details>
