### PR TITLE
fix: devtool default value should be false

### DIFF
--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -163,10 +163,6 @@ export class RspackCLI {
 				item.mode = options.mode as Mode;
 			}
 
-			// false is also a valid value for sourcemap, so don't override it
-			if (typeof item.devtool === "undefined") {
-				item.devtool = isBuild ? "source-map" : "cheap-module-source-map";
-			}
 			item.builtins = item.builtins || {};
 			if (isServe) {
 				item.builtins.progress = item.builtins.progress ?? true;


### PR DESCRIPTION
## Related issue (if exists)
#3392 
<!--- Provide link of related issues -->

## Summary
Remove the handling of the default value for the devtool option in `rspack-cli.ts`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 810411e</samp>

Removed code that overrode the `devtool` option for webpack in `rspack-cli.ts`. This allows the user to configure source maps according to their needs and preferences.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 810411e</samp>

*  Removed the code that set the `devtool` option for webpack based on the `mode` argument ([link](https://github.com/web-infra-dev/rspack/pull/3406/files?diff=unified&w=0#diff-44dee9ba83d25009b434358408609d864a6ae2c804c084a8d6cfeec82ab64ab4L166-L169)). This allows the user to configure their own `devtool` option in the `rspack.config.js` file and improves the performance and debugging experience of the application. This change also matches the documentation of the `devtool` option in the `packages/rspack-cli/README.md` file.

</details>
