### PR TITLE
chore: fix canary release

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -29,6 +29,9 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Canary release is triggered with comments. GitHub workflows that are triggered with comments sets their checkout branch to default branch. So **we should make sure to checkout to the PR branch to test corresponding Pull Request**.

Ref: https://github.com/web-infra-dev/modern.js/blob/51297712c2d9b5c0ac6a13ab5c3bc97b36f0fd89/.github/workflows/release.yml#L37

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

N/A

<!-- Can you please describe how you tested the changes you made to the code? -->
