### PR TITLE
fix: Base64Error caused by unclean base64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,8 @@ name = "rspack_base64"
 version = "0.1.0"
 dependencies = [
  "base64-simd",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -364,6 +364,12 @@ export interface JsStatsWarning {
   formatted: string
 }
 
+export interface NodeFS {
+  writeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+}
+
 export interface PathData {
   filename?: string
   hash?: string
@@ -916,5 +922,13 @@ export interface RawStyleConfig {
 
 export interface RawTrustedTypes {
   policyName?: string
+}
+
+export interface ThreadsafeNodeFS {
+  writeFile: (...args: any[]) => any
+  removeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+  removeDirAll: (...args: any[]) => any
 }
 

--- a/crates/rspack_base64/Cargo.toml
+++ b/crates/rspack_base64/Cargo.toml
@@ -8,3 +8,5 @@ version    = "0.1.0"
 
 [dependencies]
 base64-simd = { version = "0.8.0", features = ["alloc"] }
+once_cell   = { workspace = true }
+regex       = { workspace = true }

--- a/crates/rspack_base64/src/lib.rs
+++ b/crates/rspack_base64/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod base64 {
+  use std::borrow::Cow;
+
   use base64_simd::{Base64 as Raw, Error, STANDARD};
+  use once_cell::sync::Lazy;
+  use regex::Regex;
 
   pub struct Base64(Raw);
 
@@ -23,10 +27,53 @@ pub mod base64 {
     }
   }
 
+  static BASE64: Base64 = Base64::new();
+
   pub fn encode_to_string<D: AsRef<[u8]>>(data: D) -> String {
-    static BASE64: Base64 = Base64::new();
     BASE64.0.encode_to_string(data)
+  }
+
+  pub fn decode_to_vec<D: AsRef<[u8]>>(data: D) -> Result<Vec<u8>, Error> {
+    BASE64.0.decode_to_vec(data)
+  }
+
+  static INVALID_BASE64_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[^+/0-9A-Za-z-_]").expect("Invalid RegExp"));
+
+  // modified from https://github.com/feross/buffer/blob/795bbb5bda1b39f1370ebd784bea6107b087e3a7/index.js#L1942
+  // Buffer.from in nodejs will clean base64 first, which causes some inconsistent behavior with base64_simd
+  // e.g. Buffer.from("abcd?#iefix", "base64").toString("base64")
+  pub fn clean_base64(value: &str) -> Option<Cow<str>> {
+    let value = value.split('=').next()?;
+    let value = value.trim();
+    let value = INVALID_BASE64_RE.replace_all(value, "");
+    if value.len() < 2 {
+      return Some(Cow::from(""));
+    }
+    let value = value.into_owned();
+    let len = value.len();
+    let remainder = len % 4;
+    if remainder == 0 {
+      return Some(Cow::from(value));
+    }
+    let pad_len = 4 - remainder;
+    if pad_len == 1 {
+      return Some(Cow::from(value + "="));
+    }
+    if pad_len == 2 {
+      return Some(Cow::from(value + "=="));
+    }
+    // modify: add this case on the original base64clean js function
+    // why Buffer.from("abcd?#iefix", "base64") => "abcdiefi"?
+    //   1. base64clean("abcd?#iefix") => "abcdiefix==="
+    //   2. toByteArray("abcdiefix===") => "abcdiefi"
+    // but base64_simd::STANDARD.decode_to_vec("abcdiefix===") will return error
+    // because toByteArray and base64_simd::STANDARD.decode_to_vec are different with handling placeHoldersLen
+    // for detail checkout:
+    //   - https://github.com/beatgammit/base64-js/blob/88957c9943c7e2a0f03cdf73e71d579e433627d3/index.js#L80-L96
+    //   - https://docs.rs/base64-simd/0.8.0/src/base64_simd/decode.rs.html#70 (means placeHoldersLen === 3)
+    Some(Cow::from(value[..len - remainder].to_owned()))
   }
 }
 
-pub use base64::encode_to_string;
+pub use base64::{clean_base64, decode_to_vec, encode_to_string};

--- a/crates/rspack_plugin_schemes/src/data_uri.rs
+++ b/crates/rspack_plugin_schemes/src/data_uri.rs
@@ -57,9 +57,8 @@ impl Plugin for DataUriPlugin {
     if resource_data.get_scheme().is_data() && let Some(captures) = URI_REGEX.captures(&resource_data.resource) {
       let body = captures.get(4).expect("should have data uri body").as_str();
       let is_base64 = captures.get(3).is_some();
-      if is_base64 {
-        let base64 = rspack_base64::base64::Base64::new();
-        return Ok(Some(Content::Buffer(base64.decode_to_vec(body.trim()).map_err(|e| internal_error!(e.to_string()))?)))
+      if is_base64 && let Some(cleaned) = rspack_base64::clean_base64(body) {
+        return Ok(Some(Content::Buffer(rspack_base64::decode_to_vec(cleaned.as_bytes()).map_err(|e| internal_error!(e.to_string()))?)))
       }
       if !body.is_ascii() {
         return Ok(Some(Content::Buffer(urlencoding::decode_binary(body.as_bytes()).into_owned())))

--- a/packages/rspack/tests/cases/schemes/data-imports/bad-base64.css
+++ b/packages/rspack/tests/cases/schemes/data-imports/bad-base64.css
@@ -1,0 +1,4 @@
+.bad {
+  a: url('data:text/bad-base64;base64,abcd?#iefix');
+  b: url('data:text/bad-base64;base64,    abcd?#iefix');
+}

--- a/packages/rspack/tests/cases/schemes/data-imports/index.css
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.css
@@ -1,5 +1,6 @@
 @import url("data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ=="); /* .b{color: green} */
 @import url("./a.css");
+@import "./bad-base64.css";
 
 .class {
   a: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"></svg>');

--- a/packages/rspack/tests/cases/schemes/data-imports/index.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/index.js
@@ -31,6 +31,11 @@ it("data imports", () => {
 ;;;
 
 
+.bad {
+  a: url("data:text/bad-base64;base64,abcd?#iefix");
+  b: url("data:text/bad-base64;base64,    abcd?#iefix");
+}
+
 .class {
   a: url("82ee8285df64be76.svg");
   b: url("82ee8285df64be76.svg");

--- a/packages/rspack/tests/cases/schemes/data-imports/webpack.config.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/webpack.config.js
@@ -11,6 +11,10 @@ module.exports = {
 				issuer: /\.js/,
 				mimetype: /^image\/svg/,
 				type: "asset/inline"
+			},
+			{
+				mimetype: /^text\/bad-base64/,
+				type: "asset/inline"
 			}
 		]
 	},

--- a/packages/rspack/tests/cases/schemes/file-url/webpack.config.js
+++ b/packages/rspack/tests/cases/schemes/file-url/webpack.config.js
@@ -19,7 +19,8 @@ import v2 from ${JSON.stringify(
 				.slice("file://".length)
 	)};
 export const val1 = v1;
-export const val2 = v2;`
+export const val2 = v2;
+`
 );
 fs.utimesSync(file, new Date(Date.now() - 10000), new Date(Date.now() - 10000));
 


### PR DESCRIPTION
## Related issue (if exists)

fixes #3485

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b7cde0</samp>

This pull request adds a new feature to the `rspack_base64` crate, which is a utility for sanitizing and decoding base64 strings. It also fixes a bug in the `rspack_plugin_schemes` crate, which handles data URIs in the `rspack` tool. It updates the test cases and the Webpack configuration files accordingly.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3b7cde0</samp>

*  Add `clean_base64` and `decode_to_vec` functions to `rspack_base64` crate to sanitize and decode base64 strings ([link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-00d32632c3fba61f46cd68720a35e5aac67fe429aca93522472a9cccd0bfc75eL2-R6),[link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-00d32632c3fba61f46cd68720a35e5aac67fe429aca93522472a9cccd0bfc75eL26-R79),[link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-8e211d49ed477775234941e34c7e80d2caacd88a9378e7c3e5cc4bdf5fc4ea66R11-R12))
*  Use `clean_base64` function in `data_uri` module of `rspack_plugin_schemes` crate to fix bug with invalid data URIs ([link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-7ef2a053b868692703310a61bbb9d8e0155ff6bdcfa20b0be142992d9d536ec0L60-R61))
*  Add test case for data URIs with invalid base64 strings in `rspack` package, using `bad-base64.css` file and `text/bad-base64` MIME type ([link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-400eb6a15c43dc1be02df8126b172d8db0c03d3f08311d2030ac2c4dce110334R1-R4),[link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-1c7c125831fae2fee17787e5a65a37dd9e2c6a6e24ee13af5939c29937110f89R3),[link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-bc2f03406a560f2556547535400c4050a85856924abe1f2acdbf03e206df6266R34-R38),[link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-cbdec9b02ad15d482669924809604be68cec1cfabaf9af4ef28b28d42abfb0f1R14-R17))
*  Fix formatting issue in `webpack.config.js` file for `file-url` test case ([link](https://github.com/web-infra-dev/rspack/pull/3494/files?diff=unified&w=0#diff-a153b9b1e1da451e32ded6074c97b8a55952c544a4e33a7b1e32e07ea12b3cd9L22-R23))

</details>
