### PR TITLE
feat: support for partially enabled incremental rebuilds

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -534,7 +534,7 @@ export interface RawEntryItem {
 
 export interface RawExperiments {
   lazyCompilation: boolean
-  incrementalRebuild: boolean
+  incrementalRebuild: RawIncrementalRebuild
   asyncWebAssembly: boolean
   newSplitChunks: boolean
   css: boolean
@@ -617,6 +617,11 @@ export interface RawHtmlPluginConfig {
   title?: string
   favicon?: string
   meta?: Record<string, Record<string, string>>
+}
+
+export interface RawIncrementalRebuild {
+  make: boolean
+  emitAsset: boolean
 }
 
 export interface RawLibraryAuxiliaryComment {

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -1,13 +1,21 @@
 use napi_derive::napi;
-use rspack_core::Experiments;
+use rspack_core::{Experiments, IncrementalRebuild};
 use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
+pub struct RawIncrementalRebuild {
+  pub make: bool,
+  pub emit_asset: bool,
+}
 
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct RawExperiments {
   pub lazy_compilation: bool,
-  pub incremental_rebuild: bool,
+  pub incremental_rebuild: RawIncrementalRebuild,
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
   pub css: bool,
@@ -17,7 +25,10 @@ impl From<RawExperiments> for Experiments {
   fn from(value: RawExperiments) -> Self {
     Self {
       lazy_compilation: value.lazy_compilation,
-      incremental_rebuild: value.incremental_rebuild,
+      incremental_rebuild: IncrementalRebuild {
+        make: value.incremental_rebuild.make,
+        emit_asset: value.incremental_rebuild.emit_asset,
+      },
       async_web_assembly: value.async_web_assembly,
       new_split_chunks: value.new_split_chunks,
       css: value.css,

--- a/crates/rspack_core/src/cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/cache/local/code_splitting_cache.rs
@@ -26,7 +26,7 @@ where
   T: Fn(&'a mut Compilation) -> F,
   F: Future<Output = Result<&'a mut Compilation>>,
 {
-  let is_incremental_rebuild = compilation.options.is_incremental_rebuild();
+  let is_incremental_rebuild = compilation.options.is_make_use_incremental_rebuild();
   if !is_incremental_rebuild {
     task(compilation).await?;
     return Ok(());

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -138,7 +138,7 @@ where
         self.cache.clone(),
       );
 
-      let is_incremental_rebuild = self.options.is_incremental_rebuild();
+      let is_incremental_rebuild = self.options.is_make_use_incremental_rebuild();
       if is_incremental_rebuild {
         // copy field from old compilation
         // make stage used

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -280,7 +280,7 @@ where
         .write(&file_path, source.buffer())
         .await?;
 
-      if !asset.info.version.is_empty() {
+      if !asset.info.version.is_empty() && self.options.experiments.incremental_rebuild.emit_asset {
         self
           .emitted_asset_versions
           .insert(filename.to_string(), asset.info.version.clone());

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -26,7 +26,7 @@ pub struct CompilerOptions {
 }
 
 impl CompilerOptions {
-  pub fn is_incremental_rebuild(&self) -> bool {
-    self.experiments.incremental_rebuild && !matches!(self.cache, CacheOptions::Disabled)
+  pub fn is_make_use_incremental_rebuild(&self) -> bool {
+    self.experiments.incremental_rebuild.make && !matches!(self.cache, CacheOptions::Disabled)
   }
 }

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -1,7 +1,13 @@
 #[derive(Debug, Default)]
+pub struct IncrementalRebuild {
+  pub make: bool,
+  pub emit_asset: bool,
+}
+
+#[derive(Debug, Default)]
 pub struct Experiments {
   pub lazy_compilation: bool,
-  pub incremental_rebuild: bool,
+  pub incremental_rebuild: IncrementalRebuild,
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
   pub css: bool,

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -59,7 +59,7 @@ impl<'a> CodeSizeOptimizer<'a> {
   }
 
   pub async fn run(&mut self) -> Result<TWithDiagnosticArray<OptimizeDependencyResult>> {
-    let is_incremental_rebuild = self.compilation.options.is_incremental_rebuild();
+    let is_incremental_rebuild = self.compilation.options.is_make_use_incremental_rebuild();
     let is_first_time_analyze = self.compilation.optimize_analyze_result_map.is_empty();
     let analyze_result_map = par_analyze_module(self.compilation).await;
     let mut finalized_result_map = if is_incremental_rebuild {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -713,9 +713,24 @@ function getRawExperiments(
 			!isNil(newSplitChunks) &&
 			!isNil(css)
 	);
+
+	const rawIncrementalRebuild =
+		typeof incrementalRebuild === "boolean"
+			? {
+					make: incrementalRebuild,
+					emitAsset: incrementalRebuild
+			  }
+			: Object.assign(
+					{
+						make: true,
+						emitAsset: true
+					},
+					incrementalRebuild
+			  );
+
 	return {
 		lazyCompilation,
-		incrementalRebuild,
+		incrementalRebuild: rawIncrementalRebuild,
 		asyncWebAssembly,
 		newSplitChunks,
 		css

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -23,6 +23,7 @@ import type {
 	AvailableTarget,
 	Context,
 	Experiments,
+	ExperimentsNormalized,
 	ExternalsPresets,
 	InfrastructureLogging,
 	Mode,
@@ -141,12 +142,17 @@ const applyInfrastructureLoggingDefaults = (
 	D(infrastructureLogging, "appendOnly", !tty);
 };
 
-const applyExperimentsDefaults = (experiments: Experiments) => {
-	D(experiments, "incrementalRebuild", true);
+const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
+	D(experiments, "incrementalRebuild", {});
 	D(experiments, "lazyCompilation", false);
 	D(experiments, "asyncWebAssembly", false);
 	D(experiments, "newSplitChunks", true);
 	D(experiments, "css", true); // we not align with webpack about the default value for better DX
+
+	if (typeof experiments.incrementalRebuild === "object") {
+		D(experiments.incrementalRebuild, "make", true);
+		D(experiments.incrementalRebuild, "emitAsset", true);
+	}
 };
 
 const applySnapshotDefaults = (

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -229,7 +229,11 @@ export const getNormalizedRspackOptions = (
 		}),
 		plugins: nestedArray(config.plugins, p => [...p]),
 		experiments: nestedConfig(config.experiments, experiments => ({
-			...experiments
+			...experiments,
+			incrementalRebuild: optionalNestedConfig(
+				experiments.incrementalRebuild,
+				options => (options === true ? {} : options)
+			)
 		})),
 		watch: config.watch,
 		watchOptions: cloneObject(config.watchOptions),

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -360,7 +360,24 @@ module.exports = {
 				},
 				incrementalRebuild: {
 					description: "Rebuild incrementally",
-					type: "boolean"
+					anyOf: [
+						{
+							type: "boolean"
+						},
+						{
+							type: "object",
+							properties: {
+								make: {
+									description: "Make stage enable incremental rebuild",
+									type: "boolean"
+								},
+								emitAsset: {
+									description: "Emit asset enable incremental rebuild",
+									type: "boolean"
+								}
+							}
+						}
+					]
 				},
 				lazyCompilation: {
 					description:

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -48,7 +48,7 @@ export interface RspackOptionsNormalized {
 	stats: StatsValue;
 	optimization: Optimization;
 	plugins: Plugins;
-	experiments: Experiments;
+	experiments: ExperimentsNormalized;
 	watch?: Watch;
 	watchOptions: WatchOptions;
 	devServer?: DevServer;
@@ -611,12 +611,19 @@ export type RspackPluginFunction = (this: Compiler, compiler: Compiler) => void;
 ///// Experiments /////
 export interface Experiments {
 	lazyCompilation?: boolean;
-	incrementalRebuild?:
-		| boolean
-		| {
-				make?: boolean;
-				emitAsset?: boolean;
-		  };
+	incrementalRebuild?: boolean | IncrementalRebuildOptions;
+	asyncWebAssembly?: boolean;
+	outputModule?: boolean;
+	newSplitChunks?: boolean;
+	css?: boolean;
+}
+export interface IncrementalRebuildOptions {
+	make?: boolean;
+	emitAsset?: boolean;
+}
+export interface ExperimentsNormalized {
+	lazyCompilation?: boolean;
+	incrementalRebuild?: false | IncrementalRebuildOptions;
 	asyncWebAssembly?: boolean;
 	outputModule?: boolean;
 	newSplitChunks?: boolean;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -611,7 +611,12 @@ export type RspackPluginFunction = (this: Compiler, compiler: Compiler) => void;
 ///// Experiments /////
 export interface Experiments {
 	lazyCompilation?: boolean;
-	incrementalRebuild?: boolean;
+	incrementalRebuild?:
+		| boolean
+		| {
+				make?: boolean;
+				emitAsset?: boolean;
+		  };
 	asyncWebAssembly?: boolean;
 	outputModule?: boolean;
 	newSplitChunks?: boolean;

--- a/packages/rspack/src/config/zod/experiments.ts
+++ b/packages/rspack/src/config/zod/experiments.ts
@@ -3,7 +3,15 @@ import { z } from "zod";
 export function experiments() {
 	return z.object({
 		asyncWebAssembly: z.boolean().optional(),
-		incrementalRebuild: z.boolean().optional(),
+		incrementalRebuild: z
+			.boolean()
+			.or(
+				z.strictObject({
+					make: z.boolean().optional(),
+					emitAsset: z.boolean().optional()
+				})
+			)
+			.optional(),
 		lazyCompilation: z.boolean().optional(),
 		outputModule: z.boolean().optional(),
 		newSplitChunks: z.boolean().optional(),

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -51,7 +51,10 @@ exports[`snapshots should have the correct base config 1`] = `
   "experiments": {
     "asyncWebAssembly": false,
     "css": true,
-    "incrementalRebuild": true,
+    "incrementalRebuild": {
+      "emitAsset": true,
+      "make": true,
+    },
     "lazyCompilation": false,
     "newSplitChunks": true,
   },


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c49a3fd</samp>

This pull request adds support for incremental rebuild experiments in the `rspack` project. It introduces a new `IncrementalRebuild` struct in Rust and a corresponding `rawIncrementalRebuild` object in TypeScript, with two options: `make` and `emit_asset`. It also updates the existing code in both languages to handle the new shape of the experiment and to check the options before performing certain actions.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c49a3fd</samp>

*  Introduce a new `IncrementalRebuild` struct to represent the options for incremental rebuild experiments ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-c88be6064f9723a97e920eb73113c11ea487b1be35aa57be4889f5caf4fd2a74L2-R10))
*  Replace the `incremental_rebuild` field of the `Experiments` and `RawExperiments` structs with an instance of `IncrementalRebuild` and `RawIncrementalRebuild` respectively ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-c88be6064f9723a97e920eb73113c11ea487b1be35aa57be4889f5caf4fd2a74L2-R10), [link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-ee356163b888e01f5855248826002b944820b3eac1c6cb3e5868d2a34c3fc11dL8-R18))
*  Convert a `RawIncrementalRebuild` into an `IncrementalRebuild` by mapping the `make` and `emit_asset` fields ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-ee356163b888e01f5855248826002b944820b3eac1c6cb3e5868d2a34c3fc11dL20-R31))
*  Rename the `is_incremental_rebuild` method of the `CompilerOptions` struct to `is_make_use_incremental_rebuild`, to reflect that it only checks the `make` option of the `incremental_rebuild` experiment ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-d9aed4cc1e003d1128224454ff63c335e0b0b13df67c908f322af4f39e9e76f7L29-R29), [link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-b6c971a9adb8c246d789a436e09e6bb0f0077c819d437857845e60263aedf103L29-R30))
*  Update the call sites of the renamed method in the `code_splitting_cache.rs`, `hmr.rs`, and `optimizer.rs` files ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-d9aed4cc1e003d1128224454ff63c335e0b0b13df67c908f322af4f39e9e76f7L29-R29), [link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L141-R141), [link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-9c68e9018eeda590fa3e631aa7744787eb38b07c08056d5216c57e32c4c9198eL62-R62))
*  Add a condition to check the `emit_asset` option of the `incremental_rebuild` experiment before updating the `emitted_asset_versions` field of the `Compilation` struct in the `compiler/mod.rs` file ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L283-R283))
*  Adapt the TypeScript code in the `adapter.ts` file to handle the new shape of the `incremental_rebuild` experiment, which can be either a boolean or an object with `make` and `emit_asset` fields ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-5f5bb1aeb2a977ff30c5ab822c79f09b76476c503462939c69beb9e4d7552123L593-R610))
*  Update the JSON schema, TypeScript interface, and Zod schema for the `incremental_rebuild` experiment in the `schema.js`, `types.ts`, and `experiments.ts` files respectively, to allow either a boolean or an object with `make` and `emit_asset` properties ([link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-d7e2c50a4845569f35f387513dc5a6e542e9d5dde107294fd55c5ff4e8a72c88L363-R380), [link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-790d97d1c7c2bfbbe7720a38355ec1e0d462206a5ddb9826c6aa8bff7090ce0fL591-R596), [link](https://github.com/web-infra-dev/rspack/pull/3472/files?diff=unified&w=0#diff-d0d329e7eba5c2bc8a9e487bf452b933834266020393c24d092acd67b8293ce9L6-R14))

</details>
