### PR TITLE
feat: Add 'succeedModule' and 'stillValidModule' hooks

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -198,6 +198,8 @@ export interface JsHooks {
   contextModuleBeforeResolve: (...args: any[]) => any
   normalModuleFactoryResolveForScheme: (...args: any[]) => any
   chunkAsset: (...args: any[]) => any
+  succeedModule: (...args: any[]) => any
+  stillValidModule: (...args: any[]) => any
 }
 
 export interface JsLoader {
@@ -355,12 +357,6 @@ export interface JsStatsModuleReason {
 export interface JsStatsWarning {
   message: string
   formatted: string
-}
-
-export interface NodeFS {
-  writeFile: (...args: any[]) => any
-  mkdir: (...args: any[]) => any
-  mkdirp: (...args: any[]) => any
 }
 
 export interface PathData {

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -28,6 +28,8 @@ pub enum Hook {
   NormalModuleFactoryResolveForScheme,
   AfterResolve,
   BeforeResolve,
+  SucceedModule,
+  StillValidModule,
 }
 
 impl From<String> for Hook {
@@ -57,6 +59,8 @@ impl From<String> for Hook {
       "normalModuleFactoryResolveForScheme" => Hook::NormalModuleFactoryResolveForScheme,
       "afterResolve" => Hook::AfterResolve,
       "beforeResolve" => Hook::BeforeResolve,
+      "succeedModule" => Hook::SucceedModule,
+      "stillValidModule" => Hook::StillValidModule,
       hook_name => panic!("{hook_name} is an invalid hook name"),
     }
   }

--- a/crates/node_binding/src/js_values/hooks.rs
+++ b/crates/node_binding/src/js_values/hooks.rs
@@ -27,4 +27,6 @@ pub struct JsHooks {
   pub context_module_before_resolve: JsFunction,
   pub normal_module_factory_resolve_for_scheme: JsFunction,
   pub chunk_asset: JsFunction,
+  pub succeed_module: JsFunction,
+  pub still_valid_module: JsFunction,
 }

--- a/crates/node_binding/src/js_values/module.rs
+++ b/crates/node_binding/src/js_values/module.rs
@@ -15,7 +15,7 @@ pub trait ToJsModule {
   fn to_js_module(&self) -> Result<JsModule>;
 }
 
-impl ToJsModule for dyn Module {
+impl ToJsModule for dyn Module + '_ {
   fn to_js_module(&self) -> Result<JsModule> {
     let original_source = self
       .original_source()

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -358,6 +358,10 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
+  async fn still_valid_module(&self, _module: &dyn Module) -> Result<()> {
+    Ok(())
+  }
+
   fn module_ids(&mut self, _modules: &mut Compilation) -> Result<()> {
     Ok(())
   }

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -546,9 +546,18 @@ impl PluginDriver {
     Ok(())
   }
 
+  #[instrument(name = "plugin:succeed_module", skip_all)]
   pub async fn succeed_module(&self, module: &dyn Module) -> Result<()> {
     for plugin in &self.plugins {
       plugin.succeed_module(module).await?;
+    }
+    Ok(())
+  }
+
+  #[instrument(name = "plugin:still_valid_module", skip_all)]
+  pub async fn still_valid_module(&self, module: &dyn Module) -> Result<()> {
+    for plugin in &self.plugins {
+      plugin.still_valid_module(module).await?;
     }
     Ok(())
   }

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -88,6 +88,8 @@ export class Compilation {
 		finishModules: tapable.AsyncSeriesHook<[Iterable<JsModule>], undefined>;
 		chunkAsset: tapable.SyncHook<[JsChunk, string], undefined>;
 		processWarnings: tapable.SyncWaterfallHook<[Error[]]>;
+		succeedModule: tapable.SyncHook<[JsModule], undefined>;
+		stillValidModule: tapable.SyncHook<[JsModule], undefined>;
 	};
 	options: RspackOptionsNormalized;
 	outputOptions: OutputNormalized;
@@ -121,7 +123,9 @@ export class Compilation {
 			]),
 			finishModules: new tapable.AsyncSeriesHook(["modules"]),
 			chunkAsset: new tapable.SyncHook(["chunk", "filename"]),
-			processWarnings: new tapable.SyncWaterfallHook(["warnings"])
+			processWarnings: new tapable.SyncWaterfallHook(["warnings"]),
+			succeedModule: new tapable.SyncHook(["module"]),
+			stillValidModule: new tapable.SyncHook(["module"])
 		};
 		this.compiler = compiler;
 		this.resolverFactory = compiler.resolverFactory;

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -341,7 +341,9 @@ class Compiler {
 					beforeResolve: this.#beforeResolve.bind(this),
 					afterResolve: this.#afterResolve.bind(this),
 					contextModuleBeforeResolve:
-						this.#contextModuleBeforeResolve.bind(this)
+						this.#contextModuleBeforeResolve.bind(this),
+					succeedModule: this.#succeedModule.bind(this),
+					stillValidModule: this.#stillValidModule.bind(this)
 				},
 				createThreadsafeNodeFSFromRaw(this.outputFileSystem),
 				loaderContext => runLoader(loaderContext, this)
@@ -602,7 +604,9 @@ class Compiler {
 			optimizeModules: this.compilation.hooks.optimizeModules,
 			chunkAsset: this.compilation.hooks.chunkAsset,
 			beforeResolve: this.compilation.normalModuleFactory?.hooks.beforeResolve,
-			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve
+			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve,
+			succeedModule: this.compilation.hooks.succeedModule,
+			stillValidModule: this.compilation.hooks.stillValidModule
 		};
 		for (const [name, hook] of Object.entries(hookMap)) {
 			if (hook?.taps.length === 0) {
@@ -745,6 +749,16 @@ class Compiler {
 
 	async #afterEmit() {
 		await this.hooks.afterEmit.promise(this.compilation);
+		this.#updateDisabledHooks();
+	}
+
+	#succeedModule(module: binding.JsModule) {
+		this.compilation.hooks.succeedModule.call(module);
+		this.#updateDisabledHooks();
+	}
+
+	#stillValidModule(module: binding.JsModule) {
+		this.compilation.hooks.stillValidModule.call(module);
 		this.#updateDisabledHooks();
 	}
 

--- a/packages/rspack/tests/cases/hooks/stillValidModule/package.json
+++ b/packages/rspack/tests/cases/hooks/stillValidModule/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/rspack/tests/cases/hooks/stillValidModule/plugins/MyStillValidModulePlugin.js
+++ b/packages/rspack/tests/cases/hooks/stillValidModule/plugins/MyStillValidModulePlugin.js
@@ -1,0 +1,15 @@
+class MyStillValidModulePlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MyStillValidModulePlugin", compilation => {
+			compilation.hooks.stillValidModule.tap(
+				"MyStillValidModulePlugin",
+				module => {
+					console.log("this module is valid and not need rebuild");
+					console.log(module);
+				}
+			);
+		});
+	}
+}
+
+module.exports = MyStillValidModulePlugin;

--- a/packages/rspack/tests/cases/hooks/stillValidModule/src/answer.js
+++ b/packages/rspack/tests/cases/hooks/stillValidModule/src/answer.js
@@ -1,0 +1,1 @@
+export const answer = "world";

--- a/packages/rspack/tests/cases/hooks/stillValidModule/src/index.js
+++ b/packages/rspack/tests/cases/hooks/stillValidModule/src/index.js
@@ -1,0 +1,2 @@
+import { answer } from "./answer";
+console.log(`hello ${answer}`);

--- a/packages/rspack/tests/cases/hooks/stillValidModule/webpack.config.js
+++ b/packages/rspack/tests/cases/hooks/stillValidModule/webpack.config.js
@@ -1,0 +1,13 @@
+const MyStillValidModulePlugin = require("./plugins/MyStillValidModulePlugin");
+
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	context: __dirname,
+	mode: "development",
+	watch: true,
+	entry: {
+		main: "./src/index.js"
+	},
+	plugins: [new MyStillValidModulePlugin()]
+};
+module.exports = config;

--- a/packages/rspack/tests/cases/hooks/succeedModule/package.json
+++ b/packages/rspack/tests/cases/hooks/succeedModule/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "test-succeed-module-hook",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/rspack/tests/cases/hooks/succeedModule/plugins/MySucceedModulePlugin.js
+++ b/packages/rspack/tests/cases/hooks/succeedModule/plugins/MySucceedModulePlugin.js
@@ -1,0 +1,12 @@
+class MySucceedModulePlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("MySucceedModulePlugin", compilation => {
+			compilation.hooks.succeedModule.tap("MySucceedModulePlugin", module => {
+				console.log("trigger succeedModule hook success");
+				console.log(module);
+			});
+		});
+	}
+}
+
+module.exports = MySucceedModulePlugin;

--- a/packages/rspack/tests/cases/hooks/succeedModule/src/answer.js
+++ b/packages/rspack/tests/cases/hooks/succeedModule/src/answer.js
@@ -1,0 +1,1 @@
+export const answer = "world";

--- a/packages/rspack/tests/cases/hooks/succeedModule/src/index.js
+++ b/packages/rspack/tests/cases/hooks/succeedModule/src/index.js
@@ -1,0 +1,2 @@
+import { answer } from "./answer";
+console.log(`hello ${answer}`);

--- a/packages/rspack/tests/cases/hooks/succeedModule/webpack.config.js
+++ b/packages/rspack/tests/cases/hooks/succeedModule/webpack.config.js
@@ -1,0 +1,14 @@
+const MySucceedModulePlugin = require("./plugins/MySucceedModulePlugin");
+
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	context: __dirname,
+	mode: "development",
+	watch: true,
+	entry: {
+		main: "./src/index.js"
+	},
+	plugins: [new MySucceedModulePlugin()]
+};
+
+module.exports = config;


### PR DESCRIPTION
## Related issue (if exists)

[#3286 ](https://github.com/web-infra-dev/rspack/issues/3286)

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5f194f</samp>

This pull request adds two new hooks, `succeedModule` and `stillValidModule`, to the rspack web infrastructure, which allow plugins to handle module build and validity events. It implements these hooks in the Rust and JavaScript layers of the system, and adds test cases to verify their functionality. It also makes some minor changes to the types and traits related to the hooks to fix compiler errors and improve readability.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5f194f</samp>

*  Add two new hooks for plugins: `succeedModule` and `stillValidModule` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R29-R30), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R58-R59), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR28-R29), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R50-R51), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R482-R513), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R542-R543), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R621-R622), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R357-R360), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR538), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR546-R553), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R91-R92), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L124-R128), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL595-R599), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR725-R734))
  * The `succeedModule` hook is triggered when a module is successfully built ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R29-R30), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R58-R59), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR28-R29), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R50-R51), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R482-R513), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R542-R543), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R621-R622), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R357-R360), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR538), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R91-R92), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L124-R128), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL595-R599), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR725-R734))
    * Add a new variant to the `Hook` enum in `./crates/node_binding/src/hook.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R29-R30))
    * Add a new case to the `from_str` function in `./crates/node_binding/src/hook.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R58-R59))
    * Add a new field to the `JsHooks` struct in `./crates/node_binding/src/js_values/hooks.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR28-R29))
    * Add a new import, field, and method to the `PluginDriver` struct in `./crates/node_binding/src/plugins/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R50-R51), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R482-R513))
    * Add a new argument and statement to the `new` function of the `PluginDriver` struct in `./crates/node_binding/src/plugins/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R542-R543), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R591-R594))
    * Add a new argument and field to the `PluginDriver` struct initialization in `./crates/node_binding/src/plugins/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R621-R622))
    * Add a new method to the `Plugin` trait in `./crates/rspack_core/src/plugin/api.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R357-R360))
    * Add a new attribute and method to the `PluginDriver` struct in `./crates/rspack_core/src/plugin/plugin_driver.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR538))
    * Add a new field and method to the `Compilation` class in `packages/rspack/src/compilation.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R91-R92), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L124-R128))
    * Add a new field and method to the `Compiler` class in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR725-R734))
    * Add a new field to the `hooks` object in the constructor of the `Compiler` class in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338))
    * Add a new field to the `hookMap` object in the `#registerHooks` method of the `Compiler` class in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL595-R599))
  * The `stillValidModule` hook is triggered when a module is valid and does not need to be rebuilt ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R29-R30), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R58-R59), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR28-R29), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-95c957e3bc52dfdce0db5276ec60213a6223a2dacce1659810127be853604b47L18-R18), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R50-R51), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R482-R513), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R542-R543), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R621-R622), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L32-R32), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L40-R40), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L55-R55), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L104-R104), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L232-R232), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L256-R269), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R357-R360), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR546-R553), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R91-R92), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L124-R128), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL595-R599), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR725-R734))
    * Add a new variant to the `Hook` enum in `./crates/node_binding/src/hook.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R29-R30))
    * Add a new case to the `from_str` function in `./crates/node_binding/src/hook.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R58-R59))
    * Add a new field to the `JsHooks` struct in `./crates/node_binding/src/js_values/hooks.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR28-R29))
    * Add a lifetime annotation to the `ToJsModule` trait in `./crates/node_binding/src/js_values/module.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-95c957e3bc52dfdce0db5276ec60213a6223a2dacce1659810127be853604b47L18-R18))
    * Add a new import, field, and method to the `PluginDriver` struct in `./crates/node_binding/src/plugins/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L19-R20), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R50-R51), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R482-R513))
    * Add a new argument and statement to the `new` function of the `PluginDriver` struct in `./crates/node_binding/src/plugins/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R542-R543), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R591-R594))
    * Add a new argument and field to the `PluginDriver` struct initialization in `./crates/node_binding/src/plugins/mod.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R621-R622))
    * Modify the return type and value of the `use_cache` method of the `BuildModuleOccasion` struct in `./crates/rspack_core/src/cache/occasion/build_module.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L32-R32), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L40-R40), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L55-R55), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432L104-R104))
    * Modify the assignment of the `build_result` variable and add a new conditional statement to the `build_module` method of the `Queue` struct in `./crates/rspack_core/src/compiler/queue.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L232-R232), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L256-R269))
    * Add a new method to the `Plugin` trait in `./crates/rspack_core/src/plugin/api.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R357-R360))
    * Add a new method to the `PluginDriver` struct in `./crates/rspack_core/src/plugin/plugin_driver.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR546-R553))
    * Add a new field and method to the `Compilation` class in `packages/rspack/src/compilation.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R91-R92), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L124-R128))
    * Add a new field and method to the `Compiler` class in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR725-R734))
    * Add a new field to the `hooks` object in the constructor of the `Compiler` class in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL336-R338))
    * Add a new field to the `hookMap` object in the `#registerHooks` method of the `Compiler` class in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL595-R599))
* Add two test cases for the new hooks in `packages/rspack/tests/cases/hooks` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-fb03d98a375c8ff02cf5dc2509624eb8c19bd443daaf363a142e982ee863a372L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-ca452c2ae7694ea3eb89586d225c44bcd6e6c9847eff13f9e9b6fa5b547950d2R1-R15), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-c0245cc5f0286007af50707d999a3af02be65e9e550b699e6f3ad9644cb1bf13R1-R13), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-2bd9114ff3583dda01275750ea11a1a61ce7fad00a5b7b9480c19f1e5ea0182fR1), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a7ec1f67988261ce36ee4dee801b4823090833e2385bbe1484168737de94edc7R1-R2), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-9f3f53b77f122a6f354c7157ee8e479e1161aafc8595fe7c20575096b9c49fd0L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-6095ab2ec22054306a2e75dea527cecf961b80d9ecfba7b987472798445e2a5bR1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-78f83e80f848f0c3587d1a454ddf15a3fc98c84c4e658474c006f326b392a9a8R1-R14), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-e36dd5608511078d106c7d0052f0bdd2f8eb0740e2621a88defb54b301eec108R1), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-9ad9a538681b2d757c128b03b2a67c56d1a336447083f5d81c74be83e2e1921bR1-R2))
  * The `stillValidModule` test case tests the `stillValidModule` hook by logging a message and the module argument to the console when the hook is triggered ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-fb03d98a375c8ff02cf5dc2509624eb8c19bd443daaf363a142e982ee863a372L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-ca452c2ae7694ea3eb89586d225c44bcd6e6c9847eff13f9e9b6fa5b547950d2R1-R15), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-c0245cc5f0286007af50707d999a3af02be65e9e550b699e6f3ad9644cb1bf13R1-R13), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-2bd9114ff3583dda01275750ea11a1a61ce7fad00a5b7b9480c19f1e5ea0182fR1), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a7ec1f67988261ce36ee4dee801b4823090833e2385bbe1484168737de94edc7R1-R2))
    * Add a `package.json` file for the test case package ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-fb03d98a375c8ff02cf5dc2509624eb8c19bd443daaf363a142e982ee863a372L1-R17))
    * Add a custom plugin that taps into the `stillValidModule` hook in `./plugins/MyStillValidModulePlugin.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-ca452c2ae7694ea3eb89586d225c44bcd6e6c9847eff13f9e9b6fa5b547950d2R1-R15))
    * Add a configuration file that sets the `context`, `mode`, `watch`, `entry`, and `plugins` fields for the compiler in `./rspack.config.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-c0245cc5f0286007af50707d999a3af02be65e9e550b699e6f3ad9644cb1bf13R1-R13))
    * Add a main module that imports a constant from another module and logs a message to the console in `./src/index.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-a7ec1f67988261ce36ee4dee801b4823090833e2385bbe1484168737de94edc7R1-R2))
    * Add a module that exports a constant in `./src/answer.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-2bd9114ff3583dda01275750ea11a1a61ce7fad00a5b7b9480c19f1e5ea0182fR1))
  * The `succeedModule` test case tests the `succeedModule` hook by logging a message and the module argument to the console when the hook is triggered ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-9f3f53b77f122a6f354c7157ee8e479e1161aafc8595fe7c20575096b9c49fd0L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-6095ab2ec22054306a2e75dea527cecf961b80d9ecfba7b987472798445e2a5bR1-R12), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-78f83e80f848f0c3587d1a454ddf15a3fc98c84c4e658474c006f326b392a9a8R1-R14), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-e36dd5608511078d106c7d0052f0bdd2f8eb0740e2621a88defb54b301eec108R1), [link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-9ad9a538681b2d757c128b03b2a67c56d1a336447083f5d81c74be83e2e1921bR1-R2))
    * Add a `package.json` file for the test case package ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-9f3f53b77f122a6f354c7157ee8e479e1161aafc8595fe7c20575096b9c49fd0L1-R17))
    * Add a custom plugin that taps into the `succeedModule` hook in `./plugins/MySucceedModulePlugin.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-6095ab2ec22054306a2e75dea527cecf961b80d9ecfba7b987472798445e2a5bR1-R12))
    * Add a configuration file that sets the `context`, `mode`, `watch`, `entry`, and `plugins` fields for the compiler in `./rspack.config.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-78f83e80f848f0c3587d1a454ddf15a3fc98c84c4e658474c006f326b392a9a8R1-R14))
    * Add a main module that imports a constant from another module and logs a message to the console in `./src/index.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-9ad9a538681b2d757c128b03b2a67c56d1a336447083f5d81c74be83e2e1921bR1-R2))
    * Add a module that exports a constant in `./src/answer.js` ([link](https://github.com/web-infra-dev/rspack/pull/3318/files?diff=unified&w=0#diff-e36dd5608511078d106c7d0052f0bdd2f8eb0740e2621a88defb54b301eec108R1))

</details>
