### PR TITLE
chore: stale bot should make a comment, also change day until stale to 60 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -4,9 +4,17 @@
 
 # Configuration for probot-stale - https://github.com/probot/stale
 staleLabel: "stale"
-daysUntilStale: 30
+daysUntilStale: 60
 daysUntilClose: false
-markComment: false
 closeComment: false
-# exemptLabels:
-  # - ""
+exemptLabels:
+  - "tracking issue"
+issues:
+  markComment: >
+    This issue has been automatically marked as stale because it has not had recent activity.
+    **If this issue is still affecting you, please leave any comment** (for example, "bump").
+    We are sorry that we haven't been able to prioritize it yet. If you have any new additional information, please include it with your comment!
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had recent activity.
+    **If this pull request is still relevant, please leave any comment** (for example, "bump").


### PR DESCRIPTION
## Summary

It was brought to me that labeling anything as stale without context is invasive, this updates the bot to leave a comment on why a particular issue / pr is marked as stale.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bad2464</samp>

No summary available (An error occurred while summarizing these changes: Gave up after 3 retries: Failed to read error response)

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bad2464</samp>

* Increase the time before issues and pull requests are marked as stale from 30 to 60 days (`daysUntilStale` option in [link](https://github.com/web-infra-dev/rspack/pull/3355/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aL7-R20))
* Exclude issues with the label "tracking issue" from being marked as stale (`exemptLabels` option in [link](https://github.com/web-infra-dev/rspack/pull/3355/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aL7-R20))
* Customize the messages for issues and pull requests when they are marked as stale (`markComment` option in [link](https://github.com/web-infra-dev/rspack/pull/3355/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aL7-R20))
  * For issues, ask the author or participants to leave a comment if the issue is still relevant and provide any new information (`markComment.issues` in [link](https://github.com/web-infra-dev/rspack/pull/3355/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aL7-R20))
  * For pull requests, ask the author to leave a comment if the pull request is still ready for review and merge (`markComment.pullRequests` in [link](https://github.com/web-infra-dev/rspack/pull/3355/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aL7-R20))
  * Apologize for the lack of prioritization and acknowledge the potential frustration of the stale bot in both messages (`markComment.issues` and `markComment.pullRequests` in [link](https://github.com/web-infra-dev/rspack/pull/3355/files?diff=unified&w=0#diff-76cc7f7adb754443d391eb9c8df1d4a47e8cd668179e41915153685a0b83b30aL7-R20))

</details>
