### PR TITLE
feat: port JS `ParserHooks` of Webpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "rspack_error",
  "rspack_hash",
  "rspack_identifier",
+ "rspack_plugin_javascript_shared",
  "rspack_regex",
  "rspack_symbol",
  "rspack_testing",
@@ -2699,6 +2700,13 @@ dependencies = [
  "tokio",
  "url",
  "xxhash-rust",
+]
+
+[[package]]
+name = "rspack_plugin_javascript_shared"
+version = "0.0.1"
+dependencies = [
+ "swc_core",
 ]
 
 [[package]]

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -24,6 +24,7 @@ rspack_core = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 rspack_hash = { path = "../rspack_hash" }
 rspack_identifier = { path = "../rspack_identifier" }
+rspack_plugin_javascript_shared = { path = "../rspack_plugin_javascript_shared" }
 rspack_regex = { path = "../rspack_regex" }
 rspack_symbol = { path = "../rspack_symbol" }
 rustc-hash = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/js_ast_visitors/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/js_ast_visitors/common_js_scanner.rs
@@ -1,25 +1,16 @@
 use rspack_core::{CodeGeneratableDependency, RuntimeGlobals, RuntimeRequirementsDependency};
+use rspack_plugin_javascript_shared::JsAstVisitorHook;
 use swc_core::ecma::ast::Expr;
-use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
-use super::expr_matcher;
+use crate::visitors::expr_matcher;
 
-pub struct CommonJsScanner<'a> {
-  presentational_dependencies: &'a mut Vec<Box<dyn CodeGeneratableDependency>>,
+#[derive(Default)]
+pub struct CommonJsScanner {
+  pub(crate) presentational_dependencies: Vec<Box<dyn CodeGeneratableDependency>>,
 }
 
-impl<'a> CommonJsScanner<'a> {
-  pub fn new(presentational_dependencies: &'a mut Vec<Box<dyn CodeGeneratableDependency>>) -> Self {
-    Self {
-      presentational_dependencies,
-    }
-  }
-}
-
-impl Visit for CommonJsScanner<'_> {
-  noop_visit_type!();
-
-  fn visit_expr(&mut self, expr: &Expr) {
+impl JsAstVisitorHook for CommonJsScanner {
+  fn visit_expr(&mut self, expr: &Expr) -> bool {
     if expr_matcher::is_module_id(expr) {
       self
         .presentational_dependencies
@@ -34,6 +25,6 @@ impl Visit for CommonJsScanner<'_> {
           RuntimeGlobals::MODULE_LOADED,
         )));
     }
-    expr.visit_children_with(self);
+    false
   }
 }

--- a/crates/rspack_plugin_javascript/src/js_ast_visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/js_ast_visitors/mod.rs
@@ -1,0 +1,2 @@
+pub mod api_scanner;
+pub mod common_js_scanner;

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -5,6 +5,7 @@ pub(crate) mod dependency;
 mod plugin;
 pub use plugin::*;
 mod ast;
+pub(crate) mod js_ast_visitors;
 pub(crate) mod parser_and_generator;
 pub mod runtime;
 pub mod utils;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -1,7 +1,5 @@
-mod api_scanner;
 mod common_js_export_scanner;
 mod common_js_import_dependency_scanner;
-mod common_js_scanner;
 mod context_helper;
 mod harmony_detection_scanner;
 mod harmony_export_dependency_scanner;
@@ -18,13 +16,14 @@ use rspack_core::{
   ast::javascript::Program, BuildInfo, BuildMeta, BuildMetaExportsType, CodeGeneratableDependency,
   CompilerOptions, ModuleDependency, ModuleIdentifier, ModuleType, ResourceData,
 };
+use rspack_plugin_javascript_shared::JsAstVisitor;
 use swc_core::common::{comments::Comments, Mark, SyntaxContext};
 pub use util::*;
 
 use self::{
-  api_scanner::ApiScanner, common_js_export_scanner::CommonJsExportDependencyScanner,
+  common_js_export_scanner::CommonJsExportDependencyScanner,
   common_js_import_dependency_scanner::CommonJsImportDependencyScanner,
-  common_js_scanner::CommonJsScanner, harmony_detection_scanner::HarmonyDetectionScanner,
+  harmony_detection_scanner::HarmonyDetectionScanner,
   harmony_export_dependency_scanner::HarmonyExportDependencyScanner,
   harmony_import_dependency_scanner::HarmonyImportDependencyScanner,
   hot_module_replacement_scanner::HotModuleReplacementScanner,
@@ -32,6 +31,7 @@ use self::{
   node_stuff_scanner::NodeStuffScanner, require_context_scanner::RequireContextScanner,
   url_scanner::UrlScanner, worker_scanner::WorkerScanner,
 };
+use crate::js_ast_visitors::{api_scanner::ApiScanner, common_js_scanner::CommonJsScanner};
 
 pub type ScanDependenciesResult = (
   Vec<Box<dyn ModuleDependency>>,
@@ -49,16 +49,32 @@ pub fn scan_dependencies(
   build_meta: &mut BuildMeta,
   module_identifier: ModuleIdentifier,
 ) -> ScanDependenciesResult {
+  // The dependencies in `dependencies` is order-sensitive.
   let mut dependencies: Vec<Box<dyn ModuleDependency>> = vec![];
+  // The dependencies in `presentational_dependencies` isn't order-sensitive.
   let mut presentational_dependencies: Vec<Box<dyn CodeGeneratableDependency>> = vec![];
   let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
   let comments = program.comments.clone();
 
-  program.visit_with(&mut ApiScanner::new(
-    &unresolved_ctxt,
-    resource_data,
-    &mut presentational_dependencies,
-  ));
+  let mut ast_visitor = JsAstVisitor::default();
+  let mut api_scanner = ApiScanner::new(&unresolved_ctxt, resource_data);
+  ast_visitor.tap("api_scanner", &mut api_scanner);
+
+  if module_type.is_js_auto() || module_type.is_js_dynamic() {
+    let mut common_js_scanner = CommonJsScanner::default();
+
+    ast_visitor.tap("common_js_scanner", &mut common_js_scanner);
+
+    program.visit_with(&mut ast_visitor);
+
+    presentational_dependencies.append(&mut common_js_scanner.presentational_dependencies);
+  } else {
+    program.visit_with(&mut ast_visitor);
+  }
+  presentational_dependencies.append(&mut api_scanner.presentational_dependencies);
+
+  // TODO(hyf0): 👇👇👇 The following scanners should be refactored using `JsAstVisitorHook` and added
+  // to `ast_visitor`, we we could finish all scanning work in a single visit pass
 
   // TODO it should enable at js/auto or js/dynamic, but builtins provider will inject require at esm
   program.visit_with(&mut CommonJsImportDependencyScanner::new(
@@ -70,7 +86,6 @@ pub fn scan_dependencies(
     // TODO webpack scan it at CommonJsExportsParserPlugin
     // use `Dynamic` as workaround
     build_meta.exports_type = BuildMetaExportsType::Dynamic;
-    program.visit_with(&mut CommonJsScanner::new(&mut presentational_dependencies));
     program.visit_with(&mut RequireContextScanner::new(&mut dependencies));
     program.visit_with(&mut CommonJsExportDependencyScanner::new(
       &mut presentational_dependencies,

--- a/crates/rspack_plugin_javascript_shared/Cargo.toml
+++ b/crates/rspack_plugin_javascript_shared/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+edition    = "2021"
+license    = "MIT"
+name       = "rspack_plugin_javascript_shared"
+repository = "https://github.com/web-infra-dev/rspack"
+version    = "0.0.1"
+
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+swc_core = { workspace = true, features = ["ecma_ast", "ecma_visit", "__common"] }

--- a/crates/rspack_plugin_javascript_shared/src/js_ast_visitor.rs
+++ b/crates/rspack_plugin_javascript_shared/src/js_ast_visitor.rs
@@ -1,0 +1,152 @@
+//! How to add a missing hook to `JsAstVisitorHook`
+//! Find the missing hook at https://rustdoc.swc.rs/swc_ecma_visit/trait.Visit.html
+use std::{borrow::Cow, collections::HashMap};
+
+use swc_core::ecma::{
+  ast,
+  visit::{Visit, VisitWith},
+};
+
+type StaticStr = Cow<'static, str>;
+
+/// The reason why we introduce [JsAstVisitor] instead of using `swc_core::ecma_visit::Visit` is
+/// we want do finish all work in a single visit pass.
+#[derive(Default)]
+pub struct JsAstVisitor<'me> {
+  hooks: HashMap<StaticStr, Vec<&'me mut dyn JsAstVisitorHook>>,
+}
+
+impl<'me> JsAstVisitor<'me> {
+  pub fn tap(&mut self, key: impl Into<StaticStr>, hook: &'me mut dyn JsAstVisitorHook) {
+    let key = key.into();
+    self.hooks.entry(key).or_default().push(hook);
+  }
+}
+
+/// This macro is used to help of reducing boilerplate code of adding
+/// hook for various JS AST node type.
+///
+/// # Explanation
+/// For input
+/// ```ignore
+/// register_hooks!(pub trait JsAstVisitorHook {
+///   (visit_expr, ast::Expr),
+/// });
+/// ```
+///
+/// The macro would expand as
+///
+/// ```ignore
+/// trait JsAstVisitorHook {
+///   fn visit_expr(&mut self, node: &ast::Expr) {
+///      false
+///   }
+/// }
+///
+/// impl<'me> Visit for JsAstVisitor<'me> {
+///   fn visit_expr(&mut self, node: &ast::Expr) {
+///     self.hooks.values_mut().for_each(|hooks| {
+///       // Bailout if any hook returns `true`
+///       hooks.iter_mut().any(|hook| hook.visit_expr(node));
+///     });
+///     node.visit_children_with(self)
+///   }
+/// }
+/// ```
+macro_rules! register_hooks {
+  (
+    pub trait JsAstVisitorHook {
+        $( ($name:ident,  $node:ty),)*
+    }
+  ) => {
+    pub trait JsAstVisitorHook {
+      $(
+        fn $name(&mut self, _node: &$node) -> bool {
+          false
+        }
+      )*
+    }
+
+    impl<'me> Visit for JsAstVisitor<'me> {
+        $(
+        fn $name(&mut self, node: &$node) {
+          self.hooks.values_mut().for_each(|hooks| {
+            // Bailout if any hook returns `true`
+            hooks.iter_mut().any(|hook| hook.$name(node));
+          });
+          node.visit_children_with(self)
+        }
+        )*
+    }
+  };
+}
+
+// # How to register a missing hook
+// 1. Find the missing hook at https://rustdoc.swc.rs/swc_ecma_visit/trait.Visit.html
+// 2. Let's take `fn visit_expr(&mut self, n: &Expr)` as an example.
+// 3. Copy the name and Ast node type of the method and use a tuple to combine them.
+// 4. We will get a `(visit_expr, ast::Expr)`, then add it in the following postion.
+// 5. Don't forget to add the comma.
+register_hooks!(pub trait JsAstVisitorHook {
+    (visit_expr, ast::Expr),
+    (visit_ident, ast::Ident),
+
+});
+
+#[test]
+fn example_basic() {
+  use swc_core::common::util::take::Take;
+
+  let ast = ast::Module {
+    body: vec![ast::ModuleItem::Stmt(ast::Stmt::Expr(ast::ExprStmt {
+      ..ast::ExprStmt {
+        span: Default::default(),
+        expr: Box::new(ast::Expr::Array(ast::ArrayLit::dummy())),
+      }
+    }))],
+    ..ast::Module::dummy()
+  };
+
+  #[derive(Default)]
+  struct Hook {
+    pub called: bool,
+  }
+  #[derive(Default)]
+  struct Hook2 {
+    pub called: bool,
+  }
+  #[derive(Default)]
+  struct HookShouldBeSkipped {
+    pub called: bool,
+  }
+  impl JsAstVisitorHook for Hook {
+    fn visit_expr(&mut self, _node: &ast::Expr) -> bool {
+      self.called = true;
+      false
+    }
+  }
+  impl JsAstVisitorHook for Hook2 {
+    fn visit_expr(&mut self, _node: &ast::Expr) -> bool {
+      self.called = true;
+      true
+    }
+  }
+  impl JsAstVisitorHook for HookShouldBeSkipped {
+    fn visit_expr(&mut self, _node: &ast::Expr) -> bool {
+      self.called = true;
+      false
+    }
+  }
+
+  let mut ast_visitor = JsAstVisitor::default();
+  let mut hook = Hook::default();
+  let mut hook2 = Hook2::default();
+  let mut hook_should_skipped = HookShouldBeSkipped::default();
+  ast_visitor.tap("test", &mut hook);
+  ast_visitor.tap("test", &mut hook2);
+  ast_visitor.tap("test", &mut hook_should_skipped);
+  ast.visit_with(&mut ast_visitor);
+  assert!(hook.called);
+  assert!(hook2.called);
+  assert!(!hook_should_skipped.called);
+}

--- a/crates/rspack_plugin_javascript_shared/src/lib.rs
+++ b/crates/rspack_plugin_javascript_shared/src/lib.rs
@@ -1,0 +1,5 @@
+//! How to add a missing hook to `JsAstVisitorHook`
+//! Find the missing hook at https://rustdoc.swc.rs/swc_ecma_visit/trait.Visit.html
+mod js_ast_visitor;
+
+pub use js_ast_visitor::{JsAstVisitor, JsAstVisitorHook};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Port JS `ParserHooks` of Webpack.

Related issues & discussions:

- https://github.com/web-infra-dev/rspack/discussions/3619
- https://github.com/web-infra-dev/rspack/issues/3205

This PR introduces `JsAstVisitor` and the reason why we introduce it is we want to finish all scanning work in a single visit pass.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

The correctness of the build artifact could ensure by current tests.

I also add some unit tests to test the behaviors of `JsAstVisitor`. 

<!-- Can you please describe how you tested the changes you made to the code? -->
