### PR TITLE
chore: 🤖 ignore title validate

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -44,6 +44,8 @@ jobs:
           disallowScopes: |
             [A-Z]+
           # Configure additional validation for the subject based on a regex.
+          ignoreLabels: |
+            bot
 
   release-labeling:
     # See context at https://github.com/web-infra-dev/rspack/discussions/2760


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/pull/3260
<!--- Provide link of related issues -->

## Summary
reference: https://github.com/amannn/action-semantic-pull-request#:~:text=ignoreLabels%3A%20%7C%0A%20%20%20%20%20%20%20%20%20%20%20%20bot%0A%20%20%20%20%20%20%20%20%20%20%20%20ignore%2Dsemantic%2Dpull%2Drequest

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ce0b39</samp>

Add `ignoreLabels` option to `lint-pr` workflow. This prevents the linter from running on automated pull requests with the `bot` label.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7ce0b39</samp>

* Add an option to skip linting for automated pull requests ([link](https://github.com/web-infra-dev/rspack/pull/3266/files?diff=unified&w=0#diff-fc98139577eb07d54e24aa5d41da856c636f5ad318d0ad700f13a457c136cb80R47-R48))

</details>
