### PR TITLE
fix: do not expose non-webpack node interfaces

### DIFF
--- a/packages/rspack/src/compilation.ts
+++ b/packages/rspack/src/compilation.ts
@@ -611,9 +611,10 @@ export class Compilation {
 	);
 
 	get modules() {
-		return this.getModules().map(item => normalizeJsModule(item));
+		return this.__internal__getModules().map(item => normalizeJsModule(item));
 	}
 
+	// FIXME: This is not aligned with Webpack.
 	get chunks() {
 		var stats = this.getStats().toJson({
 			all: false,
@@ -642,7 +643,7 @@ export class Compilation {
 	 * @internal
 	 */
 	__internal__getAssociatedModules(chunk: JsStatsChunk): any[] | undefined {
-		let modules = this.getModules();
+		let modules = this.__internal__getModules();
 		let moduleMap: Map<string, JsModule> = new Map();
 		for (let module of modules) {
 			moduleMap.set(module.moduleIdentifier, module);
@@ -682,10 +683,23 @@ export class Compilation {
 		return modules.get(identifier);
 	}
 
-	getModules(): JsModule[] {
+	/**
+	 *
+	 * Note: This is not a webpack public API, maybe removed in future.
+	 *
+	 * @internal
+	 */
+	__internal__getModules(): JsModule[] {
 		return this.#inner.getModules();
 	}
-	getChunks(): JsChunk[] {
+
+	/**
+	 *
+	 * Note: This is not a webpack public API, maybe removed in future.
+	 *
+	 * @internal
+	 */
+	__internal__getChunks(): JsChunk[] {
 		return this.#inner.getChunks();
 	}
 

--- a/packages/rspack/src/compiler.ts
+++ b/packages/rspack/src/compiler.ts
@@ -717,14 +717,14 @@ class Compiler {
 
 	async #optimizeChunkModules() {
 		await this.compilation.hooks.optimizeChunkModules.promise(
-			this.compilation.getChunks(),
-			this.compilation.getModules()
+			this.compilation.__internal__getChunks(),
+			this.compilation.modules
 		);
 		this.#updateDisabledHooks();
 	}
 	async #optimizeModules() {
 		await this.compilation.hooks.optimizeModules.promise(
-			this.compilation.getModules()
+			this.compilation.modules
 		);
 		this.#updateDisabledHooks();
 	}
@@ -736,7 +736,7 @@ class Compiler {
 
 	async #finishModules() {
 		await this.compilation.hooks.finishModules.promise(
-			this.compilation.getModules()
+			this.compilation.modules
 		);
 		this.#updateDisabledHooks();
 	}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 02f0a57</samp>

Refactored the `Compilation` and `Compiler` classes in `rspack` to improve performance and clarity. Marked some internal methods as `@internal` to avoid confusion with webpack APIs.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 02f0a57</samp>

*  Rename and annotate internal methods of `Compilation` class to avoid confusion with webpack public APIs ([link](https://github.com/web-infra-dev/rspack/pull/3542/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L614-R617), [link](https://github.com/web-infra-dev/rspack/pull/3542/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L645-R646), [link](https://github.com/web-infra-dev/rspack/pull/3542/files?diff=unified&w=0#diff-007fbe3e2cbba14328e3a87deaa9b6557a2d94e268cc07795c9a235a5b0575a1L685-R702))
*  Update `Compiler` class methods to use the new internal methods of `Compilation` class ([link](https://github.com/web-infra-dev/rspack/pull/3542/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL720-R721), [link](https://github.com/web-infra-dev/rspack/pull/3542/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL727-R727), [link](https://github.com/web-infra-dev/rspack/pull/3542/files?diff=unified&w=0#diff-65c9f2211aa3417321f820555fd1ec4a9647fdc6cba3c80c2b96587a4d4ad4fdL739-R739))

</details>
