### PR TITLE
fix: add schema for `Rule.options` and `Rule.loader`

### DIFF
--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -1731,6 +1731,22 @@ module.exports = {
 						}
 					]
 				},
+				loader: {
+					description: "Shortcut for use.loader.",
+					oneOf: [
+						{
+							$ref: "#/definitions/RuleSetLoader"
+						}
+					]
+				},
+				options: {
+					description: "Shortcut for use.options.",
+					oneOf: [
+						{
+							$ref: "#/definitions/RuleSetLoaderOptions"
+						}
+					]
+				},
 				scheme: {
 					description: "Match module scheme.",
 					oneOf: [


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86fcfa5</samp>

Add `loader` and `options` properties to RuleSetUse schema in `packages/rspack/src/config/schema.js`. These properties simplify the configuration syntax and improve the documentation for rule sets.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 86fcfa5</samp>

*  Add `loader` and `options` properties to RuleSetUse schema ([link](https://github.com/web-infra-dev/rspack/pull/3296/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R1734-R1752))

</details>
