### PR TITLE
refactor: set dependency id at dependency init

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -619,7 +619,7 @@ impl Compilation {
                 self
                   .module_graph
                   .set_dependency_import_var(module.identifier(), dependency.request());
-                dep_ids.push(dependency.id());
+                dep_ids.push(*dependency.id());
                 self.module_graph.add_dependency(dependency);
               }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -619,8 +619,8 @@ impl Compilation {
                 self
                   .module_graph
                   .set_dependency_import_var(module.identifier(), dependency.request());
-                let dep_id = self.module_graph.add_dependency(dependency);
-                dep_ids.push(dep_id);
+                dep_ids.push(dependency.id());
+                self.module_graph.add_dependency(dependency);
               }
 
               {

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -52,7 +52,11 @@ pub struct FactorizeTaskResult {
 #[async_trait::async_trait]
 impl WorkerTask for FactorizeTask {
   async fn run(self) -> Result<TaskResult> {
-    let dependencies = self.dependencies.iter().map(|d| d.id()).collect::<Vec<_>>();
+    let dependencies = self
+      .dependencies
+      .iter()
+      .map(|d| *d.id())
+      .collect::<Vec<_>>();
     let dependency = &self.dependencies[0];
 
     let context = if let Some(context) = dependency.get_context() {

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -52,11 +52,7 @@ pub struct FactorizeTaskResult {
 #[async_trait::async_trait]
 impl WorkerTask for FactorizeTask {
   async fn run(self) -> Result<TaskResult> {
-    let dependencies = self
-      .dependencies
-      .iter()
-      .map(|d| d.id().expect("should have dependency"))
-      .collect::<Vec<_>>();
+    let dependencies = self.dependencies.iter().map(|d| d.id()).collect::<Vec<_>>();
     let dependency = &self.dependencies[0];
 
     let context = if let Some(context) = dependency.get_context() {

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -16,10 +16,10 @@ use rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt};
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  contextify, create_dependency_id, stringify_map, AstOrSource, BoxModuleDependency, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResult, Compilation,
-  ContextElementDependency, DependencyCategory, DependencyType, GenerationResult, LibIdentOptions,
-  Module, ModuleType, Resolve, ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals,
+  contextify, stringify_map, AstOrSource, BoxModuleDependency, BuildContext, BuildInfo, BuildMeta,
+  BuildResult, ChunkGraph, CodeGenerationResult, Compilation, ContextElementDependency,
+  DependencyCategory, DependencyId, DependencyType, GenerationResult, LibIdentOptions, Module,
+  ModuleType, Resolve, ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals,
   SourceType,
 };
 
@@ -434,7 +434,7 @@ impl ContextModule {
             requests.iter().for_each(|r| {
               if options.context_options.reg_exp.test(&r.request) {
                 dependencies.push(Box::new(ContextElementDependency {
-                  id: create_dependency_id(),
+                  id: DependencyId::new(),
                   request: format!(
                     "{}{}{}",
                     r.request,

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -16,10 +16,11 @@ use rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt};
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
-  contextify, stringify_map, AstOrSource, BoxModuleDependency, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, CodeGenerationResult, Compilation, ContextElementDependency,
-  DependencyCategory, DependencyType, GenerationResult, LibIdentOptions, Module, ModuleType,
-  Resolve, ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals, SourceType,
+  contextify, create_dependency_id, stringify_map, AstOrSource, BoxModuleDependency, BuildContext,
+  BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResult, Compilation,
+  ContextElementDependency, DependencyCategory, DependencyType, GenerationResult, LibIdentOptions,
+  Module, ModuleType, Resolve, ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals,
+  SourceType,
 };
 
 #[derive(Debug, Clone)]
@@ -433,7 +434,7 @@ impl ContextModule {
             requests.iter().for_each(|r| {
               if options.context_options.reg_exp.test(&r.request) {
                 dependencies.push(Box::new(ContextElementDependency {
-                  id: None,
+                  id: create_dependency_id(),
                   request: format!(
                     "{}{}{}",
                     r.request,

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -15,10 +15,6 @@ pub struct ContextElementDependency {
 }
 
 impl Dependency for ContextElementDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &self.category
   }
@@ -33,6 +29,10 @@ impl Dependency for ContextElementDependency {
 }
 
 impl ModuleDependency for ContextElementDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -5,7 +5,7 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct ContextElementDependency {
-  pub id: Option<DependencyId>,
+  pub id: DependencyId,
   // TODO remove this async dependency mark
   pub options: ContextOptions,
   pub request: String,
@@ -15,12 +15,8 @@ pub struct ContextElementDependency {
 }
 
 impl Dependency for ContextElementDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -1,16 +1,20 @@
 use crate::{
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct EntryDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: String,
 }
 
 impl EntryDependency {
   pub fn new(request: String) -> Self {
-    Self { request, id: None }
+    Self {
+      request,
+      id: create_dependency_id(),
+    }
   }
 }
 
@@ -23,12 +27,8 @@ impl Dependency for EntryDependency {
     &DependencyType::Entry
   }
 
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 }
 

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -1,6 +1,5 @@
 use crate::{
-  create_dependency_id, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -13,7 +12,7 @@ impl EntryDependency {
   pub fn new(request: String) -> Self {
     Self {
       request,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 }
@@ -26,13 +25,13 @@ impl Dependency for EntryDependency {
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::Entry
   }
-
-  fn id(&self) -> DependencyId {
-    self.id
-  }
 }
 
 impl ModuleDependency for EntryDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -155,10 +155,9 @@ impl Display for DependencyCategory {
 }
 
 pub trait Dependency: AsAny + DynClone + Send + Sync + Debug {
-  fn id(&self) -> Option<DependencyId> {
-    None
+  fn id(&self) -> DependencyId {
+    0.into()
   }
-  fn set_id(&mut self, _id: Option<DependencyId>) {}
 
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Unknown
@@ -203,11 +202,11 @@ impl ModuleDependencyExt for dyn ModuleDependency + '_ {
     (ModuleIdentifier, String, DependencyCategory),
     ModuleIdentifier,
   ) {
-    let parent = module_graph.parent_module_by_dependency_id(&self.id().expect("should have dependency id")).expect("Dependency does not have a parent module identifier. Maybe you are calling this in an `EntryDependency`?");
+    let parent = module_graph.parent_module_by_dependency_id(&self.id()).expect("Dependency does not have a parent module identifier. Maybe you are calling this in an `EntryDependency`?");
     (
       (parent, module_id, *self.category()),
       *module_graph
-        .module_identifier_by_dependency_id(&self.id().expect("should have dependency"))
+        .module_identifier_by_dependency_id(&self.id())
         .expect("Failed to resolve module graph module"),
     )
   }
@@ -317,11 +316,8 @@ impl Dependency for Box<dyn ModuleDependency> {
     (**self).get_context()
   }
 
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     (**self).id()
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    (**self).set_id(id)
   }
 }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::Entry;
 use std::path::PathBuf;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::Relaxed;
 use std::{borrow::Cow, sync::atomic::AtomicUsize};
 
 use once_cell::sync::Lazy;
@@ -23,8 +23,7 @@ pub type ImportVarMap = HashMap<String /* request */, String /* import_var */>;
 pub static DEPENDENCY_ID: Lazy<AtomicUsize> = Lazy::new(|| AtomicUsize::new(0));
 
 pub fn create_dependency_id() -> DependencyId {
-  DEPENDENCY_ID.fetch_add(1, SeqCst);
-  DEPENDENCY_ID.load(SeqCst).into()
+  DEPENDENCY_ID.fetch_add(1, Relaxed).into()
 }
 
 #[derive(Debug, Default)]
@@ -84,6 +83,9 @@ impl ModuleGraph {
   }
 
   pub fn add_dependency(&mut self, dependency: BoxModuleDependency) {
+    if self.dependencies.contains_key(&dependency.id()) {
+      panic!("dependency.id already used")
+    }
     self.dependencies.insert(dependency.id(), dependency);
   }
 

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -1542,7 +1542,7 @@ impl<'a> ModuleRefAnalyze<'a> {
           if dep.request() == src && dependency_type == dep.dependency_type() {
             self
               .module_graph
-              .module_graph_module_by_dependency_id(&dep.id().expect("should have id"))
+              .module_graph_module_by_dependency_id(&dep.id())
               .map(|module| &module.module_identifier)
           } else {
             None

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -1542,7 +1542,7 @@ impl<'a> ModuleRefAnalyze<'a> {
           if dep.request() == src && dependency_type == dep.dependency_type() {
             self
               .module_graph
-              .module_graph_module_by_dependency_id(&dep.id())
+              .module_graph_module_by_dependency_id(dep.id())
               .map(|module| &module.module_identifier)
           } else {
             None

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -1,10 +1,11 @@
 use rspack_core::{
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
 pub struct CssComposeDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: String,
   span: Option<ErrorSpan>,
 }
@@ -12,7 +13,7 @@ pub struct CssComposeDependency {
 impl CssComposeDependency {
   pub fn new(request: String, span: Option<ErrorSpan>) -> Self {
     Self {
-      id: None,
+      id: create_dependency_id(),
       request,
       span,
     }
@@ -20,11 +21,8 @@ impl CssComposeDependency {
 }
 
 impl Dependency for CssComposeDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -1,6 +1,5 @@
 use rspack_core::{
-  create_dependency_id, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
@@ -13,7 +12,7 @@ pub struct CssComposeDependency {
 impl CssComposeDependency {
   pub fn new(request: String, span: Option<ErrorSpan>) -> Self {
     Self {
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       span,
     }
@@ -21,10 +20,6 @@ impl CssComposeDependency {
 }
 
 impl Dependency for CssComposeDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CssCompose
   }
@@ -35,6 +30,10 @@ impl Dependency for CssComposeDependency {
 }
 
 impl ModuleDependency for CssComposeDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -1,11 +1,11 @@
 use rspack_core::{
-  CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
+  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
 pub struct CssImportDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: String,
   span: Option<ErrorSpan>,
   start: u32,
@@ -15,7 +15,7 @@ pub struct CssImportDependency {
 impl CssImportDependency {
   pub fn new(request: String, span: Option<ErrorSpan>, start: u32, end: u32) -> Self {
     Self {
-      id: None,
+      id: create_dependency_id(),
       request,
       span,
       start,
@@ -25,11 +25,8 @@ impl CssImportDependency {
 }
 
 impl Dependency for CssImportDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  create_dependency_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
@@ -15,7 +15,7 @@ pub struct CssImportDependency {
 impl CssImportDependency {
   pub fn new(request: String, span: Option<ErrorSpan>, start: u32, end: u32) -> Self {
     Self {
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       span,
       start,
@@ -25,10 +25,6 @@ impl CssImportDependency {
 }
 
 impl Dependency for CssImportDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CssImport
   }
@@ -39,6 +35,10 @@ impl Dependency for CssImportDependency {
 }
 
 impl ModuleDependency for CssImportDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
+  create_dependency_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
   CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, Dependency, DependencyCategory,
   DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier, PublicPath,
 };
@@ -8,7 +8,7 @@ use crate::utils::AUTO_PUBLIC_PATH_PLACEHOLDER;
 
 #[derive(Debug, Clone)]
 pub struct CssUrlDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: String,
   span: Option<ErrorSpan>,
   start: u32,
@@ -22,7 +22,7 @@ impl CssUrlDependency {
       span,
       start,
       end,
-      id: None,
+      id: create_dependency_id(),
     }
   }
 
@@ -55,11 +55,8 @@ impl CssUrlDependency {
 }
 
 impl Dependency for CssUrlDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -100,10 +97,9 @@ impl CodeGeneratableDependency for CssUrlDependency {
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
-    if let Some(id) = self.id()
-      && let Some(mgm) = compilation
+    if let Some(mgm) = compilation
         .module_graph
-        .module_graph_module_by_dependency_id(&id)
+        .module_graph_module_by_dependency_id(&self.id())
       && let Some(target_url) = self.get_target_url(&mgm.module_identifier, compilation)
     {
       source.replace(self.start, self.end, format!("url({target_url})").as_str(), None);

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  create_dependency_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
+  CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
   CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, Dependency, DependencyCategory,
   DependencyId, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier, PublicPath,
 };
@@ -22,7 +22,7 @@ impl CssUrlDependency {
       span,
       start,
       end,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 
@@ -55,10 +55,6 @@ impl CssUrlDependency {
 }
 
 impl Dependency for CssUrlDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Url
   }
@@ -69,6 +65,10 @@ impl Dependency for CssUrlDependency {
 }
 
 impl ModuleDependency for CssUrlDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -99,7 +99,7 @@ impl CodeGeneratableDependency for CssUrlDependency {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
     if let Some(mgm) = compilation
         .module_graph
-        .module_graph_module_by_dependency_id(&self.id())
+        .module_graph_module_by_dependency_id(self.id())
       && let Some(target_url) = self.get_target_url(&mgm.module_identifier, compilation)
     {
       source.replace(self.start, self.end, format!("url({target_url})").as_str(), None);

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(let_chains)]
 
 use rspack_core::{
-  Compilation, Dependency, EntryDependency, EntryOptions, MakeParam, Plugin, PluginContext,
+  Compilation, EntryDependency, EntryOptions, MakeParam, ModuleDependency, Plugin, PluginContext,
   PluginMakeHookOutput,
 };
 
@@ -35,9 +35,9 @@ impl Plugin for EntryPlugin {
     }
     let dependency = Box::new(EntryDependency::new(self.entry_request.clone()));
     let dependency_id = dependency.id();
+    compilation.add_entry(*dependency_id, self.name.clone(), self.options.clone());
+    param.add_force_build_dependency(*dependency_id, None);
     compilation.module_graph.add_dependency(dependency);
-    compilation.add_entry(dependency_id, self.name.clone(), self.options.clone());
-    param.add_force_build_dependency(dependency_id, None);
     Ok(())
   }
 }

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(let_chains)]
 
 use rspack_core::{
-  Compilation, EntryDependency, EntryOptions, MakeParam, Plugin, PluginContext,
+  Compilation, Dependency, EntryDependency, EntryOptions, MakeParam, Plugin, PluginContext,
   PluginMakeHookOutput,
 };
 
@@ -34,7 +34,8 @@ impl Plugin for EntryPlugin {
       return Ok(());
     }
     let dependency = Box::new(EntryDependency::new(self.entry_request.clone()));
-    let dependency_id = compilation.module_graph.add_dependency(dependency);
+    let dependency_id = dependency.id();
+    compilation.module_graph.add_dependency(dependency);
     compilation.add_entry(dependency_id, self.name.clone(), self.options.clone());
     param.add_force_build_dependency(dependency_id, None);
     Ok(())

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -25,7 +24,7 @@ impl CommonJsRequireDependency {
     optional: bool,
   ) -> Self {
     Self {
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       optional,
       start,
@@ -36,10 +35,6 @@ impl CommonJsRequireDependency {
 }
 
 impl Dependency for CommonJsRequireDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -50,6 +45,10 @@ impl Dependency for CommonJsRequireDependency {
 }
 
 impl ModuleDependency for CommonJsRequireDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -87,8 +86,6 @@ impl CodeGeneratableDependency for CommonJsRequireDependency {
       ..
     } = code_generatable_context;
 
-    let id: DependencyId = self.id();
-
     runtime_requirements.add(RuntimeGlobals::REQUIRE);
     source.replace(
       self.start,
@@ -96,7 +93,7 @@ impl CodeGeneratableDependency for CommonJsRequireDependency {
       format!(
         "{}({})",
         RuntimeGlobals::REQUIRE,
-        module_id(compilation, &id, &self.request, false).as_str()
+        module_id(compilation, &self.id, &self.request, false).as_str()
       )
       .as_str(),
       None,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -1,13 +1,14 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency, RuntimeGlobals,
 };
 use swc_core::ecma::atoms::JsWord;
 
 // Webpack RequireHeaderDependency + CommonJsRequireDependency
 #[derive(Debug, Clone)]
 pub struct CommonJsRequireDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   optional: bool,
   start: u32,
@@ -24,7 +25,7 @@ impl CommonJsRequireDependency {
     optional: bool,
   ) -> Self {
     Self {
-      id: None,
+      id: create_dependency_id(),
       request,
       optional,
       start,
@@ -35,11 +36,8 @@ impl CommonJsRequireDependency {
 }
 
 impl Dependency for CommonJsRequireDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -89,7 +87,7 @@ impl CodeGeneratableDependency for CommonJsRequireDependency {
       ..
     } = code_generatable_context;
 
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     runtime_requirements.add(RuntimeGlobals::REQUIRE);
     source.replace(

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ErrorSpan, ModuleDependency,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
+  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
@@ -30,17 +30,13 @@ impl RequireResolveDependency {
       request,
       weak,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       optional,
     }
   }
 }
 
 impl Dependency for RequireResolveDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -51,6 +47,10 @@ impl Dependency for RequireResolveDependency {
 }
 
 impl ModuleDependency for RequireResolveDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -90,14 +90,12 @@ impl CodeGeneratableDependency for RequireResolveDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id();
-
     source.replace(
       self.start,
       self.end,
       module_id(
         code_generatable_context.compilation,
-        &id,
+        &self.id,
         &self.request,
         self.weak,
       )

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,14 +1,14 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
-  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
 pub struct RequireResolveDependency {
   pub start: u32,
   pub end: u32,
-  pub id: Option<DependencyId>,
+  pub id: DependencyId,
   pub request: String,
   pub weak: bool,
   span: ErrorSpan,
@@ -30,19 +30,17 @@ impl RequireResolveDependency {
       request,
       weak,
       span,
-      id: None,
+      id: create_dependency_id(),
       optional,
     }
   }
 }
 
 impl Dependency for RequireResolveDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
   }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
-  }
+
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -92,7 +90,7 @@ impl CodeGeneratableDependency for RequireResolveDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  create_dependency_id, module_id_expr, normalize_context, CodeGeneratableContext,
-  CodeGeneratableDependency, CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  module_id_expr, normalize_context, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
@@ -28,16 +28,12 @@ impl CommonJsRequireContextDependency {
       args_end,
       options,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 }
 
 impl Dependency for CommonJsRequireContextDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -48,6 +44,10 @@ impl Dependency for CommonJsRequireContextDependency {
 }
 
 impl ModuleDependency for CommonJsRequireContextDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.options.request
   }
@@ -81,11 +81,9 @@ impl CodeGeneratableDependency for CommonJsRequireContextDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let id: DependencyId = self.id();
-
     let module_id = compilation
       .module_graph
-      .module_graph_module_by_dependency_id(&id)
+      .module_graph_module_by_dependency_id(&self.id)
       .map(|m| m.id(&compilation.chunk_graph))
       .expect("should have dependency id");
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  module_id_expr, normalize_context, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  create_dependency_id, module_id_expr, normalize_context, CodeGeneratableContext,
+  CodeGeneratableDependency, CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory,
+  DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
@@ -9,7 +9,7 @@ pub struct CommonJsRequireContextDependency {
   callee_start: u32,
   callee_end: u32,
   args_end: u32,
-  pub id: Option<DependencyId>,
+  pub id: DependencyId,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
 }
@@ -28,18 +28,16 @@ impl CommonJsRequireContextDependency {
       args_end,
       options,
       span,
-      id: None,
+      id: create_dependency_id(),
     }
   }
 }
 
 impl Dependency for CommonJsRequireContextDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
   }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
-  }
+
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -83,7 +81,7 @@ impl CodeGeneratableDependency for CommonJsRequireContextDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     let module_id = compilation
       .module_graph

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  module_id_expr, normalize_context, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  create_dependency_id, module_id_expr, normalize_context, CodeGeneratableContext,
+  CodeGeneratableDependency, CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory,
+  DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
@@ -9,7 +9,7 @@ pub struct ImportContextDependency {
   callee_start: u32,
   callee_end: u32,
   args_end: u32,
-  pub id: Option<DependencyId>,
+  pub id: DependencyId,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
 }
@@ -28,18 +28,16 @@ impl ImportContextDependency {
       args_end,
       options,
       span,
-      id: None,
+      id: create_dependency_id(),
     }
   }
 }
 
 impl Dependency for ImportContextDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
   }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
-  }
+
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
@@ -83,7 +81,7 @@ impl CodeGeneratableDependency for ImportContextDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     let module_id = compilation
       .module_graph

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  create_dependency_id, module_id_expr, normalize_context, CodeGeneratableContext,
-  CodeGeneratableDependency, CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  module_id_expr, normalize_context, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
@@ -28,16 +28,12 @@ impl ImportContextDependency {
       args_end,
       options,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 }
 
 impl Dependency for ImportContextDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
@@ -48,6 +44,10 @@ impl Dependency for ImportContextDependency {
 }
 
 impl ModuleDependency for ImportContextDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.options.request
   }
@@ -81,11 +81,9 @@ impl CodeGeneratableDependency for ImportContextDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let id: DependencyId = self.id();
-
     let module_id = compilation
       .module_graph
-      .module_graph_module_by_dependency_id(&id)
+      .module_graph_module_by_dependency_id(&self.id)
       .map(|m| m.id(&compilation.chunk_graph))
       .expect("should have dependency id");
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  create_dependency_id, module_id_expr, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  module_id_expr, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
+  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
@@ -20,16 +20,12 @@ impl RequireContextDependency {
       end,
       options,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 }
 
 impl Dependency for RequireContextDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -40,6 +36,10 @@ impl Dependency for RequireContextDependency {
 }
 
 impl ModuleDependency for RequireContextDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.options.request
   }
@@ -73,11 +73,9 @@ impl CodeGeneratableDependency for RequireContextDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let id: DependencyId = self.id();
-
     let module_id = compilation
       .module_graph
-      .module_graph_module_by_dependency_id(&id)
+      .module_graph_module_by_dependency_id(&self.id)
       .map(|m| m.id(&compilation.chunk_graph))
       .expect("should have dependency id");
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -1,14 +1,14 @@
 use rspack_core::{
-  module_id_expr, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
-  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals,
+  create_dependency_id, module_id_expr, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, ContextOptions, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
 pub struct RequireContextDependency {
   start: u32,
   end: u32,
-  pub id: Option<DependencyId>,
+  pub id: DependencyId,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
 }
@@ -20,18 +20,16 @@ impl RequireContextDependency {
       end,
       options,
       span,
-      id: None,
+      id: create_dependency_id(),
     }
   }
 }
 
 impl Dependency for RequireContextDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
   }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
-  }
+
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::CommonJS
   }
@@ -75,7 +73,7 @@ impl CodeGeneratableDependency for RequireContextDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     let module_id = compilation
       .module_graph

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -54,8 +54,7 @@ impl CodeGeneratableDependency for HarmonyExportImportedSpecifierDependency {
       })
       .find(|d| d.request() == &self.request)
       .expect("should have dependency")
-      .id()
-      .expect("should have dependency id");
+      .id();
 
     let import_var = compilation
       .module_graph

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -111,7 +111,7 @@ impl CodeGeneratableDependency for HarmonyExportImportedSpecifierDependency {
             true,
             import_var.clone(),
             id.1.clone().map(|i| vec![i]).unwrap_or_default(),
-            &dependency_id,
+            dependency_id,
             false,
           )),
         ));

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  import_statement, tree_shaking::visitor::SymbolRef, CodeGeneratableContext,
+  create_dependency_id, import_statement, tree_shaking::visitor::SymbolRef, CodeGeneratableContext,
   CodeGeneratableDependency, CodeGeneratableSource, Dependency, DependencyCategory, DependencyId,
   DependencyType, ErrorSpan, InitFragment, InitFragmentStage, ModuleDependency, RuntimeGlobals,
 };
@@ -20,7 +20,7 @@ pub struct HarmonyImportDependency {
   // pub start: u32,
   // pub end: u32,
   pub request: JsWord,
-  pub id: Option<DependencyId>,
+  pub id: DependencyId,
   pub span: Option<ErrorSpan>,
   pub refs: Vec<HarmonyImportSpecifierDependency>,
   pub specifiers: Vec<Specifier>,
@@ -40,7 +40,7 @@ impl HarmonyImportDependency {
     Self {
       request,
       span,
-      id: None,
+      id: create_dependency_id(),
       refs,
       specifiers,
       dependency_type,
@@ -57,7 +57,7 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
   ) {
     let compilation = &code_generatable_context.compilation;
     let module = &code_generatable_context.module;
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     let ref_mgm = compilation
       .module_graph
@@ -221,11 +221,8 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
 }
 
 impl Dependency for HarmonyImportDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  create_dependency_id, import_statement, tree_shaking::visitor::SymbolRef, CodeGeneratableContext,
+  import_statement, tree_shaking::visitor::SymbolRef, CodeGeneratableContext,
   CodeGeneratableDependency, CodeGeneratableSource, Dependency, DependencyCategory, DependencyId,
   DependencyType, ErrorSpan, InitFragment, InitFragmentStage, ModuleDependency, RuntimeGlobals,
 };
@@ -40,7 +40,7 @@ impl HarmonyImportDependency {
     Self {
       request,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       refs,
       specifiers,
       dependency_type,
@@ -57,11 +57,10 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
   ) {
     let compilation = &code_generatable_context.compilation;
     let module = &code_generatable_context.module;
-    let id: DependencyId = self.id();
 
     let ref_mgm = compilation
       .module_graph
-      .module_graph_module_by_dependency_id(&id)
+      .module_graph_module_by_dependency_id(&self.id)
       .expect("should have ref module");
     if !compilation
       .include_module_ids
@@ -71,7 +70,7 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
         dep.apply(
           source,
           code_generatable_context,
-          &id,
+          &self.id,
           self.request.as_ref(),
           false,
         )
@@ -134,7 +133,7 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
           dep.apply(
             source,
             code_generatable_context,
-            &id,
+            &self.id,
             self.request.as_ref(),
             false,
           )
@@ -147,14 +146,14 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
       dep.apply(
         source,
         code_generatable_context,
-        &id,
+        &self.id,
         self.request.as_ref(),
         true,
       )
     });
 
     let content: (String, String) =
-      import_statement(code_generatable_context, &id, &self.request, false);
+      import_statement(code_generatable_context, &self.id, &self.request, false);
 
     let CodeGeneratableContext {
       init_fragments,
@@ -166,7 +165,7 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
 
     let ref_module = compilation
       .module_graph
-      .module_identifier_by_dependency_id(&id)
+      .module_identifier_by_dependency_id(&self.id)
       .expect("should have dependency referenced module");
     let import_var = compilation
       .module_graph
@@ -221,10 +220,6 @@ impl CodeGeneratableDependency for HarmonyImportDependency {
 }
 
 impl Dependency for HarmonyImportDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
@@ -235,6 +230,10 @@ impl Dependency for HarmonyImportDependency {
 }
 
 impl ModuleDependency for HarmonyImportDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  module_namespace_promise, ChunkGroupOptions, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  create_dependency_id, module_namespace_promise, ChunkGroupOptions, CodeGeneratableContext,
+  CodeGeneratableDependency, CodeGeneratableSource, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -9,7 +9,7 @@ use swc_core::ecma::atoms::JsWord;
 pub struct ImportDependency {
   start: u32,
   end: u32,
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   span: Option<ErrorSpan>,
   /// This is used to implement `webpackChunkName`, `webpackPrefetch` etc.
@@ -30,18 +30,15 @@ impl ImportDependency {
       end,
       request,
       span,
-      id: None,
+      id: create_dependency_id(),
       group_options,
     }
   }
 }
 
 impl Dependency for ImportDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -85,7 +82,7 @@ impl CodeGeneratableDependency for ImportDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
     source.replace(
       self.start,
       self.end,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  create_dependency_id, module_namespace_promise, ChunkGroupOptions, CodeGeneratableContext,
-  CodeGeneratableDependency, CodeGeneratableSource, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ErrorSpan, ModuleDependency,
+  module_namespace_promise, ChunkGroupOptions, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -30,17 +30,13 @@ impl ImportDependency {
       end,
       request,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       group_options,
     }
   }
 }
 
 impl Dependency for ImportDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
@@ -51,6 +47,10 @@ impl Dependency for ImportDependency {
 }
 
 impl ModuleDependency for ImportDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -82,11 +82,10 @@ impl CodeGeneratableDependency for ImportDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id();
     source.replace(
       self.start,
       self.end,
-      module_namespace_promise(code_generatable_context, &id, &self.request, false).as_str(),
+      module_namespace_promise(code_generatable_context, &self.id, &self.request, false).as_str(),
       None,
     );
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
@@ -62,12 +62,7 @@ impl CodeGeneratableDependency for HarmonyAcceptDependency {
         .iter()
         .find(|d| d.request() == &dep.0 && d.category() == &dep.1 && d.dependency_type() == &dep.2)
       {
-        let stmts = import_statement(
-          code_generatable_context,
-          &dep.id().expect("should have dependency"),
-          dep.request(),
-          true,
-        );
+        let stmts = import_statement(code_generatable_context, &dep.id(), dep.request(), true);
         content.push_str(stmts.0.as_str());
         content.push_str(stmts.1.as_str());
       }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
@@ -1,32 +1,23 @@
 use rspack_core::{
   import_statement, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
-  Dependency, DependencyCategory, DependencyType, ModuleDependency, ModuleIdentifier,
+  DependencyId, ModuleDependency,
 };
-use swc_core::ecma::atoms::JsWord;
 
 #[derive(Debug, Clone)]
 pub struct HarmonyAcceptDependency {
   start: u32,
   end: u32,
   has_callback: bool,
-  module_identifier: ModuleIdentifier,
-  deps: Vec<(JsWord, DependencyCategory, DependencyType)>,
+  dependency_ids: Vec<DependencyId>,
 }
 
 impl HarmonyAcceptDependency {
-  pub fn new(
-    start: u32,
-    end: u32,
-    has_callback: bool,
-    module_identifier: ModuleIdentifier,
-    deps: Vec<(JsWord, DependencyCategory, DependencyType)>,
-  ) -> Self {
+  pub fn new(start: u32, end: u32, has_callback: bool, dependency_ids: Vec<DependencyId>) -> Self {
     Self {
       start,
       end,
       has_callback,
-      module_identifier,
-      deps,
+      dependency_ids,
     }
   }
 }
@@ -39,30 +30,11 @@ impl CodeGeneratableDependency for HarmonyAcceptDependency {
   ) {
     let CodeGeneratableContext { compilation, .. } = code_generatable_context;
 
-    let dependencies = {
-      let ids = compilation
-        .module_graph
-        .dependencies_by_module_identifier(&self.module_identifier)
-        .expect("should have dependencies");
-      ids
-        .iter()
-        .map(|id| {
-          compilation
-            .module_graph
-            .dependency_by_id(id)
-            .expect("should have dependency")
-        })
-        .collect::<Vec<_>>()
-    };
-
     let mut content = String::default();
 
-    self.deps.iter().for_each(|dep| {
-      if let Some(dep) = dependencies
-        .iter()
-        .find(|d| d.request() == &dep.0 && d.category() == &dep.1 && d.dependency_type() == &dep.2)
-      {
-        let stmts = import_statement(code_generatable_context, &dep.id(), dep.request(), true);
+    self.dependency_ids.iter().for_each(|id| {
+      if let Some(dependency) = compilation.module_graph.dependency_by_id(id) {
+        let stmts = import_statement(code_generatable_context, id, dependency.request(), true);
         content.push_str(stmts.0.as_str());
         content.push_str(stmts.1.as_str());
       }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -26,16 +25,12 @@ impl ImportMetaHotAcceptDependency {
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::ImportMetaHotAccept,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 }
 
 impl Dependency for ImportMetaHotAcceptDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     self.category
   }
@@ -46,6 +41,10 @@ impl Dependency for ImportMetaHotAcceptDependency {
 }
 
 impl ModuleDependency for ImportMetaHotAcceptDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -73,14 +72,12 @@ impl CodeGeneratableDependency for ImportMetaHotAcceptDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id = self.id();
-
     source.replace(
       self.start,
       self.end,
       module_id(
         code_generatable_context.compilation,
-        &id,
+        &self.id,
         &self.request,
         false,
       )

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,12 +1,13 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
 #[derive(Debug, Clone)]
 pub struct ImportMetaHotAcceptDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   start: u32,
   end: u32,
@@ -25,17 +26,14 @@ impl ImportMetaHotAcceptDependency {
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::ImportMetaHotAccept,
       span,
-      id: None,
+      id: create_dependency_id(),
     }
   }
 }
 
 impl Dependency for ImportMetaHotAcceptDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -75,7 +73,7 @@ impl CodeGeneratableDependency for ImportMetaHotAcceptDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id = self.id();
 
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -26,16 +25,12 @@ impl ImportMetaHotDeclineDependency {
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::ImportMetaHotDecline,
       span,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
     }
   }
 }
 
 impl Dependency for ImportMetaHotDeclineDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     self.category
   }
@@ -46,6 +41,10 @@ impl Dependency for ImportMetaHotDeclineDependency {
 }
 
 impl ModuleDependency for ImportMetaHotDeclineDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -73,14 +72,12 @@ impl CodeGeneratableDependency for ImportMetaHotDeclineDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id();
-
     source.replace(
       self.start,
       self.end,
       module_id(
         code_generatable_context.compilation,
-        &id,
+        &self.id,
         &self.request,
         false,
       )

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,12 +1,13 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
 #[derive(Debug, Clone)]
 pub struct ImportMetaHotDeclineDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   start: u32,
   end: u32,
@@ -25,17 +26,14 @@ impl ImportMetaHotDeclineDependency {
       category: &DependencyCategory::Esm,
       dependency_type: &DependencyType::ImportMetaHotDecline,
       span,
-      id: None,
+      id: create_dependency_id(),
     }
   }
 }
 
 impl Dependency for ImportMetaHotDeclineDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -75,7 +73,7 @@ impl CodeGeneratableDependency for ImportMetaHotDeclineDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -20,7 +19,7 @@ pub struct ModuleHotAcceptDependency {
 impl ModuleHotAcceptDependency {
   pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
     Self {
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       category: &DependencyCategory::CommonJS,
       dependency_type: &DependencyType::ModuleHotAccept,
@@ -32,10 +31,6 @@ impl ModuleHotAcceptDependency {
 }
 
 impl Dependency for ModuleHotAcceptDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     self.category
   }
@@ -46,6 +41,10 @@ impl Dependency for ModuleHotAcceptDependency {
 }
 
 impl ModuleDependency for ModuleHotAcceptDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -73,14 +72,12 @@ impl CodeGeneratableDependency for ModuleHotAcceptDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id();
-
     source.replace(
       self.start,
       self.end,
       module_id(
         code_generatable_context.compilation,
-        &id,
+        &self.id,
         &self.request,
         false,
       )

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,12 +1,13 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
 #[derive(Debug, Clone)]
 pub struct ModuleHotAcceptDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   start: u32,
   end: u32,
@@ -19,7 +20,7 @@ pub struct ModuleHotAcceptDependency {
 impl ModuleHotAcceptDependency {
   pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
     Self {
-      id: None,
+      id: create_dependency_id(),
       request,
       category: &DependencyCategory::CommonJS,
       dependency_type: &DependencyType::ModuleHotAccept,
@@ -31,11 +32,8 @@ impl ModuleHotAcceptDependency {
 }
 
 impl Dependency for ModuleHotAcceptDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -75,7 +73,7 @@ impl CodeGeneratableDependency for ModuleHotAcceptDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,12 +1,13 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
 #[derive(Debug, Clone)]
 pub struct ModuleHotDeclineDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   start: u32,
   end: u32,
@@ -19,7 +20,7 @@ pub struct ModuleHotDeclineDependency {
 impl ModuleHotDeclineDependency {
   pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
     Self {
-      id: None,
+      id: create_dependency_id(),
       request,
       category: &DependencyCategory::CommonJS,
       dependency_type: &DependencyType::ModuleHotDecline,
@@ -31,11 +32,8 @@ impl ModuleHotDeclineDependency {
 }
 
 impl Dependency for ModuleHotDeclineDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -75,7 +73,7 @@ impl CodeGeneratableDependency for ModuleHotDeclineDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -20,7 +19,7 @@ pub struct ModuleHotDeclineDependency {
 impl ModuleHotDeclineDependency {
   pub fn new(start: u32, end: u32, request: JsWord, span: Option<ErrorSpan>) -> Self {
     Self {
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       category: &DependencyCategory::CommonJS,
       dependency_type: &DependencyType::ModuleHotDecline,
@@ -32,10 +31,6 @@ impl ModuleHotDeclineDependency {
 }
 
 impl Dependency for ModuleHotDeclineDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     self.category
   }
@@ -46,6 +41,10 @@ impl Dependency for ModuleHotDeclineDependency {
 }
 
 impl ModuleDependency for ModuleHotDeclineDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -73,14 +72,12 @@ impl CodeGeneratableDependency for ModuleHotDeclineDependency {
     source: &mut CodeGeneratableSource,
     code_generatable_context: &mut CodeGeneratableContext,
   ) {
-    let id: DependencyId = self.id();
-
     source.replace(
       self.start,
       self.end,
       module_id(
         code_generatable_context.compilation,
-        &id,
+        &self.id,
         &self.request,
         false,
       )

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
-  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
+  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency, RuntimeGlobals,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -8,7 +9,7 @@ use swc_core::ecma::atoms::JsWord;
 pub struct URLDependency {
   start: u32,
   end: u32,
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: JsWord,
   span: Option<ErrorSpan>,
 }
@@ -18,7 +19,7 @@ impl URLDependency {
     Self {
       start,
       end,
-      id: None,
+      id: create_dependency_id(),
       request,
       span,
     }
@@ -26,11 +27,8 @@ impl URLDependency {
 }
 
 impl Dependency for URLDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -75,7 +73,7 @@ impl CodeGeneratableDependency for URLDependency {
       runtime_requirements,
       ..
     } = code_generatable_context;
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
 
     runtime_requirements.insert(RuntimeGlobals::BASE_URI);
     runtime_requirements.insert(RuntimeGlobals::REQUIRE);

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,7 +1,6 @@
 use rspack_core::{
-  create_dependency_id, module_id, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals,
+  module_id, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -19,7 +18,7 @@ impl URLDependency {
     Self {
       start,
       end,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       span,
     }
@@ -27,10 +26,6 @@ impl URLDependency {
 }
 
 impl Dependency for URLDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Url
   }
@@ -41,6 +36,10 @@ impl Dependency for URLDependency {
 }
 
 impl ModuleDependency for URLDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -73,7 +72,6 @@ impl CodeGeneratableDependency for URLDependency {
       runtime_requirements,
       ..
     } = code_generatable_context;
-    let id: DependencyId = self.id();
 
     runtime_requirements.insert(RuntimeGlobals::BASE_URI);
     runtime_requirements.insert(RuntimeGlobals::REQUIRE);
@@ -84,7 +82,7 @@ impl CodeGeneratableDependency for URLDependency {
       format!(
         "/* asset import */{}({}), {}",
         RuntimeGlobals::REQUIRE,
-        module_id(compilation, &id, &self.request, false),
+        module_id(compilation, &self.id, &self.request, false),
         RuntimeGlobals::BASE_URI
       )
       .as_str(),

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  create_dependency_id, ChunkGroupOptions, CodeGeneratableContext, CodeGeneratableDependency,
-  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals,
+  ChunkGroupOptions, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
+  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
@@ -27,7 +27,7 @@ impl WorkerDependency {
     Self {
       start,
       end,
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       request,
       span,
       group_options,
@@ -37,10 +37,6 @@ impl WorkerDependency {
 }
 
 impl Dependency for WorkerDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Worker
   }
@@ -51,6 +47,10 @@ impl Dependency for WorkerDependency {
 }
 
 impl ModuleDependency for WorkerDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }
@@ -87,10 +87,9 @@ impl CodeGeneratableDependency for WorkerDependency {
       runtime_requirements,
       ..
     } = code_generatable_context;
-    let id: DependencyId = self.id();
     let chunk_id = compilation
       .module_graph
-      .module_identifier_by_dependency_id(&id)
+      .module_identifier_by_dependency_id(&self.id)
       .map(|module| {
         compilation
           .chunk_graph

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,14 +1,14 @@
 use rspack_core::{
-  ChunkGroupOptions, CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource,
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
-  RuntimeGlobals,
+  create_dependency_id, ChunkGroupOptions, CodeGeneratableContext, CodeGeneratableDependency,
+  CodeGeneratableSource, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency, RuntimeGlobals,
 };
 
 #[derive(Debug, Clone)]
 pub struct WorkerDependency {
   start: u32,
   end: u32,
-  id: Option<DependencyId>,
+  id: DependencyId,
   request: String,
   span: Option<ErrorSpan>,
   group_options: ChunkGroupOptions,
@@ -27,7 +27,7 @@ impl WorkerDependency {
     Self {
       start,
       end,
-      id: None,
+      id: create_dependency_id(),
       request,
       span,
       group_options,
@@ -37,11 +37,8 @@ impl WorkerDependency {
 }
 
 impl Dependency for WorkerDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {
@@ -90,7 +87,7 @@ impl CodeGeneratableDependency for WorkerDependency {
       runtime_requirements,
       ..
     } = code_generatable_context;
-    let id: DependencyId = self.id().expect("should have dependency id");
+    let id: DependencyId = self.id();
     let chunk_id = compilation
       .module_graph
       .module_identifier_by_dependency_id(&id)

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -142,7 +142,6 @@ pub fn scan_dependencies(
     program.visit_with(&mut HotModuleReplacementScanner::new(
       &mut dependencies,
       &mut presentational_dependencies,
-      module_identifier,
       build_meta,
     ));
   }

--- a/crates/rspack_plugin_wasm/src/dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency.rs
@@ -1,6 +1,5 @@
 use rspack_core::{
-  create_dependency_id, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
 };
 
 use crate::WasmNode;
@@ -20,7 +19,7 @@ pub struct WasmImportDependency {
 impl WasmImportDependency {
   pub fn new(request: String, name: String, desc: WasmNode) -> Self {
     Self {
-      id: create_dependency_id(),
+      id: DependencyId::new(),
       name,
       request,
       desc,
@@ -34,10 +33,6 @@ impl WasmImportDependency {
 }
 
 impl Dependency for WasmImportDependency {
-  fn id(&self) -> DependencyId {
-    self.id
-  }
-
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Wasm
   }
@@ -48,6 +43,10 @@ impl Dependency for WasmImportDependency {
 }
 
 impl ModuleDependency for WasmImportDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
   fn request(&self) -> &str {
     &self.request
   }

--- a/crates/rspack_plugin_wasm/src/dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency.rs
@@ -1,12 +1,13 @@
 use rspack_core::{
-  Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan, ModuleDependency,
+  create_dependency_id, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
+  ModuleDependency,
 };
 
 use crate::WasmNode;
 
 #[derive(Debug, Clone)]
 pub struct WasmImportDependency {
-  id: Option<DependencyId>,
+  id: DependencyId,
   name: String,
   request: String,
   // only_direct_import: bool,
@@ -19,7 +20,7 @@ pub struct WasmImportDependency {
 impl WasmImportDependency {
   pub fn new(request: String, name: String, desc: WasmNode) -> Self {
     Self {
-      id: None,
+      id: create_dependency_id(),
       name,
       request,
       desc,
@@ -33,11 +34,8 @@ impl WasmImportDependency {
 }
 
 impl Dependency for WasmImportDependency {
-  fn id(&self) -> Option<DependencyId> {
+  fn id(&self) -> DependencyId {
     self.id
-  }
-  fn set_id(&mut self, id: Option<DependencyId>) {
-    self.id = id;
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -158,7 +158,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
             .map(|dep| {
               (
                 dep,
-                module_graph.module_graph_module_by_dependency_id(&dep.id()),
+                module_graph.module_graph_module_by_dependency_id(dep.id()),
               )
             })
             .for_each(|(dep, mgm)| {

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -158,7 +158,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
             .map(|dep| {
               (
                 dep,
-                module_graph.module_graph_module_by_dependency_id(&dep.id().expect("should be ok")),
+                module_graph.module_graph_module_by_dependency_id(&dep.id()),
               )
             })
             .for_each(|(dep, mgm)| {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Before we consider  thread lock for assign dependency id and set dependency id at after init dependency, but it caused dependencies reference isn't clear(the workaround code is very complex), so the pr set dependency id at init dependency.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

It's a code refactor, our test case should test it.
<!-- Can you please describe how you tested the changes you made to the code? -->
