### PR TITLE
feat: add finishMake hook

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -192,6 +192,7 @@ export interface JsHooks {
   beforeCompile: (...args: any[]) => any
   afterCompile: (...args: any[]) => any
   finishModules: (...args: any[]) => any
+  finishMake: (...args: any[]) => any
   beforeResolve: (...args: any[]) => any
   afterResolve: (...args: any[]) => any
   contextModuleBeforeResolve: (...args: any[]) => any

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 #[derive(PartialEq)]
 pub enum Hook {
   Make,
+  FinishMake,
   Compilation,
   ThisCompilation,
   ProcessAssetsStageAdditional,
@@ -33,6 +34,7 @@ impl From<String> for Hook {
   fn from(s: String) -> Self {
     match s.as_str() {
       "make" => Hook::Make,
+      "finishMake" => Hook::FinishMake,
       "compilation" => Hook::Compilation,
       "thisCompilation" => Hook::ThisCompilation,
       "processAssetsStageAdditional" => Hook::ProcessAssetsStageAdditional,

--- a/crates/node_binding/src/js_values/hooks.rs
+++ b/crates/node_binding/src/js_values/hooks.rs
@@ -21,6 +21,7 @@ pub struct JsHooks {
   pub before_compile: JsFunction,
   pub after_compile: JsFunction,
   pub finish_modules: JsFunction,
+  pub finish_make: JsFunction,
   pub before_resolve: JsFunction,
   pub after_resolve: JsFunction,
   pub context_module_before_resolve: JsFunction,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -147,6 +147,14 @@ where
   async fn compile(&mut self, params: SetupMakeParam) -> Result<()> {
     let option = self.options.clone();
     self.compilation.make(params).await?;
+
+    self
+      .plugin_driver
+      .write()
+      .await
+      .finish_make(&mut self.compilation)
+      .await?;
+
     self.compilation.finish(self.plugin_driver.clone()).await?;
     // by default include all module in final chunk
     self.compilation.include_module_ids = self

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -325,6 +325,10 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
+  async fn finish_make(&mut self, _compilation: &mut Compilation) -> Result<()> {
+    Ok(())
+  }
+
   async fn finish_modules(&mut self, _modules: &mut Compilation) -> Result<()> {
     Ok(())
   }

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -188,6 +188,17 @@ impl PluginDriver {
 
     Ok(())
   }
+
+  pub async fn finish_make(
+    &mut self,
+    compilation: &mut Compilation,
+  ) -> PluginCompilationHookOutput {
+    for plugin in &mut self.plugins {
+      plugin.finish_make(compilation).await?;
+    }
+
+    Ok(())
+  }
   /// Executed while initializing the compilation, right before emitting the compilation event. This hook is not copied to child compilers.
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#thiscompilation

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -136,6 +136,7 @@ class Compiler {
 		beforeCompile: tapable.AsyncSeriesHook<any>;
 		afterCompile: tapable.AsyncSeriesHook<[Compilation]>;
 		finishModules: tapable.AsyncSeriesHook<[any]>;
+		finishMake: tapable.AsyncSeriesHook<[Compilation]>;
 	};
 	options: RspackOptionsNormalized;
 	#disabledHooks: string[];
@@ -234,6 +235,7 @@ class Compiler {
 			make: new tapable.AsyncParallelHook(["compilation"]),
 			beforeCompile: new tapable.AsyncSeriesHook(["params"]),
 			afterCompile: new tapable.AsyncSeriesHook(["compilation"]),
+			finishMake: new tapable.AsyncSeriesHook(["compilation"]),
 			finishModules: new tapable.AsyncSeriesHook(["modules"])
 		};
 		this.modifiedFiles = undefined;
@@ -284,6 +286,7 @@ class Compiler {
 				{
 					beforeCompile: this.#beforeCompile.bind(this),
 					afterCompile: this.#afterCompile.bind(this),
+					finishMake: this.#finishMake.bind(this),
 					make: this.#make.bind(this),
 					emit: this.#emit.bind(this),
 					assetEmitted: this.#assetEmitted.bind(this),
@@ -565,6 +568,7 @@ class Compiler {
 			make: this.hooks.make,
 			beforeCompile: this.hooks.beforeCompile,
 			afterCompile: this.hooks.afterCompile,
+			finishMake: this.hooks.finishMake,
 			emit: this.hooks.emit,
 			assetEmitted: this.hooks.assetEmitted,
 			afterEmit: this.hooks.afterEmit,
@@ -621,6 +625,11 @@ class Compiler {
 
 	async #afterCompile() {
 		await this.hooks.afterCompile.promise(this.compilation);
+		this.#updateDisabledHooks();
+	}
+
+	async #finishMake() {
+		await this.hooks.finishMake.promise(this.compilation);
 		this.#updateDisabledHooks();
 	}
 

--- a/packages/rspack/tests/configCases/hooks/compilation-hooks/a.js
+++ b/packages/rspack/tests/configCases/hooks/compilation-hooks/a.js
@@ -1,0 +1,1 @@
+export const a = 3;

--- a/packages/rspack/tests/configCases/hooks/compilation-hooks/index.js
+++ b/packages/rspack/tests/configCases/hooks/compilation-hooks/index.js
@@ -1,0 +1,5 @@
+import { a } from "./a.js";
+
+it("should compile successfully", () => {
+	expect(a).toBe(3);
+});

--- a/packages/rspack/tests/configCases/hooks/compilation-hooks/webpack.config.js
+++ b/packages/rspack/tests/configCases/hooks/compilation-hooks/webpack.config.js
@@ -1,0 +1,41 @@
+const { deepEqual, strict } = require("assert");
+const pluginName = "plugin";
+
+class Plugin {
+	apply(compiler) {
+		let order = [];
+
+		compiler.hooks.beforeCompile.tap(pluginName, () => {
+			order.push("hooks.beforeCompile");
+		});
+		compiler.hooks.make.tap(pluginName, () => {
+			order.push("hooks.make");
+		});
+		compiler.hooks.finishMake.tap(pluginName, () => {
+			order.push("hooks.finishMake");
+		});
+		compiler.hooks.afterCompile.tap(pluginName, () => {
+			order.push("hooks.afterCompile");
+		});
+
+		compiler.hooks.done.tap(pluginName, stats => {
+			let json = stats.toJson();
+			strict(json.errors.length === 0, `${json.errors}`);
+			deepEqual(order, [
+				"hooks.beforeCompile",
+				"hooks.make",
+				"hooks.finishMake",
+				"hooks.afterCompile"
+			]);
+		});
+	}
+}
+
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: []
+	},
+	plugins: [new Plugin()]
+};


### PR DESCRIPTION
## Related issue (if exists)
https://github.com/web-infra-dev/rspack/issues/3158
<!--- Provide link of related issues -->

## Summary
Adds the afterCompile hook needed for ProgressPlugin.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f4b7af</samp>

This pull request adds a new `finishMake` hook to the rspack compiler and its node binding. The hook allows plugins to run custom functions after the modules and dependencies are created. The pull request also adds a custom plugin example and a test case that use the hook to remove the hash from the output filenames. The pull request modifies several files in the `crates` and `packages` folders to implement and expose the hook.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f4b7af</samp>

*  Add a new variant `FinishMake` to the enum `Hook` that represents the types of hooks for plugins ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R7))
*  Add a new match arm to the `from_str` function that converts a string to a `Hook` variant for the `FinishMake` case ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-073c92c06772a11c0527a8a5c1e3780c11ed64ad8a8570e0d9a67bb13f856fc6R37))
*  Add a new field `finish_make` to the struct `Hooks` that holds the JavaScript functions registered as hooks by plugins ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-f9c75b6b6bf1571ed8a920a1c40076219cb7006d1ade118a0f3af7a3dd7c84ceR24))
*  Add a new field `finish_make_tsfn` to the struct `Plugin` that wraps the `finish_make` JavaScript function in a threadsafe function ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R45))
*  Add a new method `finish_make` to the struct `Plugin` that calls the `finish_make_tsfn` with the current compilation ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R443-R464))
*  Add the `finish_make` JavaScript function to the list of arguments for the `new` function of the struct `Plugin` ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R554))
*  Initialize the `finish_make_tsfn` field with the `js_fn_into_theadsafe_fn!` macro in the `new` function of the struct `Plugin` ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R591-R592))
*  Add the `finish_make_tsfn` field to the return value of the `new` function of the struct `Plugin` ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1R632))
*  Add a new line to the `compile` method of the struct `Compiler` in `crates/rspack_core/src/compiler/mod.rs` that calls the `finish_make` method of the `plugin_driver` after the `make` method and before the `after_compile` method ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209R150-R157))
*  Add a new method `finish_make` to the trait `PluginAPI` that takes a mutable reference to a `Compilation` and returns a `Result<()>` ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695R328-R331))
*  Add a new method `finish_make` to the struct `PluginDriver` that iterates over the plugins and calls their `finish_make` methods with the current compilation ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eR191-R201))
*  Add a new file `examples/basic/rspack.config.js` that contains a custom plugin class `RemoveHashPlugin` that demonstrates the usage of the `finishMake` hook ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-daaa7eb6c8f8733a48f42bc92475fab6bc98ec02b25904537f52724fab7555f3R1-R17))
*  Add a new property `plugins` to the `config` object in `examples/basic/rspack.config.js` that contains an instance of the `RemoveHashPlugin` class ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-daaa7eb6c8f8733a48f42bc92475fab6bc98ec02b25904537f52724fab7555f3L13-R32))
*  Add a new property `finishMake` to the class `Compiler` in `packages/rspack/src/compiler.ts` that is an instance of the `tapable.AsyncSeriesHook` class that represents the `finishMake` hook ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR139))
*  Initialize the `finishMake` property with a new instance of the `tapable.AsyncSeriesHook` class in the constructor of the class `Compiler` in `packages/rspack/src/compiler.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR238))
*  Add a new property `finishMake` to the object that is returned by the `getHooks` method of the class `Compiler` in `packages/rspack/src/compiler.ts` that is assigned the value of the `#finishMake` private method of the class ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR289))
*  Add a new property `finishMake` to the object that is passed to the `createCompiler` function in `packages/rspack/src/compiler.ts` that is assigned the value of the `finishMake` property of the `hooks` object ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR571))
*  Add a new private method `#finishMake` to the class `Compiler` in `packages/rspack/src/compiler.ts` that calls the `finishMake` hook with the current compilation and updates the list of disabled hooks ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR631-R635))
*  Add a new file `packages/rspack/tests/configCases/hooks/compilation-hooks/a.js` that contains a simple export statement and is used as a dependency by the `index.js` file in the same folder ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-ff53c3657ea805271a6facda043035f7a9940023b42463ec1dbaf6e7f9d0c6eeR1))
*  Add a new file `packages/rspack/tests/configCases/hooks/compilation-hooks/index.js` that contains a simple import statement and a test case that verifies the `finishMake` hook ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-5f67ea1ae39ecb62270f8d323654a3e5d350d0461c3f13a8d4006f46c3b77d3dR1-R5))
*  Add a new file `packages/rspack/tests/configCases/hooks/compilation-hooks/webpack.config.js` that contains the configuration options for the test case that verifies the `finishMake` hook ([link](https://github.com/web-infra-dev/rspack/pull/3390/files?diff=unified&w=0#diff-9b57f704df1693ffab4bad51474d549d8adb3fbda5e8400416227b4fbafb0995R1-R41))

</details>
