### PR TITLE
chore: fix release mr

### DIFF
--- a/npm/darwin-arm64/CHANGELOG.md
+++ b/npm/darwin-arm64/CHANGELOG.md
@@ -1,0 +1,114 @@
+# @rspack/binding-darwin-arm64
+
+## 0.1.12
+
+## 0.1.11
+
+## 0.1.9
+
+## 0.1.8
+
+## 0.1.7
+
+## 0.1.6
+
+## 0.1.5
+
+## 0.1.4
+
+## 0.1.3
+
+### Patch Changes
+
+- b0cffba: feat: inline external type syntax
+
+## 0.1.2
+
+## 0.1.1
+
+### Patch Changes
+
+- 6f8706f0: fix: postcss modules warning when using postcss-loader
+- a004765a: Avoid reporting warning the export when src module format is none esm
+
+## 0.1.0
+
+## 0.0.26
+
+## 0.0.25
+
+### Patch Changes
+
+- 6d6e65e4: feat: update packages repository config
+
+## 0.0.24
+
+## 0.0.23
+
+### Patch Changes
+
+- b67418968: chore: 🤖 use module path instead of module id in diagnositc
+- 962f8a251: fix: should create different module with different module rule
+- 766c94042: fix rust test
+- c1f19b817: align webpack config optimization.sideEffects
+
+## 0.0.22
+
+### Patch Changes
+
+- 59edc2cb4: fix watch options
+- faef6fc00: Should normalize SplitChunks options correctly
+
+## 0.0.21
+
+### Patch Changes
+
+- fix watch
+
+## 0.0.20
+
+### Patch Changes
+
+- fix load extra css chunk
+
+## 0.0.19
+
+### Patch Changes
+
+- 882093b8: support module.resolve
+
+## 0.0.18
+
+### Patch Changes
+
+- bump version
+
+## 0.0.17
+
+### Patch Changes
+
+- upgrade
+
+## 0.0.16
+
+### Patch Changes
+
+- support optional dependency
+
+## 0.0.15
+
+### Patch Changes
+
+- bump version
+
+## 0.0.14
+
+### Patch Changes
+
+- bump version
+
+## 0.0.13
+
+### Patch Changes
+
+- optional strategy


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary
https://github.com/web-infra-dev/rspack/actions/runs/5184080101/jobs/9342655605 fix release pull request broken for missing changelog.md
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b5ab34</samp>

Updated the changelog file for the `@rspack/binding-darwin-arm64` package to reflect the latest patch release. This package provides the bindings for the rspack tool to run on macOS devices with ARM64 processors. The patch release includes some bug fixes and performance improvements.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b5ab34</samp>

*  Bump the version of `@rspack/binding-darwin-arm64` to 0.1.1 and update the changelog file with the patch changes ([link](https://github.com/web-infra-dev/rspack/pull/3427/files?diff=unified&w=0#diff-3c02e5dab4c22c53ac832e957de09492901983c0b95edbb3192a5bd01bd6e42eR1-R114))

</details>
