### PR TITLE
refactor: EntryOptions and EntryPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ dependencies = [
  "rspack_plugin_css",
  "rspack_plugin_dev_friendly_split_chunks",
  "rspack_plugin_devtool",
+ "rspack_plugin_entry",
  "rspack_plugin_externals",
  "rspack_plugin_html",
  "rspack_plugin_javascript",
@@ -2615,6 +2616,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rspack_plugin_entry"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "rspack_core",
+ "rspack_error",
+ "rspack_util",
+ "rustc-hash",
+]
+
+[[package]]
 name = "rspack_plugin_externals"
 version = "0.1.0"
 dependencies = [
@@ -2876,6 +2888,7 @@ dependencies = [
  "rspack_plugin_css",
  "rspack_plugin_dev_friendly_split_chunks",
  "rspack_plugin_devtool",
+ "rspack_plugin_entry",
  "rspack_plugin_externals",
  "rspack_plugin_html",
  "rspack_plugin_javascript",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -534,9 +534,11 @@ export interface RawDevServer {
   hot: boolean
 }
 
-export interface RawEntryItem {
+export interface RawEntryDescription {
   import: Array<string>
   runtime?: string
+  chunkLoading?: string
+  publicPath?: string
 }
 
 export interface RawExperiments {
@@ -725,7 +727,7 @@ export interface RawOptimizationOptions {
 }
 
 export interface RawOptions {
-  entry: Record<string, RawEntryItem>
+  entry: Record<string, RawEntryDescription>
   /**
    * Using this Vector to track the original order of user land entry configuration
    * std::collection::HashMap does not guarantee the insertion order, for more details you could refer
@@ -776,8 +778,8 @@ export interface RawOutputOptions {
   importFunctionName: string
   iife: boolean
   module: boolean
-  chunkFormat?: string
-  chunkLoading?: string
+  chunkFormat: string
+  chunkLoading: string
   enabledChunkLoadingTypes?: Array<string>
   trustedTypes?: RawTrustedTypes
   sourceMapFilename: string

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -130,7 +130,8 @@ impl rspack_core::Plugin for JsHooksAdapter {
   async fn make(
     &self,
     _ctx: rspack_core::PluginContext,
-    _compilation: &rspack_core::Compilation,
+    _compilation: &mut rspack_core::Compilation,
+    _param: &mut rspack_core::MakeParam,
   ) -> rspack_core::PluginMakeHookOutput {
     if self.is_hook_disabled(&Hook::Make) {
       return Ok(());

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -20,6 +20,7 @@ rspack_plugin_copy                      = { path = "../rspack_plugin_copy" }
 rspack_plugin_css                       = { path = "../rspack_plugin_css" }
 rspack_plugin_dev_friendly_split_chunks = { path = "../rspack_plugin_dev_friendly_split_chunks" }
 rspack_plugin_devtool                   = { path = "../rspack_plugin_devtool" }
+rspack_plugin_entry                     = { path = "../rspack_plugin_entry" }
 rspack_plugin_externals                 = { path = "../rspack_plugin_externals" }
 rspack_plugin_html                      = { path = "../rspack_plugin_html" }
 rspack_plugin_javascript                = { path = "../rspack_plugin_javascript" }

--- a/crates/rspack_binding_options/src/options/raw_entry.rs
+++ b/crates/rspack_binding_options/src/options/raw_entry.rs
@@ -1,20 +1,12 @@
 use napi_derive::napi;
-use rspack_core::EntryItem;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
-#[derive(Deserialize, Debug, Serialize)]
+#[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
-pub struct RawEntryItem {
+pub struct RawEntryDescription {
   pub import: Vec<String>,
   pub runtime: Option<String>,
-}
-
-impl From<RawEntryItem> for EntryItem {
-  fn from(value: RawEntryItem) -> Self {
-    Self {
-      import: value.import,
-      runtime: value.runtime,
-    }
-  }
+  pub chunk_loading: Option<String>,
+  pub public_path: Option<String>,
 }

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -1,5 +1,5 @@
 use napi_derive::napi;
-use rspack_core::{Experiments, IncrementalRebuild};
+use rspack_core::{Experiments, IncrementalRebuild, IncrementalRebuildMakeState};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Default)]
@@ -26,7 +26,10 @@ impl From<RawExperiments> for Experiments {
     Self {
       lazy_compilation: value.lazy_compilation,
       incremental_rebuild: IncrementalRebuild {
-        make: value.incremental_rebuild.make,
+        make: value
+          .incremental_rebuild
+          .make
+          .then(IncrementalRebuildMakeState::default),
         emit_asset: value.incremental_rebuild.emit_asset,
       },
       async_web_assembly: value.async_web_assembly,

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -1,5 +1,4 @@
 use napi_derive::napi;
-use rspack_core::{Experiments, IncrementalRebuild, IncrementalRebuildMakeState};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Default)]
@@ -19,22 +18,4 @@ pub struct RawExperiments {
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
   pub css: bool,
-}
-
-impl From<RawExperiments> for Experiments {
-  fn from(value: RawExperiments) -> Self {
-    Self {
-      lazy_compilation: value.lazy_compilation,
-      incremental_rebuild: IncrementalRebuild {
-        make: value
-          .incremental_rebuild
-          .make
-          .then(IncrementalRebuildMakeState::default),
-        emit_asset: value.incremental_rebuild.emit_asset,
-      },
-      async_web_assembly: value.async_web_assembly,
-      new_split_chunks: value.new_split_chunks,
-      css: value.css,
-    }
-  }
 }

--- a/crates/rspack_binding_options/src/options/raw_output.rs
+++ b/crates/rspack_binding_options/src/options/raw_output.rs
@@ -139,8 +139,8 @@ pub struct RawOutputOptions {
   pub import_function_name: String,
   pub iife: bool,
   pub module: bool,
-  pub chunk_format: Option<String>,
-  pub chunk_loading: Option<String>,
+  pub chunk_format: String,
+  pub chunk_loading: String,
   pub enabled_chunk_loading_types: Option<Vec<String>>,
   pub trusted_types: Option<RawTrustedTypes>,
   pub source_map_filename: String,
@@ -177,6 +177,7 @@ impl RawOptionsApply for RawOutputOptions {
       },
       webassembly_module_filename: self.webassembly_module_filename.into(),
       unique_name: self.unique_name,
+      chunk_loading: self.chunk_loading.as_str().into(),
       chunk_loading_global: to_identifier(&self.chunk_loading_global),
       filename: self.filename.into(),
       chunk_filename: self.chunk_filename.into(),
@@ -207,20 +208,20 @@ impl RawOutputOptions {
     &self,
     plugins: &mut Vec<BoxPlugin>,
   ) -> Result<(), rspack_error::Error> {
-    if let Some(chunk_format) = &self.chunk_format {
-      match chunk_format.as_str() {
-        "array-push" => {
-          plugins.push(rspack_plugin_runtime::ArrayPushCallbackChunkFormatPlugin {}.boxed());
-        }
-        "commonjs" => plugins.push(rspack_plugin_runtime::CommonJsChunkFormatPlugin {}.boxed()),
-        "module" => {
-          plugins.push(rspack_plugin_runtime::ModuleChunkFormatPlugin {}.boxed());
-        }
-        _ => {
-          return Err(internal_error!(
-            "Unsupported chunk format '{chunk_format}'."
-          ))
-        }
+    match self.chunk_format.as_str() {
+      "array-push" => {
+        plugins.push(rspack_plugin_runtime::ArrayPushCallbackChunkFormatPlugin {}.boxed());
+      }
+      "commonjs" => plugins.push(rspack_plugin_runtime::CommonJsChunkFormatPlugin {}.boxed()),
+      "module" => {
+        plugins.push(rspack_plugin_runtime::ModuleChunkFormatPlugin {}.boxed());
+      }
+      "false" => {}
+      _ => {
+        return Err(internal_error!(
+          "Unsupported chunk format '{}'",
+          self.chunk_format
+        ))
       }
     }
     Ok(())

--- a/crates/rspack_core/src/cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/cache/local/code_splitting_cache.rs
@@ -26,7 +26,7 @@ where
   T: Fn(&'a mut Compilation) -> F,
   F: Future<Output = Result<&'a mut Compilation>>,
 {
-  let is_incremental_rebuild = compilation.options.is_make_use_incremental_rebuild();
+  let is_incremental_rebuild = compilation.options.is_incremental_rebuild_make_enabled();
   if !is_incremental_rebuild {
     task(compilation).await?;
     return Ok(());

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -4,8 +4,8 @@ use rspack_identifier::IdentifierMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  Chunk, ChunkByUkey, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, ModuleIdentifier,
-  RuntimeSpec,
+  Chunk, ChunkByUkey, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, EntryOptions,
+  ModuleIdentifier, RuntimeSpec,
 };
 
 impl DatabaseItem for ChunkGroup {
@@ -34,11 +34,11 @@ pub struct ChunkGroup {
 }
 
 impl ChunkGroup {
-  pub fn new(kind: ChunkGroupKind, runtime: RuntimeSpec, name: Option<String>) -> Self {
+  pub fn new(kind: ChunkGroupKind, runtime: RuntimeSpec, group_options: ChunkGroupOptions) -> Self {
     Self {
       ukey: ChunkGroupUkey::new(),
       chunks: vec![],
-      options: ChunkGroupOptions { name },
+      options: group_options,
       module_post_order_indices: Default::default(),
       module_pre_order_indices: Default::default(),
       parents: Default::default(),
@@ -91,7 +91,7 @@ impl ChunkGroup {
   }
 
   pub fn is_initial(&self) -> bool {
-    matches!(self.kind, ChunkGroupKind::Entrypoint)
+    matches!(self.kind, ChunkGroupKind::Entrypoint { initial } if initial)
   }
 
   pub fn set_runtime_chunk(&mut self, chunk_ukey: ChunkUkey) {
@@ -100,7 +100,7 @@ impl ChunkGroup {
 
   pub fn get_runtime_chunk(&self) -> ChunkUkey {
     match self.kind {
-      ChunkGroupKind::Entrypoint => self
+      ChunkGroupKind::Entrypoint { .. } => self
         .runtime_chunk
         .expect("EntryPoint runtime chunk not set"),
       ChunkGroupKind::Normal => unreachable!("Normal chunk group doesn't have runtime chunk"),
@@ -113,7 +113,7 @@ impl ChunkGroup {
 
   pub fn get_entry_point_chunk(&self) -> ChunkUkey {
     match self.kind {
-      ChunkGroupKind::Entrypoint => self
+      ChunkGroupKind::Entrypoint { .. } => self
         .entry_point_chunk
         .expect("EntryPoint runtime chunk not set"),
       ChunkGroupKind::Normal => unreachable!("Normal chunk group doesn't have runtime chunk"),
@@ -187,11 +187,34 @@ impl ChunkGroup {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChunkGroupKind {
-  Entrypoint,
+  Entrypoint { initial: bool },
   Normal,
 }
 
-#[derive(Debug, Clone)]
+impl ChunkGroupKind {
+  pub fn new_entrypoint(initial: bool) -> Self {
+    Self::Entrypoint { initial }
+  }
+
+  pub fn is_entrypoint(&self) -> bool {
+    matches!(self, Self::Entrypoint { .. })
+  }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ChunkGroupOptions {
   pub name: Option<String>,
+  pub entry_options: Option<EntryOptions>,
+}
+
+impl ChunkGroupOptions {
+  pub fn name(mut self, v: impl Into<String>) -> Self {
+    self.name = Some(v.into());
+    self
+  }
+
+  pub fn name_optional<T: Into<String>>(mut self, v: Option<T>) -> Self {
+    self.name = v.map(|v| v.into());
+    self
+  }
 }

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -150,7 +150,7 @@ where
           std::mem::take(&mut self.compilation.make_failed_dependencies);
         new_compilation.make_failed_module =
           std::mem::take(&mut self.compilation.make_failed_module);
-        new_compilation.entries = std::mem::take(&mut self.compilation.entries);
+        new_compilation.entries = dbg!(std::mem::take(&mut self.compilation.entries));
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
         new_compilation.file_dependencies = std::mem::take(&mut self.compilation.file_dependencies);

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -130,17 +130,19 @@ where
       self.plugin_driver.resolver_factory.clear_entries();
 
       let mut new_compilation = Compilation::new(
-        // TODO: use Arc<T> instead
         self.options.clone(),
-        self.options.entry.clone(),
         Default::default(),
         self.plugin_driver.clone(),
         self.resolver_factory.clone(),
         self.cache.clone(),
       );
 
-      let is_incremental_rebuild = self.options.is_make_use_incremental_rebuild();
-      if is_incremental_rebuild {
+      if let Some(state) = self.options.get_incremental_rebuild_make_state() {
+        state.set_is_not_first();
+      }
+
+      let is_incremental_rebuild_make = self.options.is_incremental_rebuild_make_enabled();
+      if is_incremental_rebuild_make {
         // copy field from old compilation
         // make stage used
         new_compilation.module_graph = std::mem::take(&mut self.compilation.module_graph);
@@ -148,8 +150,7 @@ where
           std::mem::take(&mut self.compilation.make_failed_dependencies);
         new_compilation.make_failed_module =
           std::mem::take(&mut self.compilation.make_failed_module);
-        new_compilation.entry_dependencies =
-          std::mem::take(&mut self.compilation.entry_dependencies);
+        new_compilation.entries = std::mem::take(&mut self.compilation.entries);
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
         new_compilation.file_dependencies = std::mem::take(&mut self.compilation.file_dependencies);
@@ -194,8 +195,6 @@ where
             })
             .collect::<Vec<Option<NormalModuleAstOrSource>>>(),
         );
-      } else {
-        new_compilation.setup_entry_dependencies();
       }
 
       fast_set(&mut self.compilation, new_compilation);
@@ -213,22 +212,10 @@ where
         .compilation(&mut self.compilation)
         .await?;
 
-      let setup_make_params = if is_incremental_rebuild {
+      let setup_make_params = if is_incremental_rebuild_make {
         MakeParam::ModifiedFiles(modified_files)
       } else {
-        let deps = self
-          .compilation
-          .entry_dependencies
-          .iter()
-          .flat_map(|(_, deps)| {
-            deps
-              .clone()
-              .into_iter()
-              .map(|d| (d, None))
-              .collect::<Vec<_>>()
-          })
-          .collect::<HashSet<_>>();
-        MakeParam::ForceBuildDeps(deps)
+        MakeParam::ForceBuildDeps(Default::default())
       };
       self.compile(setup_make_params).await?;
       self.cache.begin_idle();
@@ -351,8 +338,8 @@ where
       }
 
       if !new_modules.is_empty() || !new_runtime_modules.is_empty() {
-        let mut hot_update_chunk =
-          Chunk::new(None, Some(chunk_id.to_string()), ChunkKind::HotUpdate);
+        let mut hot_update_chunk = Chunk::new(None, ChunkKind::HotUpdate);
+        hot_update_chunk.id = Some(chunk_id.to_string());
         hot_update_chunk.runtime = new_runtime.clone();
         let mut chunk_hash = RspackHash::from(&self.compilation.options.output);
         let ukey = hot_update_chunk.ukey;

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -150,7 +150,7 @@ where
           std::mem::take(&mut self.compilation.make_failed_dependencies);
         new_compilation.make_failed_module =
           std::mem::take(&mut self.compilation.make_failed_module);
-        new_compilation.entries = dbg!(std::mem::take(&mut self.compilation.entries));
+        new_compilation.entries = std::mem::take(&mut self.compilation.entries);
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
         new_compilation.file_dependencies = std::mem::take(&mut self.compilation.file_dependencies);

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::{BuildDependency, ModuleIdentifier};
+use crate::{BuildDependency, DependencyId, ModuleIdentifier};
 
 mod rebuild_deps_builder;
 pub use rebuild_deps_builder::RebuildDepsBuilder;
@@ -12,6 +12,19 @@ pub enum MakeParam {
   ModifiedFiles(HashSet<PathBuf>),
   ForceBuildDeps(HashSet<BuildDependency>),
   ForceBuildModules(HashSet<ModuleIdentifier>),
+}
+
+impl MakeParam {
+  pub fn add_force_build_dependency(
+    &mut self,
+    dep: DependencyId,
+    module: Option<ModuleIdentifier>,
+  ) -> bool {
+    match self {
+      MakeParam::ForceBuildDeps(set) => set.insert((dep, module)),
+      _ => false,
+    }
+  }
 }
 
 // TODO @jerrykingxyz migrate make method here

--- a/crates/rspack_core/src/dependency/dynamic_import.rs
+++ b/crates/rspack_core/src/dependency/dynamic_import.rs
@@ -8,9 +8,9 @@ use swc_core::{
 };
 
 use crate::{
-  create_javascript_visitor, CodeGeneratable, CodeGeneratableContext, CodeGeneratableDeclMappings,
-  CodeGeneratableResult, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  JsAstPath, ModuleDependency, ModuleDependencyExt, RuntimeGlobals,
+  create_javascript_visitor, ChunkGroupOptions, CodeGeneratable, CodeGeneratableContext,
+  CodeGeneratableDeclMappings, CodeGeneratableResult, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, JsAstPath, ModuleDependency, ModuleDependencyExt, RuntimeGlobals,
 };
 
 #[derive(Debug, Eq, Clone)]
@@ -21,8 +21,9 @@ pub struct EsmDynamicImportDependency {
   dependency_type: &'static DependencyType,
   span: Option<ErrorSpan>,
 
-  /// Used to store `webpackChunkName` in `import("/* webpackChunkName: "plugins/myModule" */")`
-  pub name: Option<String>,
+  /// This is used to implement `webpackChunkName`, `webpackPrefetch` etc.
+  /// for example: `import(/* webpackChunkName: "my-chunk-name", webpackPrefetch: true */ './module')`
+  pub group_options: ChunkGroupOptions,
 
   #[allow(unused)]
   ast_path: JsAstPath,
@@ -51,11 +52,11 @@ impl EsmDynamicImportDependency {
     request: JsWord,
     span: Option<ErrorSpan>,
     ast_path: JsAstPath,
-    name: Option<String>,
+    group_options: ChunkGroupOptions,
   ) -> Self {
     Self {
       request,
-      name,
+      group_options,
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::DynamicImport,
       span,
@@ -95,8 +96,8 @@ impl ModuleDependency for EsmDynamicImportDependency {
     self.span.as_ref()
   }
 
-  fn chunk_name(&self) -> Option<&str> {
-    self.name.as_deref()
+  fn group_options(&self) -> Option<&ChunkGroupOptions> {
+    Some(&self.group_options)
   }
 
   fn set_request(&mut self, request: String) {

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -38,7 +38,9 @@ pub use require_resolve_dependency::RequireResolveDependency;
 mod static_exports_dependency;
 pub use static_exports_dependency::*;
 
-use crate::{Context, ContextMode, ContextOptions, ErrorSpan, ModuleGraph, ModuleIdentifier};
+use crate::{
+  ChunkGroupOptions, Context, ContextMode, ContextOptions, ErrorSpan, ModuleGraph, ModuleIdentifier,
+};
 
 // Used to describe dependencies' types, see webpack's `type` getter in `Dependency`
 // Note: This is almost the same with the old `ResolveKind`
@@ -275,7 +277,8 @@ pub trait ModuleDependency: Dependency {
     None
   }
 
-  fn chunk_name(&self) -> Option<&str> {
+  // TODO: wired to place ChunkGroupOptions on dependency, should place on AsyncDependenciesBlock
+  fn group_options(&self) -> Option<&ChunkGroupOptions> {
     None
   }
 }
@@ -305,8 +308,8 @@ impl ModuleDependency for Box<dyn ModuleDependency> {
     (**self).get_optional()
   }
 
-  fn chunk_name(&self) -> Option<&str> {
-    (**self).chunk_name()
+  fn group_options(&self) -> Option<&ChunkGroupOptions> {
+    (**self).group_options()
   }
 
   fn set_request(&mut self, request: String) {

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -3,8 +3,9 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   is_async_dependency, module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject,
-  BuildMetaExportsType, ChunkGraph, DependencyId, ExportsType, FactoryMeta, ModuleDependency,
-  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleIssuer, ModuleSyntax, ModuleType,
+  BuildMetaExportsType, ChunkGraph, ChunkGroupOptions, DependencyId, ExportsType, FactoryMeta,
+  ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleIssuer,
+  ModuleSyntax, ModuleType,
 };
 
 #[derive(Debug)]
@@ -127,7 +128,7 @@ impl ModuleGraphModule {
   pub fn dynamic_depended_modules<'a>(
     &self,
     module_graph: &'a ModuleGraph,
-  ) -> Vec<(&'a ModuleIdentifier, Option<&'a str>)> {
+  ) -> Vec<(&'a ModuleIdentifier, Option<&'a ChunkGroupOptions>)> {
     self
       .dependencies
       .iter()
@@ -140,7 +141,7 @@ impl ModuleGraphModule {
           .module_identifier_by_dependency_id(id)
           .expect("should have a module here");
 
-        let chunk_name = dep.chunk_name();
+        let chunk_name = dep.group_options();
         Some((module, chunk_name))
       })
       .collect()

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -27,7 +27,6 @@ pub struct CompilerOptions {
 impl CompilerOptions {
   pub fn is_incremental_rebuild_make_enabled(&self) -> bool {
     self.experiments.incremental_rebuild.make.is_some()
-      && !matches!(self.cache, CacheOptions::Disabled)
   }
 
   pub fn get_incremental_rebuild_make_state(&self) -> Option<&IncrementalRebuildMakeState> {

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -1,12 +1,11 @@
 use crate::{
-  Builtins, BundleEntries, CacheOptions, Context, DevServerOptions, Devtool, Experiments, Mode,
-  ModuleOptions, NodeOption, Optimization, OutputOptions, Resolve, SnapshotOptions, StatsOptions,
-  Target,
+  Builtins, CacheOptions, Context, DevServerOptions, Devtool, Experiments,
+  IncrementalRebuildMakeState, Mode, ModuleOptions, NodeOption, Optimization, OutputOptions,
+  Resolve, SnapshotOptions, StatsOptions, Target,
 };
 
 #[derive(Debug)]
 pub struct CompilerOptions {
-  pub entry: BundleEntries,
   pub context: Context,
   pub dev_server: DevServerOptions,
   pub output: OutputOptions,
@@ -26,7 +25,16 @@ pub struct CompilerOptions {
 }
 
 impl CompilerOptions {
-  pub fn is_make_use_incremental_rebuild(&self) -> bool {
-    self.experiments.incremental_rebuild.make && !matches!(self.cache, CacheOptions::Disabled)
+  pub fn is_incremental_rebuild_make_enabled(&self) -> bool {
+    self.experiments.incremental_rebuild.make.is_some()
+      && !matches!(self.cache, CacheOptions::Disabled)
+  }
+
+  pub fn get_incremental_rebuild_make_state(&self) -> Option<&IncrementalRebuildMakeState> {
+    self.experiments.incremental_rebuild.make.as_ref()
+  }
+
+  pub fn is_incremental_rebuild_emit_asset_enabled(&self) -> bool {
+    self.experiments.incremental_rebuild.emit_asset
   }
 }

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -1,14 +1,28 @@
 use indexmap::IndexMap;
 
-pub type BundleEntries = IndexMap<String, EntryItem>;
+use crate::{ChunkLoading, DependencyId, PublicPath};
+
+pub type Entry = IndexMap<String, EntryData>;
+
+pub type EntryItem = Vec<String>;
 
 #[derive(Debug, Clone)]
-pub struct EntryItem {
-  pub import: Vec<String>,
+pub struct EntryDescription {
+  pub import: EntryItem,
   pub runtime: Option<String>,
+  pub chunk_loading: Option<ChunkLoading>,
+  pub public_path: Option<PublicPath>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
+pub struct EntryData {
+  pub dependencies: Vec<DependencyId>,
+  pub options: EntryOptions,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct EntryOptions {
   pub runtime: Option<String>,
+  pub chunk_loading: Option<ChunkLoading>,
+  pub public_path: Option<PublicPath>,
 }

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -1,7 +1,24 @@
+use once_cell::sync::OnceCell;
+
 #[derive(Debug, Default)]
 pub struct IncrementalRebuild {
-  pub make: bool,
+  pub make: Option<IncrementalRebuildMakeState>,
   pub emit_asset: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct IncrementalRebuildMakeState {
+  first: OnceCell<()>,
+}
+
+impl IncrementalRebuildMakeState {
+  pub fn is_first(&self) -> bool {
+    self.first.get().is_none()
+  }
+
+  pub fn set_is_not_first(&self) {
+    self.first.get_or_init(|| ());
+  }
 }
 
 #[derive(Debug, Default)]

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -25,6 +25,7 @@ pub struct OutputOptions {
   pub wasm_loading: WasmLoading,
   pub webassembly_module_filename: Filename,
   pub unique_name: String,
+  pub chunk_loading: ChunkLoading,
   pub chunk_loading_global: String,
   pub filename: Filename,
   pub chunk_filename: Filename,
@@ -57,6 +58,31 @@ impl From<&OutputOptions> for RspackHash {
 #[derive(Debug)]
 pub struct TrustedTypes {
   pub policy_name: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChunkLoading {
+  False,
+  Jsonp,
+  ImportScripts,
+  Require,
+  AsyncNode,
+  Import,
+  // TODO: Custom
+}
+
+impl From<&str> for ChunkLoading {
+  fn from(value: &str) -> Self {
+    match value {
+      "jsonp" => Self::Jsonp,
+      "import-scripts" => Self::ImportScripts,
+      "require" => Self::Require,
+      "async-node" => Self::AsyncNode,
+      "import" => Self::Import,
+      "false" => Self::False,
+      _ => unimplemented!("custom chunkLoading in not supported yet"),
+    }
+  }
 }
 
 #[derive(Debug)]
@@ -349,7 +375,7 @@ fn hash_len(hash: &str, caps: &Captures) -> usize {
     .min(hash_len)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PublicPath {
   // TODO: should be RawPublicPath(Filename)
   String(String),

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -9,8 +9,8 @@ use rspack_sources::BoxSource;
 use crate::{
   AdditionalChunkRuntimeRequirementsArgs, AssetEmittedArgs, AssetInfo, BoxLoader, BoxModule,
   ChunkAssetArgs, ChunkHashArgs, Compilation, CompilationArgs, CompilerOptions, ContentHashArgs,
-  DoneArgs, FactorizeArgs, JsChunkHashArgs, Module, ModuleArgs, ModuleFactoryResult, ModuleType,
-  NormalModule, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
+  DoneArgs, FactorizeArgs, JsChunkHashArgs, MakeParam, Module, ModuleArgs, ModuleFactoryResult,
+  ModuleType, NormalModule, NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs,
   NormalModuleFactoryContext, OptimizeChunksArgs, ParserAndGenerator, PluginContext,
   ProcessAssetsArgs, RenderArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs,
   RenderStartupArgs, Resolver, SourceType, ThisCompilationArgs,
@@ -61,7 +61,12 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(())
   }
 
-  async fn make(&self, _ctx: PluginContext, _compilation: &Compilation) -> PluginMakeHookOutput {
+  async fn make(
+    &self,
+    _ctx: PluginContext,
+    _compilation: &mut Compilation,
+    _param: &mut MakeParam,
+  ) -> PluginMakeHookOutput {
     Ok(())
   }
 

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -13,17 +13,17 @@ use crate::{
   AdditionalChunkRuntimeRequirementsArgs, ApplyContext, AssetEmittedArgs, BoxLoader,
   BoxedParserAndGeneratorBuilder, Chunk, ChunkAssetArgs, ChunkContentHash, ChunkHashArgs,
   Compilation, CompilationArgs, CompilerOptions, Content, ContentHashArgs, DoneArgs, FactorizeArgs,
-  JsChunkHashArgs, Module, ModuleArgs, ModuleType, NormalModule, NormalModuleAfterResolveArgs,
-  NormalModuleBeforeResolveArgs, NormalModuleFactoryContext, OptimizeChunksArgs, Plugin,
-  PluginAdditionalChunkRuntimeRequirementsOutput, PluginBuildEndHookOutput,
-  PluginChunkHashHookOutput, PluginCompilationHookOutput, PluginContext, PluginFactorizeHookOutput,
-  PluginJsChunkHashHookOutput, PluginMakeHookOutput, PluginModuleHookOutput,
-  PluginNormalModuleFactoryAfterResolveOutput, PluginNormalModuleFactoryBeforeResolveOutput,
-  PluginProcessAssetsOutput, PluginRenderChunkHookOutput, PluginRenderHookOutput,
-  PluginRenderManifestHookOutput, PluginRenderModuleContentOutput, PluginRenderStartupHookOutput,
-  PluginThisCompilationHookOutput, ProcessAssetsArgs, RenderArgs, RenderChunkArgs,
-  RenderManifestArgs, RenderModuleContentArgs, RenderStartupArgs, Resolver, ResolverFactory, Stats,
-  ThisCompilationArgs,
+  JsChunkHashArgs, MakeParam, Module, ModuleArgs, ModuleType, NormalModule,
+  NormalModuleAfterResolveArgs, NormalModuleBeforeResolveArgs, NormalModuleFactoryContext,
+  OptimizeChunksArgs, Plugin, PluginAdditionalChunkRuntimeRequirementsOutput,
+  PluginBuildEndHookOutput, PluginChunkHashHookOutput, PluginCompilationHookOutput, PluginContext,
+  PluginFactorizeHookOutput, PluginJsChunkHashHookOutput, PluginMakeHookOutput,
+  PluginModuleHookOutput, PluginNormalModuleFactoryAfterResolveOutput,
+  PluginNormalModuleFactoryBeforeResolveOutput, PluginProcessAssetsOutput,
+  PluginRenderChunkHookOutput, PluginRenderHookOutput, PluginRenderManifestHookOutput,
+  PluginRenderModuleContentOutput, PluginRenderStartupHookOutput, PluginThisCompilationHookOutput,
+  ProcessAssetsArgs, RenderArgs, RenderChunkArgs, RenderManifestArgs, RenderModuleContentArgs,
+  RenderStartupArgs, Resolver, ResolverFactory, Stats, ThisCompilationArgs,
 };
 
 pub struct PluginDriver {
@@ -448,9 +448,15 @@ impl PluginDriver {
   }
 
   #[instrument(name = "plugin:make", skip_all)]
-  pub async fn make(&self, compilation: &Compilation) -> PluginMakeHookOutput {
+  pub async fn make(
+    &self,
+    compilation: &mut Compilation,
+    param: &mut MakeParam,
+  ) -> PluginMakeHookOutput {
     for plugin in &self.plugins {
-      plugin.make(PluginContext::new(), compilation).await?;
+      plugin
+        .make(PluginContext::new(), compilation, param)
+        .await?;
     }
     Ok(())
   }

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -59,7 +59,10 @@ impl<'a> CodeSizeOptimizer<'a> {
   }
 
   pub async fn run(&mut self) -> Result<TWithDiagnosticArray<OptimizeDependencyResult>> {
-    let is_incremental_rebuild = self.compilation.options.is_make_use_incremental_rebuild();
+    let is_incremental_rebuild = self
+      .compilation
+      .options
+      .is_incremental_rebuild_make_enabled();
     let is_first_time_analyze = self.compilation.optimize_analyze_result_map.is_empty();
     let analyze_result_map = par_analyze_module(self.compilation).await;
     let mut finalized_result_map = if is_incremental_rebuild {

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -5,7 +5,6 @@ use std::{
   sync::Arc,
 };
 
-use indexmap::IndexMap;
 use rspack_core::{
   run_loaders, CompilerContext, CompilerOptions, Loader, LoaderRunnerContext, ResourceData,
   SideEffectOption,
@@ -33,7 +32,6 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
     &[],
     CompilerContext {
       options: std::sync::Arc::new(CompilerOptions {
-        entry: IndexMap::default(),
         context: rspack_core::Context::default(),
         dev_server: rspack_core::DevServerOptions::default(),
         devtool: rspack_core::Devtool::default(),
@@ -49,6 +47,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
           chunk_filename: rspack_core::Filename::from_str("").expect("TODO:"),
           cross_origin_loading: rspack_core::CrossOriginLoading::Disable,
           unique_name: Default::default(),
+          chunk_loading: rspack_core::ChunkLoading::Jsonp,
           chunk_loading_global: "webpackChunkwebpack".to_string(),
           css_chunk_filename: rspack_core::Filename::from_str("").expect("TODO:"),
           css_filename: rspack_core::Filename::from_str("").expect("TODO:"),

--- a/crates/rspack_loader_swc/tests/fixtures.rs
+++ b/crates/rspack_loader_swc/tests/fixtures.rs
@@ -5,7 +5,6 @@ use std::{
   sync::Arc,
 };
 
-use indexmap::IndexMap;
 use rspack_core::{
   run_loaders, CompilerContext, CompilerOptions, Loader, LoaderRunnerContext, ResourceData,
   SideEffectOption,
@@ -33,7 +32,6 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
     &[],
     CompilerContext {
       options: std::sync::Arc::new(CompilerOptions {
-        entry: IndexMap::default(),
         context: rspack_core::Context::default(),
         dev_server: rspack_core::DevServerOptions::default(),
         devtool: rspack_core::Devtool::from("source-map".to_string()),
@@ -49,6 +47,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
           chunk_filename: rspack_core::Filename::from_str("").expect("TODO:"),
           cross_origin_loading: rspack_core::CrossOriginLoading::Disable,
           unique_name: Default::default(),
+          chunk_loading: rspack_core::ChunkLoading::Jsonp,
           chunk_loading_global: "webpackChunkwebpack".to_string(),
           css_chunk_filename: rspack_core::Filename::from_str("").expect("TODO:"),
           css_filename: rspack_core::Filename::from_str("").expect("TODO:"),

--- a/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
+++ b/crates/rspack_plugin_dev_friendly_split_chunks/src/plugin.rs
@@ -185,7 +185,7 @@ impl Plugin for DevFriendlySplitChunksPlugin {
     // Yeah. Leaky abstraction, but fast.
     let mut chunk_and_cgc = split_modules
       .map(|modules| {
-        let mut chunk = Chunk::new(None, None, rspack_core::ChunkKind::Normal);
+        let mut chunk = Chunk::new(None, rspack_core::ChunkKind::Normal);
         chunk
           .chunk_reasons
           .push("Split with ref count> 1".to_string());

--- a/crates/rspack_plugin_entry/Cargo.toml
+++ b/crates/rspack_plugin_entry/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+edition    = "2021"
+license    = "MIT"
+name       = "rspack_plugin_entry"
+repository = "https://github.com/web-infra-dev/rspack"
+version    = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+async-trait  = { workspace = true }
+rspack_core  = { path = "../rspack_core" }
+rspack_error = { path = "../rspack_error" }
+rspack_util  = { path = "../rspack_util" }
+rustc-hash   = { workspace = true }

--- a/crates/rspack_plugin_entry/LICENSE
+++ b/crates/rspack_plugin_entry/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2022-present Bytedance, Inc. and its affiliates.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -1,0 +1,42 @@
+#![feature(let_chains)]
+
+use rspack_core::{
+  Compilation, EntryDependency, EntryOptions, MakeParam, Plugin, PluginContext,
+  PluginMakeHookOutput,
+};
+
+#[derive(Debug)]
+pub struct EntryPlugin {
+  name: String,
+  options: EntryOptions,
+  entry_request: String,
+}
+
+impl EntryPlugin {
+  pub fn new(name: String, entry_request: String, options: EntryOptions) -> Self {
+    Self {
+      name,
+      options,
+      entry_request,
+    }
+  }
+}
+
+#[async_trait::async_trait]
+impl Plugin for EntryPlugin {
+  async fn make(
+    &self,
+    _ctx: PluginContext,
+    compilation: &mut Compilation,
+    param: &mut MakeParam,
+  ) -> PluginMakeHookOutput {
+    if let Some(state) = compilation.options.get_incremental_rebuild_make_state() && !state.is_first() {
+      return Ok(());
+    }
+    let dependency = Box::new(EntryDependency::new(self.entry_request.clone()));
+    let dependency_id = compilation.module_graph.add_dependency(dependency);
+    compilation.add_entry(dependency_id, self.name.clone(), self.options.clone());
+    param.add_force_build_dependency(dependency_id, None);
+    Ok(())
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -1,5 +1,7 @@
 use once_cell::sync::Lazy;
-use rspack_core::{ContextMode, ContextOptions, DependencyCategory, ModuleDependency, SpanExt};
+use rspack_core::{
+  ChunkGroupOptions, ContextMode, ContextOptions, DependencyCategory, ModuleDependency, SpanExt,
+};
 use rspack_regex::RspackRegex;
 use swc_core::{
   common::{comments::Comments, Span},
@@ -76,7 +78,7 @@ impl Visit for ImportScanner<'_> {
                 node.span.real_hi(),
                 imported.value.clone(),
                 Some(node.span.into()),
-                chunk_name,
+                ChunkGroupOptions::default().name_optional(chunk_name),
               )));
             }
             Expr::Tpl(tpl) if tpl.quasis.len() == 1 => {
@@ -94,7 +96,7 @@ impl Visit for ImportScanner<'_> {
                 node.span.real_hi(),
                 request,
                 Some(node.span.into()),
-                chunk_name,
+                ChunkGroupOptions::default().name_optional(chunk_name),
               )));
             }
             _ => {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/scanner.rs
@@ -1,9 +1,10 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rspack_core::{
-  CommonJsRequireContextDependency, CompilerOptions, ConstDependency, ContextMode, ContextOptions,
-  Dependency, DependencyCategory, EsmDynamicImportDependency, ImportContextDependency,
-  ModuleDependency, RequireContextDependency, ResourceData, RuntimeGlobals,
+  ChunkGroupOptions, CommonJsRequireContextDependency, CompilerOptions, ConstDependency,
+  ContextMode, ContextOptions, Dependency, DependencyCategory, EsmDynamicImportDependency,
+  ImportContextDependency, ModuleDependency, RequireContextDependency, ResourceData,
+  RuntimeGlobals,
 };
 use rspack_regex::RspackRegex;
 use swc_core::common::comments::Comments;
@@ -154,7 +155,7 @@ impl DependencyScanner<'_> {
                 imported.value.clone(),
                 Some(node.span.into()),
                 as_parent_path(ast_path),
-                chunk_name,
+                ChunkGroupOptions::default().name_optional(chunk_name),
               )));
             }
             Expr::Tpl(tpl) if tpl.quasis.len() == 1 => {
@@ -171,7 +172,7 @@ impl DependencyScanner<'_> {
                 request,
                 Some(node.span.into()),
                 as_parent_path(ast_path),
-                chunk_name,
+                ChunkGroupOptions::default().name_optional(chunk_name),
               )));
             }
             _ => {

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -4,7 +4,7 @@ use std::{cmp, sync::atomic::AtomicU32};
 
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspack_core::{
-  Compilation, DoneArgs, Module, OptimizeChunksArgs, Plugin, PluginBuildEndHookOutput,
+  Compilation, DoneArgs, MakeParam, Module, OptimizeChunksArgs, Plugin, PluginBuildEndHookOutput,
   PluginContext, PluginMakeHookOutput, PluginOptimizeChunksOutput, PluginProcessAssetsOutput,
   ProcessAssetsArgs,
 };
@@ -48,7 +48,12 @@ impl Plugin for ProgressPlugin {
     "progress"
   }
 
-  async fn make(&self, _ctx: PluginContext, _compilation: &Compilation) -> PluginMakeHookOutput {
+  async fn make(
+    &self,
+    _ctx: PluginContext,
+    _compilation: &mut Compilation,
+    _param: &mut MakeParam,
+  ) -> PluginMakeHookOutput {
     self.progress_bar.reset();
     self.progress_bar.set_prefix(
       self

--- a/crates/rspack_testing/Cargo.toml
+++ b/crates/rspack_testing/Cargo.toml
@@ -24,6 +24,7 @@ rspack_plugin_asset                     = { path = "../rspack_plugin_asset" }
 rspack_plugin_css                       = { path = "../rspack_plugin_css" }
 rspack_plugin_dev_friendly_split_chunks = { path = "../rspack_plugin_dev_friendly_split_chunks" }
 rspack_plugin_devtool                   = { path = "../rspack_plugin_devtool" }
+rspack_plugin_entry                     = { path = "../rspack_plugin_entry" }
 rspack_plugin_externals                 = { path = "../rspack_plugin_externals" }
 rspack_plugin_html                      = { path = "../rspack_plugin_html", features = ["testing"] }
 rspack_plugin_javascript                = { path = "../rspack_plugin_javascript" }

--- a/crates/rspack_testing/src/run_fixture.rs
+++ b/crates/rspack_testing/src/run_fixture.rs
@@ -29,10 +29,7 @@ pub fn apply_from_fixture(fixture_path: &Path) -> (CompilerOptions, Vec<BoxPlugi
 pub async fn test_fixture(fixture_path: &Path) -> Compiler<AsyncNativeFileSystem> {
   enable_tracing_by_env();
 
-  let (mut options, plugins) = apply_from_fixture(fixture_path);
-  for (_, entry) in options.entry.iter_mut() {
-    entry.runtime = Some("runtime".to_string());
-  }
+  let (options, plugins) = apply_from_fixture(fixture_path);
   // clean output
   if options.output.path.exists() {
     std::fs::remove_dir_all(&options.output.path).expect("should remove output");
@@ -103,10 +100,7 @@ pub async fn test_rebuild_fixture(
 ) {
   enable_tracing_by_env();
 
-  let (mut options, plugins) = apply_from_fixture(fixture_path);
-  for (_, entry) in options.entry.iter_mut() {
-    entry.runtime = Some("runtime".to_string());
-  }
+  let (options, plugins) = apply_from_fixture(fixture_path);
   // clean output
   if options.output.path.exists() {
     std::fs::remove_dir_all(&options.output.path).expect("should remove output");

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -192,10 +192,10 @@ function getRawOutput(output: OutputNormalized): RawOptions["output"] {
 		clean: output.clean!,
 		assetModuleFilename: output.assetModuleFilename!,
 		filename: output.filename!,
-		chunkFormat: output.chunkFormat === false ? undefined : output.chunkFormat!,
+		chunkFormat: output.chunkFormat === false ? "false" : output.chunkFormat!,
 		chunkFilename: output.chunkFilename!,
 		chunkLoading:
-			output.chunkLoading === false ? undefined : output.chunkLoading!,
+			output.chunkLoading === false ? "false" : output.chunkLoading!,
 		crossOriginLoading: getRawCrossOriginLoading(output.crossOriginLoading!),
 		cssFilename: output.cssFilename!,
 		cssChunkFilename: output.cssChunkFilename!,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -155,8 +155,9 @@ const applyExperimentsDefaults = (
 		D(experiments.incrementalRebuild, "make", true);
 		D(experiments.incrementalRebuild, "emitAsset", true);
 	}
+
 	if (
-		!cache &&
+		cache === false &&
 		experiments.incrementalRebuild &&
 		experiments.incrementalRebuild.make
 	) {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -22,7 +22,6 @@ import {
 import type {
 	AvailableTarget,
 	Context,
-	Experiments,
 	ExperimentsNormalized,
 	ExternalsPresets,
 	InfrastructureLogging,
@@ -67,9 +66,9 @@ export const applyRspackOptionsDefaults = (
 	F(options, "devtool", () => false as const);
 	D(options, "watch", false);
 
-	applyExperimentsDefaults(options.experiments);
-
 	F(options, "cache", () => development);
+
+	applyExperimentsDefaults(options.experiments, { cache: options.cache! });
 
 	applySnapshotDefaults(options.snapshot, { production });
 
@@ -142,7 +141,10 @@ const applyInfrastructureLoggingDefaults = (
 	D(infrastructureLogging, "appendOnly", !tty);
 };
 
-const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
+const applyExperimentsDefaults = (
+	experiments: ExperimentsNormalized,
+	{ cache }: { cache: boolean }
+) => {
 	D(experiments, "incrementalRebuild", {});
 	D(experiments, "lazyCompilation", false);
 	D(experiments, "asyncWebAssembly", false);
@@ -152,6 +154,14 @@ const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
 	if (typeof experiments.incrementalRebuild === "object") {
 		D(experiments.incrementalRebuild, "make", true);
 		D(experiments.incrementalRebuild, "emitAsset", true);
+	}
+	if (
+		!cache &&
+		experiments.incrementalRebuild &&
+		experiments.incrementalRebuild.make
+	) {
+		experiments.incrementalRebuild.make = false;
+		// TODO: use logger to warn user enable cache for incrementalRebuild.make
 	}
 };
 

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -7,6 +7,7 @@ export * from "./stats";
 export * from "./multiStats";
 export * from "./chunk_group";
 export * from "./normalModuleFactory";
+export { cachedCleverMerge as cleverMerge } from "./util/cleverMerge";
 
 import { Configuration } from "./config";
 // TODO(hyf0): should remove this re-export when we cleanup the exports of `@rspack/core`

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -206,6 +206,9 @@ describe("snapshots", () => {
 		-   "cache": false,
 		+   "cache": true,
 		@@ ... @@
+		-       "make": false,
+		+       "make": true,
+		@@ ... @@
 		-   "mode": "none",
 		+   "mode": "development",
 		@@ ... @@
@@ -829,6 +832,9 @@ describe("snapshots", () => {
 		@@ ... @@
 		-   "cache": false,
 		+   "cache": true,
+		@@ ... @@
+		-       "make": false,
+		+       "make": true,
 	`)
 	);
 	test("cache filesystem", { cache: { type: "filesystem" } }, e =>
@@ -841,6 +847,9 @@ describe("snapshots", () => {
 		+   "cache": Object {
 		+     "type": "filesystem",
 		+   },
+		@@ ... @@
+		-       "make": false,
+		+       "make": true,
 	`)
 	);
 	test(
@@ -856,6 +865,9 @@ describe("snapshots", () => {
 			+   "cache": Object {
 			+     "type": "filesystem",
 			+   },
+			@@ ... @@
+			-       "make": false,
+			+       "make": true,
 			@@ ... @@
 			-   "mode": "none",
 			+   "mode": "development",
@@ -997,6 +1009,9 @@ describe("snapshots", () => {
 			+     "type": "filesystem",
 			+   },
 			+   "context": "<cwd>/tests/fixtures",
+			@@ ... @@
+			-       "make": false,
+			+       "make": true,
 			@@ ... @@
 			-     "chunkLoadingGlobal": "webpackChunk@rspack/core",
 			+     "chunkLoadingGlobal": "webpackChunk",

--- a/packages/rspack/tests/StatsTestCases.test.ts
+++ b/packages/rspack/tests/StatsTestCases.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import util from "util";
-import { rspack, RspackOptions } from "../src";
+import { rspack, RspackOptions, cleverMerge } from "../src";
 import serializer from "jest-serializer-path";
 
 expect.addSnapshotSerializer(serializer);
@@ -38,11 +38,11 @@ describe("StatsTestCases", () => {
 					main: "./index"
 				},
 				output: {
-					path: outputPath,
-					filename: "bundle.js" // not working by now @Todo need fixed later
+					filename: "bundle.js"
 				},
-				...config // we may need to use deepMerge to handle config merge, but we may fix it until we need it
+				...config
 			};
+			options.output!.path = outputPath;
 			const stats = await util.promisify(rspack)(options);
 			if (!stats) return expect(false);
 			const statsOptions = options.stats ?? {

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -53,7 +53,7 @@ exports[`snapshots should have the correct base config 1`] = `
     "css": true,
     "incrementalRebuild": {
       "emitAsset": true,
-      "make": true,
+      "make": false,
     },
     "lazyCompilation": false,
     "newSplitChunks": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27343,7 +27343,7 @@ packages:
       interpret: 2.2.0
       rechoir: 0.7.1
       webpack: 5.76.0_webpack-cli@4.10.0
-      webpack-merge: 5.8.0
+      webpack-merge: 5.9.0
     dev: true
 
   /webpack-dev-middleware/5.3.3:
@@ -27606,6 +27606,14 @@ packages:
 
   /webpack-merge/5.8.0:
     resolution: {integrity: sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      clone-deep: 4.0.1
+      wildcard: 2.0.0
+    dev: true
+
+  /webpack-merge/5.9.0:
+    resolution: {integrity: sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==}
     engines: {node: '>=10.0.0'}
     dependencies:
       clone-deep: 4.0.1


### PR DESCRIPTION
Pre-PR for https://github.com/web-infra-dev/rspack/issues/3552 and https://github.com/web-infra-dev/rspack/issues/2653

## Related issue (if exists)

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f26108a</samp>

This pull request introduces new structs and enums for configuring chunk groups and their entrypoints, and refactors the code that creates and manages them. It also simplifies the chunk id generation logic and removes some unused or redundant code. The main files affected are `code_splitter.rs`, `chunk_group.rs`, `chunk.rs`, `compilation.rs`, and the dependency-related files in `rspack_plugin_javascript`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f26108a</samp>

*  Add new structs and methods for configuring chunk groups and their entry options ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L190-R220), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L94-R94), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L103-R103), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L37-R41), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-a08296f5303f24e761f894dfd29ed0b1afbd4d0c04f56ea364128b94d23183acL11-R11))
*  Update imports to include new structs and methods ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L9-R12), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-86272f0bc7b7b8e6b0ab182b026116a2d16fac8ee7e4de45c4a473aaa33517abL8-R9), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L36-R43), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL11-R13), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8L41-R43), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-4d7897467e893502d6e4c09351eed5ff90f9834658555704a8eff4408d6aa8f7L6-R8), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-48492df7cfe0ccf7bce1dbb71175d0019ff15fa50d3510dcf1ff931c38ccaa51L2-R3), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-a40599a3fa2b0310d2e396c186116c51af958a3b60ef9d8fd219d8dc82bab3a5L2-R4), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL4-R7))
*  Replace `name` parameter and field with `group_options` parameter and field for dependencies that create chunk groups ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL24-R26), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL54-R59), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-65726b45e3f83132a525b4fa2c0f7dc69dc45d35e167175a1e8912bda28d82cfL98-R100), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8L278-R281), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-bc203fcb806bbd6f59d0f8e10f744904335fdf289d5470b46e60ee5b886370c8L308-R312), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-48492df7cfe0ccf7bce1dbb71175d0019ff15fa50d3510dcf1ff931c38ccaa51L16-R18), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-48492df7cfe0ccf7bce1dbb71175d0019ff15fa50d3510dcf1ff931c38ccaa51L26-R27), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-48492df7cfe0ccf7bce1dbb71175d0019ff15fa50d3510dcf1ff931c38ccaa51L34-R35), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-48492df7cfe0ccf7bce1dbb71175d0019ff15fa50d3510dcf1ff931c38ccaa51L73-R75))
*  Replace `chunk_name` method with `group_options` method for dependencies that create chunk groups ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-4d7897467e893502d6e4c09351eed5ff90f9834658555704a8eff4408d6aa8f7L130-R131), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-4d7897467e893502d6e4c09351eed5ff90f9834658555704a8eff4408d6aa8f7L143-R144))
*  Replace `chunk_name` variable with `group_options` variable and use `ChunkGroupOptions` methods to construct and extract options ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L353-R356), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L394-R397), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-a40599a3fa2b0310d2e396c186116c51af958a3b60ef9d8fd219d8dc82bab3a5L79-R81), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-a40599a3fa2b0310d2e396c186116c51af958a3b60ef9d8fd219d8dc82bab3a5L97-R99), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL157-R158), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-8281ab635aae318f63d8e3d743577a933a15bda2136698d2900e8bd8c711d2faL174-R175))
*  Remove `id` parameter from `Chunk::new` function and set `id` field to `None` or `name` by default ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-86272f0bc7b7b8e6b0ab182b026116a2d16fac8ee7e4de45c4a473aaa33517abL47-R51), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L296-R298), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L304-R306), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L355-R358), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e14b6b89580c5244c3a00b773aeed57c2ac32a5ff76793ffa4d82eb74047fc05L188-R188))
*  Remove `name` field from `Entrypoint` struct and use `ChunkGroupOptions` to store name ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L48))
*  Add new field `async_entrypoints` to `Compilation` struct to store ukeys of async entrypoint chunk groups ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R73), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R130))
*  Add new methods `add_chunk_in_group` and `add_async_entrypoint` to `Compilation` struct to create and connect chunks and chunk groups with given options and runtime ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215R312-R380))
*  Remove `add_entrypoint` method from `Compilation` struct as it is replaced by new methods ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L325))
*  Update `entrypoint` variable initialization with new `ChunkGroupKind::new_entrypoint` function and use `ChunkGroupOptions` to set name ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L68-R75))
*  Update `chunk_group` variable initialization with conditional expression and use `ChunkGroupOptions` to set name and entry options ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L422-R447))
*  Update `is_initial`, `get_runtime_chunk`, and `get_entry_point_chunk` methods of `ChunkGroup` struct to use new `ChunkGroupKind::Entrypoint` variant ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L94-R94), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L103-R103), [link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-e9bb72b14b36e8f0e6c44ef062db46f08893bbdefe39555943ca0d58d00544b0L116-R116))
*  Update `is_runtime` method of `Chunk` struct to use new `is_entrypoint` method of `ChunkGroupKind` enum ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-86272f0bc7b7b8e6b0ab182b026116a2d16fac8ee7e4de45c4a473aaa33517abL203-R215))
*  Add new method `get_entry_options` to `Chunk` struct to return entry options of chunk group that contains chunk and is entrypoint ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-86272f0bc7b7b8e6b0ab182b026116a2d16fac8ee7e4de45c4a473aaa33517abR64-R75))
*  Update `get_entry_runtime_chunks` method of `Compilation` struct to include runtime chunks of async entrypoints ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-5eb759d814281903aa0355174051f134df9444a46e9a1ce332cad27eed896215L1039-R1116))
*  Remove unused code that stored dynamic import reason in `chunk_reasons` field of `chunk` variable ([link](https://github.com/web-infra-dev/rspack/pull/3545/files?diff=unified&w=0#diff-d3f94114cda1156f8ad0133a36b6e81ae7af80ec628597a73516e92ced5012a8L403-L405))

</details>
