### PR TITLE
fix(deps): use `zod-validation-error@1.2.0` to support `node@^14.17`

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -70,6 +70,6 @@
     "watchpack": "^2.4.0",
     "webpack-sources": "3.2.3",
     "zod": "^3.21.4",
-    "zod-validation-error": "^1.3.0"
+    "zod-validation-error": "1.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,7 +856,7 @@ importers:
       webpack-dev-server: 4.13.1
       webpack-sources: 3.2.3
       zod: ^3.21.4
-      zod-validation-error: ^1.3.0
+      zod-validation-error: 1.2.0
     dependencies:
       '@rspack/binding': link:../../crates/node_binding
       '@rspack/dev-client': link:../rspack-dev-client
@@ -872,7 +872,7 @@ importers:
       watchpack: 2.4.0
       webpack-sources: 3.2.3
       zod: 3.21.4
-      zod-validation-error: 1.3.0_zod@3.21.4
+      zod-validation-error: 1.2.0_zod@3.21.4
     devDependencies:
       '@rspack/core': 'link:'
       '@rspack/plugin-minify': link:../rspack-plugin-minify
@@ -28148,9 +28148,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  /zod-validation-error/1.3.0_zod@3.21.4:
-    resolution: {integrity: sha512-4WoQnuWnj06kwKR4A+cykRxFmy+CTvwMQO5ogTXLiVx1AuvYYmMjixh7sbkSsQTr1Fvtss6d5kVz8PGeMPUQjQ==}
-    engines: {node: '>=16.0.0'}
+  /zod-validation-error/1.2.0_zod@3.21.4:
+    resolution: {integrity: sha512-laJkD/ugwEh8CpuH+xXv5L9Z+RLz3lH8alNxolfaHZJck611OJj97R4Rb+ZqA7WNly2kNtTo4QwjdjXw9scpiw==}
+    engines: {node: ^14.17 || >=16.0.0}
     peerDependencies:
       zod: ^3.18.0
     dependencies:


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

`zod-validation-error@1.3.0` doesn't support `node14`.

https://github.com/causaly/zod-validation-error/blob/8e8aa34d66bbe74614cf4bd6e13f97192bc39864/package.json#L38

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2954274</samp>

This pull request fixes a dependency issue with the `zod-validation-error` package by pinning it to version `1.2.0` in the `rspack` package and updating the `pnpm-lock.yaml` file accordingly. This ensures compatibility with the `zod` package and the Node version used by the project.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2954274</samp>

* Fix the version of `zod-validation-error` to `1.2.0` in `packages/rspack/package.json` and `pnpm-lock.yaml` to avoid a breaking change that requires Node 16 or higher ([link](https://github.com/web-infra-dev/rspack/pull/3510/files?diff=unified&w=0#diff-142a5c1a681bf6859bd9e53bbfe87fc9dd2d05e8350b0fb50bfcd652a9e36cbbL73-R73), [link](https://github.com/web-infra-dev/rspack/pull/3510/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL859-R859), [link](https://github.com/web-infra-dev/rspack/pull/3510/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL875-R875), [link](https://github.com/web-infra-dev/rspack/pull/3510/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL28151-R28153))
* Update the metadata of `zod-validation-error` in `pnpm-lock.yaml` to match the actual metadata of the `1.2.0` version, including the integrity hash, the engine requirement, and the peer dependency version range ([link](https://github.com/web-infra-dev/rspack/pull/3510/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL28151-R28153))

</details>
