### PR TITLE
fix: dynamic import may generate invalid module ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,7 @@ dependencies = [
  "rspack_identifier",
  "rspack_plugin_javascript",
  "rustc-hash",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -7,7 +7,7 @@ __webpack_require__.el("./b.js").then(__webpack_require__.bind(__webpack_require
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/dynamic-import/expected/main.js
@@ -32,7 +32,7 @@ __webpack_require__("./child Lazy  recursive ^\\.\\/.*\\.js$")("./child/".concat
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/fixtures/simple-with-query/expected/main.js
+++ b/crates/rspack/tests/fixtures/simple-with-query/expected/main.js
@@ -39,7 +39,7 @@ const a = 3;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/fixtures/static-import/expected/main.js
+++ b/crates/rspack/tests/fixtures/static-import/expected/main.js
@@ -21,7 +21,7 @@ console.log('hello, world');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-dynamic-entry/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-dynamic-entry/expected/main.js
@@ -7,7 +7,7 @@ console.log('index');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index.js
@@ -14,7 +14,7 @@ console.log('shared');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index2.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/expected/index2.js
@@ -14,7 +14,7 @@ console.log('shared');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index2.js'));
+var __webpack_exports__ = (__webpack_exec__("./index2.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index.js
@@ -18,7 +18,7 @@ console.log('shared');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index2.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/intersection/expected/index2.js
@@ -18,7 +18,7 @@ console.log('shared');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index2.js'));
+var __webpack_exports__ = (__webpack_exec__("./index2.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/self-import/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/self-import/expected/main.js
@@ -6,7 +6,7 @@ console.log('index');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/samples/remove-parent-modules/simple/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/simple/expected/main.js
@@ -14,7 +14,7 @@ console.log('shared');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/array-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/array-side-effects/expected/main.js
@@ -45,7 +45,7 @@ _app.app;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/assign-with-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/assign-with-side-effects/expected/main.js
@@ -38,7 +38,7 @@ const result = 20000;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/basic/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/basic/expected/main.js
@@ -49,7 +49,7 @@ const myanswer = _answer.answer;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/bb/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/bb/expected/main.js
@@ -45,7 +45,7 @@ _a.ccc;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
@@ -56,7 +56,7 @@ var _default = _zh_locale.default;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.ts'));
+var __webpack_exports__ = (__webpack_exec__("./index.ts"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/expected/main.js
@@ -50,7 +50,7 @@ const myanswer = 'anyser';
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/expected/main.js
@@ -16,7 +16,7 @@ __webpack_require__.es(__webpack_require__("./bar.js"), exports);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/expected/main.js
@@ -9,7 +9,7 @@ function test() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/context-module/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/context-module/expected/main.js
@@ -58,7 +58,7 @@ __webpack_require__("./child Sync  recursive ^\\.\\/.*\\.js$")(`./child/${a}.js`
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/default_export/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/default_export/expected/main.js
@@ -69,7 +69,7 @@ const myanswer = _answer.answer;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/expected/main.js
@@ -27,7 +27,7 @@ console.log(_foo.a);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/expected/main.js
@@ -40,7 +40,7 @@ console.log(_foo.a);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/expected/main.js
@@ -13,7 +13,7 @@ exports['a'] = 100000;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export-star-chain/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export-star-chain/expected/main.js
@@ -108,7 +108,7 @@ __webpack_require__.es(__webpack_require__("./something/Something.js"), exports)
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export_star/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star/expected/main.js
@@ -64,7 +64,7 @@ const c = 103330;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export_star2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star2/expected/main.js
@@ -35,7 +35,7 @@ __webpack_require__.es(__webpack_require__("./bar.js"), exports);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/expected/main.js
@@ -41,7 +41,7 @@ __webpack_require__.es(__webpack_require__("./bar.js"), exports);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-imported-unused/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-imported-unused/expected/main.js
@@ -6,7 +6,7 @@ console.log('something');
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
@@ -50,9 +50,8 @@ _export(exports, {
         return _class_call_check;
     }
 });
-var _instanceof = __webpack_require__("../../../../../node_modules/@swc/helpers/esm/_instanceof.js");
 function _class_call_check(instance, Constructor) {
-    if (!_instanceof._(instance, Constructor)) throw new TypeError("Cannot call a class as a function");
+    if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
 }
 },
 "../../../../../node_modules/@swc/helpers/esm/_create_class.js": function (module, exports, __webpack_require__) {
@@ -87,31 +86,6 @@ function _create_class(Constructor, protoProps, staticProps) {
     if (protoProps) _defineProperties(Constructor.prototype, protoProps);
     if (staticProps) _defineProperties(Constructor, staticProps);
     return Constructor;
-}
-},
-"../../../../../node_modules/@swc/helpers/esm/_instanceof.js": function (module, exports, __webpack_require__) {
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    _instanceof: function() {
-        return _instanceof1;
-    },
-    _: function() {
-        return _instanceof1;
-    }
-});
-var _instanceof = __webpack_require__("../../../../../node_modules/@swc/helpers/esm/_instanceof.js");
-function _instanceof1(left, right) {
-    if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) return !!right[Symbol.hasInstance](left);
-    else return _instanceof._(left, right);
 }
 },
 

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
@@ -91,7 +91,7 @@ function _create_class(Constructor, protoProps, staticProps) {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/expected/main.js
@@ -37,7 +37,7 @@ var _export = __webpack_require__("./export.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/expected/main.js
@@ -57,7 +57,7 @@ _c.c;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/issues_3198/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/issues_3198/expected/main.js
@@ -23,7 +23,7 @@ const obj = {};
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable1/expected/main.js
@@ -43,7 +43,7 @@ var _export = __webpack_require__("./export.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable2/expected/main.js
@@ -43,7 +43,7 @@ var _export = __webpack_require__("./export.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects1/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects1/expected/main.js
@@ -27,7 +27,7 @@ _a.a;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects2/expected/main.js
@@ -27,7 +27,7 @@ _a.a;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/expected/main.js
@@ -66,7 +66,7 @@ var _export = __webpack_require__("./export.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/named_export_alias/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/named_export_alias/expected/main.js
@@ -39,7 +39,7 @@ _export.default;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/expected/main.js
@@ -93,7 +93,7 @@ Doc.fromJS = (data)=>new Doc(data);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/prune-bailout-module/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/prune-bailout-module/expected/main.js
@@ -36,7 +36,7 @@ var _a = __webpack_require__.ir(__webpack_require__("./a.js"));
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
@@ -69,7 +69,7 @@ function useSelector() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/reexport_default_as/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/reexport_default_as/expected/main.js
@@ -36,7 +36,7 @@ var _foo = __webpack_require__("./foo.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/reexport_entry_elimination/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/reexport_entry_elimination/expected/main.js
@@ -50,7 +50,7 @@ _a.b;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rename-export-from-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rename-export-from-import/expected/main.js
@@ -36,7 +36,7 @@ const question = "2";
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/expected/main.js
@@ -39,7 +39,7 @@ console.log(answer);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/expected/main.js
@@ -32,7 +32,7 @@ new _foo.default();
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-called-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-called-import/expected/main.js
@@ -29,7 +29,7 @@ assert.equal((0, _foo.default)(), "foo");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/expected/main.js
@@ -30,7 +30,7 @@ assert.equal(_foo.foo.value, 2);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/expected/main.js
@@ -50,7 +50,7 @@ function Baz() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-var/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-var/expected/main.js
@@ -23,7 +23,7 @@ console.log(_foo.foo);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-analyzed/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-analyzed/expected/main.js
@@ -36,7 +36,7 @@ function _default() {}
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-flagged-only/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-flagged-only/expected/main.js
@@ -40,7 +40,7 @@ function _default() {}
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
@@ -30,7 +30,7 @@ const something = function() {};
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
@@ -36,7 +36,7 @@ function _default() {}
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
@@ -57,7 +57,7 @@ function ccc() {}
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/static-class/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/static-class/expected/main.js
@@ -43,7 +43,7 @@ _a.a;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/expected/main.js
@@ -27,7 +27,7 @@ console.log("side effect");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/expected/main.js
@@ -38,7 +38,7 @@ _b.b;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
@@ -32,7 +32,7 @@ var _foo = __webpack_require__.ir(__webpack_require__("./foo.js"));
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/expected/main.js
@@ -25,7 +25,7 @@ a;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -237,7 +237,7 @@ function _test() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.ts'));
+var __webpack_exports__ = (__webpack_exec__("./index.ts"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -69,17 +69,17 @@ Object.defineProperty(exports, "__generator", {
         return __generator;
     }
 });
-var extendStatics = function extendStatics1(d, b) {
-    extendStatics = Object.setPrototypeOf || _instanceof({
+var extendStatics = function(d, b) {
+    extendStatics = Object.setPrototypeOf || ({
         __proto__: []
-    }, Array) && function(d, b) {
+    }) instanceof Array && function(d, b) {
         d.__proto__ = b;
     } || function(d, b) {
         for(var p in b)if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p];
     };
     return extendStatics(d, b);
 };
-var __assign = function __assign1() {
+var __assign = function() {
     __assign = Object.assign || function __assign(t) {
         for(var s, i = 1, n = arguments.length; i < n; i++){
             s = arguments[i];
@@ -90,15 +90,31 @@ var __assign = function __assign1() {
     return __assign.apply(this, arguments);
 };
 function __generator(thisArg, body) {
-    var verb = function verb(n) {
+    var _ = {
+        label: 0,
+        sent: function() {
+            if (t[0] & 1) throw t[1];
+            return t[1];
+        },
+        trys: [],
+        ops: []
+    }, f, y, t, g;
+    return g = {
+        next: verb(0),
+        "throw": verb(1),
+        "return": verb(2)
+    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
+        return this;
+    }), g;
+    function verb(n) {
         return function(v) {
             return step([
                 n,
                 v
             ]);
         };
-    };
-    var step = function step(op) {
+    }
+    function step(op) {
         if (f) throw new TypeError("Generator is already executing.");
         while(g && (g = 0, op[0] && (_ = 0)), _)try {
             if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
@@ -166,30 +182,14 @@ function __generator(thisArg, body) {
             value: op[0] ? op[1] : void 0,
             done: true
         };
-    };
-    var _ = {
-        label: 0,
-        sent: function sent() {
-            if (t[0] & 1) throw t[1];
-            return t[1];
-        },
-        trys: [],
-        ops: []
-    }, f, y, t, g;
-    return g = {
-        next: verb(0),
-        "throw": verb(1),
-        "return": verb(2)
-    }, typeof Symbol === "function" && (g[Symbol.iterator] = function() {
-        return this;
-    }), g;
+    }
 }
-Object.create ? function __createBinding(o, m, k, k2) {
+Object.create ? function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
     if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) desc = {
         enumerable: true,
-        get: function get() {
+        get: function() {
             return m[k];
         }
     };
@@ -198,7 +198,7 @@ Object.create ? function __createBinding(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
 };
-Object.create ? function __setModuleDefault(o, v) {
+Object.create ? function(o, v) {
     Object.defineProperty(o, "default", {
         enumerable: true,
         value: v

--- a/crates/rspack/tests/tree-shaking/var-function-expr/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/var-function-expr/expected/main.js
@@ -50,7 +50,7 @@ const something = function() {};
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/expected/main.js
@@ -228,7 +228,7 @@ it("f should be used", ()=>{
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/expected/main.js
@@ -100,7 +100,7 @@ class Document {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
@@ -97,7 +97,7 @@ function withB(v) {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/expected/main.js
@@ -142,7 +142,7 @@ function f4() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/expected/main.js
@@ -45,7 +45,7 @@ function a() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
@@ -49,7 +49,7 @@ try {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/expected/main.js
@@ -106,7 +106,7 @@ var _default = 1;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
@@ -127,7 +127,7 @@ _tracker.log.should.be.eql([
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
@@ -109,7 +109,7 @@ _tracker.log.should.be.eql([
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack/tests/tree-shaking/with-assets/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/with-assets/expected/main.js
@@ -27,7 +27,7 @@ module.exports = "data:image/svg+xml;base64,";},
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_asset/tests/fixtures/rspack/asset-source/expected/main.js
+++ b/crates/rspack_plugin_asset/tests/fixtures/rspack/asset-source/expected/main.js
@@ -12,7 +12,7 @@ module.exports = "- Isn't Rspack a gamechanging bundler?\n  - Hella yeah!";},
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-advanced/expected/main.js
+++ b/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-advanced/expected/main.js
@@ -34,7 +34,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5v
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-simple/expected/main.js
+++ b/crates/rspack_plugin_asset/tests/fixtures/webpack/asset-simple/expected/main.js
@@ -42,7 +42,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5v
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_html/tests/fixtures/variant/expected/output.html
+++ b/crates/rspack_plugin_html/tests/fixtures/variant/expected/output.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <title>Rspack App</title>
-<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-6sM1HBynotlAUb+REityTS4Gz51q5xlipnmQJXAD7gKzrjRnccLnZhQRxJOsCpiqgjh0V1TJROu7J+56I3zjeA=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-EhlBY1oPqc7qxML0eaO4NDX5dvrtK8OiR6NKGfJsSHm6ThPAmD9eOpT044icXDES1RbnYtFqG/C1aLx9yJNE/Q=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-Z8PU3Ii4d2SPUxyN8IIBT+qeVhwEyS0gDBnVwfr1XrN7r20CMILhZ1GhnoENqrJIUHI9/6UVEdorpIqMuDavdQ==" /></head>
+<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-6sM1HBynotlAUb+REityTS4Gz51q5xlipnmQJXAD7gKzrjRnccLnZhQRxJOsCpiqgjh0V1TJROu7J+56I3zjeA=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-ZFH8/S9iFyoZSykwg1TRpARz/zDRiWqd5PwOAbrxjc9FSkxzxEGeVpFI/liA6zFmcwSRTAPvvGGfbb4hCWxPlg=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-Z8PU3Ii4d2SPUxyN8IIBT+qeVhwEyS0gDBnVwfr1XrN7r20CMILhZ1GhnoENqrJIUHI9/6UVEdorpIqMuDavdQ==" /></head>
 
 <body>
 

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/constant_folding/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/constant_folding/expected/main.js
@@ -7,7 +7,7 @@ __webpack_require__("./development.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/expected/main.js
@@ -258,7 +258,7 @@ var _default = 401;
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/issuse_2960/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/issuse_2960/expected/main.js
@@ -40,7 +40,7 @@ webpackContext.id = '"./resources Sync  recursive ^\\.\\/pre_.*\\.js$"';
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
@@ -12,7 +12,7 @@ __webpack_require__.el("./bug_only_single_quote.js").then(__webpack_require__.bi
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/inline/expected/main.js
@@ -13,7 +13,7 @@ module.exports = "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5v
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/new_url/resource/expected/main.js
@@ -13,7 +13,7 @@ module.exports = __webpack_require__.p + "8c7236080ec784a5.svg";},
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
@@ -137,7 +137,7 @@ process.umask = function() {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_javascript/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/simple/expected/main.js
@@ -6,7 +6,7 @@ console.log(__webpack_require__.c);
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_json/tests/fixtures/simple/expected/main.js
+++ b/crates/rspack_plugin_json/tests/fixtures/simple/expected/main.js
@@ -15,7 +15,7 @@ module.exports = {
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -18,3 +18,4 @@ rspack_hash              = { path = "../rspack_hash" }
 rspack_identifier        = { path = "../rspack_identifier" }
 rspack_plugin_javascript = { path = "../rspack_plugin_javascript" }
 rustc-hash               = { workspace = true }
+serde_json               = { workspace = true }

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -143,7 +143,7 @@ pub fn generate_entry_startup(
   entries: &IdentifierLinkedMap<ChunkGroupUkey>,
   passive: bool,
 ) -> BoxSource {
-  let mut module_ids = vec![];
+  let mut module_id_exprs = vec![];
   let mut chunks_ids = HashSet::default();
 
   for (module, entry) in entries {
@@ -153,7 +153,7 @@ pub fn generate_entry_startup(
       .map(|module| module.id(&compilation.chunk_graph))
     {
       let module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");
-      module_ids.push(module_id_expr);
+      module_id_exprs.push(module_id_expr);
     }
 
     if let Some(runtime_chunk) = compilation
@@ -188,9 +188,9 @@ pub fn generate_entry_startup(
     RuntimeGlobals::ENTRY_MODULE_ID
   ));
 
-  let module_ids_code = &module_ids
+  let module_ids_code = &module_id_exprs
     .iter()
-    .map(|id| format!("__webpack_exec__(\"{id}\")"))
+    .map(|module_id_expr| format!("__webpack_exec__({module_id_expr})"))
     .collect::<Vec<_>>()
     .join(", ");
   if chunks_ids.is_empty() {

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -189,7 +189,7 @@ pub fn generate_entry_startup(
 
   let module_ids_code = &module_ids
     .iter()
-    .map(|id: &&str| format!("__webpack_exec__(\"{id}\")"))
+    .map(|id| format!("__webpack_exec__(\"{id}\")"))
     .collect::<Vec<_>>()
     .join(", ");
   if chunks_ids.is_empty() {

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -189,7 +189,7 @@ pub fn generate_entry_startup(
 
   let module_ids_code = &module_ids
     .iter()
-    .map(|id| format!("__webpack_exec__('{id}')"))
+    .map(|id: &&str| format!("__webpack_exec__(\"{id}\")"))
     .collect::<Vec<_>>()
     .join(", ");
   if chunks_ids.is_empty() {

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -152,7 +152,8 @@ pub fn generate_entry_startup(
       .module_graph_module_by_identifier(module)
       .map(|module| module.id(&compilation.chunk_graph))
     {
-      module_ids.push(module_id);
+      let module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");
+      module_ids.push(module_id_expr);
     }
 
     if let Some(runtime_chunk) = compilation

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -181,7 +181,7 @@ impl Plugin for ModuleChunkFormatPlugin {
         let module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");
 
         startup_source.push(format!(
-          "{}__webpack_exec__(\"{module_id_expr}\");",
+          "{}__webpack_exec__({module_id_expr});",
           if i + 1 == entries.len() {
             "var __webpack_exports__ = "
           } else {

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -178,7 +178,7 @@ impl Plugin for ModuleChunkFormatPlugin {
           ));
         }
         startup_source.push(format!(
-          "{}__webpack_exec__('{module_id}');",
+          "{}__webpack_exec__(\"{module_id}\");",
           if i + 1 == entries.len() {
             "var __webpack_exports__ = "
           } else {

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -177,8 +177,11 @@ impl Plugin for ModuleChunkFormatPlugin {
             RuntimeGlobals::EXTERNAL_INSTALL_CHUNK
           ));
         }
+
+        let module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");
+
         startup_source.push(format!(
-          "{}__webpack_exec__(\"{module_id}\");",
+          "{}__webpack_exec__(\"{module_id_expr}\");",
           if i + 1 == entries.len() {
             "var __webpack_exports__ = "
           } else {

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_chunk_with_module.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_chunk_with_module.rs
@@ -62,7 +62,11 @@ impl RuntimeModule for LoadChunkWithModuleRuntimeModule {
           .module_graph
           .module_graph_module_by_identifier(identifier)
           .expect("no module found");
-        (module.id(&compilation.chunk_graph).to_string(), chunk_ids)
+
+        let module_id = module.id(&compilation.chunk_graph);
+        let module_id_expr = serde_json::to_string(module_id).expect("invalid module_id");
+
+        (module_id_expr, chunk_ids)
       })
       .collect::<HashMap<String, Vec<String>>>();
 
@@ -99,7 +103,7 @@ fn stringify_map(map: &HashMap<String, Vec<String>>) -> String {
     map.keys().sorted().fold(String::new(), |prev, cur| {
       prev
         + format!(
-          r#""{}": {},"#,
+          r#"{}: {},"#,
           cur,
           stringify_array(map.get(cur).expect("get key from map"))
         )

--- a/crates/rspack_plugin_wasm/tests/fixtures/imports-multiple/expected/main.js
+++ b/crates/rspack_plugin_wasm/tests/fixtures/imports-multiple/expected/main.js
@@ -9,7 +9,7 @@
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_plugin_wasm/tests/fixtures/v128/expected/main.js
+++ b/crates/rspack_plugin_wasm/tests/fixtures/v128/expected/main.js
@@ -23,7 +23,7 @@ __webpack_require__.a(module, async function(__webpack_handle_async_dependencies
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/crates/rspack_testing/examples/simple/expected/main.js
+++ b/crates/rspack_testing/examples/simple/expected/main.js
@@ -12,7 +12,7 @@ __webpack_require__("./d.js");
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
-var __webpack_exports__ = (__webpack_exec__('./index.js'));
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 }
 ]);

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -10,7 +10,7 @@ const config = {
 			{
 				template: "./index.html"
 			}
-		],
+		]
 	}
 };
 module.exports = config;

--- a/packages/rspack/tests/cases/schemes/data-imports/index.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.js
@@ -7,10 +7,15 @@ import inlineSvg from 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg
 import fs from "node:fs";
 import path from "node:path";
 
+import('data:text/javascript,global.d = "d";');
+import("data:text/javascript,global.e = 'e';");
+import("data:text/javascript,global.f = `f`;");
+
 it("data imports", () => {
 	expect(a).toBe("a");
 	expect(b).toBe("b");
 	expect(c).toBe("c");
+
 	expect(fs.readFileSync(path.resolve(__dirname, "main.css"), "utf-8"))
 		.toBe(`.red {
   color: red;

--- a/packages/rspack/tests/cases/schemes/data-imports/index.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.js
@@ -1,4 +1,6 @@
 import a from 'data:text/javascript,export default "a";';
+import b from "data:text/javascript,export default 'b';";
+import c from "data:text/javascript,export default `c`;";
 import "data:text/css,.red{color: red;}";
 import "./index.css";
 import inlineSvg from 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"></svg>';
@@ -7,6 +9,8 @@ import path from "node:path";
 
 it("data imports", () => {
 	expect(a).toBe("a");
+	expect(b).toBe("b");
+	expect(c).toBe("c");
 	expect(fs.readFileSync(path.resolve(__dirname, "main.css"), "utf-8"))
 		.toBe(`.red {
   color: red;

--- a/packages/rspack/tests/configCases/target/web-es5-issue-2664/index.js
+++ b/packages/rspack/tests/configCases/target/web-es5-issue-2664/index.js
@@ -1,0 +1,5 @@
+it("should be called successfully", () => {
+	class A {}
+	const a = new A();
+	expect(a instanceof A).toBeTruthy();
+});

--- a/packages/rspack/tests/configCases/target/web-es5-issue-2664/webpack.config.js
+++ b/packages/rspack/tests/configCases/target/web-es5-issue-2664/webpack.config.js
@@ -1,0 +1,23 @@
+const { ConcatSource, RawSource } = require("webpack-sources");
+
+module.exports = {
+	target: ["web", "es5"],
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.compilation.tap("MyPlugin", compilation => {
+					compilation.hooks.processAssets.tap("MyPlugin", assets => {
+						const main = assets["main.js"];
+						assets["main.js"] = new ConcatSource(
+							new RawSource(
+								";var __rspack_symbol__ = globalThis.Symbol; delete globalThis.Symbol;"
+							),
+							main,
+							new RawSource(";globalThis.Symbol = __rspack_symbol__;")
+						);
+					});
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
## Related issue (if exists)

If we use single quote in dynamic import paths, such as:

```ts
import('data:text/javascript,window.foo = 'bar';');
```

The generated code will be invaliad:

<img width="472" alt="Screen Shot 2023-06-08 at 13 49 55" src="https://github.com/web-infra-dev/rspack/assets/7237365/3d05bbe9-9eee-4d7b-ba93-47493a8369c0">

And there will be a runtime error:

<img width="604" alt="Screen Shot 2023-06-08 at 13 49 25" src="https://github.com/web-infra-dev/rspack/assets/7237365/12392c49-6b19-4b19-afae-bb262fb77ff0">


## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 058b58b</samp>

This pull request applies a code style consistency change to several test fixture and sample files in the `crates/rspack` directory. It replaces single quotes with double quotes in the module path argument of the `__webpack_exec__` function call, following the eslint rules of the project.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 058b58b</samp>

*  Replace single quotes with double quotes in module path arguments of `__webpack_exec__` function calls for code style consistency ([link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-3cb11e589f6da97e3a9e8480b660073bdf9fed62403fd6b18b842befc1f678aaL10-R10), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-3a6288d6314d317a4d96cddcf94d3fc655ce4bbade63cc83e05d5e4249025226L35-R35), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-39038f41c332d98302a67e70dae875ecf9ee2f2ea9d74c636959f0bdae795f39L42-R42), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-acaf1ebd737e4458679823f0ccef28453514a54411a47b2f622ec777ba37b5d5L24-R24), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-96f1ec9d6eb9aa4edbaa28ef9888eb6f190f2a2520e3b639066fb19160aa0351L10-R10), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-bf192ef56e0fb103a58475f2f5013d3e3668c153534310c98a7ff882c88591f8L17-R17), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-6102abbf2a2b3119b6ed52a12162204c19492ead98c0a97f881d6bb8f34385c9L17-R17), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-274b76be3daf2733e2196967d40268bed8ad7f0c93b4726d8c871bf6d894b538L21-R21), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-c073cc0019a035a965fdee8b3a2c057dff1015abac8da15a038c456e449bd89bL21-R21), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-178de7892b8b4a0714876d606adce8ca950877316f382962fb26591744bcda97L9-R9), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-593b2419bf78b5841bb3d7058305d768846bd0eba0e11ce3547b7117e8b5ca3aL17-R17), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-146db4c69e42cfd18290f6ec0820ab9e6e2ec18be5c86075aa51d0cc4aa74c3cL48-R48), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-e650ddcfd80ad303f1564e7a21389bddcbcc9dfe45456245e8d2c426934b0348L41-R41), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-652cce3cd819c6c1b0c73fd236bfe45ed3a7e14ca30963e82d0ec199f6fff496L52-R52), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-71859ba7c3dd4d282822a46de237eabc7b5b3daf819ba272c8db9f6dd1f5c837L48-R48), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-d8a7e06a11ba450e702f9617ae24a6b4d26b937c6cf954b32124e03c346fd862L59-R59), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-cb2bd133c926ed13eb84dbce831f9590b6748b78587de0d02e23f008b3305387L53-R53), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-f7aa1dc702abb1fb691010ad83efa9da8f6b5fee604a064dbe481867c77ca682L19-R19), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-a6df6c6d891b10583025a558b1cbe0fe6d1fef91eb9e5d0f61316581af71f8abL12-R12), [link](https://github.com/web-infra-dev/rspack/pull/3475/files?diff=unified&w=0#diff-88bc4b14b6b6c233cac5c549a7e1ef0563348f2ee0df7dde4f68f2e74682715aL61-R61))

</details>
