### PR TITLE
fix: rspack serve will automatically rebuild once

### DIFF
--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -33,7 +33,9 @@ impl ModuleFactoryResult {
   }
 
   pub fn file_dependency(mut self, file: PathBuf) -> Self {
-    self.file_dependencies.insert(file);
+    if file.is_absolute() {
+      self.file_dependencies.insert(file);
+    }
     self
   }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -220,7 +220,9 @@ async fn create_loader_context<'c, C: 'c>(
   context: C,
 ) -> Result<LoaderContext<'c, C>> {
   let mut file_dependencies: HashSet<PathBuf> = Default::default();
-  file_dependencies.insert(resource_data.resource_path.clone());
+  if resource_data.resource_path.is_absolute() {
+    file_dependencies.insert(resource_data.resource_path.clone());
+  }
 
   let loader_context = LoaderContext {
     cacheable: true,

--- a/packages/rspack/tests/cases/schemes/data-imports/webpack.config.js
+++ b/packages/rspack/tests/cases/schemes/data-imports/webpack.config.js
@@ -1,3 +1,19 @@
+const path = require("path");
+
+const pluginName = "plugin";
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.afterCompile.tap(pluginName, compilation => {
+			const deps = [
+				...compilation.fileDependencies,
+				...compilation.contextDependencies,
+				...compilation.missingDependencies,
+				...compilation.buildDependencies
+			];
+			expect(deps.every(item => path.isAbsolute(item))).toBe(true);
+		});
+	}
+}
 /** @type {import('webpack').Configuration} */
 module.exports = {
 	module: {
@@ -18,6 +34,7 @@ module.exports = {
 			}
 		]
 	},
+	plugins: [new Plugin()],
 	experiments: {
 		css: true
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Context

When using `rspack serve` it may automatically run a rebuild after the first build completes.
By debugging this behavior, I discovered that watchpack had emitted an array containing empty strings as deleted files which triggered the issue. And this empty string is a file_dependency which is generated by `data uri`.

## Summary

1. Modify tests to ensure all items in `compilation.*deps` are absolute paths
2. Only add the resource_path which is a absolute path



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
