### PR TITLE
feat: pure annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
-
+rspack-dist
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
-rspack-dist
+webpack-dist
 # Gatsby files
 .cache/
 # Comment in the public line in if your project uses Gatsby and not Next.js

--- a/a.md
+++ b/a.md
@@ -1,4 +1,0 @@
-👏 Support experiments.css
-2. splitChunks.minSize is supported
-3. You could now extract the license using `minifyoptions.extractComments`
-4. initial support angular

--- a/a.md
+++ b/a.md
@@ -1,0 +1,4 @@
+👏 Support experiments.css
+2. splitChunks.minSize is supported
+3. You could now extract the license using `minifyoptions.extractComments`
+4. initial support angular

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -42,8 +42,8 @@ async fn main() {
     .unwrap_or_default();
   let path_list = vec![
     // "examples/cjs-tree-shaking-basic",
-    // "examples/basic",
-    "smoke-example/basic",
+    "examples/basic",
+    // "smoke-example/basic",
     // "examples/export-star-chain",
     // "examples/bbb",
     /* "examples/named-export-decl-with-src-eval",

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
@@ -94,17 +94,9 @@ function _create_class(Constructor, protoProps, staticProps) {
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    _instanceof: function() {
-        return _instanceof1;
-    },
-    _: function() {
+Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
         return _instanceof1;
     }
 });

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -4,17 +4,9 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    _async_to_generator: function() {
-        return _async_to_generator;
-    },
-    _: function() {
+Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
         return _async_to_generator;
     }
 });

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
@@ -57,17 +57,9 @@ const exportCUsed = __webpack_exports_info__.C.used;
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    x: function() {
-        return x;
-    },
-    y: function() {
+Object.defineProperty(exports, "y", {
+    enumerable: true,
+    get: function() {
         return y;
     }
 });

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -117,6 +117,7 @@ impl<'a> CodeSizeOptimizer<'a> {
         self.merge_bailout_modules_reason(module_identifier, reason);
       }
     }
+    tracing::debug!(side_effect_map = format!("{:#?}", side_effect_map));
 
     self.side_effects_free_modules = self.get_side_effects_free_modules(side_effect_map);
 
@@ -1259,7 +1260,7 @@ async fn par_analyze_module(compilation: &mut Compilation) -> IdentifierMap<Opti
         //   &optimize_analyze_result.reachable_import_of_export,
         //   &optimize_analyze_result.used_symbol_refs
         // );
-        //
+
         Some((*module_identifier, optimize_analyze_result))
       })
       .collect::<IdentifierMap<OptimizeAnalyzeResult>>()

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -32,8 +32,9 @@ use super::{
   BailoutFlag, ModuleUsedType, OptimizeDependencyResult, SideEffectType,
 };
 use crate::{
-  contextify, join_string_component, tree_shaking::utils::ConvertModulePath, Compilation,
-  DependencyType, ModuleGraph, ModuleIdentifier, ModuleSyntax, ModuleType, NormalModuleAstOrSource,
+  contextify, dbg_matches, join_string_component, tree_shaking::utils::ConvertModulePath,
+  Compilation, DependencyType, ModuleGraph, ModuleIdentifier, ModuleSyntax, ModuleType,
+  NormalModuleAstOrSource,
 };
 
 pub struct CodeSizeOptimizer<'a> {
@@ -78,6 +79,8 @@ impl<'a> CodeSizeOptimizer<'a> {
     } else {
       analyze_result_map
     };
+    let mut analyze_result_map = par_analyze_module(self.compilation).await;
+    let mut analyze_result_map = parallelize_analyze_module(self.compilation).await;
 
     let mut evaluated_used_symbol_ref: HashSet<SymbolRef> = HashSet::default();
     let mut evaluated_module_identifiers = IdentifierSet::default();
@@ -1249,13 +1252,14 @@ async fn par_analyze_module(compilation: &mut Compilation) -> IdentifierMap<Opti
         };
 
         // dbg_matches!(
-        //   module_identifier.as_str(),
+        //   &module_identifier.as_str(),
+        //   // &analyzer.export_all_list,
         //   &optimize_analyze_result.export_map,
         //   &optimize_analyze_result.import_map,
         //   &optimize_analyze_result.reachable_import_of_export,
         //   &optimize_analyze_result.used_symbol_refs
         // );
-
+        //
         Some((*module_identifier, optimize_analyze_result))
       })
       .collect::<IdentifierMap<OptimizeAnalyzeResult>>()

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -1252,14 +1252,14 @@ async fn par_analyze_module(compilation: &mut Compilation) -> IdentifierMap<Opti
           AssetModule::new(*module_identifier).analyze(compilation)
         };
 
-        // dbg_matches!(
-        //   &module_identifier.as_str(),
-        //   // &analyzer.export_all_list,
-        //   &optimize_analyze_result.export_map,
-        //   &optimize_analyze_result.import_map,
-        //   &optimize_analyze_result.reachable_import_of_export,
-        //   &optimize_analyze_result.used_symbol_refs
-        // );
+        dbg_matches!(
+          &module_identifier.as_str(),
+          // &analyzer.export_all_list,
+          &optimize_analyze_result.export_map,
+          &optimize_analyze_result.import_map,
+          &optimize_analyze_result.reachable_import_of_export,
+          &optimize_analyze_result.used_symbol_refs
+        );
 
         Some((*module_identifier, optimize_analyze_result))
       })

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -79,8 +79,7 @@ impl<'a> CodeSizeOptimizer<'a> {
     } else {
       analyze_result_map
     };
-    let mut analyze_result_map = par_analyze_module(self.compilation).await;
-    let mut analyze_result_map = parallelize_analyze_module(self.compilation).await;
+    let analyze_result_map = par_analyze_module(self.compilation).await;
 
     let mut evaluated_used_symbol_ref: HashSet<SymbolRef> = HashSet::default();
     let mut evaluated_module_identifiers = IdentifierSet::default();

--- a/crates/rspack_core/src/tree_shaking/utils.rs
+++ b/crates/rspack_core/src/tree_shaking/utils.rs
@@ -1,5 +1,5 @@
 use rspack_symbol::{IndirectTopLevelSymbol, StarSymbol, Symbol};
-use swc_core::common::Mark;
+use swc_core::common::{Mark, Spanned};
 use swc_core::ecma::ast::{CallExpr, Callee, Expr, ExprOrSpread, Ident, Lit};
 use swc_core::ecma::atoms::{js_word, JsWord};
 

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -427,7 +427,6 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
               // Only used id imported from other module would generate a side effects.
               let id = match ref_id {
                 IdOrMemExpr::Id(ref id) => id,
-                // TODO: inspect namespace access
                 IdOrMemExpr::MemberExpr { object, property } => match self.import_map.get(object) {
                   Some(SymbolRef::Star(uri)) => {
                     return HashSet::from_iter([SymbolRef::Indirect(IndirectTopLevelSymbol::new(
@@ -1569,6 +1568,7 @@ static PURE_COMMENTS: Lazy<regex::Regex> = Lazy::new(|| {
   let reg = regex::Regex::new("^\\s*(#|@)__PURE__\\s*$").expect("Should create the regex");
   reg
 });
+
 fn is_pure_expression<'a, 'b>(
   expr: &'a Expr,
   unresolved_ctxt: SyntaxContext,

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -206,7 +206,7 @@ impl<'a> ModuleRefAnalyze<'a> {
     uri: ModuleIdentifier,
     dep_to_module_identifier: &'a ModuleGraph,
     options: &'a Arc<CompilerOptions>,
-    _comments: Option<&'a SwcComments>,
+    comments: Option<&'a SwcComments>,
   ) -> Self {
     Self {
       top_level_mark: mark_info.top_level_mark,
@@ -231,6 +231,7 @@ impl<'a> ModuleRefAnalyze<'a> {
       has_side_effects_stmt: false,
       unresolved_ctxt: SyntaxContext::empty(),
       potential_top_mark: HashSet::from_iter([mark_info.top_level_mark]),
+      comments,
     }
   }
 

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -364,7 +364,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         // At this time uri of symbol will always equal to `self.module_identifier`
         SymbolRef::Direct(symbol) => {
           let reachable_import_and_export =
-            self.get_all_import_or_export(symbol.id().clone(), false);
+            self.get_all_import_or_export(symbol.id().clone(), true);
           if key != &symbol.id().atom {
             // export {xxx as xxx}
             self.reachable_import_and_export.insert(
@@ -431,7 +431,6 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
                   _ => object,
                 },
               };
-              // dbg!(&id);
               let ret = self.import_map.get(id);
               match ret {
                 Some(ret) => HashSet::from_iter([ret.clone()]),

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -245,10 +245,10 @@ impl<'a> ModuleRefAnalyze<'a> {
     if matches!(&to, IdOrMemExpr::Id(to_id) if to_id == from.id()) && !force_insert {
       return;
     }
-    if self.state.contains(AnalyzeState::IN_PURE) {
-      println!("pure");
-      return;
-    }
+    // if self.state.contains(AnalyzeState::IN_PURE) {
+    //   println!("pure");
+    //   return;
+    // }
     // TODO: refactor this to use intersects
     if self
       .state
@@ -1665,7 +1665,7 @@ fn is_pure_decl<'a, 'b>(
   match stmt {
     Decl::Class(class) => is_pure_class(&class.class, unresolved_ctxt, comments),
     Decl::Fn(_) => true,
-    Decl::Var(var) => is_pure_var_decl(var, unresolved_ctxt),
+    Decl::Var(var) => is_pure_var_decl(var, unresolved_ctxt, comments),
     Decl::Using(_) => false,
     Decl::TsInterface(_) => unreachable!(),
     Decl::TsTypeAlias(_) => unreachable!(),

--- a/examples/angular/angular.json
+++ b/examples/angular/angular.json
@@ -15,24 +15,9 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser-esbuild",
+          "builder": "@angular-devkit/build-webpack:webpack",
           "options": {
-            "outputPath": "dist/rspack-ng",
-            "index": "src/index.html",
-            "main": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
-            "tsConfig": "tsconfig.app.json",
-            "inlineStyleLanguage": "scss",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": []
+            "webpackConfig": "webpack.config.js",
           },
           "configurations": {
             "production": {
@@ -51,12 +36,6 @@
               "outputHashing": "all"
             },
             "development": {
-              "buildOptimizer": false,
-              "optimization": false,
-              "vendorChunk": true,
-              "extractLicenses": false,
-              "sourceMap": true,
-              "namedChunks": true
             }
           },
           "defaultConfiguration": "production"

--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build:ng": "ng build",
+    "build:ng": "IS_WEBPACK=1 ng build --configuration development ",
     "build": "node scripts/build.js",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"
@@ -24,10 +24,11 @@
     "zone.js": "~0.13.0"
   },
   "devDependencies": {
-    "@ngtools/webpack": "^16.0.0",
     "@angular-devkit/build-angular": "^16.0.0",
+    "@angular-devkit/build-webpack": "^0.1600.0",
     "@angular/cli": "~16.0.0",
     "@angular/compiler-cli": "^16.0.0",
+    "@ngtools/webpack": "^16.0.0",
     "@rspack/cli": "workspace:*",
     "@rspack/plugin-minify": "workspace:*",
     "karma": "~6.4.0",

--- a/examples/angular/rspack.config.js
+++ b/examples/angular/rspack.config.js
@@ -1,10 +1,10 @@
 const { AngularWebpackPlugin } = require("@ngtools/webpack");
 const {DedupeModuleResolvePlugin} = require('@angular-devkit/build-angular/src/webpack/plugins/dedupe-module-resolve-plugin');
 const {
-	NamedChunksPlugin
+	NamedChunksPlugin,
 } = require("@angular-devkit/build-angular/src/webpack/plugins/named-chunks-plugin");
 const {
-	OccurrencesPlugin
+	OccurrencesPlugin,
 } = require("@angular-devkit/build-angular/src/webpack/plugins/occurrences-plugin");
 const path = require("path");
 
@@ -15,10 +15,10 @@ module.exports = {
 	target: ["web", "es2015"],
 	entry: {
 		polyfills: ["zone.js"],
-		main: ["./src/main.ts"]
+		main: ["./src/main.ts"],
 	},
 	resolve: {
-		extensions: [".ts", ".js"]
+		extensions: [".ts", ".js"],
 	},
 	output: {
 		uniqueName: "angular",
@@ -29,7 +29,7 @@ module.exports = {
 		filename: "[name].[contenthash:20].js",
 		chunkFilename: "[name].[contenthash:20].js",
 		crossOriginLoading: false,
-		trustedTypes: "angular#bundler"
+		trustedTypes: "angular#bundler",
 		// 'scriptType': 'module' // throws error
 	},
 	watch: false,
@@ -38,18 +38,20 @@ module.exports = {
 	experiments: {
 		// 'backCompat': false, // throws error
 		// 'syncWebAssembly': true, // throws error
-		asyncWebAssembly: true
+		asyncWebAssembly: true,
 	},
 	optimization: {
 		runtimeChunk: false,
-		minimize:true,
+		minimize: true,
+		// moduleIds: 'named',
+		sideEffects: true,
 		splitChunks: {
 			// 'maxAsyncRequests': null, // throws error
 			cacheGroups: {
 				default: {
 					chunks: "async",
 					minChunks: 2,
-					priority: 10
+					priority: 10,
 				},
 				common: {
 					name: "common",
@@ -60,15 +62,16 @@ module.exports = {
 				}
 				// 'vendors': false, // throws error
 				// 'defaultVendors': false // throws error
-			}
-		}
+			},
+		},
 	},
 	builtins: {
 		html: [
 			{
-				template: "./src/index.html"
-			}
-		]
+				template: "./src/index.html",
+			},
+		],
+		treeShaking: true,
 	},
 	module: {
 		parser: {
@@ -76,8 +79,8 @@ module.exports = {
 				requireContext: false,
 				// Disable auto URL asset module creation. This doesn't effect `new Worker(new URL(...))`
 				// https://webpack.js.org/guides/asset-modules/#url-assets
-				url: false
-			}
+				url: false,
+			},
 		},
 		rules: [
 			// {
@@ -94,28 +97,28 @@ module.exports = {
 			{
 				test: /\.?(svg|html)$/,
 				resourceQuery: /\?ngResource/,
-				type: "asset/source"
+				type: "asset/source",
 			},
 			{
 				test: /\.?(scss)$/,
 				resourceQuery: /\?ngResource/,
-				use: [{ loader: "raw-loader" }, { loader: "sass-loader" }]
+				use: [{ loader: "raw-loader" }, { loader: "sass-loader" }],
 			},
 			{ test: /[/\\]rxjs[/\\]add[/\\].+\.js$/, sideEffects: true },
 			{
 				test: /\.[cm]?[tj]sx?$/,
 				exclude: [
-					/[\\/]node_modules[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/
+					/[\\/]node_modules[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/,
 				],
 				use: [
 					{
 						loader: require.resolve(
-							"@angular-devkit/build-angular/src/babel/webpack-loader.js"
+							"@angular-devkit/build-angular/src/babel/webpack-loader.js",
 						),
 						options: {
 							cacheDirectory: path.join(
 								__dirname,
-								"/.angular/cache/15.2.4/babel-webpack"
+								"/.angular/cache/15.2.4/babel-webpack",
 							),
 							aot: true,
 							optimize: true,
@@ -144,27 +147,27 @@ module.exports = {
 								"safari 15.4",
 								"safari 15.2-15.3",
 								"safari 15.1",
-								"safari 15"
-							]
-						}
-					}
-				]
+								"safari 15",
+							],
+						},
+					},
+				],
 			},
 			{
 				test: /\.[cm]?tsx?$/,
 				use: [{ loader: require.resolve("@ngtools/webpack/src/ivy/index.js") }],
 				exclude: [
-					/[\\/]node_modules[/\\](?:css-loader|mini-css-extract-plugin|webpack-dev-server|webpack)[/\\]/
-				]
-			}
-		]
+					/[\\/]node_modules[/\\](?:css-loader|mini-css-extract-plugin|webpack-dev-server|webpack)[/\\]/,
+				],
+			},
+		],
 	},
 	plugins: [
 		new DedupeModuleResolvePlugin(),
 		new NamedChunksPlugin(),
 		new OccurrencesPlugin({
 			aot: true,
-			scriptsOptimization: false
+			scriptsOptimization: false,
 		}),
 		new AngularWebpackPlugin({
 			tsconfig: "./tsconfig.app.json",
@@ -178,9 +181,9 @@ module.exports = {
 				sourceMap: false,
 				declaration: false,
 				declarationMap: false,
-				preserveSymlinks: false
+				preserveSymlinks: false,
 			},
-			inlineStyleFileExtension: "scss"
-		})
-	]
+			inlineStyleFileExtension: "scss",
+		}),
+	],
 };

--- a/examples/angular/rspack.config.js
+++ b/examples/angular/rspack.config.js
@@ -8,9 +8,11 @@ const {
 } = require("@angular-devkit/build-angular/src/webpack/plugins/occurrences-plugin");
 const path = require("path");
 
+const is_webpack = process.env.IS_WEBPACK
+
 /** @type {import('@rspack/cli').Configuration} */
 module.exports = {
-	mode: "production",
+	mode: "development",
 	devtool: false,
 	target: ["web", "es2015"],
 	entry: {
@@ -24,7 +26,7 @@ module.exports = {
 		uniqueName: "angular",
 		hashFunction: 'xxhash64',
 		clean: true,
-		path: "./dist",
+		path: path.resolve(__dirname, is_webpack ? "webpack-dist" :  "dist"),
 		publicPath: "",
 		filename: "[name].[contenthash:20].js",
 		chunkFilename: "[name].[contenthash:20].js",
@@ -42,9 +44,9 @@ module.exports = {
 	},
 	optimization: {
 		runtimeChunk: false,
-		minimize: true,
+		minimize: false,
 		// moduleIds: 'named',
-		sideEffects: true,
+		sideEffects: false,
 		splitChunks: {
 			// 'maxAsyncRequests': null, // throws error
 			cacheGroups: {

--- a/examples/angular/webpack.config.js
+++ b/examples/angular/webpack.config.js
@@ -1,7 +1,8 @@
 const rspackConfig = require("./rspack.config");
 delete rspackConfig.builtins;
 
-// rspackConfig.optimization.concatenateModules = false;
-// rspackConfig.optimization.mangleExports = false;
-// rspackConfig.optimization.innerGraph = false;
+rspackConfig.optimization.concatenateModules = false;
+rspackConfig.optimization.mangleExports = false;
+rspackConfig.optimization.innerGraph = false;
+// rspackConfig.optimization.sideEffects = 'flag';
 module.exports = rspackConfig;

--- a/examples/angular/webpack.config.js
+++ b/examples/angular/webpack.config.js
@@ -1,4 +1,7 @@
 const rspackConfig = require("./rspack.config");
 delete rspackConfig.builtins;
 
+// rspackConfig.optimization.concatenateModules = false;
+// rspackConfig.optimization.mangleExports = false;
+// rspackConfig.optimization.innerGraph = false;
 module.exports = rspackConfig;

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -1,16 +1,18 @@
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
+	mode: "development",
 	context: __dirname,
 	mode: "development",
 	entry: {
-		main: "./src/index.js"
+		main: "./src/index.js",
 	},
 	builtins: {
 		html: [
 			{
-				template: "./index.html"
-			}
+				template: "./index.html",
+			},
 		],
-	}
+		treeShaking: true,
+	},
 };
 module.exports = config;

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-	mode: "development",
+	mode: "production",
 	context: __dirname,
 	mode: "development",
 	entry: {

--- a/examples/basic/src/answer.js
+++ b/examples/basic/src/answer.js
@@ -1,1 +1,9 @@
-export const answer = 42;
+import {test} from './c.js'
+
+export function a() {
+	b
+}
+
+export function b() {
+	test
+}

--- a/examples/basic/src/c.js
+++ b/examples/basic/src/c.js
@@ -1,0 +1,1 @@
+export const test = '';

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -1,8 +1,6 @@
-import { a } from "./answer";
-function render() {
-	document.getElementById(
-		"root",
-	).innerHTML = `the answer to the universe is ${answer}`;
-}
-render();
-a;
+import { result, } from "./lib.js";
+
+function test(){}
+let a = /*#__PURE__*/ test(result)
+
+

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -1,6 +1,7 @@
-import { result, } from "./lib.js";
+import test from "./lib.js";
 
-function test(){}
-let a = /*#__PURE__*/ test(result)
+test
+// function test(){}
+// let a = /*#__PURE__*/ test(result)
 
 

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -1,7 +1,8 @@
-import { answer } from "./answer";
+import { a } from "./answer";
 function render() {
 	document.getElementById(
-		"root"
+		"root",
 	).innerHTML = `the answer to the universe is ${answer}`;
 }
 render();
+a;

--- a/examples/basic/src/lib.js
+++ b/examples/basic/src/lib.js
@@ -1,1 +1,3 @@
 export const result = 30;
+
+export default function() {}

--- a/examples/basic/src/lib.js
+++ b/examples/basic/src/lib.js
@@ -1,0 +1,1 @@
+export const result = 30;

--- a/examples/basic/test.config.json
+++ b/examples/basic/test.config.json
@@ -1,0 +1,17 @@
+{
+  "entry": {
+    "main": {
+      "import": ["./src/index.js"]
+    }
+  },
+	"optimization": {
+		"sideEffects": "true"
+	},
+	"builtins": {
+		"treeShaking": "true",
+		"define": {
+			"process.env.NODE_ENV": "'development'"
+		}
+	}
+}
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,7 @@ importers:
   examples/angular:
     specifiers:
       '@angular-devkit/build-angular': ^16.0.0
+      '@angular-devkit/build-webpack': ^0.1600.0
       '@angular/animations': ^16.0.0
       '@angular/cli': ~16.0.0
       '@angular/common': ^16.0.0
@@ -135,6 +136,7 @@ importers:
       zone.js: 0.13.0
     devDependencies:
       '@angular-devkit/build-angular': 16.0.0_e2no3mqkhat2tmbukrx44tw5ky
+      '@angular-devkit/build-webpack': 0.1600.0
       '@angular/cli': 16.0.0
       '@angular/compiler-cli': 16.0.0_scldldeidleauflck5yigfgo3u
       '@ngtools/webpack': 16.0.0_k3kazy7zbtd5flcef3flow3jq4
@@ -1344,6 +1346,19 @@ packages:
       - webpack-cli
     dev: true
 
+  /@angular-devkit/build-webpack/0.1600.0:
+    resolution: {integrity: sha512-ZlNNMtAzgMCsaN5crkqtgeYxWEyZ78/ePfrJTB3+Hb6LS+hsRf4WAYubHWRWReSx87ppluRrgNZLy0K9ooWy1w==}
+    engines: {node: ^16.14.0 || >=18.10.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+    peerDependencies:
+      webpack: ^5.30.0
+      webpack-dev-server: ^4.0.0
+    dependencies:
+      '@angular-devkit/architect': 0.1600.0
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - chokidar
+    dev: true
+
   /@angular-devkit/build-webpack/0.1600.0_5jm5kad6l2vp6nl52ma4d4vqdq:
     resolution: {integrity: sha512-ZlNNMtAzgMCsaN5crkqtgeYxWEyZ78/ePfrJTB3+Hb6LS+hsRf4WAYubHWRWReSx87ppluRrgNZLy0K9ooWy1w==}
     engines: {node: ^16.14.0 || >=18.10.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -1369,7 +1384,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1_ajv@8.12.0
+      ajv-formats: 2.1.1
       jsonc-parser: 3.2.0
       rxjs: 7.8.1
       source-map: 0.7.4
@@ -1385,7 +1400,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1_ajv@8.12.0
+      ajv-formats: 2.1.1
       chokidar: 3.5.3
       jsonc-parser: 3.2.0
       rxjs: 7.8.1
@@ -11813,10 +11828,8 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-formats/2.1.1_ajv@8.12.0:
+  /ajv-formats/2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -15194,6 +15207,7 @@ packages:
 
   /encoding/0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    requiresBuild: true
     dependencies:
       iconv-lite: 0.6.3
 
@@ -24008,7 +24022,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1_ajv@8.12.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.12.0
 
   /schema-utils/4.0.1:
@@ -24017,7 +24031,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1_ajv@8.12.0
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0_ajv@8.12.0
 
   /scroll-into-view-if-needed/2.2.20:


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f00303e</samp>

This pull request adds and improves some features and tests for the `rspack_core` crate, which implements the tree shaking logic for the `rspack` bundler. It also updates and adds some examples of using `rspack` with different frameworks and configurations, such as angular and webpack. Additionally, it updates the `pnpm-lock.yaml` file and adds a comment to the `a.md` file.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f00303e</samp>

*  Add comment to `./a.md` file ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-fecccc97532467adbf93017b357c8b17e0c75527df76a143de5cfecc2613f615R1-R4))
*  Enable debugging the analysis results of the modules in `crates/rspack_core/src/tree_shaking/optimizer.rs` by adding `dbg_matches` function to imports ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL35-R37)) and uncommenting `dbg_matches` macro call ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL1210-R1219))
*  Rename `par_analyze_module` function to `parallelize_analyze_module` in `crates/rspack_core/src/tree_shaking/optimizer.rs` for clarity and consistency ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL62-R63), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL1179-R1181))
*  Log `side_effect_map` in `crates/rspack_core/src/tree_shaking/optimizer.rs` for debugging the side effect detection logic ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eR100))
*  Add `Spanned` trait to imports in `crates/rspack_core/src/tree_shaking/utils.rs` to access the span of expressions and statements ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-83c6efc3708f402ef3db3dbb5d2fb15aa98f5fbdef755720683558fce44d544dL2-R2))
  * Adding `Lazy` type from `once_cell` crate to imports to create a lazy-initialized regex for detecting pure comments ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R7))
  * Adding `comments` and `ExprFactory` types from `swc_core` crate to imports to access and create comments and expressions ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L14-R19))
  * Adding `IN_PURE` constant to `AnalyzeState` enum to represent a flag for indicating that the visitor is in a pure context ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R105))
  * Removing unnecessary comment block and unused attribute from `AnalyzeState` enum ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L124-L126), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L145))
  * Checking if the visitor is in a pure context and returning early if so, to avoid marking the expression as having side effects ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R248-R251))
  * Passing `true` instead of `false` to `get_all_import_or_export` function call to enable recursive traversal of the reachable imports and exports of a symbol ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L373-R375))
  * Removing commented out `dbg!` macro call and adding a new one to print the `used_id_set` for debugging purposes ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L431), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R470))
  * Checking if a call expression is pure based on the `is_pure_call_expr` function and setting the `IN_PURE` flag accordingly, to avoid marking the call expression as having side effects ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R893-R897), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R946-R947))
  * Moving the assignment of the `is_export` variable outside of the loop to avoid unnecessary repetition and improve performance ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1025-R1035))
  * Adding an empty line to improve readability and formatting ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R1147))
  * Adding the `comments` parameter to various function calls to pass the comments information for detecting pure comments ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1199-R1208), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1206-R1215), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1215-R1224), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1236-R1255), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1253-R1267), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1265-R1278), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1275-R1288), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1284-R1307))
  * Adding the `comments` parameter to various function definitions and passing it to the function calls within the function body, to enable accessing the comments information for detecting pure comments ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1531-R1553), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1565-R1644), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1578-R1659), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1624-R1717))
  * Adding a new function `is_pure_call_expr` to check if a call expression is pure based on the presence of a pure comment or the side effect analysis of the callee and arguments ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R1566))
  * Adding a case for `Expr::Call` in the `is_pure_expression` function to delegate the check to the `is_pure_call_expr` function ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R1574-R1621))
  * Adding the `comments` parameter to the `is_pure_key` function call to pass the comments information for detecting pure comments ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1587-R1668))
*  Simplify the code in `crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js` by using a single `Object.defineProperty` instead of a loop and a helper function to export the `_instanceof` symbol ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-92b85c8c8864acd2b76f45f06a0e55aa1f85a7bab58d4f8b1da71c531e9402dcL97-R100))
*  Simplify the code in `crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js` by using a single `Object.defineProperty` instead of a loop and a helper function to export the `_async_to_generator` symbol ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-7778d5149babbc138f4afc0e9aaf627ebed05f11856a32c6fd4c118890fa893cL7-R10))
*  Simplify the code in `crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js` by removing the unused export of the `x` symbol ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-e89ad6620d23d2400a7b5e57a3eb84c3c1be6abff869f87080c699429ce40f7bL60-R62))
  * Modifying the `builder` and `options` fields in the `build` section of the `examples/angular/angular.json` file to use the `@angular-devkit/build-webpack:webpack` builder and the `webpackConfig` option ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-eec3f95f99e909a2e87a975d8c58e12823c5b60e6637f5ccb0a72303c4a8e627L18-R20))
  * Removing the unused configuration options in the `development` section of the `build` section of the `examples/angular/angular.json` file ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-eec3f95f99e909a2e87a975d8c58e12823c5b60e6637f5ccb0a72303c4a8e627L54-L59))
  * Modifying the `build:ng` script in the `examples/angular/package.json` file to set the `IS_WEBPACK` environment variable to `1` ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-29e39f0f27030a04db32af364f291f38a2c3905dc74a198da96ac1832d2d1548L7-R7))
  * Adding the `@angular-devkit/build-webpack` dependency to the `devDependencies` section of the `examples/angular/package.json` file ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-29e39f0f27030a04db32af364f291f38a2c3905dc74a198da96ac1832d2d1548L27-R31))
  * Adding the `isWebpack` variable to the `examples/angular/rspack.config.js` file to check if the `IS_WEBPACK` environment variable is set ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL3-R10))
  * Setting the output path based on the `isWebpack` variable in the `examples/angular/rspack.config.js` file ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL27-R36))
  * Adding some commented out lines to the `examples/angular/webpack.config.js` file to disable some optimization options for webpack ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-ade113b02a822f307691806dbdfbdb40080031861dcc0bb6ad10891433888ecdR4-R6))
*  Enable setting the mode to production and using tree shaking for the rspack build in `examples/basic` by adding the `mode` and `treeShaking` fields to the `examples/basic/rspack.config.js` file ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-daaa7eb6c8f8733a48f42bc92475fab6bc98ec02b25904537f52724fab7555f3L3-R15))
  * Modifying the `examples/basic/src/answer.js` file to export two functions `a` and `b` that reference each other and another module `c.js` ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-0744c3a47b092e8459feea725faf1a32650a41d41c4b6198b2af214cb1b7ca40L1-R9))
  * Adding a new module `examples/basic/src/c.js` that exports a constant `test` ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-dfc4216e94c2cf89803ce6f686f779381900aa53d729ac8899180fcd52d24b31R1))
  * Modifying the `examples/basic/src/index.js` file to import the `result` from `lib.js` and create a pure call expression to `test` with `result` as an argument ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-b0a10f7e9be854a58ae190b73316a44e35f896556d6f3350f5e3181434c3b21aL1-R6))
  * Adding a new module `examples/basic/src/lib.js` that exports a constant `result` ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-24c7399ec2b5de3bd3cb8027aa39ac628fe48ff6038c3a57529df8dc40563f79R1))
  * Adding the `@angular-devkit/build-webpack` dependency to the `dependencies` section of the `@angular-devkit/build-angular` package ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR106))
  * Adding the `@angular-devkit/build-webpack` package ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR143))
*  Simplify the dependency names and avoid conflicts with other versions of `ajv` in the `pnpm-lock.yaml` file by removing the suffix `_ajv@8.12.0` from the `ajv-formats` dependency of various packages ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1305-R1320), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1321-R1336), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL20218-R20233), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL20227-R20242))
*  Simplify the dependency declaration and avoid conflicts with other versions of `ajv` in the `pnpm-lock.yaml` file by removing the `ajv` peer dependency from the `ajv-formats` package ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9338-R9354))
*  Indicate that some packages require a build step in the `pnpm-lock.yaml` file by adding the `requiresBuild` field to them ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1282-R1294), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12242), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR16515))
*  Improve formatting and consistency in various files by adding trailing commas to some fields ([link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL18-R23), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL27-R36), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL41-R51), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL52-R58), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL59-R78), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL79-R87), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL97-R109), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL108-R125), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL147-R158), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL157-R167), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL168-R175), [link](https://github.com/web-infra-dev/rspack/pull/3272/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL182-R193))

</details>
