### PR TITLE
chore: change default pr version

### DIFF
--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -7,7 +7,7 @@ on:
         type: choice
         description: "Release Version(major|minor|patch|snapshot)"
         required: true
-        default: "latest"
+        default: "patch"
         options:
           - major
           - minor
@@ -34,7 +34,7 @@ jobs:
       - name: Create Release Pull Request
         uses: hardfist/rspack-action@rspack
         with:
-          version: node ./x version ${{inputs.version || 'canary'}}
+          version: node ./x version ${{inputs.version || 'patch'}}
           createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4b23a9f</samp>

Change default and fallback version type to `patch` for release action. This improves semantic versioning and prevents accidental canary releases in `.github/workflows/release-pull-request.yml`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4b23a9f</samp>

* Change the default and fallback values for the version type to `patch` ([link](https://github.com/web-infra-dev/rspack/pull/3344/files?diff=unified&w=0#diff-16a64a20883492ca4054e74874bd1b1b2e551bb2d4729678a263a8df16b44efdL10-R10), [link](https://github.com/web-infra-dev/rspack/pull/3344/files?diff=unified&w=0#diff-16a64a20883492ca4054e74874bd1b1b2e551bb2d4729678a263a8df16b44efdL37-R37))

</details>
