### PR TITLE
perf: compilation.*Dependencies cache results and merge call

### DIFF
--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -587,33 +587,25 @@ export class Compilation {
 		);
 	}
 
-	get fileDependencies() {
-		return createFakeCompilationDependencies(
-			this.#inner.getFileDependencies(),
-			d => this.#inner.addFileDependencies(d)
-		);
-	}
+	fileDependencies = createFakeCompilationDependencies(
+		() => this.#inner.getFileDependencies(),
+		d => this.#inner.addFileDependencies(d)
+	);
 
-	get contextDependencies() {
-		return createFakeCompilationDependencies(
-			this.#inner.getContextDependencies(),
-			d => this.#inner.addContextDependencies(d)
-		);
-	}
+	contextDependencies = createFakeCompilationDependencies(
+		() => this.#inner.getContextDependencies(),
+		d => this.#inner.addContextDependencies(d)
+	);
 
-	get missingDependencies() {
-		return createFakeCompilationDependencies(
-			this.#inner.getMissingDependencies(),
-			d => this.#inner.addMissingDependencies(d)
-		);
-	}
+	missingDependencies = createFakeCompilationDependencies(
+		() => this.#inner.getMissingDependencies(),
+		d => this.#inner.addMissingDependencies(d)
+	);
 
-	get buildDependencies() {
-		return createFakeCompilationDependencies(
-			this.#inner.getBuildDependencies(),
-			d => this.#inner.addBuildDependencies(d)
-		);
-	}
+	buildDependencies = createFakeCompilationDependencies(
+		() => this.#inner.getBuildDependencies(),
+		d => this.#inner.addBuildDependencies(d)
+	);
 
 	get modules() {
 		return this.getModules().map(item => {
@@ -719,7 +711,7 @@ export class Compilation {
 		);
 	}
 
-	_rebuildModule = new MergeCaller(
+	_rebuildModuleCaller = new MergeCaller(
 		(args: Array<[string, (err: any, m: JsModule) => void]>) => {
 			this.#inner.rebuildModule(
 				args.map(item => item[0]),
@@ -738,7 +730,7 @@ export class Compilation {
 		10
 	);
 	rebuildModule(m: JsModule, f: (err: any, m: JsModule) => void) {
-		this._rebuildModule.run(m.moduleIdentifier, f);
+		this._rebuildModuleCaller.push([m.moduleIdentifier, f]);
 	}
 
 	/**

--- a/packages/rspack/src/util/MergeCaller.ts
+++ b/packages/rspack/src/util/MergeCaller.ts
@@ -1,13 +1,13 @@
-type CallFn<A, C> = (args: Array<[A, C]>) => void;
+type CallFn<D> = (args: D[]) => void;
 
-export default class MergeCaller<A, C> {
+export default class MergeCaller<D> {
 	private timer: any = null;
-	private callArgs: Array<[A, C]> = [];
+	private callArgs: D[] = [];
 
 	// add in constructor
 	private debounceTime: number;
-	private callFn: CallFn<A, C>;
-	constructor(fn: CallFn<A, C>, debounceTime: number) {
+	private callFn: CallFn<D>;
+	constructor(fn: CallFn<D>, debounceTime: number) {
 		this.debounceTime = debounceTime;
 		this.callFn = fn;
 	}
@@ -19,12 +19,12 @@ export default class MergeCaller<A, C> {
 		this.callFn(args);
 	};
 
-	run(a: A, c: C) {
+	push(...data: D[]) {
 		if (this.timer) {
 			clearTimeout(this.timer);
 		}
 
-		this.callArgs.push([a, c]);
+		this.callArgs.push(...data);
 
 		this.timer = setTimeout(this.finalCall, this.debounceTime);
 	}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 03d1e39</samp>

This pull request enhances the `Compilation` class and the fake dependency handling in `./packages/rspack/src/compilation.ts` and `./packages/rspack/src/util/fake.ts`, using a new `MergeCaller` class in `./packages/rspack/src/util/MergeCaller.ts`. These changes aim to improve the readability, efficiency, and reliability of the code.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 03d1e39</samp>

*  Refactor getters for compilation dependencies to use properties ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L590-R608))
* Rename `_rebuildModule` to `_rebuildModuleCaller` and use `push` method instead of `run` ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L722-R714), [link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L741-R733))
* Simplify generic type parameters of `MergeCaller` class from A and C to D ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-fef30bd1edec307b94c826695db42b6b34819609831f4cf93fc1bd8f340b87daL1-R10))
* Rename `run` method of `MergeCaller` class to `push` and accept variable number of arguments ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-fef30bd1edec307b94c826695db42b6b34819609831f4cf93fc1bd8f340b87daL22-R27))
* Modify `createFakeCompilationDependencies` function to accept getter function and create new `MergeCaller` instance ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-b17bba052e5129a417e2fb4be7a9651ba7fc97609d003f1b6b4bacbcecc0602cL44-R51))
* Update `has`, `add`, and `addAll` methods of fake dependency object to use getter function and `addDepsCaller` property ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-b17bba052e5129a417e2fb4be7a9651ba7fc97609d003f1b6b4bacbcecc0602cL54-R63))
* Add import statement for `MergeCaller` class in `fake.ts` file ([link](https://github.com/web-infra-dev/rspack/pull/3536/files?diff=unified&w=0#diff-b17bba052e5129a417e2fb4be7a9651ba7fc97609d003f1b6b4bacbcecc0602cR3))

</details>
