### PR TITLE
fix: resolve worker without extension

### DIFF
--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -132,7 +132,9 @@ impl From<&str> for DependencyCategory {
       "wasm" => Self::Wasm,
       "css-import" => Self::CssImport,
       "css-compose" => Self::CssCompose,
-      _ => Self::Unknown,
+      "worker" => Self::Worker,
+      "unknown" => Self::Unknown,
+      _ => unimplemented!("DependencyCategory {}", value),
     }
   }
 }

--- a/packages/rspack/tests/configCases/worker/not-fully-specified-by-default/a.js
+++ b/packages/rspack/tests/configCases/worker/not-fully-specified-by-default/a.js
@@ -1,0 +1,3 @@
+onmessage = event => {
+	postMessage("ok");
+};

--- a/packages/rspack/tests/configCases/worker/not-fully-specified-by-default/index.js
+++ b/packages/rspack/tests/configCases/worker/not-fully-specified-by-default/index.js
@@ -1,0 +1,6 @@
+import { Worker as MyWorker } from "worker_threads";
+
+it("should compile", () => {
+	new MyWorker(new URL("./a", import.meta.url));
+	expect(true);
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

```js
new Worker(new URL("./worker"), import.meta.url)
```

resolve without extension for worker should works

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

- `packages/rspack/tests/configCases/worker/not-fully-specified-by-default`

<!-- Can you please describe how you tested the changes you made to the code? -->
