### PR TITLE
ci: split `cargo check` and `cargo test` into two jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,38 @@ jobs:
               - 'Cargo.toml'
               - 'rust-toolchain.toml'
 
-  rust:
+  rust_check:
     name: Rust check
+    needs: rust_changes
+    if: ${{ needs.rust_changes.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          clippy: true
+          fmt: true
+          shared-key: check
+
+      - name: Run Cargo Check
+        run: cargo check --workspace --all-targets --locked # Not using --release because it uses too much cache, and is also slow.
+
+      - name: Run Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --all-targets -- -D warnings
+
+      - name: Run rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  rust_test:
+    name: Rust test
     needs: rust_changes
     if: ${{ needs.rust_changes.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
@@ -93,25 +123,15 @@ jobs:
       - name: Install Rust Toolchain
         uses: ./.github/actions/rustup
         with:
-          clippy: true
-          fmt: true
           save-cache: ${{ github.ref_name == 'main' }}
           shared-key: check
 
-      - name: Run rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - name: Run Cargo Check
-        run: cargo check --workspace --all-targets --locked # Not using --release because it uses too much cache, and is also slow.
-
-      - name: Run Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets -- -D warnings
+      # Compile test without debug info for reducing the CI cache size
+      - name: Change profile.test
+        shell: bash
+        run: |
+          echo '[profile.test]' >> Cargo.toml
+          echo 'debug = false' >> Cargo.toml
 
       - name: Run test
         run: cargo test --workspace -- --nocapture


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This should reduce the workload for a single job, and reduce the CI cache size

## Test Plan

See https://github.com/web-infra-dev/rspack/actions/runs/5608756480/jobs/10261543104 for passed CI (I triggered this from a push event).