### PR TITLE
fix: `chunkhash` should be available in chunk context

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -133,6 +133,9 @@ export interface JsAssetInfo {
   /**
    * the value(s) of the full hash used for this asset
    * the value(s) of the chunk hash used for this asset
+   */
+  chunkHash: Array<string>
+  /**
    * the value(s) of the module hash used for this asset
    * the value(s) of the content hash used for this asset
    */

--- a/crates/node_binding/src/js_values/asset.rs
+++ b/crates/node_binding/src/js_values/asset.rs
@@ -21,7 +21,7 @@ pub struct JsAssetInfo {
   /// the value(s) of the full hash used for this asset
   // pub full_hash:
   /// the value(s) of the chunk hash used for this asset
-  // pub chunk_hash:
+  pub chunk_hash: Vec<String>,
   /// the value(s) of the module hash used for this asset
   // pub module_hash:
   /// the value(s) of the content hash used for this asset
@@ -50,6 +50,7 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
       minimized: i.minimized,
       development: i.development,
       hot_module_replacement: i.hot_module_replacement,
+      chunk_hash: i.chunk_hash.into_iter().collect(),
       related: i.related.into(),
       content_hash: i.content_hash.into_iter().collect(),
       version: i.version,
@@ -80,6 +81,7 @@ impl From<rspack_core::AssetInfo> for JsAssetInfo {
       development: info.development,
       hot_module_replacement: info.hot_module_replacement,
       related: info.related.into(),
+      chunk_hash: info.chunk_hash.into_iter().collect(),
       content_hash: info.content_hash.into_iter().collect(),
       version: info.version,
     }

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, hash::Hash};
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 use rspack_database::DatabaseItem;
 use rspack_hash::{RspackHash, RspackHashDigest};
@@ -34,6 +34,7 @@ pub struct Chunk {
   pub runtime: RuntimeSpec,
   pub kind: ChunkKind,
   pub hash: Option<RspackHashDigest>,
+  pub rendered_hash: Option<Arc<str>>,
   pub content_hash: ChunkContentHash,
   pub chunk_reasons: Vec<String>,
 }
@@ -59,6 +60,7 @@ impl Chunk {
       runtime: HashSet::default(),
       kind,
       hash: None,
+      rendered_hash: None,
       content_hash: HashMap::default(),
       chunk_reasons: Default::default(),
     }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1131,6 +1131,25 @@ impl Compilation {
     let mut compilation_hasher = RspackHash::from(&self.options.output);
     let runtime_chunk_ukeys = self.get_chunk_graph_entries();
 
+    fn try_process_chunk_hash_results(
+      compilation: &mut Compilation,
+      chunk_hash_results: Vec<Result<(ChunkUkey, (RspackHashDigest, ChunkContentHash))>>,
+    ) -> Result<()> {
+      for hash_result in chunk_hash_results {
+        let (chunk_ukey, (chunk_hash, content_hash)) = hash_result?;
+        if let Some(chunk) = compilation.chunk_by_ukey.get_mut(&chunk_ukey) {
+          chunk.rendered_hash = Some(
+            chunk_hash
+              .rendered(compilation.options.output.hash_digest_length)
+              .into(),
+          );
+          chunk.hash = Some(chunk_hash);
+          chunk.content_hash = content_hash;
+        }
+      }
+      Ok(())
+    }
+
     let other_chunk_hash_results: Vec<Result<(ChunkUkey, (RspackHashDigest, ChunkContentHash))>> =
       self
         .chunk_by_ukey
@@ -1142,13 +1161,8 @@ impl Compilation {
         })
         .collect::<FuturesResults<_>>()
         .into_inner();
-    for hash_result in other_chunk_hash_results {
-      let (chunk_ukey, (chunk_hash, content_hash)) = hash_result?;
-      if let Some(chunk) = self.chunk_by_ukey.get_mut(&chunk_ukey) {
-        chunk.hash = Some(chunk_hash);
-        chunk.content_hash = content_hash;
-      }
-    }
+
+    try_process_chunk_hash_results(self, other_chunk_hash_results)?;
 
     // runtime chunks should be hashed after all other chunks
     self.create_runtime_module_hash();
@@ -1162,13 +1176,7 @@ impl Compilation {
         })
         .collect::<FuturesResults<_>>()
         .into_inner();
-    for hash_result in runtime_chunk_hash_results {
-      let (chunk_ukey, (chunk_hash, content_hash)) = hash_result?;
-      if let Some(chunk) = self.chunk_by_ukey.get_mut(&chunk_ukey) {
-        chunk.hash = Some(chunk_hash);
-        chunk.content_hash = content_hash;
-      }
-    }
+    try_process_chunk_hash_results(self, runtime_chunk_hash_results)?;
 
     self
       .chunk_by_ukey
@@ -1188,6 +1196,11 @@ impl Compilation {
           chunk_hash.hash(&mut hasher);
           self.hash.hash(&mut hasher);
           *chunk_hash = hasher.digest(&self.options.output.hash_digest);
+          chunk.rendered_hash = Some(
+            chunk_hash
+              .rendered(self.options.output.hash_digest_length)
+              .into(),
+          );
         }
         if let Some(content_hash) = chunk.content_hash.get_mut(&SourceType::JavaScript) {
           let mut hasher = RspackHash::from(&self.options.output);
@@ -1388,7 +1401,7 @@ pub struct AssetInfo {
   /// the value(s) of the full hash used for this asset
   // pub full_hash:
   /// the value(s) of the chunk hash used for this asset
-  // pub chunk_hash:
+  pub chunk_hash: HashSet<String>,
   /// the value(s) of the module hash used for this asset
   // pub module_hash:
   /// the value(s) of the content hash used for this asset
@@ -1443,6 +1456,10 @@ impl AssetInfo {
 
   pub fn set_content_hash(&mut self, v: String) {
     self.content_hash.insert(v);
+  }
+
+  pub fn set_chunk_hash(&mut self, v: String) {
+    self.chunk_hash.insert(v);
   }
 
   pub fn set_immutable(&mut self, v: bool) {

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -372,6 +372,19 @@ impl Filename {
       if let Some(name) = chunk.name_for_filename_template() {
         template = template.replace(NAME_PLACEHOLDER, name);
       }
+      if let Some(d) = chunk.rendered_hash.as_ref() {
+        template = CHUNK_HASH_PLACEHOLDER
+          .replace_all(&template, |caps: &Captures| {
+            let hash = &**d;
+            let hash = &hash[..hash_len(hash, caps)];
+            if let Some(asset_info) = asset_info.as_mut() {
+              asset_info.set_immutable(true);
+              asset_info.set_chunk_hash(hash.to_owned());
+            }
+            hash
+          })
+          .into_owned();
+      }
     }
 
     if let Some(id) = &options.id {

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -83,6 +83,7 @@ export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
 		development: false,
 		hotModuleReplacement: false,
 		related: {},
+		chunkHash: [],
 		contentHash: [],
 		version: "",
 		...info

--- a/packages/rspack/tests/configCases/output/chunk-filename/index.js
+++ b/packages/rspack/tests/configCases/output/chunk-filename/index.js
@@ -2,9 +2,15 @@ import fs from "fs";
 import path from "path";
 it("chunks/async-two_js.js should exist", async function () {
 	import("./two");
-	expect(
-		fs
-			.readdirSync(path.resolve(__dirname, "chunks"))
-			.includes("async-two_js.js")
-	).toBe(true);
+
+	let chunks = fs.readdirSync(path.resolve(__dirname, "chunks"));
+
+	const chunkFilename = chunks[0];
+	const expectedName = "async-two_js";
+
+	expect(chunkFilename.startsWith(expectedName));
+	expect(chunkFilename.endsWith(".js"));
+	expect(chunkFilename.length).toBe(
+		expectedName.length + ".".length + /* chunkhash */ 8 + ".js".length
+	);
 });

--- a/packages/rspack/tests/configCases/output/chunk-filename/webpack.config.js
+++ b/packages/rspack/tests/configCases/output/chunk-filename/webpack.config.js
@@ -6,6 +6,6 @@ module.exports = {
 	target: "node",
 	output: {
 		filename: "[name].js",
-		chunkFilename: "chunks/async-[name].js"
+		chunkFilename: "chunks/async-[name].[chunkhash:8].js"
 	}
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

closes #3704

## Summary

Fixed an issue that does not have `chunkhash` placeholder in chunk context.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

See changes in `rspack/test/configCases/output/chunk-filename`