### PR TITLE
fix: should not resolve to a rule if an existing rule does not have its data

### DIFF
--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -113,16 +113,24 @@ pub async fn module_rule_matcher_inner<'a>(
     return Ok(None);
   }
 
-  if let Some(description_data) = &module_rule.description_data
-    && let Some(resource_description) = &resource_data.resource_description {
-    for (k, matcher) in description_data {
-      if let Some(v) = resource_description.data().raw().get(k).and_then(|v| v.as_str()) {
-        if !matcher.try_match(v).await? {
+  if let Some(description_data) = &module_rule.description_data {
+    if let Some(resource_description) = &resource_data.resource_description {
+      for (k, matcher) in description_data {
+        if let Some(v) = resource_description
+          .data()
+          .raw()
+          .get(k)
+          .and_then(|v| v.as_str())
+        {
+          if !matcher.try_match(v).await? {
+            return Ok(None);
+          }
+        } else {
           return Ok(None);
         }
-      } else {
-        return Ok(None);
       }
+    } else {
+      return Ok(None);
     }
   }
 


### PR DESCRIPTION
## Related issue (if exists)

Given a raw module rule below,
```js
{
  descriptionData: {
     type: "module"
  },
  ...
}
```
if a resource description data is not available, this rule should not be matched.

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22bf4e7</samp>

Refactor `if let` expressions in `module_rules.rs` to improve clarity. This is part of a pull request to enhance the module rules system.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22bf4e7</samp>

*  Refactored module rules matching logic to avoid nested `if let` expressions and improve clarity ([link](https://github.com/web-infra-dev/rspack/pull/3282/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL116-R133))

</details>
