### PR TITLE
chore: add rn-web-share example

### DIFF
--- a/examples/rn-web-share/index.html
+++ b/examples/rn-web-share/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/rn-web-share/package.json
+++ b/examples/rn-web-share/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "example-basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*",
+    "null-loader": "4.0.1"
+  },
+  "sideEffects": true,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/rn-web-share/rspack.config.js
+++ b/examples/rn-web-share/rspack.config.js
@@ -1,0 +1,22 @@
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	context: __dirname,
+	mode: "development",
+	entry: {
+		main: "./src/index.ts"
+	},
+	target: "node",
+	module: {
+		rules: [
+			{
+				test: /\.native\.ts$/,
+				use: [
+					{
+						loader: "null-loader"
+					}
+				]
+			}
+		]
+	}
+};
+module.exports = config;

--- a/examples/rn-web-share/src/Foo.native.ts
+++ b/examples/rn-web-share/src/Foo.native.ts
@@ -1,0 +1,4 @@
+export type name = "native";
+import { square } from "./flow";
+export { square };
+console.log("native");

--- a/examples/rn-web-share/src/Foo.ts
+++ b/examples/rn-web-share/src/Foo.ts
@@ -1,0 +1,4 @@
+import web from "./Foo.web";
+import { name, square } from "./Foo.native";
+console.log("square:", square);
+export default web as name;

--- a/examples/rn-web-share/src/Foo.web.ts
+++ b/examples/rn-web-share/src/Foo.web.ts
@@ -1,0 +1,1 @@
+export default "web";

--- a/examples/rn-web-share/src/flow.js
+++ b/examples/rn-web-share/src/flow.js
@@ -1,0 +1,3 @@
+export function square(n: number): number {
+	return n * n;
+}

--- a/examples/rn-web-share/src/index.ts
+++ b/examples/rn-web-share/src/index.ts
@@ -1,0 +1,2 @@
+import Foo from "./Foo";
+console.log("Foo", Foo);


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at affd098</samp>

This pull request adds an example project that demonstrates how to use rspack to build a cross-platform web and native app. It includes the necessary files for the web entry point, the package configuration, the rspack configuration, and some sample TypeScript and Flow modules.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at affd098</samp>

*  Add a basic HTML template for the web entry point of the example project ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-9c6de56ccfcaac8aa775e14ce85350a2d441f0aa85c7e070acf5c01f4536c365R1-R12))
*  Add a package.json file for the example project, specifying the dependencies, scripts, and metadata ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-28fc1521a3e4b4c7d80c8d02ad67c92e140d1c803468ce993880e4fb441477efL1-R18))
*  Add a rspack.config.js file for the example project, configuring the webpack-based build tool for the web and native platforms ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-a6028354fcfb32dcf14dfbf7f3a1fedfc1ddcc04bbea85efafd5969092b832a7R1-R22))
*  Exclude the native-specific files from the web bundle using the null-loader ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-a6028354fcfb32dcf14dfbf7f3a1fedfc1ddcc04bbea85efafd5969092b832a7R1-R22))
*  Add a flow.js file that exports a function that squares a number using flow type annotations ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-845a73169cced7ccc4e452cbf65d01fa6a2db4487a79e50792022a0560c74f9cR1-R3))
*  Add a Foo.ts file that imports and re-exports the web or native version of Foo depending on the platform ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-92f8d5beb709bfaa8e68a803eacf2f1f1da32169cc7c9685dcdb732b182a8a4fR1-R4))
*  Add a Foo.web.ts file that exports a string indicating the web platform ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-3e650f301e8d31a095dc04f874a78ae9d12546f641771c30d5d4d442bd6bb1daR1))
*  Add a Foo.native.ts file that exports a type and a function imported from the flow.js file and logs the native platform ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-68489ca7c35319e4f37ed274ce332e4dba6d6b1371d1ae4f06bc1a9737ea2251R1-R4))
*  Add an index.ts file that imports and logs the default export from the Foo.ts file as the main entry point for the example project ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-82621aaf3a85f02549bde68bd3125a4c68cfcbf40fdfb1f46f77e7dc649ef2eaR1-R2))
*  Log the result of the square function from the flow.js file in the Foo.ts file ([link](https://github.com/web-infra-dev/rspack/pull/3273/files?diff=unified&w=0#diff-92f8d5beb709bfaa8e68a803eacf2f1f1da32169cc7c9685dcdb732b182a8a4fR1-R4))

</details>
