### PR TITLE
fix(types): type error for `runtimeChunk`

### DIFF
--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -17,6 +17,7 @@ import type {
 	RspackOptions,
 	RspackOptionsNormalized
 } from "./types";
+import { OptimizationRuntimeChunkConfig } from "./zod/optimization";
 
 export const getNormalizedRspackOptions = (
 	config: RspackOptions
@@ -271,7 +272,7 @@ const getNormalizedEntryStatic = (entry: EntryStatic) => {
 };
 
 const getNormalizedOptimizationRuntimeChunk = (
-	runtimeChunk?: OptimizationRuntimeChunk
+	runtimeChunk?: OptimizationRuntimeChunkConfig
 ): OptimizationRuntimeChunkNormalized | undefined => {
 	if (runtimeChunk === undefined) return undefined;
 	if (runtimeChunk === false) return false;
@@ -286,9 +287,10 @@ const getNormalizedOptimizationRuntimeChunk = (
 		};
 	}
 	const { name } = runtimeChunk;
-	return {
+	const opts: OptimizationRuntimeChunkNormalized = {
 		name: typeof name === "function" ? name : () => name
 	};
+	return opts;
 };
 
 const nestedConfig = <T, R>(value: T | undefined, fn: (value: T) => R) =>

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -574,7 +574,7 @@ export type OptimizationRuntimeChunk =
 export type OptimizationRuntimeChunkNormalized =
 	| false
 	| {
-			name: Function;
+			name: (...args: any[]) => string | undefined;
 	  };
 
 ///// Plugins /////

--- a/packages/rspack/src/config/zod/optimization/index.ts
+++ b/packages/rspack/src/config/zod/optimization/index.ts
@@ -17,7 +17,10 @@ export function optimization() {
 			.or(z.boolean())
 			.or(
 				z.strictObject({
-					name: z.string().or(z.function()).optional()
+					name: z
+						.string()
+						.or(z.function().returns(z.string().or(z.undefined())))
+						.optional()
 				})
 			)
 			.optional(),
@@ -29,3 +32,7 @@ export function optimization() {
 }
 
 export type OptimizationConfig = z.TypeOf<ReturnType<typeof optimization>>;
+
+export type OptimizationRuntimeChunkConfig = NonNullable<
+	OptimizationConfig["runtimeChunk"]
+>;


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75ad01d</samp>

This pull request enhances the type safety and validation of the `runtimeChunk` option in the webpack optimization configuration. It updates the zod schema, the normalization function, and the output type to match the possible values of the option.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75ad01d</samp>

*  Import and use `OptimizationRuntimeChunkConfig` type for `runtimeChunk` option ([link](https://github.com/web-infra-dev/rspack/pull/3442/files?diff=unified&w=0#diff-78648f723799beccc94c4b2e506997d12d1ace8216aeb31c0731c37a6dce024aR20), [link](https://github.com/web-infra-dev/rspack/pull/3442/files?diff=unified&w=0#diff-78648f723799beccc94c4b2e506997d12d1ace8216aeb31c0731c37a6dce024aL274-R275), [link](https://github.com/web-infra-dev/rspack/pull/3442/files?diff=unified&w=0#diff-646fa8be4d60a6fee5b03462e3f09a66bd32344962254fda67be20275002d114R35-R38))
* Update the `name` property of `OptimizationRuntimeChunkNormalized` type and the zod schema for `runtimeChunk` option ([link](https://github.com/web-infra-dev/rspack/pull/3442/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL577-R577), [link](https://github.com/web-infra-dev/rspack/pull/3442/files?diff=unified&w=0#diff-646fa8be4d60a6fee5b03462e3f09a66bd32344962254fda67be20275002d114L20-R23))
* Assign normalized `runtimeChunk` option to a variable before returning it ([link](https://github.com/web-infra-dev/rspack/pull/3442/files?diff=unified&w=0#diff-78648f723799beccc94c4b2e506997d12d1ace8216aeb31c0731c37a6dce024aL289-R293))

</details>
