### PR TITLE
chore(examples): add missing private to two example packages

### DIFF
--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "example-loader-compat",
+  "name": "example-plugin-compat",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "dev": "rspack serve",
     "build": "rspack build"

--- a/examples/proxy/package.json
+++ b/examples/proxy/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "build": "rspack build",
     "dev": "rspack serve"


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c0ca1d</samp>

Renamed `example-loader-compat` to `example-plugin-compat` and added `private` fields to `package.json` files in examples. These changes improve the clarity and safety of the rspack examples.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c0ca1d</samp>

* Rename example package and add `private` field to prevent publishing ([link](https://github.com/web-infra-dev/rspack/pull/3275/files?diff=unified&w=0#diff-7c79896436e137329e49b20866aa4502be0fe10e49a15ceb45974993392878c1L2-R6))
* Add `private` field to proxy example package for the same reason ([link](https://github.com/web-infra-dev/rspack/pull/3275/files?diff=unified&w=0#diff-ee5b412eed6d68094c56546b270e898c98e1e2db84439c95e704881f40ca8912R6))

</details>
