### PR TITLE
fix: data uri base64 encoded content with whitespace

### DIFF
--- a/crates/rspack_plugin_schemes/src/data_uri.rs
+++ b/crates/rspack_plugin_schemes/src/data_uri.rs
@@ -59,7 +59,7 @@ impl Plugin for DataUriPlugin {
       let is_base64 = captures.get(3).is_some();
       if is_base64 {
         let base64 = rspack_base64::base64::Base64::new();
-        return Ok(Some(Content::Buffer(base64.decode_to_vec(body).map_err(|e| internal_error!(e.to_string()))?)))
+        return Ok(Some(Content::Buffer(base64.decode_to_vec(body.trim()).map_err(|e| internal_error!(e.to_string()))?)))
       }
       if !body.is_ascii() {
         return Ok(Some(Content::Buffer(urlencoding::decode_binary(body.as_bytes()).into_owned())))

--- a/packages/rspack/tests/cases/schemes/data-imports/index.css
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.css
@@ -5,4 +5,5 @@
   a: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"></svg>');
   b: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>');
   c: url('data:image/svg;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==');
+  d: url('data:image/svg;base64,    PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==');
 }

--- a/packages/rspack/tests/cases/schemes/data-imports/index.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.js
@@ -26,6 +26,7 @@ it("data imports", () => {
   a: url("2c6053f86393fdda.svg");
   b: url("2c6053f86393fdda.svg");
   c: url("2c6053f86393fdda");
+  d: url("2c6053f86393fdda");
 }`);
 	expect(inlineSvg).toBe(
 		'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>'


### PR DESCRIPTION
## Related issue (if exists)

fixes #3288

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f779c4</samp>

Fix a bug in the `data_uri` plugin and add test cases for data URI imports. The bug caused base64 decoding to fail for data URIs with whitespace. The test cases cover different encoding and content types for data URIs in CSS and JS files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f779c4</samp>

* Fix base64 decoding bug in data URI scheme plugin by trimming the body before decoding ([link](https://github.com/web-infra-dev/rspack/pull/3289/files?diff=unified&w=0#diff-7ef2a053b868692703310a61bbb9d8e0155ff6bdcfa20b0be142992d9d536ec0L62-R62))
  * Test importing base64-encoded SVG content in CSS file ([link](https://github.com/web-infra-dev/rspack/pull/3289/files?diff=unified&w=0#diff-1c7c125831fae2fee17787e5a65a37dd9e2c6a6e24ee13af5939c29937110f89R8))
  * Test importing hex-encoded binary content in JS file ([link](https://github.com/web-infra-dev/rspack/pull/3289/files?diff=unified&w=0#diff-bc2f03406a560f2556547535400c4050a85856924abe1f2acdbf03e206df6266R29))

</details>
