### PR TITLE
chore: change monoreo root version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
   "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [["@rspack/*"]],
+  "fixed": [["@rspack/*", "monorepo"]],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "0.1.12",
+  "name": "monorepo",
   "version": "0.1.12",
   "license": "MIT",
   "description": "A Fast Rust-based web bundler",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "monorepo",
-  "version": "1.0.0",
+  "name": "0.1.12",
+  "version": "0.1.12",
   "license": "MIT",
   "description": "A Fast Rust-based web bundler",
   "private": true,


### PR DESCRIPTION
## Related issue (if exists)
pull request action need to get version from package root
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6faab3e</samp>

The pull request updates the `.changeset/config.json` and `package.json` files to enable fixed versioning and publishing of the `monorepo` and `@rspack/*` packages. This improves the consistency and reliability of the `rspack` project, which is a Rust-based web bundler.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6faab3e</samp>

*  Update `fixed` field in `.changeset/config.json` to include `monorepo` as a fixed dependency of all `@rspack/*` packages ([link](https://github.com/web-infra-dev/rspack/pull/3323/files?diff=unified&w=0#diff-ed5b41335ff968c5cfd8035d4b8f8c8c0538b6746182d522adb0312eb9137fc5L5-R5))
*  Align `name` and `version` fields in `package.json` of `monorepo` with `@rspack/*` packages ([link](https://github.com/web-infra-dev/rspack/pull/3323/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L2-R3))

</details>
