### PR TITLE
fix(rspack_core): context delete file

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -3,7 +3,7 @@ use std::{
   fmt::{self, Display},
   fs,
   hash::Hash,
-  path::Path,
+  path::{Path, PathBuf},
   sync::Arc,
 };
 
@@ -14,6 +14,7 @@ use rspack_identifier::{Identifiable, Identifier};
 use rspack_regex::RspackRegex;
 use rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt};
 use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   contextify, stringify_map, AstOrSource, BoxModuleDependency, BuildContext, BuildInfo, BuildMeta,
@@ -474,8 +475,12 @@ impl ContextModule {
     let mut hasher = RspackHash::from(&build_context.compiler_options.output);
     self.update_hash(&mut hasher);
 
+    let mut context_dependencies: HashSet<PathBuf> = Default::default();
+    context_dependencies.insert(PathBuf::from(&self.options.resource));
+
     let build_info = BuildInfo {
       hash: Some(hasher.digest(&build_context.compiler_options.output.hash_digest)),
+      context_dependencies,
       ..Default::default()
     };
 

--- a/packages/playground/cases/context/delete-file/index.test.ts
+++ b/packages/playground/cases/context/delete-file/index.test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@/fixtures";
+
+
+test("delete file should work", async ({ page, request, fileAction, rspack }) => {
+  // asset page status
+  const statusText = await page.textContent("#root");
+  expect(statusText).toBe('__PAGE_RENDER__');
+  // asset script content
+  const response = await request.get(`http://localhost:${rspack.devServer.options.port}/main.js`);
+  const bodyResponse = (await response.body()).toString();
+  expect(bodyResponse).toContain('this is mod1');
+  expect(bodyResponse).toContain('this is mod2');
+  // mock file delete action
+  fileAction.deleteFile("src/mod1.js");
+  await rspack.waitingForHmr(async () => {
+    // ensure page status changed
+    const statusText = await page.textContent("#root");
+    return statusText === "__HMR_UPDATED__";
+  });
+  // asset new script content
+  const responseAfterDelete = await request.get(`http://localhost:${rspack.devServer.options.port}/main.js`);
+  const bodyResponseAfterDelete = (await responseAfterDelete.body()).toString();
+  expect(bodyResponseAfterDelete).not.toContain('this is mod1');
+  expect(bodyResponseAfterDelete).toContain('this is mod2');
+});
+

--- a/packages/playground/cases/context/delete-file/rspack.config.js
+++ b/packages/playground/cases/context/delete-file/rspack.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+	context: __dirname,
+	mode: "development",
+	entry: {
+		main: "./src/index.js"
+	},
+	devServer: {
+		hot: true
+	},
+	cache: false,
+	stats: "none",
+	infrastructureLogging: {
+		debug: false
+	},
+	builtins: {
+		html: [
+			{
+				template: "./src/index.html"
+			}
+		]
+	},
+	watchOptions: {
+		poll: 1000
+	}
+};

--- a/packages/playground/cases/context/delete-file/src/index.html
+++ b/packages/playground/cases/context/delete-file/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+</head>
+
+<body>
+    <div id="root"></div>
+</body>
+
+</html>

--- a/packages/playground/cases/context/delete-file/src/index.js
+++ b/packages/playground/cases/context/delete-file/src/index.js
@@ -1,0 +1,13 @@
+const context = require.context("./", false, /mod/);
+
+console.log(context);
+
+document.getElementById("root").textContent = "__PAGE_RENDER__";
+
+if (module.hot) {
+	module.hot.addStatusHandler(status => {
+		if (status === "idle") {
+			document.getElementById("root").textContent = "__HMR_UPDATED__";
+		}
+	});
+}

--- a/packages/playground/cases/context/delete-file/src/mod1.js
+++ b/packages/playground/cases/context/delete-file/src/mod1.js
@@ -1,0 +1,3 @@
+export function fn1() {
+	console.log("this is mod1");
+}

--- a/packages/playground/cases/context/delete-file/src/mod2.js
+++ b/packages/playground/cases/context/delete-file/src/mod2.js
@@ -1,0 +1,3 @@
+export function fn2() {
+	console.log("this is mod2");
+}


### PR DESCRIPTION
## Summary

Fix the "resolve error" when delete module in a context directory on development mode, which mentioned in #2901 .

Add context_dependency to build_info may make this context be watched by watchpack correctly. So when some module in this context is deleted, the context can be passed to compilation as modified_files and make the snapshot become invalid.

## Test Plan

Add a E2E test case in playground to mock the file delete action.
