### PR TITLE
chore: remove override

### DIFF
--- a/examples/react-storybook/package.json
+++ b/examples/react-storybook/package.json
@@ -24,6 +24,6 @@
     "@types/react-dom": "^18.0.8",
     "prop-types": "^15.8.1",
     "storybook": "^7.0.0",
-    "storybook-react-rspack": "7.0.0-rc.16"
+    "storybook-react-rspack": "7.0.0-rc.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,10 +73,5 @@
     "sass-embedded-win32-ia32": "1.58.3",
     "sass-embedded-win32-x64": "1.58.3"
   },
-  "packageManager": "pnpm@7.32.0",
-  "pnpm": {
-    "overrides": {
-      "@rspack/core": "0.1.12"
-    }
-  }
+  "packageManager": "pnpm@7.32.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,5 @@
 lockfileVersion: 5.4
 
-overrides:
-  '@rspack/core': 0.1.12
-
 importers:
 
   .:
@@ -515,7 +512,7 @@ importers:
       react: ^17.0.2
       react-dom: ^17.0.2
       storybook: ^7.0.0
-      storybook-react-rspack: 7.0.0-rc.16
+      storybook-react-rspack: 7.0.0-rc.18
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -531,7 +528,7 @@ importers:
       '@types/react-dom': 18.2.4
       prop-types: 15.8.1
       storybook: 7.0.15
-      storybook-react-rspack: 7.0.0-rc.16_sfoxds7t5ydpegc3knd667wn6m
+      storybook-react-rspack: 7.0.0-rc.18_sfoxds7t5ydpegc3knd667wn6m
 
   examples/react-with-less:
     specifiers:
@@ -735,7 +732,7 @@ importers:
 
   packages/playground:
     specifiers:
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@rspack/dev-server': workspace:*
       '@types/fs-extra': 11.0.1
       fs-extra: 11.1.1
@@ -778,7 +775,7 @@ importers:
   packages/rspack:
     specifiers:
       '@rspack/binding': workspace:*
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@rspack/dev-client': workspace:*
       '@rspack/plugin-minify': workspace:^
       '@rspack/plugin-node-polyfill': workspace:^
@@ -869,7 +866,7 @@ importers:
   packages/rspack-cli:
     specifiers:
       '@discoveryjs/json-ext': ^0.5.7
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@rspack/dev-server': workspace:*
       '@types/webpack-bundle-analyzer': ^4.6.0
       colorette: 2.0.19
@@ -910,7 +907,7 @@ importers:
 
   packages/rspack-dev-middleware:
     specifiers:
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@types/mime-types': 2.1.1
       mime-types: 2.1.35
       webpack-dev-middleware: 6.0.2
@@ -923,7 +920,7 @@ importers:
 
   packages/rspack-dev-server:
     specifiers:
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@rspack/dev-client': workspace:*
       '@rspack/dev-middleware': workspace:*
       '@rspack/dev-server': workspace:*
@@ -960,7 +957,7 @@ importers:
 
   packages/rspack-plugin-html:
     specifiers:
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@types/html-minifier-terser': 7.0.0
       '@types/lodash.template': ^4.5.1
       '@types/pug': ^2.0.6
@@ -1072,7 +1069,7 @@ importers:
   webpack-test:
     specifiers:
       '@rspack/binding': workspace:*
-      '@rspack/core': 0.1.12
+      '@rspack/core': workspace:*
       '@rspack/dev-client': workspace:*
       '@rspack/plugin-minify': workspace:^
       '@rspack/plugin-node-polyfill': workspace:^
@@ -3709,7 +3706,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
   /@babel/plugin-syntax-typescript/7.20.0_@babel+core@7.21.0:
@@ -3719,7 +3716,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.21.5
     dev: true
 
   /@babel/plugin-transform-arrow-functions/7.18.6:
@@ -7308,7 +7305,7 @@ packages:
       webpack: 5.76.0
     dev: false
 
-  /@pmmmwh/react-refresh-webpack-plugin/0.5.10_prxwy2zxcolvdag5hfkyuqbcze:
+  /@pmmmwh/react-refresh-webpack-plugin/0.5.10_react-refresh@0.11.0:
     resolution: {integrity: sha512-j0Ya0hCFZPd4x40qLzbhGsh9TMtdb+CJQiso+WxLOPNasohq9cc5SNUcwsZaRH6++Xh91Xkm/xHCkuIiIu0LUA==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -7344,8 +7341,6 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.1.1
       source-map: 0.7.4
-      webpack: 5.74.0
-      webpack-dev-server: 4.11.1_webpack@5.74.0
     dev: true
 
   /@pmmmwh/react-refresh-webpack-plugin/0.5.10_react-refresh@0.14.0:
@@ -7908,6 +7903,26 @@ packages:
       - webpack-plugin-serve
     dev: true
 
+  /@rspack/dev-client/0.1.12_react-refresh@0.11.0:
+    resolution: {integrity: sha512-LmqO7qKDH+tosk7WUc2CPbM3AeosPJqEdiNAp7z+qgO8h5ts3L/TOf+VYanKEABnCPm8/ZecJkA57evsswVr6w==}
+    peerDependencies:
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      react-refresh:
+        optional: true
+    dependencies:
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_react-refresh@0.11.0
+      react-refresh: 0.11.0
+    transitivePeerDependencies:
+      - '@types/webpack'
+      - sockjs-client
+      - type-fest
+      - webpack
+      - webpack-dev-server
+      - webpack-hot-middleware
+      - webpack-plugin-serve
+    dev: true
+
   /@rspack/dev-client/0.1.12_react-refresh@0.14.0:
     resolution: {integrity: sha512-LmqO7qKDH+tosk7WUc2CPbM3AeosPJqEdiNAp7z+qgO8h5ts3L/TOf+VYanKEABnCPm8/ZecJkA57evsswVr6w==}
     peerDependencies:
@@ -7948,38 +7963,8 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/dev-client/0.1.7_react-refresh@0.11.0:
-    resolution: {integrity: sha512-NhW+bGZN5TGRQncE+HqA5EwkfyO6DEGMLlIpmDlmJtA7ut5islwKCRX/B109D402DpwlcepVWzf+qOH+SA6Auw==}
-    peerDependencies:
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      react-refresh:
-        optional: true
-    dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_prxwy2zxcolvdag5hfkyuqbcze
-      events: 3.3.0
-      react-refresh: 0.11.0
-      webpack: 5.74.0
-      webpack-dev-server: 4.11.1_webpack@5.74.0
-      ws: 8.8.1
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/webpack'
-      - bufferutil
-      - debug
-      - esbuild
-      - sockjs-client
-      - supports-color
-      - type-fest
-      - uglify-js
-      - utf-8-validate
-      - webpack-cli
-      - webpack-hot-middleware
-      - webpack-plugin-serve
-    dev: true
-
-  /@rspack/dev-middleware/0.1.7_qm4rr5mytgdyqzehxbm6j4rrt4:
-    resolution: {integrity: sha512-upxbL7jeJyYfr3bNde3RHs6nZg3CiJURTuMH00VdOsydXbbWlGAAMjmkOKBmOuj4czKvvvFzdivms3Kyjf5bMQ==}
+  /@rspack/dev-middleware/0.1.12_qm4rr5mytgdyqzehxbm6j4rrt4:
+    resolution: {integrity: sha512-1q/0cJwLup/i6Cg/wdum7B1ctLtuly93rh/AhTLUYGk3PSxfBj/tPF2jJN93q0eBGGzxmAmc+rORm7nirVpNVw==}
     dependencies:
       '@rspack/core': 0.1.12_qm4rr5mytgdyqzehxbm6j4rrt4
       mime-types: 2.1.35
@@ -7994,8 +7979,13 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspack/plugin-html/0.1.7_qm4rr5mytgdyqzehxbm6j4rrt4:
-    resolution: {integrity: sha512-Msq41PFQeEjE8zooxtgRWdvGNNqMRt1a2KouWxMqwBhk3WxX+r2o9aZPgxqPvwcqUwHEpoTKnr3ZML9VUHXpFQ==}
+  /@rspack/plugin-html/0.1.12_@rspack+core@0.1.12:
+    resolution: {integrity: sha512-psXGN6DPnerEzazbeANfyc+E/ehhv1ouu6IdJtJaqfQf1kzQcJMs19lBNlfq6TxoVD6oS8BGigoYH7XrlQZRmQ==}
+    peerDependencies:
+      '@rspack/core': 0.1.12
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
     dependencies:
       '@rspack/core': 0.1.12_qm4rr5mytgdyqzehxbm6j4rrt4
       '@types/html-minifier-terser': 7.0.0
@@ -8003,14 +7993,6 @@ packages:
       lodash.template: 4.5.0
       parse5: 7.1.1
       tapable: 2.2.1
-    transitivePeerDependencies:
-      - '@types/webpack'
-      - sockjs-client
-      - type-fest
-      - webpack
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
     dev: true
 
   /@schematics/angular/16.0.0:
@@ -24794,8 +24776,8 @@ packages:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
     dev: true
 
-  /storybook-builder-rspack/7.0.0-rc.16_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-AO1pzkZIiQL1ypc0u+ODRjx+5J4loi4DJ9yVUErmoJR78Tm0MGNioDknTg8L74GwcJirc39hu3HlnGVmoVyObA==}
+  /storybook-builder-rspack/7.0.0-rc.18_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-KPRnuBqeow3PXDz1SP3ldvj2ozHFtoQHjXKdsBZKWtthpFfaCLmCEhMqNX54fpL5x5EEoFujIz5cqCBM85KLZA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -24806,8 +24788,8 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@rspack/core': 0.1.12_qm4rr5mytgdyqzehxbm6j4rrt4
-      '@rspack/dev-middleware': 0.1.7_qm4rr5mytgdyqzehxbm6j4rrt4
-      '@rspack/plugin-html': 0.1.7_qm4rr5mytgdyqzehxbm6j4rrt4
+      '@rspack/dev-middleware': 0.1.12_qm4rr5mytgdyqzehxbm6j4rrt4
+      '@rspack/plugin-html': 0.1.12_@rspack+core@0.1.12
       '@storybook/addon-docs': 7.0.0_lps2pwb3rzegptlzya6mxdlhc4
       '@storybook/addons': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/api': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
@@ -24822,6 +24804,7 @@ packages:
       '@storybook/global': 5.0.0
       '@storybook/manager-api': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/mdx1-csf': 1.0.0_react@17.0.2
+      '@storybook/mdx2-csf': 1.1.0
       '@storybook/node-logger': 7.0.0
       '@storybook/preview': 7.0.0
       '@storybook/preview-api': 7.0.0
@@ -24833,11 +24816,13 @@ packages:
       babel-loader: 9.1.2_@babel+core@7.21.0
       babel-plugin-named-exports-order: 0.0.2
       browser-assert: 1.2.1
-      css-loader: 6.7.3
+      chokidar: 3.5.3
+      css-loader: 6.7.4
       express: 4.18.1
       fork-ts-checker-webpack-plugin: 7.3.0
       fs-extra: 11.1.1
       glob-promise: 6.0.2
+      minimatch: 9.0.0
       path-browserify: 1.0.1
       process: 0.11.10
       react: 17.0.2
@@ -24863,8 +24848,8 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /storybook-preset-react-rspack/7.0.0-rc.16_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-lJ+r1j7WbZD0IYs/N/I4SGKle5vQCIiBHIpf1dw6uRXpLI1mZeLg1MBewF4VcaEgNPBhLX3OrIo0V1+8ukdirw==}
+  /storybook-preset-react-rspack/7.0.0-rc.18_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-GzaFaNT8KES5+cbGtETSRkd3t2shTWJmZ9jvtihdgsfxzoGlxK7hhR6mXn66lLy0wBqh5JbRtureE1SHsv/eaA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@babel/core': ^7.11.5
@@ -24879,7 +24864,7 @@ packages:
     dependencies:
       '@babel/plugin-syntax-typescript': 7.20.0
       '@rspack/core': 0.1.12
-      '@rspack/dev-client': 0.1.7_react-refresh@0.11.0
+      '@rspack/dev-client': 0.1.12_react-refresh@0.11.0
       '@storybook/docs-tools': 7.0.0
       '@storybook/node-logger': 7.0.0
       '@storybook/react': 7.0.0_sfoxds7t5ydpegc3knd667wn6m
@@ -24898,25 +24883,18 @@ packages:
       semver: 7.5.1
       tinypool: 0.4.0
     transitivePeerDependencies:
-      - '@swc/core'
       - '@types/webpack'
-      - bufferutil
-      - debug
-      - esbuild
       - sockjs-client
       - supports-color
       - type-fest
-      - uglify-js
-      - utf-8-validate
       - webpack
-      - webpack-cli
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
     dev: true
 
-  /storybook-react-rspack/7.0.0-rc.16_sfoxds7t5ydpegc3knd667wn6m:
-    resolution: {integrity: sha512-vrHvhLiqd3GOy8e/9kWwTsSFDpncCQJ+sIJDPHcXjv3bcBPe5miEIGO+ajJ3ld9mYBcxCr5K4eMAe+73Oebaow==}
+  /storybook-react-rspack/7.0.0-rc.18_sfoxds7t5ydpegc3knd667wn6m:
+    resolution: {integrity: sha512-fnATwo1wrlWq5EjALizbqbZz1zik7u0+5y+dsGDxCNd60ZJJ0IsOzS9LraKi76TsAvDSa3OmvRzlvQtDduEysw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@babel/core': ^7.11.5
@@ -24933,23 +24911,16 @@ packages:
       '@types/node': 16.11.7
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      storybook-builder-rspack: 7.0.0-rc.16_sfoxds7t5ydpegc3knd667wn6m
-      storybook-preset-react-rspack: 7.0.0-rc.16_sfoxds7t5ydpegc3knd667wn6m
+      storybook-builder-rspack: 7.0.0-rc.18_sfoxds7t5ydpegc3knd667wn6m
+      storybook-preset-react-rspack: 7.0.0-rc.18_sfoxds7t5ydpegc3knd667wn6m
     transitivePeerDependencies:
-      - '@swc/core'
       - '@types/webpack'
-      - bufferutil
-      - debug
-      - esbuild
       - glob
       - sockjs-client
       - supports-color
       - type-fest
-      - uglify-js
-      - utf-8-validate
       - vue-template-compiler
       - webpack
-      - webpack-cli
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
@@ -27117,20 +27088,6 @@ packages:
       schema-utils: 4.0.1
     dev: true
 
-  /webpack-dev-middleware/5.3.3_webpack@5.74.0:
-    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      colorette: 2.0.19
-      memfs: 3.4.12
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.0.1
-      webpack: 5.74.0
-    dev: true
-
   /webpack-dev-middleware/5.3.3_webpack@5.76.0:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
@@ -27189,54 +27146,6 @@ packages:
       range-parser: 1.2.1
       schema-utils: 4.0.0
       webpack: 5.80.0_esbuild@0.17.18
-    dev: true
-
-  /webpack-dev-server/4.11.1_webpack@5.74.0:
-    resolution: {integrity: sha512-lILVz9tAUy1zGFwieuaQtYiadImb5M3d+H+L1zDYalYoDl0cksAB1UNyuE5MMWJrG6zR1tXkCP2fitl7yoUJiw==}
-    engines: {node: '>= 12.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
-      '@types/express': 4.17.14
-      '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.0
-      '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.3
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.0.14
-      chokidar: 3.5.3
-      colorette: 2.0.19
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.1
-      graceful-fs: 4.2.10
-      html-entities: 2.3.3
-      http-proxy-middleware: 2.0.6_@types+express@4.17.14
-      ipaddr.js: 2.0.1
-      open: 8.4.2
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.0.1
-      selfsigned: 2.1.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack: 5.74.0
-      webpack-dev-middleware: 5.3.3_webpack@5.74.0
-      ws: 8.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
     dev: true
 
   /webpack-dev-server/4.13.1:


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 20b973d</samp>

Updated storybook-related packages and improved dependency management in `web-infra-dev/rspack`. This is to use the latest features and fixes of the storybook builder for React projects and to avoid version conflicts and duplication of local packages.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 20b973d</samp>

*  Update `storybook-react-rspack` to `7.0.0-rc.18` in `package.json` and `pnpm-lock.yaml` to use the latest storybook builder and preset for React projects that use rspack as the bundler ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-d931f723d2fead736e07acae0f34912a87744eaa2d786394dab66d5b21c25adaL27-L26), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL518-R515), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL534-R531), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24797-R24780), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24809-R24792), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24901-R24890), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24918-R24897), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24936-R24923))
*  Remove `pnpm` section with `overrides` field from `package.json` and `pnpm-lock.yaml` to avoid overriding the `@rspack/core` dependency with a fixed version and instead use the workspace version ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L76-R76), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3-L5))
*  Change `@rspack/core` dependency from a fixed version to a workspace version in `pnpm-lock.yaml` to use the local version of the core rspack package instead of a published one ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL738-R735), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL781-R778), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL872-R869), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL913-R910), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL926-R923), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL963-R960), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1075-R1072))
*  Update `@babel/helper-plugin-utils` to `7.21.5` in `pnpm-lock.yaml` to use the latest version of the babel helper package that provides some utility functions for babel plugins ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3712-R3709), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL3722-R3719))
*  Change `@pmmmwh/react-refresh-webpack-plugin` dependency from using a hash-based resolution to using a react-refresh-based resolution in `pnpm-lock.yaml` to use a more readable and consistent way of resolving the plugin that enables hot reloading for React components ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7311-R7308), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7919-R7915), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7939-R7934), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7959-R7967))
*  Remove `webpack` and `webpack-dev-server` dependencies from `@pmmmwh/react-refresh-webpack-plugin` in `pnpm-lock.yaml` to avoid unnecessary duplication of these dependencies that are already provided by `storybook-builder-rspack` ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7347-L7348))
*  Change `@rspack/dev-client` dependency from using a hash-based resolution to using a react-refresh-based resolution in `pnpm-lock.yaml` to use a more readable and consistent way of resolving the dev client that connects to the dev server and enables hot reloading ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7911-R7906), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7931-R7926))
*  Update `@rspack/dev-client` to `0.1.12` in `pnpm-lock.yaml` to use the latest features and bug fixes of the dev client that connects to the dev server and enables hot reloading ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7951-R7947), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24882-R24867))
*  Update `@rspack/dev-middleware` to `0.1.12` and add some peer dependency metadata in `pnpm-lock.yaml` to use the latest version of the dev middleware that handles the requests from the dev client and serves the bundled files ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7997-R7988))
*  Remove `transitivePeerDependencies` section from `@rspack/dev-middleware` and `storybook-preset-react-rspack` in `pnpm-lock.yaml` to avoid unnecessary listing of transitive peer dependencies that are already provided by `storybook-builder-rspack` ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8006-L8013), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24901-R24890))
*  Add `@storybook/mdx2-csf` dependency to `storybook-builder-rspack` in `pnpm-lock.yaml` to use the new package that converts MDX files to CSF format for storybook ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR24807))
*  Update `css-loader` to `6.7.4`, and add `chokidar` and `minimatch` dependencies to `storybook-builder-rspack` in `pnpm-lock.yaml` to use the latest version of the css loader that handles css modules and imports, and to use the new dependencies that enable watching and matching files for changes ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL24836-R24825))
*  Remove `webpack-dev-middleware` and `webpack-dev-server` dependencies from `pnpm-lock.yaml` to avoid unnecessary duplication of these dependencies that are already provided by `storybook-builder-rspack` ([link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27120-L27133), [link](https://github.com/web-infra-dev/rspack/pull/3339/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27194-L27241))

</details>
