### PR TITLE
chore: add debug shell

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,6 +21,13 @@ name: Reusable Release
 #       target: ${{ matrix.target }}
 
 on:
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
+        required: false
+        default: false
   workflow_call:
     inputs:
       target:
@@ -58,6 +65,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Setup Rust Target
         run: rustup target add ${{ inputs.target }}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1a5a4ca</samp>

Add manual trigger and tmate debugging to `reusable-build` workflow. This feature helps users troubleshoot build failures and inspect the runner environment.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1a5a4ca</samp>

* Add a new input parameter to manually trigger the workflow and enable tmate debugging ([link](https://github.com/web-infra-dev/rspack/pull/3261/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R24-R30))
* Set up a tmate session on the runner if debug_enabled is true and print the SSH and web URLs for access ([link](https://github.com/web-infra-dev/rspack/pull/3261/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R68-R70))

</details>
