### PR TITLE
fix(css): should skip when `last_module == selected_module` and align more with Webpack

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -179,12 +179,12 @@ impl ChunkGraph {
     modules
   }
 
-  pub fn get_chunk_modules_iterable_by_source_type<'module, 'me: 'module>(
+  pub fn get_chunk_modules_iterable_by_source_type<'module_graph: 'me, 'me>(
     &'me self,
     chunk: &ChunkUkey,
     source_type: SourceType,
-    module_graph: &'module ModuleGraph,
-  ) -> impl Iterator<Item = &'module dyn Module> + 'module {
+    module_graph: &'module_graph ModuleGraph,
+  ) -> impl Iterator<Item = &'module_graph dyn Module> + 'me {
     let chunk_graph_chunk = self.get_chunk_graph_chunk(chunk);
     chunk_graph_chunk
       .modules

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -30,7 +30,7 @@ impl CssPlugin {
     ordered_css_modules: &[&dyn Module],
   ) -> rspack_error::Result<ConcatSource> {
     let module_sources = ordered_css_modules
-      .into_iter()
+      .iter()
       .map(|module| {
         let module_id = &module.identifier();
         let code_gen_result = compilation

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -7,10 +7,10 @@ use rspack_core::rspack_sources::ReplaceSource;
 use rspack_core::{
   get_css_chunk_filename_template,
   rspack_sources::{ConcatSource, MapOptions, RawSource, Source, SourceExt},
-  Chunk, ChunkKind, ModuleType, ParserAndGenerator, PathData, Plugin, RenderManifestEntry,
+  Chunk, ChunkKind, Module, ModuleType, ParserAndGenerator, PathData, Plugin, RenderManifestEntry,
   SourceType,
 };
-use rspack_core::{Compilation, LibIdentOptions, ModuleIdentifier};
+use rspack_core::{Compilation, LibIdentOptions};
 use rspack_error::Result;
 use rspack_hash::RspackHash;
 
@@ -20,18 +20,19 @@ use crate::utils::AUTO_PUBLIC_PATH_PLACEHOLDER_REGEX;
 use crate::CssPlugin;
 
 struct CssModuleDebugInfo<'a> {
-  pub module_id: &'a ModuleIdentifier,
+  pub module: &'a dyn Module,
 }
 
 impl CssPlugin {
   fn render_chunk_to_source(
     compilation: &Compilation,
     chunk: &Chunk,
-    ordered_css_modules: &[ModuleIdentifier],
+    ordered_css_modules: &[&dyn Module],
   ) -> rspack_error::Result<ConcatSource> {
     let module_sources = ordered_css_modules
-      .iter()
-      .map(|module_id| {
+      .into_iter()
+      .map(|module| {
+        let module_id = &module.identifier();
         let code_gen_result = compilation
           .code_generation_results
           .get(module_id, Some(&chunk.runtime))?;
@@ -41,7 +42,8 @@ impl CssPlugin {
           .map(|result| result.ast_or_source.clone().try_into_source())
           .transpose();
 
-        module_source.map(|source| source.map(|source| (CssModuleDebugInfo { module_id }, source)))
+        module_source
+          .map(|source| source.map(|source| (CssModuleDebugInfo { module: *module }, source)))
       })
       .collect::<Result<Vec<_>>>()?;
 
@@ -82,10 +84,7 @@ impl CssPlugin {
     }
 
     let context = compilation.options.context.as_str();
-    let module = compilation
-      .module_graph
-      .module_by_identifier(debug_info.module_id)
-      .expect("should have a module");
+    let module = debug_info.module;
 
     let debug_module_id = module
       .lib_ident(LibIdentOptions { context })
@@ -155,12 +154,12 @@ impl Plugin for CssPlugin {
 
     ordered_modules
       .iter()
-      .map(|mgm| {
+      .map(|m| {
         (
           compilation
             .code_generation_results
-            .get_hash(mgm, Some(&chunk.runtime)),
-          compilation.chunk_graph.get_module_id(*mgm),
+            .get_hash(&m.identifier(), Some(&chunk.runtime)),
+          compilation.chunk_graph.get_module_id(m.identifier()),
         )
       })
       .for_each(|(current, id)| {

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -117,12 +117,12 @@ impl CssPlugin {
     Self { config }
   }
 
-  pub(crate) fn get_ordered_chunk_css_modules<'module_graph, 'chunk_graph>(
+  pub(crate) fn get_ordered_chunk_css_modules<'chunk_graph>(
     chunk: &Chunk,
     chunk_graph: &'chunk_graph ChunkGraph,
-    module_graph: &'module_graph ModuleGraph,
+    module_graph: &'chunk_graph ModuleGraph,
     compilation: &Compilation,
-  ) -> Vec<&'module_graph dyn Module> {
+  ) -> Vec<&'chunk_graph dyn Module> {
     // Align with https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/css/CssModulesPlugin.js#L368
     let mut css_modules = chunk_graph
       .get_chunk_modules_iterable_by_source_type(&chunk.ukey, SourceType::Css, module_graph)

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -1,16 +1,15 @@
 #![allow(clippy::comparison_chain)]
 mod impl_plugin_for_css_plugin;
-use std::cmp;
+use std::cmp::{self, Reverse};
 use std::hash::Hash;
 use std::str::FromStr;
 
 use anyhow::bail;
 use bitflags::bitflags;
-use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use rspack_core::Filename;
 use rspack_core::{Chunk, ChunkGraph, Compilation, Module, ModuleGraph, PathData, SourceType};
-use rspack_core::{Filename, ModuleIdentifier};
 use rspack_identifier::IdentifierSet;
 
 use crate::pxtorem::options::PxToRemOptions;
@@ -118,76 +117,85 @@ impl CssPlugin {
     Self { config }
   }
 
-  pub(crate) fn get_ordered_chunk_css_modules<'module>(
+  pub(crate) fn get_ordered_chunk_css_modules<'module_graph, 'chunk_graph>(
     chunk: &Chunk,
-    chunk_graph: &'module ChunkGraph,
-    module_graph: &'module ModuleGraph,
+    chunk_graph: &'chunk_graph ChunkGraph,
+    module_graph: &'module_graph ModuleGraph,
     compilation: &Compilation,
-  ) -> Vec<ModuleIdentifier> {
+  ) -> Vec<&'module_graph dyn Module> {
     // Align with https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/css/CssModulesPlugin.js#L368
     let mut css_modules = chunk_graph
       .get_chunk_modules_iterable_by_source_type(&chunk.ukey, SourceType::Css, module_graph)
       .collect::<Vec<_>>();
     css_modules.sort_unstable_by_key(|module| module.identifier());
 
-    let css_modules: Vec<ModuleIdentifier> =
-      Self::get_modules_in_order(chunk, css_modules, compilation);
+    let css_modules = Self::get_modules_in_order(chunk, css_modules, compilation);
 
     css_modules
   }
 
-  pub(crate) fn get_modules_in_order(
+  pub(crate) fn get_modules_in_order<'module>(
     chunk: &Chunk,
-    modules: Vec<&dyn Module>,
+    modules: Vec<&'module dyn Module>,
     compilation: &Compilation,
-  ) -> Vec<ModuleIdentifier> {
+  ) -> Vec<&'module dyn Module> {
     // Align with https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/css/CssModulesPlugin.js#L269
     if modules.is_empty() {
       return vec![];
     };
 
-    let modules_list = modules.into_iter().map(|m| m.identifier()).collect_vec();
+    let modules_list = modules.clone();
 
     // Get ordered list of modules per chunk group
-    // Lists are in reverse order to allow to use Array.pop()
+
     let mut modules_by_chunk_group = chunk
       .groups
       .iter()
-      .filter_map(|ukey| compilation.chunk_group_by_ukey.get(ukey))
+      .map(|group| group.as_ref(&compilation.chunk_group_by_ukey))
       .map(|chunk_group| {
-        let sorted_modules = modules_list
+        let mut indexed_modules = modules_list
           .clone()
           .into_iter()
-          .filter_map(|module_id| {
-            let order = chunk_group.module_post_order_index(&module_id);
-            order.map(|order| (module_id, order))
+          .filter_map(|module| {
+            // ->: import
+            // For A -> B -> C, the pre order is A: 0, B: 1, C: 2.
+            // The post order is A: 2, B: 1, C: 0.
+            chunk_group
+              .module_post_order_index(&module.identifier())
+              .map(|index| (index, module))
           })
-          .sorted_by(|a, b| {
-            if b.1 > a.1 {
-              std::cmp::Ordering::Less
-            } else if b.1 < a.1 {
-              std::cmp::Ordering::Greater
-            } else {
-              std::cmp::Ordering::Equal
-            }
-          })
-          .map(|item| item.0)
-          .collect_vec();
+          .collect::<Vec<_>>();
+
+        // After sort, we get a list [A, B, C].
+        // Lists are in reverse order to allow to use `.pop()`
+        let sorted_modules = {
+          indexed_modules.sort_by_key(|item| Reverse(item.0));
+          indexed_modules
+            .into_iter()
+            .map(|item| item.1)
+            .collect::<Vec<_>>()
+        };
 
         SortedModules {
-          set: sorted_modules.clone().into_iter().collect(),
+          set: sorted_modules.iter().map(|m| m.identifier()).collect(),
           list: sorted_modules,
         }
       })
       .collect::<Vec<_>>();
 
     if modules_by_chunk_group.len() == 1 {
-      return modules_by_chunk_group[0].list.clone();
+      let mut ret = modules_by_chunk_group
+        .into_iter()
+        .next()
+        .expect("must have one")
+        .list;
+      ret.reverse();
+      return ret;
     };
 
     modules_by_chunk_group.sort_unstable_by(compare_module_lists);
 
-    let mut final_modules: Vec<ModuleIdentifier> = vec![];
+    let mut final_modules: Vec<&'module dyn Module> = vec![];
 
     loop {
       let mut failed_modules: IdentifierSet = Default::default();
@@ -204,14 +212,14 @@ impl CssPlugin {
             continue;
           }
           let last_module = *list.last().expect("TODO:");
-          if last_module != selected_module {
+          if last_module == selected_module {
             continue;
           }
-          if !set.contains(&selected_module) {
+          if !set.contains(&selected_module.identifier()) {
             continue;
           }
-          failed_modules.insert(selected_module);
-          if failed_modules.contains(&last_module) {
+          failed_modules.insert(selected_module.identifier());
+          if failed_modules.contains(&last_module.identifier()) {
             // There is a conflict, try other alternatives
             has_failed = Some(last_module);
             continue;
@@ -250,8 +258,8 @@ impl CssPlugin {
         let last_module = list.last();
         if last_module.map_or(false, |last_module| last_module == &selected_module) {
           list.pop();
-          set.remove(&selected_module);
-        } else if has_failed.is_some() && set.contains(&selected_module) {
+          set.remove(&selected_module.identifier());
+        } else if has_failed.is_some() && set.contains(&selected_module.identifier()) {
           let idx = list.iter().position(|m| m == &selected_module);
           if let Some(idx) = idx {
             list.remove(idx);
@@ -265,8 +273,8 @@ impl CssPlugin {
   }
 }
 
-struct SortedModules {
-  pub list: Vec<ModuleIdentifier>,
+struct SortedModules<'module> {
+  pub list: Vec<&'module dyn Module>,
   pub set: IdentifierSet,
 }
 
@@ -282,7 +290,10 @@ fn compare_module_lists(a: &SortedModules, b: &SortedModules) -> cmp::Ordering {
   } else if b.is_empty() {
     cmp::Ordering::Less
   } else {
-    compare_modules_by_identifier(a.last().expect("TODO:"), b.last().expect("TODO:"))
+    compare_modules_by_identifier(
+      &a.last().expect("Must have a module").identifier(),
+      &b.last().expect("Must have a module").identifier(),
+    )
   }
 }
 


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f166528</samp>

This pull request refactors the `rspack_plugin_css` crate to use references to `dyn Module` for better performance and readability, and fixes a bug in the module ordering logic. It also improves the lifetime parameter of a function in the `rspack_core` crate for consistency.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f166528</samp>

*  Update the lifetime parameters of `get_chunk_modules_iterable_by_source_type` and `get_ordered_chunk_css_modules` to use `'module_graph` and `'chunk_graph` respectively, to avoid conflicts and be consistent with other functions ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-1e0eaa9697d538fa03d275db44b65e1238a0f197f6ca3748b790e8f4e48af81cL182-R187), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L121-R125))
*  Change the argument and return types of `get_chunk_css_source`, `get_modules_in_order`, and `get_ordered_chunk_css_modules` to use references to `dyn Module` instead of `ModuleIdentifier`, to access more information about the modules without looking them up again ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L30-R35), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L121-R125), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L133-R141))
*  Change the `CssModuleDebugInfo` struct to store a reference to `dyn Module` instead of `ModuleIdentifier`, and update the related functions to use the `module` field instead of the `module_id` field ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L23-R23), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L44-R46), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L85-R87), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L158-R162))
*  Use the `identifier` method to get the module identifier from the reference to `dyn Module` wherever needed, instead of using the `ModuleIdentifier` directly ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L30-R35), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L158-R162), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L149-R180), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L207-R222), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L253-R262), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L285-R296))
*  Fix a logical error in the `get_modules_in_order` function, where the original code checked if the last module was equal to the selected module, instead of checking if they were different ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L207-R222))
*  Reverse the order of the sorted modules list in the `get_modules_in_order` and `get_ordered_chunk_css_modules` functions, since the original code used `pop` to get the modules in the desired order, while the new code uses `next` to iterate over the modules in the desired order ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L149-R180), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L185-R198))
*  Clone the list instead of the iterator in the `get_ordered_chunk_css_modules` function, since the iterator is consumed by the `next` method ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L185-R198))
*  Add the import of `Reverse` in `crates/rspack_plugin_css/src/plugin/mod.rs`, which is a wrapper type that reverses the ordering of a value, and is used in the `get_modules_in_order` function to sort the modules by their post-order index ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L3-R3))
*  Remove the unused imports of `ModuleIdentifier` and `Filename` and add the import of `Module` in `crates/rspack_plugin_css/src/plugin/mod.rs` and `crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs`, which is the trait that defines the common interface for different types of modules in the module graph ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L10-R13), [link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L9-R12))
*  Update the `SortedModules` struct to use a lifetime parameter and store a vector of references to `dyn Module` instead of `ModuleIdentifier`, to be consistent with the previous changes ([link](https://github.com/web-infra-dev/rspack/pull/3535/files?diff=unified&w=0#diff-2d1fa350910d0b1761e03780986070250dab9983fad54d36abfcae174a1392b6L268-R277))

</details>
