### PR TITLE
feat: add entryOption hook

### DIFF
--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -612,8 +612,7 @@ class Compiler {
 			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve,
 			succeedModule: this.compilation.hooks.succeedModule,
 			stillValidModule: this.compilation.hooks.stillValidModule,
-			buildModule: this.compilation.hooks.buildModule,
-			entryOption: this.hooks.entryOption
+			buildModule: this.compilation.hooks.buildModule
 		};
 		for (const [name, hook] of Object.entries(hookMap)) {
 			if (hook?.taps.length === 0) {

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -14,6 +14,7 @@ import * as tapable from "tapable";
 import { Callback, SyncBailHook, SyncHook } from "tapable";
 import type { WatchOptions } from "watchpack";
 import {
+	EntryNormalized,
 	OutputNormalized,
 	RspackOptionsNormalized,
 	RspackPluginInstance
@@ -138,6 +139,7 @@ class Compiler {
 		afterCompile: tapable.AsyncSeriesHook<[Compilation]>;
 		finishModules: tapable.AsyncSeriesHook<[any]>;
 		finishMake: tapable.AsyncSeriesHook<[Compilation]>;
+		entryOption: tapable.SyncBailHook<[string, EntryNormalized], any>;
 	};
 	options: RspackOptionsNormalized;
 	#disabledHooks: string[];
@@ -237,7 +239,8 @@ class Compiler {
 			beforeCompile: new tapable.AsyncSeriesHook(["params"]),
 			afterCompile: new tapable.AsyncSeriesHook(["compilation"]),
 			finishMake: new tapable.AsyncSeriesHook(["compilation"]),
-			finishModules: new tapable.AsyncSeriesHook(["modules"])
+			finishModules: new tapable.AsyncSeriesHook(["modules"]),
+			entryOption: new tapable.SyncBailHook(["context", "entry"])
 		};
 		this.modifiedFiles = undefined;
 		this.removedFiles = undefined;
@@ -609,7 +612,11 @@ class Compiler {
 			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve,
 			succeedModule: this.compilation.hooks.succeedModule,
 			stillValidModule: this.compilation.hooks.stillValidModule,
+<<<<<<< HEAD
 			buildModule: this.compilation.hooks.buildModule
+=======
+			entryOption: this.hooks.entryOption
+>>>>>>> feat: add entryOption hook
 		};
 		for (const [name, hook] of Object.entries(hookMap)) {
 			if (hook?.taps.length === 0) {

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -612,11 +612,8 @@ class Compiler {
 			afterResolve: this.compilation.normalModuleFactory?.hooks.afterResolve,
 			succeedModule: this.compilation.hooks.succeedModule,
 			stillValidModule: this.compilation.hooks.stillValidModule,
-<<<<<<< HEAD
-			buildModule: this.compilation.hooks.buildModule
-=======
+			buildModule: this.compilation.hooks.buildModule,
 			entryOption: this.hooks.entryOption
->>>>>>> feat: add entryOption hook
 		};
 		for (const [name, hook] of Object.entries(hookMap)) {
 			if (hook?.taps.length === 0) {

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -88,6 +88,7 @@ function createCompiler(userOptions: RspackOptions): Compiler {
 	compiler.hooks.environment.call();
 	compiler.hooks.afterEnvironment.call();
 	new RspackOptionsApply().process(compiler.options, compiler);
+	compiler.hooks.entryOption.call(options.context, options.entry);
 	compiler.hooks.initialize.call();
 	return compiler;
 }

--- a/packages/rspack/tests/cases/hooks/entryOption/package.json
+++ b/packages/rspack/tests/cases/hooks/entryOption/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "example-basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "dev": "rspack serve",
+    "build": "rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "workspace:*"
+  },
+  "sideEffects": false,
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/packages/rspack/tests/cases/hooks/entryOption/plugins/MyEntryOptionPlugin.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/plugins/MyEntryOptionPlugin.js
@@ -1,0 +1,9 @@
+class MyEntryOptionPlugin {
+	apply(compiler) {
+		compiler.hooks.entryOption.tap("MyEntryOptionPlugin", (context, entry) => {
+			console.log(entry, context);
+		});
+	}
+}
+
+module.exports = MyEntryOptionPlugin;

--- a/packages/rspack/tests/cases/hooks/entryOption/plugins/MyEntryOptionPlugin.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/plugins/MyEntryOptionPlugin.js
@@ -1,9 +1,0 @@
-class MyEntryOptionPlugin {
-	apply(compiler) {
-		compiler.hooks.entryOption.tap("MyEntryOptionPlugin", (context, entry) => {
-			console.log(entry, context);
-		});
-	}
-}
-
-module.exports = MyEntryOptionPlugin;

--- a/packages/rspack/tests/cases/hooks/entryOption/src/answer.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/src/answer.js
@@ -1,0 +1,1 @@
+export const answer = 42;

--- a/packages/rspack/tests/cases/hooks/entryOption/src/index.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/src/index.js
@@ -1,0 +1,3 @@
+import { answer } from "./answer";
+
+console.log(`index: ${answer}`);

--- a/packages/rspack/tests/cases/hooks/entryOption/src/index.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/src/index.js
@@ -1,3 +1,4 @@
 import { answer } from "./answer";
-
-console.log(`index: ${answer}`);
+it("should compile successfully with entryOption", () => {
+	expect(answer).toBe(42);
+});

--- a/packages/rspack/tests/cases/hooks/entryOption/src/index2.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/src/index2.js
@@ -1,3 +1,4 @@
 import { answer } from "./answer";
-
-console.log(`index2: ${answer}`);
+it("should compile successfully with entryOption", () => {
+	expect(answer).toBe(42);
+});

--- a/packages/rspack/tests/cases/hooks/entryOption/src/index2.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/src/index2.js
@@ -1,0 +1,3 @@
+import { answer } from "./answer";
+
+console.log(`index2: ${answer}`);

--- a/packages/rspack/tests/cases/hooks/entryOption/webpack.config.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/webpack.config.js
@@ -1,5 +1,19 @@
+const assert = require("assert").strict;
+
+class MyEntryOptionPlugin {
+	apply(compiler) {
+		compiler.hooks.entryOption.tap("MyEntryOptionPlugin", (context, entry) => {
+			assert(context === config.context, "Context is not equal.");
+			assert.deepStrictEqual(
+				entry,
+				config.entry,
+				"Entry is not strictly equal."
+			);
+		});
+	}
+}
+
 /** @type {import('@rspack/cli').Configuration} */
-const MyEntryOptionPlugin = require("./plugins/MyEntryOptionPlugin");
 const config = {
 	context: __dirname,
 	mode: "development",

--- a/packages/rspack/tests/cases/hooks/entryOption/webpack.config.js
+++ b/packages/rspack/tests/cases/hooks/entryOption/webpack.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@rspack/cli').Configuration} */
+const MyEntryOptionPlugin = require("./plugins/MyEntryOptionPlugin");
+const config = {
+	context: __dirname,
+	mode: "development",
+	entry: {
+		main: "./src/index.js",
+		test: "./src/index2.js"
+	},
+	plugins: [new MyEntryOptionPlugin()]
+};
+module.exports = config;


### PR DESCRIPTION
## Related issue (if exists)

https://github.com/web-infra-dev/rspack/issues/3448

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5da3f4b</samp>

This pull request adds a new hook `entryOption` to the `Compiler` class in `./packages/rspack/src/compiler.ts` that allows plugins to customize the entry option for the compilation. It also adds a new test case in `./packages/rspack/tests/cases/hooks/entryOption` that demonstrates the usage of the hook with a custom plugin.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5da3f4b</samp>

*  Add a new `entryOption` hook to the `Compiler` class that allows plugins to modify or reject the entry option before the compilation starts ([link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR17), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdR141), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL239-R242), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL609-R613), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-f8cb4d24a4c7e2bccefde48c7cc6285ac03900bac4879f0b6cd40ead5608e393R91))
*  Add a new test case for the `entryOption` hook in the `./tests/cases/hooks/entryOption` folder ([link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-60b12f1c7be35a8c2be92349bc48f39c819c3cddf0a96d09ceafa06b3fe2ff14L1-R17), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-2a7b7b2fcd1407e5816086e8a2d7a6e3646bfcc4693b258ff3d6acc8f4ba4d46R1-R12))
   *  Add a new plugin that uses the `entryOption` hook to log the entry option and the context to the console in the `./tests/cases/hooks/entryOption/plugins` folder ([link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-376147482c96c35d44c2030f02f0906a3e80cff808b89b495173e260e0fa2183R1-R9))
   *  Add two entry points and a module that export and log the constant `answer` in the `./tests/cases/hooks/entryOption/src` folder ([link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-7d86742ec4e64111f7d6c161d5bf115a4be3c3503887b5a8b7abc2304398b62eR1), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-095f976d2c3ea0c015ed0829727f2345ecbd599c675494caafc529544b4a5bb3R1-R3), [link](https://github.com/web-infra-dev/rspack/pull/3499/files?diff=unified&w=0#diff-d57ae9b8007d3e7a74a1b91138c298b1b58f551e6a1ccf78935cfff1cb427899R1-R3))

</details>
