### PR TITLE
feat(cli): Use proxy config in the preview command

### DIFF
--- a/.changeset/twelve-dots-repair.md
+++ b/.changeset/twelve-dots-repair.md
@@ -1,0 +1,5 @@
+---
+"@rspack/cli": patch
+---
+
+Use devServer proxy configs for the preview command

--- a/packages/rspack-cli/src/commands/preview.ts
+++ b/packages/rspack-cli/src/commands/preview.ts
@@ -72,6 +72,7 @@ async function getPreviewConfig(
 				publicPath: options.publicPath ?? "/"
 			},
 			port: options.port ?? 8080,
+			proxy: item.devServer?.proxy,
 			host: options.host ?? item.devServer?.host,
 			open: options.open ?? item.devServer?.open,
 			server: options.server ?? item.devServer?.server,


### PR DESCRIPTION
## Summary

Use devServer proxy configs for the preview command

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 494aae3</samp>

This pull request fixes a bug in the `@rspack/cli` package that prevented the preview command from using the proxy settings from the rspack config file. It updates the `preview.ts` file and adds a changeset file to document the patch update.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 494aae3</samp>

*  Add a changeset file to document the patch update for the `@rspack/cli` package ([link](https://github.com/web-infra-dev/rspack/pull/3287/files?diff=unified&w=0#diff-68f20342295c229d2159989bf683577b99612acf8d11dcd25381e099ab257713R1-R5))
*  Enable the preview command to use the proxy option from the devServer section of the rspack config file ([link](https://github.com/web-infra-dev/rspack/pull/3287/files?diff=unified&w=0#diff-28711f1759e2f66de1a772d88d33a4e9c27de09f779fbc6ca14314998231bb9cR75))

</details>
