### PR TITLE
chore: avoid config check in webpack-test && add external test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test:example": "pnpm --filter \"example-*\" build",
     "test:unit": "pnpm --filter \"@rspack/*\" test",
     "test:e2e": "pnpm --filter \"@rspack-e2e/*\" test",
-    "test:ci": "NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:example && pnpm run test:unit"
+    "test:webpack": "pnpm --filter \"webpack-test\" test",
+    "test:ci": "NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:example && pnpm run test:unit && pnpm test:webpack"
   },
   "lint-staged": {
     "*.rs": "rustfmt --edition 2021",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
     "crates/rspack_plugin_runtime/**/*.{ts,js}": "prettier --write",
     "*.toml": "npx @taplo/cli format"
   },
-  "engines": {
-    "pnpm": "7.32.0"
-  },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/webpack-test/ChangesAndRemovalsTemp/temp-file.js
+++ b/webpack-test/ChangesAndRemovalsTemp/temp-file.js
@@ -1,2 +1,0 @@
-module.exports = function temp() {return 'temp file';};
- require('./temp-file2')

--- a/webpack-test/ChangesAndRemovalsTemp/temp-file2.js
+++ b/webpack-test/ChangesAndRemovalsTemp/temp-file2.js
@@ -1,1 +1,0 @@
-module.exports = function temp2() {return 'temp file 2';};

--- a/webpack-test/Stats.test.js
+++ b/webpack-test/Stats.test.js
@@ -159,10 +159,10 @@ describe("Stats", () => {
 			      "assets": [
 			        {
 			          "name": "entryB.js",
-			          "size": 4839,
+			          "size": 4837,
 			        },
 			      ],
-			      "assetsSize": 4839,
+			      "assetsSize": 4837,
 			      "chunks": [
 			        "entryB",
 			      ],
@@ -202,7 +202,7 @@ describe("Stats", () => {
 			        "hotModuleReplacement": false,
 			      },
 			      "name": "entryB.js",
-			      "size": 4839,
+			      "size": 4837,
 			      "type": "asset",
 			    },
 			    {

--- a/webpack-test/helpers/createLazyTestEnv.js
+++ b/webpack-test/helpers/createLazyTestEnv.js
@@ -1,18 +1,6 @@
-const STATE_SYM = Object.getOwnPropertySymbols(global).find(
-	Symbol("x").description
-		? s => s.description === "JEST_STATE_SYMBOL"
-		: s => s.toString() === "Symbol(JEST_STATE_SYMBOL)"
-);
-if (!STATE_SYM) {
-	throw new Error(
-		`Unable to find JEST_STATE_SYMBOL in ${Object.getOwnPropertySymbols(global)
-			.map(s => s.toString())
-			.join(", ")}`
-	);
-}
 
 module.exports = (globalTimeout = 2000, nameSuffix = "") => {
-	const state = global[STATE_SYM];
+	const state = global["JEST_STATE_SYMBOL"];
 	let currentDescribeBlock;
 	let currentlyRunningTest;
 	let runTests = -1;

--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -110,7 +110,7 @@
       "<rootDir>/schemas",
       "<rootDir>/node_modules"
     ],
-    "testEnvironment": "node",
+    "testEnvironment": "../scripts/test/patch-node-env.cjs",
     "coverageReporters": [
       "json"
     ]

--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -64,6 +64,7 @@
   },
   "jest": {
     "forceExit": true,
+    "setupFiles": ["<rootDir>/setupEnv.js"],
     "setupFilesAfterEnv": [
       "<rootDir>/setupTestFramework.js"
     ],

--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -110,7 +110,7 @@
       "<rootDir>/schemas",
       "<rootDir>/node_modules"
     ],
-    "testEnvironment": "../scripts/test/patch-node-env.cjs",
+    "testEnvironment": "./patch-node-env.js",
     "coverageReporters": [
       "json"
     ]

--- a/webpack-test/patch-node-env.js
+++ b/webpack-test/patch-node-env.js
@@ -1,0 +1,20 @@
+const NodeEnvironment =
+	// For jest@29
+	require("jest-environment-node").TestEnvironment ||
+	// For jest@27
+	require("jest-environment-node");
+
+class CustomEnvironment extends NodeEnvironment {
+	constructor(config, context) {
+		super(config, context);
+	}
+
+	// Workaround for `Symbol('JEST_STATE_SYMBOL')`
+	async handleTestEvent(event, state) {
+		if (!this.global["JEST_STATE_SYMBOL"]) {
+			this.global["JEST_STATE_SYMBOL"] = state;
+		}
+	}
+}
+
+module.exports = CustomEnvironment;

--- a/webpack-test/setupEnv.js
+++ b/webpack-test/setupEnv.js
@@ -1,0 +1,1 @@
+process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4552108</samp>

This pull request enables and updates some test cases for the externals feature of rspack, and adds a setup file to configure the rspack validation mode for the tests. It modifies `test.filter.js` files in `externals/global` and `externals/this` config cases, and adds `setupFiles` to `package.json` and `setupEnv.js` to `webpack-test`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4552108</samp>

* Enable testing global and this externals features of rspack by changing `test.filter.js` files to return `true` ([link](https://github.com/web-infra-dev/rspack/pull/3312/files?diff=unified&w=0#diff-fd49752f0d2e95496a79ab85b9b45c96b5750922adc57df2d3fab0b589fbd8daL1-L0), [link](https://github.com/web-infra-dev/rspack/pull/3312/files?diff=unified&w=0#diff-8dd12688eb658ec79f498c5a3bcc99dde9c81e240d58563fad59f0d3d73b56a1L1-L0))
* Add a `setupFiles` property to `package.json` to specify a `setupEnv.js` file for jest tests ([link](https://github.com/web-infra-dev/rspack/pull/3312/files?diff=unified&w=0#diff-ef6960a9216f589d8971ac9a37817f62fe5b99fe6e01f049e5325bb3c84a7159R67))
* Set `RSPACK_CONFIG_VALIDATE` environment variable to `loose-silent` in `setupEnv.js` to avoid validation errors or warnings in test cases ([link](https://github.com/web-infra-dev/rspack/pull/3312/files?diff=unified&w=0#diff-7e0e15753d2c756519df6ecc7d2a49dd5957659baadbd7776c8b99f12a342e55L1-L-1))

</details>
