### PR TITLE
ci: remove nightly step from full release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,21 +66,6 @@ jobs:
       - name: Link optional dependencies
         run: pnpm install --no-frozen-lockfile
 
-      - name: Release Nightly
-        uses: web-infra-dev/actions@v2
-        with:
-          version: "canary"
-          npmTag: "nightly"
-          type: "release"
-          branch: ""
-          tools: "changeset"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          REF: ${{ github.ref }}
-          ONLY_RELEASE_TAG: true
-
       - name: Release Full
         uses: web-infra-dev/actions@v2
         with:


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1386098</samp>

Remove nightly release step from `release.yml` workflow. This prevents publishing unnecessary versions of the `rspack` package to npm.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1386098</samp>

* Remove the Release Nightly step from the release workflow to avoid publishing unnecessary versions of the rspack package (.github/workflows/release.yml, [link](https://github.com/web-infra-dev/rspack/pull/3265/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L69-L83))

</details>
