### PR TITLE
chore: 🤖 keep comments

### DIFF
--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 exports["default"] = void 0;
-var _default = {};
+/* eslint-disable no-template-curly-in-string */ var _default = {};
 exports["default"] = _default;
 },
 "./antd/index.ts": function (module, exports, __webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/default_export/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/default_export/expected/main.js
@@ -10,7 +10,7 @@ Object.defineProperty(exports, "answer", {
         return answer;
     }
 });
-const answer = 103330;
+const answer = 103330; // export default answer;
 },
 "./app.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/expected/main.js
@@ -14,6 +14,7 @@ var Response = function() {
     "use strict";
     function Response(mode) {
         _class_call_check._(this, Response);
+        // eslint-disable-next-line no-undefined
         if (mode.data === undefined) mode.data = {};
         this.data = mode.data;
         this.isMatchIgnored = false;

--- a/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/expected/main.js
@@ -45,6 +45,7 @@ __webpack_require__.es(__webpack_require__("./a.js"), exports);
 const b = 'foo';
 },
 "./index.js": function (module, exports, __webpack_require__) {
+// require("./c.js");
 "use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true

--- a/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-prune/expected/main.js
@@ -5,6 +5,9 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 __webpack_require__.es(__webpack_require__("./lib.js"), exports);
+ // export {
+ //   result as test
+ // }
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";
@@ -12,7 +15,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 var _app = __webpack_require__("./app.js");
-(0, _app.something)();
+(0, _app.something)(); // a;
 },
 "./lib.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/side-effects-two/expected/main.js
@@ -11,6 +11,9 @@ Object.defineProperty(exports, "something", {
     }
 });
 var _lib = __webpack_require__.ir(__webpack_require__("./lib.js"));
+ // export {
+ //   result as test
+ // }
 },
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
@@ -1,6 +1,6 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (module, exports, __webpack_require__) {
-"use strict";
+/* TREE-SHAKING */ "use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
@@ -9,6 +9,9 @@ console.log(_maths.xxx.test);
 console.log(_maths['square']);
 },
 "./maths.js": function (module, exports, __webpack_require__) {
+// maths.js
+// This function isn't used anywhere, so
+// Rollup excludes it from the bundle...
 "use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/expected/main.js
@@ -20,7 +20,8 @@ exports.test = 30;
 {
     const res = __webpack_require__("./a.js");
     module.exports = res;
-}},
+} // export default function () {}
+},
 "./index.js": function (module, exports, __webpack_require__) {
 "use strict";
 Object.defineProperty(exports, "__esModule", {

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/expected/main.js
@@ -59,7 +59,20 @@ Object.defineProperty(exports, "_", {
 var _tslibes6 = __webpack_require__("../../../../../node_modules/tslib/tslib.es6.js");
 },
 "../../../../../node_modules/tslib/tslib.es6.js": function (module, exports, __webpack_require__) {
-"use strict";
+/******************************************************************************
+Copyright (c) Microsoft Corporation.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+***************************************************************************** */ /* global Reflect, Promise */ "use strict";
 Object.defineProperty(exports, "__esModule", {
     value: true
 });

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/expected/main.js
@@ -41,6 +41,7 @@ var _somemodule = __webpack_require__("./some-module.js");
 function getType(obj) {
     return obj.type;
 }
+// Local functions
 function doSomethingWithBlock(obj) {
     return _somemodule.Block.doSomething(obj);
 }
@@ -50,6 +51,7 @@ function doSomethingWithInline(obj) {
 function doSomethingWithDocument(obj) {
     return _somemodule.Document.doSomething(obj);
 }
+// Exported functions
 function doSomething(obj) {
     const type = getType(obj);
     switch(type){

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/expected/main.js
@@ -41,7 +41,7 @@ try {
 }
 try {
     var ok2 = false;
-    eval("");
+    eval(""); // TODO terser has a bug and incorrectly remove this code, eval opts out
 } catch (e) {
     var ok2 = true;
 }

--- a/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/expected/main.js
@@ -10,10 +10,12 @@ var _script1 = __webpack_require__("./package2/script.js");
 it("should load module correctly", ()=>{
     __webpack_require__("./module.js");
 });
+// if (process.env.NODE_ENV === "production") {
 it("default export should be unused", ()=>{
     expect(_script.exportDefaultUsed).toBe(false);
     expect(_script2.exportDefaultUsed).toBe(false);
 });
+// }
 it("default export should be used", ()=>{
     expect(_script1.exportDefaultUsed).toBe(true);
 });

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -1,5 +1,5 @@
 use napi_derive::napi;
-use rspack_core::{Builtins, CodeGeneration, Define, Minification, PluginExt, PresetEnv, Provide};
+use rspack_core::{Builtins, Define, Minification, PluginExt, PresetEnv, Provide};
 use rspack_error::internal_error;
 use rspack_plugin_banner::{BannerConfig, BannerPlugin};
 use rspack_plugin_copy::CopyPlugin;
@@ -55,13 +55,6 @@ pub struct RawPresetEnv {
   pub core_js: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[napi(object)]
-pub struct RawCodeGeneration {
-  pub keep_comments: bool,
-}
-
 impl From<RawMinification> for Minification {
   fn from(value: RawMinification) -> Self {
     Self {
@@ -87,13 +80,6 @@ impl From<RawPresetEnv> for PresetEnv {
   }
 }
 
-impl From<RawCodeGeneration> for CodeGeneration {
-  fn from(raw_code_generation: RawCodeGeneration) -> Self {
-    Self {
-      keep_comments: raw_code_generation.keep_comments,
-    }
-  }
-}
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
@@ -118,7 +104,6 @@ pub struct RawBuiltins {
   pub banner: Option<Vec<RawBannerConfig>>,
   pub plugin_import: Option<Vec<RawPluginImportConfig>>,
   pub relay: Option<RawRelayConfig>,
-  pub code_generation: Option<RawCodeGeneration>,
 }
 
 impl RawOptionsApply for RawBuiltins {
@@ -186,7 +171,6 @@ impl RawOptionsApply for RawBuiltins {
         .plugin_import
         .map(|plugin_imports| plugin_imports.into_iter().map(Into::into).collect()),
       relay: self.relay.map(Into::into),
-      code_generation: self.code_generation.map(Into::into),
     })
   }
 }

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -55,6 +55,13 @@ pub struct RawPresetEnv {
   pub core_js: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
+pub struct RawCodeGeneration {
+  pub keep_comments: bool,
+}
+
 impl From<RawMinification> for Minification {
   fn from(value: RawMinification) -> Self {
     Self {
@@ -104,6 +111,7 @@ pub struct RawBuiltins {
   pub banner: Option<Vec<RawBannerConfig>>,
   pub plugin_import: Option<Vec<RawPluginImportConfig>>,
   pub relay: Option<RawRelayConfig>,
+  pub code_generation: Option<RawCodeGeneration>,
 }
 
 impl RawOptionsApply for RawBuiltins {

--- a/crates/rspack_core/src/options/builtins.rs
+++ b/crates/rspack_core/src/options/builtins.rs
@@ -93,7 +93,6 @@ pub struct Builtins {
   pub dev_friendly_split_chunks: bool,
   pub plugin_import: Option<Vec<PluginImportConfig>>,
   pub relay: Option<RelayConfig>,
-  pub code_generation: Option<CodeGeneration>,
 }
 
 #[derive(Debug, Clone, Default, Hash)]
@@ -102,11 +101,6 @@ pub struct Minification {
   pub drop_console: bool,
   pub pure_funcs: Vec<String>,
   pub extract_comments: Option<String>,
-}
-
-#[derive(Debug, Copy, Clone, Default)]
-pub struct CodeGeneration {
-  pub keep_comments: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_loader_swc/tests/fixtures/esm/expected/main.js
+++ b/crates/rspack_loader_swc/tests/fixtures/esm/expected/main.js
@@ -3,7 +3,7 @@
 class a {
 }
 function A() {
-    return React.createElement("div", null, "123");
+    return /*#__PURE__*/ React.createElement("div", null, "123");
 }
 },
 

--- a/crates/rspack_loader_swc/tests/fixtures/ts/expected/main.js
+++ b/crates/rspack_loader_swc/tests/fixtures/ts/expected/main.js
@@ -3,7 +3,7 @@
 class a {
 }
 function A() {
-    return React.createElement("div", null, "123");
+    return /*#__PURE__*/ React.createElement("div", null, "123");
 }
 const b = {
     a: 123

--- a/crates/rspack_plugin_javascript/src/ast/stringify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/stringify.rs
@@ -37,11 +37,11 @@ pub fn stringify(
         names: Default::default(),
       },
       false,
-      if let Some(true) = keep_comments {
-        program.comments.as_ref().map(|c| c as &dyn Comments)
-      } else {
-        None
-      },
+      // if let Some(true) = keep_comments {
+      program.comments.as_ref().map(|c| c as &dyn Comments),
+      // } else {
+      //   None
+      // },
       false,
     )
   })

--- a/crates/rspack_plugin_javascript/src/ast/stringify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/stringify.rs
@@ -20,11 +20,7 @@ use swc_core::{
 
 use crate::TransformOutput;
 
-pub fn stringify(
-  ast: &Ast,
-  devtool: &Devtool,
-  keep_comments: Option<bool>,
-) -> Result<TransformOutput> {
+pub fn stringify(ast: &Ast, devtool: &Devtool) -> Result<TransformOutput> {
   ast.visit(|program, context| {
     print(
       program.get_inner_program(),
@@ -37,11 +33,7 @@ pub fn stringify(
         names: Default::default(),
       },
       false,
-      // if let Some(true) = keep_comments {
       program.comments.as_ref().map(|c| c as &dyn Comments),
-      // } else {
-      //   None
-      // },
       false,
     )
   })

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -120,18 +120,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         .try_into_ast()?
         .try_into_javascript()?;
       run_after_pass(&mut ast, module, generate_context)?;
-      let keep_comments = generate_context
-        .compilation
-        .options
-        .builtins
-        .code_generation
-        .as_ref()
-        .map(|cg| cg.keep_comments);
-      let output = crate::ast::stringify(
-        &ast,
-        &generate_context.compilation.options.devtool,
-        keep_comments,
-      )?;
+      let output = crate::ast::stringify(&ast, &generate_context.compilation.options.devtool)?;
       if let Some(map) = output.map {
         Ok(GenerationResult {
           ast_or_source: SourceMapSource::new(SourceMapSourceOptions {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/string_replace.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/string_replace.rs
@@ -83,8 +83,7 @@ impl ParserAndGenerator for JavaScriptStringReplaceParserAndGenerator {
       &source,
     )?;
 
-    let output: crate::TransformOutput =
-      crate::ast::stringify(&ast, &compiler_options.devtool, Some(true))?;
+    let output: crate::TransformOutput = crate::ast::stringify(&ast, &compiler_options.devtool)?;
 
     let mut scan_ast = match crate::ast::parse(
       output.code.clone(), // TODO avoid code clone

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -480,9 +480,6 @@ impl TestConfig {
           extract_comments: op.extract_comments,
         }),
         preset_env: self.builtins.preset_env.map(Into::into),
-        code_generation: self.builtins.code_generation.map(|op| c::CodeGeneration {
-          keep_comments: op.keep_comments,
-        }),
         ..Default::default()
       },
       module: c::ModuleOptions {

--- a/packages/rspack/src/config/builtins.ts
+++ b/packages/rspack/src/config/builtins.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-
+import util from "util";
 import type {
 	RawBuiltins,
 	RawBannerConfig,
@@ -489,6 +489,9 @@ export function resolveCodeGeneration(builtins: Builtins): RawCodeGeneration {
 	if (!builtins.codeGeneration) {
 		return { keepComments: Boolean(builtins.minifyOptions?.extractComments) };
 	}
+	// TODO: remove this configuration in 0.3.0
+	util.deprecate(() => {},
+	"`builtins.codeGeneration` will be removed in 0.3.0")();
 	return {
 		keepComments: false,
 		...builtins.codeGeneration

--- a/packages/rspack/tests/configCases/builtins/code-generation-keep-comments/index.js
+++ b/packages/rspack/tests/configCases/builtins/code-generation-keep-comments/index.js
@@ -1,7 +1,0 @@
-const fs = require("fs");
-// should preserve comments in generated code
-
-it("should preserve comments in generated code", function () {
-	const content = fs.readFileSync(__filename, "utf-8");
-	expect(content).toContain("// should preserve comments in generated code");
-});

--- a/packages/rspack/tests/configCases/builtins/code-generation-keep-comments/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/code-generation-keep-comments/webpack.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-	builtins: {
-		codeGeneration: {
-			keepComments: true
-		}
-	}
-};

--- a/packages/rspack/tests/copyPlugin/build/main.js
+++ b/packages/rspack/tests/copyPlugin/build/main.js
@@ -1,6 +1,7 @@
 (function() {
 var __webpack_modules__ = {
 "../helpers/enter.js": function (module, exports, __webpack_require__) {
+// Entry point for tests
 },
 
 }


### PR DESCRIPTION
## Related issue (if exists)

<!--- Provide link of related issues -->

## Summary
1. Enable keepComments by default, comments like pure annotation(`#PURE`) could give minifier more hints to eliminate side effects free statements.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29abfd6</samp>

Fix comment preservation issue in JavaScript plugin. Always pass program comments to `print` function in `stringify.rs`.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 29abfd6</samp>

* Fix comment preservation issue in JavaScript plugin by always passing program comments to `print` function ([link](https://github.com/web-infra-dev/rspack/pull/3551/files?diff=unified&w=0#diff-62fb7ccbaf372e970e53773bea70689577f6736d9b2f3d30209e0247022738b4L40-R44) in `crates/rspack_plugin_javascript/src/ast/stringify.rs`)

</details>
