### PR TITLE
fix: non amd external break amd library

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -319,6 +319,7 @@ impl Module for ExternalModule {
         );
       }
     };
+    cgr.runtime_requirements.insert(RuntimeGlobals::MODULE);
     Ok(cgr)
   }
 

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -49,6 +49,10 @@ impl Plugin for AmdLibraryPlugin {
           .module_graph
           .module_by_identifier(identifier)
           .and_then(|module| module.as_external_module())
+          .and_then(|m| {
+            let ty = m.get_external_type();
+            (ty == "amd" || ty == "amd-require").then_some(m)
+          })
       })
       .collect::<Vec<&ExternalModule>>();
     let external_deps_array = external_dep_array(&modules);

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -47,13 +47,7 @@ impl Plugin for SystemLibraryPlugin {
           .module_graph
           .module_by_identifier(identifier)
           .and_then(|module| module.as_external_module())
-          .and_then(|m| {
-            if m.get_external_type() == "system" {
-              Some(m)
-            } else {
-              None
-            }
-          })
+          .and_then(|m| (m.get_external_type() == "system").then_some(m))
       })
       .collect::<Vec<&ExternalModule>>();
     let external_deps_array = external_system_dep_array(&modules);

--- a/packages/rspack/tests/configCases/externals/non-amd-externals-amd/index.js
+++ b/packages/rspack/tests/configCases/externals/non-amd-externals-amd/index.js
@@ -1,0 +1,32 @@
+var fs = require("fs");
+
+var dependencyArrayRegex = /define\((\[[^\]]*\]), (function)?\(/;
+var source = fs.readFileSync(__filename, "utf-8");
+var [, deps] = dependencyArrayRegex.exec(source);
+
+it("should correctly import a AMD external", function () {
+	var external = require("external0");
+	expect(external).toBe("module 0");
+});
+
+it("should contain the AMD external in the dependency array", function () {
+	expect(deps).toContain('"external0"');
+});
+
+it("should correctly import a non-AMD external", function () {
+	var external = require("external1");
+	expect(external).toBe("abc");
+});
+
+it("should not contain the non-AMD external in the dependency array", function () {
+	expect(deps).not.toContain('"external1"');
+});
+
+it("should correctly import a asset external", function () {
+	var asset = new URL("#hash", import.meta.url);
+	expect(asset.href).toBe("https://test.cases/path/index.html" + "#hash");
+});
+
+it("should not contain asset external in the dependency array", function () {
+	expect(deps).not.toContain('"#hash"');
+});

--- a/packages/rspack/tests/configCases/externals/non-amd-externals-amd/test.config.js
+++ b/packages/rspack/tests/configCases/externals/non-amd-externals-amd/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	modules: {
+		external0: "module 0"
+	}
+};

--- a/packages/rspack/tests/configCases/externals/non-amd-externals-amd/webpack.config.js
+++ b/packages/rspack/tests/configCases/externals/non-amd-externals-amd/webpack.config.js
@@ -1,0 +1,26 @@
+const webpack = require("../../../../");
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "amd"
+	},
+	externals: {
+		external0: "external0",
+		external1: "var 'abc'"
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	target: "web",
+	externalsPresets: {
+		node: true
+	},
+	builtins: {
+		banner: {
+			raw: true,
+			banner:
+				"function define(deps, fn) { fn(...deps.map(dep => require(dep))); }\n"
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/library/amd-unnamed/index.js
+++ b/packages/rspack/tests/configCases/library/amd-unnamed/index.js
@@ -4,5 +4,5 @@ it("should name define", function () {
 	var fs = require("fs");
 	var source = fs.readFileSync(__filename, "utf-8");
 
-	expect(source).toMatch(/define\(\[[^\]]*\]/);
+	expect(source).toMatch(/define\((function)?\(/);
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

https://github.com/webpack/webpack/pull/17466

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

- `packages/rspack/tests/configCases/externals/non-amd-externals-amd`

<!-- Can you please describe how you tested the changes you made to the code? -->
