### PR TITLE
fix: shouldn't diff hot update chunk at hmr

### DIFF
--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -109,19 +109,11 @@ where
       })
       .collect::<HashMap<String, HotUpdateContent>>();
 
-    let mut old_chunks: Vec<(String, IdentifierSet, RuntimeSpec)> = vec![];
-    for (ukey, chunk) in old.compilation.chunk_by_ukey.iter() {
-      let modules = old
-        .compilation
-        .chunk_graph
-        .get_chunk_graph_chunk(ukey)
-        .modules
-        .clone();
-      old_chunks.push((
-        chunk.expect_id().to_string(),
-        modules,
-        chunk.runtime.clone(),
-      ));
+    let mut old_chunks: Vec<(String, RuntimeSpec)> = vec![];
+    for (_, chunk) in old.compilation.chunk_by_ukey.iter() {
+      if chunk.kind != ChunkKind::HotUpdate {
+        old_chunks.push((chunk.expect_id().to_string(), chunk.runtime.clone()));
+      }
     }
 
     // build without stats
@@ -280,7 +272,7 @@ where
     // TODO: hash
     // if old.hash == now.hash { return  } else { // xxxx}
 
-    for (chunk_id, _old_chunk_modules, old_runtime) in &old_chunks {
+    for (chunk_id, old_runtime) in &old_chunks {
       let mut new_modules = vec![];
       let mut new_runtime_modules = vec![];
       let mut chunk_id = chunk_id.to_string();


### PR DESCRIPTION
## Related issue (if exists)

close https://github.com/web-infra-dev/rspack/issues/3401
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46db5c2</samp>

Improve hot module replacement logic in `rspack_core` crate. Simplify and optimize the data structure and chunk filtering in `hmr.rs`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 46db5c2</samp>

*  Simplify `old_chunks` vector by removing unused module sets and filtering out `HotUpdate` chunks ([link](https://github.com/web-infra-dev/rspack/pull/3411/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L112-R116))
*  Adjust loop variable to match new `old_chunks` structure ([link](https://github.com/web-infra-dev/rspack/pull/3411/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L283-R275))

</details>
