### PR TITLE
test: 💍 support test.filter.js return string

### DIFF
--- a/webpack-test/lib/util/filterUtil.js
+++ b/webpack-test/lib/util/filterUtil.js
@@ -5,6 +5,9 @@ function getNormalizedFilterName(flag, testName) {
 		case -1:
 			return `WillNotSupport${testName}`;
 		default:
+			if (typeof flag === 'string') {
+				return flag
+			}
 			return "";
 	}
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f46bba</samp>

Fix filterUtil to accept string flags as custom filter names. This allows using `webpack-test` with filters that are not predefined in `filterUtil.js`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f46bba</samp>

* Return the flag as the normalized filter name if it is a string ([link](https://github.com/web-infra-dev/rspack/pull/3541/files?diff=unified&w=0#diff-587632e3a808a5f82f84af50bd84270407ded04d9c9b5094e00dd13657637278R8-R10))

</details>
