### PR TITLE
ci: publish nightly with release script

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -24,4 +24,4 @@ runs:
 
     - name: Install Npm Dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Release Nightly
+    name: Build Nightly
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
@@ -27,9 +27,7 @@ jobs:
       target: ${{ matrix.target }}
 
   release:
-    name: Nightly
-    permissions:
-      contents: write
+    name: Release Nightly
     runs-on: ubuntu-latest
     needs: build
     steps:
@@ -53,29 +51,41 @@ jobs:
       - name: Show binding packages
         run: ls -R npm
 
-      - name: Link optional dependencies
+      - name: Resolve dependencies for bindings
         run: pnpm install --no-frozen-lockfile
 
-      - name: Prevent changeset crashing on empty changesets
-        shell: bash
-        run: |
-          pnpm run changeset add --empty
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git add .
-          git commit -m "chore: bump nightly"
-
       - name: Release
-        uses: web-infra-dev/actions@v2
-        with:
-          version: "canary"
-          npmTag: "nightly"
-          type: "release"
-          branch: ""
-          tools: "changeset"
+        run: |
+          ./x version snapshot
+          ./x publish snapshot --tag nightly
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+
+  notify:
+    name: Notify if failed
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.RSPACK_BOT_ACCESS_TOKEN }}
+          script: |
+            const title = "Nightly Failed";
+            const body = "See job:\n* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}";
+
+            console.log(title);
+            console.log(body);
+
+            const result = await github.rest.issues.create({
+              owner: 'web-infra-dev',
+              repo: 'rspack',
+              title: title,
+              body: body,
+            });
+
+            console.log(result);


### PR DESCRIPTION
## Summary

Successful run: https://github.com/web-infra-dev/rspack/actions/runs/5064708382/jobs/9092920559

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57d5a86</samp>

The pull request improves the nightly release workflow for the project by using custom scripts, creating issues on failures, and updating the lockfile. It also modifies the `pnpm-cache` action to use the `--no-frozen-lockfile` option.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 57d5a86</samp>

*  Modify `pnpm install` command to use `--no-frozen-lockfile` option for nightly builds ([link](https://github.com/web-infra-dev/rspack/pull/3276/files?diff=unified&w=0#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7L27-R27))
* Rename build job to "Build Nightly" and remove unnecessary permissions field ([link](https://github.com/web-infra-dev/rspack/pull/3276/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L11-R11), [link](https://github.com/web-infra-dev/rspack/pull/3276/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L30-R30))
* Replace web-infra-dev/actions with custom scripts for versioning and publishing snapshot versions to npm ([link](https://github.com/web-infra-dev/rspack/pull/3276/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L56-R60))
* Add notify job to create an issue in rspack repository if any previous job failed ([link](https://github.com/web-infra-dev/rspack/pull/3276/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554R67-R91))

</details>
