### PR TITLE
feat: add hot module replacement string replace dependency

### DIFF
--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -1,6 +1,6 @@
 use crate::{
-  to_identifier, CodeReplaceSourceDependencyContext, DependencyId, ExportsType, InitFragment,
-  InitFragmentStage, ModuleGraph, ModuleIdentifier, RuntimeGlobals,
+  to_identifier, CodeReplaceSourceDependencyContext, Compilation, DependencyId, ExportsType,
+  InitFragment, InitFragmentStage, ModuleGraph, ModuleIdentifier, RuntimeGlobals,
 };
 
 pub fn export_from_import(
@@ -103,6 +103,16 @@ pub fn module_id_expr(request: &str, module_id: &str) -> String {
     request,
     serde_json::to_string(module_id).expect("should render module id")
   )
+}
+
+pub fn module_id(compilation: &Compilation, id: &DependencyId, request: &str) -> String {
+  let module_id = compilation
+    .module_graph
+    .module_graph_module_by_dependency_id(id)
+    .map(|m| m.id(&compilation.chunk_graph))
+    .expect("should have dependency id");
+
+  module_id_expr(request, module_id)
 }
 
 pub fn import_statement(

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -61,7 +61,7 @@ pub enum BuildMetaDefaultObject {
   RedirectWarn,
 }
 
-#[derive(Debug, Default, Clone, Hash)]
+#[derive(Debug, Clone, Hash)]
 pub struct BuildMeta {
   pub strict: bool,
   pub strict_harmony_module: bool,
@@ -71,6 +71,21 @@ pub struct BuildMeta {
   pub default_object: BuildMetaDefaultObject,
   pub module_argument: &'static str,
   pub exports_argument: &'static str,
+}
+
+impl Default for BuildMeta {
+  fn default() -> Self {
+    Self {
+      strict: Default::default(),
+      strict_harmony_module: Default::default(),
+      is_async: Default::default(),
+      esm: Default::default(),
+      exports_type: Default::default(),
+      default_object: Default::default(),
+      module_argument: "module",
+      exports_argument: "exports",
+    }
+  }
 }
 
 // webpack build info

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency,
+  create_javascript_visitor, module_id, CodeGeneratable, CodeGeneratableContext,
+  CodeGeneratableResult, CodeReplaceSourceDependency, CodeReplaceSourceDependencyContext,
+  CodeReplaceSourceDependencyReplaceSource, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, JsAstPath, ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
@@ -87,5 +88,92 @@ impl CodeGeneratable for ImportMetaModuleHotAcceptDependency {
     }
 
     Ok(code_gen)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportMetaHotAcceptDependency {
+  id: Option<DependencyId>,
+  request: JsWord,
+  start: u32,
+  end: u32,
+  category: &'static DependencyCategory,
+  dependency_type: &'static DependencyType,
+
+  span: Option<ErrorSpan>,
+}
+
+impl ImportMetaHotAcceptDependency {
+  pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
+    Self {
+      start,
+      end,
+      request,
+      category: &DependencyCategory::Esm,
+      dependency_type: &DependencyType::ImportMetaHotAccept,
+      span,
+      id: None,
+    }
+  }
+}
+
+impl Dependency for ImportMetaHotAcceptDependency {
+  fn id(&self) -> Option<DependencyId> {
+    self.id
+  }
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
+  }
+
+  fn category(&self) -> &DependencyCategory {
+    self.category
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    self.dependency_type
+  }
+}
+
+impl ModuleDependency for ImportMetaHotAcceptDependency {
+  fn request(&self) -> &str {
+    &self.request
+  }
+
+  fn user_request(&self) -> &str {
+    &self.request
+  }
+
+  fn span(&self) -> Option<&ErrorSpan> {
+    self.span.as_ref()
+  }
+
+  fn as_code_replace_source_dependency(&self) -> Option<Box<dyn CodeReplaceSourceDependency>> {
+    Some(Box::new(self.clone()))
+  }
+}
+
+impl CodeGeneratable for ImportMetaHotAcceptDependency {
+  fn generate(
+    &self,
+    _code_generatable_context: &mut CodeGeneratableContext,
+  ) -> rspack_error::Result<CodeGeneratableResult> {
+    todo!()
+  }
+}
+
+impl CodeReplaceSourceDependency for ImportMetaHotAcceptDependency {
+  fn apply(
+    &self,
+    source: &mut CodeReplaceSourceDependencyReplaceSource,
+    code_generatable_context: &mut CodeReplaceSourceDependencyContext,
+  ) {
+    let id: DependencyId = self.id().expect("should have dependency id");
+
+    source.replace(
+      self.start,
+      self.end,
+      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      None,
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency,
+  create_javascript_visitor, module_id, CodeGeneratable, CodeGeneratableContext,
+  CodeGeneratableResult, CodeReplaceSourceDependency, CodeReplaceSourceDependencyContext,
+  CodeReplaceSourceDependencyReplaceSource, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, JsAstPath, ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
@@ -87,5 +88,92 @@ impl CodeGeneratable for ImportMetaModuleHotDeclineDependency {
     }
 
     Ok(code_gen)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportMetaHotDeclineDependency {
+  id: Option<DependencyId>,
+  request: JsWord,
+  start: u32,
+  end: u32,
+  category: &'static DependencyCategory,
+  dependency_type: &'static DependencyType,
+
+  span: Option<ErrorSpan>,
+}
+
+impl ImportMetaHotDeclineDependency {
+  pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
+    Self {
+      start,
+      end,
+      request,
+      category: &DependencyCategory::Esm,
+      dependency_type: &DependencyType::ImportMetaHotDecline,
+      span,
+      id: None,
+    }
+  }
+}
+
+impl Dependency for ImportMetaHotDeclineDependency {
+  fn id(&self) -> Option<DependencyId> {
+    self.id
+  }
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
+  }
+
+  fn category(&self) -> &DependencyCategory {
+    self.category
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    self.dependency_type
+  }
+}
+
+impl ModuleDependency for ImportMetaHotDeclineDependency {
+  fn request(&self) -> &str {
+    &self.request
+  }
+
+  fn user_request(&self) -> &str {
+    &self.request
+  }
+
+  fn span(&self) -> Option<&ErrorSpan> {
+    self.span.as_ref()
+  }
+
+  fn as_code_replace_source_dependency(&self) -> Option<Box<dyn CodeReplaceSourceDependency>> {
+    Some(Box::new(self.clone()))
+  }
+}
+
+impl CodeGeneratable for ImportMetaHotDeclineDependency {
+  fn generate(
+    &self,
+    _code_generatable_context: &mut CodeGeneratableContext,
+  ) -> rspack_error::Result<CodeGeneratableResult> {
+    todo!()
+  }
+}
+
+impl CodeReplaceSourceDependency for ImportMetaHotDeclineDependency {
+  fn apply(
+    &self,
+    source: &mut CodeReplaceSourceDependencyReplaceSource,
+    code_generatable_context: &mut CodeReplaceSourceDependencyContext,
+  ) {
+    let id: DependencyId = self.id().expect("should have dependency id");
+
+    source.replace(
+      self.start,
+      self.end,
+      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      None,
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/mod.rs
@@ -6,5 +6,5 @@ mod import_meta_hot_accept;
 pub use import_meta_hot_accept::*;
 mod import_meta_hot_decline;
 pub use import_meta_hot_decline::*;
-// mod harmony_accept_dependency;
-// pub use harmony_accept_dependency::HarmonyAcceptDependency;
+mod harmony_accept_dependency;
+pub use harmony_accept_dependency::HarmonyAcceptDependency;

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency,
+  create_javascript_visitor, module_id, CodeGeneratable, CodeGeneratableContext,
+  CodeGeneratableResult, CodeReplaceSourceDependency, CodeReplaceSourceDependencyContext,
+  CodeReplaceSourceDependencyReplaceSource, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, JsAstPath, ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
@@ -87,5 +88,92 @@ impl CodeGeneratable for ModuleHotAcceptDependency {
     }
 
     Ok(code_gen)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewModuleHotAcceptDependency {
+  id: Option<DependencyId>,
+  request: JsWord,
+  start: u32,
+  end: u32,
+  category: &'static DependencyCategory,
+  dependency_type: &'static DependencyType,
+
+  span: Option<ErrorSpan>,
+}
+
+impl NewModuleHotAcceptDependency {
+  pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
+    Self {
+      id: None,
+      request,
+      category: &DependencyCategory::CommonJS,
+      dependency_type: &DependencyType::ModuleHotAccept,
+      span,
+      start,
+      end,
+    }
+  }
+}
+
+impl Dependency for NewModuleHotAcceptDependency {
+  fn id(&self) -> Option<DependencyId> {
+    self.id
+  }
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
+  }
+
+  fn category(&self) -> &DependencyCategory {
+    self.category
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    self.dependency_type
+  }
+}
+
+impl ModuleDependency for NewModuleHotAcceptDependency {
+  fn request(&self) -> &str {
+    &self.request
+  }
+
+  fn user_request(&self) -> &str {
+    &self.request
+  }
+
+  fn span(&self) -> Option<&ErrorSpan> {
+    self.span.as_ref()
+  }
+
+  fn as_code_replace_source_dependency(&self) -> Option<Box<dyn CodeReplaceSourceDependency>> {
+    Some(Box::new(self.clone()))
+  }
+}
+
+impl CodeGeneratable for NewModuleHotAcceptDependency {
+  fn generate(
+    &self,
+    _code_generatable_context: &mut CodeGeneratableContext,
+  ) -> rspack_error::Result<CodeGeneratableResult> {
+    todo!()
+  }
+}
+
+impl CodeReplaceSourceDependency for NewModuleHotAcceptDependency {
+  fn apply(
+    &self,
+    source: &mut CodeReplaceSourceDependencyReplaceSource,
+    code_generatable_context: &mut CodeReplaceSourceDependencyContext,
+  ) {
+    let id: DependencyId = self.id().expect("should have dependency id");
+
+    source.replace(
+      self.start,
+      self.end,
+      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      None,
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,
-  ModuleDependency,
+  create_javascript_visitor, module_id, CodeGeneratable, CodeGeneratableContext,
+  CodeGeneratableResult, CodeReplaceSourceDependency, CodeReplaceSourceDependencyContext,
+  CodeReplaceSourceDependencyReplaceSource, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, JsAstPath, ModuleDependency,
 };
 use swc_core::ecma::atoms::{Atom, JsWord};
 
@@ -87,5 +88,92 @@ impl CodeGeneratable for ModuleHotDeclineDependency {
     }
 
     Ok(code_gen)
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct NewModuleHotDeclineDependency {
+  id: Option<DependencyId>,
+  request: JsWord,
+  start: u32,
+  end: u32,
+  category: &'static DependencyCategory,
+  dependency_type: &'static DependencyType,
+
+  span: Option<ErrorSpan>,
+}
+
+impl NewModuleHotDeclineDependency {
+  pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
+    Self {
+      id: None,
+      request,
+      category: &DependencyCategory::CommonJS,
+      dependency_type: &DependencyType::ModuleHotDecline,
+      span,
+      start,
+      end,
+    }
+  }
+}
+
+impl Dependency for NewModuleHotDeclineDependency {
+  fn id(&self) -> Option<DependencyId> {
+    self.id
+  }
+  fn set_id(&mut self, id: Option<DependencyId>) {
+    self.id = id;
+  }
+
+  fn category(&self) -> &DependencyCategory {
+    self.category
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    self.dependency_type
+  }
+}
+
+impl ModuleDependency for NewModuleHotDeclineDependency {
+  fn request(&self) -> &str {
+    &self.request
+  }
+
+  fn user_request(&self) -> &str {
+    &self.request
+  }
+
+  fn span(&self) -> Option<&ErrorSpan> {
+    self.span.as_ref()
+  }
+
+  fn as_code_replace_source_dependency(&self) -> Option<Box<dyn CodeReplaceSourceDependency>> {
+    Some(Box::new(self.clone()))
+  }
+}
+
+impl CodeGeneratable for NewModuleHotDeclineDependency {
+  fn generate(
+    &self,
+    _code_generatable_context: &mut CodeGeneratableContext,
+  ) -> rspack_error::Result<CodeGeneratableResult> {
+    todo!()
+  }
+}
+
+impl CodeReplaceSourceDependency for NewModuleHotDeclineDependency {
+  fn apply(
+    &self,
+    source: &mut CodeReplaceSourceDependencyReplaceSource,
+    code_generatable_context: &mut CodeReplaceSourceDependencyContext,
+  ) {
+    let id: DependencyId = self.id().expect("should have dependency id");
+
+    source.replace(
+      self.start,
+      self.end,
+      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      None,
+    );
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/string_replace.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/string_replace.rs
@@ -42,6 +42,7 @@ impl ParserAndGenerator for JavaScriptStringReplaceParserAndGenerator {
       compiler_options,
       build_info,
       build_meta,
+      module_identifier,
       ..
     } = parse_context;
 
@@ -122,6 +123,7 @@ impl ParserAndGenerator for JavaScriptStringReplaceParserAndGenerator {
           module_type,
           build_info,
           build_meta,
+          module_identifier,
         )
       });
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
@@ -1,0 +1,160 @@
+use rspack_core::{
+  BoxModuleDependency, BuildMeta, CodeReplaceSourceDependency, ErrorSpan, ModuleDependency,
+  ModuleIdentifier, ReplaceConstDependency, RuntimeGlobals, SpanExt,
+};
+use swc_core::{
+  common::Spanned,
+  ecma::{
+    ast::{CallExpr, Expr, Lit},
+    atoms::JsWord,
+    visit::{noop_visit_type, Visit, VisitWith},
+  },
+};
+
+use super::{is_module_hot_accept_call, is_module_hot_decline_call};
+use crate::{
+  dependency::{
+    HarmonyAcceptDependency, ImportMetaHotAcceptDependency, ImportMetaHotDeclineDependency,
+    NewModuleHotAcceptDependency, NewModuleHotDeclineDependency,
+  },
+  visitors::{is_import_meta_hot_accept_call, is_import_meta_hot_decline_call},
+};
+
+pub struct HotModuleReplacementScanner<'a> {
+  pub dependencies: &'a mut Vec<BoxModuleDependency>,
+  pub code_generable_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+  pub module_identifier: ModuleIdentifier,
+  pub build_meta: &'a BuildMeta,
+}
+
+type CreateDependency = fn(u32, u32, JsWord, Option<ErrorSpan>) -> BoxModuleDependency;
+
+impl<'a> HotModuleReplacementScanner<'a> {
+  pub fn new(
+    dependencies: &'a mut Vec<BoxModuleDependency>,
+    code_generable_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+    module_identifier: ModuleIdentifier,
+    build_meta: &'a BuildMeta,
+  ) -> Self {
+    Self {
+      dependencies,
+      code_generable_dependencies,
+      module_identifier,
+      build_meta,
+    }
+  }
+
+  pub fn collect_dependencies(
+    &mut self,
+    call_expr: &CallExpr,
+    kind: &str,
+    create_dependency: CreateDependency,
+  ) {
+    self
+      .code_generable_dependencies
+      .push(Box::new(ReplaceConstDependency::new(
+        call_expr.callee.span().real_lo(),
+        call_expr.callee.span().real_hi(),
+        format!("module.hot.{kind}").into(),
+        Some(RuntimeGlobals::MODULE),
+      )));
+
+    let mut deps = vec![];
+
+    if let Some(first_arg) = call_expr.args.get(0) {
+      match &*first_arg.expr {
+        Expr::Lit(Lit::Str(s)) => {
+          deps.push(create_dependency(
+            s.span.real_lo(),
+            s.span.real_hi(),
+            s.value.clone(),
+            Some(s.span.into()),
+          ));
+        }
+        Expr::Array(array_lit) => {
+          array_lit.elems.iter().for_each(|e| {
+            if let Some(expr) = e {
+              if let Expr::Lit(Lit::Str(s)) = &*expr.expr {
+                deps.push(create_dependency(
+                  s.span.real_lo(),
+                  s.span.real_hi(),
+                  s.value.clone(),
+                  Some(s.span.into()),
+                ));
+              }
+            }
+          });
+        }
+        _ => {}
+      }
+    }
+
+    if self.build_meta.esm && kind == "accept" {
+      let ref_deps = deps
+        .iter()
+        .map(|dep| {
+          (
+            dep.request().into(),
+            *dep.category(),
+            dep.dependency_type().clone(),
+          )
+        })
+        .collect::<Vec<_>>();
+      if let Some(callback_arg) = call_expr.args.get(1) {
+        self
+          .code_generable_dependencies
+          .push(Box::new(HarmonyAcceptDependency::new(
+            callback_arg.span().real_lo(),
+            callback_arg.span().real_hi(),
+            true,
+            self.module_identifier,
+            ref_deps,
+          )));
+      } else {
+        self
+          .code_generable_dependencies
+          .push(Box::new(HarmonyAcceptDependency::new(
+            call_expr.span().real_hi() - 1,
+            0,
+            false,
+            self.module_identifier,
+            ref_deps,
+          )));
+      }
+    }
+
+    self.dependencies.extend(deps);
+  }
+}
+
+impl<'a> Visit for HotModuleReplacementScanner<'a> {
+  noop_visit_type!();
+
+  fn visit_call_expr(&mut self, call_expr: &CallExpr) {
+    if is_module_hot_accept_call(call_expr) {
+      self.collect_dependencies(call_expr, "accept", |start, end, request, span| {
+        Box::new(NewModuleHotAcceptDependency::new(start, end, request, span))
+      });
+    } else if is_module_hot_decline_call(call_expr) {
+      self.collect_dependencies(call_expr, "decline", |start, end, request, span| {
+        Box::new(NewModuleHotDeclineDependency::new(
+          start, end, request, span,
+        ))
+      });
+    } else if is_import_meta_hot_accept_call(call_expr) {
+      self.collect_dependencies(call_expr, "accept", |start, end, request, span| {
+        Box::new(ImportMetaHotAcceptDependency::new(
+          start, end, request, span,
+        ))
+      });
+    } else if is_import_meta_hot_decline_call(call_expr) {
+      self.collect_dependencies(call_expr, "decline", |start, end, request, span| {
+        Box::new(ImportMetaHotDeclineDependency::new(
+          start, end, request, span,
+        ))
+      });
+    } else {
+      call_expr.visit_children_with(self);
+    }
+  }
+}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 89005cb</samp>

Moved HMR dependency logic from `rspack_plugin_javascript` to `rspack_core` and added `module_id` function. This improves code reuse and consistency for hot module replacement across plugins. Added HMR dependency scanning to the JavaScript plugin using the `HotModuleReplacementScanner` visitor. This enables detecting and replacing HMR dependencies based on the module identifier and the compiler options.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 89005cb</samp>

*  Add `module_id` function to `runtime_template.rs` to generate module id expressions in the runtime ([link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5L2-R3), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5R108-R117))
*  Move HMR dependencies from `rspack_plugin_javascript` crate to `rspack_core` crate and use `module_id` function to replace source code ([link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-9eb52a5de59a9741ea5dc00b420f84f282ae54717643453286dfa1313f81725bL2-R4), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-9eb52a5de59a9741ea5dc00b420f84f282ae54717643453286dfa1313f81725bL14-R14), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-9eb52a5de59a9741ea5dc00b420f84f282ae54717643453286dfa1313f81725bL24-R23), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-9eb52a5de59a9741ea5dc00b420f84f282ae54717643453286dfa1313f81725bL31-R95), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-42fb633c6e41bd78676d0a4929876d1962208f2046257e56025f90b9683d0985L2-R5), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-42fb633c6e41bd78676d0a4929876d1962208f2046257e56025f90b9683d0985R93-R175), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-c457e8e58a59a08dc806c9794008811cf5ddb1e655f8778da9747ea75ae7f622L2-R5), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-c457e8e58a59a08dc806c9794008811cf5ddb1e655f8778da9747ea75ae7f622R93-R175), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-a9f5dcf0610b6f3338469cf9dad04c3a06b204ade7264ab96e6ff99000d6e03fL2-R5), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-a9f5dcf0610b6f3338469cf9dad04c3a06b204ade7264ab96e6ff99000d6e03fR93-R175), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-37ebd37489f0978e68943dd41ec03b517899190e8d98c80bc4646e20a0173773L2-R5), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-37ebd37489f0978e68943dd41ec03b517899190e8d98c80bc4646e20a0173773R93-R175))
*  Remove `#[derive(Default)]` attribute from `BuildMeta` struct and implement `Default` trait manually ([link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0L62-R62), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-6d6ee10fb57dcb86a4a0d44d272155b4466773c75b8a006f4c2b4bbe6209efa0R74-R88))
*  Uncomment `HarmonyAcceptDependency` re-export in `hmr/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-97561b343404171ba405a1f6e0224358c6b3d07f95576e395bd5375d589df0a0L9-R10))
*  Add `module_identifier` field to `StringReplaceDependencyScanner` struct and pass it to `HotModuleReplacementScanner` visitor ([link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-ef3fe3b34f136d41212214c0b5c1cdf80d11436046bf271595e451a97b09138aR45), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-ef3fe3b34f136d41212214c0b5c1cdf80d11436046bf271595e451a97b09138aR126))
*  Add `HotModuleReplacementScanner` visitor to scan AST for HMR dependencies and add them to dependency vectors ([link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-15fa83afe3a5cf8ae9a97ae8bcee2d8edf08c000cb73953cfa510ca626587c7aR1-R160), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1R9), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L18-R19), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L28-R32), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1L109-R120), [link](https://github.com/web-infra-dev/rspack/pull/3301/files?diff=unified&w=0#diff-16e57d21479f7ef3c2b121761f877d4b66003b7329055509e1288a7449f52ec1R167-R175))

</details>
