### PR TITLE
ci: refactor release-canary

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build Canary
-    # if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
@@ -62,7 +62,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
-          # COMMENT: ${{ toJson(github.event.comment) }}
+          COMMENT: ${{ toJson(github.event.comment) }}
 
       - name: Write a new comment
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,4 +1,5 @@
-# Release Canary by commention with "!canary"
+# Release Canary by comment with "!canary"
+
 name: Release Canary
 
 on:
@@ -7,37 +8,45 @@ on:
 
 jobs:
   build:
-    name: Release Canary
+    name: Build Canary
     if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false # Build and test everything so we can look at all the errors
+      matrix:
+        target:
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      target: ${{ matrix.target }}
+      profile: 'debug'
+      test: false
+
+  release:
+    name: Release Canary
     steps:
-      - name: Checkout Repo
+      - name: Checkout Branch
         uses: actions/checkout@v3
-        with:
-          # This makes Actions fetch only one branch to release
-          fetch-depth: 1
-          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache
 
-      - name: Install Rust
-        run: rustup show
-
-      - uses: goto-bus-stop/setup-zig@v2
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
         with:
-          version: 0.10.1
+          path: artifacts
 
-      - name: Setup target
-        run: |
-          rustup target add aarch64-apple-darwin
-          rustup target add x86_64-apple-darwin
-          rustup target add x86_64-unknown-linux-gnu
+      - name: Build node packages
+        run: pnpm run build:js
 
-      - name: Build
-        run: |
-          set -e
-          USE_ZIG=1 pnpm -w build:cli:release:all
+      - name: Move artifacts
+        run: node scripts/build-npm.cjs
+
+      - name: Show binding packages
+        run: ls -R npm
+
+      - name: Resolve dependencies for bindings
+        run: pnpm install --no-frozen-lockfile
 
       - name: Release
         run: |
@@ -57,4 +66,3 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
 
           body-path: 'version_output'
-              

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -3,9 +3,6 @@
 name: Release Canary
 
 on:
-  push:
-    branches:
-      - canary
   issue_comment:
     types: [created]
 

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -27,6 +27,8 @@ jobs:
 
   release:
     name: Release Canary
+    runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -3,13 +3,16 @@
 name: Release Canary
 
 on:
+  push:
+    branches:
+      release-canary
   issue_comment:
     types: [created]
 
 jobs:
   build:
     name: Build Canary
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
+    # if: github.event.issue.pull_request && contains(github.event.comment.body, '!canary')
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
@@ -57,7 +60,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
-          COMMENT: ${{ toJson(github.event.comment) }}
+          # COMMENT: ${{ toJson(github.event.comment) }}
 
       - name: Write a new comment
         uses: peter-evans/create-or-update-comment@v3

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -5,7 +5,7 @@ name: Release Canary
 on:
   push:
     branches:
-      release-canary
+      - canary
   issue_comment:
     types: [created]
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -30,6 +30,10 @@ on:
         default: 'release'
         required: false
         type: string
+      test: # Run tests?
+        type: boolean
+        required: false
+        default: true
 
 jobs:
   select:
@@ -164,7 +168,7 @@ jobs:
   e2e:
     name: E2E Testing
     needs: [select, build]
-    if: inputs.target == 'x86_64-unknown-linux-gnu'
+    if: inputs.target == 'x86_64-unknown-linux-gnu' && inputs.test == 'true'
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.35.0-jammy
@@ -190,6 +194,7 @@ jobs:
 
   test:
     needs: [select, build]
+    if: inputs.test == 'true'
     runs-on: ${{ needs.select.outputs.host }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -168,7 +168,7 @@ jobs:
   e2e:
     name: E2E Testing
     needs: [select, build]
-    if: inputs.target == 'x86_64-unknown-linux-gnu' && inputs.test == 'true'
+    if: inputs.target == 'x86_64-unknown-linux-gnu' && inputs.test
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.35.0-jammy
@@ -194,7 +194,7 @@ jobs:
 
   test:
     needs: [select, build]
-    if: inputs.test == 'true'
+    if: inputs.test
     runs-on: ${{ needs.select.outputs.host }}
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
## Summary

This PR refactors the release canary workflow.

## Test Plan

I used the trick to force a build, we can't use `!canary` because it uses the file from the main branch.

```
  push:
    branches:
      - canary
```

CI succeeds:
* https://github.com/web-infra-dev/rspack/actions/runs/5420876863/jobs/9855999770

Npm has the correct canary version:
* https://www.npmjs.com/package/@rspack/core/v/0.2.4-canary-e11ab9b-20230630084907