### PR TITLE
chore: setup gitconfig in ci

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -24,8 +24,8 @@ export async function publish_handler(mode, options) {
 	if (options.pushTags) {
 		console.info("git config user");
 		await $`git config --global --add safe.directory /github/workspace`;
-		await $`git config --global --user.name "github-actions[bot]"`;
-		await $`git config --global --user.email "github-actions[bot]@users.noreply.github.com"`;
+		await $`git config --global user.name "github-actions[bot]"`;
+		await $`git config --global user.email "github-actions[bot]@users.noreply.github.com"`;
 		console.info("git commit all...");
 		await $`git status`;
 		await $`git add .`;


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2476b2b</samp>

Fix a bug in the `publish.mjs` script that prevented setting the correct git user for the release commit. Remove the `--` syntax from the `git config` commands.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2476b2b</samp>

* Fix git config bug in release script by removing `--` from options ([link](https://github.com/web-infra-dev/rspack/pull/3342/files?diff=unified&w=0#diff-121ac8f9e24f2b43274b72e2b02402ecdef16563740899434511ba9ecc099dc8L27-R28))

</details>
