### PR TITLE
chore(webpack-test): --forceExit for open handles

### DIFF
--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.d.ts",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail",
-    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --json | node scripts/test-metric.js",
-    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --json"
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --forceExit",
+    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --forceExit --json | node scripts/test-metric.js",
+    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --json --forceExit"
   },
   "files": [
     "dist"


### PR DESCRIPTION
The test currently has 3 known open handles, force exit for now.

## Summary

<details>
<summary>pnpm run test --detectOpenHandles</summary>
Jest has detected the following 13 open handles potentially keeping Jest from exiting:

  ●  CustomGC

      102 |         try {
      103 |           if (localFileExisted) {
    > 104 |             nativeBinding = require('./rspack.darwin-x64.node')
          |                             ^
      105 |           } else {
      106 |             nativeBinding = require('@rspack/binding-darwin-x64')
      107 |           }

      at Runtime._loadModule (../node_modules/jest-runtime/build/index.js:1009:29)
      at Object.require (../crates/node_binding/binding.js:104:29)
      at Object.require (../packages/rspack/src/compiler.ts:10:1)
      at Object.require (../packages/rspack/src/index.ts:1:1)
      at getDefaultConfig (Defaults.unittest.js:65:69)
      at Defaults.unittest.js:73:21
      at Object.<anonymous> (Defaults.unittest.js:72:10)


  ●  napi_rs_threadsafe_function

      59 | 		this.suspended = false;
      60 |
    > 61 | 		process.nextTick(() => {
         | 		        ^
      62 | 			if (this.#initial) this.#invalidate();
      63 | 		});
      64 | 	}

      at new nextTick (../packages/rspack/src/watching.ts:61:11)
      at Compiler.watch (../packages/rspack/src/compiler.ts:852:19)
      at Object.<anonymous> (ChangesAndRemovals.test.js:103:22)


  ●  napi_rs_threadsafe_function

      59 | 		this.suspended = false;
      60 |
    > 61 | 		process.nextTick(() => {
         | 		        ^
      62 | 			if (this.#initial) this.#invalidate();
      63 | 		});
      64 | 	}

      at new nextTick (../packages/rspack/src/watching.ts:61:11)
      at Compiler.watch (../packages/rspack/src/compiler.ts:852:19)
      at Object.<anonymous> (ChangesAndRemovals.test.js:127:22)


  ●  napi_rs_threadsafe_function

      59 | 		this.suspended = false;
      60 |
    > 61 | 		process.nextTick(() => {
         | 		        ^
      62 | 			if (this.#initial) this.#invalidate();
      63 | 		});
      64 | 	}

      at new nextTick (../packages/rspack/src/watching.ts:61:11)
      at Compiler.watch (../packages/rspack/src/compiler.ts:852:19)
      at Object.<anonymous> (ChangesAndRemovals.test.js:151:22)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/compiler.ts:784:11)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:779:20)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:775:25)
      at Compiler.doRun [as run] (../packages/rspack/src/compiler.ts:810:4)
      at Object.<anonymous> (MemoryLimitTestCases.test.js:111:6)


  ●  napi_rs_threadsafe_function

      59 | 		this.suspended = false;
      60 |
    > 61 | 		process.nextTick(() => {
         | 		        ^
      62 | 			if (this.#initial) this.#invalidate();
      63 | 		});
      64 | 	}

      at new nextTick (../packages/rspack/src/watching.ts:61:11)
      at Compiler.watch (../packages/rspack/src/compiler.ts:852:19)
      at Object.<anonymous> (WatcherEvents.test.js:41:28)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/watching.ts:255:19)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at Watching.callAsync (../packages/rspack/src/watching.ts:238:32)
      at Watching.call (../packages/rspack/src/watching.ts:208:11)
      at Watching.call [as invalidate] (../packages/rspack/src/watching.ts:187:19)
      at invalidate (../packages/rspack/src/multiCompiler.ts:541:38)
      at run (../packages/rspack/src/multiCompiler.ts:481:6)
      at MultiCompiler.processQueueWorker (../packages/rspack/src/multiCompiler.ts:504:3)
      at MultiCompiler.call [as watch] (../packages/rspack/src/multiCompiler.ts:523:36)
      at Object.<anonymous> (WatcherEvents.test.js:59:28)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/compiler.ts:784:11)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:779:20)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:775:25)
      at Compiler.doRun [as run] (../packages/rspack/src/compiler.ts:810:4)
      at Stats.test.js:12:12
      at compile (Stats.test.js:8:9)
      at Object.<anonymous> (Stats.test.js:55:23)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/compiler.ts:784:11)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:779:20)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:775:25)
      at Compiler.doRun [as run] (../packages/rspack/src/compiler.ts:810:4)
      at Stats.test.js:12:12
      at compile (Stats.test.js:8:9)
      at Object.<anonymous> (Stats.test.js:67:24)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/compiler.ts:784:11)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:779:20)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:775:25)
      at Compiler.doRun [as run] (../packages/rspack/src/compiler.ts:810:4)
      at Stats.test.js:12:12
      at compile (Stats.test.js:8:9)
      at Object.<anonymous> (Stats.test.js:115:24)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/compiler.ts:784:11)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:779:20)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:775:25)
      at Compiler.doRun [as run] (../packages/rspack/src/compiler.ts:810:4)
      at Stats.test.js:12:12
      at compile (Stats.test.js:8:9)
      at Object.<anonymous> (Stats.test.js:176:24)


  ●  napi_rs_threadsafe_function

      278 | 				});
      279 | 		};
    > 280 | 		const options = getRawOptions(this.options, this, processResource);
          | 		 ^
      281 |
      282 | 		this.#_instance =
      283 | 			this.#_instance ??

      at Compiler._Compiler_instance_get (../packages/rspack/src/compiler.ts:280:4)
      at Object.<anonymous>.__classPrivateFieldGet (../packages/rspack/dist/compiler.js:43:46)
      at Compiler.__classPrivateFieldGet [as build] (../packages/rspack/src/compiler.ts:815:24)
      at build (../packages/rspack/src/compiler.ts:784:11)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:779:20)
      at Hook.eval [as callAsync] (eval at create (../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:15:1)
      at Hook.callAsync [as _callAsync] (../node_modules/tapable/lib/Hook.js:18:14)
      at callAsync (../packages/rspack/src/compiler.ts:775:25)
      at Compiler.doRun [as run] (../packages/rspack/src/compiler.ts:810:4)
      at run (../packages/rspack/src/multiCompiler.ts:561:41)
      at run (../packages/rspack/src/multiCompiler.ts:481:6)
      at MultiCompiler.processQueueWorker (../packages/rspack/src/multiCompiler.ts:504:3)
      at MultiCompiler.call [as run] (../packages/rspack/src/multiCompiler.ts:559:18)
      at Object.<anonymous> (MultiStats.test.js:21:12)


  ●  napi_rs_threadsafe_function

      59 | 		this.suspended = false;
      60 |
    > 61 | 		process.nextTick(() => {
         | 		        ^
      62 | 			if (this.#initial) this.#invalidate();
      63 | 		});
      64 | 	}

      at new nextTick (../packages/rspack/src/watching.ts:61:11)
      at Compiler.watch (../packages/rspack/src/compiler.ts:852:19)
      at Object.<anonymous> (WatchClose.test.js:28:23)

</details>

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02bb763</samp>

Update rspack to use Node.js 16 and latest dependencies. Add `--forceExit` flag to test scripts in `webpack-test/package.json` to fix Jest hanging issue.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02bb763</samp>

* Add `--forceExit` flag to test scripts to prevent Jest from hanging on Node.js 16 ([link](https://github.com/web-infra-dev/rspack/pull/3432/files?diff=unified&w=0#diff-ef6960a9216f589d8971ac9a37817f62fe5b99fe6e01f049e5325bb3c84a7159L8-R10))

</details>
