### PR TITLE
chore: use latest npm version as snapshot prefix

### DIFF
--- a/scripts/release/version.mjs
+++ b/scripts/release/version.mjs
@@ -15,13 +15,13 @@ export async function getLastVersion(root) {
 	});
 	return result.default.version;
 }
-export async function getSnapshotVersion() {
+export async function getSnapshotVersion(lastVersion) {
 	const commitId = await getCommitId();
 	const dateTime = new Date()
 		.toISOString()
 		.replace(/\.\d{3}Z$/, "")
 		.replace(/[^\d]/g, "");
-	return `0.0.0-canary-${commitId}-${dateTime}`;
+	return `${lastVersion}-canary-${commitId}-${dateTime}`;
 }
 export async function version_handler(version) {
 	const allowedVersion = ["major", "minor", "patch", "snapshot"];
@@ -35,7 +35,7 @@ export async function version_handler(version) {
 	const lastVersion = await getLastVersion(root);
 	let nextVersion;
 	if (version === "snapshot") {
-		nextVersion = await getSnapshotVersion();
+		nextVersion = await getSnapshotVersion(lastVersion);
 	} else {
 		nextVersion = semver.inc(lastVersion, version);
 	}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary
* before: 0.0.0-canary-c5e633857-20230607064924
* after: 0.2.1-canary-c5e633857-20230607064924
current 0-0-0 is not useful to track which version nightly version is bound with so use latest version as prefix
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c5e6338</samp>

Enhanced snapshot versioning for `rspack` package. The script `scripts/release/version.mjs` now generates more meaningful snapshot versions based on the package history.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c5e6338</samp>

*  Modify `getSnapshotVersion` function to accept and use `lastVersion` parameter ([link](https://github.com/web-infra-dev/rspack/pull/3450/files?diff=unified&w=0#diff-bc014aa85ab36e7f64b4db4a41fc22a77ab466b0daf69f2f71fa2023e87cc1c0L18-R18), [link](https://github.com/web-infra-dev/rspack/pull/3450/files?diff=unified&w=0#diff-bc014aa85ab36e7f64b4db4a41fc22a77ab466b0daf69f2f71fa2023e87cc1c0L24-R24))
*  Pass `lastVersion` parameter to `getSnapshotVersion` function in `version_handler` function when `version` argument is `"snapshot"` ([link](https://github.com/web-infra-dev/rspack/pull/3450/files?diff=unified&w=0#diff-bc014aa85ab36e7f64b4db4a41fc22a77ab466b0daf69f2f71fa2023e87cc1c0L38-R38))

</details>
