### PR TITLE
feat: nested module rules

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -618,6 +618,7 @@ export interface RawModuleRule {
   scheme?: RawRuleSetCondition
   mimetype?: RawRuleSetCondition
   oneOf?: Array<RawModuleRule>
+  rules?: Array<RawModuleRule>
   /** Specifies the category of the loader. No value means normal loader. */
   enforce?: 'pre' | 'post'
 }

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -238,6 +238,7 @@ pub struct RawModuleRule {
   pub scheme: Option<RawRuleSetCondition>,
   pub mimetype: Option<RawRuleSetCondition>,
   pub one_of: Option<Vec<RawModuleRule>>,
+  pub rules: Option<Vec<RawModuleRule>>,
   /// Specifies the category of the loader. No value means normal loader.
   #[napi(ts_type = "'pre' | 'post'")]
   pub enforce: Option<String>,
@@ -360,6 +361,16 @@ impl RawOptionsApply for RawModuleRule {
       })
       .transpose()?;
 
+    let rules = self
+      .rules
+      .map(|rule| {
+        rule
+          .into_iter()
+          .map(|raw| raw.apply(_plugins, loader_runner))
+          .collect::<rspack_error::Result<Vec<_>>>()
+      })
+      .transpose()?;
+
     let description_data = self
       .description_data
       .map(|data| {
@@ -404,6 +415,7 @@ impl RawOptionsApply for RawModuleRule {
       scheme: self.scheme.map(|raw| raw.try_into()).transpose()?,
       mimetype: self.mimetype.map(|raw| raw.try_into()).transpose()?,
       one_of,
+      rules,
       enforce,
     })
   }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -12,7 +12,7 @@ use sugar_path::{AsPath, SugarPath};
 use swc_core::common::Span;
 
 use crate::{
-  cache::Cache, module_rule_matcher, parse_resource, resolve, stringify_loaders_and_resource,
+  cache::Cache, module_rules_matcher, parse_resource, resolve, stringify_loaders_and_resource,
   AssetGeneratorOptions, AssetParserOptions, BoxLoader, CompilerOptions, Dependency,
   DependencyCategory, DependencyType, FactorizeArgs, FactoryMeta, MissingModule, ModuleArgs,
   ModuleDependency, ModuleExt, ModuleFactory, ModuleFactoryCreateData, ModuleFactoryResult,
@@ -551,18 +551,14 @@ impl NormalModuleFactory {
     dependency: &DependencyCategory,
   ) -> Result<Vec<&ModuleRule>> {
     let mut rules = Vec::new();
-    for rule in &self.context.options.module.rules {
-      if let Some(rule) = module_rule_matcher(
-        rule,
-        resource_data,
-        self.context.issuer.as_deref(),
-        dependency,
-      )
-      .await?
-      {
-        rules.push(rule);
-      }
-    }
+    module_rules_matcher(
+      &self.context.options.module.rules,
+      resource_data,
+      self.context.issuer.as_deref(),
+      dependency,
+      &mut rules,
+    )
+    .await?;
     Ok(rules)
   }
 

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -146,6 +146,7 @@ pub struct ModuleRule {
   pub generator: Option<AssetGeneratorOptions>,
   pub resolve: Option<Resolve>,
   pub one_of: Option<Vec<ModuleRule>>,
+  pub rules: Option<Vec<ModuleRule>>,
   pub enforce: ModuleRuleEnforce,
 }
 

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -1,71 +1,58 @@
 use async_recursion::async_recursion;
-use rspack_error::{internal_error, Result};
+use rspack_error::Result;
 use rspack_loader_runner::{ResourceData, Scheme};
 
 use crate::{DependencyCategory, ModuleRule};
 
+pub async fn module_rules_matcher<'a>(
+  rules: &'a [ModuleRule],
+  resource_data: &ResourceData,
+  issuer: Option<&'a str>,
+  dependency: &DependencyCategory,
+  matched_rules: &mut Vec<&'a ModuleRule>,
+) -> Result<()> {
+  for rule in rules {
+    module_rule_matcher(rule, resource_data, issuer, dependency, matched_rules).await?;
+  }
+  Ok(())
+}
+
 /// Match the `ModuleRule` against the given `ResourceData`, and return the matching `ModuleRule` if matched.
+#[async_recursion]
 pub async fn module_rule_matcher<'a>(
   module_rule: &'a ModuleRule,
   resource_data: &ResourceData,
   issuer: Option<&'a str>,
   dependency: &DependencyCategory,
-) -> Result<Option<&'a ModuleRule>> {
-  if module_rule.test.is_none()
-    && module_rule.resource.is_none()
-    && module_rule.resource_query.is_none()
-    && module_rule.resource_fragment.is_none()
-    && module_rule.include.is_none()
-    && module_rule.exclude.is_none()
-    && module_rule.issuer.is_none()
-    && module_rule.scheme.is_none()
-    && module_rule.mimetype.is_none()
-    && module_rule.dependency.is_none()
-    && module_rule.description_data.is_none()
-    && module_rule.one_of.is_none()
-  {
-    return Err(internal_error!(
-      "ModuleRule must have at least one condition"
-    ));
-  }
-
-  module_rule_matcher_inner(module_rule, resource_data, issuer, dependency).await
-}
-
-#[async_recursion]
-pub async fn module_rule_matcher_inner<'a>(
-  module_rule: &'a ModuleRule,
-  resource_data: &ResourceData,
-  issuer: Option<&'a str>,
-  dependency: &DependencyCategory,
-) -> Result<Option<&'a ModuleRule>> {
+  matched_rules: &mut Vec<&'a ModuleRule>,
+) -> Result<bool> {
   // Include all modules that pass test assertion. If you supply a Rule.test option, you cannot also supply a `Rule.resource`.
   // See: https://webpack.js.org/configuration/module/#ruletest
   if let Some(test_rule) = &module_rule.test
     && !test_rule.try_match(&resource_data.resource_path.to_string_lossy()).await? {
-    return Ok(None);
+    return Ok(false);
   } else if let Some(resource_rule) = &module_rule.resource
     && !resource_rule.try_match(&resource_data.resource_path.to_string_lossy()).await? {
-    return Ok(None);
+    return Ok(false);
   }
 
   if let Some(include_rule) = &module_rule.include
     && !include_rule.try_match(&resource_data.resource_path.to_string_lossy()).await? {
-    return Ok(None);
+    return Ok(false);
   }
 
   if let Some(exclude_rule) = &module_rule.exclude
     && exclude_rule.try_match(&resource_data.resource_path.to_string_lossy()).await? {
-    return Ok(None);
+    return Ok(false);
   }
 
   if let Some(resource_query_rule) = &module_rule.resource_query {
     if let Some(resource_query) = &resource_data.resource_query {
       if !resource_query_rule.try_match(resource_query).await? {
-        return Ok(None);
+        return Ok(false);
       }
     } else {
-      return Ok(None);
+      return Ok(false);
     }
   }
 
@@ -75,42 +62,42 @@ pub async fn module_rule_matcher_inner<'a>(
         .try_match(resource_fragment)
         .await?
       {
-        return Ok(None);
+        return Ok(false);
       }
     } else {
-      return Ok(None);
+      return Ok(false);
     }
   }
 
   if let Some(mimetype_condition) = &module_rule.mimetype {
     if let Some(mimetype) = &resource_data.mimetype {
       if !mimetype_condition.try_match(mimetype).await? {
-        return Ok(None);
+        return Ok(false);
       }
     } else {
-      return Ok(None);
+      return Ok(false);
     }
   }
 
   if let Some(scheme_condition) = &module_rule.scheme {
     let scheme = resource_data.get_scheme();
     if scheme == &Scheme::None {
-      return Ok(None);
+      return Ok(false);
     }
     if !scheme_condition.try_match(&scheme.to_string()).await? {
-      return Ok(None);
+      return Ok(false);
     }
   }
 
   if let Some(issuer_rule) = &module_rule.issuer
     && let Some(issuer) = issuer
     && !issuer_rule.try_match(issuer).await? {
-    return Ok(None);
+    return Ok(false);
   }
 
   if let Some(dependency_rule) = &module_rule.dependency
     && !dependency_rule.try_match(&dependency.to_string()).await? {
-    return Ok(None);
+    return Ok(false);
   }
 
   if let Some(description_data) = &module_rule.description_data {
@@ -123,25 +110,29 @@ pub async fn module_rule_matcher_inner<'a>(
           .and_then(|v| v.as_str())
         {
           if !matcher.try_match(v).await? {
-            return Ok(None);
+            return Ok(false);
           }
         } else {
-          return Ok(None);
+          return Ok(false);
         }
       }
     } else {
-      return Ok(None);
+      return Ok(false);
     }
   }
 
   if let Some(one_of) = &module_rule.one_of {
     for rule in one_of {
-      if let Some(rule) = module_rule_matcher_inner(rule, resource_data, issuer, dependency).await?
-      {
-        return Ok(Some(rule));
+      if module_rule_matcher(rule, resource_data, issuer, dependency, matched_rules).await? {
+        break;
       }
     }
   }
 
-  Ok(Some(module_rule))
+  if let Some(rules) = &module_rule.rules {
+    module_rules_matcher(rules, resource_data, issuer, dependency, matched_rules).await?;
+  }
+
+  matched_rules.push(module_rule);
+  Ok(true)
 }

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -272,7 +272,7 @@ function getRawModule(
 		!isNil(module.defaultRules),
 		"module.defaultRules should not be nil after defaults"
 	);
-	// "..." in defaultRules will be flatten in `applyModuleDefaults`, and "..." rules is empty, so it's safe to use `as RuleSetRule[]` at here
+	// "..." in defaultRules will be flatten in `applyModuleDefaults`, and "..." in rules is empty, so it's safe to use `as RuleSetRule[]` at here
 	const ruleSet = [
 		{ rules: module.defaultRules as RuleSetRule[] },
 		{ rules: module.rules as RuleSetRule[] }

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -272,10 +272,14 @@ function getRawModule(
 		!isNil(module.defaultRules),
 		"module.defaultRules should not be nil after defaults"
 	);
-	// TODO: workaround for module.defaultRules
-	const rules = (
-		[...module.defaultRules, ...module.rules] as RuleSetRule[]
-	).map<RawModuleRule>(i => getRawModuleRule(i, options));
+	// "..." in defaultRules will be flatten in `applyModuleDefaults`, and "..." rules is empty, so it's safe to use `as RuleSetRule[]` at here
+	const ruleSet = [
+		{ rules: module.defaultRules as RuleSetRule[] },
+		{ rules: module.rules as RuleSetRule[] }
+	];
+	const rules = ruleSet.map((rule, index) =>
+		getRawModuleRule(rule, `ruleSet[${index}]`, options)
+	);
 	return {
 		rules,
 		parser: module.parser
@@ -284,6 +288,7 @@ function getRawModule(
 
 const getRawModuleRule = (
 	rule: RuleSetRule,
+	path: string,
 	options: ComposeJsUseOptions
 ): RawModuleRule => {
 	// Rule.loader is a shortcut to Rule.use: [ { loader } ].
@@ -323,13 +328,20 @@ const getRawModuleRule = (
 		scheme: rule.scheme ? getRawRuleSetCondition(rule.scheme) : undefined,
 		mimetype: rule.mimetype ? getRawRuleSetCondition(rule.mimetype) : undefined,
 		sideEffects: rule.sideEffects,
-		use: createRawModuleRuleUses(rule.use ?? [], options),
+		use: createRawModuleRuleUses(rule.use ?? [], `${path}.use`, options),
 		type: rule.type,
 		parser: rule.parser,
 		generator: rule.generator,
 		resolve: rule.resolve ? getRawResolve(rule.resolve) : undefined,
 		oneOf: rule.oneOf
-			? rule.oneOf.map(i => getRawModuleRule(i, options))
+			? rule.oneOf.map((rule, index) =>
+					getRawModuleRule(rule, `${path}.oneOf[${index}]`, options)
+			  )
+			: undefined,
+		rules: rule.rules
+			? rule.rules.map((rule, index) =>
+					getRawModuleRule(rule, `${path}.rules[${index}]`, options)
+			  )
 			: undefined,
 		enforce: rule.enforce
 	};

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -330,6 +330,7 @@ export interface RuleSetRule {
 		[k: string]: RuleSetCondition;
 	};
 	oneOf?: RuleSetRule[];
+	rules?: RuleSetRule[];
 	type?: string;
 	loader?: RuleSetLoader;
 	options?: RuleSetLoaderOptions;


### PR DESCRIPTION
## Related issue (if exists)

fixes #3379 

- use path (`ruleSet[1].rules[0].use[2]`) instead of random string for loader ident
- support `rule.rules`

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6c9da1f</samp>

This pull request adds a feature to support nested rules in the module system, which allows more flexibility and granularity in configuring how modules are resolved and loaded. It modifies the `RawModule`, `Module`, and `ModuleOptions` structs in the `rspack_core` and `rspack_binding_options` crates, and the `RuleSetRule` interface in the `rspack` package, to include a new `rules` field. It also implements the logic to process and match the nested rules in the `normal_module_factory` and `module_rules` modules of the `rspack_core` crate, and to generate unique identifiers for the rule uses in the `adapter` and `adapter-rule-use` modules of the `rspack` package.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6c9da1f</samp>

*  Add support for nested rules in the module system ([link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R241), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R364-R373), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-88d56d7c2fc780fbf03115c225e86e027a11aea2e0d1eb1dda2c0a1034aaaa59R418), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-06c579a7786ea5f17871a0f626ca314d0a41ffb8ba25152ce1d7661e6d1f3d8eR149), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL139-R137), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L275-R282), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L332-R345), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR333))
* Refactor the `module_rule_matcher` function to the `module_rules_matcher` function, which takes a slice of `ModuleRule` and a mutable vector to store the matched rules ([link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL15-R15), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL554-R561), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL2-R46), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL65-R55), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL78-R68), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL88-R78), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL98-R88), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL108-R100), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-3c7cf7d79a49a8bba240679cc9a01c97dbdd5f8affa7e72535fbb294f9526fdbL126-R120))
* Generate unique identifiers for the rule uses based on the path of the rule in the configuration ([link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0R198), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L207-R214), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L219-R220), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L228-R233), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0R241), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L250-R256), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-b53dc9e956708bceb549f1119eebd13e3e11fda6bdf771cd87c71599137567e0L263-L273), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R291), [link](https://github.com/web-infra-dev/rspack/pull/3380/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L326-R331))

</details>
