### PR TITLE
fix(provide): fix object-expr

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/provide.rs
@@ -31,7 +31,6 @@ impl<'a> ProvideBuiltin<'a> {
   }
 
   fn handle_ident(&mut self, ident: &Ident) {
-    dbg!(&ident);
     if ident.span.has_mark(self.unresolved_mark) && self.opts.get(&ident.sym.to_string()).is_some()
     {
       self.current_import_provide.insert(ident.sym.to_string());

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/expected/main.js
@@ -1,10 +1,29 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
 var process = __webpack_require__("./process.js");
+__webpack_require__("./name.js");
 console.log(process.env);
 (function(process) {
     console.log(process, process[0], process.env);
 })({});
+},
+"./name.js": function (module, exports, __webpack_require__) {
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "default", {
+    enumerable: true,
+    get: function() {
+        return _default;
+    }
+});
+const lib = {
+    get: ()=>{
+        return "my-name";
+    }
+};
+var _default = lib;
 },
 "./process.js": function (module, exports, __webpack_require__) {
 var process = module.exports = {};

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/index.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/index.js
@@ -4,3 +4,9 @@ console.log(process.env);
 (function (process) {
 	console.log(process, process[0], process.env);
 })({});
+
+function a(){
+	return {
+		name
+	}
+}

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/name.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/name.js
@@ -1,0 +1,7 @@
+const lib = {
+	get: () => {
+		return "my-name";
+	},
+};
+
+export default lib;

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/test.config.json
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/test.config.json
@@ -3,7 +3,8 @@
 		"provide": {
 			"process": [
 				"./process.js"
-			]
+			],
+      "name": ["./name.js"]
 		},
 		"treeShaking": "true"
 	}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->
Closes https://github.com/web-infra-dev/rspack/issues/3433
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1332da</samp>

Improved the `provide` visitor for JavaScript plugin to handle object literals with shorthand properties and added test fixtures and configuration for this feature. Modified the `handle_ident` method to use `PropOrSpread` enum.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1332da</samp>

* Import `PropOrSpread` enum to handle object literals with shorthand properties in `Provide` visitor ([link](https://github.com/web-infra-dev/rspack/pull/3486/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL8-R8))
* Extend `handle_ident` method to check and replace shorthand properties with provided modules ([link](https://github.com/web-infra-dev/rspack/pull/3486/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cR149-R157))
* Add `dbg!` macro to print `ident` argument for debugging purposes ([link](https://github.com/web-infra-dev/rspack/pull/3486/files?diff=unified&w=0#diff-ceac836b6796451c62fe37267c43d2739a75e6b9356c825ddce76c5900c2a18cL33-R34))
* Add test fixture files to test `provide` feature with object literals with shorthand properties ([link](https://github.com/web-infra-dev/rspack/pull/3486/files?diff=unified&w=0#diff-c20b2d0e81223d90dcbb99e404820ec61e04b4d420afac879abac24a5f120e25R7-R12), [link](https://github.com/web-infra-dev/rspack/pull/3486/files?diff=unified&w=0#diff-a7bf100c6d3b36dcc2ceb9a04a3312360bf836c026ff88bd288f43203692e9edR1-R7))
* Modify test configuration file to add `name` entry for `provide` option with `./name.js` module ([link](https://github.com/web-infra-dev/rspack/pull/3486/files?diff=unified&w=0#diff-56fc1acd6dd1a2bc2c34d996c2f05a3b6474a76587f80f1076611877f952851fL6-R7))

</details>
