### PR TITLE
chore: move swc_plugin_import to this repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4394,9 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_import"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1e28011697cf5bab340ab7689860d1eb8fb8035e97d89b999c2a8d3758dc79"
+version = "0.1.5"
 dependencies = [
  "handlebars",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ swc_error_reporters = { version = "=0.15.10" }
 swc_html            = { version = "=0.124.16" }
 swc_html_minifier   = { version = "=0.121.16" }
 swc_node_comments   = { version = "=0.18.10" }
-swc_plugin_import   = { version = "=0.1.7" }
 tikv-jemallocator   = { version = "=0.4.3", features = ["disable_initial_exec_tls"] }
 
 [profile.dev]

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -48,6 +48,6 @@ napi-derive       = { workspace = true }
 serde             = { workspace = true, features = ["derive"] }
 serde_json        = { workspace = true }
 swc_core          = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-swc_plugin_import = { workspace = true }
+swc_plugin_import = { path = "../swc_plugin_import" }
 tokio             = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 tracing           = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -71,7 +71,7 @@ swc_core = { workspace = true, features = [
 swc_emotion = { workspace = true }
 swc_error_reporters = { workspace = true }
 swc_node_comments = { workspace = true }
-swc_plugin_import = { workspace = true }
+swc_plugin_import = { path = "../swc_plugin_import" }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -46,7 +46,7 @@ swc_core = { workspace = true, features = [
 swc_ecma_minifier = { workspace = true, features = ["concurrent"] }
 swc_emotion = { workspace = true }
 swc_node_comments = { workspace = true }
-swc_plugin_import = { workspace = true }
+swc_plugin_import = { path = "../swc_plugin_import" }
 tokio = { workspace = true, features = ["rt"] }
 url = "2.3.1"
 xxhash-rust = { version = "0.8.6", features = ["xxh32"] }

--- a/crates/swc_plugin_import/Cargo.toml
+++ b/crates/swc_plugin_import/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+description = "babel-plugin-import rewritten in Rust"
+edition     = "2021"
+license     = "MIT"
+name        = "swc_plugin_import"
+version     = "0.1.5"
+
+[dependencies]
+handlebars = "4.3.3"
+regex      = { workspace = true }
+rustc-hash = { workspace = true }
+serde      = { workspace = true }
+swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit"] }
+
+[dev-dependencies]
+# test_plugins = { path = "../test_plugins" }

--- a/crates/swc_plugin_import/src/lib.rs
+++ b/crates/swc_plugin_import/src/lib.rs
@@ -1,0 +1,498 @@
+#![allow(clippy::unwrap_used)]
+
+mod visit;
+use std::fmt::Debug;
+
+use handlebars::{Context, Helper, HelperResult, Output, RenderContext, Template};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use serde::Deserialize;
+use swc_core::{
+  common::{util::take::Take, BytePos, Span, SyntaxContext, DUMMY_SP},
+  ecma::{
+    ast::{
+      Ident, ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportSpecifier, Module,
+      ModuleDecl, ModuleExportName, ModuleItem, Str,
+    },
+    atoms::JsWord,
+    visit::{as_folder, Fold, VisitMut, VisitWith},
+  },
+};
+
+use crate::visit::IdentComponent;
+
+#[derive(Debug, Deserialize, Clone)]
+pub enum StyleConfig {
+  StyleLibraryDirectory(String),
+  #[serde(skip)]
+  Custom(CustomTransform),
+  Css,
+  Bool(bool),
+  None,
+}
+
+#[derive(Deserialize)]
+pub enum CustomTransform {
+  #[serde(skip)]
+  Fn(Box<dyn Sync + Send + Fn(String) -> Option<String>>),
+  Tpl(String),
+}
+
+impl Clone for CustomTransform {
+  fn clone(&self) -> Self {
+    match self {
+      Self::Fn(_) => panic!("Function cannot be cloned"),
+      Self::Tpl(s) => Self::Tpl(s.clone()),
+    }
+  }
+}
+
+impl Debug for CustomTransform {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      CustomTransform::Fn(_) => f.write_str("Function"),
+      CustomTransform::Tpl(t) => f.write_str(t),
+    }
+  }
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+pub struct PluginImportConfig {
+  pub library_name: String,
+  pub library_directory: Option<String>, // default to `lib`
+  #[serde(skip)]
+  pub custom_name: Option<CustomTransform>,
+  #[serde(skip)]
+  pub custom_style_name: Option<CustomTransform>, // If this is set, `style` option will be ignored
+  pub style: Option<StyleConfig>,
+
+  pub camel_to_dash_component_name: Option<bool>, // default to true
+  pub transform_to_default_import: Option<bool>,
+
+  pub ignore_es_component: Option<Vec<String>>,
+  pub ignore_style_component: Option<Vec<String>>,
+}
+
+const CUSTOM_JS: &str = "CUSTOM_JS_NAME";
+const CUSTOM_STYLE: &str = "CUSTOM_STYLE";
+const CUSTOM_STYLE_NAME: &str = "CUSTOM_STYLE_NAME";
+
+pub fn plugin_import(config: &Vec<PluginImportConfig>) -> impl Fold + '_ {
+  let mut renderer = handlebars::Handlebars::new();
+
+  renderer.register_helper(
+    "kebabCase",
+    Box::new(
+      |helper: &Helper<'_, '_>,
+       _: &'_ handlebars::Handlebars<'_>,
+       _: &'_ Context,
+       _: &mut RenderContext<'_, '_>,
+       out: &mut dyn Output|
+       -> HelperResult {
+        let param = helper
+          .param(0)
+          .and_then(|v| v.value().as_str())
+          .unwrap_or("");
+        out.write(param.camel_to_kebab().as_ref())?;
+        Ok(())
+      },
+    ),
+  );
+
+  renderer.register_helper(
+    "upperCase",
+    Box::new(
+      |helper: &Helper<'_, '_>,
+       _: &'_ handlebars::Handlebars<'_>,
+       _: &'_ Context,
+       _: &mut RenderContext<'_, '_>,
+       out: &mut dyn Output|
+       -> HelperResult {
+        let param = helper
+          .param(0)
+          .and_then(|v| v.value().as_str())
+          .unwrap_or("");
+        out.write(param.to_uppercase().as_ref())?;
+        Ok(())
+      },
+    ),
+  );
+
+  renderer.register_helper(
+    "lowerCase",
+    Box::new(
+      |helper: &Helper<'_, '_>,
+       _: &'_ handlebars::Handlebars<'_>,
+       _: &'_ Context,
+       _: &mut RenderContext<'_, '_>,
+       out: &mut dyn Output|
+       -> HelperResult {
+        let param = helper
+          .param(0)
+          .and_then(|v| v.value().as_str())
+          .unwrap_or("");
+        out.write(param.to_lowercase().as_ref())?;
+        Ok(())
+      },
+    ),
+  );
+
+  config.iter().for_each(|cfg| {
+    if let Some(CustomTransform::Tpl(tpl)) = &cfg.custom_name {
+      renderer.register_template(
+        &(cfg.library_name.clone() + CUSTOM_JS),
+        Template::compile(tpl).unwrap(),
+      )
+    }
+
+    if let Some(CustomTransform::Tpl(tpl)) = &cfg.custom_style_name {
+      renderer.register_template(
+        &(cfg.library_name.clone() + CUSTOM_STYLE_NAME),
+        Template::compile(tpl).unwrap(),
+      )
+    }
+
+    if let Some(StyleConfig::Custom(CustomTransform::Tpl(tpl))) = &cfg.style {
+      renderer.register_template(
+        &(cfg.library_name.clone() + CUSTOM_STYLE),
+        Template::compile(tpl).unwrap(),
+      )
+    }
+  });
+
+  as_folder(ImportPlugin { config, renderer })
+}
+
+#[derive(Debug)]
+struct EsSpec {
+  source: String,
+  default_spec: String,
+  as_name: Option<String>,
+  use_default_import: bool,
+  mark: u32,
+}
+
+pub struct ImportPlugin<'a> {
+  pub config: &'a Vec<PluginImportConfig>,
+  pub renderer: handlebars::Handlebars<'a>,
+}
+
+impl<'a> ImportPlugin<'a> {
+  // return (import_es, import_css)
+  fn transform(
+    &self,
+    name: String,
+    config: &PluginImportConfig,
+  ) -> (Option<String>, Option<String>) {
+    let should_ignore = &config
+      .ignore_es_component
+      .as_ref()
+      .map(|list| list.iter().any(|c| c == &name))
+      .unwrap_or(false);
+
+    if *should_ignore {
+      return (None, None);
+    }
+
+    let should_ignore_css = &config
+      .ignore_style_component
+      .as_ref()
+      .map(|list| list.iter().any(|c| c == &name))
+      .unwrap_or(false);
+
+    let transformed_name = if config.camel_to_dash_component_name.unwrap_or(true) {
+      name.camel_to_kebab()
+    } else {
+      name.clone()
+    };
+
+    let path = if let Some(transform) = &config.custom_name {
+      match transform {
+        CustomTransform::Fn(f) => f(name.clone()),
+        CustomTransform::Tpl(_) => Some(
+          self
+            .renderer
+            .render(
+              format!("{}{}", &config.library_name, CUSTOM_JS).as_str(),
+              &render_context(name.clone()),
+            )
+            .unwrap(),
+        ),
+      }
+    } else {
+      Some(format!(
+        "{}/{}/{}",
+        &config.library_name,
+        config
+          .library_directory
+          .as_ref()
+          .unwrap_or(&"lib".to_string()),
+        transformed_name
+      ))
+    };
+
+    if path.is_none() {
+      return (None, None);
+    }
+
+    let js_source = path.unwrap();
+
+    let css = if *should_ignore_css {
+      None
+    } else if let Some(custom) = &config.custom_style_name {
+      match custom {
+        CustomTransform::Fn(f) => f(name),
+        CustomTransform::Tpl(_) => Some(
+          self
+            .renderer
+            .render(
+              &format!("{}{}", &config.library_name, CUSTOM_STYLE_NAME),
+              &render_context(name),
+            )
+            .unwrap(),
+        ),
+      }
+    } else if let Some(style) = &config.style {
+      match style {
+        StyleConfig::StyleLibraryDirectory(lib) => Some(format!(
+          "{}/{}/{}",
+          config.library_name, lib, &transformed_name
+        )),
+        StyleConfig::Custom(custom) => match custom {
+          CustomTransform::Fn(f) => f(js_source.clone()),
+          CustomTransform::Tpl(_) => Some(
+            self
+              .renderer
+              .render(
+                &format!("{}{}", config.library_name, CUSTOM_STYLE),
+                &render_context(js_source.clone()),
+              )
+              .expect("Should success"),
+          ),
+        },
+        StyleConfig::Css => Some(format!("{js_source}/style/css")),
+        StyleConfig::Bool(should_transform) => {
+          if *should_transform {
+            Some(format!("{}/style", &js_source))
+          } else {
+            None
+          }
+        }
+        StyleConfig::None => None,
+      }
+    } else {
+      None
+    };
+
+    (Some(js_source), css)
+  }
+}
+
+impl<'a> VisitMut for ImportPlugin<'a> {
+  fn visit_mut_module(&mut self, module: &mut Module) {
+    // use visitor to collect all ident reference, and then remove imported component and type that is never referenced
+    let mut visitor = IdentComponent {
+      ident_set: HashSet::default(),
+      type_ident_set: HashSet::default(),
+      in_ts_type_ref: false,
+    };
+    module.body.visit_with(&mut visitor);
+
+    let ident_referenced = |ident: &Ident| -> bool { visitor.ident_set.contains(&ident.to_id()) };
+    let type_ident_referenced =
+      |ident: &Ident| -> bool { visitor.type_ident_set.contains(&ident.to_id()) };
+
+    let mut specifiers_css = vec![];
+    let mut specifiers_es = vec![];
+    let mut specifiers_rm_es = HashSet::default();
+
+    let config = &self.config;
+
+    for (item_index, item) in module.body.iter_mut().enumerate() {
+      if let ModuleItem::ModuleDecl(ModuleDecl::Import(var)) = item {
+        let source = &*var.src.value;
+
+        if let Some(child_config) = config.iter().find(|&c| c.library_name == source) {
+          let mut rm_specifier = HashSet::default();
+
+          for (specifier_idx, specifier) in var.specifiers.iter().enumerate() {
+            match specifier {
+              ImportSpecifier::Named(ref s) => {
+                let imported = s.imported.as_ref().map(|imported| match imported {
+                  ModuleExportName::Ident(ident) => ident.sym.to_string(),
+                  ModuleExportName::Str(str) => str.value.to_string(),
+                });
+
+                let as_name: Option<String> = imported.is_some().then(|| s.local.sym.to_string());
+                let ident: String = imported.unwrap_or_else(|| s.local.sym.to_string());
+
+                let mark = s.local.span.ctxt.as_u32();
+
+                if ident_referenced(&s.local) {
+                  let use_default_import = child_config.transform_to_default_import.unwrap_or(true);
+
+                  let (import_es_source, import_css_source) =
+                    self.transform(ident.clone(), child_config);
+
+                  if let Some(source) = import_es_source {
+                    specifiers_es.push(EsSpec {
+                      source,
+                      default_spec: ident,
+                      as_name,
+                      use_default_import,
+                      mark,
+                    });
+                    rm_specifier.insert(specifier_idx);
+                  }
+
+                  if let Some(source) = import_css_source {
+                    specifiers_css.push(source);
+                  }
+                } else if type_ident_referenced(&s.local) {
+                  // type referenced
+                  continue;
+                } else {
+                  // not referenced, should tree shaking
+                  rm_specifier.insert(specifier_idx);
+                }
+              }
+              ImportSpecifier::Default(ref _s) => {}
+              ImportSpecifier::Namespace(ref _ns) => {}
+            }
+          }
+          if rm_specifier.len() == var.specifiers.len() {
+            // all specifier remove, just remove whole stmt
+            specifiers_rm_es.insert(item_index);
+          } else {
+            // only remove some specifier
+            var.specifiers = var
+              .specifiers
+              .take()
+              .into_iter()
+              .enumerate()
+              .filter_map(|(idx, spec)| (!rm_specifier.contains(&idx)).then_some(spec))
+              .collect();
+          }
+        }
+      }
+    }
+
+    module.body = module
+      .body
+      .take()
+      .into_iter()
+      .enumerate()
+      .filter_map(|(idx, stmt)| (!specifiers_rm_es.contains(&idx)).then_some(stmt))
+      .collect();
+
+    let body = &mut module.body;
+
+    for js_source in specifiers_es {
+      let js_source_ref = js_source.source.as_str();
+      let dec = ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+        span: DUMMY_SP,
+        specifiers: if js_source.use_default_import {
+          vec![ImportSpecifier::Default(ImportDefaultSpecifier {
+            span: DUMMY_SP,
+            local: Ident {
+              span: Span::new(
+                BytePos::DUMMY,
+                BytePos::DUMMY,
+                SyntaxContext::from_u32(js_source.mark),
+              ),
+              sym: JsWord::from(js_source.as_name.unwrap_or(js_source.default_spec).as_str()),
+              optional: false,
+            },
+          })]
+        } else {
+          vec![ImportSpecifier::Named(ImportNamedSpecifier {
+            span: DUMMY_SP,
+            imported: if js_source.as_name.is_some() {
+              Some(ModuleExportName::Ident(Ident {
+                span: DUMMY_SP,
+                sym: JsWord::from(js_source.default_spec.as_str()),
+                optional: false,
+              }))
+            } else {
+              None
+            },
+            local: Ident {
+              span: Span::new(
+                BytePos::DUMMY,
+                BytePos::DUMMY,
+                SyntaxContext::from_u32(js_source.mark),
+              ),
+              sym: JsWord::from(js_source.as_name.unwrap_or(js_source.default_spec).as_str()),
+              optional: false,
+            },
+            is_type_only: false,
+          })]
+        },
+        src: Box::new(Str {
+          span: DUMMY_SP,
+          value: JsWord::from(js_source_ref),
+          raw: None,
+        }),
+        type_only: false,
+        asserts: None,
+      }));
+      body.insert(0, dec);
+    }
+
+    for css_source in specifiers_css {
+      let dec = ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+        span: DUMMY_SP,
+        specifiers: vec![],
+        src: Box::new(Str {
+          span: DUMMY_SP,
+          value: JsWord::from(css_source),
+          raw: None,
+        }),
+        type_only: false,
+        asserts: None,
+      }));
+      body.insert(0, dec);
+    }
+  }
+}
+
+fn render_context(s: String) -> HashMap<&'static str, String> {
+  let mut ctx = HashMap::default();
+  ctx.insert("member", s);
+  ctx
+}
+
+trait KebabCase {
+  fn camel_to_kebab(&self) -> String;
+}
+
+impl<T> KebabCase for T
+where
+  T: AsRef<str>,
+{
+  fn camel_to_kebab(&self) -> String {
+    let s: &str = self.as_ref();
+    let mut output = String::with_capacity(s.len());
+
+    s.chars().enumerate().for_each(|(idx, c)| {
+      if c.is_uppercase() {
+        if idx > 0 {
+          output.push('-');
+        }
+        output.push_str(c.to_lowercase().to_string().as_str());
+      } else {
+        output.push(c);
+      }
+    });
+
+    output
+  }
+}
+
+#[test]
+fn test_kebab_case() {
+  assert_eq!("ABCD".camel_to_kebab(), "a-b-c-d");
+  assert_eq!("AbCd".camel_to_kebab(), "ab-cd");
+  assert_eq!("Aaaa".camel_to_kebab(), "aaaa");
+  assert_eq!("A".camel_to_kebab(), "a");
+  assert_eq!("".camel_to_kebab(), "");
+}

--- a/crates/swc_plugin_import/src/visit.rs
+++ b/crates/swc_plugin_import/src/visit.rs
@@ -1,0 +1,36 @@
+use rustc_hash::FxHashSet as HashSet;
+use swc_core::ecma::{
+  ast::{Id, Ident, ImportDecl, TsTypeRef},
+  visit::{Visit, VisitWith},
+};
+
+#[derive(Default)]
+pub struct IdentComponent {
+  pub ident_set: HashSet<Id>,
+  pub type_ident_set: HashSet<Id>,
+  pub in_ts_type_ref: bool,
+}
+
+///
+/// track ident reference
+impl Visit for IdentComponent {
+  // need to skip import decl
+  fn visit_import_decl(&mut self, _: &ImportDecl) {}
+
+  fn visit_ident(&mut self, ident: &Ident) {
+    if self.in_ts_type_ref {
+      self.type_ident_set.insert(ident.to_id());
+    } else {
+      self.ident_set.insert(ident.to_id());
+    }
+  }
+
+  fn visit_ts_type_ref(&mut self, type_ref: &TsTypeRef) {
+    let store_in_ts_type_ref = self.in_ts_type_ref;
+    self.in_ts_type_ref = true;
+
+    type_ref.type_name.visit_with(self);
+
+    self.in_ts_type_ref = store_in_ts_type_ref;
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/basic/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/basic/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/basic/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/basic/expected.js
@@ -1,0 +1,2 @@
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/basic/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/basic/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": false
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/custom-name-fn/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-name-fn/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase, KebabCase } from "foo";
+
+console.log(PascalCase, KebabCase);

--- a/crates/swc_plugin_import/tests/fixtures/custom-name-fn/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-name-fn/expected.js
@@ -1,0 +1,3 @@
+import KebabCase from "foo/__custom_es__/KebabCase";
+import { PascalCase } from "foo";
+console.log(PascalCase, KebabCase);

--- a/crates/swc_plugin_import/tests/fixtures/custom-name-fn/option.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-name-fn/option.js
@@ -1,0 +1,16 @@
+module.exports = {
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "customName": (name) => {
+          if (name === 'PascalCase') {
+            return undefined
+          } else {
+            return `foo/__custom_es__/${name}`
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/custom-name-tpl/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-name-tpl/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/custom-name-tpl/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-name-tpl/expected.js
@@ -1,0 +1,2 @@
+import PascalCase from "foo/__custom_es__/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/custom-name-tpl/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/custom-name-tpl/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "customName": "foo/__custom_es__/{{kebabCase member }}"
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/custom-style-name/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-style-name/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/custom-style-name/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/custom-style-name/expected.js
@@ -1,0 +1,3 @@
+import "foo/__custom__/pascal-case";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/custom-style-name/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/custom-style-name/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "customStyleName": "foo/__custom__/{{kebabCase member}}"
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/ignore-es-component/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/ignore-es-component/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase, Button } from 'foo'
+
+console.log(PascalCase, Button)

--- a/crates/swc_plugin_import/tests/fixtures/ignore-es-component/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/ignore-es-component/expected.js
@@ -1,0 +1,4 @@
+import "foo/lib/button/style";
+import Button from "foo/lib/button";
+import { PascalCase } from "foo";
+console.log(PascalCase, Button);

--- a/crates/swc_plugin_import/tests/fixtures/ignore-es-component/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/ignore-es-component/option.json
@@ -1,0 +1,11 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": true,
+        "ignoreEsComponent": ["PascalCase"]
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/ignore-style-component/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/ignore-style-component/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase, Button } from 'foo'
+
+console.log(PascalCase, Button)

--- a/crates/swc_plugin_import/tests/fixtures/ignore-style-component/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/ignore-style-component/expected.js
@@ -1,0 +1,4 @@
+import "foo/lib/button/style";
+import Button from "foo/lib/button";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase, Button);

--- a/crates/swc_plugin_import/tests/fixtures/ignore-style-component/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/ignore-style-component/option.json
@@ -1,0 +1,11 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": true,
+        "ignoreStyleComponent": ["PascalCase"]
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/no-default/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/no-default/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/no-default/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/no-default/expected.js
@@ -1,0 +1,2 @@
+import { PascalCase } from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/no-default/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/no-default/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "transformToDefaultImport": false
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/style-css/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-css/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/style-css/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-css/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case/style/css";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/style-css/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/style-css/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": "css"
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/style-fn/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-fn/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/style-fn/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-fn/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case.css";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/style-fn/option.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-fn/option.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": (dir) => `${dir}.css`
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/style-library/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-library/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/style-library/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-library/expected.js
@@ -1,0 +1,3 @@
+import "foo/css/pascal-case";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/style-library/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/style-library/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "styleLibraryDirectory": "css"
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/style-tpl/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-tpl/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/style-tpl/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-tpl/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case.css";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/style-tpl/option.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-tpl/option.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": "{{member}}.css"
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/fixtures/style-true/actual.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-true/actual.js
@@ -1,0 +1,3 @@
+import { PascalCase } from 'foo'
+
+console.log(PascalCase)

--- a/crates/swc_plugin_import/tests/fixtures/style-true/expected.js
+++ b/crates/swc_plugin_import/tests/fixtures/style-true/expected.js
@@ -1,0 +1,3 @@
+import "foo/lib/pascal-case/style";
+import PascalCase from "foo/lib/pascal-case";
+console.log(PascalCase);

--- a/crates/swc_plugin_import/tests/fixtures/style-true/option.json
+++ b/crates/swc_plugin_import/tests/fixtures/style-true/option.json
@@ -1,0 +1,10 @@
+{
+  "extensions": {
+    "pluginImport": [
+      {
+        "libraryName": "foo",
+        "style": true
+      }
+    ]
+  }
+}

--- a/crates/swc_plugin_import/tests/main.rs
+++ b/crates/swc_plugin_import/tests/main.rs
@@ -1,0 +1,1 @@
+// All test logic is in {project root}/tests/index.test.ts


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

To ship fast, we need to move code of swc_plugin_import to this repo.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Tests are disabled. It would be enabled in a another PR.

<!-- Can you please describe how you tested the changes you made to the code? -->
