### PR TITLE
ci: no need to listen for synchronize event in "lint pr title"

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,11 +1,10 @@
-name: "Lint PR"
+name: Lint PR Title
 
 on:
   pull_request_target:
     types:
       - opened
       - edited
-      - synchronize
 
 jobs:
   lint-pr-title:


### PR DESCRIPTION
synchronize event is triggered by git pushes, which doesn't change the pr title

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fc8a8a4</samp>

Improve linting workflow for pull request titles. Rename `.github/workflows/lint-pr.yaml` and refactor its steps to use a reusable action.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fc8a8a4</samp>

* Rename the workflow to Lint PR Title for clarity and consistency ([link](https://github.com/web-infra-dev/rspack/pull/3314/files?diff=unified&w=0#diff-fc98139577eb07d54e24aa5d41da856c636f5ad318d0ad700f13a457c136cb80L1-R1))
* Remove the synchronize event from the trigger list to avoid unnecessary linting runs ([link](https://github.com/web-infra-dev/rspack/pull/3314/files?diff=unified&w=0#diff-fc98139577eb07d54e24aa5d41da856c636f5ad318d0ad700f13a457c136cb80L8))

</details>
