### PR TITLE
chore(packages): upload less files to npm

### DIFF
--- a/packages/postcss-loader/package.json
+++ b/packages/postcss-loader/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "echo success"
   },
+  "files": [
+    "src"
+  ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -8,6 +8,9 @@
     "dev": "tsc -w",
     "test": "echo success"
   },
+  "files": [
+    "dist"
+  ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -9,6 +9,10 @@
     "build": "tsc",
     "dev": "tsc -w"
   },
+  "files": [
+    "index.js",
+    "dist"
+  ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-dev-middleware/package.json
+++ b/packages/rspack-dev-middleware/package.json
@@ -10,7 +10,7 @@
     "dev": "tsc -w"
   },
   "files": [
-    "index.js",
+    "index.cjs",
     "dist"
   ],
   "homepage": "https://rspack.dev",

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -10,6 +10,9 @@
     "dev": "tsc -w",
     "test": "rimraf .test-temp && jest --runInBand"
   },
+  "files": [
+    "dist"
+  ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -10,6 +10,10 @@
     "dev": "tsc -w",
     "test": "jest --runInBand --verbose"
   },
+  "files": [
+    "index.cjs",
+    "dist"
+  ],
   "keywords": [
     "rspack",
     "html"

--- a/packages/rspack-plugin-minify/package.json
+++ b/packages/rspack-plugin-minify/package.json
@@ -5,6 +5,9 @@
   "description": "Minify plugin for rspack",
   "main": "src/index.js",
   "scripts": {},
+  "files": [
+    "src"
+  ],
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-plugin-node-polyfill/package.json
+++ b/packages/rspack-plugin-node-polyfill/package.json
@@ -7,6 +7,9 @@
   "scripts": {
     "test": "echo success"
   },
+  "files": [
+    "src"
+  ],
   "access": "public",
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",


### PR DESCRIPTION
## Summary

- [ ] Sync with https://github.com/web-infra-dev/rspack/pull/3358

<img width="1183" alt="image" src="https://github.com/web-infra-dev/rspack/assets/1430279/ea0472e9-7527-4d1f-bdb3-516c82986ed6">

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60c066a</samp>

Added `files` field to `package.json` files of various packages in the `rspack` monorepo. This is to limit the published files to only the essential ones.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60c066a</samp>

*  Add `files` field to `package.json` files of six packages to specify which files or directories to include in the published package ([link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-60234f94c0ef832fdcdd49834d65853a43a3ca2f0afd749a429a2f12780dee3cR10-R12), [link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-fe803544b5ac2002f5f1fdc7bd165fabf6be7b72bf4547dd0b021b3d9eb530f2R11-R13), [link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-504d587d455e9a7b90cb4298d6ddd50c8975fcb3dcaea5318a34fecd3dd08c35R12-R14), [link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-fa2af2cbbd416f67bb21aaa181218db15fb78d0b36da8b031ff14bf18d0770dcR13-R15), [link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-fc52b26886589aa1494cf1db2f29410f17edad240e6b47d4a616abe688b09646R13-R15), [link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-8d7facb33f56a6db3c94b6c76126a185e94e5792ee4db2ac07615553e5d9ed93R8-R10), [link](https://github.com/web-infra-dev/rspack/pull/3362/files?diff=unified&w=0#diff-62c992a519e11d92a876776eaa7094268fc0ada195d2ef477ba010a9634c87c4R10-R12))

</details>
