### PR TITLE
chore: correct comments

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -19,10 +19,9 @@ pub type ChunkContentHash = HashMap<SourceType, RspackHashDigest>;
 
 #[derive(Debug, Clone)]
 pub struct Chunk {
-  // - If the chunk is create by entry, the name is the entry name
-  // - (Rspack doesn't support it yet)If the chunk is create by dynamic import, the name
-  // is the valid in MagicComment `import(/* webpackChunkName: "someChunk" * / './someModule.js')`.
-  // - TODO: HMR chunk will have name. Not sure this is expected. Need to discuss with underfin
+  // - If the chunk is create by entry config, the name is the entry name
+  // - The name of chunks create by dynamic import is `None` unless users use
+  // magic comment like `import(/* webpackChunkName: "someChunk" * / './someModule.js')` to specify it.
   pub name: Option<String>,
   pub ukey: ChunkUkey,
   pub id: Option<String>,

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -351,11 +351,8 @@ where
       }
 
       if !new_modules.is_empty() || !new_runtime_modules.is_empty() {
-        let mut hot_update_chunk = Chunk::new(
-          Some(chunk_id.to_string()),
-          Some(chunk_id.to_string()),
-          ChunkKind::HotUpdate,
-        );
+        let mut hot_update_chunk =
+          Chunk::new(None, Some(chunk_id.to_string()), ChunkKind::HotUpdate);
         hot_update_chunk.runtime = new_runtime.clone();
         let mut chunk_hash = RspackHash::from(&self.compilation.options.output);
         let ukey = hot_update_chunk.ukey;

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -193,7 +193,7 @@ impl Plugin for CssPlugin {
       compilation,
     );
 
-    // Prevent generating css files for chunks which doesn't contain css modules.
+    // Prevent generating css files for chunks which don't contain css modules.
     if ordered_css_modules.is_empty() {
       return Ok(Default::default());
     }

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/chunk.rs
@@ -8,11 +8,9 @@ use crate::SplitChunksPlugin;
 impl SplitChunksPlugin {
   /// Affected by `splitChunks.cacheGroups.{cacheGroup}.reuseExistingChunk`
   ///
-  /// If the current chunk contains modules already split out from the main bundle,
-  /// it will be reused instead of a new one being generated. This can affect the
-  /// resulting file name of the chunk.
-  ///
-  /// the best means the reused chunks contains all modules in this ModuleGroup
+  /// If there is a code splitting chunk that the contains the same modules as the current `ModuleGroup`,
+  /// with `reuseExistingChunk: true`,the code splitting chunks will be reused instead of create a new one
+  /// for the current `ModuleGroup`.
   pub(crate) fn find_the_best_reusable_chunk(
     &self,
     compilation: &mut Compilation,
@@ -26,7 +24,7 @@ impl SplitChunksPlugin {
         .get_number_of_chunk_modules(&chunk.ukey)
         != module_group.modules.len()
       {
-        // Fast path for checking is the chunk reusable for this `ModuleGroup`.
+        // Fast path
         return None;
       }
 
@@ -36,11 +34,10 @@ impl SplitChunksPlugin {
           .get_number_of_entry_modules(&chunk.ukey)
           > 0
       {
-        // `module_group.chunks.len() > 1`: this ModuleGroup are related multiple chunks generated in code splitting.
-        // `get_number_of_entry_modules(&chunk.ukey) > 0`:  current chunk is an initial chunk.
+        // `module_group.chunks.len() > 1`: This `ModuleGroup` are related to multiple code splitting chunks.
+        // `get_number_of_entry_modules(&chunk.ukey) > 0`:  Current chunk is an initial chunk.
 
-        // I(hyf0) don't see why breaking for this condition. But ChatGPT3.5 told me:
-
+        // I(hyf0) don't see why the process needs to bailout for this condition. But ChatGPT3.5 told me:
         // The condition means that if there are multiple chunks in item and the current chunk is an
         // entry chunk, then it cannot be reused. This is because entry chunks typically contain the core
         // code of an application, while other chunks contain various parts of the application. If


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 82d0d56</samp>

This pull request improves the documentation and naming of some code related to chunking and hot module replacement in rspack. It also fixes a minor grammatical error in a comment.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 82d0d56</samp>

*  Update the comment for the `name` field of the `Chunk` struct to reflect the current behavior of rspack and clarify the difference between entry config and entry point ([link](https://github.com/web-infra-dev/rspack/pull/3549/files?diff=unified&w=0#diff-86272f0bc7b7b8e6b0ab182b026116a2d16fac8ee7e4de45c4a473aaa33517abL22-R24))
*  Omit the name of hot update chunks in the `Chunk::new` constructor, as they are not relevant for the output ([link](https://github.com/web-infra-dev/rspack/pull/3549/files?diff=unified&w=0#diff-269c100a13b91351b9f928955094fdd7641e93f1f3062c0de339fd041fb4e763L354-R355))
*  Fix the grammar of the comment for the early return condition in the `emit` method of the `CssPlugin` ([link](https://github.com/web-infra-dev/rspack/pull/3549/files?diff=unified&w=0#diff-4f05e0b5ac142e0ecce31d329e0f16a333da474fb39a55453f67099d53fd8749L196-R196))
*  Rewrite and simplify the comments for the `find_the_best_reusable_chunk` method of the `ModuleGroup` struct in `crates/rspack_plugin_split_chunks_new/src/plugin/chunk.rs`, which explains the effect of the `reuseExistingChunk` option and the criteria for finding a reusable chunk for a given module group ([link](https://github.com/web-infra-dev/rspack/pull/3549/files?diff=unified&w=0#diff-f95f4b897cc295e831c48ba3c2b5f5c124d03ccb0dfc95b125dec06b4f9d6ba4L11-R13), [link](https://github.com/web-infra-dev/rspack/pull/3549/files?diff=unified&w=0#diff-f95f4b897cc295e831c48ba3c2b5f5c124d03ccb0dfc95b125dec06b4f9d6ba4L29-R27), [link](https://github.com/web-infra-dev/rspack/pull/3549/files?diff=unified&w=0#diff-f95f4b897cc295e831c48ba3c2b5f5c124d03ccb0dfc95b125dec06b4f9d6ba4L39-R40))

</details>
