### PR TITLE
chore: add dry-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "lint-staged": {
     "*.rs": "rustfmt --edition 2021",
     "packages/**/*.{ts,js}": "prettier --write",
+    "x.mjs": "prettier --write",
     "crates/rspack_plugin_runtime/**/*.{ts,js}": "prettier --write",
     "*.toml": "npx @taplo/cli format"
   },

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -13,7 +13,9 @@ export async function publish_handler(mode, options) {
 			`//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`
 		);
 	}
-	await $`pnpm changeset publish --tag ${options.tag}`;
+	await $`pnpm publish -r ${options.dryRun ? "--dry-run" : ""} --tag ${
+		options.tag
+	} --no-git-checks`;
 	const version = await getLastVersion(root);
 	/**
 	 * @Todo test stable release later

--- a/x.mjs
+++ b/x.mjs
@@ -16,19 +16,19 @@ program
 
 // x ready
 program
-  .command("ready")
-  .alias("r")
-  .description("ready to create a pull request, build and run all tests")
-  .action(async function () {
-    await $`cargo check`;
-    await $`cargo lint`;
-    await $`cargo test`;
-    await $`pnpm install`;
-    await $`pnpm run build:cli:release`;
-    await $`pnpm run test:example`;
-    await $`pnpm run test:unit`;
-    console.log(chalk.green('All passed.'))
-  });
+	.command("ready")
+	.alias("r")
+	.description("ready to create a pull request, build and run all tests")
+	.action(async function () {
+		await $`cargo check`;
+		await $`cargo lint`;
+		await $`cargo test`;
+		await $`pnpm install`;
+		await $`pnpm run build:cli:release`;
+		await $`pnpm run test:example`;
+		await $`pnpm run test:unit`;
+		console.log(chalk.green("All passed."));
+	});
 
 // x install
 program
@@ -122,6 +122,10 @@ let releaseCommand = program
 	.command("publish")
 	.argument("<mode>", "publish mode (snapshot|stable)")
 	.requiredOption("--tag <char>", "publish tag")
+	.option(
+		"--dry-run",
+		"Does everything a publish would do except actually publishing to the registry"
+	)
 	.description("publish package after version bump")
 	.action(publish_handler);
 let argv = process.argv.slice(2); // remove the `node` and script call


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 33d6db0</samp>

This pull request improves the code quality and the publish process of the x.mjs file. It formats the code with `prettier`, adds a `--dry-run` option to the `publish` command, and switches to `pnpm` as the package manager.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 33d6db0</samp>

* Add a new script to run prettier on `x.mjs` ([link](https://github.com/web-infra-dev/rspack/pull/3300/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R39))
* Switch to pnpm for publishing packages and add a --dry-run option ([link](https://github.com/web-infra-dev/rspack/pull/3300/files?diff=unified&w=0#diff-121ac8f9e24f2b43274b72e2b02402ecdef16563740899434511ba9ecc099dc8L16-R18), [link](https://github.com/web-infra-dev/rspack/pull/3300/files?diff=unified&w=0#diff-866d8c4b601772273677680d6cedcec91a98ae1b64b2cda04eff6dab131dfcf1R125-R128))
* Format `x.mjs` with prettier and pass --dry-run option to publish command ([link](https://github.com/web-infra-dev/rspack/pull/3300/files?diff=unified&w=0#diff-866d8c4b601772273677680d6cedcec91a98ae1b64b2cda04eff6dab131dfcf1L19-R31), [link](https://github.com/web-infra-dev/rspack/pull/3300/files?diff=unified&w=0#diff-866d8c4b601772273677680d6cedcec91a98ae1b64b2cda04eff6dab131dfcf1R125-R128))

</details>
