### PR TITLE
fix: fix wrong context in external function

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -630,6 +630,7 @@ impl NormalModuleFactory {
       .await
       .factorize(
         FactorizeArgs {
+          context: &data.context,
           dependency: &*data.dependency,
           plugin_driver: &self.plugin_driver,
         },

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -76,6 +76,7 @@ impl<'me> RenderManifestArgs<'me> {
 
 #[derive(Debug, Clone)]
 pub struct FactorizeArgs<'me> {
+  pub context: &'me Option<String>,
   pub dependency: &'me dyn ModuleDependency,
   pub plugin_driver: &'me SharedPluginDriver,
 }

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -118,13 +118,13 @@ impl Plugin for ExternalPlugin {
         }
         ExternalItem::Fn(f) => {
           let request = args.dependency.request();
-
+          let context = args
+            .context
+            .as_ref()
+            .expect(&format!("{request} should have context"))
+            .to_string();
           let result = f(ExternalItemFnCtx {
-            context: PathBuf::from(request.to_string())
-              .parent()
-              .expect("should have context")
-              .to_string_lossy()
-              .to_string(),
+            context,
             request: request.to_string(),
             dependency_type: args.dependency.category().to_string(),
           })


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4518bd7</samp>

This pull request adds a `context` field to the structs and arguments used for module creation and dependency resolution. This improves the performance and reliability of the `ExternalPlugin` and allows it to access the directory of the module that requires the dependency.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4518bd7</samp>

*  Add `context` field to `NormalModuleFactoryCreateData` to pass the directory of the module that requires the dependency ([link](https://github.com/web-infra-dev/rspack/pull/3370/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR633))
*  Add `context` field to `ExternalPluginArgs` to pass the reference to the `context` field from `NormalModuleFactoryCreateData` to the `ExternalPlugin` ([link](https://github.com/web-infra-dev/rspack/pull/3370/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337R79))
*  Use `context` field from `ExternalPluginArgs` instead of deriving it from `request` in `ExternalPlugin` implementation in `plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3370/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L121-R128))
*  Add `expect` call to ensure `context` field is present and provide a more informative error message in `ExternalPlugin` implementation in `plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3370/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L121-R128))

</details>
