### PR TITLE
fix: hmr should work for inject css link to body

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/css_loading.js
@@ -54,7 +54,7 @@ var loadStylesheet = function(chunkId, url, done, hmr) {
 		link.onload = onLinkComplete.bind(null, link.onload);
 	} else onLinkComplete(undefined, { type: "load", target: link });
 	hmr
-		? document.head.insertBefore(link, hmr)
+		? hmr.parentNode.insertBefore(link, hmr)
 		: needAttach && document.head.appendChild(link);
 	return link;
 };

--- a/packages/playground/cases/css/render-to-body/index.test.ts
+++ b/packages/playground/cases/css/render-to-body/index.test.ts
@@ -1,9 +1,16 @@
 import { test, expect } from "@/fixtures";
 
-test("should update body css", async ({ page, fileAction }) => {
+test("should update body css", async ({ page, fileAction, rspack }) => {
 	await expect(page.locator("body")).toHaveCSS("display", "block");
 	fileAction.updateFile("src/index.css", content =>
 		content.replace("block", "flex")
 	);
-	await expect(page.locator("body")).toHaveCSS("display", "flex");
+	await rspack.waitingForHmr(async function () {
+		try {
+			await expect(page.locator("body")).toHaveCSS("display", "flex");
+			return true;
+		} catch (e) {
+			return false;
+		}
+	});
 });

--- a/packages/playground/cases/css/render-to-body/index.test.ts
+++ b/packages/playground/cases/css/render-to-body/index.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "@/fixtures";
+
+test("should update body css", async ({ page, fileAction }) => {
+	await expect(page.locator("body")).toHaveCSS("display", "block");
+	fileAction.updateFile("src/index.css", content =>
+		content.replace("block", "flex")
+	);
+	await expect(page.locator("body")).toHaveCSS("display", "flex");
+});

--- a/packages/playground/cases/css/render-to-body/rspack.config.js
+++ b/packages/playground/cases/css/render-to-body/rspack.config.js
@@ -1,0 +1,25 @@
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	mode: "development",
+	entry: "./src/index.js",
+	devServer: {
+		hot: true
+	},
+	cache: false,
+	stats: "none",
+	infrastructureLogging: {
+		debug: false
+	},
+	builtins: {
+		html: [
+			{
+				template: "./src/index.html",
+				inject: "body"
+			}
+		]
+	},
+	watchOptions: {
+		poll: 1000
+	}
+};

--- a/packages/playground/cases/css/render-to-body/src/index.css
+++ b/packages/playground/cases/css/render-to-body/src/index.css
@@ -1,0 +1,3 @@
+body {
+    display: block;
+}

--- a/packages/playground/cases/css/render-to-body/src/index.html
+++ b/packages/playground/cases/css/render-to-body/src/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+</head>
+
+<body>
+    <div id="root"></div>
+</body>
+
+</html>

--- a/packages/playground/cases/css/render-to-body/src/index.js
+++ b/packages/playground/cases/css/render-to-body/src/index.js
@@ -1,0 +1,1 @@
+import "./index.css";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The webpack css hmr runtime use `document.head` to update css but maybe the user inject css link to body, the pr is fixed it.  `mini-css-extract-plugin` do it at https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/src/index.js#L908.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added e2e

<!-- Can you please describe how you tested the changes you made to the code? -->
