### PR TITLE
feat: support resolve.extensionAlias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,9 +1513,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.84"
+version = "0.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2510e8ad37a58f71f24d7d477e7804c40f6ad3fba89ee68ebc4369b3767beb6"
+checksum = "0888a13446f0fdd633445f143c74ff4b377918e190523f5e428a72b6b20c9e39"
 dependencies = [
  "daachorse",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ json               = { version = "0.12.4" }
 linked_hash_set    = { version = "0.1.4" }
 mimalloc-rust      = { version = "0.2" }
 mime_guess         = { version = "2.0.4" }
-nodejs-resolver    = { version = "0.0.84" }
+nodejs-resolver    = { version = "0.0.86" }
 once_cell          = { version = "1.17.1" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -349,12 +349,6 @@ export interface JsStatsWarning {
   formatted: string
 }
 
-export interface NodeFS {
-  writeFile: (...args: any[]) => any
-  mkdir: (...args: any[]) => any
-  mkdirp: (...args: any[]) => any
-}
-
 export interface PathData {
   filename?: string
   hash?: string
@@ -804,6 +798,7 @@ export interface RawResolveOptions {
   byDependency?: Record<string, RawResolveOptions>
   fullySpecified?: boolean
   exportsFields?: Array<string>
+  extensionAlias?: Record<string, Array<string>>
 }
 
 export interface RawRuleSetCondition {
@@ -861,12 +856,5 @@ export interface RawStyleConfig {
 
 export interface RawTrustedTypes {
   policyName?: string
-}
-
-export interface ThreadsafeNodeFS {
-  writeFile: (...args: any[]) => any
-  mkdir: (...args: any[]) => any
-  mkdirp: (...args: any[]) => any
-  removeDirAll: (...args: any[]) => any
 }
 

--- a/crates/rspack_binding_options/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_options/src/options/raw_resolve.rs
@@ -29,6 +29,9 @@ pub struct RawResolveOptions {
   pub by_dependency: Option<HashMap<String, RawResolveOptions>>,
   pub fully_specified: Option<bool>,
   pub exports_fields: Option<Vec<String>>,
+  #[serde(serialize_with = "ordered_map")]
+  #[napi(ts_type = "Record<string, Array<string>>")]
+  pub extension_alias: Option<HashMap<String, Vec<String>>>,
 }
 
 fn normalize_alias(alias: Option<RawAliasOption>) -> anyhow::Result<Option<Alias>> {
@@ -94,7 +97,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
     let exports_field = value
       .exports_fields
       .map(|v| v.into_iter().map(|s| vec![s]).collect());
-
+    let extension_alias = value.extension_alias.map(|v| v.into_iter().collect());
     Ok(Resolve {
       modules,
       prefer_relative,
@@ -110,6 +113,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
       by_dependency,
       fully_specified,
       exports_field,
+      extension_alias,
     })
   }
 }

--- a/crates/rspack_core/src/options/resolve.rs
+++ b/crates/rspack_core/src/options/resolve.rs
@@ -179,13 +179,13 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
 
   let alias = overwrite(base.alias, other.alias, |pre, mut now| {
     now.extend(pre.into_iter());
-    let now: indexmap::IndexSet<(String, Vec<AliasMap>)> = now.into_iter().collect();
-    now.into_iter().collect()
+    now.dedup();
+    now
   });
   let fallback = overwrite(base.fallback, other.fallback, |pre, mut now| {
     now.extend(pre.into_iter());
-    let now: indexmap::IndexSet<(String, Vec<AliasMap>)> = now.into_iter().collect();
-    now.into_iter().collect()
+    now.dedup();
+    now
   });
   let prefer_relative = overwrite(base.prefer_relative, other.prefer_relative, |_, value| {
     value
@@ -222,8 +222,8 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
     other.extension_alias,
     |pre, mut now| {
       now.extend(pre.into_iter());
-      let now: indexmap::IndexSet<(String, Vec<String>)> = now.into_iter().collect();
-      now.into_iter().collect()
+      now.dedup();
+      now
     },
   );
   Resolve {

--- a/crates/rspack_core/src/options/resolve.rs
+++ b/crates/rspack_core/src/options/resolve.rs
@@ -48,6 +48,9 @@ pub struct Resolve {
   /// A list of exports fields in descriptions files
   /// Default is `[["exports"]]`.
   pub exports_field: Option<Vec<Vec<String>>>,
+  /// A list map ext to another.
+  /// Default is `[]`
+  pub extension_alias: Option<Vec<(String, Vec<String>)>>,
   pub by_dependency: Option<ByDependency>,
 }
 
@@ -92,6 +95,7 @@ impl Resolve {
     let exports_field = options
       .exports_field
       .unwrap_or_else(|| vec![vec!["exports".to_string()]]);
+    let extension_alias = options.extension_alias.unwrap_or_default();
     nodejs_resolver::Options {
       fallback,
       modules,
@@ -110,6 +114,7 @@ impl Resolve {
       resolve_to_context,
       fully_specified,
       exports_field,
+      extension_alias,
     }
   }
 
@@ -212,6 +217,15 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
   });
   let tsconfig = overwrite(base.tsconfig, other.tsconfig, |_, value| value);
   let exports_field = overwrite(base.exports_field, other.exports_field, |_, value| value);
+  let extension_alias = overwrite(
+    base.extension_alias,
+    other.extension_alias,
+    |pre, mut now| {
+      now.extend(pre.into_iter());
+      let now: indexmap::IndexSet<(String, Vec<String>)> = now.into_iter().collect();
+      now.into_iter().collect()
+    },
+  );
   Resolve {
     fallback,
     modules,
@@ -227,6 +241,7 @@ fn merge_resolver_options(base: Resolve, other: Resolve) -> Resolve {
     by_dependency,
     fully_specified,
     exports_field,
+    extension_alias,
   }
 }
 

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -153,6 +153,10 @@ function getRawResolve(resolve: Resolve): RawOptions["resolve"] {
 		...resolve,
 		alias: getRawAlias(resolve.alias),
 		fallback: getRawAlias(resolve.fallback),
+		extensionAlias: getRawAlias(resolve.extensionAlias) as Record<
+			string,
+			Array<string>
+		>,
 		byDependency: getRawResolveByDependency(resolve.byDependency)
 	};
 }

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -1404,6 +1404,29 @@ module.exports = {
 						type: "string"
 					}
 				},
+				extensionAlias: {
+					description: "An object which maps extension to extension aliases.",
+					type: "object",
+					additionalProperties: {
+						description: "Extension alias.",
+						anyOf: [
+							{
+								description: "Multiple extensions.",
+								type: "array",
+								items: {
+									description: "Aliased extension.",
+									type: "string",
+									minLength: 1
+								}
+							},
+							{
+								description: "Aliased extension.",
+								type: "string",
+								minLength: 1
+							}
+						]
+					}
+				},
 				extensions: {
 					description:
 						"Extensions added to the request when trying to find the file.",

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -293,6 +293,7 @@ export interface ResolveOptions {
 	tsConfigPath?: string;
 	fullySpecified?: boolean;
 	exportsFields?: string[];
+	extensionAlias?: Record<string, string | string[]>;
 	byDependency?: {
 		[k: string]: ResolveOptions;
 	};

--- a/packages/rspack/tests/configCases/resolve/extension-alias/index.js
+++ b/packages/rspack/tests/configCases/resolve/extension-alias/index.js
@@ -1,0 +1,5 @@
+import value from "./src/index.mjs";
+
+it("extension-alias should work", () => {
+	expect(value).toBe("in ts");
+});

--- a/packages/rspack/tests/configCases/resolve/extension-alias/src/index.mts
+++ b/packages/rspack/tests/configCases/resolve/extension-alias/src/index.mts
@@ -1,0 +1,1 @@
+module.exports = "in ts"

--- a/packages/rspack/tests/configCases/resolve/extension-alias/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve/extension-alias/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	entry: "./index.js",
+	resolve: {
+		extensionAlias: {
+			".mjs": [".mts"]
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

* #2993

## Summary

- support `resolve.extensionAlias`
- fix some exports bug, test case: https://github.com/web-infra-dev/nodejs_resolver/pull/188/files#diff-110e61eb735b79c762510f02f157a12094bcf2b9a15d2ed767532a0e3d5f7bafR489

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c6d0538</samp>

Added support for custom extension mapping for module resolution using the `extensionAlias` option. This option allows users to specify alternative extensions for resolving modules in webpack. Implemented the option in Rust and TypeScript and added a test case.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c6d0538</samp>

*  Update `nodejs-resolver` dependency to `0.0.86` in `Cargo.toml` ([link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L28-R28))
*  Add `extension_alias` field to `RawResolve` and `Resolve` structs to map extensions to extension aliases for module resolution ([link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-d0ff551abe7f965b57ac363f3b8e70ef24bc589ce21b7ebcb16c119ffd7e82c7R32-R34), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R51-R53))
*  Initialize `extension_alias` field from N-API value, `RawResolve` instance, or default value in `RawResolve` and `Resolve` methods ([link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-d0ff551abe7f965b57ac363f3b8e70ef24bc589ce21b7ebcb16c119ffd7e82c7L97-R100), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-d0ff551abe7f965b57ac363f3b8e70ef24bc589ce21b7ebcb16c119ffd7e82c7R116), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R98), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R117))
*  Merge `extension_alias` field from two `Resolve` instances using `overwrite` helper function in `Resolve::merge` method ([link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R220-R228), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-06b1d12f612b7a97c143d790f2ccf66e147b91f04b3afb662ec2a5e38eb6c3a0R244))
*  Add `extensionAlias` property to `ResolveOptions` interface, `resolve` schema, and `getRawResolve` function in TypeScript files to enable configuration and serialization of extension aliases ([link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R156-R159), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R1407-R1429), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR296))
*  Add test case for `extensionAlias` feature in `packages/rspack/tests/configCases/resolve/extension-alias` folder, which imports a value from a `.mjs` file that is aliased to `.mts` ([link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-2702e77553b107ccdaceeb9a10c8ca939b238c19964c98e3cb1924dc47c1ccdfR1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-b117e844617e7157281a972cfa08c4e657ae8b7dbd6890a2f8556c2abe0039a5R1), [link](https://github.com/web-infra-dev/rspack/pull/3249/files?diff=unified&w=0#diff-251c204ccc7c8123d8744ad9158ade458434e29b1b1fb84424719d1102c236d8R1-R8))

</details>
