### PR TITLE
chore: fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Release Full
         run: |
-          ./x publish stable --tag ${{inputs.tag}} $${inputs.dry_run && '--dry-run' || '--no-dry-run'} $${inputs.push_tags && '--push-tags' || '--no-push-tags'}
+          ./x publish stable --tag ${{inputs.tag}} ${{inputs.dry_run && '--dry-run' || '--no-dry-run'}} ${{inputs.push_tags && '--push-tags' || '--no-push-tags'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f3918c2</samp>

Fixed a syntax error in the release workflow that prevented inputs from being passed to the publish script. Updated `.github/workflows/release.yml` to use double curly braces for interpolation.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f3918c2</samp>

* Fix input interpolation syntax in run command ([link](https://github.com/web-infra-dev/rspack/pull/3336/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L80-R80))

</details>
