### PR TITLE
feat: enable the new implementation of `SplitChunksPlugin` by default

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -523,7 +523,8 @@ function getRawSplitChunksOptions(
 							minSize: group.minSize,
 							maxAsyncSize: group.maxAsyncSize,
 							maxInitialSize: group.maxInitialSize,
-							maxSize: group.maxSize
+							maxSize: group.maxSize,
+							enforce: group.enforce
 						};
 						return [key, normalizedGroup];
 					})

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -145,7 +145,7 @@ const applyExperimentsDefaults = (experiments: Experiments) => {
 	D(experiments, "incrementalRebuild", true);
 	D(experiments, "lazyCompilation", false);
 	D(experiments, "asyncWebAssembly", false);
-	D(experiments, "newSplitChunks", false);
+	D(experiments, "newSplitChunks", true);
 	D(experiments, "css", true); // we not align with webpack about the default value for better DX
 };
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -628,6 +628,7 @@ export interface OptimizationSplitChunksCacheGroup {
 	maxSize?: number;
 	maxAsyncSize?: number;
 	maxInitialSize?: number;
+	enforce?: boolean;
 }
 export type OptimizationSplitChunksSizes = number;
 export type OptimizationRuntimeChunk =

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -53,7 +53,7 @@ exports[`snapshots should have the correct base config 1`] = `
     "css": true,
     "incrementalRebuild": true,
     "lazyCompilation": false,
-    "newSplitChunks": false,
+    "newSplitChunks": true,
   },
   "externals": undefined,
   "externalsPresets": {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f5d8f45</samp>

Enable `newSplitChunks` experiment in `rspack` config to improve webpack performance and optimization. This change updates `rspack` to use the latest webpack features and provide better DX.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f5d8f45</samp>

* Enable the `newSplitChunks` experiment for webpack by default ([link](https://github.com/web-infra-dev/rspack/pull/3295/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL148-R148)). This improves the code splitting and chunking logic of webpack, which can enhance the performance and optimization of the output bundles. The change affects the `packages/rspack/src/config/defaults.ts` file, which defines the default configuration options for rspack.

</details>
