### PR TITLE
feat: use immutable reference for process asset hook

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -224,7 +224,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_additional(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -241,7 +241,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_pre_process(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -258,7 +258,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_additions(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -275,7 +275,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_none(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -292,7 +292,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_optimize_inline(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -311,7 +311,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_summarize(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -329,7 +329,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_optimize_hash(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {
@@ -346,7 +346,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn process_assets_stage_report(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     _args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsHookOutput {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -984,7 +984,7 @@ impl Compilation {
   #[instrument(name = "compilation:process_asssets", skip_all)]
   async fn process_assets(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     plugin_driver
-      .write()
+      .read()
       .await
       .process_assets(ProcessAssetsArgs { compilation: self })
       .await

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -222,7 +222,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_additional(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -230,7 +230,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_additions(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -238,7 +238,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_pre_process(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -246,7 +246,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_none(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -254,7 +254,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_optimize_size(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -262,7 +262,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_dev_tooling(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -270,7 +270,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_optimize_inline(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -278,7 +278,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_summarize(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -286,7 +286,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_optimize_hash(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -294,7 +294,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn process_assets_stage_report(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -432,10 +432,10 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:process_assets", skip_all)]
-  pub async fn process_assets(&mut self, args: ProcessAssetsArgs<'_>) -> PluginProcessAssetsOutput {
+  pub async fn process_assets(&self, args: ProcessAssetsArgs<'_>) -> PluginProcessAssetsOutput {
     macro_rules! run_stage {
       ($stage: ident) => {
-        for plugin in &mut self.plugins {
+        for plugin in &self.plugins {
           plugin
             .$stage(
               PluginContext::new(),

--- a/crates/rspack_plugin_banner/src/lib.rs
+++ b/crates/rspack_plugin_banner/src/lib.rs
@@ -148,7 +148,7 @@ impl BannerPlugin {
     Self { config, comment }
   }
 
-  fn update_source(&mut self, comment: String, old: BoxSource, footer: Option<bool>) -> BoxSource {
+  fn update_source(&self, comment: String, old: BoxSource, footer: Option<bool>) -> BoxSource {
     let old_source = old.to_owned();
 
     if let Some(footer) = footer && footer {
@@ -174,7 +174,7 @@ impl Plugin for BannerPlugin {
   }
 
   async fn process_assets_stage_additions(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -451,7 +451,7 @@ impl Plugin for CopyPlugin {
   }
 
   async fn process_assets_stage_additional(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     mut args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -209,7 +209,7 @@ impl Plugin for CssPlugin {
   }
 
   async fn process_assets_stage_optimize_size(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -95,7 +95,7 @@ impl Plugin for DevtoolPlugin {
   }
 
   async fn process_assets_stage_dev_tooling(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_html/src/plugin.rs
+++ b/crates/rspack_plugin_html/src/plugin.rs
@@ -53,7 +53,7 @@ impl Plugin for HtmlPlugin {
   }
 
   async fn process_assets_stage_optimize_inline(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::ProcessAssetsArgs<'_>,
   ) -> rspack_core::PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -224,7 +224,7 @@ impl Plugin for JsPlugin {
   }
 
   async fn process_assets_stage_optimize_size(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -100,7 +100,7 @@ impl Plugin for ProgressPlugin {
   }
 
   async fn process_assets_stage_additional(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -27,7 +27,7 @@ pub struct RealContentHashPlugin;
 #[async_trait::async_trait]
 impl Plugin for RealContentHashPlugin {
   async fn process_assets_stage_optimize_hash(
-    &mut self,
+    &self,
     ctx: PluginContext,
     args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
@@ -37,7 +37,7 @@ impl Plugin for RealContentHashPlugin {
 
 impl RealContentHashPlugin {
   async fn inner_impl(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

Prerequisite for #3403.

The current implementation causes locking more frequently, 
we should discuss this in the future.

Edit: discussion https://github.com/web-infra-dev/rspack/discussions/3456

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cad9888</samp>

This pull request refactors the `Plugin` trait and its implementations to use shared references instead of mutable references. This allows concurrent plugin execution without locking the plugin driver. The pull request also updates the `Compilation` and `PluginDriver` structs to use read locks instead of write locks when accessing the plugin driver. This improves the performance and concurrency of the asset processing pipeline. The pull request affects the files `crates/node_binding/src/plugins/mod.rs`, `crates/rspack_core/src/plugin/api.rs`, `crates/rspack_core/src/compiler/compilation.rs`, `crates/rspack_core/src/plugin/plugin_driver.rs`, and all the files in the `crates/rspack_plugin_*` directories.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cad9888</samp>

*  Change the `Plugin` trait methods to take a shared reference instead of a mutable reference, allowing concurrent plugin execution ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L227-R227),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L244-R244),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L261-R261),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L278-R278),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L295-R295),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L314-R314),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L332-R332),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L349-R349),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L225-R225),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L233-R233),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L241-R241),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L249-R249),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L257-R257),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L265-R265),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L273-R273),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L281-R281),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L289-R289),[link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L297-R297))
*  Change the `process_assets` method of the `Compilation` struct to use a read lock instead of a write lock on the plugin driver, avoiding blocking other threads ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L987-R987))
*  Change the `process_assets` method of the `PluginDriver` struct to take a shared reference instead of a mutable reference, enabling concurrent reads ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL435-R438))
*  Change the `update_source` method of the `BannerPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-f84cf2ba28a1730ebd4bbb4ee6c307fa65bcfd3e5c308130a31b64522f25d481L151-R151))
*  Change the `process_assets_stage_additions` method of the `BannerPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-f84cf2ba28a1730ebd4bbb4ee6c307fa65bcfd3e5c308130a31b64522f25d481L177-R177))
*  Change the `process_assets_stage_additional` method of the `CopyPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-cde7edc635e72d8f64c982c4e78298d248e671f6f022318cc20440f6091b70baL454-R454))
*  Change the `process_assets_stage_optimize_size` method of the `CssPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L212-R212))
*  Change the `process_assets_stage_dev_tooling` method of the `DevToolPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-a3ed34d20f0b15a073bdeaac181d27e0fe74d19b63f7a0eb6cc1868192ef6dd9L98-R98))
*  Change the `process_assets_stage_optimize_inline` method of the `HtmlPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-a889d0e910b514418c3aefad6b3a13a395a9a030ab135118edcf0d82bd2673fcL56-R56))
*  Change the `process_assets_stage_optimize_size` method of the `JsPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-cb100885778a02cf058ed143db3d44a406d7751a96f61993055827e493082287L227-R227))
*  Change the `process_assets_stage_additional` method of the `ProgressPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-74d45e75be91aa846fb37ea837a09fb96f501229aaa991892ccd11f12da006beL103-R103))
*  Change the `process_assets_stage_optimize_hash` method of the `RealContentHashPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-139f1141d4c9fc51ca5d8e4995a32fcd2227265ec58ef73a9a9bf7f6e92314f1L30-R30))
*  Change the `inner_impl` method of the `RealContentHashPlugin` struct to take a shared reference instead of a mutable reference, aligning with the trait implementation ([link](https://github.com/web-infra-dev/rspack/pull/3455/files?diff=unified&w=0#diff-139f1141d4c9fc51ca5d8e4995a32fcd2227265ec58ef73a9a9bf7f6e92314f1L40-R40))

</details>
