### PR TITLE
ci: remove setup-zip because it is no longer needed

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -147,11 +147,6 @@ jobs:
         run: RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
 
       # Mac
-      - uses: goto-bus-stop/setup-zig@v2
-        if: ${{ contains(inputs.target, 'apple') }}
-        with:
-          version: 0.10.1
-
       - name: Build x86_64-apple-darwin
         if: ${{ inputs.target == 'x86_64-apple-darwin' }}
         run: |


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

We have a zig installation which is never used, this PR removes it

## Test Plan

Our current CI doesn't run mac builds, so I did a separate CI run to make sure Mac builds succeed.

https://github.com/web-infra-dev/rspack/actions/runs/5462017982/jobs/9941882978