### PR TITLE
feat(hooks): add shouldEmit hook

### DIFF
--- a/examples/validate-asset/index.html
+++ b/examples/validate-asset/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/validate-asset/package.json
+++ b/examples/validate-asset/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "example-perfsee",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "PERFSEE_NO_UPLOAD=true rspack build",
+    "analyze": "PERFSEE_AUDIT=true rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*",
+    "@perfsee/webpack": "1.6.0"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/validate-asset/rspack.config.js
+++ b/examples/validate-asset/rspack.config.js
@@ -11,9 +11,9 @@ const convertSourceToString = source => {
 
 class AssetValidatorPlugin {
 	apply(compiler) {
-		compiler.hooks.shouldEmit.tap("AssetValidatorPlugin", compilation => {
-			this.validateAssets(compilation);
-		});
+		compiler.hooks.shouldEmit.tap("AssetValidatorPlugin", compilation =>
+			this.validateAssets(compilation)
+		);
 	}
 
 	validateAssets(compilation) {
@@ -28,6 +28,8 @@ class AssetValidatorPlugin {
 			const matches = contents.match(regex);
 
 			if (matches) {
+				// could be also false
+				// return false;
 				throw new Error(
 					"Our tool has identified the presence of the string 'MY_SUPER_SECRET' in your compiled code. Compilation has been aborted."
 				);

--- a/examples/validate-asset/rspack.config.js
+++ b/examples/validate-asset/rspack.config.js
@@ -1,0 +1,55 @@
+/** @type {import('@rspack/cli').Configuration} */
+
+// more info here: https://dev.to/mellis481/how-to-inspect-files-packaged-by-webpack-before-they-are-emitted-337j
+const convertSourceToString = source => {
+	if (typeof source === "string") {
+		return source;
+	} else {
+		return new TextDecoder().decode(source);
+	}
+};
+
+class AssetValidatorPlugin {
+	apply(compiler) {
+		compiler.hooks.shouldEmit.tap("AssetValidatorPlugin", compilation => {
+			this.validateAssets(compilation);
+		});
+	}
+
+	validateAssets(compilation) {
+		const assets = Object.entries(compilation.assets);
+		const regex = new RegExp("MY_SUPER_SECRET", "g");
+
+		for (let i = 0; i < assets.length; i++) {
+			const [fileName] = assets[i];
+			const asset = compilation.getAsset(fileName);
+			const source = asset.source.source();
+			const contents = convertSourceToString(source);
+			const matches = contents.match(regex);
+
+			if (matches) {
+				throw new Error(
+					"Our tool has identified the presence of the string 'MY_SUPER_SECRET' in your compiled code. Compilation has been aborted."
+				);
+			}
+		}
+
+		return true;
+	}
+}
+
+const config = {
+	context: __dirname,
+	entry: {
+		main: "./src/index.js"
+	},
+	builtins: {
+		html: [
+			{
+				template: "./index.html"
+			}
+		]
+	},
+	plugins: [new AssetValidatorPlugin()]
+};
+module.exports = config;

--- a/examples/validate-asset/src/index.js
+++ b/examples/validate-asset/src/index.js
@@ -1,0 +1,6 @@
+const MY_SUPER_SECRET = "MY_SUPER_SECRET";
+
+function render() {
+	document.getElementById("root").innerHTML = `foobar`;
+}
+render();

--- a/examples/validate-asset/src/index.js
+++ b/examples/validate-asset/src/index.js
@@ -1,6 +1,6 @@
-const MY_SUPER_SECRET = "MY_SUPER_SECRET";
+const MY_SUPER_SECRET = "Don't share me!";
 
 function render() {
-	document.getElementById("root").innerHTML = `foobar`;
+	document.getElementById("root").innerHTML = `Hello "${MY_SUPER_SECRET}"!`;
 }
 render();

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -846,18 +846,26 @@ class Compiler {
 						if (err) {
 							return finalCallback(err);
 						}
-						if (!this.hooks.shouldEmit.call(this.compilation)) {
-							this.compilation.startTime = startTime;
-							this.compilation.endTime = Date.now();
-							const stats = new Stats(this.compilation);
-							this.hooks.done.callAsync(stats, err => {
-								if (err) {
-									return finalCallback(err);
-								} else {
-									return finalCallback(null, stats);
-								}
-							});
+
+						try {
+							// @ts-expect-error
+							if (this.hooks.shouldEmit.call(this.compilation) === false) {
+								return;
+							}
+						} catch (e) {
+							return finalCallback(e);
 						}
+
+						this.compilation.startTime = startTime;
+						this.compilation.endTime = Date.now();
+						const stats = new Stats(this.compilation);
+						this.hooks.done.callAsync(stats, err => {
+							if (err) {
+								return finalCallback(err);
+							} else {
+								return finalCallback(null, stats);
+							}
+						});
 					});
 				});
 			});

--- a/packages/rspack/src/watching.ts
+++ b/packages/rspack/src/watching.ts
@@ -238,7 +238,7 @@ class Watching {
 		this.compiler.hooks.watchRun.callAsync(this.compiler, err => {
 			if (err) return this._done(err, null);
 
-			if (this.compiler.hooks.shouldEmit.call(this.compiler.compilation)) {
+			if (!this.compiler.hooks.shouldEmit.call(this.compiler.compilation)) {
 				return this._done(null, this.compiler.compilation);
 			}
 

--- a/packages/rspack/src/watching.ts
+++ b/packages/rspack/src/watching.ts
@@ -238,6 +238,10 @@ class Watching {
 		this.compiler.hooks.watchRun.callAsync(this.compiler, err => {
 			if (err) return this._done(err, null);
 
+			if (this.compiler.hooks.shouldEmit.call(this.compiler.compilation)) {
+				return this._done(null, this.compiler.compilation);
+			}
+
 			const canRebuild =
 				this.compiler.options.devServer &&
 				!this.#initial &&


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

Add shouldEmit hook

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 001a67a</samp>

This pull request adds a new example project to the `web-infra-dev/rspack` repository that shows how to use a custom webpack plugin to validate the assets before emitting them. The plugin hooks into the `Compiler` class and throws an error if any of the assets contain a secret string. The example project also demonstrates how to use the `@rspack/cli` and `@perfsee/webpack` packages to configure and run the webpack bundler.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 001a67a</samp>

*  Add a new example project that demonstrates how to use a custom webpack plugin to validate the assets before emitting them ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-43424f658bea10a5f201d29a4b1e3782514d08d538c14531c586440f661ac1cdR1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-83b47e7125e8ae7b71f61ea33590ea44c0a6e623f7625237d4a1ae7a9a497cccL1-R19), [link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-f1870a60c06c142385b83a3297a98f746e97e1b16c87ecc8a89c2d1045d4b9fbR1-R55), [link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-0dd98e4c8d42fcfb4e87f601ff8a865f53cde9993741a3f6dd315a22a074bdc0R1-R6))
  * Create a basic HTML template in `examples/validate-asset/index.html` ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-43424f658bea10a5f201d29a4b1e3782514d08d538c14531c586440f661ac1cdR1-R12))
  * Create a `package.json` file in `examples/validate-asset` that specifies the dependencies and scripts for the project ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-83b47e7125e8ae7b71f61ea33590ea44c0a6e623f7625237d4a1ae7a9a497cccL1-R19))
  * Create a `rspack.config.js` file in `examples/validate-asset` that exports a configuration object for the `@rspack/cli` tool ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-f1870a60c06c142385b83a3297a98f746e97e1b16c87ecc8a89c2d1045d4b9fbR1-R55))
    * Define the entry point, the builtins, and the plugins for the webpack bundler ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-f1870a60c06c142385b83a3297a98f746e97e1b16c87ecc8a89c2d1045d4b9fbR1-R55))
    * Include a new custom plugin called `AssetValidatorPlugin` that hooks into the `shouldEmit` event of the compiler and checks if any of the assets contain the string `MY_SUPER_SECRET` ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-f1870a60c06c142385b83a3297a98f746e97e1b16c87ecc8a89c2d1045d4b9fbR1-R55))
  * Create a `src/index.js` file in `examples/validate-asset` that contains a simple JavaScript module that defines a constant called `MY_SUPER_SECRET` and a function called `render` that updates the DOM ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-0dd98e4c8d42fcfb4e87f601ff8a865f53cde9993741a3f6dd315a22a074bdc0R1-R6))
* Add a new property called `shouldEmit` to the `Compiler` class in the `packages/rspack/src/compiler.ts` file that allows plugins to control whether the compilation should emit the assets or not ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR120), [link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR215), [link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL776-R789))
  * Initialize the `shouldEmit` property as an instance of the `SyncBailHook` class from the `tapable` package in the constructor ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR215))
  * Add a conditional statement to the `run` method that calls the `shouldEmit` hook with the `compilation` object and checks if it returns a truthy value ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL776-R789))
    * If so, proceed with the normal workflow of setting the start and end time, creating the stats object, and calling the `done` hook ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL776-R789))
    * If not, skip the emission of the assets and return the stats object ([link](https://github.com/web-infra-dev/rspack/pull/3258/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL776-R789))

</details>
