### PR TITLE
fix: migrate more string replace dependency for test

### DIFF
--- a/crates/rspack_core/src/dependency/dynamic_import.rs
+++ b/crates/rspack_core/src/dependency/dynamic_import.rs
@@ -94,6 +94,10 @@ impl ModuleDependency for EsmDynamicImportDependency {
   fn span(&self) -> Option<&ErrorSpan> {
     self.span.as_ref()
   }
+
+  fn chunk_name(&self) -> Option<&str> {
+    self.name.as_deref()
+  }
 }
 
 impl CodeGeneratable for EsmDynamicImportDependency {

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -272,6 +272,10 @@ pub trait ModuleDependency: Dependency {
   fn as_code_replace_source_dependency(&self) -> Option<Box<dyn CodeReplaceSourceDependency>> {
     None
   }
+
+  fn chunk_name(&self) -> Option<&str> {
+    None
+  }
 }
 
 impl ModuleDependency for Box<dyn ModuleDependency> {
@@ -297,6 +301,10 @@ impl ModuleDependency for Box<dyn ModuleDependency> {
 
   fn get_optional(&self) -> bool {
     (**self).get_optional()
+  }
+
+  fn chunk_name(&self) -> Option<&str> {
+    (**self).chunk_name()
   }
 }
 

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -1,7 +1,9 @@
 use rspack_error::Result;
 
 use crate::{
-  CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, Dependency, RuntimeGlobals,
+  CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult, CodeReplaceSourceDependency,
+  CodeReplaceSourceDependencyContext, CodeReplaceSourceDependencyReplaceSource, Dependency,
+  RuntimeGlobals,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -21,6 +23,18 @@ impl CodeGeneratable for RuntimeRequirementsDependency {
       .add(self.runtime_requirements);
 
     Ok(CodeGeneratableResult::default())
+  }
+}
+
+impl CodeReplaceSourceDependency for RuntimeRequirementsDependency {
+  fn apply(
+    &self,
+    _source: &mut CodeReplaceSourceDependencyReplaceSource,
+    code_generatable_context: &mut CodeReplaceSourceDependencyContext,
+  ) {
+    code_generatable_context
+      .runtime_requirements
+      .add(self.runtime_requirements);
   }
 }
 

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -2,10 +2,9 @@ use rspack_error::{internal_error, Result};
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  dependency::EsmDynamicImportDependency, is_async_dependency, module_graph::ConnectionId,
-  BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, DependencyId,
-  ExportsType, FactoryMeta, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  ModuleIssuer, ModuleSyntax, ModuleType,
+  is_async_dependency, module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject,
+  BuildMetaExportsType, ChunkGraph, DependencyId, ExportsType, FactoryMeta, ModuleDependency,
+  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleIssuer, ModuleSyntax, ModuleType,
 };
 
 #[derive(Debug)]
@@ -141,11 +140,7 @@ impl ModuleGraphModule {
           .module_identifier_by_dependency_id(id)
           .expect("should have a module here");
 
-        let chunk_name = dep
-          .as_ref()
-          .as_any()
-          .downcast_ref::<EsmDynamicImportDependency>()
-          .and_then(|f| f.name.as_deref());
+        let chunk_name = dep.chunk_name();
         Some((module, chunk_name))
       })
       .collect()

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
@@ -2,3 +2,5 @@ mod require;
 pub use require::*;
 mod common_js_require_dependency;
 pub use common_js_require_dependency::CommonJsRequireDependency;
+mod require_resolve_dependency;
+pub use require_resolve_dependency::RequireResolveDependency;

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -107,6 +107,7 @@ impl CodeReplaceSourceDependency for CommonJsRequireContextDependency {
     let context = normalize_context(&self.options.request);
 
     if !context.is_empty() {
+      source.insert(self.callee_end, "(", None);
       source.insert(
         self.args_end,
         format!(".replace('{context}', './'))").as_str(),

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -107,6 +107,7 @@ impl CodeReplaceSourceDependency for ImportContextDependency {
     let context = normalize_context(&self.options.request);
 
     if !context.is_empty() {
+      source.insert(self.callee_end, "(", None);
       source.insert(
         self.args_end,
         format!(".replace('{context}', './'))").as_str(),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  import_statement, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
+  get_import_var, import_statement, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   CodeReplaceSourceDependency, CodeReplaceSourceDependencyContext,
   CodeReplaceSourceDependencyReplaceSource, Dependency, DependencyCategory, DependencyId,
   DependencyType, ErrorSpan, InitFragment, InitFragmentStage, ModuleDependency,
@@ -46,15 +46,46 @@ impl CodeReplaceSourceDependency for HarmonyImportDependency {
       .iter()
       .for_each(|dep| dep.apply(source, code_generatable_context, &id, self.request.as_ref()));
 
-    let content = import_statement(code_generatable_context, &id, &self.request);
+    let content: (String, String) =
+      import_statement(code_generatable_context, &id, &self.request, false);
 
-    code_generatable_context
-      .init_fragments
-      .push(InitFragment::new(
+    let CodeReplaceSourceDependencyContext {
+      init_fragments,
+      compilation,
+      ..
+    } = code_generatable_context;
+
+    let ref_module = compilation
+      .module_graph
+      .module_identifier_by_dependency_id(&id)
+      .expect("should have dependency referenced module");
+
+    if compilation.module_graph.is_async(ref_module) {
+      let import_var = get_import_var(&self.request);
+      init_fragments.push(InitFragment::new(
+        content.0,
+        InitFragmentStage::STAGE_HARMONY_IMPORTS,
+        None,
+      ));
+      init_fragments.push(InitFragment::new(
+        format!(
+          "var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([{import_var}]);\n([{import_var}] = __webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__);"
+        ),
+        InitFragmentStage::STAGE_HARMONY_IMPORTS,
+        None,
+      ));
+      init_fragments.push(InitFragment::new(
+        content.1,
+        InitFragmentStage::STAGE_ASYNC_HARMONY_IMPORTS,
+        None,
+      ));
+    } else {
+      init_fragments.push(InitFragment::new(
         format!("{}{}", content.0, content.1),
         InitFragmentStage::STAGE_HARMONY_IMPORTS,
         None,
       ));
+    }
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -1,10 +1,7 @@
 use rspack_core::{
   export_from_import, get_import_var, CodeReplaceSourceDependencyContext,
-  CodeReplaceSourceDependencyReplaceSource, DependencyId, InitFragment, InitFragmentStage,
-  RuntimeGlobals,
+  CodeReplaceSourceDependencyReplaceSource, DependencyId,
 };
-
-use super::format_exports;
 
 #[derive(Debug, Clone)]
 pub struct HarmonyImportSpecifierDependency {
@@ -13,7 +10,6 @@ pub struct HarmonyImportSpecifierDependency {
   end: u32,
   // harmony_harmony_import_dependency: &'a HarmonyImportDependency,
   ids: Option<String>,
-  export: Option<String>,
 }
 
 impl HarmonyImportSpecifierDependency {
@@ -23,7 +19,6 @@ impl HarmonyImportSpecifierDependency {
     end: u32,
     // harmony_harmony_import_dependency: &'a HarmonyImportDependency,
     ids: Option<String>,
-    export: Option<String>,
   ) -> Self {
     Self {
       shorthand,
@@ -31,7 +26,6 @@ impl HarmonyImportSpecifierDependency {
       end,
       // harmony_harmony_import_dependency,
       ids,
-      export,
     }
   }
 
@@ -56,32 +50,7 @@ impl HarmonyImportSpecifierDependency {
       id,
       false,
     );
-
-    if let Some(export) = &self.export {
-      let CodeReplaceSourceDependencyContext {
-        runtime_requirements,
-        init_fragments,
-        compilation,
-        module,
-        ..
-      } = code_generatable_context;
-      let exports_argument = compilation
-        .module_graph
-        .module_graph_module_by_identifier(&module.identifier())
-        .expect("should have mgm")
-        .get_exports_argument();
-      runtime_requirements.add(RuntimeGlobals::EXPORTS);
-      runtime_requirements.add(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
-      init_fragments.push(InitFragment::new(
-        format!(
-          "{}({exports_argument}, {});\n",
-          RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
-          format_exports(&[(export.to_string(), export_expr)])
-        ),
-        InitFragmentStage::STAGE_HARMONY_EXPORTS,
-        None,
-      ));
-    } else if self.shorthand {
+    if self.shorthand {
       source.insert(self.end, format!(": {export_expr}").as_str(), None);
     } else {
       source.replace(self.start, self.end, export_expr.as_str(), None)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -69,6 +69,10 @@ impl ModuleDependency for ImportDependency {
   fn as_code_replace_source_dependency(&self) -> Option<Box<dyn CodeReplaceSourceDependency>> {
     Some(Box::new(self.clone()))
   }
+
+  fn chunk_name(&self) -> Option<&str> {
+    self.name.as_deref()
+  }
 }
 
 impl CodeGeneratable for ImportDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
@@ -67,6 +67,7 @@ impl CodeReplaceSourceDependency for HarmonyAcceptDependency {
           code_generatable_context,
           &dep.id().expect("should have dependency"),
           dep.request(),
+          true,
         );
         content.push_str(stmts.0.as_str());
         content.push_str(stmts.1.as_str());

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -172,7 +172,13 @@ impl CodeReplaceSourceDependency for ImportMetaHotAcceptDependency {
     source.replace(
       self.start,
       self.end,
-      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      module_id(
+        code_generatable_context.compilation,
+        &id,
+        &self.request,
+        false,
+      )
+      .as_str(),
       None,
     );
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -172,7 +172,13 @@ impl CodeReplaceSourceDependency for ImportMetaHotDeclineDependency {
     source.replace(
       self.start,
       self.end,
-      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      module_id(
+        code_generatable_context.compilation,
+        &id,
+        &self.request,
+        false,
+      )
+      .as_str(),
       None,
     );
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -172,7 +172,13 @@ impl CodeReplaceSourceDependency for NewModuleHotAcceptDependency {
     source.replace(
       self.start,
       self.end,
-      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      module_id(
+        code_generatable_context.compilation,
+        &id,
+        &self.request,
+        false,
+      )
+      .as_str(),
       None,
     );
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -172,7 +172,13 @@ impl CodeReplaceSourceDependency for NewModuleHotDeclineDependency {
     source.replace(
       self.start,
       self.end,
-      module_id(code_generatable_context.compilation, &id, &self.request).as_str(),
+      module_id(
+        code_generatable_context.compilation,
+        &id,
+        &self.request,
+        false,
+      )
+      .as_str(),
       None,
     );
   }

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,3 +1,5 @@
+mod new_url_dependency;
+pub use new_url_dependency::NewURLDependency;
 use rspack_core::{
   create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableResult,
   Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, JsAstPath,

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -1,7 +1,8 @@
 use rayon::prelude::*;
 use rspack_core::rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt};
 use rspack_core::{
-  ChunkInitFragments, ChunkUkey, Compilation, RenderModuleContentArgs, RuntimeGlobals, SourceType,
+  ChunkInitFragments, ChunkUkey, Compilation, InitFragment, RenderModuleContentArgs,
+  RuntimeGlobals, SourceType,
 };
 use rspack_error::{internal_error, Result};
 use rustc_hash::FxHashSet as HashSet;
@@ -186,6 +187,10 @@ pub fn render_chunk_init_fragments(
   chunk_init_fragments: &mut ChunkInitFragments,
 ) -> BoxSource {
   let mut fragments = chunk_init_fragments.values().collect::<Vec<_>>();
+  render_init_fragments(source, &mut fragments)
+}
+
+pub fn render_init_fragments(source: BoxSource, fragments: &mut [&InitFragment]) -> BoxSource {
   fragments.sort_unstable_by_key(|m| m.stage);
 
   let mut sources = ConcatSource::default();

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -149,7 +149,7 @@ impl Visit for ApiScanner<'_> {
         .push(Box::new(ReplaceConstDependency::new(
           expr.span().real_lo(),
           expr.span().real_hi(),
-          "module.id".into(),
+          "module.id".into(), // todo module_arguments
           Some(RuntimeGlobals::MODULE_ID),
         )));
     }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -3,10 +3,7 @@ use rustc_hash::FxHashMap;
 use swc_core::{
   common::{Span, SyntaxContext},
   ecma::{
-    ast::{
-      ExportSpecifier, Ident, ImportDecl, ImportSpecifier, ModuleExportName, NamedExport, Program,
-      Prop,
-    },
+    ast::{Ident, ImportDecl, ImportSpecifier, ModuleExportName, NamedExport, Program, Prop},
     atoms::JsWord,
     visit::{noop_visit_type, Visit, VisitWith},
   },
@@ -140,7 +137,6 @@ impl Visit for HarmonyImportRefDependencyScanner<'_> {
                 shorthand.span.real_lo(),
                 shorthand.span.real_hi(),
                 reference.1.clone(),
-                None,
               ))
             })
             .or_default();
@@ -161,47 +157,11 @@ impl Visit for HarmonyImportRefDependencyScanner<'_> {
           ident.span.real_lo(),
           ident.span.real_hi(),
           reference.1.clone(),
-          None,
         ));
     }
   }
 
   fn visit_import_decl(&mut self, _decl: &ImportDecl) {}
 
-  fn visit_named_export(&mut self, named_export: &NamedExport) {
-    if named_export.src.is_none() {
-      named_export
-        .specifiers
-        .iter()
-        .for_each(|specifier| match specifier {
-          ExportSpecifier::Namespace(_ns) => {
-            unreachable!()
-          }
-          ExportSpecifier::Default(_default) => {
-            unreachable!();
-          }
-          ExportSpecifier::Named(named) => {
-            if let ModuleExportName::Ident(orig) = &named.orig {
-              if let Some(Some(reference)) = self.import_map.get(&orig.to_id()) {
-                self
-                  .ref_dependencies
-                  .entry(reference.0.clone())
-                  .or_insert(vec![])
-                  .push(HarmonyImportSpecifierDependency::new(
-                    false,
-                    named.span.real_lo(),
-                    named.span.real_hi(),
-                    reference.1.clone(),
-                    Some(match &named.exported {
-                      Some(ModuleExportName::Ident(export)) => export.sym.to_string(),
-                      None => orig.sym.to_string(),
-                      _ => unreachable!(),
-                    }),
-                  ));
-              }
-            }
-          }
-        });
-    }
-  }
+  fn visit_named_export(&mut self, _named_export: &NamedExport) {}
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
@@ -11,7 +11,7 @@ use swc_core::{
   },
 };
 
-use super::{is_module_hot_accept_call, is_module_hot_decline_call};
+use super::{expr_matcher, is_module_hot_accept_call, is_module_hot_decline_call};
 use crate::{
   dependency::{
     HarmonyAcceptDependency, ImportMetaHotAcceptDependency, ImportMetaHotDeclineDependency,
@@ -50,15 +50,6 @@ impl<'a> HotModuleReplacementScanner<'a> {
     kind: &str,
     create_dependency: CreateDependency,
   ) {
-    self
-      .code_generable_dependencies
-      .push(Box::new(ReplaceConstDependency::new(
-        call_expr.callee.span().real_lo(),
-        call_expr.callee.span().real_hi(),
-        format!("module.hot.{kind}").into(),
-        Some(RuntimeGlobals::MODULE),
-      )));
-
     let mut deps = vec![];
 
     if let Some(first_arg) = call_expr.args.get(0) {
@@ -89,7 +80,7 @@ impl<'a> HotModuleReplacementScanner<'a> {
       }
     }
 
-    if self.build_meta.esm && kind == "accept" {
+    if self.build_meta.esm && kind == "accept" && !call_expr.args.is_empty() {
       let ref_deps = deps
         .iter()
         .map(|dep| {
@@ -130,6 +121,20 @@ impl<'a> HotModuleReplacementScanner<'a> {
 impl<'a> Visit for HotModuleReplacementScanner<'a> {
   noop_visit_type!();
 
+  fn visit_expr(&mut self, expr: &Expr) {
+    if expr_matcher::is_module_hot(expr) || expr_matcher::is_import_meta_webpack_hot(expr) {
+      self
+        .code_generable_dependencies
+        .push(Box::new(ReplaceConstDependency::new(
+          expr.span().real_lo(),
+          expr.span().real_hi(),
+          "module.hot".into(), // TODO module_argument
+          Some(RuntimeGlobals::MODULE),
+        )));
+    }
+    expr.visit_children_with(self);
+  }
+
   fn visit_call_expr(&mut self, call_expr: &CallExpr) {
     if is_module_hot_accept_call(call_expr) {
       self.collect_dependencies(call_expr, "accept", |start, end, request, span| {
@@ -153,8 +158,7 @@ impl<'a> Visit for HotModuleReplacementScanner<'a> {
           start, end, request, span,
         ))
       });
-    } else {
-      call_expr.visit_children_with(self);
     }
+    call_expr.visit_children_with(self);
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/new_common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/new_common_js_scanner.rs
@@ -1,0 +1,43 @@
+use rspack_core::{CodeReplaceSourceDependency, RuntimeGlobals, RuntimeRequirementsDependency};
+use swc_core::ecma::{
+  ast::Expr,
+  visit::{noop_visit_type, Visit, VisitWith},
+};
+
+use super::expr_matcher;
+
+pub struct NewCommonJsScanner<'a> {
+  code_generable_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+}
+
+impl<'a> NewCommonJsScanner<'a> {
+  pub fn new(
+    code_generable_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+  ) -> Self {
+    Self {
+      code_generable_dependencies,
+    }
+  }
+}
+
+impl Visit for NewCommonJsScanner<'_> {
+  noop_visit_type!();
+
+  fn visit_expr(&mut self, expr: &Expr) {
+    if expr_matcher::is_module_id(expr) {
+      self
+        .code_generable_dependencies
+        .push(Box::new(RuntimeRequirementsDependency::new(
+          RuntimeGlobals::MODULE_ID,
+        )));
+    }
+    if expr_matcher::is_module_loaded(expr) {
+      self
+        .code_generable_dependencies
+        .push(Box::new(RuntimeRequirementsDependency::new(
+          RuntimeGlobals::MODULE_LOADED,
+        )));
+    }
+    expr.visit_children_with(self);
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/new_import_meta_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/new_import_meta_scanner.rs
@@ -1,0 +1,137 @@
+use rspack_core::{
+  CodeReplaceSourceDependency, CompilerOptions, ReplaceConstDependency, ResourceData, SpanExt,
+};
+use swc_core::common::Spanned;
+use swc_core::ecma::ast::{Expr, Ident, NewExpr, UnaryExpr, UnaryOp};
+use swc_core::ecma::atoms::js_word;
+use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
+use url::Url;
+
+use super::{
+  expr_matcher, is_member_expr_starts_with_import_meta,
+  is_member_expr_starts_with_import_meta_webpack_hot,
+};
+
+// Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/ImportMetaPlugin.js
+// TODO:
+// - scan `import.meta.webpack`
+// - scan `import.meta.url.indexOf("index.js")`
+// - evaluate expression. eg `import.meta.env && import.meta.env.xx` should be `false`
+// - add warning for `import.meta`
+pub struct NewImportMetaScanner<'a> {
+  pub code_replace_source_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+  pub compiler_options: &'a CompilerOptions,
+  pub resource_data: &'a ResourceData,
+}
+
+impl<'a> NewImportMetaScanner<'a> {
+  pub fn new(
+    code_replace_source_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+    resource_data: &'a ResourceData,
+    compiler_options: &'a CompilerOptions,
+  ) -> Self {
+    Self {
+      code_replace_source_dependencies,
+      resource_data,
+      compiler_options,
+    }
+  }
+}
+
+impl Visit for NewImportMetaScanner<'_> {
+  noop_visit_type!();
+
+  fn visit_unary_expr(&mut self, unary_expr: &UnaryExpr) {
+    if let UnaryExpr {
+      op: UnaryOp::TypeOf,
+      arg: box expr,
+      ..
+    } = unary_expr
+    {
+      if expr_matcher::is_import_meta(expr) {
+        self
+          .code_replace_source_dependencies
+          .push(Box::new(ReplaceConstDependency::new(
+            unary_expr.span().real_lo(),
+            unary_expr.span().real_hi(),
+            "'object'".into(),
+            None,
+          )));
+      } else if expr_matcher::is_import_meta_url(expr) {
+        self
+          .code_replace_source_dependencies
+          .push(Box::new(ReplaceConstDependency::new(
+            unary_expr.span().real_lo(),
+            unary_expr.span().real_hi(),
+            "'string'".into(),
+            None,
+          )));
+      } else if is_member_expr_starts_with_import_meta(expr) {
+        self
+          .code_replace_source_dependencies
+          .push(Box::new(ReplaceConstDependency::new(
+            unary_expr.span().real_lo(),
+            unary_expr.span().real_hi(),
+            "'undefined'".into(),
+            None,
+          )));
+      }
+    } else {
+      unary_expr.visit_children_with(self);
+    }
+  }
+
+  fn visit_expr(&mut self, expr: &Expr) {
+    // exclude import.meta.webpackHot
+    if is_member_expr_starts_with_import_meta_webpack_hot(expr) {
+      return;
+    }
+
+    // import.meta
+    if expr_matcher::is_import_meta(expr) {
+      // TODO(underfin): add warning
+      self
+        .code_replace_source_dependencies
+        .push(Box::new(ReplaceConstDependency::new(
+          expr.span().real_lo(),
+          expr.span().real_hi(),
+          "({})".into(),
+          None,
+        )));
+    } else if expr_matcher::is_import_meta_url(expr) {
+      // import.meta.url
+      let url = Url::from_file_path(&self.resource_data.resource).expect("should be a path");
+      self
+        .code_replace_source_dependencies
+        .push(Box::new(ReplaceConstDependency::new(
+          expr.span().real_lo(),
+          expr.span().real_hi(),
+          format!("'{url}'").into(),
+          None,
+        )));
+    } else if is_member_expr_starts_with_import_meta(expr) {
+      self
+        .code_replace_source_dependencies
+        .push(Box::new(ReplaceConstDependency::new(
+          expr.span().real_lo(),
+          expr.span().real_hi(),
+          "undefined".into(),
+          None,
+        )));
+    } else {
+      expr.visit_children_with(self);
+    }
+  }
+
+  fn visit_new_expr(&mut self, new_expr: &NewExpr) {
+    // exclude new URL("", import.meta.url)
+    if let Expr::Ident(Ident {
+      sym: js_word!("URL"),
+      ..
+    }) = &*new_expr.callee
+    {
+      return;
+    }
+    new_expr.visit_children_with(self);
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/new_node_stuff_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/new_node_stuff_scanner.rs
@@ -1,0 +1,116 @@
+use rspack_core::{
+  CodeReplaceSourceDependency, CompilerOptions, NodeOption, ReplaceConstDependency, ResourceData,
+  RuntimeGlobals, SpanExt,
+};
+use sugar_path::SugarPath;
+use swc_core::common::SyntaxContext;
+use swc_core::ecma::ast::Ident;
+use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
+
+const DIR_NAME: &str = "__dirname";
+const FILE_NAME: &str = "__filename";
+const GLOBAL: &str = "global";
+
+pub struct NewNodeStuffScanner<'a> {
+  pub code_replace_source_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+  pub unresolved_ctxt: &'a SyntaxContext,
+  pub compiler_options: &'a CompilerOptions,
+  pub node_option: &'a NodeOption,
+  pub resource_data: &'a ResourceData,
+}
+
+impl<'a> NewNodeStuffScanner<'a> {
+  pub fn new(
+    code_replace_source_dependencies: &'a mut Vec<Box<dyn CodeReplaceSourceDependency>>,
+    unresolved_ctxt: &'a SyntaxContext,
+    compiler_options: &'a CompilerOptions,
+    node_option: &'a NodeOption,
+    resource_data: &'a ResourceData,
+  ) -> Self {
+    Self {
+      code_replace_source_dependencies,
+      unresolved_ctxt,
+      compiler_options,
+      node_option,
+      resource_data,
+    }
+  }
+}
+
+impl Visit for NewNodeStuffScanner<'_> {
+  noop_visit_type!();
+
+  fn visit_ident(&mut self, ident: &Ident) {
+    if ident.span.ctxt == *self.unresolved_ctxt {
+      match ident.sym.as_ref() as &str {
+        DIR_NAME => {
+          let dirname = match self.node_option.dirname.as_str() {
+            "mock" => Some("/".to_string()),
+            "warn-mock" => Some("/".to_string()),
+            "true" => Some(
+              self
+                .resource_data
+                .resource_path
+                .parent()
+                .expect("TODO:")
+                .relative(self.compiler_options.context.as_ref())
+                .to_string_lossy()
+                .to_string(),
+            ),
+            _ => None,
+          };
+          if let Some(dirname) = dirname {
+            self
+              .code_replace_source_dependencies
+              .push(Box::new(ReplaceConstDependency::new(
+                ident.span.real_lo(),
+                ident.span.real_hi(),
+                format!("'{dirname}'").into(),
+                None,
+              )));
+          }
+        }
+        FILE_NAME => {
+          let filename = match self.node_option.filename.as_str() {
+            "mock" => Some("/index.js".to_string()),
+            "warn-mock" => Some("/index.js".to_string()),
+            "true" => Some(
+              self
+                .resource_data
+                .resource_path
+                .relative(self.compiler_options.context.as_ref())
+                .to_string_lossy()
+                .to_string(),
+            ),
+            _ => None,
+          };
+          if let Some(filename) = filename {
+            self
+              .code_replace_source_dependencies
+              .push(Box::new(ReplaceConstDependency::new(
+                ident.span.real_lo(),
+                ident.span.real_hi(),
+                format!("'{filename}'").into(),
+                None,
+              )));
+          }
+        }
+        GLOBAL => {
+          if matches!(self.node_option.global.as_str(), "true" | "warn") {
+            self
+              .code_replace_source_dependencies
+              .push(Box::new(ReplaceConstDependency::new(
+                ident.span.real_lo(),
+                ident.span.real_hi(),
+                RuntimeGlobals::GLOBAL.name().into(),
+                Some(RuntimeGlobals::GLOBAL),
+              )));
+          }
+        }
+        _ => {}
+      }
+    } else {
+      ident.visit_children_with(self);
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
@@ -1,0 +1,58 @@
+use rspack_core::{ModuleDependency, SpanExt};
+use swc_core::common::Spanned;
+use swc_core::ecma::{
+  ast::{Expr, ExprOrSpread, Ident, Lit, NewExpr},
+  atoms::js_word,
+  visit::{noop_visit_type, Visit, VisitWith},
+};
+
+use super::expr_matcher;
+use crate::dependency::NewURLDependency;
+pub struct UrlScanner<'a> {
+  pub dependencies: &'a mut Vec<Box<dyn ModuleDependency>>,
+}
+
+// new URL("./foo.png", import.meta.url);
+impl<'a> UrlScanner<'a> {
+  pub fn new(dependencies: &'a mut Vec<Box<dyn ModuleDependency>>) -> Self {
+    Self { dependencies }
+  }
+}
+
+impl Visit for UrlScanner<'_> {
+  noop_visit_type!();
+
+  fn visit_new_expr(&mut self, new_expr: &NewExpr) {
+    if let Expr::Ident(Ident {
+      sym: js_word!("URL"),
+      ..
+    }) = &*new_expr.callee
+    {
+      if let Some(args) = &new_expr.args {
+        if let (Some(first), Some(second)) = (args.first(), args.get(1)) {
+          if let (
+            ExprOrSpread {
+              spread: None,
+              expr: box Expr::Lit(Lit::Str(path)),
+            },
+            ExprOrSpread {
+              spread: None,
+              expr:
+                box expr
+            },
+          ) = (first, second) && expr_matcher::is_import_meta_url(expr)
+          {
+            self.dependencies.push(Box::new(NewURLDependency::new(
+              path.span.real_lo(),
+              expr.span().real_hi(),
+              path.value.clone(),
+              Some(new_expr.span.into()),
+            )));
+          }
+        }
+      }
+    } else {
+      new_expr.visit_children_with(self);
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -57,11 +57,13 @@ pub(crate) mod expr_matcher {
   // - `import.meta.xxx` is a MemberExpr
   // - Matching would ignore Span and SyntaxContext
   define_expr_matchers!({
+    is_require: "require",
     is_require_context: "require.context",
     is_require_resolve: "require.resolve",
     is_require_resolve_weak: "require.resolveWeak",
     is_module_hot_accept: "module.hot.accept",
     is_module_hot_decline: "module.hot.decline",
+    is_module_hot: "module.hot",
     is_module_id: "module.id",
     is_module_loaded: "module.loaded",
     is_require_cache: "require.cache",

--- a/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
+++ b/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
@@ -88,6 +88,20 @@ impl Plugin for BasicRuntimeRequirementPlugin {
       runtime_requirements.insert(RuntimeGlobals::GET_FULL_HASH);
     }
 
+    if runtime_requirements.contains(RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT) {
+      runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
+    }
+
+    if runtime_requirements.contains(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT) {
+      runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
+      runtime_requirements.insert(RuntimeGlobals::MAKE_NAMESPACE_OBJECT);
+      runtime_requirements.insert(RuntimeGlobals::REQUIRE);
+    }
+
+    if runtime_requirements.contains(RuntimeGlobals::DEFINE_PROPERTY_GETTERS) {
+      runtime_requirements.insert(RuntimeGlobals::HAS_OWN_PROPERTY);
+    }
+
     let mut sorted_runtime_requirement = runtime_requirements.iter().collect::<Vec<_>>();
     // TODO: we don't need sort since iter is deterministic for BitFlags
     sorted_runtime_requirement.sort_unstable_by_key(|r| r.name());

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.js
@@ -1,8 +1,9 @@
 // getDefaultExport function for compatibility with non-harmony modules
 __webpack_require__.n = function(module) {
-	var getter = module && module.__esModule ?
-        function() { return module['default']; } :
-        function() { return module; }
-	__webpack_require__.d(getter, { a: getter });
-	return getter;
+	// var getter = module && module.__esModule ?
+    //     function() { return module['default']; } :
+    //     function() { return module; }
+	// __webpack_require__.d(getter, { a: getter });
+	// return getter;
+	return module && module.__esModule ? module['default'] : module;
 };


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ecba181</samp>

This pull request enhances the code generation logic for various dependency types in the `rspack_plugin_javascript` crate, and adds support for async modules, `require.resolve`, and `new URL` expressions. It also refactors some common code to the `runtime_template` module and fixes some syntax errors.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ecba181</samp>

*  Move the `module_id` and `HarmonyExportImportedSpecifierDependency` functions from the `crates/rspack_plugin_javascript/src/dependency` modules to the `crates/rspack_core/src/dependency/runtime_template.rs` file, as they are used by multiple dependencies and not specific to esm or commonjs ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26f86abf819946e457f1e554056eb79ea6a1bf4526a750c07a7fa59179d52b1aL2-R5), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-cd01971b66c721eda04313cf26bd5bc76922c5338c1f776593f28fb25d3a7191L2-R27), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-cd01971b66c721eda04313cf26bd5bc76922c5338c1f776593f28fb25d3a7191L22-R98))
* Add a new function `get_reexport_var` to the `crates/rspack_core/src/dependency/runtime_template.rs` file, which returns a string representing the re-exported variable from an imported variable and an export name ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5R6-R9))
* Add a new parameter `update` to the `import_statement` function in the `crates/rspack_core/src/dependency/runtime_template.rs` file, which indicates whether a new variable should be created or the existing one updated for the import, and use it to conditionally add the `var` declaration to the import variables ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5R133), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5L140-R155), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5L152-R166))
* Modify the `module_id` function in the `crates/rspack_core/src/dependency/runtime_template.rs` file to handle the case when the dependency is weak and does not have a module identifier or id, and return a placeholder string in that case ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5L108-R126))
* Remove the parentheses from the `import_var_default` expression in the `crates/rspack_core/src/dependency/runtime_template.rs` file, as they are not needed and may cause parsing errors ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26ce71468538ae66bcee391c32b2bcc82ac16f453fde4406e636e12b0544e2c5L30-R34))
* Use the `module_id` function to generate code for the module id in various dependencies, such as `CommonJSRequireDependency`, `HarmonyImportDependency`, `HarmonyAcceptDependency`, `ImportMetaHotAcceptDependency`, `ImportMetaHotDeclineDependency`, `ModuleHotAcceptDependency`, `ModuleHotDeclineDependency`, and `NewURLDependency`, and pass the appropriate value for the `weak` parameter ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-26f86abf819946e457f1e554056eb79ea6a1bf4526a750c07a7fa59179d52b1aL113-R108), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-a7eaafb4447c0e80199a8e2dee0b34bfbdfd3df6981b4fe465f85b56b6e47c84L49-R88), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-9eb52a5de59a9741ea5dc00b420f84f282ae54717643453286dfa1313f81725bR70), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-42fb633c6e41bd78676d0a4929876d1962208f2046257e56025f90b9683d0985L175-R181), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-c457e8e58a59a08dc806c9794008811cf5ddb1e655f8778da9747ea75ae7f622L175-R181), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-a9f5dcf0610b6f3338469cf9dad04c3a06b204ade7264ab96e6ff99000d6e03fL175-R181), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-37ebd37489f0978e68943dd41ec03b517899190e8d98c80bc4646e20a0173773L175-R181), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-ef8b9f26c8cdc081641258c3b88699fa356d44e3fd63e19b731c3b446010f6d3R1-R102))
* Use the `import_statement` function to generate code for the import statements in various dependencies, such as `HarmonyImportDependency` and `HarmonyAcceptDependency`, and pass the appropriate value for the `update` parameter ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-a7eaafb4447c0e80199a8e2dee0b34bfbdfd3df6981b4fe465f85b56b6e47c84L49-R88), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-9eb52a5de59a9741ea5dc00b420f84f282ae54717643453286dfa1313f81725bR70))
* Use the `get_import_var` function to get the import variable name from the request in the `HarmonyImportDependency` struct ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-a7eaafb4447c0e80199a8e2dee0b34bfbdfd3df6981b4fe465f85b56b6e47c84L49-R88))
* Use the `export_from_import` function to generate code for the re-exports in the `HarmonyExportImportedSpecifierDependency` struct, and add a new field `module_identifier` to store the module identifier of the dependency ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-cd01971b66c721eda04313cf26bd5bc76922c5338c1f776593f28fb25d3a7191L22-R98))
* Add code to handle the case when the imported module is async and needs to be awaited in the `HarmonyImportDependency` and `HarmonyCompatibilityDependency` structs, and add the `RuntimeGlobals::MODULE` and `RuntimeGlobals::ASYNC_MODULE` to the `runtime_requirements` ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-a7eaafb4447c0e80199a8e2dee0b34bfbdfd3df6981b4fe465f85b56b6e47c84L49-R88), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-0c58eea54ed3d552213f65718d6eb71a0f0f390d6ddd15bf07216649cc5cdb77L40-R57))
* Remove the `export` field from the `HarmonyImportSpecifierDependency` struct and its methods, as it is no longer needed, and remove the code that generates code for re-exporting the imported specifier ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-59d0c6cb6757c6d012012ed57baf3238c064a5e00034ebea3ee929c1925de006L3-R5), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-59d0c6cb6757c6d012012ed57baf3238c064a5e00034ebea3ee929c1925de006L16), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-59d0c6cb6757c6d012012ed57baf3238c064a5e00034ebea3ee929c1925de006L26), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-59d0c6cb6757c6d012012ed57baf3238c064a5e00034ebea3ee929c1925de006L34), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-59d0c6cb6757c6d012012ed57baf3238c064a5e00034ebea3ee929c1925de006L59-R53))
* Add a new module and struct `require_resolve_dependency` and `RequireResolveDependency`, which represent a dependency for the `require.resolve` expression, and generate code for it using the `module_id` function ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-69052168d95c67f73968f29e68cc2fd32986f37bb0071c5283d7fe4be57cbcd3R5-R6), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-f4f1f6a2c69c3bd66805aa0582b55dc91f3d493e4de17bd98ee3496ca512a5b9R1-R114))
* Add a new module and struct `new_url_dependency` and `NewURLDependency`, which represent a dependency for the `new URL` expression, and generate code for it using the `module_id` and `RuntimeGlobals::REQUIRE` functions ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-07718b2b1704392b73874e8ee8abf0e343e4ea3f3eef2924c9a206cb66263e0aR1-R2), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-ef8b9f26c8cdc081641258c3b88699fa356d44e3fd63e19b731c3b446010f6d3R1-R102))
* Fix a syntax error when generating code for the `require.context` and `import` expressions, which take a function argument, by inserting a `(` character after the `callee_end` position in the `CommonJSRequireContextDependency` and `ImportContextDependency` structs ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-791cd04d76e624c1730c4cfe8921d1d0913a8037b57ff75234967856f094d808R110), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-114ca742689ca834126468fe1e55880371c03113a9a7a6d9e668eccc56b0489eR110))
* Add a comment `// todo module_arguments` to the `apply` method of the `ModuleIdDependency` struct, to indicate that the code needs to be updated to use the module arguments instead of the hardcoded `"module.id"` string ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-0bd4e39491943a489c38997b7b30157151e5b3ba6c9a0706ae2c913642e98872L152-R152))
* Add a function `render_init_fragments` to the `crates/rspack_plugin_javascript/src/runtime.rs` file, which takes a source code and a list of init fragments, and inserts the fragments to the source code according to their stage and order, and use it in the `generate` method of the `StringReplace` struct ([link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-805767c722570267c13719882d913768d72e72229fe68ed197baf1daed8ae8b4L4-R5), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-805767c722570267c13719882d913768d72e72229fe68ed197baf1daed8ae8b4R190-R193), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-ef3fe3b34f136d41212214c0b5c1cdf80d11436046bf271595e451a97b09138aR12), [link](https://github.com/web-infra-dev/rspack/pull/3341/files?diff=unified&w=0#diff-ef3fe3b34f136d41212214c0b5c1cdf80d11436046bf271595e451a97b09138aL193-R201))

</details>
