### PR TITLE
fix: sourcemap as an empty string

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -157,6 +157,23 @@ function getCurrentLoader(
 	return null;
 }
 
+function serializeObject(
+	map: string | object | undefined | null
+): Buffer | undefined {
+	if (isNil(map)) {
+		return undefined;
+	}
+
+	if (typeof map === "string") {
+		if (map) {
+			return toBuffer(map);
+		}
+		return undefined;
+	}
+
+	return toBuffer(JSON.stringify(map));
+}
+
 export async function runLoader(
 	rawContext: JsLoaderContext,
 	compiler: Compiler
@@ -540,16 +557,8 @@ export async function runLoader(
 				const [content, sourceMap, additionalData] = result;
 				resolve({
 					content: isNil(content) ? undefined : toBuffer(content),
-					sourceMap: isNil(sourceMap)
-						? undefined
-						: toBuffer(
-								typeof sourceMap === "string"
-									? sourceMap
-									: JSON.stringify(sourceMap)
-						  ),
-					additionalData: isNil(additionalData)
-						? undefined
-						: toBuffer(JSON.stringify(additionalData)),
+					sourceMap: serializeObject(sourceMap),
+					additionalData: serializeObject(additionalData),
 					buildDependencies,
 					cacheable,
 					fileDependencies,
@@ -580,16 +589,8 @@ export async function runLoader(
 					const [content, sourceMap, additionalData] = result;
 					resolve({
 						content: isNil(content) ? undefined : toBuffer(content),
-						sourceMap: isNil(sourceMap)
-							? undefined
-							: toBuffer(
-									typeof sourceMap === "string"
-										? sourceMap
-										: JSON.stringify(sourceMap)
-							  ),
-						additionalData: isNil(additionalData)
-							? undefined
-							: toBuffer(JSON.stringify(additionalData)),
+						sourceMap: serializeObject(sourceMap),
+						additionalData: serializeObject(additionalData),
 						buildDependencies,
 						cacheable,
 						fileDependencies,

--- a/packages/rspack/tests/configCases/loader/issue-3418/index.js
+++ b/packages/rspack/tests/configCases/loader/issue-3418/index.js
@@ -1,0 +1,4 @@
+it("should compile if loader map returns an empty string (#3418)", () => {
+	const actual = require("./lib");
+	expect(actual).toBe("lib-foo");
+});

--- a/packages/rspack/tests/configCases/loader/issue-3418/lib.js
+++ b/packages/rspack/tests/configCases/loader/issue-3418/lib.js
@@ -1,0 +1,1 @@
+module.exports = "lib";

--- a/packages/rspack/tests/configCases/loader/issue-3418/loader.js
+++ b/packages/rspack/tests/configCases/loader/issue-3418/loader.js
@@ -1,0 +1,6 @@
+function loader(content) {
+	content += `;module.exports += "-foo"`;
+	this.callback(null, content, "");
+}
+
+module.exports = loader;

--- a/packages/rspack/tests/configCases/loader/issue-3418/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/issue-3418/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: /lib\.js$/,
+				loader: "./loader.js"
+			}
+		]
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

fixes #3418 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bf0990</samp>

This pull request refactors the loader-runner module and adds a test case for issue #3418. It improves the serialization logic of `runLoader` and verifies that it can handle a loader that returns an empty source map.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bf0990</samp>

* Add a new function `serializeObject` to convert values to buffers or undefined ([link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863R160-R176))
* Use `serializeObject` to simplify the serialization logic in `runLoader` ([link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L543-R561), [link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-b648afe2e36e78cf24dc37166b5030e9f878ed20adbe17a08b892785bc659863L583-R593))
* Add a test case for issue #3418, which reported a bug with loaders that return empty source maps ([link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-3cf25eaf5afdde15f8c40c1834cfbd586e39e443697e501b05dda9ca653f8f67R1-R4), [link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-6860d04f1b8f085168a9b44dc0af9b860dfbba0e89c9a2edbf8bb8a281a64765R1), [link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-32f8e5f08babfd4b11f99dfb4e0919a34dff5925ca58f1f82e0663434609595cR1-R6), [link](https://github.com/web-infra-dev/rspack/pull/3426/files?diff=unified&w=0#diff-a68873845283415dbed0f7023517b0f2cee32a05c200f95ee69b01a888cb4b72R1-R11))

</details>
