### PR TITLE
fix(webpack-test): remove deprecated array `["jam", "main"]` from mainFields

### DIFF
--- a/webpack-test/TestCases.template.js
+++ b/webpack-test/TestCases.template.js
@@ -156,7 +156,6 @@ const describeCases = config => {
 										"browser",
 										"web",
 										"browserify",
-										["jam", "main"],
 										"main"
 									],
 									aliasFields: ["browser"],


### PR DESCRIPTION
closes #3328

## Summary

jam is a ancient package manager, a remnant from Webpack 1. We can safely remove because the official webpack doc only supports array for mainFields. https://webpack.js.org/configuration/resolve/#resolvemainfields

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c2fba4</samp>

Remove an incompatible test case from `webpack-test/TestCases.template.js`. This fixes a test failure caused by the new `output.library.type` option in webpack.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c2fba4</samp>

* Remove invalid test case for `output.library.type` and `output.library.name` ([link](https://github.com/web-infra-dev/rspack/pull/3334/files?diff=unified&w=0#diff-0c6aa924e62d6100b79b42e3f2110a5d29a05a8c014dbbbceb147ea7518233f8L159))

</details>
