### PR TITLE
chore: enable string_replace in webpack_tests

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -20,7 +20,9 @@ use rspack_hash::RspackHash;
 use swc_config::config_types::BoolOrDataConfig;
 use swc_ecma_minifier::option::terser::TerserCompressorOptions;
 
-use crate::parser_and_generator::JavaScriptParserAndGenerator;
+use crate::parser_and_generator::{
+  JavaScriptParserAndGenerator, JavaScriptStringReplaceParserAndGenerator,
+};
 // use crate::parser_and_generator::JavaScriptStringReplaceParserAndGenerator;
 use crate::{JsMinifyOptions, JsPlugin};
 
@@ -30,12 +32,14 @@ impl Plugin for JsPlugin {
     "javascript"
   }
   fn apply(&self, ctx: PluginContext<&mut rspack_core::ApplyContext>) -> Result<()> {
-    let create_parser_and_generator =
-      move || Box::new(JavaScriptParserAndGenerator::new()) as Box<dyn ParserAndGenerator>;
-
-    // let create_parser_and_generator = move || {
-    //   Box::new(JavaScriptStringReplaceParserAndGenerator::new()) as Box<dyn ParserAndGenerator>
-    // };
+    let enable_string_replace = std::env::var("RSPACK_WEBPACK_TEST").is_ok();
+    let create_parser_and_generator = if enable_string_replace {
+      move || {
+        Box::new(JavaScriptStringReplaceParserAndGenerator::new()) as Box<dyn ParserAndGenerator>
+      }
+    } else {
+      move || Box::new(JavaScriptParserAndGenerator::new()) as Box<dyn ParserAndGenerator>
+    };
 
     ctx
       .context

--- a/webpack-test/cases/mjs/cjs-import-default/test.filter.js
+++ b/webpack-test/cases/mjs/cjs-import-default/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
 							

--- a/webpack-test/cases/mjs/esm-by-default/test.filter.js
+++ b/webpack-test/cases/mjs/esm-by-default/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return 'should not use mjs extension by default failed'}
 
 							

--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.d.ts",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest  --logHeapUsage --runInBand --bail --forceExit",
-    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --forceExit --json | node scripts/test-metric.js",
-    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --json --forceExit"
+    "test": "cross-env RSPACK_WEBPACK_TEST=true NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest  --logHeapUsage --runInBand --bail --forceExit",
+    "test:metric": "cross-env  RSPACK_WEBPACK_TEST=true NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --forceExit --json | node scripts/test-metric.js",
+    "test:metric:json": "cross-env  RSPACK_WEBPACK_TEST=true NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --json --forceExit"
   },
   "files": [
     "dist"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
currently there're no tests running against string_replacement implementation, and we can use webpack_tests to test agains string_replacement implementation and which makes interop_test of custom runtime easy

## Test Plan
<!-- Can you please describe how you tested the changes you made to the code? -->
all test webpack-tests are running on string_replacement implementation