### PR TITLE
fix: partially fix polyfill

### DIFF
--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
@@ -50,9 +50,8 @@ _export(exports, {
         return _class_call_check;
     }
 });
-var _instanceof = __webpack_require__("../../../../../node_modules/@swc/helpers/esm/_instanceof.js");
 function _class_call_check(instance, Constructor) {
-    if (!_instanceof._(instance, Constructor)) throw new TypeError("Cannot call a class as a function");
+    if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
 }
 },
 "../../../../../node_modules/@swc/helpers/esm/_create_class.js": function (module, exports, __webpack_require__) {
@@ -87,31 +86,6 @@ function _create_class(Constructor, protoProps, staticProps) {
     if (protoProps) _defineProperties(Constructor.prototype, protoProps);
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
-}
-},
-"../../../../../node_modules/@swc/helpers/esm/_instanceof.js": function (module, exports, __webpack_require__) {
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    _instanceof: function() {
-        return _instanceof1;
-    },
-    _: function() {
-        return _instanceof1;
-    }
-});
-var _instanceof = __webpack_require__("../../../../../node_modules/@swc/helpers/esm/_instanceof.js");
-function _instanceof1(left, right) {
-    if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) return !!right[Symbol.hasInstance](left);
-    else return _instanceof._(left, right);
 }
 },
 

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -69,17 +69,17 @@ Object.defineProperty(exports, "__generator", {
         return __generator;
     }
 });
-var extendStatics = function extendStatics1(d, b) {
-    extendStatics = Object.setPrototypeOf || _instanceof({
+var extendStatics = function(d, b) {
+    extendStatics = Object.setPrototypeOf || ({
         __proto__: []
-    }, Array) && function(d, b) {
+    }) instanceof Array && function(d, b) {
         d.__proto__ = b;
     } || function(d, b) {
         for(var p in b)if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
     };
     return extendStatics(d, b);
 };
-var __assign = function __assign1() {
+var __assign = function() {
     __assign = Object.assign || function __assign(t) {
         for(var s, i = 1, n = arguments.length; i < n; i++){
             s = arguments[i];
@@ -90,15 +90,31 @@ var __assign = function __assign1() {
     return __assign.apply(this, arguments);
 };
 function __generator(thisArg, body) {
-    var verb = function verb(n) {
+    var _ = {
+        label: 0,
+        sent: function() {
+            if (t[0] & 1) throw t[1];
+            return t[1];
+        },
+        trys: [],
+        ops: []
+    }, f, y, t, g;
+    return g = {
+        next: verb(0),
+        "throw": verb(1),
+        "return": verb(2)
+    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
+        return this;
+    }), g;
+    function verb(n) {
         return function(v) {
             return step([
                 n,
                 v
             ]);
         };
-    };
-    var step = function step(op) {
+    }
+    function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
         while(g && (g = 0, op[0] && (_ = 0)), _)try {
             if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
@@ -166,30 +182,14 @@ function __generator(thisArg, body) {
             value: op[0] ? op[1] : void 0,
             done: true
         };
-    };
-    var _ = {
-        label: 0,
-        sent: function sent() {
-            if (t[0] & 1) throw t[1];
-            return t[1];
-        },
-        trys: [],
-        ops: []
-    }, f, y, t, g;
-    return g = {
-        next: verb(0),
-        "throw": verb(1),
-        "return": verb(2)
-    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
-        return this;
-    }), g;
+    }
 }
-Object.create ? function __createBinding(o, m, k, k2) {
+Object.create ? function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
     if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) desc = {
         enumerable: true,
-        get: function get() {
+        get: function() {
             return m[k];
         }
     };
@@ -198,7 +198,7 @@ Object.create ? function __createBinding(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
 };
-Object.create ? function __setModuleDefault(o, v) {
+Object.create ? function(o, v) {
     Object.defineProperty(o, "default", {
         enumerable: true,
         value: v

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -10,7 +10,7 @@ const config = {
 			{
 				template: "./index.html"
 			}
-		],
+		]
 	}
 };
 module.exports = config;

--- a/packages/rspack/tests/configCases/target/web-es5-issue-2664/index.js
+++ b/packages/rspack/tests/configCases/target/web-es5-issue-2664/index.js
@@ -1,0 +1,5 @@
+it("should be called successfully", () => {
+	class A {}
+	const a = new A();
+	expect(a instanceof A).toBeTruthy();
+});

--- a/packages/rspack/tests/configCases/target/web-es5-issue-2664/webpack.config.js
+++ b/packages/rspack/tests/configCases/target/web-es5-issue-2664/webpack.config.js
@@ -1,0 +1,23 @@
+const { ConcatSource, RawSource } = require("webpack-sources");
+
+module.exports = {
+	target: ["web", "es5"],
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("MyPlugin", compilation => {
+					compilation.hooks.processAssets.tap("MyPlugin", assets => {
+						const main = assets["main.js"];
+						assets["main.js"] = new ConcatSource(
+							new RawSource(
+								";var __rspack_symbol__ = globalThis.Symbol; delete globalThis.Symbol;"
+							),
+							main,
+							new RawSource(";globalThis.Symbol = __rspack_symbol__;")
+						);
+					});
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

Partially workaround #2664 and in favor of swc-loader in the future

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3685f34</samp>

This pull request enhances the JavaScript plugin for `rspack` by skipping unnecessary compatibility checks and fixes a bug with the `instanceof` operator in the web es5 target. It also adds a test case and a minor formatting improvement.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3685f34</samp>

* Add a variable `resource_path` to store the resource data path and use it to conditionally apply the compatibility visitor ([link](https://github.com/web-infra-dev/rspack/pull/3469/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861R83-R84), [link](https://github.com/web-infra-dev/rspack/pull/3469/files?diff=unified&w=0#diff-1621f855a96215026c0f2e5347bf21bc07f0673324b11be7155b194141d8e861L157-R171)) in `visitors/mod.rs`
* Remove a trailing comma from the `plugins` array in `rspack.config.js` for consistency and syntax safety ([link](https://github.com/web-infra-dev/rspack/pull/3469/files?diff=unified&w=0#diff-daaa7eb6c8f8733a48f42bc92475fab6bc98ec02b25904537f52724fab7555f3L13-R13))

</details>
