### PR TITLE
chore: add release nigthly after full release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,3 +84,13 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+      - name: Release Nightly(After Full)
+        run: |
+          ./x version snapshot
+          ./x publish snapshot --tag nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          ONLY_RELEASE_TAG: true


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 288f423</samp>

Add a new workflow step to publish nightly snapshots of the package to npm. The step uses the `x` script and some environment variables to create and publish the snapshot with the `nightly` tag.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 288f423</samp>

* Add a step to publish a nightly snapshot of the package to npm ([link](https://github.com/web-infra-dev/rspack/pull/3429/files?diff=unified&w=0#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R87-R96))

</details>
