### PR TITLE
chore: add nightly release on Tuesday

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -3,8 +3,8 @@ name: Release Nightly
 on:
   workflow_dispatch:
   schedule:
-    # 08:00 AM Beijing Time. Except Tuesday, which is for full release
-    - cron: "0 0 * * 0,1,3,4,5,6"
+    # 08:00 AM Beijing Time on everyday
+    - cron: "0 0 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
- trigger ecosystem-ci for Tuesday stable release (release-pull-request and release-nightly both scheduled at 08:00 AM Beijing Time)
- `"@rspack/cli": "nightly"` users can have a latest nightly release on Tuesday

TODO: comment the ecosystem-ci result on release PR

## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18993ed</samp>

Adjusted the cron schedule for the nightly release workflow in `.github/workflows/release-nightly.yml` to run every day. This reflects the change of the full release workflow to a separate repository.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18993ed</samp>

* Change the cron schedule for the nightly release workflow to run every day ([link](https://github.com/web-infra-dev/rspack/pull/3530/files?diff=unified&w=0#diff-e3889abd7e85ba6d5d9dec9274d72a1ce3314fe8169ec90742fecefb40dbe554L6-R7))

</details>
