### PR TITLE
chore: release canary with x86_64-unknown-linux-gnu for Cloud IDE

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,6 +16,7 @@ jobs:
         target:
           - x86_64-apple-darwin
           - aarch64-apple-darwin
+          - x86_64-unknown-linux-gnu # For Cloud IDE
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add `x86_64-unknown-linux-gnu` to canary so it can be tested on Cloud IDEs.

## Test Plan

None