### PR TITLE
feat(css): emit debug info in development mode

### DIFF
--- a/crates/rspack_core/src/options/mode.rs
+++ b/crates/rspack_core/src/options/mode.rs
@@ -5,6 +5,12 @@ pub enum Mode {
   None,
 }
 
+impl Mode {
+  pub fn is_development(&self) -> bool {
+    matches!(self, Mode::Development)
+  }
+}
+
 impl From<String> for Mode {
   fn from(value: String) -> Self {
     match value.as_ref() {

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -73,10 +73,12 @@ impl CssPlugin {
   fn render_module_debug_info(
     compilation: &Compilation,
     debug_info: &CssModuleDebugInfo,
-  ) -> (RawSource, RawSource) {
+  ) -> (ConcatSource, ConcatSource) {
+    let mut start = ConcatSource::default();
+    let mut end = ConcatSource::default();
     let is_dev = compilation.options.mode.is_development();
     if !is_dev {
-      return (RawSource::from(""), RawSource::from(""));
+      return (start, end);
     }
 
     let context = compilation.options.context.as_str();
@@ -89,20 +91,21 @@ impl CssPlugin {
       .lib_ident(LibIdentOptions { context })
       .unwrap_or("None".into());
 
-    let module = compilation
-      .module_graph
-      .module_by_identifier(debug_info.module_id)
-      .expect("should have a module");
-
-    let rendering_start = RawSource::from(format!(
-      "/* start {:?}\n- type: {}\n*/\n",
+    start.add(RawSource::from(format!(
+      "/* #region {:?} */\n",
       debug_module_id,
+    )));
+
+    start.add(RawSource::from(format!(
+      "/*\n- type: {}\n*/\n",
       module.module_type(),
-    ));
+    )));
 
-    let rendering_end = RawSource::from(format!("/* end {:?} */\n\n", debug_module_id));
+    end.add(RawSource::from(format!(
+      "/* #endregion {debug_module_id:?} */\n\n"
+    )));
 
-    (rendering_start, rendering_end)
+    (start, end)
   }
 }
 

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -6,11 +6,11 @@ use rayon::prelude::*;
 use rspack_core::rspack_sources::ReplaceSource;
 use rspack_core::{
   get_css_chunk_filename_template,
-  rspack_sources::{BoxSource, ConcatSource, MapOptions, RawSource, Source, SourceExt},
+  rspack_sources::{ConcatSource, MapOptions, RawSource, Source, SourceExt},
   Chunk, ChunkKind, ModuleType, ParserAndGenerator, PathData, Plugin, RenderManifestEntry,
   SourceType,
 };
-use rspack_core::{Compilation, ModuleIdentifier};
+use rspack_core::{Compilation, LibIdentOptions, ModuleIdentifier};
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 
@@ -18,6 +18,10 @@ use crate::parser_and_generator::CssParserAndGenerator;
 use crate::swc_css_compiler::{SwcCssSourceMapGenConfig, SWC_COMPILER};
 use crate::utils::AUTO_PUBLIC_PATH_PLACEHOLDER_REGEX;
 use crate::CssPlugin;
+
+struct CssModuleDebugInfo<'a> {
+  pub module_id: &'a ModuleIdentifier,
+}
 
 impl CssPlugin {
   fn render_chunk_to_source(
@@ -37,9 +41,9 @@ impl CssPlugin {
           .map(|result| result.ast_or_source.clone().try_into_source())
           .transpose();
 
-        module_source
+        module_source.map(|source| source.map(|source| (CssModuleDebugInfo { module_id }, source)))
       })
-      .collect::<Result<Vec<Option<BoxSource>>>>()?;
+      .collect::<Result<Vec<_>>>()?;
 
     let source = module_sources
       .into_par_iter()
@@ -47,17 +51,58 @@ impl CssPlugin {
       // Should we return a Error if there is a `None` in `module_sources`?
       // Webpack doesn't throw. It just do a best-effort checking https://github.com/webpack/webpack/blob/5e3c4d0ddf8ae6a6e45fea42be4e8950fe49c0bb/lib/css/CssModulesPlugin.js#L565-L568
       .flatten()
-      .fold(ConcatSource::default, |mut output, cur| {
-        output.add(cur);
-        output.add(RawSource::from("\n"));
-        output
-      })
+      .fold(
+        ConcatSource::default,
+        |mut acc, (debug_info, cur_source)| {
+          let (start, end) = Self::render_module_debug_info(compilation, &debug_info);
+          acc.add(start);
+          acc.add(cur_source);
+          acc.add(RawSource::from("\n"));
+          acc.add(end);
+          acc
+        },
+      )
       .reduce(ConcatSource::default, |mut acc, cur| {
         acc.add(cur);
         acc
       });
 
     Ok(source)
+  }
+
+  fn render_module_debug_info(
+    compilation: &Compilation,
+    debug_info: &CssModuleDebugInfo,
+  ) -> (RawSource, RawSource) {
+    let is_dev = compilation.options.mode.is_development();
+    if !is_dev {
+      return (RawSource::from(""), RawSource::from(""));
+    }
+
+    let context = compilation.options.context.as_str();
+    let module = compilation
+      .module_graph
+      .module_by_identifier(debug_info.module_id)
+      .expect("should have a module");
+
+    let debug_module_id = module
+      .lib_ident(LibIdentOptions { context })
+      .unwrap_or("None".into());
+
+    let module = compilation
+      .module_graph
+      .module_by_identifier(debug_info.module_id)
+      .expect("should have a module");
+
+    let rendering_start = RawSource::from(format!(
+      "/* start {:?}\n- type: {}\n*/\n",
+      debug_module_id,
+      module.module_type(),
+    ));
+
+    let rendering_end = RawSource::from(format!("/* end {:?} */\n\n", debug_module_id));
+
+    (rendering_start, rendering_end)
   }
 }
 

--- a/packages/rspack/tests/__snapshots__/case.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/case.test.ts.snap
@@ -1,27 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cases exported tests data imports 1`] = `
-".red {
+"/* start "data:text/css,.red{color: red;}"
+- type: css
+*/
+.red {
   color: red;
 }
+/* end "data:text/css,.red{color: red;}" */
+
+/* start "data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ=="
+- type: css
+*/
 .b {
   color: green;
 }
+/* end "data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ==" */
+
+/* start "./a.css"
+- type: css
+*/
 .a {
   color: palegreen;
 }
 ;;;
 
+/* end "./a.css" */
+
+/* start "./bad-base64.css"
+- type: css
+*/
 .bad {
   a: url("data:text/bad-base64;base64,abcd?#iefix");
   b: url("data:text/bad-base64;base64,    abcd?#iefix");
 }
+/* end "./bad-base64.css" */
+
+/* start "./index.css"
+- type: css
+*/
 .class {
   a: url("82ee8285df64be76.svg");
   b: url("82ee8285df64be76.svg");
   c: url("82ee8285df64be76");
   d: url("82ee8285df64be76");
 }
+/* end "./index.css" */
+
 "
 `;
 

--- a/packages/rspack/tests/__snapshots__/case.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/case.test.ts.snap
@@ -1,23 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`cases exported tests data imports 1`] = `
-"/* start "data:text/css,.red{color: red;}"
+"/* #region "data:text/css,.red{color: red;}" */
+/*
 - type: css
 */
 .red {
   color: red;
 }
-/* end "data:text/css,.red{color: red;}" */
+/* #endregion "data:text/css,.red{color: red;}" */
 
-/* start "data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ=="
+/* #region "data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ==" */
+/*
 - type: css
 */
 .b {
   color: green;
 }
-/* end "data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ==" */
+/* #endregion "data:text/css;base64,LmJ7Y29sb3I6IGdyZWVufQ==" */
 
-/* start "./a.css"
+/* #region "./a.css" */
+/*
 - type: css
 */
 .a {
@@ -25,18 +28,20 @@ exports[`cases exported tests data imports 1`] = `
 }
 ;;;
 
-/* end "./a.css" */
+/* #endregion "./a.css" */
 
-/* start "./bad-base64.css"
+/* #region "./bad-base64.css" */
+/*
 - type: css
 */
 .bad {
   a: url("data:text/bad-base64;base64,abcd?#iefix");
   b: url("data:text/bad-base64;base64,    abcd?#iefix");
 }
-/* end "./bad-base64.css" */
+/* #endregion "./bad-base64.css" */
 
-/* start "./index.css"
+/* #region "./index.css" */
+/*
 - type: css
 */
 .class {
@@ -45,7 +50,7 @@ exports[`cases exported tests data imports 1`] = `
   c: url("82ee8285df64be76");
   d: url("82ee8285df64be76");
 }
-/* end "./index.css" */
+/* #endregion "./index.css" */
 
 "
 `;


### PR DESCRIPTION
## Related issue (if exists)

Closes #3327

<!--- Provide link of related issues -->

## Summary

before
```css
.ae {
  background: green;
}
.aa {
  background: green;
}
.ab {
  background: green;
}
.ac {
  background: green;
}
.ad {
  background: green;
}
body {
  background: red;
}
.ba {
  background: green;
}
.bb {
  background: green;
}
body {
  background: yellow;
}
```

after
```css
/* #region "./ae.css" */
/*
- type: css
*/
.ae {
  background: green;
}
/* #endregion "./ae.css" */

/* #region "./aa.css" */
/*
- type: css
*/
.aa {
  background: green;
}
/* #endregion "./aa.css" */

/* #region "./ab.css" */
/*
- type: css
*/
.ab {
  background: green;
}
/* #endregion "./ab.css" */

/* #region "./ac.css" */
/*
- type: css
*/
.ac {
  background: green;
}
/* #endregion "./ac.css" */

/* #region "./ad.css" */
/*
- type: css
*/
.ad {
  background: green;
}
/* #endregion "./ad.css" */

/* #region "./a.css" */
/*
- type: css
*/
body {
  background: red;
}
/* #endregion "./a.css" */

/* #region "./ba.css" */
/*
- type: css
*/
.ba {
  background: green;
}
/* #endregion "./ba.css" */

/* #region "./bb.css" */
/*
- type: css
*/
.bb {
  background: green;
}
/* #endregion "./bb.css" */

/* #region "./b.css" */
/*
- type: css
*/
body {
  background: yellow;
}
/* #endregion "./b.css" */
```

Support [folding](https://github.com/microsoft/vscode/issues/46591)

![image](https://github.com/web-infra-dev/rspack/assets/49502170/56a825a9-b070-4e19-9d77-d866ddbe161e)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 531345f</samp>

This pull request adds a feature to the `rspack_plugin_css` crate that enables debug comments in the CSS output in development mode. It also adds a convenience method `is_development` to the `Mode` enum in the `rspack_core` crate. These changes can help with debugging and tracing the CSS generation process.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 531345f</samp>

* Add a convenience method `is_development` to the `Mode` enum ([link](https://github.com/web-infra-dev/rspack/pull/3531/files?diff=unified&w=0#diff-32372e9e19bf1bc1d1ee67a99d5de26687f2dfca980fd312cd842a418e805669R8-R13))
* Refactor and clean up the imports in `impl_plugin_for_css_plugin.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3531/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L9-R13))
* Introduce a new struct `CssModuleDebugInfo` to store module identifiers for debugging ([link](https://github.com/web-infra-dev/rspack/pull/3531/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749R22-R25))
* Pass the `CssModuleDebugInfo` along with the module sources to the rendering process ([link](https://github.com/web-infra-dev/rspack/pull/3531/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L40-R46))
* Render debug comments before and after each module source in development mode using the `CssModuleDebugInfo` ([link](https://github.com/web-infra-dev/rspack/pull/3531/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L50-R64), [link](https://github.com/web-infra-dev/rspack/pull/3531/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749R72-R106))

</details>
