### PR TITLE
fix(minifier): fix minifier options difference between minifications

### DIFF
--- a/examples/angular/scripts/build.js
+++ b/examples/angular/scripts/build.js
@@ -1,4 +1,5 @@
 const { spawn, spawnSync } = require("node:child_process");
+const path = require("node:path");
 const ls = spawn("node", ["-v"]);
 
 ls.stdout.on("data", data => {
@@ -25,9 +26,16 @@ ls.stderr.on("data", data => {
 function build() {
 	return new Promise((resolve, reject) => {
 		try {
-			const { status, error, stderr } = spawnSync("npx", ["rspack", "build"], {
-				stdio: "inherit"
-			});
+			const { status, error, stderr } = spawnSync(
+				"node",
+				[
+					path.resolve(__dirname, "../node_modules/@rspack/cli/bin/rspack"),
+					"build"
+				],
+				{
+					stdio: "inherit"
+				}
+			);
 			if (status !== 0) {
 				reject(stderr?.toString() || error);
 				return;

--- a/examples/angular/scripts/build.js
+++ b/examples/angular/scripts/build.js
@@ -1,31 +1,37 @@
 const { spawn, spawnSync } = require("node:child_process");
 const ls = spawn("node", ["-v"]);
 
-ls.stdout.on("data", (data) => {
+ls.stdout.on("data", data => {
 	let res = data.toString().trim();
 	const [a, _] = res.split(".");
 	if (a >= "v16") {
 		build()
 			.then(console.log)
-			.catch((err) => {
+			.catch(err => {
 				console.error(err);
-				process.exit(-1);
+				process.exit(1);
 			});
 	} else {
-		console.log("The Angular CLI requires a minimum of v16.13")
+		console.log("The Angular CLI requires a minimum of v16.13");
 		// Working around angular not support node14, but we need to test node v14 in CI
 		process.exit(0);
 	}
 });
 
-ls.stderr.on("data", (data) => {
+ls.stderr.on("data", data => {
 	throw new Error(`${data}`);
 });
 
 function build() {
 	return new Promise((resolve, reject) => {
 		try {
-			spawnSync("npx", ["rspack", "build"], { stdio: "inherit" });
+			const { status, error, stderr } = spawnSync("npx", ["rspack", "build"], {
+				stdio: "inherit"
+			});
+			if (status !== 0) {
+				reject(stderr?.toString() || error);
+				return;
+			}
 			resolve();
 		} catch (err) {
 			reject(err);

--- a/packages/rspack-plugin-minify/src/index.js
+++ b/packages/rspack-plugin-minify/src/index.js
@@ -31,16 +31,17 @@ module.exports = class RspackMinifyPlugin {
 				minifyWhitespace: true
 			});
 		} else if (this.options.minifier === "terser") {
-			delete this.options.minifier;
-			delete this.options.target;
-			delete this.options.css;
+			const options = Object.assign({}, this.options);
+			delete options.minifier;
+			delete options.target;
+			delete options.css;
 			const result = await minify(
 				{
 					[sourcefile]: code
 				},
 				{
 					sourceMap: sourcemap,
-					...this.options
+					...options
 				}
 			);
 			return result;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Directly deleting options from the original object will cause the `this.options` cannot be used for the next run. 
This also causes failure on the angular example.

Fixed build exit code for angular and the example itself.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
