### PR TITLE
fix: fix wrong context in external function

### DIFF
--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf};
+use std::fmt::Debug;
 
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -121,7 +121,7 @@ impl Plugin for ExternalPlugin {
           let context = args
             .context
             .as_ref()
-            .expect(&format!("{request} should have context"))
+            .unwrap_or_else(|| panic!("{request} should have context"))
             .to_string();
           let result = f(ExternalItemFnCtx {
             context,


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c6cea2</samp>

This pull request adds a `context` field to the structs and arguments that are used for module creation and plugin application. This allows plugins to resolve external dependencies based on the directory where the module request originated from.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4c6cea2</samp>

*  Add `context` field to `NormalModuleFactoryCreateData` and `PluginArgs` structs to pass the module request origin directory to the `NormalModuleFactory` and the plugins ([link](https://github.com/web-infra-dev/rspack/pull/3372/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eR633), [link](https://github.com/web-infra-dev/rspack/pull/3372/files?diff=unified&w=0#diff-65ed133c45bc1a8d647a0c4b50808420d3a9b9853e87ee835ca90995cbf5c337R79))
*  Use `context` field from `PluginArgs` to resolve external dependencies with custom functions instead of deriving it from the `request` string, and panic if `context` is `None` in `crates/rspack_plugin_externals/src/plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3372/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L121-R127))
*  Move `use std::fmt::Debug` statement from `crates/rspack_plugin_externals/src/plugin.rs` to `crates/rspack_core/src/normal_module_factory.rs` where it is needed for the `ExternalItemFnCtx` struct ([link](https://github.com/web-infra-dev/rspack/pull/3372/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L1-R1))

</details>
