### PR TITLE
ci: use debug build for tests

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -9,6 +9,10 @@ inputs:
   image:
     required: true
     type: string
+  profile:
+    default: 'release'
+    required: false
+    type: string
   pre:
     required: false
     default: ""
@@ -38,5 +42,5 @@ runs:
           ${{ inputs.pre }}
           rustup target add ${{ inputs.target }}
           corepack enable
-          RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+          RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
           ${{ inputs.post }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,14 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: x86_64-unknown-linux-gnu
+      profile: 'debug'
 
   test-windows:
     name: Test Windows
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: x86_64-pc-windows-msvc
+      profile: 'debug'
 
   test-mac:
     name: Test Mac
@@ -46,6 +48,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: x86_64-apple-darwin
+      profile: 'debug'
 
   spell:
     name: Spell check

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -26,6 +26,10 @@ on:
       target:
         required: true
         type: string
+      profile: # Rust profile, "debug" or "release"
+        default: 'release'
+        required: false
+        type: string
 
 jobs:
   select:
@@ -85,6 +89,7 @@ jobs:
         with:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
           target: ${{ inputs.target }}
+          profile: ${{ inputs.profile }}
           pre: unset CC_x86_64_unknown_linux_gnu && unset CC # for jemallocator to compile
 
       - name: Build aarch64-unknown-linux-gnu in Docker
@@ -93,6 +98,7 @@ jobs:
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
+          profile: ${{ inputs.profile }}
           pre: export JEMALLOC_SYS_WITH_LG_PAGE=16 && export CC_aarch64_unknown_linux_gnu=/usr/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc # for jemallocator to compile
 
       - name: Build x86_64-unknown-linux-musl in Docker
@@ -101,6 +107,7 @@ jobs:
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          profile: ${{ inputs.profile }}
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' }}
@@ -108,6 +115,7 @@ jobs:
         with:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          profile: ${{ inputs.profile }}
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
 
@@ -115,15 +123,15 @@ jobs:
 
       - name: Build i686-pc-windows-msvc
         if: ${{ inputs.target == 'i686-pc-windows-msvc' }}
-        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
 
       - name: Build x86_64-pc-windows-msvc
         if: ${{ inputs.target == 'x86_64-pc-windows-msvc' }}
-        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
 
       - name: Build aarch64-pc-windows-msvc
         if: ${{ inputs.target == 'aarch64-pc-windows-msvc' }}
-        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+        run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
 
       # Mac
       - uses: goto-bus-stop/setup-zig@v2
@@ -134,7 +142,7 @@ jobs:
       - name: Build x86_64-apple-darwin
         if: ${{ inputs.target == 'x86_64-apple-darwin' }}
         run: |
-          RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+          RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
 
       - name: Build aarch64-apple-darwin
         if: ${{ inputs.target == 'aarch64-apple-darwin' }}
@@ -144,7 +152,7 @@ jobs:
           export CXX=$(xcrun -f clang++);
           SYSROOT=$(xcrun --sdk macosx --show-sdk-path);
           export CFLAGS="-isysroot $SYSROOT -isystem $SYSROOT";
-          RUST_TARGET=${{ inputs.target }} pnpm build:binding:release
+          RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v3
@@ -233,7 +241,7 @@ jobs:
       ### Note that, We can't merge this script, because this script only runs on main branch
       - name: Update main branch test compatibility metric
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && github.ref_name == 'main' && matrix.node == '18' }}
-        run: node ./webpack-test/scripts/generate.js ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}  
+        run: node ./webpack-test/scripts/generate.js ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}
 
       # ### update metric diff against main branch when pull request change
       - name: Update


### PR DESCRIPTION
## Summary

This should:
* reduce ci build time
* have a debug build available to download from the uploaded artifacts

We can tune some of the dependencies to use optimization if things start to run slow.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26e239a</samp>

This pull request adds support for building the binding with different Rust profiles using a new `profile` parameter for the `docker-build` action and the workflows that use it. This allows for faster and more flexible builds of the binding for different purposes.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26e239a</samp>

*  Add `profile` input parameter to `docker-build` action to allow specifying Rust profile for building the binding ([link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-f1d084efa26a0f0f45c8ba872e6dc750a73daca60a47dfa42121b28eda7e32b3R12-R15),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-f1d084efa26a0f0f45c8ba872e6dc750a73daca60a47dfa42121b28eda7e32b3L41-R45))
*  Add `profile` parameter to `reusable-build` workflow to pass it to `docker-build` action for different targets ([link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R29-R32),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R92),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R100),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R108),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R116),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L116-R132),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L135-R143),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L145-R153))
*  Set `profile` parameter to `debug` in `ci` workflow for faster builds and more debugging features ([link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR36),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR43),[link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR51))
*  Remove trailing whitespace from `reusable-build` workflow ([link](https://github.com/web-infra-dev/rspack/pull/3374/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L234-R242))

</details>
