### PR TITLE
fix: builtins.provide function params transform bug

### DIFF
--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
@@ -2,9 +2,11 @@
 "./index.js": function (module, exports, __webpack_require__) {
 var process = __webpack_require__("./process.js");
 console.log(process.env);
+(function(process) {
+    console.log(process, process[0], process.env);
+})({});
 },
 "./process.js": function (module, exports, __webpack_require__) {
-__webpack_require__("./process.js");
 var process = module.exports = {};
 var cachedSetTimeout;
 var cachedClearTimeout;

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/index.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/index.js
@@ -1,2 +1,6 @@
 // var process = {};
-console.log(process.env)
+console.log(process.env);
+
+(function (process) {
+	console.log(process, process[0], process.env);
+})({});

--- a/packages/rspack/tests/configCases/builtins/provide/index.js
+++ b/packages/rspack/tests/configCases/builtins/provide/index.js
@@ -56,6 +56,14 @@ it("should variable coverage", function () {
 	expect(process.a).toBe(123);
 });
 
+it("should not provide for function defined variable", function () {
+	function test(process) {
+		expect(process[0]).toBe(undefined);
+		expect(process.a).toBe(undefined);
+	}
+	test({});
+});
+
 // TODO: Add support for these cases
 // it("should provide a module for a nested var within a IIFE's this", function () {
 // 	(function () {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d05c84d</samp>

This pull request enhances the provide plugin for JavaScript, which resolves unresolved identifiers with built-in modules. It improves the plugin's logic and performance, adds a new test case, and updates the existing test cases to cover more scenarios. The changes affect the `provide.rs` file, the `crates/rspack_plugin_javascript/tests/fixtures/provide` folder, and the `packages/rspack/tests/configCases/builtins/provide` folder.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d05c84d</samp>

*  Add a condition to avoid providing built-in modules for unresolved identifiers ([link](https://github.com/web-infra-dev/rspack/pull/3347/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL34-R35))
*  Simplify the logic of getting the name of a nested identifier ([link](https://github.com/web-infra-dev/rspack/pull/3347/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL40-R41), [link](https://github.com/web-infra-dev/rspack/pull/3347/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL52-R66))
*  Modify the provide plugin test case to check if the provided module is not overwritten by a function parameter (`crates/rspack_plugin_javascript/tests/fixtures/provide/index.js`, `crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js`, [link](https://github.com/web-infra-dev/rspack/pull/3347/files?diff=unified&w=0#diff-35bca6b107cd0329c7a1af193d64eb596cb0afb6530cd1b866d8a3962047648fL5-R9), [link](https://github.com/web-infra-dev/rspack/pull/3347/files?diff=unified&w=0#diff-c20b2d0e81223d90dcbb99e404820ec61e04b4d420afac879abac24a5f120e25L2-R6))
*  Add a new test case to the builtins provide config case to check if the provide plugin does not inject a module for a function defined variable (`packages/rspack/tests/configCases/builtins/provide/index.js`, [link](https://github.com/web-infra-dev/rspack/pull/3347/files?diff=unified&w=0#diff-e5a24d044c31e364d739eeaa5774a5b6c9aa45a30b526423c8e98e19f99734ffR59-R66))

</details>
