### PR TITLE
fix(rust): use jemallocator for linux gnu, mimalloc for everything else

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -28,10 +28,10 @@ runs:
         options: >
           --privileged
           --user 0:0
-          -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db:cached
-          -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache:cached
-          -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index:cached
-          -v ${{ github.workspace }}:/build:cached
+          -v ${{ github.workspace }}/.cargo/git/db:/usr/local/cargo/git/db
+          -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache
+          -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index
+          -v ${{ github.workspace }}:/build
           -w /build
         run: |
           set -e

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -85,6 +85,7 @@ jobs:
         with:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           target: ${{ inputs.target }}
+          pre: unset CC_x86_64_unknown_linux_gnu && unset CC # for jemallocator to compile
 
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "rspack_fs",
  "rspack_testing",
  "rspack_tracing",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -806,6 +807,12 @@ dependencies = [
  "swc_macros_common",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2161,6 +2168,7 @@ dependencies = [
  "serde",
  "serde_json",
  "testing_macros",
+ "tikv-jemallocator",
  "tokio",
  "ustr",
  "xshell",
@@ -2239,7 +2247,6 @@ dependencies = [
 name = "rspack_build"
 version = "0.1.0"
 dependencies = [
- "mimalloc-rust",
  "rspack_core",
  "rspack_error",
  "rspack_fs",
@@ -2463,6 +2470,7 @@ dependencies = [
  "rspack_napi_shared",
  "rspack_tracing",
  "testing_macros",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -4474,6 +4482,27 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.3+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5b7bcecfafe4998587d636f9ae9d55eb9d0499877b88757767c346875067098"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ swc_html            = { version = "=0.124.16" }
 swc_html_minifier   = { version = "=0.121.16" }
 swc_node_comments   = { version = "=0.18.10" }
 swc_plugin_import   = { version = "=0.1.7" }
+tikv-jemallocator   = { version = "=0.4.3", features = ["disable_initial_exec_tls"] }
 
 [profile.dev]
 debug       = 2

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -11,11 +11,15 @@ version    = "0.1.0"
 rspack_core    = { path = "../rspack_core" }
 rspack_fs      = { path = "../rspack_fs", features = ["async"] }
 rspack_testing = { path = "../rspack_testing" }
+rspack_tracing = { path = "../rspack_tracing" }
 tokio          = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 
-[target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
-mimalloc-rust  = { workspace = true }
-rspack_tracing = { path = "../rspack_tracing" }
+[target.'cfg(not(target_os = "linux"))'.dependencies]
+mimalloc-rust = { workspace = true }
+
+[target.'cfg(all(target_os = "linux", target_env = "gnu", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+tikv-jemallocator = { workspace = true }
+
 [features]
 hmr     = []
 tracing = []

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -2,7 +2,6 @@ mod termcolorful;
 use std::str::FromStr;
 use std::{path::PathBuf, time::Instant};
 
-use mimalloc_rust::GlobalMiMalloc;
 use rspack_core::Compiler;
 use rspack_fs::AsyncNativeFileSystem;
 use rspack_testing::apply_from_fixture;
@@ -10,9 +9,17 @@ use rspack_testing::apply_from_fixture;
 use rspack_tracing::{enable_tracing_by_env, enable_tracing_by_env_with_chrome_layer};
 use termcolorful::println_string_with_fg_color;
 
-#[cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))]
+#[cfg(not(target_os = "linux"))]
 #[global_allocator]
-static GLOBAL: GlobalMiMalloc = GlobalMiMalloc;
+static GLOBAL: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
+
+#[cfg(all(
+  target_os = "linux",
+  target_env = "gnu",
+  any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[derive(Default, Clone, Copy)]
 enum Layer {

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -35,8 +35,8 @@ napi-sys    = { workspace = true }
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = { workspace = true }
 
-[target.'cfg(all(target_os = "linux", not(all(target_env = "musl", target_arch = "aarch64"))))'.dependencies]
-mimalloc-rust = { workspace = true, features = ["local-dynamic-tls"] }
+[target.'cfg(all(target_os = "linux", target_env = "gnu", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
+tikv-jemallocator = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -28,9 +28,17 @@ use plugins::*;
 use rspack_binding_options::*;
 use utils::*;
 
-#[cfg(all(not(all(target_os = "linux", target_env = "musl"))))]
+#[cfg(not(target_os = "linux"))]
 #[global_allocator]
-static ALLOC: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
+static GLOBAL: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
+
+#[cfg(all(
+  target_os = "linux",
+  target_env = "gnu",
+  any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 // **Note** that Node's main thread and the worker thread share the same binding context. Using `Mutex<HashMap>` would cause deadlocks if multiple compilers exist.
 struct SingleThreadedHashMap<K, V>(DashMap<K, V>);

--- a/crates/rspack/Cargo.toml
+++ b/crates/rspack/Cargo.toml
@@ -27,8 +27,11 @@ testing_macros = { workspace = true }
 ustr           = { workspace = true }
 xshell         = "0.2.2"
 
-[target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dev-dependencies]
+[target.'cfg(not(target_os = "linux"))'.dev-dependencies]
 mimalloc-rust = { workspace = true }
+
+[target.'cfg(all(target_os = "linux", target_env = "gnu", any(target_arch = "x86_64", target_arch = "aarch64")))'.dev-dependencies]
+tikv-jemallocator = { workspace = true }
 
 [[bench]]
 harness = false

--- a/crates/rspack_build/Cargo.toml
+++ b/crates/rspack_build/Cargo.toml
@@ -12,8 +12,5 @@ rspack_fs      = { path = "../rspack_fs", features = ["async"] }
 rspack_testing = { path = "../rspack_testing" }
 tokio          = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 
-[target.'cfg(all(not(all(target_os = "linux", target_arch = "aarch64", target_env = "musl"))))'.dependencies]
-mimalloc-rust = { workspace = true }
-
 [[bin]]
 name = "rspack_build"


### PR DESCRIPTION
This is aligned with swc, see https://github.com/swc-project/swc/blob/ad8e6a006c35977d70b719e67b5a45244c017ca1/crates/swc_node_base/Cargo.toml#LL16C1-L20C81

## Summary

This may fix CI crashing on linux machines

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0318b14</samp>

This pull request updates the memory allocator settings for different target platforms in the `rspack` project. It replaces the `mimalloc-rust` crate with the `jemallocator` crate for some Linux targets, to improve performance and compatibility. It also removes some unnecessary dependencies and adds some configuration attributes in various `Cargo.toml` and `src` files.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0318b14</samp>

*  Add `jemallocator` crate as a dependency to use `jemalloc` as the global allocator for some Linux targets ([link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R24))
*  Remove `rspack_tracing` dependency from the benchmarking crate and refine target-specific dependencies for `mimalloc-rust` and `jemallocator` based on performance and compatibility ([link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dL14-R22))
*  Remove unused `use mimalloc_rust::GlobalMiMalloc` statements from the benchmarking crate and the benchmarking tests ([link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL5), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-89ef11f0a86d66a23c336004fbf4c46d6eb506ef55fa05833874c668dc19cf23L5))
*  Set `jemalloc` as the global allocator for Linux targets with `gnu` environment and either `x86_64` or `aarch64` architecture using `#[global_allocator]` and `static GLOBAL` in the benchmarking crate, the benchmarking tests, and the Node.js binding crate (`Cargo.toml` [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dL14-R22), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L38-R39), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-f51d8e1dc90c204d99678ea03628f395c2f28efb9acf6c590d8f6a2046782d02L30-R35); `main.rs` [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL13-R23), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-89ef11f0a86d66a23c336004fbf4c46d6eb506ef55fa05833874c668dc19cf23L11-R21); `lib.rs` [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL31-R42))
*  Update `#[cfg]` attributes for `mimalloc-rust` to set `mimalloc` as the global allocator for non-Linux targets in the benchmarking crate, the benchmarking tests, and the Node.js binding crate (`Cargo.toml` [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-040c5f33e1823527ff67bf803367fe638dd1b961a62a2718463407cc236d814dL14-R22), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7L38-R39), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-f51d8e1dc90c204d99678ea03628f395c2f28efb9acf6c590d8f6a2046782d02L30-R35); `main.rs` [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-9abedd04f90b98e09e7a37d793fbc40c9bbea96d72a625db310e7a0dc858322cL13-R23), [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-89ef11f0a86d66a23c336004fbf4c46d6eb506ef55fa05833874c668dc19cf23L11-R21); `lib.rs` [link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-7e63afe9a4959737c9b531f9b79b43a10060593534a3c4e7797bd41515ee14eaL31-R42))
*  Remove unnecessary `mimalloc-rust` dependency from the build script crate ([link](https://github.com/web-infra-dev/rspack/pull/3350/files?diff=unified&w=0#diff-f07f423257fb3c175025f7a9fd07aecd985e708ed2c9ebbf0295378d9627ec56L15-L17))

</details>
