### PR TITLE
feat(splitChunks): support `splitChunks.{cacheGroup}.type`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -479,6 +479,7 @@ export interface RawCacheGroupOptions {
   test?: string
   /** What kind of chunks should be selected. */
   chunks?: RegExp | 'async' | 'initial' | 'all'
+  type?: RegExp | string
   minChunks?: number
   minSize?: number
   maxSize?: number

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -100,7 +100,7 @@ impl From<rspack_core::StatsModule> for JsStatsModule {
       name: stats.name,
       size: stats.size,
       chunks: stats.chunks,
-      module_type: stats.module_type.to_string(),
+      module_type: stats.module_type.as_str().to_string(),
       identifier: stats.identifier.to_string(),
       id: stats.id,
       issuer: stats.issuer,

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(anonymous_lifetime_in_impl_trait)]
 
-use std::{borrow::Cow, fmt, sync::Arc};
+use std::{fmt, sync::Arc};
 
 use rspack_database::Database;
 pub mod external_module;
@@ -181,7 +181,6 @@ impl ModuleType {
       ModuleType::AssetResource => "asset/resource",
       ModuleType::AssetInline => "asset/inline",
     }
-    .into()
   }
 }
 

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -3,7 +3,7 @@
 #![feature(box_patterns)]
 #![feature(anonymous_lifetime_in_impl_trait)]
 
-use std::{fmt, sync::Arc};
+use std::{borrow::Cow, fmt, sync::Arc};
 
 use rspack_database::Database;
 pub mod external_module;
@@ -154,39 +154,40 @@ impl ModuleType {
       ModuleType::JsDynamic | ModuleType::JsxDynamic | ModuleType::Ts | ModuleType::Tsx
     )
   }
+
+  pub fn as_str(&self) -> &str {
+    match self {
+      ModuleType::Js => "javascript/auto",
+      ModuleType::JsEsm => "javascript/esm",
+      ModuleType::JsDynamic => "javascript/dynamic",
+
+      ModuleType::Jsx => "javascriptx",
+      ModuleType::JsxEsm => "javascriptx/esm",
+      ModuleType::JsxDynamic => "javascriptx/dynamic",
+
+      ModuleType::Ts => "typescript",
+      ModuleType::Tsx => "typescriptx",
+
+      ModuleType::Css => "css",
+      ModuleType::CssModule => "css/module",
+
+      ModuleType::Json => "json",
+
+      ModuleType::WasmSync => "webassembly/sync",
+      ModuleType::WasmAsync => "webassembly/async",
+
+      ModuleType::Asset => "asset",
+      ModuleType::AssetSource => "asset/source",
+      ModuleType::AssetResource => "asset/resource",
+      ModuleType::AssetInline => "asset/inline",
+    }
+    .into()
+  }
 }
 
 impl fmt::Display for ModuleType {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(
-      f,
-      "{}",
-      match self {
-        ModuleType::Js => "javascript/auto",
-        ModuleType::JsEsm => "javascript/esm",
-        ModuleType::JsDynamic => "javascript/dynamic",
-
-        ModuleType::Jsx => "javascriptx",
-        ModuleType::JsxEsm => "javascriptx/esm",
-        ModuleType::JsxDynamic => "javascriptx/dynamic",
-
-        ModuleType::Ts => "typescript",
-        ModuleType::Tsx => "typescriptx",
-
-        ModuleType::Css => "css",
-        ModuleType::CssModule => "css/module",
-
-        ModuleType::Json => "json",
-
-        ModuleType::WasmSync => "webassembly/sync",
-        ModuleType::WasmAsync => "webassembly/async",
-
-        ModuleType::Asset => "asset",
-        ModuleType::AssetSource => "asset/source",
-        ModuleType::AssetResource => "asset/resource",
-        ModuleType::AssetInline => "asset/inline",
-      }
-    )
+    write!(f, "{}", self.as_str(),)
   }
 }
 

--- a/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/cache_group.rs
@@ -1,6 +1,8 @@
 use derivative::Derivative;
 
-use crate::common::{ChunkFilter, ChunkNameGetter, ModuleFilter, SplitChunkSizes};
+use crate::common::{
+  ChunkFilter, ChunkNameGetter, ModuleFilter, ModuleTypeFilter, SplitChunkSizes,
+};
 
 #[derive(Derivative)]
 #[derivative(Debug)]
@@ -20,6 +22,8 @@ pub struct CacheGroup {
   pub chunk_filter: ChunkFilter,
   #[derivative(Debug = "ignore")]
   pub test: ModuleFilter,
+  #[derivative(Debug = "ignore")]
+  pub r#type: ModuleTypeFilter,
   /// `name` is used to create chunk
   #[derivative(Debug = "ignore")]
   pub name: ChunkNameGetter,

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -11,6 +11,11 @@ use rspack_core::{Chunk, ChunkGroupByUkey, Module, SourceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub type ChunkFilter = Arc<dyn Fn(&Chunk, &ChunkGroupByUkey) -> bool + Send + Sync>;
+pub type ModuleTypeFilter = Arc<dyn Fn(&dyn Module) -> bool + Send + Sync>;
+
+pub fn create_default_module_type_filter() -> ModuleTypeFilter {
+  Arc::new(|_| true)
+}
 
 pub fn create_async_chunk_filter() -> ChunkFilter {
   Arc::new(|chunk, chunk_group_db| !chunk.can_be_initial(chunk_group_db))

--- a/crates/rspack_plugin_split_chunks_new/src/lib.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/lib.rs
@@ -10,9 +10,10 @@ pub use crate::{
   cache_group::CacheGroup,
   common::{
     create_all_chunk_filter, create_async_chunk_filter, create_chunk_filter_from_str,
-    create_chunk_name_getter_by_const_name, create_empty_chunk_name_getter,
-    create_initial_chunk_filter, create_module_filter, create_module_filter_from_rspack_regex,
-    create_regex_chunk_filter_from_str, ChunkFilter, FallbackCacheGroup, SplitChunkSizes,
+    create_chunk_name_getter_by_const_name, create_default_module_type_filter,
+    create_empty_chunk_name_getter, create_initial_chunk_filter, create_module_filter,
+    create_module_filter_from_rspack_regex, create_regex_chunk_filter_from_str, ChunkFilter,
+    FallbackCacheGroup, ModuleTypeFilter, SplitChunkSizes,
   },
   plugin::{PluginOptions, SplitChunksPlugin},
 };

--- a/packages/rspack/src/config/zod/optimization/split-chunks.ts
+++ b/packages/rspack/src/config/zod/optimization/split-chunks.ts
@@ -23,6 +23,7 @@ const cacheGroupOptions = z.strictObject({
 	priority: z.number().optional(),
 	enforce: z.boolean().optional(),
 	reuseExistingChunk: z.boolean().optional(),
+	type: z.string().or(z.instanceof(RegExp)).optional(),
 	...sharedCacheGroupConfigPart
 });
 

--- a/webpack-test/configCases/split-chunks/module-type-filter/test.filter.js
+++ b/webpack-test/configCases/split-chunks/module-type-filter/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return false}
+module.exports = () => true


### PR DESCRIPTION
## Related issue (if exists)

Closes #3504 

<!--- Provide link of related issues -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5120f4a</samp>

This pull request adds support for the `type` option in the `splitChunks` configuration object, which allows filtering modules by their type in the split chunks plugin. It updates the `rspack_binding_options`, `rspack_core`, and `rspack_plugin_split_chunks_new` crates to handle the new option and adds a corresponding field to the `cacheGroupOptions` schema in the `rspack` package. It also fixes a bug in the `node_binding` crate and modifies a test case in the `webpack-test` package.

<details open=true>
  <summary><h2>Walkthrough</h2></summary>

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5120f4a</samp>

*  Fix `module_type` serialization bug in `Stats` struct by using `as_str` method of `ModuleType` enum ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-24cf9834c453e48f48a49ce682855a67ec4bf939e01ad4af22356b03d6dbdae8L103-R103))
  *  Add `new_split_chunks_plugin` and `rspack_regex` dependencies to `raw_split_chunks.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968L6-R10))
  *  Add `r#type` field to `RawSplitChunksOptions` and `CacheGroupOptions` structs as `Either<JsRegExp, JsString>` and `ModuleTypeFilter` respectively ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R131-R134), [link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-0aab5b8bd0e625e143e1d9cfe68dbf4e7339d9646deffa103a03eaef98c527ebR25-R26))
  *  Create `ModuleTypeFilter` from `r#type` field using `create_module_type_filter` function that accepts `Either<JsRegExp, JsString>` and returns a function that tests the module type ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R236-R240), [link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R318-R331))
  *  Pass `r#type` field to `SplitChunksOptions` and `CacheGroupOptions` constructors ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-0ffdb52a1a2c06dd32d3378adb43a463da9c779f285d0b41e8bad0fcc6582968R264))
  *  Add `type` field to `cacheGroupOptions` schema in `split-chunks.ts` as optional `string` or `RegExp` ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-63d7f1baf054835cd3b506980d3b33f1541c4cf726fea7fe44fd64c9fc734abbR26))
*  Add `as_str` method to `ModuleType` enum that returns a `&str` representation of the enum variant ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-8d48f40e42d64ce16c665a30278f5e9d4b9426eaa0790c7686c6a787c66d8825L157-R193))
  *  Use `as_str` method to simplify `fmt::Display` implementation of `ModuleType` enum ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-8d48f40e42d64ce16c665a30278f5e9d4b9426eaa0790c7686c6a787c66d8825L6-R6))
  *  Add `std::borrow::Cow` dependency to `lib.rs` to return a borrowed or owned string from `as_str` method ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-8d48f40e42d64ce16c665a30278f5e9d4b9426eaa0790c7686c6a787c66d8825L6-R6))
*  Add `ModuleTypeFilter` type alias and `create_default_module_type_filter` function to `common.rs` that return a function that accepts all module types ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-5333b4dda3fcc6f86cfcd38f67764a1123d5d0a159da62f881f7624d686b45a9L14-R19))
  *  Export `ModuleTypeFilter` and `create_default_module_type_filter` from `common` module in `lib.rs` ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-68521d603ace0ec833298b9dd6d5a2afd08219d5003d72f1022193ae9a820812L13-R16))
*  Modify `test.filter.js` in `module-type-filter` test case to return `true` instead of `false` to pass the test ([link](https://github.com/web-infra-dev/rspack/pull/3569/files?diff=unified&w=0#diff-fa4de4dddf3c22a8308165c36ad5c18ba4a6a893f34da84ed38a9e4fe53177b2L1-R1))

</details>
