### PR TITLE
fix(splitChunk): custom cacheGroup default priority consistent with webpack

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -235,7 +235,7 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
               .name
               .map(new_split_chunks_plugin::create_chunk_name_getter_by_const_name)
               .unwrap_or_else(|| overall_name_getter.clone()),
-            priority: v.priority.unwrap_or(-20) as f64,
+            priority: v.priority.unwrap_or(0) as f64,
             test: new_split_chunks_plugin::create_module_filter(v.test.clone()),
             chunk_filter: v.chunks.map(create_chunks_filter).unwrap_or_else(|| {
               overall_chunk_filter

--- a/packages/rspack/tests/configCases/split-chunks/default-priority/a.js
+++ b/packages/rspack/tests/configCases/split-chunks/default-priority/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/configCases/split-chunks/default-priority/b.js
+++ b/packages/rspack/tests/configCases/split-chunks/default-priority/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/packages/rspack/tests/configCases/split-chunks/default-priority/c.js
+++ b/packages/rspack/tests/configCases/split-chunks/default-priority/c.js
@@ -1,0 +1,1 @@
+module.exports = "c";

--- a/packages/rspack/tests/configCases/split-chunks/default-priority/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/default-priority/index.js
@@ -1,0 +1,5 @@
+import "./a";
+import "./b";
+import "./c";
+
+it("should compile fine", () => {});

--- a/packages/rspack/tests/configCases/split-chunks/default-priority/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/default-priority/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["lib-js.js", "lib-b.js", "main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks/default-priority/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/default-priority/webpack.config.js
@@ -1,0 +1,32 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		filename: "[name].js"
+	},
+	target: "web",
+	optimization: {
+		splitChunks: {
+			chunks: "all",
+			cacheGroups: {
+				// priority: lib-b > lib-js > lib-a
+				vendor: {
+					test: /\.js/,
+					name: "lib-js",
+					priority: -10,
+					enforce: true
+				},
+				a: {
+					test: /a\.js/,
+					name: "lib-a",
+					priority: -30,
+					enforce: true
+				},
+				b: {
+					test: /b\.js/,
+					name: "lib-b",
+					enforce: true
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
## Related issue (if exists)

closed: #3481
<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b8e6a7</samp>

This pull request fixes a bug in the split chunks plugin by changing the default priority of the cache groups in `raw_split_chunks.rs`. It also adds a new test case in `split-chunks/default-priority` to verify the expected behavior of the plugin.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b8e6a7</samp>

* Change the default priority of cache groups in the split chunks plugin to 0 ([link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L238-R238))
* Add a new test case `split-chunks/default-priority` to verify the effect of the priority change ([link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-54c36242969dd303f24feb8f1cea1068bce6941256f9d6adf394a6f889b777cbR1), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-a0e31bbafe9adbdc035b412bd44082db09fb683ce6bb096ea9293e914c42a7e6R1), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-dd8f7efcb908d7431dde6607a13c123d3a6a5210ab19a7e815a24bdda5c84489R1), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-72b87fb45fcead5389bab1d7aa02d548d5e0abc0194bc2cd4f364f0836005006R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-ed7bae238a70c9217dccf0d256c0688b082cc61bc96365741b7cb049ab29b2bbR1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-9bfad85172d2c57fd0a114fac84afa3bdaeb55b9a83ad8a37dc53cfe027aff14R1-R32))
  * Create three modules `a.js`, `b.js`, and `c.js` that export different strings ([link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-54c36242969dd303f24feb8f1cea1068bce6941256f9d6adf394a6f889b777cbR1), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-a0e31bbafe9adbdc035b412bd44082db09fb683ce6bb096ea9293e914c42a7e6R1), [link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-dd8f7efcb908d7431dde6607a13c123d3a6a5210ab19a7e815a24bdda5c84489R1))
  * Create an entry point `index.js` that imports the three modules and runs a simple test ([link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-72b87fb45fcead5389bab1d7aa02d548d5e0abc0194bc2cd4f364f0836005006R1-R5))
  * Create a webpack configuration `webpack.config.js` that uses the split chunks plugin with custom cache groups `vendor`, `a`, and `b` ([link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-9bfad85172d2c57fd0a114fac84afa3bdaeb55b9a83ad8a37dc53cfe027aff14R1-R32))
  * Create a test configuration `test.config.js` that exports a function that returns the expected bundle names ([link](https://github.com/web-infra-dev/rspack/pull/3482/files?diff=unified&w=0#diff-ed7bae238a70c9217dccf0d256c0688b082cc61bc96365741b7cb049ab29b2bbR1-R5))

</details>
