### PR TITLE
fix: replace module refrence or __webpack_module__ to module argument

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/mod.rs
@@ -2,12 +2,14 @@ mod commonjs;
 mod context;
 mod esm;
 mod hmr;
+mod module_argument_dependency;
 mod url;
 mod worker;
 pub use commonjs::*;
 pub use context::*;
 pub use esm::*;
 pub use hmr::*;
+pub use module_argument_dependency::*;
 pub use worker::*;
 
 pub use self::url::*;

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -1,0 +1,50 @@
+use rspack_core::{
+  CodeGeneratableContext, CodeGeneratableDependency, CodeGeneratableSource, RuntimeGlobals,
+};
+
+#[derive(Debug)]
+pub struct ModuleArgumentDependency {
+  pub start: u32,
+  pub end: u32,
+  pub id: Option<&'static str>,
+}
+
+impl ModuleArgumentDependency {
+  pub fn new(start: u32, end: u32, id: Option<&'static str>) -> Self {
+    Self { start, end, id }
+  }
+}
+
+impl CodeGeneratableDependency for ModuleArgumentDependency {
+  fn apply(
+    &self,
+    source: &mut CodeGeneratableSource,
+    code_generatable_context: &mut CodeGeneratableContext,
+  ) {
+    let CodeGeneratableContext {
+      runtime_requirements,
+      compilation,
+      module,
+      ..
+    } = code_generatable_context;
+
+    runtime_requirements.insert(RuntimeGlobals::MODULE);
+
+    let module_argument = compilation
+      .module_graph
+      .module_graph_module_by_identifier(&module.identifier())
+      .expect("should have mgm")
+      .get_module_argument();
+
+    if let Some(id) = self.id {
+      source.replace(
+        self.start,
+        self.end,
+        format!("{module_argument}.{id}").as_str(),
+        None,
+      );
+    } else {
+      source.replace(self.start, self.end, module_argument, None);
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -168,6 +168,7 @@ impl Visit for ApiScanner<'_> {
           expr.span().real_hi(),
           Some("id"),
         )));
+      return;
     }
     expr.visit_children_with(self);
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -1,5 +1,6 @@
 use rspack_core::{
-  CodeGeneratableDependency, ConstDependency, ResourceData, RuntimeGlobals, SpanExt,
+  CodeGeneratableDependency, ConstDependency, ResourceData, RuntimeGlobals,
+  RuntimeRequirementsDependency, SpanExt,
 };
 use swc_core::{
   common::{Spanned, SyntaxContext},
@@ -10,9 +11,11 @@ use swc_core::{
 };
 
 use super::expr_matcher;
+use crate::dependency::ModuleArgumentDependency;
 pub const WEBPACK_HASH: &str = "__webpack_hash__";
 pub const WEBPACK_PUBLIC_PATH: &str = "__webpack_public_path__";
 pub const WEBPACK_MODULES: &str = "__webpack_modules__";
+pub const WEBPACK_MODULE: &str = "__webpack_module__";
 pub const WEBPACK_RESOURCE_QUERY: &str = "__resourceQuery";
 pub const WEBPACK_CHUNK_LOAD: &str = "__webpack_chunk_load__";
 
@@ -129,6 +132,15 @@ impl Visit for ApiScanner<'_> {
             Some(RuntimeGlobals::ENSURE_CHUNK),
           )));
       }
+      WEBPACK_MODULE => {
+        self
+          .presentational_dependencies
+          .push(Box::new(ModuleArgumentDependency::new(
+            ident.span.real_lo(),
+            ident.span.real_hi(),
+            None,
+          )));
+      }
       _ => {}
     }
   }
@@ -146,11 +158,15 @@ impl Visit for ApiScanner<'_> {
     } else if expr_matcher::is_webpack_module_id(expr) {
       self
         .presentational_dependencies
-        .push(Box::new(ConstDependency::new(
+        .push(Box::new(RuntimeRequirementsDependency::new(
+          RuntimeGlobals::MODULE_ID,
+        )));
+      self
+        .presentational_dependencies
+        .push(Box::new(ModuleArgumentDependency::new(
           expr.span().real_lo(),
           expr.span().real_hi(),
-          "module.id".into(), // todo module_arguments
-          Some(RuntimeGlobals::MODULE_ID),
+          Some("id"),
         )));
     }
     expr.visit_children_with(self);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  BoxModuleDependency, BuildMeta, CodeGeneratableDependency, ConstDependency, ErrorSpan,
-  ModuleDependency, ModuleIdentifier, RuntimeGlobals, SpanExt,
+  BoxModuleDependency, BuildMeta, CodeGeneratableDependency, ErrorSpan, ModuleDependency,
+  ModuleIdentifier, SpanExt,
 };
 use swc_core::{
   common::Spanned,
@@ -15,7 +15,7 @@ use super::{expr_matcher, is_module_hot_accept_call, is_module_hot_decline_call}
 use crate::{
   dependency::{
     HarmonyAcceptDependency, ImportMetaHotAcceptDependency, ImportMetaHotDeclineDependency,
-    ModuleHotAcceptDependency, ModuleHotDeclineDependency,
+    ModuleArgumentDependency, ModuleHotAcceptDependency, ModuleHotDeclineDependency,
   },
   visitors::{is_import_meta_hot_accept_call, is_import_meta_hot_decline_call},
 };
@@ -125,11 +125,10 @@ impl<'a> Visit for HotModuleReplacementScanner<'a> {
     if expr_matcher::is_module_hot(expr) || expr_matcher::is_import_meta_webpack_hot(expr) {
       self
         .presentational_dependencies
-        .push(Box::new(ConstDependency::new(
+        .push(Box::new(ModuleArgumentDependency::new(
           expr.span().real_lo(),
           expr.span().real_hi(),
-          "module.hot".into(), // TODO module_argument
-          Some(RuntimeGlobals::MODULE),
+          Some("hot"),
         )));
     }
     expr.visit_children_with(self);

--- a/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/swc_visitor/react.rs
@@ -87,7 +87,7 @@ function $RefreshReg$(type, id) {
   __webpack_modules__.$ReactRefreshRuntime$.register(type, __webpack_module__.id+ "_" + id);
 }
 Promise.resolve().then(function(){
-  __webpack_modules__.$ReactRefreshRuntime$.refresh(__webpack_module__.id, module.hot);
+  __webpack_modules__.$ReactRefreshRuntime$.refresh(__webpack_module__.id, __webpack_module__.hot);
 })
 "#;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Replace `module.id` `module.hot` `__webpack_module__` to module argument. Also, avoid react refresh runtime use `module.hot` directly.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

These test at js side and already test it. 