### PR TITLE
chore: remove unused import

### DIFF
--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, path::PathBuf};
+use std::fmt::Debug;
 
 use once_cell::sync::Lazy;
 use regex::Regex;


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c79d021</samp>

Removed an unnecessary import from `rspack_plugin_externals` crate. This simplifies the code and reduces dependencies.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c79d021</samp>

* Remove unused import of `path::PathBuf` in `plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3373/files?diff=unified&w=0#diff-5645889363b08ef4a327ab1c9fc5b82c2dc4fe1e668b62a29d89b242a86c69e3L1-R1))

</details>
