### PR TITLE
fix(core): Typo in html builtins types

### DIFF
--- a/packages/rspack/src/config/zod/builtins.ts
+++ b/packages/rspack/src/config/zod/builtins.ts
@@ -31,7 +31,7 @@ export function builtins() {
 				template: z.string().optional(),
 				templateParameters: z.record(z.string()).optional(),
 				inject: z.enum(["head", "body"]).optional(),
-				publicPathz: z.string().optional(),
+				publicPath: z.string().optional(),
 				scriptLoading: z.enum(["blocking", "defer", "module"]).optional(),
 				chunks: z.string().array().optional(),
 				excludedChunks: z.string().array().optional(),


### PR DESCRIPTION
## Summary

Fixes what looks like an accidental typo in `builtins.html` types generated with zod. The name of `publicPath` instead is `publicPathz`. The [official documentation](https://www.rspack.dev/config/builtins.html#builtinshtml) correctly lists `publicPath`.

## Test Plan

I've discovered the issue in a project. `publicPath` is still the only working option, it's just the types that are wrong, no need to test anything.