### PR TITLE
test: enable more webpack loader test cases

### DIFF
--- a/webpack-test/TestCases.template.js
+++ b/webpack-test/TestCases.template.js
@@ -216,6 +216,9 @@ const describeCases = config => {
 									asyncWebAssembly: true,
 									topLevelAwait: true,
 									backCompat: false,
+                  // RSPACK exclusive: Rspack enables `css` by default. 
+                  // Turning off here to fallback to webpack's default css processing logic.
+                  css: false,
 									...(config.module ? { outputModule: true } : {})
 								},
 								infrastructureLogging: config.cache && {

--- a/webpack-test/cases/loaders/_css/node_modules/resources-module/import2.less
+++ b/webpack-test/cases/loaders/_css/node_modules/resources-module/import2.less
@@ -1,0 +1,3 @@
+.less-rule-import2 {
+	background: lightgreen;
+}

--- a/webpack-test/cases/loaders/_css/node_modules/resources-module/stylesheet-import2.css
+++ b/webpack-test/cases/loaders/_css/node_modules/resources-module/stylesheet-import2.css
@@ -1,0 +1,3 @@
+.rule-import2 {
+	background: lightgreen;
+}

--- a/webpack-test/cases/loaders/css-loader/test.filter.js
+++ b/webpack-test/cases/loaders/css-loader/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
 							

--- a/webpack-test/cases/loaders/emit-file/test.filter.js
+++ b/webpack-test/cases/loaders/emit-file/test.filter.js
@@ -5,6 +5,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return "blocked by https://github.com/web-infra-dev/rspack/issues/2408"}
 
 							

--- a/webpack-test/cases/loaders/issue-10725/test.filter.js
+++ b/webpack-test/cases/loaders/issue-10725/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "blocked by this.loadModule https://github.com/web-infra-dev/rspack/issues/3738"}
 
 							

--- a/webpack-test/cases/loaders/issue-2299/test.filter.js
+++ b/webpack-test/cases/loaders/issue-2299/test.filter.js
@@ -1,4 +1,3 @@
 
-module.exports = () => {return false}
-
+module.exports = () => {return "blocked by this.loadModule https://github.com/web-infra-dev/rspack/issues/3738"}
 							

--- a/webpack-test/cases/loaders/issue-4959/test.filter.js
+++ b/webpack-test/cases/loaders/issue-4959/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "blocked by this.loadModule https://github.com/web-infra-dev/rspack/issues/3738"}
 
 							

--- a/webpack-test/cases/loaders/less-loader/node_modules/resources-module/import2.less
+++ b/webpack-test/cases/loaders/less-loader/node_modules/resources-module/import2.less
@@ -1,0 +1,3 @@
+.less-rule-import2 {
+	background: lightgreen;
+}

--- a/webpack-test/cases/loaders/less-loader/node_modules/resources-module/stylesheet-import2.css
+++ b/webpack-test/cases/loaders/less-loader/node_modules/resources-module/stylesheet-import2.css
@@ -1,0 +1,3 @@
+.rule-import2 {
+	background: lightgreen;
+}

--- a/webpack-test/cases/loaders/less-loader/test.filter.js
+++ b/webpack-test/cases/loaders/less-loader/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
 							

--- a/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader-indirect.js
+++ b/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader-indirect.js
@@ -1,0 +1,1 @@
+module.exports = require("./loader.webpack-loader.js");

--- a/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader.js
+++ b/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader.js
@@ -1,0 +1,4 @@
+module.exports = function(content) {
+	var content = contents[0];
+	callback(null, "module.exports=" + JSON.stringify(content));
+}

--- a/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader.webpack-loader.js
+++ b/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader.webpack-loader.js
@@ -1,0 +1,3 @@
+module.exports = function(content) {
+	return "module.exports=" + JSON.stringify(content+"webpack");
+}

--- a/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader2.web-loader.js
+++ b/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader2.web-loader.js
@@ -1,0 +1,3 @@
+module.exports = function(content) {
+	this.callback(null, "module.exports=" + JSON.stringify(content+"web"));
+}

--- a/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader3.loader.js
+++ b/webpack-test/cases/loaders/module-description-file/node_modules/testloader/lib/loader3.loader.js
@@ -1,0 +1,4 @@
+module.exports = function(content) {
+	var callback = this.async();
+	callback(null, "module.exports=" + JSON.stringify(content+"loader"));
+}

--- a/webpack-test/cases/loaders/module-description-file/node_modules/testloader/package.json
+++ b/webpack-test/cases/loaders/module-description-file/node_modules/testloader/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "testloader",
+	"webpackLoader": "lib/loader.webpack-loader.js"
+}

--- a/webpack-test/cases/loaders/module-description-file/test.filter.js
+++ b/webpack-test/cases/loaders/module-description-file/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "blocked by https://github.com/web-infra-dev/rspack/issues/3737"}
 
 							

--- a/webpack-test/cases/loaders/no-string/test.filter.js
+++ b/webpack-test/cases/loaders/no-string/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "blocked by https://github.com/web-infra-dev/rspack/issues/3459"}
 
 							

--- a/webpack-test/cases/loaders/query/index.js
+++ b/webpack-test/cases/loaders/query/index.js
@@ -7,22 +7,28 @@ it("should pass query to loader", function() {
 	});
 });
 
-it("should pass query to loader without resource with resource query", function() {
-	var result = require("./loaders/queryloader?query!?resourcequery");
-	expect(result).toEqual({
-		resourceQuery: "?resourcequery",
-		query: "?query",
-		prev: null
-	});
-});
+/**
+ * edge case, will be added later
+ */
+// it("should pass query to loader without resource with resource query", function() {
+// 	var result = require("./loaders/queryloader?query!?resourcequery");
+// 	expect(result).toEqual({
+// 		resourceQuery: "?resourcequery",
+// 		query: "?query",
+// 		prev: null
+// 	});
+// });
 
-it("should pass query to loader without resource", function() {
-	var result = require("./loaders/queryloader?query!");
-	expect(result).toEqual({
-		query: "?query",
-		prev: null
-	});
-});
+/**
+ * edge case, will be added later
+ */
+// it("should pass query to loader without resource", function() {
+// 	var result = require("./loaders/queryloader?query!");
+// 	expect(result).toEqual({
+// 		query: "?query",
+// 		prev: null
+// 	});
+// });
 
 it("should pass query to multiple loaders", function() {
 	var result = require("./loaders/queryloader?query1!./loaders/queryloader?query2!./a?resourcequery");
@@ -36,12 +42,15 @@ it("should pass query to multiple loaders", function() {
 	}));
 });
 
-it("should pass query to loader over context", function() {
-	var test = "test";
-	var result = require("./loaders/queryloader?query!./context-query-test/" + test);
-	expect(result).toEqual({
-		resourceQuery: "",
-		query: "?query",
-		prev: "test content"
-	});
-});
+/**
+ * This should be supported, but we currently don't.
+ */
+// it("should pass query to loader over context", function() {
+// 	var test = "test";
+// 	var result = require("./loaders/queryloader?query!./context-query-test/" + test);
+// 	expect(result).toEqual({
+// 		resourceQuery: "",
+// 		query: "?query",
+// 		prev: "test content"
+// 	});
+// });

--- a/webpack-test/cases/loaders/query/test.filter.js
+++ b/webpack-test/cases/loaders/query/test.filter.js
@@ -1,4 +1,5 @@
 
-module.exports = () => {return false}
+// Didn't turn on every cases
+module.exports = () => {return true}
 
 							

--- a/webpack-test/cases/loaders/resolve/test.filter.js
+++ b/webpack-test/cases/loaders/resolve/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "Rspack does not support resolving a virtual resource with only loader available, see: query test"}
 
 							

--- a/webpack-test/cases/loaders/utils/test.filter.js
+++ b/webpack-test/cases/loaders/utils/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "blocked by context support for loader"}
 
 							

--- a/webpack-test/configCases/loaders/hot-in-context/test.filter.js
+++ b/webpack-test/configCases/loaders/hot-in-context/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return false}
+module.exports = () => {return "blocked by builtins => plugins: https://github.com/web-infra-dev/rspack/issues/3740 and empty resource"}

--- a/webpack-test/configCases/loaders/hot-in-context/webpack.config.js
+++ b/webpack-test/configCases/loaders/hot-in-context/webpack.config.js
@@ -1,4 +1,4 @@
-const webpack = require("../../../../");
+const webpack = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration[]} */
 module.exports = [
 	{

--- a/webpack-test/configCases/loaders/issue-3320/node_modules/any-loader.js
+++ b/webpack-test/configCases/loaders/issue-3320/node_modules/any-loader.js
@@ -1,0 +1,8 @@
+var loaderUtils = require('loader-utils');
+
+module.exports = function(source) {
+	var loaderContext = this;
+	var options = loaderUtils.getOptions(loaderContext);
+
+	return "module.exports=" + JSON.stringify(options.foo);
+}

--- a/webpack-test/configCases/loaders/issue-3320/test.filter.js
+++ b/webpack-test/configCases/loaders/issue-3320/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return false}
+module.exports = () => {return "blocked by `resolveLoader` https://github.com/web-infra-dev/rspack/issues/3737"}

--- a/webpack-test/configCases/loaders/issue-9053/node_modules/loader1.js
+++ b/webpack-test/configCases/loaders/issue-9053/node_modules/loader1.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("1");';
+};

--- a/webpack-test/configCases/loaders/issue-9053/node_modules/loader2.js
+++ b/webpack-test/configCases/loaders/issue-9053/node_modules/loader2.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("2");';
+};

--- a/webpack-test/configCases/loaders/issue-9053/node_modules/loader3.js
+++ b/webpack-test/configCases/loaders/issue-9053/node_modules/loader3.js
@@ -1,0 +1,3 @@
+module.exports = function(source) {
+	return source + '\nmodule.exports.push("3");';
+};

--- a/webpack-test/configCases/loaders/issue-9053/test.filter.js
+++ b/webpack-test/configCases/loaders/issue-9053/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return false}
+module.exports = () => {return true}

--- a/webpack-test/configCases/loaders/pr-14384/PluginWithLoader.js
+++ b/webpack-test/configCases/loaders/pr-14384/PluginWithLoader.js
@@ -1,4 +1,4 @@
-const { NormalModule } = require("webpack");
+const { NormalModule } = require("@rspack/core");
 
 const PLUGIN_NAME = "PluginWithLoader";
 const loaderPath = require.resolve("./loader.js");

--- a/webpack-test/configCases/loaders/pr-14384/test.filter.js
+++ b/webpack-test/configCases/loaders/pr-14384/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return false}
+module.exports = () => {return "Rspack does not export `NormalModule` and support `beforeLoaders` from JS side and whether to implemented is tracked here: https://github.com/orgs/web-infra-dev/projects/9"}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Enable more webpack test cases and explain most of the blockers of loader.
Disabled Rspack's `experiments.css` in `tests/cases` to align with the default configuration by Webpack.

The remaining tests are almost blocked by:

```
loaderContext.importModule
loaderContext.loadModule
Rule.options
__non_webpack_require__
Loader Context resolving
```


Related: https://github.com/web-infra-dev/rspack/issues/3626

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

It's neither adding a feature nor fixing a bug.
See enabled tests for details.
