### PR TITLE
chore: trigger nightly ecosystem-ci after nightly release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Resolve dependencies for bindings
         run: pnpm install --no-frozen-lockfile
 
-      - name: Release
-        id: release
+      - name: Publish
+        id: publish
         run: |
           ./x version snapshot
           ./x publish snapshot --tag nightly
@@ -65,6 +65,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+    outputs:
+      version: ${{ steps.publish.outputs.version }}
 
   trigger-ecosystem-ci:
     name: Trigger Ecosystem CI if successed

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -66,7 +66,29 @@ jobs:
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
 
-  
+  trigger-ecosystem-ci:
+    name: Trigger Ecosystem CI if successed
+    needs: [release]
+    runs-on: ubuntu-latest
+    if: ${{ always() && !contains(needs.*.result, 'failure') }}
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.ECOSYSTEM_CI_ACCESS_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: 'rspack-ecosystem-ci',
+              workflow_id: 'ecosystem-ci-selected.yml',
+              ref: 'main',
+              inputs: {
+                refType: 'release',
+                ref: '${{ needs.release.outputs.version }}',
+                repo: 'web-infra-dev/rspack',
+                suite: '-'
+              }
+            });
+            console.log(result);
 
   notify:
     name: Notify if failed

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -55,6 +55,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Release
+        id: release
         run: |
           ./x version snapshot
           ./x publish snapshot --tag nightly
@@ -64,6 +65,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+
+  
 
   notify:
     name: Notify if failed

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -1,5 +1,6 @@
 import { getLastVersion } from "./version.mjs";
 import * as core from "@actions/core";
+
 export async function publish_handler(mode, options) {
 	console.log("options:", options);
 	const npmrcPath = `${process.env.HOME}/.npmrc`;
@@ -18,6 +19,8 @@ export async function publish_handler(mode, options) {
 		options.tag
 	} --no-git-checks`;
 	const version = await getLastVersion(root);
+	core.setOutput('published-version', version);
+	core.notice(`Published Version: ${version}`);
 	/**
 	 * @Todo test stable release later
 	 */

--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -19,8 +19,8 @@ export async function publish_handler(mode, options) {
 		options.tag
 	} --no-git-checks`;
 	const version = await getLastVersion(root);
-	core.setOutput('published-version', version);
-	core.notice(`Published Version: ${version}`);
+	core.setOutput('version', version);
+	core.notice(`Version: ${version}`);
 	/**
 	 * @Todo test stable release later
 	 */


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 283ff61</samp>

The pull request enhances the nightly release workflow by renaming the publish step and adding a new job to trigger a CI pipeline on `rspack-ecosystem-ci`. This ensures that the latest `rspack` version is tested against the ecosystem projects.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 283ff61</samp>

* Change the name and id of the step that runs the `./x version snapshot` command to Publish, and set an output variable with the version ([link](https://github.com/web-infra-dev/rspack/pull/3480/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L57-R58), [link](https://github.com/web-infra-dev/rspack/pull/3480/files?diff=unified&w=0#diff-121ac8f9e24f2b43274b72e2b02402ecdef16563740899434511ba9ecc099dc8R22-R23))
* Add a new job to trigger a workflow dispatch event on the rspack-ecosystem-ci repository with the refType, ref, repo, and suite inputs ([link](https://github.com/web-infra-dev/rspack/pull/3480/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L67-R94))
* Add an empty line to the beginning of the `scripts/release/publish.mjs` file ([link](https://github.com/web-infra-dev/rspack/pull/3480/files?diff=unified&w=0#diff-121ac8f9e24f2b43274b72e2b02402ecdef16563740899434511ba9ecc099dc8R3))
* Log a notice message with the version at the end of the `scripts/release/publish.mjs` file ([link](https://github.com/web-infra-dev/rspack/pull/3480/files?diff=unified&w=0#diff-121ac8f9e24f2b43274b72e2b02402ecdef16563740899434511ba9ecc099dc8R22-R23))

</details>
