### PR TITLE
ci: only cache pnpm on main branch for avoiding 10GB cache limit

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -11,17 +11,39 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+
     # https://pnpm.io/continuous-integration#github-actions
     # Uses `packageManagement` field from package.json
     - name: Install pnpm
       uses: pnpm/action-setup@v2
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ inputs.node-version }}
-        cache: 'pnpm'
+    - name: Get pnpm store directory
+      id: pnpm-cache
+      shell: bash
+      run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
-    - name: Install Npm Dependencies
+    - name: Setup pnpm cache
+      uses: actions/cache@v3
+      if: github.ref_name == 'main' # Only save cache on main branch
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-cache-${{ runner.os }}-pnpm-
+
+    - name: Setup pnpm cache
+      uses: actions/cache/restore@v3 # Note: this is `restore`, not `save`
+      if: github.ref_name != 'main' # Only restore cache on non-main branch
+      with:
+        path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+        key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          node-cache-${{ runner.os }}-pnpm-
+
+    - name: Install dependencies
       shell: bash
       run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary

We are creating way too many pnpm caches 

<img width="1296" alt="image" src="https://github.com/web-infra-dev/rspack/assets/1430279/4494d391-6326-4b10-b462-f9a0be0bc785">

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 412ead8</samp>

This pull request enhances the `pnpm-cache` action for GitHub workflows by installing Node.js, optimizing the cache usage, and renaming a step. These changes improve the web-infra-dev/rspack repository's workflow speed and stability.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 412ead8</samp>

* Install Node.js using `actions/setup-node@v3` action with the specified version ([link](https://github.com/web-infra-dev/rspack/pull/3284/files?diff=unified&w=0#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7R14-R18))
* Setup and use pnpm cache using `actions/cache@v3` action for the `~/.pnpm-store` directory ([link](https://github.com/web-infra-dev/rspack/pull/3284/files?diff=unified&w=0#diff-703261f283281b1446d87cf7f07bc488f0ce5f0d7fc9162b04baf83bce29f5c7L19-R47))

</details>
