### PR TITLE
ci: release canary without debug mode because binary size is too big to upload (>1G)

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -20,7 +20,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: ${{ matrix.target }}
-      profile: 'debug'
       test: false
 
   release:


### PR DESCRIPTION
closes #3784

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Debug mode creates 1 bloated >1G binary which can not be uploaded to npm.

## Test Plan

We can try a canary once this is merged, but it should pass because this is now the same as all the other full releases.