### PR TITLE
feat: electron support

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -359,6 +359,12 @@ export interface JsStatsWarning {
   formatted: string
 }
 
+export interface NodeFS {
+  writeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+}
+
 export interface PathData {
   filename?: string
   hash?: string
@@ -528,6 +534,10 @@ export interface RawExternalItemValue {
 export interface RawExternalsPresets {
   node: boolean
   web: boolean
+  electron: boolean
+  electronMain: boolean
+  electronPreload: boolean
+  electronRenderer: boolean
 }
 
 export interface RawFallbackCacheGroupOptions {

--- a/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
@@ -1,5 +1,4 @@
-exports.ids = ['main'];
-exports.modules = {
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./child Lazy  recursive ^\\.\\/.*\\.js$": function (module, exports, __webpack_require__) {
 var map = {"./a.js": "./child/a.js","./b.js": "./child/b.js",};
 function webpackAsyncContext(req) {
@@ -31,8 +30,9 @@ __webpack_require__("./child Lazy  recursive ^\\.\\/.*\\.js$")(('./child/' + req
 __webpack_require__("./child Lazy  recursive ^\\.\\/.*\\.js$")("./child/".concat(request, ".js").replace("./child/", "./")).then(({ a  })=>console.log("context_module_concat", a));
 },
 
-};
-var __webpack_require__ = require('./runtime.js');
-__webpack_require__.C(exports)
+},function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
 var __webpack_exports__ = (__webpack_exec__('./index.js'));
+
+}
+]);

--- a/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/runtime.js
@@ -89,6 +89,46 @@ __webpack_require__.ir = function (obj, nodeInterop) {
 };
 
 })();
+// webpack/runtime/on_chunk_loaded
+(function() {
+var deferred = [];
+__webpack_require__.O = function (result, chunkIds, fn, priority) {
+	if (chunkIds) {
+		priority = priority || 0;
+		for (var i = deferred.length; i > 0 && deferred[i - 1][2] > priority; i--)
+			deferred[i] = deferred[i - 1];
+		deferred[i] = [chunkIds, fn, priority];
+		return;
+	}
+	var notFulfilled = Infinity;
+	for (var i = 0; i < deferred.length; i++) {
+		var chunkIds = deferred[i][0],
+			fn = deferred[i][1],
+			priority = deferred[i][2];
+		var fulfilled = true;
+		for (var j = 0; j < chunkIds.length; j++) {
+			if (
+				(priority & (1 === 0) || notFulfilled >= priority) &&
+				Object.keys(__webpack_require__.O).every(function (key) {
+					return __webpack_require__.O[key](chunkIds[j]);
+				})
+			) {
+				chunkIds.splice(j--, 1);
+			} else {
+				fulfilled = false;
+				if (priority < notFulfilled) notFulfilled = priority;
+			}
+		}
+		if (fulfilled) {
+			deferred.splice(i--, 1);
+			var r = fn();
+			if (r !== undefined) result = r;
+		}
+	}
+	return result;
+};
+
+})();
 // webpack/runtime/load_chunk_with_module
 (function() {
 var map = {"./child/a.js": ["child_a_js",],"./child/b.js": ["child_b_js",],};
@@ -106,11 +146,90 @@ var map = {"./child/a.js": ["child_a_js",],"./child/b.js": ["child_b_js",],};
     }
     
 })();
+// webpack/runtime/get_chunk_filename/__webpack_require__.k
+(function() {
+// This function allow to reference chunks
+        __webpack_require__.k = function (chunkId) {
+          // return url for filenames based on template
+          return {"child_a_js": "child_a_js.css","child_b_js": "child_b_js.css",}[chunkId];
+        };
+      
+})();
+// webpack/runtime/load_script
+(function() {
+var inProgress = {};
+
+// var dataWebpackPrefix = "webpack:";
+// loadScript function to load a script via script tag
+__webpack_require__.l = function loadScript(url, done, key, chunkId) {
+	// TODO add this after hash
+	// if (inProgress[url]) {
+	// 	inProgress[url].push(done);
+	// 	return;
+	// }
+	var script, needAttach;
+	if (key !== undefined) {
+		var scripts = document.getElementsByTagName("script");
+		for (var i = 0; i < scripts.length; i++) {
+			var s = scripts[i];
+			if (
+				s.getAttribute("src") == url
+				// || s.getAttribute("data-webpack") == dataWebpackPrefix + key
+			) {
+				script = s;
+				break;
+			}
+		}
+	}
+	if (!script) {
+		needAttach = true;
+		script = document.createElement("script");
+
+		script.charset = "utf-8";
+		script.timeout = 120;
+		// script.setAttribute("data-webpack", dataWebpackPrefix + key);
+		script.src = url;
+
+		if (false && script.src.indexOf(window.location.origin + '/') !== 0) {
+			script.crossOrigin = false;
+		}
+	}
+	inProgress[url] = [done];
+	var onScriptComplete = function (prev, event) {
+		script.onerror = script.onload = null;
+		clearTimeout(timeout);
+		var doneFns = inProgress[url];
+		delete inProgress[url];
+		script.parentNode && script.parentNode.removeChild(script);
+		doneFns &&
+			doneFns.forEach(function (fn) {
+				return fn(event);
+			});
+		if (prev) return prev(event);
+	};
+	var timeout = setTimeout(
+		onScriptComplete.bind(null, undefined, {
+			type: "timeout",
+			target: script
+		}),
+		120000
+	);
+	script.onerror = onScriptComplete.bind(null, script.onerror);
+	script.onload = onScriptComplete.bind(null, script.onload);
+	needAttach && document.head.appendChild(script);
+};
+
+})();
 // webpack/runtime/has_own_property
 (function() {
 __webpack_require__.o = function (obj, prop) {
 	return Object.prototype.hasOwnProperty.call(obj, prop);
 };
+
+})();
+// webpack/runtime/public_path
+(function() {
+__webpack_require__.p = "/";
 
 })();
 // webpack/runtime/get_chunk_filename/__webpack_require__.u
@@ -122,36 +241,221 @@ __webpack_require__.o = function (obj, prop) {
         };
       
 })();
-// webpack/runtime/require_chunk_loading
+// webpack/runtime/css_loading
 (function() {
-var installedChunks = {"runtime": 0,};
-// object to store loaded chunks
-// "1" means "loaded", otherwise not loaded yet
+var installedChunks = {};
+var uniqueName = "webpack";
+// loadCssChunkData is unnecessary
+var loadingAttribute = "data-webpack-loading";
+var loadStylesheet = function(chunkId, url, done, hmr) {
+	var link,
+		needAttach,
+		key = "chunk-" + chunkId;
+	if (!hmr) {
+		var links = document.getElementsByTagName("link");
+		for (var i = 0; i < links.length; i++) {
+			var l = links[i];
+			var href = l.getAttribute("href") || l.href;
+			if (href && !href.startsWith(__webpack_require__.p)) {
+				href =
+					__webpack_require__.p + (href.startsWith("/") ? href.slice(1) : href);
+			}
+			if (
+				l.rel == "stylesheet" &&
+				((href && href.startsWith(url)) ||
+					l.getAttribute("data-webpack") == uniqueName + ":" + key)
+			) {
+				link = l;
+				break;
+			}
+		}
+		if (!done) return link;
+	}
+	if (!link) {
+		needAttach = true;
+		link = document.createElement("link");
+		link.setAttribute("data-webpack", uniqueName + ":" + key);
+		link.setAttribute(loadingAttribute, 1);
+		link.rel = "stylesheet";
+		link.href = url;
 
-var installChunk = function (chunk) {
-	var moreModules = chunk.modules,
-		chunkIds = chunk.ids,
-		runtime = chunk.runtime;
-	for (var moduleId in moreModules) {
-		if (__webpack_require__.o(moreModules, moduleId)) {
-			__webpack_require__.m[moduleId] = moreModules[moduleId];
+		if (false && link.href.indexOf(window.location.origin + '/') !== 0) {
+			link.crossOrigin = false;
 		}
 	}
-	if (runtime) runtime(__webpack_require__);
-	for (var i = 0; i < chunkIds.length; i++) installedChunks[chunkIds[i]] = 1;
-	
+	var onLinkComplete = function (prev, event) {
+		link.onerror = link.onload = null;
+		link.removeAttribute(loadingAttribute);
+		clearTimeout(timeout);
+		if (event && event.type != "load") link.parentNode.removeChild(link);
+		done(event);
+		if (prev) return prev(event);
+	};
+	if (link.getAttribute(loadingAttribute)) {
+		var timeout = setTimeout(
+			onLinkComplete.bind(null, undefined, { type: "timeout", target: link }),
+			120000
+		);
+		link.onerror = onLinkComplete.bind(null, link.onerror);
+		link.onload = onLinkComplete.bind(null, link.onload);
+	} else onLinkComplete(undefined, { type: "load", target: link });
+	hmr
+		? document.head.insertBefore(link, hmr)
+		: needAttach && document.head.appendChild(link);
+	return link;
 };
-// require() chunk loading for javascript
-__webpack_require__.f.require = function (chunkId, promises) {
-	// "1" is the signal for "already loaded"
-	if (!installedChunks[chunkId]) {
-		if (chunkId) {
-			installChunk(require("./" + __webpack_require__.u(chunkId)));
-		} else installedChunks[chunkId] = 1;
+__webpack_require__.f.css = function (chunkId, promises) {
+	// css chunk loading
+	var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
+		? installedChunks[chunkId]
+		: undefined;
+	if (installedChunkData !== 0) {
+		// 0 means "already installed".
+
+		// a Promise means "currently loading".
+		if (installedChunkData) {
+			promises.push(installedChunkData[2]);
+		} else {
+			if ([].indexOf(chunkId) > -1) {
+				// setup Promise in chunk cache
+				var promise = new Promise(function (resolve, reject) {
+					installedChunkData = installedChunks[chunkId] = [resolve, reject];
+				});
+				promises.push((installedChunkData[2] = promise));
+
+				// start chunk loading
+				var url = __webpack_require__.p + __webpack_require__.k(chunkId);
+				// create error before stack unwound to get useful stacktrace later
+				var error = new Error();
+				var loadingEnded = function (event) {
+					if (__webpack_require__.o(installedChunks, chunkId)) {
+						installedChunkData = installedChunks[chunkId];
+						if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+						if (installedChunkData) {
+							if (event.type !== "load") {
+								var errorType = event && event.type;
+								var realSrc = event && event.target && event.target.src;
+								error.message =
+									"Loading css chunk " +
+									chunkId +
+									" failed.\n(" +
+									errorType +
+									": " +
+									realSrc +
+									")";
+								error.name = "ChunkLoadError";
+								error.type = errorType;
+								error.request = realSrc;
+								installedChunkData[1](error);
+							} else {
+								// loadCssChunkData(__webpack_require__.m, link, chunkId);
+								installedChunkData[0]();
+							}
+						}
+					}
+				};
+				var link = loadStylesheet(chunkId, url, loadingEnded);
+			} else installedChunks[chunkId] = 0;
+		}
 	}
 };
-module.exports = __webpack_require__;
-__webpack_require__.C = installChunk;
+
+})();
+// webpack/runtime/jsonp_chunk_loading
+(function() {
+var installedChunks = {"runtime": 0,};
+__webpack_require__.f.j = function (chunkId, promises) {
+	// JSONP chunk loading for javascript
+	var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
+		? installedChunks[chunkId]
+		: undefined;
+	if (installedChunkData !== 0) {
+		// 0 means "already installed".
+
+		// a Promise means "currently loading".
+		if (installedChunkData) {
+			promises.push(installedChunkData[2]);
+		} else {
+			if (chunkId) {
+				// setup Promise in chunk cache
+				var promise = new Promise(function (resolve, reject) {
+					installedChunkData = installedChunks[chunkId] = [resolve, reject];
+				});
+				promises.push((installedChunkData[2] = promise));
+
+				// start chunk loading
+				var url = __webpack_require__.p + __webpack_require__.u(chunkId);
+				// create error before stack unwound to get useful stacktrace later
+				var error = new Error();
+				var loadingEnded = function (event) {
+					if (__webpack_require__.o(installedChunks, chunkId)) {
+						installedChunkData = installedChunks[chunkId];
+						if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+						if (installedChunkData) {
+							var errorType =
+								event && (event.type === "load" ? "missing" : event.type);
+							var realSrc = event && event.target && event.target.src;
+							error.message =
+								"Loading chunk " +
+								chunkId +
+								" failed.\n(" +
+								errorType +
+								": " +
+								realSrc +
+								")";
+							error.name = "ChunkLoadError";
+							error.type = errorType;
+							error.request = realSrc;
+							installedChunkData[1](error);
+						}
+					}
+				};
+				__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
+			} else installedChunks[chunkId] = 0;
+		}
+	}
+};
+__webpack_require__.O.j = function (chunkId) {
+	return installedChunks[chunkId] === 0;
+};
+// install a JSONP callback for chunk loading
+var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
+	var chunkIds = data[0],
+	moreModules = data[1],
+	runtime = data[2];
+	// add "moreModules" to the modules object,
+	// then flag all "chunkIds" as loaded and fire callback
+	var moduleId,
+		chunkId,
+		i = 0;
+	if (chunkIds.some(function(id) { return installedChunks[id] !== 0 })) {
+		for (moduleId in moreModules) {
+			if (__webpack_require__.o(moreModules, moduleId)) {
+				__webpack_require__.m[moduleId] = moreModules[moduleId];
+			}
+		}
+		if (runtime) var result = runtime(__webpack_require__);
+	}
+	if (parentChunkLoadingFunction) parentChunkLoadingFunction(data);
+	for (; i < chunkIds.length; i++) {
+		chunkId = chunkIds[i];
+		if (
+			__webpack_require__.o(installedChunks, chunkId) &&
+			installedChunks[chunkId]
+		) {
+			installedChunks[chunkId][0]();
+		}
+		installedChunks[chunkId] = 0;
+	}
+	return __webpack_require__.O(result);
+};
+
+var chunkLoadingGlobal = self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || [];
+chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
+chunkLoadingGlobal.push = webpackJsonpCallback.bind(
+	null,
+	chunkLoadingGlobal.push.bind(chunkLoadingGlobal)
+);
 
 })();
 

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -151,6 +151,34 @@ impl RawOptionsApply for RawOptions {
     if self.externals_presets.node {
       plugins.push(rspack_plugin_externals::node_target_plugin());
     }
+    if self.externals_presets.electron_main {
+      rspack_plugin_externals::electron_target_plugin(
+        rspack_plugin_externals::ElectronTargetContext::Main,
+        plugins,
+      );
+    }
+    if self.externals_presets.electron_preload {
+      rspack_plugin_externals::electron_target_plugin(
+        rspack_plugin_externals::ElectronTargetContext::Preload,
+        plugins,
+      );
+    }
+    if self.externals_presets.electron_renderer {
+      rspack_plugin_externals::electron_target_plugin(
+        rspack_plugin_externals::ElectronTargetContext::Renderer,
+        plugins,
+      );
+    }
+    if self.externals_presets.electron
+      && !self.externals_presets.electron_main
+      && !self.externals_presets.electron_preload
+      && !self.externals_presets.electron_renderer
+    {
+      rspack_plugin_externals::electron_target_plugin(
+        rspack_plugin_externals::ElectronTargetContext::None,
+        plugins,
+      );
+    }
     if self.externals_presets.web || (self.externals_presets.node && experiments.css) {
       plugins.push(rspack_plugin_externals::http_url_external_plugin(
         experiments.css,

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -173,4 +173,8 @@ impl TryFrom<RawExternalItem> for ExternalItem {
 pub struct RawExternalsPresets {
   pub node: bool,
   pub web: bool,
+  pub electron: bool,
+  pub electron_main: bool,
+  pub electron_preload: bool,
+  pub electron_renderer: bool,
 }

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -10,6 +10,7 @@ pub struct CompilerOptions {
   pub context: Context,
   pub dev_server: DevServerOptions,
   pub output: OutputOptions,
+  // TODO(swc-loader): target should not exist on compiler options
   pub target: Target,
   pub mode: Mode,
   pub resolve: Resolve,

--- a/crates/rspack_core/src/options/target.rs
+++ b/crates/rspack_core/src/options/target.rs
@@ -1,23 +1,7 @@
 use anyhow::anyhow;
 pub use swc_core::ecma::ast::EsVersion;
 
-#[derive(Debug, Clone)]
-pub enum TargetPlatform {
-  Web,
-  WebWorker,
-  Node(String),
-  None,
-}
-
-impl TargetPlatform {
-  pub fn is_none(&self) -> bool {
-    matches!(self, TargetPlatform::None)
-  }
-  pub fn is_web(&self) -> bool {
-    matches!(self, TargetPlatform::Web)
-  }
-}
-
+// TODO(swc-loader): Target still coupled with javascript downgrade, it should only affect runtime
 #[derive(Debug, Clone)]
 pub enum TargetEsVersion {
   Esx(EsVersion),
@@ -36,13 +20,11 @@ impl TargetEsVersion {
 
 #[derive(Debug, Clone)]
 pub struct Target {
-  pub platform: TargetPlatform,
   pub es_version: TargetEsVersion,
 }
 
 impl Target {
   pub fn new(args: &Vec<String>) -> anyhow::Result<Target> {
-    let mut platform = TargetPlatform::None;
     let mut es_version = TargetEsVersion::None;
 
     for item in args {
@@ -71,24 +53,8 @@ impl Target {
         es_version = version;
         continue;
       }
-
-      // platform
-      if !platform.is_none() {
-        return Err(anyhow!("Target platform conflict"));
-      }
-      platform = match item {
-        "web" => TargetPlatform::Web,
-        "webworker" => TargetPlatform::WebWorker,
-        "node" => TargetPlatform::Node(String::new()),
-        _ => {
-          return Err(anyhow!("Unknown target platform {}", item));
-        }
-      };
     }
 
-    Ok(Target {
-      platform,
-      es_version,
-    })
+    Ok(Target { es_version })
   }
 }

--- a/crates/rspack_plugin_externals/src/electron_target_plugin.rs
+++ b/crates/rspack_plugin_externals/src/electron_target_plugin.rs
@@ -1,0 +1,71 @@
+use rspack_core::{BoxPlugin, ExternalItem, PluginExt};
+
+use crate::ExternalPlugin;
+
+pub enum ElectronTargetContext {
+  Main,
+  Preload,
+  Renderer,
+  None,
+}
+
+pub fn electron_target_plugin(context: ElectronTargetContext, plugins: &mut Vec<BoxPlugin>) {
+  plugins.push(
+    ExternalPlugin::new(
+      "node-commonjs".to_string(),
+      [
+        "clipboard",
+        "crash-reporter",
+        "electron",
+        "ipc",
+        "native-image",
+        "original-fs",
+        "screen",
+        "shell",
+      ]
+      .into_iter()
+      .map(|i| ExternalItem::String(i.to_string()))
+      .collect(),
+    )
+    .boxed(),
+  );
+  match context {
+    ElectronTargetContext::Main => plugins.push(
+      ExternalPlugin::new(
+        "node-commonjs".to_string(),
+        [
+          "app",
+          "auto-updater",
+          "browser-window",
+          "content-tracing",
+          "dialog",
+          "global-shortcut",
+          "ipc-main",
+          "menu",
+          "menu-item",
+          "power-monitor",
+          "power-save-blocker",
+          "protocol",
+          "session",
+          "tray",
+          "web-contents",
+        ]
+        .into_iter()
+        .map(|i| ExternalItem::String(i.to_string()))
+        .collect(),
+      )
+      .boxed(),
+    ),
+    ElectronTargetContext::Preload | ElectronTargetContext::Renderer => plugins.push(
+      ExternalPlugin::new(
+        "node-commonjs".to_string(),
+        ["desktop-capturer", "ipc-renderer", "remote", "web-frame"]
+          .into_iter()
+          .map(|i| ExternalItem::String(i.to_string()))
+          .collect(),
+      )
+      .boxed(),
+    ),
+    ElectronTargetContext::None => {}
+  }
+}

--- a/crates/rspack_plugin_externals/src/lib.rs
+++ b/crates/rspack_plugin_externals/src/lib.rs
@@ -1,9 +1,11 @@
 #![feature(let_chains)]
 
+mod electron_target_plugin;
 mod http_external_plugin;
 mod node_target_plugin;
 mod plugin;
 
+pub use electron_target_plugin::{electron_target_plugin, ElectronTargetContext};
 pub use http_external_plugin::http_url_external_plugin;
 pub use node_target_plugin::node_target_plugin;
 pub use plugin::ExternalPlugin;

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -6,7 +6,7 @@ use std::{
   sync::Arc,
 };
 
-use rspack_core::{BoxLoader, BoxPlugin, CompilerOptions, ModuleType, PluginExt, TargetPlatform};
+use rspack_core::{BoxLoader, BoxPlugin, CompilerOptions, ModuleType, PluginExt};
 use rspack_plugin_css::pxtorem::options::PxToRemOptions;
 use rspack_plugin_html::config::HtmlPluginConfig;
 use rspack_regex::RspackRegex;
@@ -546,22 +546,10 @@ impl TestConfig {
       }
     }
     plugins.push(rspack_plugin_json::JsonPlugin {}.boxed());
-    match &options.target.platform {
-      TargetPlatform::Web => {
-        plugins.push(rspack_plugin_runtime::ArrayPushCallbackChunkFormatPlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::CssModulesPlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::JsonpChunkLoadingPlugin {}.boxed());
-      }
-      TargetPlatform::Node(_) => {
-        plugins.push(rspack_plugin_runtime::CommonJsChunkFormatPlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
-        plugins.push(rspack_plugin_runtime::CommonJsChunkLoadingPlugin {}.boxed());
-      }
-      _ => {
-        plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
-      }
-    };
+    plugins.push(rspack_plugin_runtime::ArrayPushCallbackChunkFormatPlugin {}.boxed());
+    plugins.push(rspack_plugin_runtime::RuntimePlugin {}.boxed());
+    plugins.push(rspack_plugin_runtime::CssModulesPlugin {}.boxed());
+    plugins.push(rspack_plugin_runtime::JsonpChunkLoadingPlugin {}.boxed());
     if options.dev_server.hot {
       plugins.push(rspack_plugin_runtime::HotModuleReplacementPlugin {}.boxed());
     }

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -214,7 +214,11 @@ function getRawExternalsPresets(
 ): RawOptions["externalsPresets"] {
 	return {
 		web: presets.web ?? false,
-		node: presets.node ?? false
+		node: presets.node ?? false,
+		electron: presets.electron ?? false,
+		electronMain: presets.electronMain ?? false,
+		electronPreload: presets.electronPreload ?? false,
+		electronRenderer: presets.electronRenderer ?? false
 	};
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -542,6 +542,32 @@ const applyExternalsPresetsDefaults = (
 ) => {
 	D(externalsPresets, "web", targetProperties && targetProperties.web);
 	D(externalsPresets, "node", targetProperties && targetProperties.node);
+	D(
+		externalsPresets,
+		"electron",
+		targetProperties && targetProperties.electron
+	);
+	D(
+		externalsPresets,
+		"electronMain",
+		targetProperties &&
+			targetProperties.electron &&
+			targetProperties.electronMain
+	);
+	D(
+		externalsPresets,
+		"electronPreload",
+		targetProperties &&
+			targetProperties.electron &&
+			targetProperties.electronPreload
+	);
+	D(
+		externalsPresets,
+		"electronRenderer",
+		targetProperties &&
+			targetProperties.electron &&
+			targetProperties.electronRenderer
+	);
 };
 
 const applyNodeDefaults = (

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -459,6 +459,31 @@ module.exports = {
 					description:
 						"Treat node.js built-in modules like fs, path or vm as external and load them via require() when used.",
 					type: "boolean"
+				},
+				web: {
+					description:
+						"Treat references to 'http(s)://...' and 'std:...' as external and load them via import when used (Note that this changes execution order as externals are executed before any other code in the chunk).",
+					type: "boolean"
+				},
+				electron: {
+					description:
+						"Treat common electron built-in modules in main and preload context like 'electron', 'ipc' or 'shell' as external and load them via require() when used.",
+					type: "boolean"
+				},
+				electronMain: {
+					description:
+						"Treat electron built-in modules in the main context like 'app', 'ipc-main' or 'shell' as external and load them via require() when used.",
+					type: "boolean"
+				},
+				electronPreload: {
+					description:
+						"Treat electron built-in modules in the preload context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.",
+					type: "boolean"
+				},
+				electronRenderer: {
+					description:
+						"Treat electron built-in modules in the renderer context like 'web-frame', 'ipc-renderer' or 'shell' as external and load them via require() when used.",
+					type: "boolean"
 				}
 			}
 		},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -65,7 +65,7 @@ export type Dependencies = Name[];
 ///// Context /////
 export type Context = string;
 
-///// Mode */////
+///// Mode /////
 export type Mode = "development" | "production" | "none";
 
 ///// Entry /////
@@ -365,18 +365,20 @@ export interface ModuleOptionsNormalized {
 
 export type AvailableTarget =
 	| "node"
+	| `node${number}`
+	| `node${number}.${number}`
+	| "electron-main"
+	| `electron${number}-main`
+	| `electron${number}.${number}-main`
+	| "electron-renderer"
+	| `electron${number}-renderer`
+	| `electron${number}.${number}-renderer`
+	| "electron-preload"
+	| `electron${number}-preload`
+	| `electron${number}.${number}-preload`
 	| "web"
 	| "webworker"
-	| "es3"
-	| "es5"
-	| "es2015"
-	| "es2016"
-	| "es2017"
-	| "es2018"
-	| "es2019"
-	| "es2020"
-	| "es2021"
-	| "es2022"
+	| `es${number}`
 	| "browserslist";
 
 ///// Target /////
@@ -463,6 +465,10 @@ export type ExternalsType =
 export interface ExternalsPresets {
 	node?: boolean;
 	web?: boolean;
+	electron?: boolean;
+	electronMain?: boolean;
+	electronPreload?: boolean;
+	electronRenderer?: boolean;
 }
 
 ///// InfrastructureLogging /////

--- a/packages/rspack/src/config/zod/externals-presets.ts
+++ b/packages/rspack/src/config/zod/externals-presets.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 export function externalsPresets() {
 	return z
 		.object({
-			node: z.boolean().optional()
+			web: z.boolean().optional(),
+			node: z.boolean().optional(),
+			electron: z.boolean().optional(),
+			electronMain: z.boolean().optional(),
+			electronPreload: z.boolean().optional(),
+			electronRenderer: z.boolean().optional()
 		})
 		.strict();
 }

--- a/packages/rspack/src/config/zod/target.ts
+++ b/packages/rspack/src/config/zod/target.ts
@@ -1,21 +1,68 @@
 import { z } from "zod";
 
-const allowTarget = z.enum([
-	"node",
-	"web",
-	"webworker",
-	"es3",
-	"es5",
-	"es2015",
-	"es2016",
-	"es2017",
-	"es2018",
-	"es2019",
-	"es2020",
-	"es2021",
-	"es2022",
-	"browserslist"
-]);
+const allowTarget = z
+	.enum([
+		"web",
+		"webworker",
+		"es3",
+		"es5",
+		"es2015",
+		"es2016",
+		"es2017",
+		"es2018",
+		"es2019",
+		"es2020",
+		"es2021",
+		"es2022",
+		"browserslist"
+	])
+	.or(z.literal("node"))
+	.or(
+		z.custom<`node${number}`>(
+			value => typeof value === "string" && /^node\d+$/.test(value)
+		)
+	)
+	.or(
+		z.custom<`node${number}.${number}`>(
+			value => typeof value === "string" && /^node\d+\.\d+$/.test(value)
+		)
+	)
+	.or(z.literal("electron-main"))
+	.or(
+		z.custom<`electron${number}-main`>(
+			value => typeof value === "string" && /^electron\d+-main$/.test(value)
+		)
+	)
+	.or(
+		z.custom<`electron${number}.${number}-main`>(
+			value =>
+				typeof value === "string" && /^electron\d+\.\d+-main$/.test(value)
+		)
+	)
+	.or(z.literal("electron-renderer"))
+	.or(
+		z.custom<`electron${number}-renderer`>(
+			value => typeof value === "string" && /^electron\d+-renderer$/.test(value)
+		)
+	)
+	.or(
+		z.custom<`electron${number}.${number}-renderer`>(
+			value =>
+				typeof value === "string" && /^electron\d+\.\d+-renderer$/.test(value)
+		)
+	)
+	.or(z.literal("electron-preload"))
+	.or(
+		z.custom<`electron${number}-preload`>(
+			value => typeof value === "string" && /^electron\d+-preload$/.test(value)
+		)
+	)
+	.or(
+		z.custom<`electron${number}.${number}-preload`>(
+			value =>
+				typeof value === "string" && /^electron\d+\.\d+-preload$/.test(value)
+		)
+	);
 
 export function target() {
 	return z.literal(false).or(allowTarget).or(allowTarget.array());

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -642,6 +642,11 @@ describe("snapshots", () => {
 		+ Received
 
 		@@ ... @@
+		-     "electron": false,
+		-     "electronMain": false,
+		+     "electron": true,
+		+     "electronMain": true,
+		@@ ... @@
 		-     "node": false,
 		-     "web": true,
 		+     "node": true,
@@ -710,6 +715,12 @@ describe("snapshots", () => {
 		- Expected
 		+ Received
 
+		@@ ... @@
+		-     "electron": false,
+		+     "electron": true,
+		@@ ... @@
+		-     "electronPreload": false,
+		+     "electronPreload": true,
 		@@ ... @@
 		-     "node": false,
 		+     "node": true,

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -57,6 +57,10 @@ exports[`snapshots should have the correct base config 1`] = `
   },
   "externals": undefined,
   "externalsPresets": {
+    "electron": false,
+    "electronMain": false,
+    "electronPreload": false,
+    "electronRenderer": false,
     "node": false,
     "web": true,
   },

--- a/packages/rspack/tests/configCases/target/electron-renderer/.gitignore
+++ b/packages/rspack/tests/configCases/target/electron-renderer/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/target/electron-renderer/index.js
+++ b/packages/rspack/tests/configCases/target/electron-renderer/index.js
@@ -1,0 +1,5 @@
+const foo = require("foo");
+
+it("should use browser main field", () => {
+	expect(foo).toBe("browser");
+});

--- a/packages/rspack/tests/configCases/target/electron-renderer/node_modules/foo/browser.js
+++ b/packages/rspack/tests/configCases/target/electron-renderer/node_modules/foo/browser.js
@@ -1,0 +1,1 @@
+module.exports = "browser";

--- a/packages/rspack/tests/configCases/target/electron-renderer/node_modules/foo/main.js
+++ b/packages/rspack/tests/configCases/target/electron-renderer/node_modules/foo/main.js
@@ -1,0 +1,1 @@
+module.exports = "main";

--- a/packages/rspack/tests/configCases/target/electron-renderer/node_modules/foo/package.json
+++ b/packages/rspack/tests/configCases/target/electron-renderer/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "foo",
+	"version": "1.0.0",
+	"browser": "./browser.js",
+	"main": "./main.js"
+}

--- a/packages/rspack/tests/configCases/target/electron-renderer/webpack.config.js
+++ b/packages/rspack/tests/configCases/target/electron-renderer/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	target: "electron-renderer",
+	optimization: {
+		minimize: false
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

closes #3412

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 191a058</samp>

The pull request improves the target and externals options for the rspack tool and the rspack core and plugin crates. It simplifies the target logic by removing unused code and refactoring the target parsing and validation. It implements JSONP chunk loading for dynamic imports in the test fixture. It adds support for externalizing common electron modules in different contexts based on the target and externals presets. It updates the documentation, schema, and tests for the target and externals options.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 191a058</samp>

*  Add electron target plugin and presets to externalize common electron modules ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-c8d061ed21897caebe63ce5a159b65df3dfd38620f4fd4a902504c59bf40f052R1-R71), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-675991f6e765627c5acbd6484c811589d6fc5f6d2998e65c535cb27f9f340936L3-R8), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-6112b39f2c1def8a0f89824413cfd6936f187aa6ca3712e1e6aeb4d34f67ae41R154-R181), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L217-R221), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-55e0fbd74437dff4e251152f5d93efd7f5871cbad72a7959dddb6add8fbf60ccR545-R570), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88R462-R486), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fR468-R471), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-8c9c55e119547fb481071dee846c579a8df388a933cd5628c0249875644a8478L6-R11))
*  Change target type and schema to include more node and electron variants ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL368-R381), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-e63a3b8814d8c67470d1e315c43b58f648e3e3b22a266598a23a5d2a44dbf2a7L3-R56))
*  Remove platform field and logic from target struct and test config module ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-4232ded1f7ad0508146d85a38c706a1493b225c379a187ddcfe67a2700430655L4-R5), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-4232ded1f7ad0508146d85a38c706a1493b225c379a187ddcfe67a2700430655L39), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-4232ded1f7ad0508146d85a38c706a1493b225c379a187ddcfe67a2700430655L45), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-4232ded1f7ad0508146d85a38c706a1493b225c379a187ddcfe67a2700430655L74-R58), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-8b7ae8eae42b4d9202dbd35407c3338295c42d2b3b863c1a9c179c23502c86c2L9-R9), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-8b7ae8eae42b4d9202dbd35407c3338295c42d2b3b863c1a9c179c23502c86c2L549-R552))
*  Add TODO comment to move target option out of compiler options ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-b6c971a9adb8c246d789a436e09e6bb0f0077c819d437857845e60263aedf103R13))
*  Add new fields to raw external struct for electron externals presets ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-b3d4e4741437a4af781bf0c7ffc91117b42dcefe17fd5ad19fb175e303124332R176-R179))
*  Remove extra asterisk from mode section comment ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL68-R68))
*  Add test case for electron renderer target ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-b45bb451dbeb216c46cf560a6a8f26ef1ac5bdeb26d936a8fa0703aae326dde3R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-fc80d9d773a38a2228ca4a3c3123924683d08ceef858a86c9fa12f4c4cde3183R1-R6))
*  Update test case outputs for electron main and preload targets ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R645-R649), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-68435635c7abf06035e99ade8f46eeda6ad7614810533989afc5a1e324eb9db9R719-R724))
*  Wrap exports in self-invoking function and pass require as parameter for JSONP chunk loading ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-3a6288d6314d317a4d96cddcf94d3fc655ce4bbade63cc83e05d5e4249025226L1-R1), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-3a6288d6314d317a4d96cddcf94d3fc655ce4bbade63cc83e05d5e4249025226L34-R37))
*  Add runtime functions and variables for resolving and loading chunks via JSONP ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72R92-R131), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72R149-R222), [link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72R230-R234))
*  Remove module.exports assignment and wrap runtime code in second argument of self-invoking function ([link](https://github.com/web-infra-dev/rspack/pull/3414/files?diff=unified&w=0#diff-aa99eb877db60c83f83c419092e413c6bd69e4a0dc0298f83e5adb7458405c72L125-R459))

</details>
