### PR TITLE
fix: shorthand filed symbol unsed

### DIFF
--- a/crates/rspack/tests/tree-shaking/class-extend/app.js
+++ b/crates/rspack/tests/tree-shaking/class-extend/app.js
@@ -2,4 +2,8 @@ import { Lib as OriginLib, value } from "./lib";
 
 export class Lib extends OriginLib {}
 
+function foo() {
+    return { OriginLib }
+}
+
 export const v = value;

--- a/crates/rspack/tests/tree-shaking/class-extend/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/class-extend/expected/main.js
@@ -9,6 +9,11 @@ __webpack_require__.d(__webpack_exports__, {
 
  class Lib extends /* "./lib" unused */null {
 }
+function foo() {
+    return {
+        OriginLib: /* "./lib" unused */null
+    };
+}
  const v = _lib__WEBPACK_IMPORTED_MODULE_0_["value"];
 },
 "./index.js": function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -107,12 +107,12 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
 
     if !used {
       // TODO do this by PureExpressionDependency.
-      source.replace(
-        self.start,
-        self.end,
-        &format!("/* \"{}\" unused */null", self.request),
-        None,
-      );
+      let value = format!("/* \"{}\" unused */null", self.request);
+      if self.shorthand {
+        source.insert(self.end, &format!(": {value}"), None);
+      } else {
+        source.replace(self.start, self.end, &value, None)
+      }
       return;
     }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Before will replace shorthand filed to null, it will throw `Cannot use a reserved word as a shorthand property`.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added

<!-- Can you please describe how you tested the changes you made to the code? -->
