### PR TITLE
fix: `source` could be unavailable if asset was deleted

### DIFF
--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -47,6 +47,11 @@ import {
 
 export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
 export type Assets = Record<string, Source>;
+export interface Asset {
+	name: string;
+	source?: Source;
+	info: JsAssetInfo;
+}
 export interface LogEntry {
 	type: string;
 	args: any[];
@@ -349,15 +354,14 @@ export class Compilation {
 	 *
 	 * See: [Compilation.getAssets](https://webpack.js.org/api/compilation-object/#getassets)
 	 * Source: [getAssets](https://github.com/webpack/webpack/blob/9fcaa243573005d6fdece9a3f8d89a0e8b399613/lib/Compilation.js#L4448)
-	 *
-	 * @return {Readonly<JsAsset>[]}
 	 */
-	getAssets() {
+	getAssets(): Readonly<Asset>[] {
 		const assets = this.#inner.getAssets();
 
 		return assets.map(asset => {
-			// @ts-expect-error
-			const source = createSourceFromRaw(asset.source);
+			const source = asset.source
+				? createSourceFromRaw(asset.source)
+				: undefined;
 			return {
 				...asset,
 				source

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -444,7 +444,11 @@ class Compiler {
 
 			this.parentCompilation!.children.push(compilation);
 			for (const { name, source, info } of compilation.getAssets()) {
-				this.parentCompilation!.emitAsset(name, source, info);
+				// Do not emit asset if source is not available.
+				// Webpack will emit it anyway.
+				if (source) {
+					this.parentCompilation!.emitAsset(name, source, info);
+				}
 			}
 
 			const entries = [];


### PR DESCRIPTION
## Related issue (if exists)

closes #3147 

<!--- Provide link of related issues -->

## Summary

Assets can be deleted using either `deleteAsset` or `delete` keyword. 
If an asset was deleted using the latter one, the source will not be available.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 988f1d1</samp>

This pull request enhances the `rspack` package to handle JavaScript assets more robustly and avoid emitting unnecessary or duplicate assets to webpack. It introduces a new `Asset` interface and updates the `Compilation` and `Compiler` classes.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 988f1d1</samp>

*  Introduce `Asset` interface to represent JavaScript assets with name, source and info ([link](https://github.com/web-infra-dev/rspack/pull/3250/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R50-R54))
*  Modify `getAssets` method of `Compilation` class to handle assets without source and return them as `undefined` ([link](https://github.com/web-infra-dev/rspack/pull/3250/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L352-R364))
*  Update `Compiler` class to skip emitting assets without source to parent compilation in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3250/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL447-R451))

</details>
