### PR TITLE
fix(angular_example): updating the example to include now working options

### DIFF
--- a/examples/angular/rspack.config.js
+++ b/examples/angular/rspack.config.js
@@ -1,6 +1,5 @@
 const { AngularWebpackPlugin } = require("@ngtools/webpack");
-
-// const {DedupeModuleResolvePlugin} = require('@angular-devkit/build-angular/src/webpack/plugins/dedupe-module-resolve-plugin');
+const {DedupeModuleResolvePlugin} = require('@angular-devkit/build-angular/src/webpack/plugins/dedupe-module-resolve-plugin');
 const {
 	NamedChunksPlugin
 } = require("@angular-devkit/build-angular/src/webpack/plugins/named-chunks-plugin");
@@ -8,6 +7,7 @@ const {
 	OccurrencesPlugin
 } = require("@angular-devkit/build-angular/src/webpack/plugins/occurrences-plugin");
 const path = require("path");
+
 /** @type {import('@rspack/cli').Configuration} */
 module.exports = {
 	mode: "production",
@@ -21,10 +21,10 @@ module.exports = {
 		extensions: [".ts", ".js"]
 	},
 	output: {
-		uniqueName: "zackAngularCli",
-		// 'hashFunction': 'xxhash64', // throws error
+		uniqueName: "angular",
+		hashFunction: 'xxhash64',
 		clean: true,
-		// path: "./dist",
+		path: "./dist",
 		publicPath: "",
 		filename: "[name].[contenthash:20].js",
 		chunkFilename: "[name].[contenthash:20].js",
@@ -55,7 +55,7 @@ module.exports = {
 					name: "common",
 					chunks: "async",
 					minChunks: 2,
-					// 'enforce': true, // throws error
+					enforce: true,
 					priority: 5
 				}
 				// 'vendors': false, // throws error
@@ -160,8 +160,7 @@ module.exports = {
 		]
 	},
 	plugins: [
-		// TODO: Add this back after https://github.com/web-infra-dev/rspack/issues/2619 lands
-		// new DedupeModuleResolvePlugin(),
+		new DedupeModuleResolvePlugin(),
 		new NamedChunksPlugin(),
 		new OccurrencesPlugin({
 			aot: true,


### PR DESCRIPTION
Several hooks needed for Angular have been added. This PR updates the example that we have to leverage the now available hooks / added compatibility. 
## Related issue (if exists)

Related to #3158

## Summary

As contributors are making updates we need to keep the examples up to date to reflect current reality. 

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 354e2e9</samp>

This file updates the rspack configuration for the Angular example to enhance the webpack bundling and caching process. It applies a plugin to avoid module duplication, adjusts the output settings for speed and uniqueness, and fine-tunes the async cache group enforcement.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 354e2e9</samp>

*  Enable and add `DedupeModuleResolvePlugin` to avoid duplicate modules and improve bundle performance and size ([link](https://github.com/web-infra-dev/rspack/pull/3302/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL2-R2), [link](https://github.com/web-infra-dev/rspack/pull/3302/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL163-R163))
*  Change `output` configuration to use faster hashing, avoid name conflicts, and specify output directory ([link](https://github.com/web-infra-dev/rspack/pull/3302/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL24-R27))
*  Force new chunk creation for `defaultAsync` cache group to optimize async loading and reduce initial bundle size ([link](https://github.com/web-infra-dev/rspack/pull/3302/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cL58-R58))
*  Add empty line for readability ([link](https://github.com/web-infra-dev/rspack/pull/3302/files?diff=unified&w=0#diff-efbae1a48cc71a1791202740465e837719c30221ce77cb2bb106495e0a60a55cR10))

</details>
