### PR TITLE
chore: add check for [ext] in output.filename

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -349,6 +349,12 @@ export interface JsStatsWarning {
   formatted: string
 }
 
+export interface NodeFS {
+  writeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+}
+
 export interface PathData {
   filename?: string
   hash?: string
@@ -856,5 +862,12 @@ export interface RawStyleConfig {
 
 export interface RawTrustedTypes {
   policyName?: string
+}
+
+export interface ThreadsafeNodeFS {
+  writeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+  removeDirAll: (...args: any[]) => any
 }
 

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -56,7 +56,14 @@ export const getNormalizedRspackOptions = (
 							name: libraryAsName
 					  } as LibraryOptions)
 					: undefined;
-
+			if (
+				typeof output.filename === "string" &&
+				output.filename.includes("[ext]")
+			) {
+				throw new Error(
+					"[ext] in output.filename is not supported, please use output.filename and output.cssFilename to specify different ext fo js and css file"
+				);
+			}
 			return {
 				path: output.path,
 				publicPath: output.publicPath,

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -56,13 +56,32 @@ export const getNormalizedRspackOptions = (
 							name: libraryAsName
 					  } as LibraryOptions)
 					: undefined;
-			if (
-				typeof output.filename === "string" &&
-				output.filename.includes("[ext]")
-			) {
-				throw new Error(
-					"[ext] in output.filename is not supported, please use output.filename and output.cssFilename to specify different ext fo js and css file"
-				);
+			// DEPRECATE: remove this in after version
+			{
+				const yellow = (content: string) =>
+					`\u001b[1m\u001b[33m${content}\u001b[39m\u001b[22m`;
+				const ext = "[ext]";
+				const filenames = [
+					"filename",
+					"chunkFilename",
+					"cssFilename",
+					"cssChunkFilename"
+				] as const;
+				const checkFilename = (prop: typeof filenames[number]) => {
+					const oldFilename = output[prop];
+					if (typeof oldFilename === "string" && oldFilename.endsWith(ext)) {
+						const newFilename =
+							oldFilename.slice(0, -ext.length) +
+							(prop.includes("css") ? ".css" : ".js");
+						console.warn(
+							yellow(
+								`Deprecated: output.${prop} ends with [ext] is now deprecated, please use ${newFilename} instead.`
+							)
+						);
+						output[prop] = newFilename;
+					}
+				};
+				filenames.forEach(checkFilename);
 			}
 			return {
 				path: output.path,


### PR DESCRIPTION
## Related issue (if exists)
closes #3270 
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9fe31f2</samp>

Validate output.filename option in webpack config normalization. Reject [ext] placeholder and throw an error if used, as it is incompatible with the library plugin.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9fe31f2</samp>

* Add a validation check for the output.filename option to prevent using [ext] as a placeholder ([link](https://github.com/web-infra-dev/rspack/pull/3290/files?diff=unified&w=0#diff-78648f723799beccc94c4b2e506997d12d1ace8216aeb31c0731c37a6dce024aL59-R63))

</details>
