### PR TITLE
feat(splitChunks): support passing `false` to `splitChunks.{cacheGroup}.xxx`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -364,6 +364,12 @@ export interface JsStatsWarning {
   formatted: string
 }
 
+export interface NodeFS {
+  writeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+}
+
 export interface PathData {
   filename?: string
   hash?: string

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -527,7 +527,7 @@ function toRawSplitChunksOptions(
 		name: name === false ? undefined : name,
 		cacheGroups: Object.fromEntries(
 			Object.entries(cacheGroups)
-				.filter(([_key, group]) => !group)
+				.filter(([_key, group]) => group !== false)
 				.map(([key, group]) => {
 					group = group as Exclude<typeof group, false>;
 

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -32,7 +32,6 @@ import {
 	ModuleOptionsNormalized,
 	Node,
 	Optimization,
-	OptimizationSplitChunksOptions,
 	OutputNormalized,
 	Resolve,
 	RspackOptionsNormalized,
@@ -43,6 +42,7 @@ import {
 	StatsValue,
 	Target
 } from "./types";
+import { SplitChunksConfig } from "./zod/optimization/split-chunks";
 
 export const getRawOptions = (
 	options: RspackOptionsNormalized,
@@ -506,9 +506,7 @@ function getRawOptimization(
 		"optimization.moduleIds, optimization.removeAvailableModules, optimization.removeEmptyChunks, optimization.sideEffects, optimization.realContentHash should not be nil after defaults"
 	);
 	return {
-		splitChunks: optimization.splitChunks
-			? getRawSplitChunksOptions(optimization.splitChunks)
-			: undefined,
+		splitChunks: toRawSplitChunksOptions(optimization.splitChunks),
 		moduleIds: optimization.moduleIds,
 		removeAvailableModules: optimization.removeAvailableModules,
 		removeEmptyChunks: optimization.removeEmptyChunks,
@@ -517,42 +515,32 @@ function getRawOptimization(
 	};
 }
 
-function getRawSplitChunksOptions(
-	sc: OptimizationSplitChunksOptions
-): RawOptions["optimization"]["splitChunks"] {
+function toRawSplitChunksOptions(
+	sc?: SplitChunksConfig
+): RawOptions["optimization"]["splitChunks"] | undefined {
+	if (!sc) {
+		return;
+	}
+
+	const { name, cacheGroups = {}, ...passThrough } = sc;
 	return {
-		name: sc.name === false ? undefined : sc.name,
-		cacheGroups: sc.cacheGroups
-			? Object.fromEntries(
-					Object.entries(sc.cacheGroups).map(([key, group]) => {
-						let normalizedGroup: RawCacheGroupOptions = {
-							test: group.test ? group.test.source : undefined,
-							name: group.name === false ? undefined : group.name,
-							priority: group.priority,
-							minChunks: group.minChunks,
-							chunks: group.chunks,
-							reuseExistingChunk: group.reuseExistingChunk,
-							minSize: group.minSize,
-							maxAsyncSize: group.maxAsyncSize,
-							maxInitialSize: group.maxInitialSize,
-							maxSize: group.maxSize,
-							enforce: group.enforce
-						};
-						return [key, normalizedGroup];
-					})
-			  )
-			: {},
-		chunks: sc.chunks,
-		maxAsyncRequests: sc.maxAsyncRequests,
-		maxInitialRequests: sc.maxInitialRequests,
-		minChunks: sc.minChunks,
-		minSize: sc.minSize,
-		enforceSizeThreshold: sc.enforceSizeThreshold,
-		minRemainingSize: sc.minRemainingSize,
-		maxSize: sc.maxSize,
-		maxAsyncSize: sc.maxAsyncSize,
-		maxInitialSize: sc.maxInitialSize,
-		fallbackCacheGroup: sc.fallbackCacheGroup
+		name: name === false ? undefined : name,
+		cacheGroups: Object.fromEntries(
+			Object.entries(cacheGroups)
+				.filter(([_key, group]) => !group)
+				.map(([key, group]) => {
+					group = group as Exclude<typeof group, false>;
+
+					const { test, name, ...passThrough } = group;
+					const rawGroup: RawCacheGroupOptions = {
+						test: test?.source,
+						name: name === false ? undefined : name,
+						...passThrough
+					};
+					return [key, rawGroup];
+				})
+		),
+		...passThrough
 	};
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -560,37 +560,6 @@ export interface StatsOptions {
 	nestedModules?: boolean;
 }
 
-export interface OptimizationSplitChunksOptions {
-	cacheGroups?: {
-		[k: string]: OptimizationSplitChunksCacheGroup;
-	};
-	chunks?: "initial" | "async" | "all";
-	maxAsyncRequests?: number;
-	maxInitialRequests?: number;
-	minChunks?: number;
-	minSize?: OptimizationSplitChunksSizes;
-	enforceSizeThreshold?: OptimizationSplitChunksSizes;
-	minRemainingSize?: OptimizationSplitChunksSizes;
-	name?: string | false;
-	maxSize?: number;
-	maxAsyncSize?: number;
-	maxInitialSize?: number;
-	fallbackCacheGroup?: RawFallbackCacheGroupOptions;
-}
-export interface OptimizationSplitChunksCacheGroup {
-	chunks?: "initial" | "async" | "all";
-	minChunks?: number;
-	name?: string | false;
-	priority?: number;
-	reuseExistingChunk?: boolean;
-	test?: RegExp;
-	minSize?: number;
-	maxSize?: number;
-	maxAsyncSize?: number;
-	maxInitialSize?: number;
-	enforce?: boolean;
-}
-export type OptimizationSplitChunksSizes = number;
 export type OptimizationRuntimeChunk =
 	| ("single" | "multiple")
 	| boolean

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -13,7 +13,6 @@ import webpackDevServer from "webpack-dev-server";
 import { Compiler } from "../compiler";
 import * as oldBuiltins from "./builtins";
 import { Compilation } from "..";
-import { RawFallbackCacheGroupOptions } from "@rspack/binding";
 import type { Options as RspackOptions } from "./zod/_rewrite";
 import type { OptimizationConfig as Optimization } from "./zod/optimization";
 export type { RspackOptions, Optimization };

--- a/packages/rspack/src/config/zod/optimization/split-chunks.ts
+++ b/packages/rspack/src/config/zod/optimization/split-chunks.ts
@@ -18,21 +18,19 @@ const sharedCacheGroupConfigPart = {
 	maxInitialSize: z.number().optional()
 };
 
+const cacheGroupOptions = z.strictObject({
+	test: z.instanceof(RegExp).optional(),
+	priority: z.number().optional(),
+	enforce: z.boolean().optional(),
+	reuseExistingChunk: z.boolean().optional(),
+	...sharedCacheGroupConfigPart
+});
+
 export function splitChunks() {
 	return z.literal(false).or(
 		// We use loose object here to prevent breaking change on config
 		z.object({
-			cacheGroups: z
-				.record(
-					z.strictObject({
-						test: z.instanceof(RegExp).optional(),
-						priority: z.number().optional(),
-						enforce: z.boolean().optional(),
-						reuseExistingChunk: z.boolean().optional(),
-						...sharedCacheGroupConfigPart
-					})
-				)
-				.optional(),
+			cacheGroups: z.record(z.literal(false).or(cacheGroupOptions)).optional(),
 			maxAsyncRequests: z.number().optional(),
 			maxInitialRequests: z.number().optional(),
 			fallbackCacheGroup: z
@@ -48,3 +46,6 @@ export function splitChunks() {
 		})
 	);
 }
+
+export type SplitChunksConfig = z.TypeOf<ReturnType<typeof splitChunks>>;
+export type CacheGroupOptionsConfig = z.TypeOf<typeof cacheGroupOptions>;


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

- This is quite useful when users want to overwrite the default `cacheGroup` item.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35e7073</samp>

Refactored and improved the split chunks configuration logic in `rspack`. Extracted and exported Zod schema and types for split chunks options and cache groups. Removed redundant interfaces from `types.ts`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35e7073</samp>

* Remove unused interface `OptimizationSplitChunksOptions` from `adapter.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L35))
* Import `SplitChunksConfig` type from `split-chunks.ts` to `adapter.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123R45))
* Rename and refactor `getRawSplitChunksOptions` function in `adapter.ts` to `toRawSplitChunksOptions` and move conditional check inside the function ([link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L509-R509), [link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L520-R543))
* Remove `OptimizationSplitChunksOptions` and `OptimizationSplitChunksCacheGroup` interfaces from `types.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL563-L593))
* Extract `cacheGroupOptions` schema and export `SplitChunksConfig` and `CacheGroupOptionsConfig` types from `split-chunks.ts` ([link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-63d7f1baf054835cd3b506980d3b33f1541c4cf726fea7fe44fd64c9fc734abbL21-R33), [link](https://github.com/web-infra-dev/rspack/pull/3420/files?diff=unified&w=0#diff-63d7f1baf054835cd3b506980d3b33f1541c4cf726fea7fe44fd64c9fc734abbR49-R51))

</details>
