### PR TITLE
fix: support config version when emitAsset

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -144,6 +144,11 @@ export interface JsAssetInfo {
    * related object to other assets, keyed by type of relation (only points from parent to child)
    */
   related: JsAssetInfoRelated
+  /**
+   * the asset version, emit can be skipped when both filename and version are the same
+   * An empty string means no version, it will always emit
+   */
+  version: string
 }
 
 export interface JsAssetInfoRelated {

--- a/crates/node_binding/src/js_values/asset.rs
+++ b/crates/node_binding/src/js_values/asset.rs
@@ -38,6 +38,9 @@ pub struct JsAssetInfo {
   // pub javascript_module:
   /// related object to other assets, keyed by type of relation (only points from parent to child)
   pub related: JsAssetInfoRelated,
+  /// the asset version, emit can be skipped when both filename and version are the same
+  /// An empty string means no version, it will always emit
+  pub version: String,
 }
 
 impl From<JsAssetInfo> for rspack_core::AssetInfo {
@@ -49,7 +52,7 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
       hot_module_replacement: i.hot_module_replacement,
       related: i.related.into(),
       content_hash: i.content_hash.into_iter().collect(),
-      version: Default::default(),
+      version: i.version,
     }
   }
 }
@@ -78,6 +81,7 @@ impl From<rspack_core::AssetInfo> for JsAssetInfo {
       hot_module_replacement: info.hot_module_replacement,
       related: info.related.into(),
       content_hash: info.content_hash.into_iter().collect(),
+      version: info.version,
     }
   }
 }

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -84,6 +84,7 @@ export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
 		hotModuleReplacement: false,
 		related: {},
 		contentHash: [],
+		version: "",
 		...info
 	};
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f48eccc</samp>

Added a `version` field to assets in Rust and TypeScript, to enable caching and skipping asset emission when possible. This affects the `Asset` struct in `crates/node_binding/src/js_values/asset.rs` and the `JsAssetInfo` interface in `packages/rspack/src/util/index.ts`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f48eccc</samp>

*  Add `version` field to `Asset` struct in Rust to store asset version information ([link](https://github.com/web-infra-dev/rspack/pull/3415/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67R41-R43))
*  Preserve `version` field when converting between `AssetInfo` and `Asset` in Rust ([link](https://github.com/web-infra-dev/rspack/pull/3415/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67L52-R55), [link](https://github.com/web-infra-dev/rspack/pull/3415/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67R84))
*  Expose `version` field to JavaScript side of node binding by adding it to `JsAssetInfo` interface in TypeScript ([link](https://github.com/web-infra-dev/rspack/pull/3415/files?diff=unified&w=0#diff-d96ad87ef082a47a811e2eefdb6f63c91f4eec85a48a53afd1c9aeeb11cd3c67R84), [link](https://github.com/web-infra-dev/rspack/pull/3415/files?diff=unified&w=0#diff-4f9ce3f0a4a955f4fe94737ce6792ad1b9b5f04e0d5136c2616eb2de4b4072ebR87))

</details>
