### PR TITLE
feat: make plugin driver immutable

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -66,7 +66,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn compilation(
-    &mut self,
+    &self,
     args: rspack_core::CompilationArgs<'_>,
   ) -> rspack_core::PluginCompilationHookOutput {
     if self.is_hook_disabled(&Hook::Compilation) {
@@ -88,7 +88,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn this_compilation(
-    &mut self,
+    &self,
     args: rspack_core::ThisCompilationArgs<'_>,
   ) -> rspack_core::PluginThisCompilationHookOutput {
     if self.is_hook_disabled(&Hook::ThisCompilation) {
@@ -109,7 +109,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
   }
 
-  async fn chunk_asset(&mut self, args: &ChunkAssetArgs) -> rspack_error::Result<()> {
+  async fn chunk_asset(&self, args: &ChunkAssetArgs) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::ChunkAsset) {
       return Ok(());
     }
@@ -363,7 +363,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn optimize_modules(
-    &mut self,
+    &self,
     compilation: &mut rspack_core::Compilation,
   ) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::OptimizeModules) {
@@ -383,7 +383,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn optimize_chunk_modules(
-    &mut self,
+    &self,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::OptimizeChunkModules) {
@@ -405,7 +405,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn before_compile(
-    &mut self,
+    &self,
     // args: &mut rspack_core::CompilationArgs<'_>
   ) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::BeforeCompile) {
@@ -421,7 +421,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn after_compile(
-    &mut self,
+    &self,
     compilation: &mut rspack_core::Compilation,
   ) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::AfterCompile) {
@@ -443,7 +443,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn finish_make(
-    &mut self,
+    &self,
     compilation: &mut rspack_core::Compilation,
   ) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::FinishMake) {
@@ -465,7 +465,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
   }
 
   async fn finish_modules(
-    &mut self,
+    &self,
     compilation: &mut rspack_core::Compilation,
   ) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::FinishModules) {
@@ -486,7 +486,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to finish modules: {err}"))?
   }
 
-  async fn emit(&mut self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+  async fn emit(&self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::Emit) {
       return Ok(());
     }
@@ -513,7 +513,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .map_err(|err| internal_error!("Failed to call asset emitted: {err}"))?
   }
 
-  async fn after_emit(&mut self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+  async fn after_emit(&self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
     if self.is_hook_disabled(&Hook::AfterEmit) {
       return Ok(());
     }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -358,15 +358,7 @@ impl Compilation {
 
   #[instrument(name = "compilation:make", skip_all)]
   pub async fn make(&mut self, params: SetupMakeParam) -> Result<()> {
-    if let Some(e) = self
-      .plugin_driver
-      .clone()
-      .read()
-      .await
-      .make(self)
-      .await
-      .err()
-    {
+    if let Some(e) = self.plugin_driver.clone().make(self).await.err() {
       self.push_batch_diagnostic(e.into());
     }
 
@@ -930,8 +922,6 @@ impl Compilation {
       .values()
       .map(|chunk| async {
         let manifest = plugin_driver
-          .read()
-          .await
           .render_manifest(RenderManifestArgs {
             chunk_ukey: chunk.ukey,
             compilation: self,
@@ -984,8 +974,6 @@ impl Compilation {
   #[instrument(name = "compilation:process_asssets", skip_all)]
   async fn process_assets(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     plugin_driver
-      .read()
-      .await
       .process_assets(ProcessAssetsArgs { compilation: self })
       .await
   }
@@ -1001,11 +989,7 @@ impl Compilation {
       .chunk_by_ukey
       .get(&chunk_ukey)
       .unwrap_or_else(|| panic!("chunk({chunk_ukey:?}) should be in chunk_by_ukey",));
-    _ = plugin_driver
-      .write()
-      .await
-      .chunk_asset(current_chunk, filename)
-      .await;
+    _ = plugin_driver.chunk_asset(current_chunk, filename).await;
     Ok(())
   }
 
@@ -1017,7 +1001,7 @@ impl Compilation {
 
   pub async fn done(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     let stats = &mut Stats::new(self);
-    plugin_driver.write().await.done(stats).await?;
+    plugin_driver.done(stats).await?;
     Ok(())
   }
 
@@ -1035,7 +1019,7 @@ impl Compilation {
 
   #[instrument(name = "compilation:finish", skip_all)]
   pub async fn finish(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
-    plugin_driver.write().await.finish_modules(self).await?;
+    plugin_driver.finish_modules(self).await?;
     Ok(())
   }
 
@@ -1043,27 +1027,15 @@ impl Compilation {
   pub async fn seal(&mut self, plugin_driver: SharedPluginDriver) -> Result<()> {
     use_code_splitting_cache(self, |compilation| async {
       build_chunk_graph(compilation)?;
-      plugin_driver
-        .write()
-        .await
-        .optimize_modules(compilation)
-        .await?;
-      plugin_driver
-        .write()
-        .await
-        .optimize_chunks(compilation)
-        .await?;
+      plugin_driver.optimize_modules(compilation).await?;
+      plugin_driver.optimize_chunks(compilation).await?;
       Ok(compilation)
     })
     .await?;
-    plugin_driver
-      .write()
-      .await
-      .optimize_chunk_modules(self)
-      .await?;
+    plugin_driver.optimize_chunk_modules(self).await?;
 
-    plugin_driver.write().await.module_ids(self)?;
-    plugin_driver.write().await.chunk_ids(self)?;
+    plugin_driver.module_ids(self)?;
+    plugin_driver.chunk_ids(self)?;
 
     self.code_generation().await?;
 
@@ -1150,14 +1122,13 @@ impl Compilation {
       chunk_requirements.insert(*chunk_ukey, set);
     }
     for (chunk_ukey, set) in chunk_requirements.iter_mut() {
-      plugin_driver
-        .read()
-        .await
-        .additional_chunk_runtime_requirements(&mut AdditionalChunkRuntimeRequirementsArgs {
+      plugin_driver.additional_chunk_runtime_requirements(
+        &mut AdditionalChunkRuntimeRequirementsArgs {
           compilation: self,
           chunk: chunk_ukey,
           runtime_requirements: set,
-        })?;
+        },
+      )?;
 
       self
         .chunk_graph
@@ -1181,22 +1152,19 @@ impl Compilation {
         set.add(*runtime_requirements);
       }
 
-      plugin_driver
-        .read()
-        .await
-        .additional_tree_runtime_requirements(&mut AdditionalChunkRuntimeRequirementsArgs {
-          compilation: self,
-          chunk: entry_ukey,
-          runtime_requirements: &mut set,
-        })?;
-
-      plugin_driver.read().await.runtime_requirements_in_tree(
+      plugin_driver.additional_tree_runtime_requirements(
         &mut AdditionalChunkRuntimeRequirementsArgs {
           compilation: self,
           chunk: entry_ukey,
           runtime_requirements: &mut set,
         },
       )?;
+
+      plugin_driver.runtime_requirements_in_tree(&mut AdditionalChunkRuntimeRequirementsArgs {
+        compilation: self,
+        chunk: entry_ukey,
+        runtime_requirements: &mut set,
+      })?;
 
       self
         .chunk_graph
@@ -1272,8 +1240,6 @@ impl Compilation {
       chunk.update_hash(&mut hasher, self);
     }
     plugin_driver
-      .read()
-      .await
       .chunk_hash(&mut ChunkHashArgs {
         chunk_ukey,
         compilation: self,
@@ -1283,8 +1249,6 @@ impl Compilation {
     let chunk_hash = hasher.digest(&self.options.output.hash_digest);
 
     let content_hash = plugin_driver
-      .read()
-      .await
       .content_hash(&ContentHashArgs {
         chunk_ukey,
         compilation: self,

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -126,12 +126,7 @@ where
       self
         .cache
         .set_modified_files(modified_files.iter().cloned().collect::<Vec<_>>());
-      self
-        .plugin_driver
-        .read()
-        .await
-        .resolver_factory
-        .clear_entries();
+      self.plugin_driver.resolver_factory.clear_entries();
 
       let mut new_compilation = Compilation::new(
         // TODO: use Arc<T> instead
@@ -186,15 +181,11 @@ where
       // Fake this compilation as *currently* rebuilding does not create a new compilation
       self
         .plugin_driver
-        .write()
-        .await
         .this_compilation(&mut self.compilation)
         .await?;
 
       self
         .plugin_driver
-        .write()
-        .await
         .compilation(&mut self.compilation)
         .await?;
 
@@ -388,8 +379,6 @@ where
         let render_manifest = self
           .compilation
           .plugin_driver
-          .read()
-          .await
           .render_manifest(RenderManifestArgs {
             compilation: &self.compilation,
             chunk_ukey: ukey,

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -227,11 +227,7 @@ impl WorkerTask for BuildTask {
     let (build_result, is_cache_valid) = match cache
       .build_module_occasion
       .use_cache(&mut module, |module| async {
-        plugin_driver
-          .read()
-          .await
-          .build_module(module.as_mut())
-          .await?;
+        plugin_driver.build_module(module.as_mut()).await?;
 
         let result = module
           .build(BuildContext {
@@ -244,7 +240,7 @@ impl WorkerTask for BuildTask {
           })
           .await;
 
-        plugin_driver.read().await.succeed_module(&**module).await?;
+        plugin_driver.succeed_module(&**module).await?;
 
         result
       })
@@ -255,11 +251,7 @@ impl WorkerTask for BuildTask {
     };
 
     if is_cache_valid {
-      plugin_driver
-        .read()
-        .await
-        .still_valid_module(module.as_ref())
-        .await?;
+      plugin_driver.still_valid_module(module.as_ref()).await?;
     }
 
     build_result.map(|build_result| {

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -47,8 +47,6 @@ impl ContextModuleFactory {
     };
     if let Ok(Some(false)) = self
       .plugin_driver
-      .read()
-      .await
       .context_module_before_resolve(&mut before_resolve_args)
       .await
     {
@@ -114,7 +112,7 @@ impl ContextModuleFactory {
             .expect("should has options")
             .clone(),
         },
-        plugin_driver.read().await.resolver_factory.clone(),
+        plugin_driver.resolver_factory.clone(),
       )) as BoxModule,
       Ok(ResolveResult::Ignored) => {
         let ident = format!("{}/{}", data.context, specifier);

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -45,7 +45,6 @@ pub use chunk::*;
 mod dependency;
 pub use dependency::*;
 mod utils;
-use tokio::sync::RwLock;
 pub use utils::*;
 mod chunk_graph;
 pub use chunk_graph::*;
@@ -232,4 +231,4 @@ impl TryFrom<&str> for ModuleType {
 
 pub type ChunkByUkey = Database<Chunk>;
 pub type ChunkGroupByUkey = Database<ChunkGroup>;
-pub(crate) type SharedPluginDriver = Arc<RwLock<PluginDriver>>;
+pub(crate) type SharedPluginDriver = Arc<PluginDriver>;

--- a/crates/rspack_core/src/loader/process_resource.rs
+++ b/crates/rspack_core/src/loader/process_resource.rs
@@ -20,12 +20,7 @@ impl LoaderRunnerPlugin for LoaderRunnerPluginProcessResource {
   }
 
   async fn process_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
-    let result = self
-      .plugin_driver
-      .read()
-      .await
-      .read_resource(resource_data)
-      .await?;
+    let result = self.plugin_driver.read_resource(resource_data).await?;
     if result.is_some() {
       return Ok(result);
     }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -353,12 +353,7 @@ impl Module for NormalModule {
     let mut build_meta = BuildMeta::default();
     let mut diagnostics = Vec::new();
 
-    build_context
-      .plugin_driver
-      .read()
-      .await
-      .before_loaders(self)
-      .await?;
+    build_context.plugin_driver.before_loaders(self).await?;
 
     let loader_result = {
       run_loaders(

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -74,8 +74,6 @@ impl NormalModuleFactory {
     };
     if let Ok(Some(false)) = self
       .plugin_driver
-      .read()
-      .await
       .before_resolve(&mut before_resolve_args)
       .await
     {
@@ -107,8 +105,6 @@ impl NormalModuleFactory {
   ) -> Result<Option<TWithDiagnosticArray<ModuleFactoryResult>>> {
     if let Ok(Some(false)) = self
       .plugin_driver
-      .read()
-      .await
       .after_resolve(NormalModuleAfterResolveArgs {
         request: data.dependency.request(),
         context: data.context.as_ref(),
@@ -161,8 +157,6 @@ impl NormalModuleFactory {
     {
       // resource with scheme
       plugin_driver
-        .read()
-        .await
         .normal_module_factory_resolve_for_scheme(ResourceData::new(
           request_without_match_resource.to_string(),
           "".into(),
@@ -172,7 +166,7 @@ impl NormalModuleFactory {
     // TODO: resource within scheme, call resolveInScheme hook
     else {
       {
-        let plugin_driver = self.plugin_driver.read().await;
+        let plugin_driver = &self.plugin_driver;
         let context = data.context.as_path();
         request_without_match_resource = {
           let match_resource_match = MATCH_RESOURCE_REGEX.captures(request_without_match_resource);
@@ -440,8 +434,6 @@ impl NormalModuleFactory {
 
     let resolved_parser_and_generator = self
       .plugin_driver
-      .read()
-      .await
       .registered_parser_and_generator_builder
       .get(&resolved_module_type)
       .ok_or_else(|| {
@@ -469,8 +461,6 @@ impl NormalModuleFactory {
 
     let module = if let Some(module) = self
       .plugin_driver
-      .read()
-      .await
       .module(ModuleArgs {
         dependency_type: data.dependency.dependency_type().clone(),
         indentfiler: normal_module.identifier(),
@@ -570,8 +560,6 @@ impl NormalModuleFactory {
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>> {
     let result = self
       .plugin_driver
-      .read()
-      .await
       .factorize(
         FactorizeArgs {
           context: &data.context,

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -1,10 +1,10 @@
 use std::{fmt::Debug, path::Path};
 
+use dashmap::DashMap;
 use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
 use rspack_loader_runner::{Content, ResourceData};
 use rspack_sources::BoxSource;
-use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   AdditionalChunkRuntimeRequirementsArgs, AssetEmittedArgs, AssetInfo, BoxLoader, BoxModule,
@@ -46,16 +46,16 @@ pub trait Plugin: Debug + Send + Sync {
     "unknown"
   }
 
-  fn apply(&mut self, _ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
+  fn apply(&self, _ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
     Ok(())
   }
 
-  async fn compilation(&mut self, _args: CompilationArgs<'_>) -> PluginCompilationHookOutput {
+  async fn compilation(&self, _args: CompilationArgs<'_>) -> PluginCompilationHookOutput {
     Ok(())
   }
 
   async fn this_compilation(
-    &mut self,
+    &self,
     _args: ThisCompilationArgs<'_>,
   ) -> PluginThisCompilationHookOutput {
     Ok(())
@@ -66,7 +66,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn done<'s, 'c>(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: DoneArgs<'s, 'c>,
   ) -> PluginBuildEndHookOutput {
@@ -161,7 +161,7 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   /// webpack `compilation.hooks.chunkAsset`
-  async fn chunk_asset(&mut self, _args: &ChunkAssetArgs) -> Result<()> {
+  async fn chunk_asset(&self, _args: &ChunkAssetArgs) -> Result<()> {
     Ok(())
   }
 
@@ -302,34 +302,34 @@ pub trait Plugin: Debug + Send + Sync {
   }
 
   async fn optimize_chunks(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: OptimizeChunksArgs<'_>,
   ) -> PluginOptimizeChunksOutput {
     Ok(())
   }
 
-  async fn optimize_modules(&mut self, _compilation: &mut Compilation) -> Result<()> {
+  async fn optimize_modules(&self, _compilation: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
-  async fn optimize_chunk_modules(&mut self, _args: OptimizeChunksArgs<'_>) -> Result<()> {
+  async fn optimize_chunk_modules(&self, _args: OptimizeChunksArgs<'_>) -> Result<()> {
     Ok(())
   }
 
-  async fn before_compile(&mut self) -> Result<()> {
+  async fn before_compile(&self) -> Result<()> {
     Ok(())
   }
 
-  async fn after_compile(&mut self, _compilation: &mut Compilation) -> Result<()> {
+  async fn after_compile(&self, _compilation: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
-  async fn finish_make(&mut self, _compilation: &mut Compilation) -> Result<()> {
+  async fn finish_make(&self, _compilation: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
-  async fn finish_modules(&mut self, _modules: &mut Compilation) -> Result<()> {
+  async fn finish_modules(&self, _modules: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
@@ -362,15 +362,15 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
-  fn module_ids(&mut self, _modules: &mut Compilation) -> Result<()> {
+  fn module_ids(&self, _modules: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
-  fn chunk_ids(&mut self, _compilation: &mut Compilation) -> Result<()> {
+  fn chunk_ids(&self, _compilation: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
-  async fn emit(&mut self, _compilation: &mut Compilation) -> Result<()> {
+  async fn emit(&self, _compilation: &mut Compilation) -> Result<()> {
     Ok(())
   }
 
@@ -378,7 +378,7 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
-  async fn after_emit(&mut self, _compilation: &mut Compilation) -> Result<()> {
+  async fn after_emit(&self, _compilation: &mut Compilation) -> Result<()> {
     Ok(())
   }
 }
@@ -445,18 +445,13 @@ pub type BoxedParserAndGeneratorBuilder =
 
 #[derive(Default)]
 pub struct ApplyContext {
-  // pub(crate) registered_parser: HashMap<ModuleType, BoxedParser>,
   pub(crate) registered_parser_and_generator_builder:
-    HashMap<ModuleType, BoxedParserAndGeneratorBuilder>,
+    DashMap<ModuleType, BoxedParserAndGeneratorBuilder>,
 }
 
 impl ApplyContext {
-  // pub fn register_parser(&mut self, module_type: ModuleType, parser: BoxedParser) {
-  //   self.registered_parser.insert(module_type, parser);
-  // }
-
   pub fn register_parser_and_generator_builder(
-    &mut self,
+    &self,
     module_type: ModuleType,
     parser_and_generator_builder: BoxedParserAndGeneratorBuilder,
   ) {

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -138,11 +138,8 @@ impl PluginDriver {
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#compilation
   #[instrument(name = "plugin:compilation", skip_all)]
-  pub async fn compilation(
-    &mut self,
-    compilation: &mut Compilation,
-  ) -> PluginCompilationHookOutput {
-    for plugin in &mut self.plugins {
+  pub async fn compilation(&self, compilation: &mut Compilation) -> PluginCompilationHookOutput {
+    for plugin in &self.plugins {
       plugin.compilation(CompilationArgs { compilation }).await?;
     }
 
@@ -150,12 +147,8 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:chunk_asset", skip_all)]
-  pub async fn chunk_asset(
-    &mut self,
-    chunk: &Chunk,
-    filename: String,
-  ) -> PluginCompilationHookOutput {
-    for plugin in &mut self.plugins {
+  pub async fn chunk_asset(&self, chunk: &Chunk, filename: String) -> PluginCompilationHookOutput {
+    for plugin in &self.plugins {
       plugin
         .chunk_asset(&ChunkAssetArgs {
           chunk,
@@ -168,32 +161,26 @@ impl PluginDriver {
   }
 
   pub async fn before_compile(
-    &mut self,
+    &self,
     // compilationParams: &mut CompilationParams<'_>,
   ) -> PluginCompilationHookOutput {
-    for plugin in &mut self.plugins {
+    for plugin in &self.plugins {
       plugin.before_compile().await?;
     }
 
     Ok(())
   }
 
-  pub async fn after_compile(
-    &mut self,
-    compilation: &mut Compilation,
-  ) -> PluginCompilationHookOutput {
-    for plugin in &mut self.plugins {
+  pub async fn after_compile(&self, compilation: &mut Compilation) -> PluginCompilationHookOutput {
+    for plugin in &self.plugins {
       plugin.after_compile(compilation).await?;
     }
 
     Ok(())
   }
 
-  pub async fn finish_make(
-    &mut self,
-    compilation: &mut Compilation,
-  ) -> PluginCompilationHookOutput {
-    for plugin in &mut self.plugins {
+  pub async fn finish_make(&self, compilation: &mut Compilation) -> PluginCompilationHookOutput {
+    for plugin in &self.plugins {
       plugin.finish_make(compilation).await?;
     }
 
@@ -203,10 +190,10 @@ impl PluginDriver {
   ///
   /// See: https://webpack.js.org/api/compiler-hooks/#thiscompilation
   pub async fn this_compilation(
-    &mut self,
+    &self,
     compilation: &mut Compilation,
   ) -> PluginThisCompilationHookOutput {
-    for plugin in &mut self.plugins {
+    for plugin in &self.plugins {
       plugin
         .this_compilation(ThisCompilationArgs {
           this_compilation: compilation,
@@ -469,8 +456,8 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:done", skip_all)]
-  pub async fn done<'s, 'c>(&mut self, stats: &'s mut Stats<'c>) -> PluginBuildEndHookOutput {
-    for plugin in &mut self.plugins {
+  pub async fn done<'s, 'c>(&self, stats: &'s mut Stats<'c>) -> PluginBuildEndHookOutput {
+    for plugin in &self.plugins {
       plugin
         .done(PluginContext::new(), DoneArgs { stats })
         .await?;
@@ -478,8 +465,8 @@ impl PluginDriver {
     Ok(())
   }
   #[instrument(name = "plugin:optimize_chunks", skip_all)]
-  pub async fn optimize_chunks(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub async fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin
         .optimize_chunks(PluginContext::new(), OptimizeChunksArgs { compilation })
         .await?;
@@ -488,16 +475,16 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:optimize_modules", skip_all)]
-  pub async fn optimize_modules(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub async fn optimize_modules(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin.optimize_modules(compilation).await?;
     }
     Ok(())
   }
 
   #[instrument(name = "plugin:optimize_chunk_modules", skip_all)]
-  pub async fn optimize_chunk_modules(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub async fn optimize_chunk_modules(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin
         .optimize_chunk_modules(OptimizeChunksArgs { compilation })
         .await?;
@@ -506,8 +493,8 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:finish_modules", skip_all)]
-  pub async fn finish_modules(&mut self, modules: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub async fn finish_modules(&self, modules: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin.finish_modules(modules).await?;
     }
     Ok(())
@@ -563,24 +550,24 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:module_ids", skip_all)]
-  pub fn module_ids(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin.module_ids(compilation)?;
     }
     Ok(())
   }
 
   #[instrument(name = "plugin:chunk_ids", skip_all)]
-  pub fn chunk_ids(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub fn chunk_ids(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin.chunk_ids(compilation)?;
     }
     Ok(())
   }
 
   #[instrument(name = "plugin:emit", skip_all)]
-  pub async fn emit(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub async fn emit(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin.emit(compilation).await?;
     }
     Ok(())
@@ -595,8 +582,8 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:after_emit", skip_all)]
-  pub async fn after_emit(&mut self, compilation: &mut Compilation) -> Result<()> {
-    for plugin in &mut self.plugins {
+  pub async fn after_emit(&self, compilation: &mut Compilation) -> Result<()> {
+    for plugin in &self.plugins {
       plugin.after_emit(compilation).await?;
     }
     Ok(())

--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -14,7 +14,7 @@ pub async fn resolve(
   plugin_driver: &SharedPluginDriver,
   //  _job_context: &mut NormalModuleFactoryContext,
 ) -> Result<ResolveResult, ResolveError> {
-  let plugin_driver = plugin_driver.read().await;
+  let plugin_driver = plugin_driver;
   let importer = args.importer.map(|i| i.to_string());
   let base_dir = args.context.as_ref();
 

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -10,7 +10,7 @@ use crate::id_helpers::{
 pub struct DeterministicModuleIdsPlugin;
 
 impl Plugin for DeterministicModuleIdsPlugin {
-  fn module_ids(&mut self, compilation: &mut Compilation) -> Result<()> {
+  fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
     let (mut used_ids, modules) = get_used_module_ids_and_modules(compilation, None);
 
     let module_graph = &compilation.module_graph;

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -23,7 +23,7 @@ impl NamedChunkIdsPlugin {
 }
 
 impl Plugin for NamedChunkIdsPlugin {
-  fn chunk_ids(&mut self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+  fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
     let mut used_ids = get_used_chunk_ids(compilation);
     let chunk_graph = &compilation.chunk_graph;
     let module_graph = &compilation.module_graph;

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -14,7 +14,7 @@ impl Plugin for NamedModuleIdsPlugin {
     "NamedModuleIdsPlugin"
   }
 
-  fn module_ids(&mut self, compilation: &mut rspack_core::Compilation) -> Result<()> {
+  fn module_ids(&self, compilation: &mut rspack_core::Compilation) -> Result<()> {
     // Align with https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/ids/NamedModuleIdsPlugin.js
     let context: &str = compilation.options.context.as_ref();
     let (mut used_ids, modules) = get_used_module_ids_and_modules(compilation, None);

--- a/crates/rspack_ids/src/stable_named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/stable_named_chunk_ids_plugin.rs
@@ -22,7 +22,7 @@ impl StableNamedChunkIdsPlugin {
 }
 
 impl Plugin for StableNamedChunkIdsPlugin {
-  fn chunk_ids(&mut self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+  fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
     use rayon::prelude::*;
     // code_splitting_chunk means chunks generated in code splitting
     let code_splitting_chunk_to_root_module = compilation

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -414,10 +414,7 @@ impl Plugin for AssetPlugin {
     "asset"
   }
 
-  fn apply(
-    &mut self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     let data_url_condition = self
       .config
       .parse_options

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -24,10 +24,7 @@ impl Plugin for CssPlugin {
     "css"
   }
 
-  fn apply(
-    &mut self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     let config = self.config.clone();
     let builder = move || {
       Box::new(CssParserAndGenerator {

--- a/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
+++ b/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
@@ -32,7 +32,7 @@ impl Plugin for DevFriendlySplitChunksPlugin {
   }
 
   async fn optimize_chunks(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -74,7 +74,7 @@ impl Plugin for ExternalPlugin {
     "external"
   }
 
-  fn apply(&mut self, _ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
+  fn apply(&self, _ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -29,7 +29,7 @@ impl Plugin for JsPlugin {
   fn name(&self) -> &'static str {
     "javascript"
   }
-  fn apply(&mut self, ctx: PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
+  fn apply(&self, ctx: PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     let create_parser_and_generator =
       move || Box::new(JavaScriptParserAndGenerator::new()) as Box<dyn ParserAndGenerator>;
 

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -14,7 +14,7 @@ impl Plugin for InferAsyncModulesPlugin {
     "InferAsyncModulesPlugin"
   }
 
-  async fn finish_modules(&mut self, compilation: &mut Compilation) -> Result<()> {
+  async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
     // fix: mut for-in
     let mut queue = LinkedHashSet::new();
     let mut uniques = HashSet::new();

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -293,17 +293,14 @@ impl JsPlugin {
         .keys()
         .last()
         .expect("should have last entry module");
-      if let Some(source) =
-        compilation
-          .plugin_driver
-          .read()
-          .await
-          .render_startup(RenderStartupArgs {
-            compilation,
-            chunk: &chunk.ukey,
-            module: *last_entry_module,
-            source: startup,
-          })?
+      if let Some(source) = compilation
+        .plugin_driver
+        .render_startup(RenderStartupArgs {
+          compilation,
+          chunk: &chunk.ukey,
+          module: *last_entry_module,
+          source: startup,
+        })?
       {
         sources.add(source);
       }
@@ -317,7 +314,7 @@ impl JsPlugin {
       sources.boxed()
     };
     final_source = render_chunk_init_fragments(final_source, &mut chunk_init_fragments);
-    if let Some(source) = compilation.plugin_driver.read().await.render(RenderArgs {
+    if let Some(source) = compilation.plugin_driver.render(RenderArgs {
       compilation,
       chunk: &args.chunk_ukey,
       source: &final_source,
@@ -338,8 +335,6 @@ impl JsPlugin {
       .compilation
       .plugin_driver
       .clone()
-      .read()
-      .await
       .render_chunk(RenderChunkArgs {
         compilation: args.compilation,
         chunk_ukey: &args.chunk_ukey,
@@ -363,8 +358,6 @@ impl JsPlugin {
     compilation
       .plugin_driver
       .clone()
-      .read()
-      .await
       .js_chunk_hash(JsChunkHashArgs {
         compilation,
         chunk_ukey,

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -22,10 +22,7 @@ pub fn render_chunk_modules(
     .get(chunk_ukey)
     .expect("chunk not found");
 
-  let plugin_driver = tokio::task::block_in_place(move || {
-    tokio::runtime::Handle::current()
-      .block_on(async move { compilation.plugin_driver.read().await })
-  });
+  let plugin_driver = &compilation.plugin_driver;
 
   let include_module_ids = &compilation.include_module_ids;
 

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -140,10 +140,7 @@ impl Plugin for JsonPlugin {
     "json"
   }
 
-  fn apply(
-    &mut self,
-    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     ctx.context.register_parser_and_generator_builder(
       rspack_core::ModuleType::Json,
       Box::new(|| Box::new(JsonParserAndGenerator {})),

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -81,7 +81,7 @@ impl Plugin for ProgressPlugin {
     let modules_done = previous_modules_done + 1;
     let percent = (modules_done as f32)
       / (cmp::max(
-        self.last_modules_count.read().unwrap().unwrap_or(1),
+        self.last_modules_count.read().expect("TODO:").unwrap_or(1),
         self.modules_count.load(SeqCst),
       ) as f32);
     self
@@ -117,7 +117,7 @@ impl Plugin for ProgressPlugin {
   ) -> PluginBuildEndHookOutput {
     self.progress_bar.set_message("done");
     self.progress_bar.finish();
-    *self.last_modules_count.write().unwrap() = Some(self.modules_count.load(SeqCst));
+    *self.last_modules_count.write().expect("TODO:") = Some(self.modules_count.load(SeqCst));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -1,4 +1,5 @@
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::RwLock;
 use std::{cmp, sync::atomic::AtomicU32};
 
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
@@ -21,7 +22,7 @@ pub struct ProgressPlugin {
   pub progress_bar: ProgressBar,
   pub modules_count: AtomicU32,
   pub modules_done: AtomicU32,
-  pub last_modules_count: Option<u32>,
+  pub last_modules_count: RwLock<Option<u32>>,
 }
 
 impl ProgressPlugin {
@@ -36,7 +37,7 @@ impl ProgressPlugin {
       progress_bar,
       modules_count: AtomicU32::new(0),
       modules_done: AtomicU32::new(0),
-      last_modules_count: None,
+      last_modules_count: RwLock::new(None),
     }
   }
 }
@@ -80,7 +81,7 @@ impl Plugin for ProgressPlugin {
     let modules_done = previous_modules_done + 1;
     let percent = (modules_done as f32)
       / (cmp::max(
-        self.last_modules_count.unwrap_or(1),
+        self.last_modules_count.read().unwrap().unwrap_or(1),
         self.modules_count.load(SeqCst),
       ) as f32);
     self
@@ -90,7 +91,7 @@ impl Plugin for ProgressPlugin {
   }
 
   async fn optimize_chunks(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: OptimizeChunksArgs<'_>,
   ) -> PluginOptimizeChunksOutput {
@@ -110,13 +111,13 @@ impl Plugin for ProgressPlugin {
   }
 
   async fn done<'s, 'c>(
-    &mut self,
+    &self,
     _ctx: PluginContext,
     _args: DoneArgs<'s, 'c>,
   ) -> PluginBuildEndHookOutput {
     self.progress_bar.set_message("done");
     self.progress_bar.finish();
-    self.last_modules_count = Some(self.modules_count.load(SeqCst));
+    *self.last_modules_count.write().unwrap() = Some(self.modules_count.load(SeqCst));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
+++ b/crates/rspack_plugin_remove_empty_chunks/src/lib.rs
@@ -34,7 +34,7 @@ impl RemoveEmptyChunksPlugin {
 #[async_trait::async_trait]
 impl Plugin for RemoveEmptyChunksPlugin {
   async fn optimize_chunks(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -22,10 +22,7 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
     "ArrayPushCallbackChunkFormatPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 
@@ -151,18 +148,15 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
             .keys()
             .last()
             .expect("should have last entry module");
-          if let Some(s) =
-            args
-              .compilation
-              .plugin_driver
-              .read()
-              .await
-              .render_startup(RenderStartupArgs {
-                compilation: args.compilation,
-                chunk: &chunk.ukey,
-                module: *last_entry_module,
-                source: start_up_source,
-              })?
+          if let Some(s) = args
+            .compilation
+            .plugin_driver
+            .render_startup(RenderStartupArgs {
+              compilation: args.compilation,
+              chunk: &chunk.ukey,
+              module: *last_entry_module,
+              source: start_up_source,
+            })?
           {
             source.add(s);
           }

--- a/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
+++ b/crates/rspack_plugin_runtime/src/basic_runtime_requirements.rs
@@ -23,10 +23,7 @@ impl Plugin for BasicRuntimeRequirementPlugin {
     "BasicRuntimeRequirementPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -25,10 +25,7 @@ impl Plugin for CommonJsChunkFormatPlugin {
     "CommonJsChunkFormatPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 
@@ -140,18 +137,15 @@ impl Plugin for CommonJsChunkFormatPlugin {
         .keys()
         .last()
         .expect("should have last entry module");
-      if let Some(s) =
-        args
-          .compilation
-          .plugin_driver
-          .read()
-          .await
-          .render_startup(RenderStartupArgs {
-            compilation: args.compilation,
-            chunk: &chunk.ukey,
-            module: *last_entry_module,
-            source: start_up_source,
-          })?
+      if let Some(s) = args
+        .compilation
+        .plugin_driver
+        .render_startup(RenderStartupArgs {
+          compilation: args.compilation,
+          chunk: &chunk.ukey,
+          module: *last_entry_module,
+          source: start_up_source,
+        })?
       {
         sources.add(s);
       }

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_loading.rs
@@ -16,10 +16,7 @@ impl Plugin for CommonJsChunkLoadingPlugin {
     "CommonJsChunkLoadingPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/css_modules.rs
+++ b/crates/rspack_plugin_runtime/src/css_modules.rs
@@ -16,10 +16,7 @@ impl Plugin for CssModulesPlugin {
     "CssModulesPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/hot_module_replacement.rs
+++ b/crates/rspack_plugin_runtime/src/hot_module_replacement.rs
@@ -16,10 +16,7 @@ impl Plugin for HotModuleReplacementPlugin {
     "HotModuleReplacementPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/import_scripts_chunk_loading.rs
@@ -16,10 +16,7 @@ impl Plugin for ImportScriptsChunkLoadingPlugin {
     "ImportScriptsChunkLoadingPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/jsonp_chunk_loading.rs
@@ -16,10 +16,7 @@ impl Plugin for JsonpChunkLoadingPlugin {
     "JsonpChunkLoadingPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/lazy_compilation.rs
+++ b/crates/rspack_plugin_runtime/src/lazy_compilation.rs
@@ -91,7 +91,7 @@ impl Plugin for LazyCompilationPlugin {
     "LazyCompilationPlugin"
   }
 
-  fn apply(&mut self, _ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
+  fn apply(&self, _ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -49,10 +49,7 @@ impl Plugin for RuntimePlugin {
     "RuntimePlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -26,10 +26,7 @@ impl Plugin for ModuleChunkFormatPlugin {
     "ModuleChunkFormatPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 
@@ -196,8 +193,6 @@ impl Plugin for ModuleChunkFormatPlugin {
         .expect("should have last entry module");
       if let Some(s) = compilation
         .plugin_driver
-        .read()
-        .await
         .render_startup(RenderStartupArgs {
           compilation,
           chunk: &chunk.ukey,

--- a/crates/rspack_plugin_runtime/src/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_loading.rs
@@ -16,10 +16,7 @@ impl Plugin for ModuleChunkLoadingPlugin {
     "ModuleChunkLoadingPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_runtime/src/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/startup_chunk_dependencies.rs
@@ -28,10 +28,7 @@ impl Plugin for StartupChunkDependenciesPlugin {
     "StartupChunkDependenciesPlugin"
   }
 
-  fn apply(
-    &mut self,
-    _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
-  ) -> Result<()> {
+  fn apply(&self, _ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
+++ b/crates/rspack_plugin_split_chunks/src/split_chunks_plugin.rs
@@ -617,7 +617,7 @@ impl Plugin for SplitChunksPlugin {
   #[allow(clippy::collapsible_else_if)]
   #[allow(unused)]
   async fn optimize_chunks(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/mod.rs
@@ -143,7 +143,7 @@ impl Debug for SplitChunksPlugin {
 impl Plugin for SplitChunksPlugin {
   #[tracing::instrument(name = "SplitChunksPlugin::optimize_chunks", skip_all)]
   async fn optimize_chunks(
-    &mut self,
+    &self,
     _ctx: rspack_core::PluginContext,
     args: rspack_core::OptimizeChunksArgs<'_>,
   ) -> rspack_core::PluginOptimizeChunksOutput {

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -30,7 +30,7 @@ impl Plugin for AsyncWasmPlugin {
     "AsyncWebAssemblyModulesPlugin"
   }
 
-  fn apply(&mut self, ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
+  fn apply(&self, ctx: PluginContext<&mut ApplyContext>) -> Result<()> {
     let module_id_to_filename_without_ext = self.module_id_to_filename_without_ext.clone();
 
     let builder = move || {


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

closes #3461 
Discussed in https://github.com/web-infra-dev/rspack/discussions/3456

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 63f3736</samp>

This pull request refactors the plugin system of the `rspack_core` crate and its dependencies, by removing unnecessary mutability and locking from the `PluginDriver` struct and its methods, and using shared references instead. This improves the performance, concurrency, safety, and readability of the code. It also updates the existing plugins to use shared references in their methods, to be consistent with the new plugin API.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 63f3736</samp>

*  Remove `RwLock` from `PluginDriver` and change its methods to take shared references ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L69-R69),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L91-R91),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L112-R112),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L366-R366),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L386-R386),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L408-R408),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L424-R424),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L446-R446),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L468-R468),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L489-R489),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-de65e35cd9f7b92416361921863c2eeb8b86694203ddd217395f16ce4e8164a1L516-R516),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-8d48f40e42d64ce16c665a30278f5e9d4b9426eaa0790c7686c6a787c66d8825L235-R234),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L448-R454),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL141-R142),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL153-R151),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL171-R167),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL181-R175),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL192-R183),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL206-R196),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL472-R460),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL481-R469),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL491-R479),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL499-R487),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL509-R497),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL566-R554),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL574-R562),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL582-R570),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3b15a372a6196f40438132383341257e7e52046aab993f8be03b053dc88e4c7eL598-R586))
*  Change `Plugin` trait methods to take shared references ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L49-R58),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L69-R69),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L164-R164),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L305-R305),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L312-R332),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L365-R373),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L381-R381))
*  Remove `read` and `await` calls from `plugin_driver` access in various methods and functions ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L361-R361),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L933-L934),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L987-L988),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1004-R992),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1020-R1004),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1038-R1022),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1046-R1038),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1153-R1131),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1184-R1155),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1275-L1276),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1286-L1287),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L129-R129),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L189-L190),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L196-L197),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L391-L392),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L17),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L89-R88),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L109-R107),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L121-L122),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L153-L154),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L198-R190),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L249-R235),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L274-R255),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L324-L325),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L230-R230),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L247-R243),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5354812b8e30bff2ce2e8f7dfc292bdee3bad5022b1efc6fc1b85ab5a084eb14L258-R254),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-18c60b97bd3384589d0fba20abd98f1368309f53b65bcf6bcd24e2118dce265fL50-L51),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-18c60b97bd3384589d0fba20abd98f1368309f53b65bcf6bcd24e2118dce265fL117-R115),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-8390e2e37223b1f6ac009194ef6d1a9272f9f15e2430da928b938d7d19723822L23-R23),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-bb344009ce65860c820c92132f4f7d7653f6d19c7260699cd3d27b58818ddd90L356-R356),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL77-L78),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL110-L111),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL164-L165),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL175-R169),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL443-L444),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL472-L473),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL573-L574),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-e3cb84e19ccc823fb214fdbb9dcd1afe8de633c34762f11d11a2c22a1fff2238L17-R17))
*  Add `read` and `await` calls to `plugin_driver` access in `add_runtime_module` method of `Compilation` struct ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R1163-R1168))
*  Change `plugin_driver` variable to use a reference instead of a clone in `create_normal_module` method of `NormalModuleFactory` struct ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL175-R169))
*  Use `DashMap` instead of `HashMap` to store parser and generator builders in `ApplyContext` struct ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L3-R7),[link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L448-R454))
*  Change `register_parser_and_generator_builder` method of `ApplyContext` struct to take a shared reference ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-45ea00c1ab2a153d4a93ce2b5c307abd718b9613de4a66064e6379a82fdbf695L448-R454))
*  Change `ResolverFactory` struct to implement `Clone` and `Copy` ([link](https://github.com/web-infra-dev/rspack/pull/3464/files?diff=unified&w=0#diff-4e77827441656f6c0f2713ed92f4f4a58029006543ba5e686c842d1b28de6c0eL175-R169))

</details>
