### PR TITLE
feat: enable realContentHash in production by default

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -870,6 +870,7 @@ export interface RawTrustedTypes {
 
 export interface ThreadsafeNodeFS {
   writeFile: (...args: any[]) => any
+  removeFile: (...args: any[]) => any
   mkdir: (...args: any[]) => any
   mkdirp: (...args: any[]) => any
   removeDirAll: (...args: any[]) => any

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -576,8 +576,7 @@ const applyOptimizationDefaults = (
 	});
 	F(optimization, "sideEffects", () => (production ? true : "flag"));
 	D(optimization, "runtimeChunk", false);
-	// TODO: change to true in production once realContentHash is stable
-	D(optimization, "realContentHash", false);
+	D(optimization, "realContentHash", production);
 	D(optimization, "minimize", production);
 	A(optimization, "minimizer", () => []);
 	const { splitChunks } = optimization;

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -126,7 +126,9 @@ describe("snapshots", () => {
 		+     "minimize": true,
 		@@ ... @@
 		-     "moduleIds": "named",
+		-     "realContentHash": false,
 		+     "moduleIds": "deterministic",
+		+     "realContentHash": true,
 		@@ ... @@
 		-     "sideEffects": "flag",
 		+     "sideEffects": true,
@@ -175,7 +177,9 @@ describe("snapshots", () => {
 		+     "minimize": true,
 		@@ ... @@
 		-     "moduleIds": "named",
+		-     "realContentHash": false,
 		+     "moduleIds": "deterministic",
+		+     "realContentHash": true,
 		@@ ... @@
 		-     "sideEffects": "flag",
 		+     "sideEffects": true,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3e5c02e</samp>

Updated webpack configuration and dependencies in `rspack` package. Enabled `realContentHash` option for deterministic hashing in production mode.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3e5c02e</samp>

* Enable deterministic hashing of output files based on content in production mode (`realContentHash` option in [link](https://github.com/web-infra-dev/rspack/pull/3338/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccL579-R579))

</details>
