### PR TITLE
fix: modify Configuration type to support MultiRspackOptions

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -10,7 +10,8 @@
     "build": "tsc -b ./tsconfig.build.json",
     "prepare": "pnpm precompile-schema",
     "dev": "tsc -w",
-    "test": "node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage",
+    "test": "pnpm test:tc && node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage",
+    "test:tc": "tsc -p tsconfig.test.json",
     "precompile-schema": "node ./scripts/precompile-schema.js"
   },
   "files": [

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -11,7 +11,7 @@
 import watchpack from "watchpack";
 import { Compiler } from "../compiler";
 import * as oldBuiltins from "./builtins";
-import { Compilation } from "..";
+import { Compilation, MultiRspackOptions } from "..";
 import type * as webpackDevServer from "webpack-dev-server";
 import type { Options as RspackOptions } from "./zod/_rewrite";
 import type { OptimizationConfig as Optimization } from "./zod/optimization";
@@ -26,7 +26,7 @@ export type {
 	LoaderDefinition
 } from "./adapter-rule-use";
 
-export type Configuration = RspackOptions;
+export type Configuration = MultiRspackOptions | RspackOptions;
 
 export interface RspackOptionsNormalized {
 	name?: Name;

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -11,8 +11,8 @@ export { cachedCleverMerge as cleverMerge } from "./util/cleverMerge";
 export { BannerPlugin } from "./lib/BannerPlugin";
 export { EnvironmentPlugin } from "./lib/EnvironmentPlugin";
 export { LoaderOptionsPlugin } from "./lib/LoaderOptionsPlugin";
-import { Configuration } from "./config";
+import { RspackOptions } from "./config";
 // TODO(hyf0): should remove this re-export when we cleanup the exports of `@rspack/core`
 export type OptimizationSplitChunksOptions = NonNullable<
-	Configuration["optimization"]
+	RspackOptions["optimization"]
 >["splitChunks"];

--- a/packages/rspack/tests/configCases/type/multiple-options/index.js
+++ b/packages/rspack/tests/configCases/type/multiple-options/index.js
@@ -1,0 +1,1 @@
+it("should pass type checking", function () {});

--- a/packages/rspack/tests/configCases/type/multiple-options/respack.config.js
+++ b/packages/rspack/tests/configCases/type/multiple-options/respack.config.js
@@ -1,0 +1,11 @@
+// @ts-check
+/** @type {import("@rspack/core").Configuration} */
+const config = [];
+
+/** @type {import("@rspack/core").Configuration} */
+export const config2 = [{}];
+
+/** @type {import("@rspack/core").Configuration} */
+export const config3 = [{}, {}];
+
+module.exports = config;

--- a/packages/rspack/tests/configCases/type/multiple-options/rspack.config.js
+++ b/packages/rspack/tests/configCases/type/multiple-options/rspack.config.js
@@ -8,4 +8,8 @@ export const config2 = [{}];
 /** @type {import("@rspack/core").Configuration} */
 export const config3 = [{}, {}];
 
+/** @type {import("@rspack/core").Configuration} */
+//@ts-expect-error
+export const config4 = [{}, { devtool: true }];
+
 module.exports = config;

--- a/packages/rspack/tests/configCases/type/multiple-options/rspack.config.js
+++ b/packages/rspack/tests/configCases/type/multiple-options/rspack.config.js
@@ -1,15 +1,60 @@
 // @ts-check
-/** @type {import("@rspack/core").Configuration} */
-const config = [];
 
 /** @type {import("@rspack/core").Configuration} */
-export const config2 = [{}];
+// empty object is a valid configuration
+export const shouldAcceptEmptyObject = {};
 
 /** @type {import("@rspack/core").Configuration} */
-export const config3 = [{}, {}];
+export const shouldAcceptEmptyArr = [];
 
 /** @type {import("@rspack/core").Configuration} */
-//@ts-expect-error
-export const config4 = [{}, { devtool: true }];
+export const shouldAcceptArrWithRealWorldConfig = [
+	{
+		context: __dirname,
+		module: {
+			rules: [
+				{
+					test: /\.svg$/,
+					type: "asset/resource"
+				}
+			]
+		},
+		builtins: {
+			treeShaking: true
+		},
+		optimization: {
+			sideEffects: true
+		},
+		externalsPresets: {
+			node: true
+		}
+	}
+];
 
-module.exports = config;
+/** @type {import("@rspack/core").Configuration} */
+export const shouldRejectArrWithWrongConfig = [
+	{
+		context: __dirname,
+		module: {
+			rules: [
+				{
+					// @ts-expect-error should be a regexp
+					test: 1,
+					type: "asset/resource"
+				}
+			]
+		},
+		builtins: {
+			// @ts-expect-error should be boolean
+			treeShaking: "1"
+		},
+		// @ts-expect-error should not be an array
+		optimization: [],
+		externalsPresets: {
+			// @ts-expect-error should be string
+			node: 1
+		}
+	}
+];
+
+module.exports = shouldAcceptArrWithRealWorldConfig;

--- a/packages/rspack/tests/configCases/type/multiple-options/rspack.config.js
+++ b/packages/rspack/tests/configCases/type/multiple-options/rspack.config.js
@@ -2,13 +2,13 @@
 
 /** @type {import("@rspack/core").Configuration} */
 // empty object is a valid configuration
-export const shouldAcceptEmptyObject = {};
+const shouldAcceptEmptyObject = {};
 
 /** @type {import("@rspack/core").Configuration} */
-export const shouldAcceptEmptyArr = [];
+const shouldAcceptEmptyArr = [];
 
 /** @type {import("@rspack/core").Configuration} */
-export const shouldAcceptArrWithRealWorldConfig = [
+const shouldAcceptArrWithRealWorldConfig = [
 	{
 		context: __dirname,
 		module: {
@@ -32,7 +32,7 @@ export const shouldAcceptArrWithRealWorldConfig = [
 ];
 
 /** @type {import("@rspack/core").Configuration} */
-export const shouldRejectArrWithWrongConfig = [
+const shouldRejectArrWithWrongConfig = [
 	{
 		context: __dirname,
 		module: {

--- a/packages/rspack/tsconfig.test.json
+++ b/packages/rspack/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "tests",
+    "allowJs": true,
+    "noEmit": true
+  },
+  "include": ["**/type/**/*"]
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->



## Summary

Fixes #3607.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Rspack config files should support MultiRspackOptions. But for the `Configuration` type, only "single" `RspackOptions` are used.

This PR changes the definition of `Configuration` type in `packages/rspack/src/config/types.ts` to add support to MultiRspackOptions. After this, we expect following `rspack.config.js` will emit no error:

```js
// @ts-check
/** @type {import('@rspack/cli').Configuration} */
const test = [];
module.exports = test;
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

Added several test cases to ensure such configuration can pass type checking.