### PR TITLE
fix: remove css updatedModulesList at hmr

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading_with_hmr.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading_with_hmr.js
@@ -76,8 +76,6 @@ __webpack_require__.hmrC.css = function (
 							// Object.keys(factories).forEach(function(id) {
 							//     (updatedModulesList.push(id));
 							// });
-							// workaround for loadCssChunkData
-							updatedModulesList.push(url);
 							link.sheet.disabled = true;
 							oldTags.push(oldTag);
 							newTags.push([chunkId, link]);


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

webpack-hot-middleware(https://github.com/webpack-contrib/webpack-hot-middleware/blob/master/process-update.js#L102) will diff `updateModulesList` and `renewedModules`, if they are not same, it will reload. The rspack css module will collect at the updated js module, So the workaround is need remove.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7e116a1</samp>

Fix HMR bug for CSS modules. Remove redundant code that added CSS module url to updatedModulesList array in `css_loading_with_hmr.js`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7e116a1</samp>

* Remove unnecessary line of code that added CSS module url to HMR tracking array ([link](https://github.com/web-infra-dev/rspack/pull/3399/files?diff=unified&w=0#diff-dda0ef5ba2ad8858b35a5743e5e748eb8a94217995895954c2e9eeee85e9e683L79-L80))

</details>
