### PR TITLE
fix: 🐛 ignore github ID for typos check

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -9,7 +9,6 @@ extend-exclude = [
   "webpack-test",
   "./examples",
   "**/CHANGELOG.md",
-  "**/CHANGELOG.md",
   "pnpm-lock.yaml",
 ]
 

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,10 +9,6 @@ extend-exclude = [
   "webpack-test",
   "./examples",
   "**/CHANGELOG.md",
+  "GOVERNANCE.md",
   "pnpm-lock.yaml",
 ]
-
-
-[default.extend-identifiers]
-# *sigh* this just isn't worth the cost of fixing
-JSerFeng = "JSerFeng"

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,5 +9,11 @@ extend-exclude = [
   "webpack-test",
   "./examples",
   "**/CHANGELOG.md",
+  "**/CHANGELOG.md",
   "pnpm-lock.yaml",
 ]
+
+
+[default.extend-identifiers]
+# *sigh* this just isn't worth the cost of fixing
+JSerFeng = "JSerFeng"


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b05da09</samp>

Fix `.typos.toml` configuration and add custom spelling for `JSerFeng`. This change improves the accuracy and consistency of the `typos` tool for checking spelling errors in the codebase.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b05da09</samp>

*  Add a new section `default.extend-identifiers` to the `.typos.toml` file to customize the spelling of certain identifiers that are not recognized by the `typos` tool ([link](https://github.com/web-infra-dev/rspack/pull/3540/files?diff=unified&w=0#diff-f4eaaba6f80f920c13375550e7c86add0532f1cbc10516f037a8edd8bdf7cce7L12-R19))
* Remove the duplicate entry for `**/CHANGELOG.md` from the `default.exclude` array in the `.typos.toml` file, as it is already specified in the previous line ([link](https://github.com/web-infra-dev/rspack/pull/3540/files?diff=unified&w=0#diff-f4eaaba6f80f920c13375550e7c86add0532f1cbc10516f037a8edd8bdf7cce7L12-R19))

</details>
