### PR TITLE
feat(config): zod scheme for plugins

### DIFF
--- a/packages/rspack/src/config/zod/_rewrite.ts
+++ b/packages/rspack/src/config/zod/_rewrite.ts
@@ -1,12 +1,6 @@
 import { z } from "zod";
 import { configSchema } from "./index";
-import type {
-	Output,
-	ModuleOptions,
-	Plugins,
-	Builtins,
-	DevServer
-} from "../types";
+import type { Output, ModuleOptions, Builtins, DevServer } from "../types";
 
 // The final goal is to infer the type using the schema without any rewriting.
 // But currently there are some schema are loose, so we need to rewrite the `Config`
@@ -16,7 +10,6 @@ type Config = z.infer<ReturnType<typeof configSchema>>;
 type Rewritten = {
 	output?: Output;
 	module?: ModuleOptions;
-	plugins?: Plugins;
 	builtins?: Omit<Builtins, keyof NonNullable<Config["builtins"]>> &
 		NonNullable<Config["builtins"]>;
 	devServer?: DevServer;

--- a/packages/rspack/src/config/zod/index.ts
+++ b/packages/rspack/src/config/zod/index.ts
@@ -15,6 +15,7 @@ import { output } from "./output";
 import { devtool } from "./devtool";
 import { optimization } from "./optimization";
 import { resolve } from "./resolve";
+import { plugins } from "./plugins";
 
 export function configSchema() {
 	return z
@@ -39,12 +40,12 @@ export function configSchema() {
 			snapshot: snapshot().optional(),
 			optimization: optimization().optional(),
 			resolve: resolve().optional(),
+			plugins: plugins().optional(),
 			// TODO(hyf0): what's the usage of this?
 			name: z.string().optional(),
 			// TODO
 			devServer: z.object({}).optional(),
 			output: output().optional(),
-			plugins: z.any().optional(),
 			builtins: builtins().optional(),
 			module: z.any().optional()
 		})

--- a/packages/rspack/src/config/zod/plugins.ts
+++ b/packages/rspack/src/config/zod/plugins.ts
@@ -7,6 +7,7 @@ const rspackPluginFunction = z
 	.returns(z.void());
 
 const rspackPluginInstance = z.object({
+	name: z.string().optional(),
 	apply: rspackPluginFunction
 });
 

--- a/packages/rspack/src/config/zod/plugins.ts
+++ b/packages/rspack/src/config/zod/plugins.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { Compiler } from "../../compiler";
+
+const rspackPluginFunction = z
+	.function()
+	.args(z.instanceof(Compiler))
+	.returns(z.void());
+
+const rspackPluginInstance = z.object({
+	apply: rspackPluginFunction
+});
+
+export function plugins() {
+	const functionOrInstance = rspackPluginFunction.or(rspackPluginInstance);
+	return functionOrInstance.array();
+}


### PR DESCRIPTION
## Related issue (if exists)

#3439 

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41e984d</samp>

Improved validation and simplification of plugins in rspack config schema. Created `plugins` function in `packages/rspack/src/config/zod/plugins.ts` to define the schema for plugin functions or instances. Removed unused and redundant code from `packages/rspack/src/config/zod/_rewrite.ts`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 41e984d</samp>

*  Remove unused `Plugins` type and `plugins` property from `Rewritten` type ([link](https://github.com/web-infra-dev/rspack/pull/3498/files?diff=unified&w=0#diff-bd8525628aa18fe2735262e8e0528ec0b40d0bac1d18250050ba0e2e112e2a50L3-R3), [link](https://github.com/web-infra-dev/rspack/pull/3498/files?diff=unified&w=0#diff-bd8525628aa18fe2735262e8e0528ec0b40d0bac1d18250050ba0e2e112e2a50L19))
*  Import `plugins` function from `./plugins.ts` to validate plugin functions or instances ([link](https://github.com/web-infra-dev/rspack/pull/3498/files?diff=unified&w=0#diff-9a73f0c83f0cf8363ded94e6e095ba53087a6ae86ef35d56df11f456a446a571R18))
*  Add `plugins` property to `configSchema` function with `plugins().optional()` value ([link](https://github.com/web-infra-dev/rspack/pull/3498/files?diff=unified&w=0#diff-9a73f0c83f0cf8363ded94e6e095ba53087a6ae86ef35d56df11f456a446a571R43))
*  Delete placeholder `plugins` property from `configSchema` function with `z.any().optional()` value ([link](https://github.com/web-infra-dev/rspack/pull/3498/files?diff=unified&w=0#diff-9a73f0c83f0cf8363ded94e6e095ba53087a6ae86ef35d56df11f456a446a571L47))
*  Create `./plugins.ts` file with `plugins` function that defines schema for plugin functions or instances using `zod` library ([link](https://github.com/web-infra-dev/rspack/pull/3498/files?diff=unified&w=0#diff-975485b24b68394e5e055b49ef824d2e4f19bbd379ba1094516a109473545536R1-R16))

</details>
