### PR TITLE
chore: remove hacky code of supporting css modules

### DIFF
--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -119,7 +119,6 @@ impl Plugin for CssPlugin {
     let builder = move || {
       Box::new(CssParserAndGenerator {
         config: config.clone(),
-        meta: None,
         exports: None,
       }) as Box<dyn ParserAndGenerator>
     };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Rspack used `@rspack/postcss-loader` to deal with `css modules`. But, now, Rspack could use css-loader or native CSS to deal with CSS modules.

`@rspack/postcss-loader` is deprecated, so the related code could be removed now.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

Not need.
