### PR TITLE
feat: support compilation.rebuildModule

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "rspack_identifier",
  "rspack_napi_shared",
  "rspack_tracing",
+ "rustc-hash",
  "testing_macros",
  "tikv-jemallocator",
  "tokio",

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -25,6 +25,7 @@ backtrace   = { workspace = true }
 dashmap     = { workspace = true }
 futures     = { workspace = true }
 once_cell   = { workspace = true }
+rustc-hash  = { workspace = true }
 tokio       = { workspace = true, features = ["rt", "rt-multi-thread", "macros"] }
 tracing     = { workspace = true }
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -35,6 +35,7 @@ export class JsCompilation {
   addContextDependencies(deps: Array<string>): void
   addMissingDependencies(deps: Array<string>): void
   addBuildDependencies(deps: Array<string>): void
+  rebuildModule(moduleIdentifiers: Array<string>, f: (...args: any[]) => any): void
 }
 
 export class JsStats {

--- a/crates/node_binding/src/js_values/compilation.rs
+++ b/crates/node_binding/src/js_values/compilation.rs
@@ -5,12 +5,14 @@ use napi::bindgen_prelude::*;
 use napi::NapiRaw;
 use rspack_core::rspack_sources::BoxSource;
 use rspack_core::AssetInfo;
+use rspack_core::ModuleIdentifier;
 use rspack_core::{rspack_sources::SourceExt, AstOrSource, NormalModuleAstOrSource};
 use rspack_identifier::Identifier;
 use rspack_napi_shared::NapiResultExt;
 
 use super::module::ToJsModule;
 use super::PathWithInfo;
+use crate::utils::callbackify;
 use crate::{
   js_values::{chunk::JsChunk, module::JsModule, PathData},
   CompatSource, JsAsset, JsAssetInfo, JsChunkGroup, JsCompatSource, JsStats, ToJsCompatSource,
@@ -382,6 +384,30 @@ impl JsCompilation {
       .inner
       .build_dependencies
       .extend(deps.into_iter().map(PathBuf::from))
+  }
+
+  #[napi]
+  pub fn rebuild_module(
+    &'static mut self,
+    env: Env,
+    module_identifiers: Vec<String>,
+    f: JsFunction,
+  ) -> Result<()> {
+    callbackify(env, f, async {
+      let modules = self
+        .inner
+        .rebuild_module(rustc_hash::FxHashSet::from_iter(
+          module_identifiers.into_iter().map(ModuleIdentifier::from),
+        ))
+        .await
+        .map_err(|e| Error::new(napi::Status::GenericFailure, format!("{e}")))?;
+      Ok(
+        modules
+          .into_iter()
+          .filter_map(|item| item.to_js_module().ok())
+          .collect::<Vec<_>>(),
+      )
+    })
   }
 }
 

--- a/crates/rspack_core/src/cache/occasion/build_module.rs
+++ b/crates/rspack_core/src/cache/occasion/build_module.rs
@@ -2,6 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use futures::Future;
 use rspack_error::{Result, TWithDiagnosticArray};
+use rspack_identifier::Identifier;
 
 use crate::{
   cache::snapshot::{Snapshot, SnapshotManager},
@@ -22,6 +23,12 @@ impl BuildModuleOccasion {
     Self {
       storage,
       snapshot_manager,
+    }
+  }
+
+  pub fn remove_cache(&self, id: &Identifier) {
+    if let Some(s) = self.storage.as_ref() {
+      s.remove(id);
     }
   }
 

--- a/crates/rspack_core/src/cache/storage/memory.rs
+++ b/crates/rspack_core/src/cache/storage/memory.rs
@@ -28,4 +28,7 @@ where
   fn set(&self, id: Identifier, data: Item) {
     self.data.insert(id, data);
   }
+  fn remove(&self, id: &Identifier) {
+    self.data.remove(id);
+  }
 }

--- a/crates/rspack_core/src/cache/storage/mod.rs
+++ b/crates/rspack_core/src/cache/storage/mod.rs
@@ -10,6 +10,7 @@ use memory::MemoryStorage;
 pub trait Storage<Item>: Debug + Send + Sync {
   fn get(&self, id: &Identifier) -> Option<Item>;
   fn set(&self, id: Identifier, data: Item);
+  fn remove(&self, id: &Identifier);
   // fn begin_idle(&self);
   // fn end_idle(&self);
   // fn clear(&self);

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+use rustc_hash::FxHashSet as HashSet;
+
+use crate::{BuildDependency, ModuleIdentifier};
+
+mod rebuild_deps_builder;
+pub use rebuild_deps_builder::RebuildDepsBuilder;
+
+#[derive(Debug)]
+pub enum MakeParam {
+  ModifiedFiles(HashSet<PathBuf>),
+  ForceBuildDeps(HashSet<BuildDependency>),
+  ForceBuildModules(HashSet<ModuleIdentifier>),
+}
+
+// TODO @jerrykingxyz migrate make method here
+// pub async fn updateModuleGraph(params: Vec<MakeParam>, module_graph: &mut ModuleGraph) {
+// }

--- a/crates/rspack_core/src/compiler/make/rebuild_deps_builder.rs
+++ b/crates/rspack_core/src/compiler/make/rebuild_deps_builder.rs
@@ -1,0 +1,81 @@
+use rustc_hash::FxHashSet as HashSet;
+
+use super::MakeParam;
+use crate::{BuildDependency, ModuleGraph, ModuleIdentifier};
+
+#[derive(Debug, Default)]
+pub struct RebuildDepsBuilder {
+  /// the modules that need to be built
+  force_build_modules: HashSet<ModuleIdentifier>,
+  /// the deps that need to be built
+  force_build_deps: HashSet<BuildDependency>,
+}
+
+impl RebuildDepsBuilder {
+  pub fn new(params: Vec<MakeParam>, module_graph: &ModuleGraph) -> Self {
+    let mut builder = Self::default();
+
+    for item in params {
+      match item {
+        MakeParam::ModifiedFiles(files) => {
+          builder.extend_force_build_modules(module_graph.modules().values().filter_map(|module| {
+            // check has dependencies modified
+            if module_graph.has_dependencies(&module.identifier(), &files) {
+              Some(module.identifier())
+            } else {
+              None
+            }
+          }))
+        }
+        MakeParam::ForceBuildDeps(deps) => {
+          builder.extend_force_build_deps(module_graph, deps);
+        }
+        MakeParam::ForceBuildModules(modules) => {
+          builder.extend_force_build_modules(modules);
+        }
+      };
+    }
+
+    builder
+  }
+
+  pub fn extend_force_build_modules<I: IntoIterator<Item = ModuleIdentifier>>(
+    &mut self,
+    modules: I,
+  ) {
+    self.force_build_modules.extend(modules);
+  }
+
+  pub fn extend_force_build_deps<I: IntoIterator<Item = BuildDependency>>(
+    &mut self,
+    module_graph: &ModuleGraph,
+    deps: I,
+  ) {
+    for item in deps {
+      let (dependency_id, _) = &item;
+      // add deps bindings module to force_build_modules
+      if let Some(mid) = module_graph.module_identifier_by_dependency_id(dependency_id) {
+        self.force_build_modules.insert(*mid);
+      }
+      self.force_build_deps.insert(item);
+    }
+  }
+
+  pub fn get_force_build_modules(&self) -> &HashSet<ModuleIdentifier> {
+    &self.force_build_modules
+  }
+
+  //  pub fn get_force_build_deps(&self) -> &HashSet<BuildDependency> {
+  //    &self.force_build_deps
+  //  }
+
+  pub fn revoke_modules(mut self, module_graph: &mut ModuleGraph) -> HashSet<BuildDependency> {
+    self.force_build_deps.extend(
+      self
+        .force_build_modules
+        .iter()
+        .flat_map(|id| module_graph.revoke_module(id)),
+    );
+    self.force_build_deps
+  }
+}

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,5 +1,6 @@
 mod compilation;
 mod hmr;
+mod make;
 mod queue;
 mod resolver;
 
@@ -7,6 +8,7 @@ use std::{path::Path, sync::Arc};
 
 pub use compilation::*;
 use dashmap::DashMap;
+use make::MakeParam;
 pub use queue::*;
 pub use resolver::*;
 use rspack_error::Result;
@@ -127,14 +129,14 @@ where
           .collect::<Vec<_>>()
       })
       .collect::<HashSet<_>>();
-    self.compile(SetupMakeParam::ForceBuildDeps(deps)).await?;
+    self.compile(MakeParam::ForceBuildDeps(deps)).await?;
     self.cache.begin_idle();
     self.compile_done().await?;
     Ok(())
   }
 
   #[instrument(name = "compile", skip_all)]
-  async fn compile(&mut self, params: SetupMakeParam) -> Result<()> {
+  async fn compile(&mut self, params: MakeParam) -> Result<()> {
     let option = self.options.clone();
     self.compilation.make(params).await?;
 

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -718,6 +718,14 @@ export class Compilation {
 			plugins
 		);
 	}
+
+	rebuildModule(m: JsModule, f: (err: any, m: JsModule) => void) {
+		// TODO merge rebuildModule calls
+		this.#inner.rebuildModule([m.moduleIdentifier], function (err, modules) {
+			f(err, modules[0]);
+		});
+	}
+
 	/**
 	 * Get the `Source` of a given asset filename.
 	 *

--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -11,7 +11,6 @@ import * as tapable from "tapable";
 import { Source } from "webpack-sources";
 
 import {
-	JsAsset,
 	JsAssetInfo,
 	JsChunk,
 	JsCompatSource,
@@ -44,6 +43,7 @@ import {
 	createFakeCompilationDependencies,
 	createFakeProcessAssetsHook
 } from "./util/fake";
+import MergeCaller from "./util/MergeCaller";
 
 export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
 export type Assets = Record<string, Source>;
@@ -719,11 +719,26 @@ export class Compilation {
 		);
 	}
 
+	_rebuildModule = new MergeCaller(
+		(args: Array<[string, (err: any, m: JsModule) => void]>) => {
+			this.#inner.rebuildModule(
+				args.map(item => item[0]),
+				function (err: any, modules: JsModule[]) {
+					for (const [id, callback] of args) {
+						const m = modules.find(item => item.moduleIdentifier === id);
+						if (m) {
+							callback(err, m);
+						} else {
+							callback(err || new Error("module no found"), null as any);
+						}
+					}
+				}
+			);
+		},
+		10
+	);
 	rebuildModule(m: JsModule, f: (err: any, m: JsModule) => void) {
-		// TODO merge rebuildModule calls
-		this.#inner.rebuildModule([m.moduleIdentifier], function (err, modules) {
-			f(err, modules[0]);
-		});
+		this._rebuildModule.run(m.moduleIdentifier, f);
 	}
 
 	/**

--- a/packages/rspack/src/util/MergeCaller.ts
+++ b/packages/rspack/src/util/MergeCaller.ts
@@ -1,0 +1,31 @@
+type CallFn<A, C> = (args: Array<[A, C]>) => void;
+
+export default class MergeCaller<A, C> {
+	private timer: any = null;
+	private callArgs: Array<[A, C]> = [];
+
+	// add in constructor
+	private debounceTime: number;
+	private callFn: CallFn<A, C>;
+	constructor(fn: CallFn<A, C>, debounceTime: number) {
+		this.debounceTime = debounceTime;
+		this.callFn = fn;
+	}
+
+	private finalCall = () => {
+		this.timer = null;
+		const args = this.callArgs;
+		this.callArgs = [];
+		this.callFn(args);
+	};
+
+	run(a: A, c: C) {
+		if (this.timer) {
+			clearTimeout(this.timer);
+		}
+
+		this.callArgs.push([a, c]);
+
+		this.timer = setTimeout(this.finalCall, this.debounceTime);
+	}
+}

--- a/packages/rspack/tests/configCases/compilation/rebuild-module/a.js
+++ b/packages/rspack/tests/configCases/compilation/rebuild-module/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rspack/tests/configCases/compilation/rebuild-module/index.js
+++ b/packages/rspack/tests/configCases/compilation/rebuild-module/index.js
@@ -1,0 +1,5 @@
+import { a } from "./a";
+
+it("compilation rebuild module should works", () => {
+	expect(a).toEqual(2);
+});

--- a/packages/rspack/tests/configCases/compilation/rebuild-module/loader.js
+++ b/packages/rspack/tests/configCases/compilation/rebuild-module/loader.js
@@ -1,0 +1,5 @@
+let times = 0;
+module.exports = function loader(content) {
+	times++;
+	return content.replace("1", times);
+};

--- a/packages/rspack/tests/configCases/compilation/rebuild-module/webpack.config.js
+++ b/packages/rspack/tests/configCases/compilation/rebuild-module/webpack.config.js
@@ -1,0 +1,49 @@
+const pluginName = "plugin";
+
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(pluginName, compilation => {
+			compilation.hooks.finishModules.tapPromise(pluginName, async modules => {
+				const oldModule = modules.find(item => item.resource.endsWith("a.js"));
+				if (!oldModule) {
+					throw new Error("module not found");
+				}
+
+				expect(
+					oldModule.originalSource.source.toString().includes("a = 1")
+				).toBe(true);
+
+				const newModule = await new Promise((res, rej) => {
+					compilation.rebuildModule(oldModule, function (err, m) {
+						if (err) {
+							rej(err);
+						} else {
+							res(m);
+						}
+					});
+				});
+
+				expect(
+					newModule.originalSource.source.toString().includes("a = 2")
+				).toBe(true);
+			});
+		});
+	}
+}
+
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /a\.js$/,
+				use: [
+					{
+						loader: "./loader"
+					}
+				]
+			}
+		]
+	},
+	plugins: [new Plugin()]
+};


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

1. extract part of make code to `compiler/make/xxx`
2. generate `update_module_graph` method to reuse code between `make` and `rebuild_module`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51a6e8c</samp>

This pull request adds a new feature to the rspack project, which allows rebuilding modules in a compilation object using a Node.js API. It also improves the cache and compiler functionality of the rspack_core crate, and adds a new dependency and some utility types and functions. It includes some test files to demonstrate and verify the new feature.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 51a6e8c</samp>

*  Add a new method to the Compilation class and the JsCompilation struct to expose the rebuild_module functionality to the JavaScript API ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1R721-R728), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefR388-R413))
* Refactor the make method of the Compilation struct to use the MakeParam enum and the RebuildDepsBuilder struct, which simplify the logic of collecting and rebuilding the dependencies ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R28), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L60-L65), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L360-R411), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L455-R434), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L733-R710), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L776-R762), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-fc81afbae305d0709a5b1a265ce66e113cf47d61660718c8c060e10ccf4fb978R1-R19), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-d1405a5857f0cd13c99a026d7c1fa539a67ed3b3662d3b9cb5f6614d071f7851R1-R81), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209R3), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209R11), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L137-R139))
* Refactor the run and compile methods of the Compiler and Hmr structs to use the MakeParam enum instead of the SetupMakeParam enum, which is consistent with the make method of the Compilation struct ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L193-R217), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L207-R231), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-3fbb9f7dfbadceab7b0c89038c54de9851f25ae957a1f91aea05b0e46da2b209L130-R132))
* Add a new method to the Storage trait and the MemoryStorage struct to implement the remove functionality for cache storage ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432R29-R32), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-2293e56cdfc27fc02d74819e50fe362b7b346e2b8442e6615f662a24c99d650bR31-R33))
* Add a new dependency on the rustc-hash crate to the node_binding crate, which provides a fast hash map and set implementation ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-dec41026e2dec6ab7a5bfe4f75643010bc788214bcd83257e4a00f5ec31338e7R28))
* Add a new test case to the configCases/compilation/rebuild-module folder, which verifies the rebuild_module functionality using a custom loader and a plugin ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-acb03d05b3190484c550c23c92547584ce3dde00a037ec37b020a2b02cef97a0R1), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-2bb336e819cd3631858f8eb064bf46a1f6019bc466c8fd1b92a1700f93e74745R1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-340da3b9818c483aa78332d960b7e0b0e9566b6930936048275e027b5b2ddd3aR1-R5), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-b262551ab0125d07678950f9a041e9b597d49a1db45f36c6b6ff2ab9713e5bffR1-R49))
* Remove some unused imports from the compilation module ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L33-R42))
* Import some types and functions from other modules to the js_values/compilation, cache/storage/memory, and hmr modules ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefR8), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-84c93e470c657e7170febfee9e8e496a92bed9f6edea0251e8c6aaf6a160cfefR15), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-a98a14845029e2b2f9e0b9efc5c0fefe00d7d1c2e97ec1dbef9a4e2475745432R5), [link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L11-R14))
* Set the has_module_import_export_change flag to false and remove the previous build ASTs from the modules before calling the compile method in the run method of the Hmr struct ([link](https://github.com/web-infra-dev/rspack/pull/3496/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763R174-R196))

</details>
