### PR TITLE
chore(splitChunks): add instrument to methods of `SplitChunksPlugin`

### DIFF
--- a/crates/rspack_plugin_split_chunks_new/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/chunk.rs
@@ -126,6 +126,7 @@ impl SplitChunksPlugin {
   }
 
   /// This de-duplicated each module fro other chunks, make sure there's only one copy of each module.
+  #[tracing::instrument(skip_all)]
   pub(crate) fn move_modules_to_new_chunk_and_remove_from_old_chunks(
     &self,
     item: &ModuleGroup,
@@ -154,6 +155,7 @@ impl SplitChunksPlugin {
   /// create a connection between the `new_chunk` and `original_chunks`.
   /// Thus, if `original_chunks` want to know which chunk contains moved modules,
   /// it could easily find out.
+  #[tracing::instrument(skip_all)]
   pub(crate) fn split_from_original_chunks(
     &self,
     _item: &ModuleGroup,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/max_request.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/max_request.rs
@@ -8,6 +8,7 @@ use crate::{CacheGroup, SplitChunksPlugin};
 impl SplitChunksPlugin {
   /// Affected by `splitChunks.maxInitialRequests`/`splitChunks.cacheGroups.{cacheGroup}.maxInitialRequests`
   /// Affected by `splitChunks.maxAsyncRequests`/`splitChunks.cacheGroups.{cacheGroup}.maxAsyncRequests`
+  #[tracing::instrument(skip_all)]
   pub(crate) fn ensure_max_request_fit(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/max_size.rs
@@ -160,6 +160,7 @@ struct ChunkWithSizeInfo<'a> {
 
 impl SplitChunksPlugin {
   /// Affected by `splitChunks.minSize`/`splitChunks.cacheGroups.{cacheGroup}.minSize`
+  #[tracing::instrument(skip_all)]
   pub(super) fn ensure_max_size_fit(
     &self,
     compilation: &mut Compilation,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
@@ -6,6 +6,7 @@ use crate::SplitChunksPlugin;
 
 impl SplitChunksPlugin {
   /// Affected by `splitChunks.minSize`/`splitChunks.cacheGroups.{cacheGroup}.minSize`
+  #[tracing::instrument(skip_all)]
   pub(crate) fn ensure_min_size_fit(
     &self,
     compilation: &Compilation,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/mod.rs
@@ -141,17 +141,13 @@ impl Debug for SplitChunksPlugin {
 
 #[async_trait::async_trait]
 impl Plugin for SplitChunksPlugin {
+  #[tracing::instrument(name = "SplitChunksPlugin::optimize_chunks", skip_all)]
   async fn optimize_chunks(
     &mut self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {
-    // use std::time::Instant;
-    // let start = Instant::now();
     self.inner_impl(args.compilation).await;
-
-    // let duration = start.elapsed();
-    // tracing::trace!("SplitChunksPlugin is: {:?}", duration);
     Ok(())
   }
 }

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 impl SplitChunksPlugin {
+  #[tracing::instrument(skip_all)]
   pub(crate) fn find_best_module_group(
     &self,
     module_group_map: &mut ModuleGroupMap,
@@ -35,6 +36,7 @@ impl SplitChunksPlugin {
     (best_entry_key, best_module_group)
   }
 
+  #[tracing::instrument(skip_all)]
   pub(crate) async fn prepare_module_group_map(
     &self,
     compilation: &mut Compilation,
@@ -108,6 +110,7 @@ impl SplitChunksPlugin {
             )
             .await;
 
+            #[tracing::instrument(skip_all)]
             async fn merge_matched_item_into_module_group_map(
               matched_item: MatchedItem<'_>,
               module_group_map: &DashMap<String, ModuleGroup>,
@@ -152,6 +155,7 @@ impl SplitChunksPlugin {
     module_group_map.into_iter().collect()
   }
 
+  #[tracing::instrument(skip_all)]
   pub(crate) fn remove_all_modules_from_other_module_groups(
     &self,
     item: &ModuleGroup,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f3c861</samp>

This pull request adds tracing support to various methods and structs in the `rspack_plugin_split_chunks_new` crate using the `tracing::instrument` attribute. This enables easier debugging and performance analysis of the plugin logic for splitting chunks based on different criteria. The `skip_all` argument is used to reduce the tracing overhead where possible.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f3c861</samp>

*  Add `tracing::instrument` attributes to various methods and closures to enable tracing of their execution ([link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-f95f4b897cc295e831c48ba3c2b5f5c124d03ccb0dfc95b125dec06b4f9d6ba4R129), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-f95f4b897cc295e831c48ba3c2b5f5c124d03ccb0dfc95b125dec06b4f9d6ba4R158), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-df5e22b8430b27c0d6936f0c0a74a3f449f5b84a3b60d7c84eacb5fb719e88b9R11), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-d37e7d6b15dacdb49c0f24c23ab58b699e5e218e9171a910bb3b4637164e4a5aR163), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-aea417a2412d75c4062fa5334fcf6a8598277f96282261dc9769e39f63be059dR9), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-8ae45ec9606865dac58ced163f0e1e7efb9b21d0d014132b5a2de6587f1d4a4aR144), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-491710d760a9177c165f505436fcb4f19f6f00caaeb2cd888f6377d881827d23R15), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-491710d760a9177c165f505436fcb4f19f6f00caaeb2cd888f6377d881827d23R39), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-491710d760a9177c165f505436fcb4f19f6f00caaeb2cd888f6377d881827d23R113), [link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-491710d760a9177c165f505436fcb4f19f6f00caaeb2cd888f6377d881827d23R158))
* Remove commented out code for measuring duration of `SplitChunksPlugin::optimize_chunks` method in `mod.rs` since tracing can provide the same information ([link](https://github.com/web-infra-dev/rspack/pull/3361/files?diff=unified&w=0#diff-8ae45ec9606865dac58ced163f0e1e7efb9b21d0d014132b5a2de6587f1d4a4aL149-R150))

</details>
