### PR TITLE
fix: npm package contains default_index.ejs file

### DIFF
--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -12,6 +12,7 @@
   },
   "files": [
     "index.cjs",
+    "default_index.ejs",
     "dist"
   ],
   "keywords": [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

```js
const HtmlWebpackPlugin = require('@rspack/plugin-html')
module.exports = {
  // ... other config
  plugins: [
    new HtmlWebpackPlugin({ title: 'My App' })
  ]
}
```

Error: ENOENT: no such file or directory, open '/Users/xxx/project/node_modules/@rspack/plugin-html/default_index.ejs'


## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
