### PR TITLE
chore: remove commit step when publishing

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -28,9 +28,6 @@ export async function publish_handler(mode, options) {
 		await $`git config --global user.email "github-actions[bot]@users.noreply.github.com"`;
 		console.info("git commit all...");
 		await $`git status`;
-		await $`git add .`;
-		await $`git commit -m "publish ${version}"`;
-		await $`git status`;
 		await $`git tag ${version} -m ${version} `;
 		await $`git push origin --follow-tags`;
 	}


### PR DESCRIPTION
## Related issue (if exists)
<!--- Provide link of related issues -->

## Summary
commit in publish will pollute commit history so we disable it

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d38b257</samp>

Simplify publishing script by removing git commands. The script `scripts/release/publish.mjs` no longer commits and shows the git status after publishing a new version, as this is handled by a GitHub action.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d38b257</samp>

*  Simplify publishing script by removing unnecessary git commands ([link](https://github.com/web-infra-dev/rspack/pull/3395/files?diff=unified&w=0#diff-121ac8f9e24f2b43274b72e2b02402ecdef16563740899434511ba9ecc099dc8L31-L33))

</details>
