### PR TITLE
perf: 🤖 optimize tree shaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+webpack-dist
 
 # Gatsby files
 .cache/

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -4,17 +4,9 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    _async_to_generator: function() {
-        return _async_to_generator;
-    },
-    _: function() {
+Object.defineProperty(exports, "_", {
+    enumerable: true,
+    get: function() {
         return _async_to_generator;
     }
 });

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/expected/main.js
@@ -57,17 +57,9 @@ const exportCUsed = __webpack_exports_info__.C.used;
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-function _export(target, all) {
-    for(var name in all)Object.defineProperty(target, name, {
-        enumerable: true,
-        get: all[name]
-    });
-}
-_export(exports, {
-    x: function() {
-        return x;
-    },
-    y: function() {
+Object.defineProperty(exports, "y", {
+    enumerable: true,
+    get: function() {
         return y;
     }
 });

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -364,7 +364,7 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         // At this time uri of symbol will always equal to `self.module_identifier`
         SymbolRef::Direct(symbol) => {
           let reachable_import_and_export =
-            self.get_all_import_or_export(symbol.id().clone(), false);
+            self.get_all_import_or_export(symbol.id().clone(), true);
           if key != &symbol.id().atom {
             // export {xxx as xxx}
             self.reachable_import_and_export.insert(

--- a/packages/rspack-plugin-minify/src/index.js
+++ b/packages/rspack-plugin-minify/src/index.js
@@ -38,17 +38,6 @@ module.exports = class RspackMinifyPlugin {
 				{
 					sourceMap: sourcemap
 				}
-				// { module: false, ecma: 2015 }
-				// {
-				// 	sourceMap: sourcemap,
-				// 	ecma: 5,
-				// 	mangle: true,
-				// 	keep_classnames: true,
-				// 	keep_fnames: true,
-				// 	compress: {
-				// 		passes: 2
-				// 	}
-				// }
 			);
 			return result;
 		}


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ad8d2a</samp>

This pull request fixes a tree-shaking bug in `rspack_core`, improves the output size and efficiency of some test cases, and cleans up some unused code in `rspack-plugin-minify`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6ad8d2a</samp>

* Fix tree-shaking bug that would miss some reachable imports or exports ([link](https://github.com/web-infra-dev/rspack/pull/3547/files?diff=unified&w=0#diff-9256f31ef29461b1e1f2648e534a8c337b8144a30679154ada803910c6039440L367-R367))
* Simplify export of `_async_to_generator` function using `Object.defineProperty` ([link](https://github.com/web-infra-dev/rspack/pull/3547/files?diff=unified&w=0#diff-7778d5149babbc138f4afc0e9aaf627ebed05f11856a32c6fd4c118890fa893cL7-R10))
* Remove unused export of `x` variable from circular dependency ([link](https://github.com/web-infra-dev/rspack/pull/3547/files?diff=unified&w=0#diff-e89ad6620d23d2400a7b5e57a3eb84c3c1be6abff869f87080c699429ce40f7bL60-R62))

</details>
