### PR TITLE
feat: easier way for converting `JsRegExp` to `RspackRegex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2467,6 +2467,7 @@ version = "0.1.0"
 dependencies = [
  "napi",
  "rspack_error",
+ "rspack_regex",
  "tokio",
 ]
 

--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -5,9 +5,8 @@ use napi::{Either, JsString};
 use napi_derive::napi;
 use new_split_chunks_plugin::ModuleTypeFilter;
 use rspack_core::SourceType;
-use rspack_napi_shared::{JsRegExp, JsStringExt};
+use rspack_napi_shared::{JsRegExp, JsRegExpExt, JsStringExt};
 use rspack_plugin_split_chunks::{CacheGroupOptions, ChunkType, SplitChunksOptions, TestFn};
-use rspack_regex::RspackRegex;
 use serde::Deserialize;
 
 type Chunks = Either<JsRegExp, JsString>;
@@ -156,8 +155,7 @@ use rspack_plugin_split_chunks_new as new_split_chunks_plugin;
 fn create_chunks_filter(raw: Chunks) -> rspack_plugin_split_chunks_new::ChunkFilter {
   match raw {
     Either::A(reg) => {
-      let reg = reg.source();
-      rspack_plugin_split_chunks_new::create_regex_chunk_filter_from_str(&reg)
+      rspack_plugin_split_chunks_new::create_regex_chunk_filter_from_str(reg.to_rspack_regex())
     }
     Either::B(str) => {
       let str = str.into_string();
@@ -319,8 +317,7 @@ pub struct RawFallbackCacheGroupOptions {
 fn create_module_type_filter(raw: Either<JsRegExp, JsString>) -> ModuleTypeFilter {
   match raw {
     Either::A(js_reg) => {
-      let raw_reg = js_reg.source();
-      let regex = RspackRegex::new(&raw_reg).expect("Should be valid regex");
+      let regex = js_reg.to_rspack_regex();
       Arc::new(move |m| regex.test(m.module_type().as_str()))
     }
     Either::B(js_str) => {

--- a/crates/rspack_napi_shared/Cargo.toml
+++ b/crates/rspack_napi_shared/Cargo.toml
@@ -10,4 +10,5 @@ version    = "0.1.0"
 [dependencies]
 napi         = { workspace = true, features = ["async", "tokio_rt", "serde-json", "napi4", "anyhow"] }
 rspack_error = { path = "../rspack_error" }
+rspack_regex = { path = "../rspack_regex" }
 tokio        = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }

--- a/crates/rspack_napi_shared/src/ext/js_reg_exp_ext.rs
+++ b/crates/rspack_napi_shared/src/ext/js_reg_exp_ext.rs
@@ -1,0 +1,18 @@
+use crate::JsRegExp;
+
+pub trait JsRegExpExt {
+  fn to_rspack_regex(&self) -> rspack_regex::RspackRegex;
+}
+
+impl JsRegExpExt for JsRegExp {
+  fn to_rspack_regex(&self) -> rspack_regex::RspackRegex {
+    let pat = self.source();
+    let flags = self.flags();
+    rspack_regex::RspackRegex::with_flags(&pat, &flags).unwrap_or_else(|_| {
+      panic!(
+        "Try convert {:?} to RspackRegex with flags: {:?} failed",
+        pat, flags
+      )
+    })
+  }
+}

--- a/crates/rspack_napi_shared/src/ext/mod.rs
+++ b/crates/rspack_napi_shared/src/ext/mod.rs
@@ -1,1 +1,2 @@
+pub mod js_reg_exp_ext;
 pub mod js_string_ext;

--- a/crates/rspack_napi_shared/src/js_values/js_reg_exp.rs
+++ b/crates/rspack_napi_shared/src/js_values/js_reg_exp.rs
@@ -22,6 +22,13 @@ impl JsRegExp {
       .get_named_property("source")
       .expect("RegExp should have `source` property")
   }
+
+  pub fn flags(&self) -> String {
+    self
+      .0
+      .get_named_property("flags")
+      .expect("RegExp should have `flags` property")
+  }
 }
 
 impl NapiRaw for JsRegExp {

--- a/crates/rspack_napi_shared/src/lib.rs
+++ b/crates/rspack_napi_shared/src/lib.rs
@@ -14,6 +14,7 @@ thread_local! {
 }
 
 pub use crate::{
-  ext::js_string_ext::JsStringExt, js_values::js_reg_exp::JsRegExp,
+  ext::{js_reg_exp_ext::JsRegExpExt, js_string_ext::JsStringExt},
+  js_values::js_reg_exp::JsRegExp,
   utils::object_prototype_to_string_call,
 };

--- a/crates/rspack_plugin_split_chunks_new/src/common.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/common.rs
@@ -8,6 +8,7 @@ use std::{
 use derivative::Derivative;
 use futures_util::FutureExt;
 use rspack_core::{Chunk, ChunkGroupByUkey, Module, SourceType};
+use rspack_regex::RspackRegex;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 pub type ChunkFilter = Arc<dyn Fn(&Chunk, &ChunkGroupByUkey) -> bool + Send + Sync>;
@@ -38,10 +39,7 @@ pub fn create_chunk_filter_from_str(chunks: &str) -> ChunkFilter {
   }
 }
 
-pub fn create_regex_chunk_filter_from_str(regex: &str) -> ChunkFilter {
-  let re =
-    rspack_regex::RspackRegex::new(regex).unwrap_or_else(|_| panic!("Invalid regex: {regex}"));
-
+pub fn create_regex_chunk_filter_from_str(re: RspackRegex) -> ChunkFilter {
   Arc::new(move |chunk, _| chunk.name.as_ref().map_or(false, |name| re.test(name)))
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- This PR makes converting `JsRegExp` to `RspackRegex` easier.
- The converting also covered `flags` of `RegExp` in JS.
- It would be better to merge #3573 with this PR together.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
