### PR TITLE
fix: react class component hmr

### DIFF
--- a/packages/playground/cases/react/class-component/index.test.ts
+++ b/packages/playground/cases/react/class-component/index.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@/fixtures";
+
+test("render should work", async ({ page }) => {
+	expect(await page.textContent(".header")).toBe("Hello World");
+});
+
+test("class component hmr should work", async ({
+	page,
+	fileAction,
+	rspack
+}) => {
+	expect(await page.textContent("button")).toBe("10");
+	await page.click("button");
+	expect(await page.textContent("button")).toBe("11");
+	expect(await page.textContent(".placeholder")).toBe("__PLACE_HOLDER__");
+	fileAction.updateFile("src/App.jsx", content =>
+		content.replace("__PLACE_HOLDER__", "__EDITED__")
+	);
+	await rspack.waitingForHmr(async function () {
+		return (await page.textContent(".placeholder")) === "__EDITED__";
+	});
+	// class component will not keep local status
+	expect(await page.textContent("button")).toBe("10");
+});

--- a/packages/playground/cases/react/class-component/react-refresh.js
+++ b/packages/playground/cases/react/class-component/react-refresh.js
@@ -1,0 +1,17 @@
+const reactRefresh = require("@rspack/dev-client/react-refresh");
+
+function shouldLooksLikeAModuleId(id) {
+	console.log(id);
+	if (typeof id === "string" && !id.includes("[object Object]")) {
+		return;
+	}
+	throw new Error(`Looks like ${id} is not a module.id`);
+}
+
+module.exports = {
+	...reactRefresh,
+	register(type, id) {
+		shouldLooksLikeAModuleId(id);
+		return reactRefresh.register(type, id);
+	}
+};

--- a/packages/playground/cases/react/class-component/rspack.config.js
+++ b/packages/playground/cases/react/class-component/rspack.config.js
@@ -1,0 +1,27 @@
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	mode: "development",
+	entry: ["@rspack/dev-client/react-refresh-entry", "./src/index.jsx"],
+	devServer: {
+		hot: true
+	},
+	cache: false,
+	stats: "none",
+	infrastructureLogging: {
+		debug: false
+	},
+	builtins: {
+		provide: {
+			$ReactRefreshRuntime$: [require.resolve("./react-refresh.js")]
+		},
+		html: [
+			{
+				template: "./src/index.html"
+			}
+		]
+	},
+	watchOptions: {
+		poll: 1000
+	}
+};

--- a/packages/playground/cases/react/class-component/src/App.jsx
+++ b/packages/playground/cases/react/class-component/src/App.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+const Button = () => {
+	const [count, setCount] = React.useState(10);
+	return <button onClick={() => setCount(count => count + 1)}>{count}</button>;
+};
+
+export class App extends React.Component {
+	render() {
+		return (
+			<div className="App">
+				<div className="header">Hello World</div>
+				<Button />
+				<div className="placeholder">__PLACE_HOLDER__</div>
+			</div>
+		);
+	}
+}

--- a/packages/playground/cases/react/class-component/src/index.html
+++ b/packages/playground/cases/react/class-component/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Document</title>
+	</head>
+	<body>
+		<div id="root"></div>
+	</body>
+</html>

--- a/packages/playground/cases/react/class-component/src/index.jsx
+++ b/packages/playground/cases/react/class-component/src/index.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { App } from './App';
+import { CountProvider } from "./CountProvider";
+
+const container = createRoot(document.getElementById("root"));
+container.render(
+    <CountProvider>
+        <App />
+    </CountProvider>
+);

--- a/packages/playground/cases/react/class-component/src/index.jsx
+++ b/packages/playground/cases/react/class-component/src/index.jsx
@@ -1,11 +1,6 @@
-import React from "react";
-import { createRoot } from "react-dom/client";
-import { App } from './App';
-import { CountProvider } from "./CountProvider";
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import { App } from './App'
 
-const container = createRoot(document.getElementById("root"));
-container.render(
-    <CountProvider>
-        <App />
-    </CountProvider>
-);
+const container = createRoot(document.getElementById('root'))
+container.render(<App />)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->


## Summary

Because the code which react class component transformed by `react-refresh` hasn't `$RefreshReg$/$RefreshSig$` flag, so it isn't inject refresh runtime.It caused react class component only update by bubble to parent component at hmr. The pr always inject refresh runtime to fix it.

Note: class component hmr will not preserve status, you can see at https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added

<!-- Can you please describe how you tested the changes you made to the code? -->
