### PR TITLE
chore(devServer): use webpack-dev-middleware instead of @rspack/dev-middleware

### DIFF
--- a/packages/rspack-cli/tsconfig.json
+++ b/packages/rspack-cli/tsconfig.json
@@ -14,9 +14,6 @@
       "path": "../rspack"
     },
     {
-      "path": "../rspack-dev-middleware"
-    },
-    {
       "path": "../rspack-dev-server"
     }
   ]

--- a/packages/rspack-dev-middleware/src/index.ts
+++ b/packages/rspack-dev-middleware/src/index.ts
@@ -7,6 +7,6 @@ import util from "util";
  */
 const rdm: typeof wdm = util.deprecate((compiler, options) => {
 	return wdm(compiler, options);
-}, "@rspack/dev-middleware has the same functionality as webpack-dev-middleware, please use webpack-dev-middleware instead.");
+}, "@rspack/dev-middleware has the same functionality as webpack-dev-middleware, please use webpack-dev-middleware instead. This package will be removed in the next 'minor' release.");
 
 export default rdm;

--- a/packages/rspack-dev-middleware/src/index.ts
+++ b/packages/rspack-dev-middleware/src/index.ts
@@ -1,7 +1,12 @@
 import wdm from "webpack-dev-middleware";
+import util from "util";
 
-const rdm: typeof wdm = (compiler, options) => {
+/** @deprecated
+ *
+ * This package has the same functionality as webpack-dev-middleware, please use webpack-dev-middleware instead.
+ */
+const rdm: typeof wdm = util.deprecate((compiler, options) => {
 	return wdm(compiler, options);
-};
+}, "@rspack/dev-middleware has the same functionality as webpack-dev-middleware, please use webpack-dev-middleware instead.");
 
 export default rdm;

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@rspack/dev-client": "workspace:*",
-    "@rspack/dev-middleware": "workspace:*",
+    "webpack-dev-middleware": "6.0.2",
     "@rspack/dev-server": "workspace:*",
     "chokidar": "3.5.3",
     "connect-history-api-fallback": "2.0.0",

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -10,7 +10,7 @@
 import { Compiler, MultiCompiler } from "@rspack/core";
 import type { Socket } from "net";
 import type { FSWatcher } from "chokidar";
-import rdm from "@rspack/dev-middleware";
+import rdm from "webpack-dev-middleware";
 import type { Server } from "http";
 import fs from "fs";
 import WebpackDevServer from "webpack-dev-server";

--- a/packages/rspack-dev-server/tsconfig.json
+++ b/packages/rspack-dev-server/tsconfig.json
@@ -6,10 +6,5 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src"
-  },
-  "references": [
-    {
-      "path": "../rspack-dev-middleware"
-    }
-  ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -757,6 +757,9 @@ importers:
   npm/linux-x64-gnu:
     specifiers: {}
 
+  npm/win32-x64-msvc:
+    specifiers: {}
+
   packages/create-rspack:
     specifiers:
       prompts: 2.4.2
@@ -956,7 +959,6 @@ importers:
     specifiers:
       '@rspack/core': workspace:*
       '@rspack/dev-client': workspace:*
-      '@rspack/dev-middleware': workspace:*
       '@rspack/dev-server': workspace:*
       '@types/connect-history-api-fallback': 1.3.5
       '@types/express': 4.17.14
@@ -970,11 +972,11 @@ importers:
       mime-types: 2.1.35
       puppeteer: 19.4.0
       webpack: 5.76.0
+      webpack-dev-middleware: 6.0.2
       webpack-dev-server: 4.13.1
       ws: 8.8.1
     dependencies:
       '@rspack/dev-client': link:../rspack-dev-client
-      '@rspack/dev-middleware': link:../rspack-dev-middleware
       '@rspack/dev-server': 'link:'
       chokidar: 3.5.3
       connect-history-api-fallback: 2.0.0
@@ -982,6 +984,7 @@ importers:
       http-proxy-middleware: 2.0.6_@types+express@4.17.14
       mime-types: 2.1.35
       webpack: 5.76.0
+      webpack-dev-middleware: 6.0.2_webpack@5.76.0
       webpack-dev-server: 4.13.1_webpack@5.76.0
       ws: 8.8.1
     devDependencies:
@@ -11658,6 +11661,7 @@ packages:
     dependencies:
       webpack: 5.76.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.76.0
+    dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -11666,6 +11670,7 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0_webpack@5.76.0
+    dev: true
 
   /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -11677,6 +11682,7 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.10.0_webpack@5.76.0
+    dev: true
 
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -13558,6 +13564,7 @@ packages:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+    dev: true
 
   /clone-response/1.0.2:
     resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
@@ -15322,6 +15329,7 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /err-code/2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -16021,6 +16029,7 @@ packages:
   /fastest-levenshtein/1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
+    dev: true
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -17656,6 +17665,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -17793,6 +17803,7 @@ packages:
   /interpret/2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
+    dev: true
 
   /into-stream/3.1.0:
     resolution: {integrity: sha512-TcdjPibTksa1NQximqep2r17ISRiNE9fwlfbg3F8ANdvP5/yrFTew86VcO//jk4QTaMlbjypPBq76HN2zaKfZQ==}
@@ -18148,6 +18159,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
+    dev: true
 
   /is-plain-object/5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -18338,6 +18350,7 @@ packages:
   /isobject/3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /isomorphic-fetch/2.2.1:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
@@ -19244,6 +19257,7 @@ packages:
   /kind-of/6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -23290,6 +23304,7 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.1
+    dev: true
 
   /redux/4.2.0:
     resolution: {integrity: sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==}
@@ -23569,6 +23584,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -23577,6 +23593,7 @@ packages:
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-pathname/3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -24271,6 +24288,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
+    dev: true
 
   /shallowequal/1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -25781,7 +25799,7 @@ packages:
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.76.0_webpack-cli@4.10.0
+      webpack: 5.76.0
 
   /terser/5.16.1:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
@@ -27192,6 +27210,7 @@ packages:
       rechoir: 0.7.1
       webpack: 5.76.0_webpack-cli@4.10.0
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-dev-middleware/5.3.3:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -27247,7 +27266,24 @@ packages:
       memfs: 3.4.12
       mime-types: 2.1.35
       range-parser: 1.2.1
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
+
+  /webpack-dev-middleware/6.0.2_webpack@5.76.0:
+    resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
+    engines: {node: '>= 14.15.0'}
+    peerDependencies:
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+    dependencies:
+      colorette: 2.0.19
+      memfs: 3.4.12
+      mime-types: 2.1.35
+      range-parser: 1.2.1
+      schema-utils: 4.0.1
+      webpack: 5.76.0
+    dev: false
 
   /webpack-dev-middleware/6.0.2_webpack@5.80.0:
     resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
@@ -27262,7 +27298,7 @@ packages:
       memfs: 3.4.12
       mime-types: 2.1.35
       range-parser: 1.2.1
-      schema-utils: 4.0.0
+      schema-utils: 4.0.1
       webpack: 5.80.0_esbuild@0.17.18
     dev: true
 
@@ -27440,6 +27476,7 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
+    dev: true
 
   /webpack-sources/2.3.1:
     resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
@@ -27593,6 +27630,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.80.0_esbuild@0.17.18:
     resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
@@ -27760,6 +27798,7 @@ packages:
 
   /wildcard/2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+    dev: true
 
   /window-size/0.1.0:
     resolution: {integrity: sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==}


### PR DESCRIPTION
## Related issue (if exists)

related PR: https://github.com/web-infra-dev/rspack/pull/3476

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06bae2f</samp>

This pull request updates the `@rspack/dev-server` package to use the `webpack-dev-middleware` package instead of the deprecated `@rspack/dev-middleware` package, and fixes some minor issues in the `package.json` and `tsconfig.json` files of the affected packages.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 06bae2f</samp>

*  Deprecate `@rspack/dev-middleware` package and replace it with `webpack-dev-middleware` package in `@rspack/dev-server` package ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-7b286545f33392d57e2d0f6bf46b7ae379a0fcb938c1b4dde14c8c6119ba5da9L2-R10), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-fa2af2cbbd416f67bb21aaa181218db15fb78d0b36da8b031ff14bf18d0770dcL34-R34), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-fa2af2cbbd416f67bb21aaa181218db15fb78d0b36da8b031ff14bf18d0770dcL48-L47), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-6195dbe0219b3b7ba39567cf6de6d629fb3a7b78c582c6b0b2957d1425105922L13-R13), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-0686c3baa4dd9819409dfbe5baa38baff613feee339353a79f24f59f1a269e3fL9-L13), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL959), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL973-R979), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR987))
* Remove reference to `@rspack/dev-middleware` package from `@rspack/cli` package ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-f9045684342a31be1de450b74c75ca28ed92e7f494eb757b1bae24a4ddf4d34eL17-L19))
* Add `npm/win32-x64-msvc` package to `pnpm-lock.yaml` file for Windows compatibility ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR760-R762))
* Add `dev: true` flag to several development-only packages in `pnpm-lock.yaml` file ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11664), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11673), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11685), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR13567), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15332), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR16032), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17668), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17806), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR18162), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR18353), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR19260), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23307), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23587), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR23596), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR24291), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR27213), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR27479), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR27633), [link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR27801))
* Update `schema-utils` package from version `4.0.0` to `4.0.1` in `webpack-dev-middleware` package in `pnpm-lock.yaml` file ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27250-R27287))
* Remove `_webpack-cli@4.10.0` suffix from `webpack` package in `pnpm-lock.yaml` file ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL25784-R25802))
* Add metadata and dependencies for `webpack-dev-middleware` package with `webpack@5.76.0` peer dependency to `pnpm-lock.yaml` file ([link](https://github.com/web-infra-dev/rspack/pull/3478/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL27265-R27301))

</details>
