### PR TITLE
chore: support short build commands

### DIFF
--- a/x.mjs
+++ b/x.mjs
@@ -60,6 +60,17 @@ cleanCommand
 // x build
 const buildCommand = program.command("build").alias("b").description("build");
 
+buildCommand
+	.option("-a", "build all")
+	.option("-b", "build rust binding")
+	.option("-j", "build js packages")
+	.option("-r", "release")
+	.action(async function ({ a, b = a, j = a, r }) {
+		let mode = r ? "release" : "debug";
+		b && (await $`pnpm --filter @rspack/binding build:${mode}`);
+		j && (await $`pnpm --filter "@rspack/*" build`);
+	});
+
 // x build binding
 buildCommand
 	.command("binding")


### PR DESCRIPTION
## Related issue (if exists)

Support build commands

```sh
./x b -ar # building release packages for both
./x b -b # building binding crates
```

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f1844b4</samp>

Add options and action to `buildCommand` in `x.mjs`. This allows the user to choose which parts of the rspack project to build and in which mode.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f1844b4</samp>

* Add options and action to `buildCommand` object for building and releasing project ([link](https://github.com/web-infra-dev/rspack/pull/3400/files?diff=unified&w=0#diff-866d8c4b601772273677680d6cedcec91a98ae1b64b2cda04eff6dab131dfcf1R63-R73))

</details>
