### PR TITLE
chore: add back configCases/target in webpack-test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ justfile
 /webpack-test/temp
 /webpack-test/ChangesAndRemovals
 /webpack-test/**/dev-defaults.webpack.lock
+!/webpack-test/**/target
 
 /webpack-examples/**/dist
 

--- a/webpack-test/configCases/target/amd-container-named/index.js
+++ b/webpack-test/configCases/target/amd-container-named/index.js
@@ -1,0 +1,8 @@
+it("should run", function() {});
+
+it("should name define", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch("window['clientContainer'].define(\"clientContainer\",");
+});

--- a/webpack-test/configCases/target/amd-container-named/test.filter.js
+++ b/webpack-test/configCases/target/amd-container-named/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/amd-container-named/webpack.config.js
+++ b/webpack-test/configCases/target/amd-container-named/webpack.config.js
@@ -1,0 +1,22 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	output: {
+		library: {
+			type: "amd",
+			name: "clientContainer",
+			amdContainer: "window['clientContainer']"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner:
+				"function define(name, deps, fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { define };\n"
+		})
+	]
+};

--- a/webpack-test/configCases/target/amd-container-require/index.js
+++ b/webpack-test/configCases/target/amd-container-require/index.js
@@ -1,0 +1,8 @@
+it("should run", function() {});
+
+it("should name require", function() {
+	var fs = nodeRequire("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/window\['clientContainer'\]\.require\(\[[^\]]*\], (function)?\(/);
+});

--- a/webpack-test/configCases/target/amd-container-require/test.filter.js
+++ b/webpack-test/configCases/target/amd-container-require/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/amd-container-require/webpack.config.js
+++ b/webpack-test/configCases/target/amd-container-require/webpack.config.js
@@ -1,0 +1,21 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	output: {
+		library: {
+			type: "amd-require",
+			amdContainer: "window['clientContainer']"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner:
+				"var nodeRequire = require;\nvar require = function(deps, fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { require };\n"
+		})
+	]
+};

--- a/webpack-test/configCases/target/amd-container-unnamed/index.js
+++ b/webpack-test/configCases/target/amd-container-unnamed/index.js
@@ -1,0 +1,8 @@
+it("should run", function() {});
+
+it("should name define", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/window\['clientContainer'\]\.define\(\[[^\]]*\], (function)?\(/);
+});

--- a/webpack-test/configCases/target/amd-container-unnamed/test.filter.js
+++ b/webpack-test/configCases/target/amd-container-unnamed/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/amd-container-unnamed/webpack.config.js
+++ b/webpack-test/configCases/target/amd-container-unnamed/webpack.config.js
@@ -1,0 +1,21 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../types").Configuration} */
+module.exports = {
+	output: {
+		library: {
+			type: "amd",
+			amdContainer: "window['clientContainer']"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner:
+				"function define(deps, fn) { fn(); }\nconst window = {};\nwindow['clientContainer'] = { define };\n"
+		})
+	]
+};

--- a/webpack-test/configCases/target/amd-named/index.js
+++ b/webpack-test/configCases/target/amd-named/index.js
@@ -1,0 +1,10 @@
+it("should run", function() {
+
+});
+
+it("should name define", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch("define(\"NamedLibrary\",");
+});

--- a/webpack-test/configCases/target/amd-named/test.filter.js
+++ b/webpack-test/configCases/target/amd-named/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/amd-named/webpack.config.js
+++ b/webpack-test/configCases/target/amd-named/webpack.config.js
@@ -1,0 +1,18 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: "NamedLibrary",
+		libraryTarget: "amd"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner: "function define(name, deps, fn) { fn(); }\n"
+		})
+	]
+};

--- a/webpack-test/configCases/target/amd-require/index.js
+++ b/webpack-test/configCases/target/amd-require/index.js
@@ -1,0 +1,8 @@
+it("should run", function() {});
+
+it("should name require", function() {
+	var fs = nodeRequire("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/require\(\[[^\]]*\], (function)?\(/);
+});

--- a/webpack-test/configCases/target/amd-require/test.filter.js
+++ b/webpack-test/configCases/target/amd-require/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/amd-require/webpack.config.js
+++ b/webpack-test/configCases/target/amd-require/webpack.config.js
@@ -1,0 +1,18 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "amd-require"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner:
+				"var nodeRequire = require;\nvar require = function(deps, fn) { fn(); }\n"
+		})
+	]
+};

--- a/webpack-test/configCases/target/amd-unnamed/index.js
+++ b/webpack-test/configCases/target/amd-unnamed/index.js
@@ -1,0 +1,8 @@
+it("should run", function() {});
+
+it("should name define", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch(/define\(\[[^\]]*\], (function)?\(/);
+});

--- a/webpack-test/configCases/target/amd-unnamed/test.filter.js
+++ b/webpack-test/configCases/target/amd-unnamed/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/amd-unnamed/webpack.config.js
+++ b/webpack-test/configCases/target/amd-unnamed/webpack.config.js
@@ -1,0 +1,17 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "amd"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	plugins: [
+		new webpack.BannerPlugin({
+			raw: true,
+			banner: "function define(deps, fn) { fn(); }\n"
+		})
+	]
+};

--- a/webpack-test/configCases/target/chunk-loading-per-entry/chunk.js
+++ b/webpack-test/configCases/target/chunk-loading-per-entry/chunk.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/webpack-test/configCases/target/chunk-loading-per-entry/test.config.js
+++ b/webpack-test/configCases/target/chunk-loading-per-entry/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return i === 0 ? "./web-0.js" : "./webworker-1.js";
+	}
+};

--- a/webpack-test/configCases/target/chunk-loading-per-entry/test.filter.js
+++ b/webpack-test/configCases/target/chunk-loading-per-entry/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => 'https://github.com/web-infra-dev/rspack/issues/2408'

--- a/webpack-test/configCases/target/chunk-loading-per-entry/web.js
+++ b/webpack-test/configCases/target/chunk-loading-per-entry/web.js
@@ -1,0 +1,13 @@
+it("should allow to load a shared chunk in web", async () => {
+	const promise = import(/* webpackChunkName: "chunk" */ "./chunk");
+	expect(document.head._children).toHaveLength(1);
+	const script = document.head._children[0];
+	__non_webpack_require__("./chunk-0.js");
+	script.onload();
+
+	expect(await promise).toEqual(
+		nsObj({
+			default: 42
+		})
+	);
+});

--- a/webpack-test/configCases/target/chunk-loading-per-entry/webpack.config.js
+++ b/webpack-test/configCases/target/chunk-loading-per-entry/webpack.config.js
@@ -1,0 +1,16 @@
+const base = {
+	entry: {
+		web: "./web",
+		webworker: {
+			import: "./webworker",
+			chunkLoading: "import-scripts"
+		}
+	},
+	target: "web"
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+	{ ...base, output: { ...base.output, filename: "[name]-0.js" } },
+	{ ...base, output: { ...base.output, filename: "[name]-1.js" } }
+];

--- a/webpack-test/configCases/target/chunk-loading-per-entry/webworker.js
+++ b/webpack-test/configCases/target/chunk-loading-per-entry/webworker.js
@@ -1,0 +1,7 @@
+it("should allow to load a shared chunk in a WebWorker", async () => {
+	expect(await import(/* webpackChunkName: "chunk" */ "./chunk")).toEqual(
+		nsObj({
+			default: 42
+		})
+	);
+});

--- a/webpack-test/configCases/target/electron-renderer/index.js
+++ b/webpack-test/configCases/target/electron-renderer/index.js
@@ -1,0 +1,5 @@
+const foo = require("foo");
+
+it("should use browser main field", () => {
+	expect(foo).toBe("browser");
+});

--- a/webpack-test/configCases/target/electron-renderer/node_modules/foo/browser.js
+++ b/webpack-test/configCases/target/electron-renderer/node_modules/foo/browser.js
@@ -1,0 +1,1 @@
+module.exports = "browser";

--- a/webpack-test/configCases/target/electron-renderer/node_modules/foo/main.js
+++ b/webpack-test/configCases/target/electron-renderer/node_modules/foo/main.js
@@ -1,0 +1,1 @@
+module.exports = "main";

--- a/webpack-test/configCases/target/electron-renderer/node_modules/foo/package.json
+++ b/webpack-test/configCases/target/electron-renderer/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+	"name": "foo",
+	"version": "1.0.0",
+	"browser": "./browser.js",
+	"main": "./main.js"
+}

--- a/webpack-test/configCases/target/electron-renderer/test.filter.js
+++ b/webpack-test/configCases/target/electron-renderer/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/electron-renderer/webpack.config.js
+++ b/webpack-test/configCases/target/electron-renderer/webpack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "electron-renderer",
+	optimization: {
+		minimize: false
+	}
+};

--- a/webpack-test/configCases/target/node-dynamic-import/dir/one.js
+++ b/webpack-test/configCases/target/node-dynamic-import/dir/one.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/webpack-test/configCases/target/node-dynamic-import/dir/three.js
+++ b/webpack-test/configCases/target/node-dynamic-import/dir/three.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/webpack-test/configCases/target/node-dynamic-import/dir/two.js
+++ b/webpack-test/configCases/target/node-dynamic-import/dir/two.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/webpack-test/configCases/target/node-dynamic-import/dir2/one.js
+++ b/webpack-test/configCases/target/node-dynamic-import/dir2/one.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/webpack-test/configCases/target/node-dynamic-import/dir2/three.js
+++ b/webpack-test/configCases/target/node-dynamic-import/dir2/three.js
@@ -1,0 +1,1 @@
+module.exports = 3;

--- a/webpack-test/configCases/target/node-dynamic-import/dir2/two.js
+++ b/webpack-test/configCases/target/node-dynamic-import/dir2/two.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/webpack-test/configCases/target/node-dynamic-import/index.js
+++ b/webpack-test/configCases/target/node-dynamic-import/index.js
@@ -1,0 +1,72 @@
+function testCase(load, done) {
+	load("two", 2, function() {
+		var sync = true;
+		load("one", 1, function() {
+			expect(sync).toBe(false);
+			load("three", 3, function() {
+				var sync = true;
+				load("two", 2, function() {
+					expect(sync).toBe(true);
+					done();
+				});
+				Promise.resolve().then(function() {}).then(function() {}).then(function() {
+					sync = false;
+				});
+			});
+		});
+		Promise.resolve().then(function() {
+			sync = false;
+		});
+	});
+}
+
+it("should be able to use expressions in import", function(done) {
+	function load(name, expected, callback) {
+		import("./dir/" + name + '.js')
+			.then((result) => {expect(result).toEqual(nsObj({
+				default: expected
+			})); callback()})
+			.catch((err) => {done(err)});
+	}
+	testCase(load, done);
+});
+
+it("should be able to use expressions in lazy-once import", function(done) {
+	function load(name, expected, callback) {
+		import(/* webpackMode: "lazy-once" */ "./dir/" + name + '.js')
+			.then((result) => {expect(result).toEqual(nsObj({
+				default: expected
+			})); callback()})
+			.catch((err) => {done(err)});
+	}
+	testCase(load, done);
+});
+
+it("should be able to use expressions in import", function(done) {
+	function load(name, expected, callback) {
+		import("./dir2/" + name).then((result) => {
+			expect(result).toEqual(nsObj({
+				default: expected
+			}));
+			callback();
+		}).catch((err) => {
+			done(err);
+		});
+	}
+	testCase(load, done);
+});
+
+it("should convert to function in node", function() {
+	expect((typeof __webpack_require__.e)).toBe("function");
+})
+
+it("should be able to use import", function(done) {
+	import("./two").then((two) => {
+		expect(two).toEqual(nsObj({
+			default: 2
+		}));
+		done();
+	}).catch(function(err) {
+		done(err);
+	});
+});

--- a/webpack-test/configCases/target/node-dynamic-import/test.filter.js
+++ b/webpack-test/configCases/target/node-dynamic-import/test.filter.js
@@ -1,0 +1,6 @@
+// var supportsArrowFn = require("../../../helpers/supportsArrowFunctionExpression");
+
+module.exports = function (config) {
+	// return supportsArrowFn();
+	return false
+};

--- a/webpack-test/configCases/target/node-dynamic-import/two.js
+++ b/webpack-test/configCases/target/node-dynamic-import/two.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/webpack-test/configCases/target/node-dynamic-import/webpack.config.js
+++ b/webpack-test/configCases/target/node-dynamic-import/webpack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "node",
+	performance: {
+		hints: false
+	}
+};

--- a/webpack-test/configCases/target/strict-mode-global/index.js
+++ b/webpack-test/configCases/target/strict-mode-global/index.js
@@ -1,0 +1,6 @@
+"use strict";
+
+it("should be able to use global in strict mode", function() {
+	expect((typeof global)).toBe("object");
+	expect((global === null)).toBe(false)
+});

--- a/webpack-test/configCases/target/strict-mode-global/test.filter.js
+++ b/webpack-test/configCases/target/strict-mode-global/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/strict-mode-global/webpack.config.js
+++ b/webpack-test/configCases/target/strict-mode-global/webpack.config.js
@@ -1,0 +1,4 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	target: "web"
+};

--- a/webpack-test/configCases/target/system-context/index.js
+++ b/webpack-test/configCases/target/system-context/index.js
@@ -1,0 +1,8 @@
+// This test verifies that the System.register context is made available to webpack bundles
+
+it("should be able to use the System.register context", function() {
+  expect(__system_context__).toBeTruthy();
+  expect(__system_context__.meta).toBeTruthy();
+  expect(typeof __system_context__.import).toBe("function");
+  expect(typeof __system_context__.meta.url).toBe("string");
+});

--- a/webpack-test/configCases/target/system-context/test.config.js
+++ b/webpack-test/configCases/target/system-context/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/webpack-test/configCases/target/system-context/test.filter.js
+++ b/webpack-test/configCases/target/system-context/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/system-context/webpack.config.js
+++ b/webpack-test/configCases/target/system-context/webpack.config.js
@@ -1,0 +1,12 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: {
+			type: "system"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/system-export/index.js
+++ b/webpack-test/configCases/target/system-export/index.js
@@ -1,0 +1,13 @@
+// This test verifies that values exported by a webpack bundle are consumable by systemjs.
+
+export const namedThing = {
+	hello: "there"
+};
+
+export default "the default export";
+
+it("should successfully export values to System", function() {
+	const exports = eval("System").registry["(anonym)"].exports;
+	expect(exports["default"]).toBe("the default export");
+	expect(exports.namedThing).toBe(namedThing);
+});

--- a/webpack-test/configCases/target/system-export/test.config.js
+++ b/webpack-test/configCases/target/system-export/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/webpack-test/configCases/target/system-export/test.filter.js
+++ b/webpack-test/configCases/target/system-export/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/system-export/webpack.config.js
+++ b/webpack-test/configCases/target/system-export/webpack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/system-named-assets-path/index.js
+++ b/webpack-test/configCases/target/system-named-assets-path/index.js
@@ -1,0 +1,5 @@
+/* This test verifies that when output.library is specified that the compiled bundle provides
+ * the library name to System during the System.register
+ */
+
+it("should call System.register with a name assets path", function() {});

--- a/webpack-test/configCases/target/system-named-assets-path/test.config.js
+++ b/webpack-test/configCases/target/system-named-assets-path/test.config.js
@@ -1,0 +1,12 @@
+const System = require("../../../helpers/fakeSystem");
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute(`named-system-module-main`);
+	}
+};

--- a/webpack-test/configCases/target/system-named-assets-path/test.filter.js
+++ b/webpack-test/configCases/target/system-named-assets-path/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/system-named-assets-path/webpack.config.js
+++ b/webpack-test/configCases/target/system-named-assets-path/webpack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: "named-system-module-[name]",
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/system-named/index.js
+++ b/webpack-test/configCases/target/system-named/index.js
@@ -1,0 +1,5 @@
+/* This test verifies that when output.library is specified that the compiled bundle provides
+ * the library name to System during the System.register
+ */
+
+it("should call System.register with a name", function() {});

--- a/webpack-test/configCases/target/system-named/test.config.js
+++ b/webpack-test/configCases/target/system-named/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("named-system-module");
+	}
+};

--- a/webpack-test/configCases/target/system-named/test.filter.js
+++ b/webpack-test/configCases/target/system-named/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/system-named/webpack.config.js
+++ b/webpack-test/configCases/target/system-named/webpack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: "named-system-module",
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/system-unnamed/index.js
+++ b/webpack-test/configCases/target/system-unnamed/index.js
@@ -1,0 +1,5 @@
+/* This test verifies that when there is no output.library specified that the call to
+ * System.register does not include a name argument.
+ */
+
+it("should call System.register without a name", function() {});

--- a/webpack-test/configCases/target/system-unnamed/test.config.js
+++ b/webpack-test/configCases/target/system-unnamed/test.config.js
@@ -1,0 +1,13 @@
+const System = require("../../../helpers/fakeSystem");
+
+module.exports = {
+	beforeExecute: () => {
+		System.init();
+	},
+	moduleScope(scope) {
+		scope.System = System;
+	},
+	afterExecute: () => {
+		System.execute("(anonym)");
+	}
+};

--- a/webpack-test/configCases/target/system-unnamed/test.filter.js
+++ b/webpack-test/configCases/target/system-unnamed/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/system-unnamed/webpack.config.js
+++ b/webpack-test/configCases/target/system-unnamed/webpack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "system"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/umd-auxiliary-comments-object/index.js
+++ b/webpack-test/configCases/target/umd-auxiliary-comments-object/index.js
@@ -1,0 +1,13 @@
+it("should run", function() {
+
+});
+
+it("should have auxiliary comments", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch("//test " + "comment " + "commonjs");
+	expect(source).toMatch("//test " + "comment " + "commonjs2");
+	expect(source).toMatch("//test " + "comment " + "amd");
+	expect(source).toMatch("//test " + "comment " + "root");
+});

--- a/webpack-test/configCases/target/umd-auxiliary-comments-object/test.filter.js
+++ b/webpack-test/configCases/target/umd-auxiliary-comments-object/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/umd-auxiliary-comments-object/webpack.config.js
+++ b/webpack-test/configCases/target/umd-auxiliary-comments-object/webpack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: "NamedLibrary",
+		libraryTarget: "umd",
+		umdNamedDefine: true,
+		auxiliaryComment: {
+			commonjs: "test comment commonjs",
+			commonjs2: "test comment commonjs2",
+			amd: "test comment amd",
+			root: "test comment root"
+		}
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/umd-auxiliary-comments-string/index.js
+++ b/webpack-test/configCases/target/umd-auxiliary-comments-string/index.js
@@ -1,0 +1,10 @@
+it("should run", function() {
+
+});
+
+it("should have auxiliary comment string", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch("//test " + "comment");
+});

--- a/webpack-test/configCases/target/umd-auxiliary-comments-string/test.filter.js
+++ b/webpack-test/configCases/target/umd-auxiliary-comments-string/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/umd-auxiliary-comments-string/webpack.config.js
+++ b/webpack-test/configCases/target/umd-auxiliary-comments-string/webpack.config.js
@@ -1,0 +1,13 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: "NamedLibrary",
+		libraryTarget: "umd",
+		umdNamedDefine: true,
+		auxiliaryComment: "test comment"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};

--- a/webpack-test/configCases/target/umd-named-define/index.js
+++ b/webpack-test/configCases/target/umd-named-define/index.js
@@ -1,0 +1,10 @@
+it("should run", function() {
+
+});
+
+it("should name define", function() {
+	var fs = require("fs");
+	var source = fs.readFileSync(__filename, "utf-8");
+
+	expect(source).toMatch("define(\"NamedLibrary\",");
+});

--- a/webpack-test/configCases/target/umd-named-define/test.filter.js
+++ b/webpack-test/configCases/target/umd-named-define/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => false

--- a/webpack-test/configCases/target/umd-named-define/webpack.config.js
+++ b/webpack-test/configCases/target/umd-named-define/webpack.config.js
@@ -1,0 +1,12 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		library: "NamedLibrary",
+		libraryTarget: "umd",
+		umdNamedDefine: true
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

add back configCases/target, gitignored before

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
