### PR TITLE
fix(splitChunks): should validate `min_size` of `ModuleGroup` in the each end of round

### DIFF
--- a/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
@@ -90,7 +90,7 @@ impl SplitChunksPlugin {
         }
 
         if Self::remove_min_size_violating_modules(
-          &module_group_key,
+          module_group_key,
           compilation,
           module_group,
           cache_group,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/min_size.rs
@@ -2,9 +2,72 @@ use rayon::prelude::*;
 use rspack_core::{Compilation, SourceType};
 
 use super::ModuleGroupMap;
-use crate::SplitChunksPlugin;
+use crate::{module_group::ModuleGroup, CacheGroup, SplitChunksPlugin};
 
 impl SplitChunksPlugin {
+  /// Return `true` if the `ModuleGroup` become empty.
+  pub(crate) fn remove_min_size_violating_modules(
+    module_group_key: &str,
+    compilation: &Compilation,
+    module_group: &mut ModuleGroup,
+    cache_group: &CacheGroup,
+  ) -> bool {
+    // Find out what `SourceType`'s size is not fit the min_size
+    let violating_source_types = module_group
+    .sizes
+    .iter()
+    .filter_map(|(module_group_ty, module_group_ty_size)| {
+      let cache_group_ty_min_size = cache_group
+        .min_size
+        .get(module_group_ty)
+        .copied()
+        .unwrap_or_default();
+
+      if *module_group_ty_size < cache_group_ty_min_size {
+        tracing::trace!(
+          "ModuleGroup({}) have violating SourceType({:?}). Reason: module_group_ty_size({:?}) < CacheGroup({}).min_size({:?})",
+          module_group_key,
+          module_group_ty,
+          module_group_ty_size,
+          cache_group.key,
+          cache_group_ty_min_size,
+        );
+        Some(*module_group_ty)
+      } else {
+        None
+      }
+    })
+    .collect::<Box<[_]>>();
+
+    // Remove modules having violating SourceType
+    let violating_modules = module_group
+      .modules
+      .par_iter()
+      .filter_map(|module_id| {
+        let module = &**compilation
+          .module_graph
+          .module_by_identifier(module_id)
+          .expect("Should have a module");
+        let having_violating_source_type = violating_source_types
+          .iter()
+          .any(|ty: &SourceType| module.source_types().contains(ty));
+        if having_violating_source_type {
+          Some(module)
+        } else {
+          None
+        }
+      })
+      .collect::<Vec<_>>();
+
+    // question: After removing violating modules, the size of other `SourceType`s of this `ModuleGroup`
+    // may not fit again. But Webpack seems ignore this case. Not sure if it is on purpose.
+    violating_modules
+      .into_iter()
+      .for_each(|violating_module| module_group.remove_module(violating_module));
+
+    module_group.modules.is_empty()
+  }
+
   /// Affected by `splitChunks.minSize`/`splitChunks.cacheGroups.{cacheGroup}.minSize`
   #[tracing::instrument(skip_all)]
   pub(crate) fn ensure_min_size_fit(
@@ -26,60 +89,12 @@ impl SplitChunksPlugin {
           return None;
         }
 
-        // Find out what `SourceType`'s size is not fit the min_size
-        let violating_source_types: Box<[SourceType]> = module_group
-          .sizes
-          .iter()
-          .filter_map(|(module_group_ty, module_group_ty_size)| {
-            let cache_group_ty_min_size = cache_group
-              .min_size
-              .get(module_group_ty)
-              .copied()
-              .unwrap_or_default();
-
-            if *module_group_ty_size < cache_group_ty_min_size {
-              tracing::trace!(
-                "ModuleGroup({}) have violating SourceType({:?}). Reason: module_group_ty_size({:?}) < CacheGroup({}).min_size({:?})",
-                module_group_key,
-                module_group_ty,
-                module_group_ty_size,
-                cache_group.key,
-                cache_group_ty_min_size,
-              );
-              Some(*module_group_ty)
-            } else {
-              None
-            }
-          })
-          .collect::<Box<[_]>>();
-
-        // Remove modules having violating SourceType
-        let violating_modules = module_group
-          .modules
-          .par_iter()
-          .filter_map(|module_id| {
-            let module = &**compilation
-              .module_graph
-              .module_by_identifier(module_id)
-              .expect("Should have a module");
-            let having_violating_source_type = violating_source_types
-              .iter()
-              .any(|ty: &SourceType| module.source_types().contains(ty));
-            if having_violating_source_type {
-              Some(module)
-            } else {
-              None
-            }
-          })
-          .collect::<Vec<_>>();
-
-        // question: After removing violating modules, the size of other `SourceType`s of this `ModuleGroup`
-        // may not fit again. But Webpack seems ignore this case. Not sure if it is on purpose.
-        violating_modules
-          .into_iter()
-          .for_each(|violating_module| module_group.remove_module(violating_module));
-
-        if module_group.modules.is_empty() {
+        if Self::remove_min_size_violating_modules(
+          &module_group_key,
+          compilation,
+          module_group,
+          cache_group,
+        ) {
           Some(module_group_key.clone())
         } else {
           None

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -224,7 +224,7 @@ impl SplitChunksPlugin {
         }
 
         // Validate `min_size` again
-        if Self::remove_min_size_violating_modules(&key, compilation, other_module_group, cache_group) {
+        if Self::remove_min_size_violating_modules(key, compilation, other_module_group, cache_group) {
           tracing::trace!(
             "{key} is deleted for violating min_size {:#?}",
             cache_group.min_size,

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -160,7 +160,7 @@ impl SplitChunksPlugin {
   #[tracing::instrument(skip_all)]
   pub(crate) fn remove_all_modules_from_other_module_groups(
     &self,
-    item: &ModuleGroup,
+    current_module_group: &ModuleGroup,
     module_group_map: &mut ModuleGroupMap,
     used_chunks: &FxHashSet<ChunkUkey>,
     compilation: &mut Compilation,
@@ -177,46 +177,57 @@ impl SplitChunksPlugin {
           .next()
           .is_some()
       })
-      .filter_map(|(key, each_module_group)| {
-        item.modules.iter().for_each(|module| {
-          if each_module_group.modules.contains(module) {
+      .filter_map(|(key, other_module_group)| {
+        current_module_group.modules.iter().for_each(|module| {
+          if other_module_group.modules.contains(module) {
             tracing::trace!("remove module({module}) from {key}");
             let module = compilation
               .module_graph
               .module_by_identifier(module)
               .unwrap_or_else(|| panic!("Module({module}) not found"));
-            each_module_group.remove_module(&**module);
+            other_module_group.remove_module(&**module);
           }
         });
 
-        if each_module_group.modules.is_empty() {
+        if other_module_group.modules.is_empty() {
           tracing::trace!(
             "{key} is deleted for having empty modules",
           );
           return Some(key.clone());
         }
 
-        tracing::trace!("each_module_group: {each_module_group:#?}");
-        tracing::trace!("item.modules: {:#?}", item.modules);
+        tracing::trace!("other_module_group: {other_module_group:#?}");
+        tracing::trace!("item.modules: {:#?}", current_module_group.modules);
 
         // Since there are modules removed, make sure the rest of chunks are all used.
-        each_module_group.chunks.retain(|c| {
-          let is_used_chunk = each_module_group
+        other_module_group.chunks.retain(|c| {
+          let is_used_chunk = other_module_group
             .modules
             .iter()
             .any(|m| compilation.chunk_graph.is_module_in_chunk(m, *c));
           is_used_chunk
         });
 
-        let cache_group: &CacheGroup = &self.cache_groups[each_module_group.cache_group_index];
+        let cache_group = &self.cache_groups[other_module_group.cache_group_index];
 
-        // There are some unused chunks, which is removed
-        if each_module_group.chunks.len() < cache_group.min_chunks as usize {
-          // `min_size` is not satisfied, remove this invalid `ModuleGroup`
+        // Since we removed some modules and chunks from the `other_module_group`. There are chances
+        // that the `min_chunks` and `min_size` validation is not satisfied anymore.
+
+        // Validate `min_chunks` again
+        if other_module_group.chunks.len() < cache_group.min_chunks as usize {
           tracing::trace!(
             "{key} is deleted for each_module_group.chunks.len()({:?}) < cache_group.min_chunks({:?})",
-            each_module_group.chunks.len(),
+            other_module_group.chunks.len(),
             cache_group.min_chunks
+          );
+          return Some(key.clone());
+        }
+
+        // Validate `min_size` again
+        if Self::remove_min_size_violating_modules(&key, compilation, other_module_group, cache_group) {
+          tracing::trace!(
+            "{key} is deleted for violating min_size {:#?}",
+            cache_group.min_size,
           );
           return Some(key.clone());
         }

--- a/packages/rspack/tests/configCases/split-chunks/issue-3646/src/another.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-3646/src/another.js
@@ -1,0 +1,2 @@
+import "./shared";
+export default "another.js";

--- a/packages/rspack/tests/configCases/split-chunks/issue-3646/src/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-3646/src/index.js
@@ -1,0 +1,11 @@
+import fs from "fs";
+import path from "path";
+import "./shared";
+export default "index.js";
+
+it("issue-3646", () => {
+	expect(fs.existsSync(path.resolve(__dirname, "./defaultVendors.js"))).toBe(
+		true
+	);
+	expect(fs.existsSync(path.resolve(__dirname, "./default.js"))).toBe(false);
+});

--- a/packages/rspack/tests/configCases/split-chunks/issue-3646/src/shared.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-3646/src/shared.js
@@ -1,0 +1,2 @@
+import _ from "lodash";
+console.log(_);

--- a/packages/rspack/tests/configCases/split-chunks/issue-3646/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-3646/webpack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: {
+		main: "./src/index.js",
+		another: "./src/another.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			chunks: "all"
+		}
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Since we removed some modules and chunks from the `other_module_group`. There are chances that the `min_chunks` and `min_size` validation is not satisfied anymore. So we need run validations again.

This prevents creating small chunks that violate the `minSize` option.

Related issue

- #3646 

I will close this issue after I change the docs.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Add a test.

<!-- Can you please describe how you tested the changes you made to the code? -->
