### PR TITLE
ci: adjust timeout-minutes for CI because mac is too slow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -183,8 +183,7 @@ jobs:
   test:
     needs: [select, build]
     runs-on: ${{ needs.select.outputs.host }}
-    # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
-    timeout-minutes: 15
+    timeout-minutes: 30
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
@@ -214,26 +213,29 @@ jobs:
       ### x86_64-unknown-linux-gnu
 
       - name: Test x86_64-unknown-linux-gnu
+        timeout-minutes: 15 # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' }}
         run: pnpm run test:ci
 
       ### x86_64-apple-darwin
 
       - name: Test x86_64-apple-darwin
+        timeout-minutes: 15 # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
         if: ${{ inputs.target == 'x86_64-apple-darwin' }}
         run: pnpm run test:ci
 
       ### x86_64-pc-windows-msvc
 
       - name: Test x86_64-pc-windows-msvc
-        if: ${{  inputs.target == 'x86_64-pc-windows-msvc' }}
+        timeout-minutes: 15 # Tests should finish within 15 mins, please fix your tests instead of changing this to a higher timeout.
+        if: ${{ inputs.target == 'x86_64-pc-windows-msvc' }}
         run: pnpm run test:ci
 
       ### write the latest metric into branch gh-pages
       ### Note that, We can't merge this script, because this script only runs on main branch
       - name: Update main branch test compatibility metric
         if: ${{ inputs.target == 'x86_64-unknown-linux-gnu' && github.ref_name == 'main' && matrix.node == '18' }}
-        run: node ./webpack-test/scripts/generate.js ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}  
+        run: node ./webpack-test/scripts/generate.js ${{ secrets.GITHUB_TOKEN }} ${{ github.sha }}
 
       # ### update metric diff against main branch when pull request change
       - name: Update


### PR DESCRIPTION
## Related issue (if exists)

* https://github.com/web-infra-dev/rspack/issues/3488

## Summary

Mac disk operations are too slow

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5330a93</samp>

Increased the timeout limit for the test job in the reusable build workflow, and added individual limits for each platform. Fixed a minor formatting issue.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5330a93</samp>

*  Increase the timeout-minutes for the test job to 30, to avoid timeout errors ([link](https://github.com/web-infra-dev/rspack/pull/3491/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L186-R186))
*  Add the timeout-minutes for each test:ci script and set them to 15, to enforce the previous timeout limit for each platform ([link](https://github.com/web-infra-dev/rspack/pull/3491/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R216), [link](https://github.com/web-infra-dev/rspack/pull/3491/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R223), [link](https://github.com/web-infra-dev/rspack/pull/3491/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L229-R231))
*  Remove a trailing whitespace from the end of a line in `.github/workflows/reusable-build.yml`, to follow the code style guidelines ([link](https://github.com/web-infra-dev/rspack/pull/3491/files?diff=unified&w=0#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3L236-R238))

</details>
