### PR TITLE
chore(types): should not return null when only called rspack with one parameter

### DIFF
--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -97,6 +97,11 @@ function isMultiRspackOptions(o: unknown): o is MultiRspackOptions {
 	return Array.isArray(o);
 }
 
+function rspack(options: MultiRspackOptions): MultiCompiler;
+function rspack(options: RspackOptions): Compiler;
+function rspack(
+	options: MultiRspackOptions | RspackOptions
+): MultiCompiler | Compiler;
 function rspack(
 	options: MultiRspackOptions,
 	callback?: Callback<Error, MultiStats>


### PR DESCRIPTION
fix type: should not return null when only called rspack with only one parameter

use ts function overload to handle the rspack return type

<img width="444" alt="image" src="https://github.com/web-infra-dev/rspack/assets/22373761/54e8a09a-c942-418c-9896-fc354f5bbc35">

<img width="568" alt="image" src="https://github.com/web-infra-dev/rspack/assets/22373761/706c043e-b020-4f22-9f6a-ba52c7a33bd0">

<img width="588" alt="image" src="https://github.com/web-infra-dev/rspack/assets/22373761/597e0daf-da13-4c84-bd90-e84437012e1a">


<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
