### PR TITLE
fix: bump swc to fix many bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ast_node"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f7fd7740c5752c16281a1c1f9442b1e69ba41738acde85dc604aaf3ce41890"
+checksum = "c704e2f6ee1a98223f5a7629a6ef0f3decb3b552ed282889dc957edff98ce1e6"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -2997,9 +2997,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
 ]
@@ -3027,9 +3027,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.163"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3309,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.260.36"
+version = "0.261.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e95458f97247dbadf1dbca23db39f475619db09e847551466beef68541a7ee6"
+checksum = "5805d495e0e4a380d9bc300bf7f0cc56ee0b8bee8826dc518e54bb7850bb4485"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -3357,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.5.3"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593c2f3e4cea60ddc4179ed731cabebe7eacec209d9e76a3bbcff4b2b020e3f5"
+checksum = "93d0307dc4bfd107d49c7528350c372758cfca94fb503629b9a056e6a1572860"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -3385,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.31.5"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f876f826866e402da364d77aa97448fdf67cb4aeb6a5f1c0de39cacf35aa89a"
+checksum = "8b6e3021cd5a356db738aebb678a571615cb70d3dac4e4179401dbdca66fa5f7"
 dependencies = [
  "ahash 0.7.6",
  "ast_node",
@@ -3441,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.75.35"
+version = "0.76.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bbb0725eae7d4157439e1d5dc700f99097260137f4f320d63b6ebf1f155cca"
+checksum = "237195f2d914d8a8aa523e9bd31137d55b48667c74ed9d57732aeb42bd4d23ae"
 dependencies = [
  "swc",
  "swc_atoms",
@@ -3477,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_ast"
-version = "0.137.5"
+version = "0.137.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fadc4b9192ee616e7cba2c1612ae79a616546e23856ab23edb5db9c43e9612a"
+checksum = "ae2a0affbb00b3b0fa72c97b6b15a6c1f19c21b9e92e3f2d2343498d2814fd45"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -3489,9 +3489,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_codegen"
-version = "0.147.6"
+version = "0.147.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d27c1d2b7ebf21cc5cfe5e7b3d7e08a038a5aa7fc93ea263aa4bd7dc0641bca"
+checksum = "069230777e0f81f8a971e61548cb08fa8d6972d105f036d650b6df901e799929"
 dependencies = [
  "auto_impl",
  "bitflags 2.1.0",
@@ -3519,9 +3519,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_compat"
-version = "0.23.6"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8dbb86390644c9c6d230f294d5cf528964d84206a65bd48b08b1875b2ef0d4"
+checksum = "741b6a8e7ecbe51027ac897f043c3de171f4907e7815ae991277b1445121b6d2"
 dependencies = [
  "bitflags 2.1.0",
  "once_cell",
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_minifier"
-version = "0.112.6"
+version = "0.112.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ac731b7b246784c5d153c66c68163e63cdb54ced604dd44940dc001f358fdf"
+checksum = "7af2d5f8775ba15a119af6b6c937b4fa606b62821de2ef856a5edccd93de2c37"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3550,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_modules"
-version = "0.25.6"
+version = "0.25.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650f2adbf58150567564846accb31a22278735192e9f40a6dc9e319cfc1ede99"
+checksum = "0846c3a33bd5a44fbb1c32c2c5833c31750195eb374cb9ec655354da5df4f65b"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -3566,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.146.6"
+version = "0.146.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a14a42f39156a50d34f1e3d351c534b4929b27b7b47135055fa2a9a06649ea7"
+checksum = "a17306a7ff2fcc33944b5cf4bc1438b05f9eaf3696484388675900ea5997cd97"
 dependencies = [
  "bitflags 2.1.0",
  "lexical",
@@ -3580,9 +3580,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_prefixer"
-version = "0.149.7"
+version = "0.149.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c12cf20c0e40ea4793ac3d23a04969e9badfc3f9cc478c562f60f1e302fd80f"
+checksum = "c80a89965c150b0c32da50ae9d8694837f3b4aae34f4df3509a592161a0fb1ef"
 dependencies = [
  "once_cell",
  "preset_env_base",
@@ -3597,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_utils"
-version = "0.134.5"
+version = "0.134.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6360cbced8a80618320b5d143299bb8c9684c71a46facc01fe648b198bf0200d"
+checksum = "3a5e47f09981d835179b7c4a5d7bcf8d0065053b398b74ba994245054bb70e3d"
 dependencies = [
  "once_cell",
  "serde",
@@ -3612,9 +3612,9 @@ dependencies = [
 
 [[package]]
 name = "swc_css_visit"
-version = "0.136.5"
+version = "0.136.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6749283744944ee224fd0199ae218fdc4c3b3d1b51e176ee43caf47ae0d67a"
+checksum = "fb99af98e1408f44965dbe6ff0171bfef29a29ca744365eb4d0e9810fa9c5a94"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -3625,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.103.5"
+version = "0.104.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1087786027e9e938588c0a66d45d1044a5e2285922b0928e023303f03a60900f"
+checksum = "fee855d082369cbc8acaf367d7e53bcb88bdc3fb10fca4ee6b426969291db2a3"
 dependencies = [
  "bitflags 2.1.0",
  "is-macro",
@@ -3642,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.138.14"
+version = "0.139.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c3f251e6727627cebf186f25e523961e9e23bf7513e624ed08f0a0acb42757"
+checksum = "5aceee845609805c012698c9487176f7c9388a1526168cbfafa83797753a04c6"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -3674,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "0.102.11"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ac924af6552610a6d66f4066c2f25e42a32f51d246e4d05467631f5c09c48e"
+checksum = "21ab2877e690e74a0a9d4b8fe351cd47b72d05735d41bd12a8983f74c1af8c6b"
 dependencies = [
  "phf",
  "swc_atoms",
@@ -3688,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_lints"
-version = "0.81.17"
+version = "0.82.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b604613334af23468fdd047d9dc2a7dcf3b530d5a03dfd420f28154dd92936a6"
+checksum = "1817d31cc719a292d5cc10b8a601c614eeb50d06f0270e9a29734141e6e39738"
 dependencies = [
  "ahash 0.7.6",
  "auto_impl",
@@ -3709,9 +3709,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "0.43.7"
+version = "0.43.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b853be4b7380384dc3bac5564697c1ba30b47eff94b81449567032fa44d3d0c"
+checksum = "69d34c082764316fb7ff24fa13bf4952c6577a1c7d04a01761c247a26b7b306d"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -3731,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.180.28"
+version = "0.181.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5456ca1170053a4fe8d94b1fe120e47a5cc3bf774f703433328f3f07628274"
+checksum = "018cc0cd2445ef2f0e4864ec76e152413c13a0036e96283bd0aaf4192f382a3d"
 dependencies = [
  "ahash 0.7.6",
  "arrayvec",
@@ -3767,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.133.11"
+version = "0.134.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c8494e9ddb892339a1cc3e08c9db1f9d803b9c6fa92eebc775b7cd64027711"
+checksum = "36b9e770f5dcae13145c4e14fd32805b5f89d19c3531c67307b2f83340605eac"
 dependencies = [
  "either",
  "lexical",
@@ -3787,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.194.26"
+version = "0.195.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f681f7b42608739f041a160db630d15d20b86c3ef973e92d82fde1d89a525df"
+checksum = "8c5049a0f8275b2c35dfe13039cb1e5a4342809bda884ffcf2ca39b0a5141005"
 dependencies = [
  "ahash 0.7.6",
  "anyhow",
@@ -3812,9 +3812,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "0.44.11"
+version = "0.45.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee81779a2037bcbab761a72c598e8b5e5b2c274a2535d5ca206ffb73a9414bf"
+checksum = "a443944a961b6d2efd59a7b19f4bd68bf5f396e28d42c8fb926d462441e1d4ef"
 dependencies = [
  "anyhow",
  "pmutil",
@@ -3830,9 +3830,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.217.25"
+version = "0.218.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf1035f6cb5551c34ccc461be5de6574bf217eb339215b90ef31cc81c30b50"
+checksum = "e503af987eeee31067f58ae92fc0d787dcec5ccccbeebfe2c1d83ae1850a1e69"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3850,9 +3850,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.126.17"
+version = "0.127.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bdb624eb49379b33b1ba56cf3604aaafdcf287567750ff7951926dfc98777e"
+checksum = "e238bade06742aff91b9e50551bd12c64c46e5601e0569c2c5c4b04297cc8d06"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.1.0",
@@ -3874,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "0.115.17"
+version = "0.116.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9964e8ffdbefdd86fa1e0027b6313106ad454166456f99b6335b30947385cd87"
+checksum = "f3c5ff9c6a76622ea4a0aa84f4222e6518c4631f818880a0a984a838f3ea1a71"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -3888,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "0.152.18"
+version = "0.153.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9943225f1e9100d4c7239b881f2de5f523ca61a34d184d2bddb88e5b96034add"
+checksum = "39347647499281c956b28feb71fc807f6f1a087403e737b7d276feaed3f1b9e6"
 dependencies = [
  "ahash 0.7.6",
  "arrayvec",
@@ -3927,9 +3927,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.169.22"
+version = "0.170.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4104199899631bc6beb21855409e63a6d1291f9c0566d6c8f367db6bd30634"
+checksum = "39ed7f0e4e556a0fe6fd526ed766f7297533b645acb5fc521600c949c38e9c7e"
 dependencies = [
  "Inflector",
  "ahash 0.7.6",
@@ -3955,9 +3955,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.186.25"
+version = "0.187.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc66573ce8973757dca6621be2092bbf5f1dc0aca648a574cb1739a4514ca8df"
+checksum = "2086fe38de4084fc9cc3a27bd47fe299bd589b4479ea8b2f7948602fcb122a4e"
 dependencies = [
  "ahash 0.7.6",
  "dashmap",
@@ -3981,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.160.20"
+version = "0.161.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a745680d9005997f7dc44c227e50ab35bb91407f8791552fb444222c9ac43296"
+checksum = "382ec2104c79030c86477b4400a16c48a39cc62fb72274fd1e803ee42ea3fe49"
 dependencies = [
  "either",
  "rustc-hash",
@@ -4001,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "0.172.24"
+version = "0.173.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8049e53c3e0273ab8b702d6c8fa8c1707e4061bf21ee5908ea040dad69a422"
+checksum = "43c96b071f75a6d237c3c1dfd5e91d1b40015dca9a1170c86b4a9f1f16a83ce7"
 dependencies = [
  "ahash 0.7.6",
  "base64",
@@ -4026,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.176.24"
+version = "0.177.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a23c126d1f3f28c1513d8d08982372d8fc4ebaf2cbdc25127350b26eae2e6d"
+checksum = "b4a5921e53bb5f06ce6f57597de0b9e9e803f941a198c19cfe56053c96c60145"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4042,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "0.12.11"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15e582f493c227e535bd45874809584efb01acde8fb9547ec9efb4359c9991"
+checksum = "15aff60e26c55bec5a9d41319fd4673c578bf7d826f8d21061dcad4442f9ccdc"
 dependencies = [
  "ahash 0.7.6",
  "indexmap",
@@ -4060,9 +4060,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "0.116.11"
+version = "0.117.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea67b796253a2d99ec02d5751f83d174c4d894d439353e77cff50477463816f"
+checksum = "cdc2a22dacab6d563df26b908c18e7714f69e0434594274bebda221903c40a1c"
 dependencies = [
  "indexmap",
  "num_cpus",
@@ -4079,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.89.5"
+version = "0.90.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4490a5ed042234d72986e1a0c8afb54291fcf82b42af78ea72507b52bcbe13dd"
+checksum = "f728b2441b27bb7910e28e78d945b1bd69fb53c017edb6ff58b22ea8480908a7"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -4093,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "swc_emotion"
-version = "0.30.5"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d29e57e3f9bfd1586ae0b26ce7a24c7bc5e994cc574760add93d350ae3fb904"
+checksum = "d37eface98570bfeb180eb3fd2dcb22c3598af05cae31beac4c06274b8130766"
 dependencies = [
  "base64",
  "byteorder",
@@ -4123,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.15.5"
+version = "0.15.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3afbf2e52ddce38da1ee204252f7b9019a12176ca73aaa0fd0c36ded1ecbec7d"
+checksum = "60cd51fd8f4290023ded586a8409ee752a31aa9594f13eef411412f92e3ea9fb"
 dependencies = [
  "anyhow",
  "miette",
@@ -4136,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.19.5"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95683baee47d2cbf10e0bf8ad14d4e8f6160674d9eb96b3ab560aa39fa37ccdc"
+checksum = "7c075775b193075f3dbe2fa3575736cf7e9d233e4a88b6ca6350d897eeeaeec9"
 dependencies = [
  "indexmap",
  "petgraph",
@@ -4148,9 +4148,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "0.123.26"
+version = "0.124.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa64f18921762ec955d65ec9adb366df2143a750e911b748b3bbaf08b341cb5"
+checksum = "5b20be9574455b65a4218e7679e66eb183319d3672eaa363be35b8cb51d04213"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -4160,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_ast"
-version = "0.31.5"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0131726c17d3f3420cdadebd461096d5c264846d3cd5f4718e68fc78043c1b4d"
+checksum = "685acc42b2a6d69903cd5e79839dedf8d30831a7102702e2efcb5b30e1f75c1e"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -4172,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_codegen"
-version = "0.40.6"
+version = "0.40.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "018ef935a8ad1d84268aab0824ce888d555946ab7e12f8d83c9076ab58796103"
+checksum = "d5312afef1f57123431fb4ef490b8748b0d07250c88f873f50dfb9ddfd2e5236"
 dependencies = [
  "auto_impl",
  "bitflags 2.1.0",
@@ -4201,9 +4201,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "0.120.26"
+version = "0.121.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b70a53e0217ccad692c7e15b3986efd81135fba5fbbbe6554cf0e0bf4298e4"
+checksum = "817e82e969be72b12ca21addd2949130f035317630cadf5f07a08fdf87533b01"
 dependencies = [
  "once_cell",
  "serde",
@@ -4230,9 +4230,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_parser"
-version = "0.37.6"
+version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a06302db43e6428618803f5d5d642703fbc51e02de572a3263d80744cd864ab"
+checksum = "93fbcef6045bfa48d8b22f38d316a6956137a4134ddd7feafb120c77ceecfbd6"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -4242,9 +4242,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_utils"
-version = "0.16.5"
+version = "0.16.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4386350ca4d760cf7f78a4e7988498d8563e5f44853bafd47adb409cbf321b8a"
+checksum = "785d07bf040333e6edeba52c1c26b8baa6b3f2e45748135cb3d532df16bed3b4"
 dependencies = [
  "once_cell",
  "serde",
@@ -4255,9 +4255,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_visit"
-version = "0.31.5"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3f2e2791bad63a5889f328e942805a28a719bbf5f6b59c67569699762da636a"
+checksum = "6b9044cd41c99dd8479e78ee0ead5d82f84fb5e73c73accea604d2869feb836c"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -4280,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "0.18.5"
+version = "0.18.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d3be08cc983291059f7a16a62ff297bdb83c1282cfe876416fd52b3466e791"
+checksum = "d12fc3899dc8358f1fa67df6a5bd51e8f6d8f24d995e1cd9dc6a7c4275ec4098"
 dependencies = [
  "ahash 0.7.6",
  "dashmap",
@@ -4292,9 +4292,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_import"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e138774dc34d575c209cda7449fd0bab1c4cf9b54a673b8a40aa3b5087c1bd2"
+checksum = "3a1e28011697cf5bab340ab7689860d1eb8fb8035e97d89b999c2a8d3758dc79"
 dependencies = [
  "handlebars",
  "regex",
@@ -4305,9 +4305,9 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.19.6"
+version = "0.19.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d525672140610b0797da5ee7a3f5bcb0dbf13940c84d63c9f966c0239f26cb7"
+checksum = "5e4f86a89e5c540f30714e44b0f0c3351c4e3d1abda7b62716f896365d7ee7c0"
 dependencies = [
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,15 +54,15 @@ napi-build          = { version = "=2.0.1" }
 napi-derive         = { version = "=2.12.3" }
 napi-sys            = { version = "=2.2.3" }
 swc_config          = { version = "=0.1.5" }
-swc_core            = { version = "=0.75.35", default-features = false }
-swc_css             = { version = "=0.153.7" }
-swc_ecma_minifier   = { version = "=0.180.28", default-features = false }
-swc_emotion         = { version = "=0.30.5" }
-swc_error_reporters = { version = "=0.15.5" }
-swc_html            = { version = "=0.123.26" }
-swc_html_minifier   = { version = "=0.120.26" }
-swc_node_comments   = { version = "=0.18.5" }
-swc_plugin_import   = { version = "=0.1.5" }
+swc_core            = { version = "=0.76.26", default-features = false }
+swc_css             = { version = "=0.153.12" }
+swc_ecma_minifier   = { version = "=0.181.16", default-features = false }
+swc_emotion         = { version = "=0.33.0" }
+swc_error_reporters = { version = "=0.15.10" }
+swc_html            = { version = "=0.124.16" }
+swc_html_minifier   = { version = "=0.121.16" }
+swc_node_comments   = { version = "=0.18.10" }
+swc_plugin_import   = { version = "=0.1.7" }
 
 [profile.dev]
 debug       = 2

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -635,6 +635,10 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
                 )),
               );
             }
+            Decl::Using(_) => {
+              // TODO(hyf0): swc bump
+              unimplemented!()
+            }
             Decl::Var(var) => {
               self.state |= AnalyzeState::EXPORT_DECL;
               var.visit_with(self);
@@ -1067,7 +1071,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
       Decl::TsInterface(_) | Decl::TsTypeAlias(_) | Decl::TsEnum(_) | Decl::TsModule(_) => {
         unreachable!("We have been transformed typescript to javascript before.")
       }
-      Decl::Class(_) | Decl::Fn(_) | Decl::Var(_) => {
+      Decl::Class(_) | Decl::Fn(_) | Decl::Var(_) | Decl::Using(_) => {
         node.visit_children_with(self);
       }
     }
@@ -1581,6 +1585,7 @@ fn is_pure_decl(stmt: &Decl, unresolved_ctxt: SyntaxContext) -> bool {
     Decl::Class(class) => is_pure_class(&class.class, unresolved_ctxt),
     Decl::Fn(_) => true,
     Decl::Var(var) => is_pure_var_decl(var, unresolved_ctxt),
+    Decl::Using(_) => false,
     Decl::TsInterface(_) => unreachable!(),
     Decl::TsTypeAlias(_) => unreachable!(),
 

--- a/crates/rspack_plugin_javascript/src/visitors/tree_shaking.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/tree_shaking.rs
@@ -243,6 +243,10 @@ impl<'a> TreeShaker<'a> {
           }))
         }
       }
+      Decl::Using(_) => {
+        // TODO(hyf0): swc bump
+        unimplemented!()
+      }
       Decl::Fn(mut func) => {
         let id = func.ident.to_id();
         let symbol = SymbolRef::Direct(Symbol::new(

--- a/packages/rspack/tests/configCases/rule-set/module-type/app.tsx
+++ b/packages/rspack/tests/configCases/rule-set/module-type/app.tsx
@@ -4,4 +4,7 @@ const React = {
 function Component<T>() {
 	return <div></div>;
 }
-export const App = () => <Component<any>></Component>;
+
+export function App() {
+	return <Component<any>></Component>;
+}


### PR DESCRIPTION
## Related issue (if exists)

Fixes #3019.


<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5f84f9</samp>

Updated swc dependencies and added support for TypeScript `using` declarations in the tree shaking visitors. Refactored a JSX component to a regular function.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5f84f9</samp>

*  Update swc dependencies to the latest versions in `Cargo.toml` ([link](https://github.com/web-infra-dev/rspack/pull/3279/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L57-R65))
*  Add placeholders for handling the new `Decl::Using` variant from swc in the tree shaking visitors for the core and JavaScript plugins ([link](https://github.com/web-infra-dev/rspack/pull/3279/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R638-R641), [link](https://github.com/web-infra-dev/rspack/pull/3279/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L1070-R1074), [link](https://github.com/web-infra-dev/rspack/pull/3279/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440R1588), [link](https://github.com/web-infra-dev/rspack/pull/3279/files?diff=unified&w=0#diff-c5218dcdb499019aee70f975e9ae8b7b965922bc593ddb2beca6bd55dc9eb430R246-R249))
*  Refactor `App` component from an arrow function to a regular function in the test case for the module type rule set ([link](https://github.com/web-infra-dev/rspack/pull/3279/files?diff=unified&w=0#diff-c5bc5e84328237a74266e1c651dd9186bf4f587316d536381408849e08487fcdL7-R10))

</details>
