### PR TITLE
chore: use v0.x.y instead of 0.x.y for release tag

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -3,7 +3,6 @@ import * as core from "@actions/core";
 import * as path from "path";
 import { fileURLToPath } from "url";
 
-
 const __filename = path.resolve(fileURLToPath(import.meta.url));
 const __dirname = path.dirname(__filename);
 
@@ -18,7 +17,7 @@ export async function publish_handler(mode, options) {
 
 		fs.writeFileSync(
 			npmrcPath,
-			`//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`,
+			`//registry.npmjs.org/:_authToken=${process.env.NPM_TOKEN}`
 		);
 	}
 	await $`pnpm publish -r ${options.dryRun ? "--dry-run" : ""} --tag ${
@@ -39,7 +38,7 @@ export async function publish_handler(mode, options) {
 		await $`git config --global user.email "github-actions[bot]@users.noreply.github.com"`;
 		console.info("git commit all...");
 		await $`git status`;
-		await $`git tag ${version} -m ${version} `;
+		await $`git tag v${version} -m v${version} `;
 		await $`git push origin --follow-tags`;
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
I just noticed that we use `0.x.y` other than `v0.x.y` for release tag which is not popular in OSS, both react、vue and other projects all use 'v0.x.y' for release tag, and since we will introduce minor branch soon, I think we should use '0.x.y' for branch name and 'v0.x.y' for release tag name, in case we mix them and do wrong operations on it.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
No Test Needed
<!-- Can you please describe how you tested the changes you made to the code? -->
