### PR TITLE
feat: zod schema for `buliltins.postcss` and deprecate `buliltins.postcss`

### DIFF
--- a/packages/rspack/src/config/zod/_rewrite.ts
+++ b/packages/rspack/src/config/zod/_rewrite.ts
@@ -19,7 +19,8 @@ type Rewritten = {
 	resolve?: Resolve;
 	module?: ModuleOptions;
 	plugins?: Plugins;
-	builtins?: Builtins;
+	builtins?: Omit<Builtins, keyof NonNullable<Config["builtins"]>> &
+		NonNullable<Config["builtins"]>;
 	devServer?: DevServer;
 };
 

--- a/packages/rspack/src/config/zod/builtins.ts
+++ b/packages/rspack/src/config/zod/builtins.ts
@@ -1,6 +1,28 @@
 import { z } from "zod";
 
 export function builtins() {
-	// TODO(hyf0): need to enable strict mode when developer have time to write these schema
-	return z.record(z.any());
+	// TODO(hyf0): need to use `strictObject` mode when developer have time to finish the whole schema
+	return z.object({
+		postcss: z
+			.strictObject({
+				pxtorem: z
+					.strictObject({
+						rootValue: z.number().optional(),
+						unitPrecision: z.number().optional(),
+						selectorBlackList: z.string().array().optional(),
+						propList: z.string().array().optional(),
+						replace: z.boolean().optional(),
+						mediaQuery: z.boolean().optional(),
+						minPixelValue: z.number().optional()
+					})
+					.optional()
+			})
+			.refine(() => {
+				console.warn(
+					"warn: `builtins.postcss` is going to be deprecated and will be removed at 0.3. See details at https://github.com/web-infra-dev/rspack/issues/3452"
+				);
+				return true;
+			})
+			.optional()
+	});
 }


### PR DESCRIPTION
## Related issue (if exists)

Closes https://github.com/web-infra-dev/rspack/issues/3453

Part of #3441

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02c4718</samp>

This pull request enhances the type and schema definitions for the `Rewritten` and `builtins` config properties in `packages/rspack/src/config/zod/_rewrite.ts` and `packages/rspack/src/config/zod/builtins.ts`. It also moves the `builtins` function to the same file as the `Rewritten` type and adds a deprecation warning for the `builtins.postcss` property.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02c4718</samp>

*  Refine the type of the `builtins` property in the `Rewritten` type to exclude the keys already defined in the `Config` type and ensure they are not undefined ([link](https://github.com/web-infra-dev/rspack/pull/3458/files?diff=unified&w=0#diff-bd8525628aa18fe2735262e8e0528ec0b40d0bac1d18250050ba0e2e112e2a50L22-R23))
* Move the `builtins` function from `builtins.ts` to `_rewrite.ts` to keep it in the same file as the `Rewritten` type ([link](https://github.com/web-infra-dev/rspack/pull/3458/files?diff=unified&w=0#diff-2aaf2d605b13329eee31f67946b79bd691b267f1a6274851df7a60276b1e9d37L4-R27))
* Add a more detailed schema for the `builtins.postcss` property, which defines the options for the `postcss.pxtorem` plugin and warns the user about the deprecation of the property ([link](https://github.com/web-infra-dev/rspack/pull/3458/files?diff=unified&w=0#diff-2aaf2d605b13329eee31f67946b79bd691b267f1a6274851df7a60276b1e9d37L4-R27))

</details>
