### PR TITLE
chore: use dep_id instead of module id

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -624,6 +624,11 @@ impl Compilation {
                 build_result,
                 diagnostics,
               } = task_result;
+              if self.options.builtins.tree_shaking.enable() {
+                self
+                  .optimize_analyze_result_map
+                  .insert(module.identifier(), build_result.analyze_result);
+              }
 
               if !diagnostics.is_empty() {
                 make_failed_module.insert(module.identifier());

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -494,6 +494,7 @@ impl ContextModule {
         build_info,
         build_meta: BuildMeta::default(),
         dependencies,
+        analyze_result: Default::default(),
       }
       .with_diagnostic(vec![]),
     )

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -270,6 +270,7 @@ impl Module for ExternalModule {
       build_info,
       build_meta: Default::default(),
       dependencies: Vec::new(),
+      analyze_result: Default::default(),
     };
     // TODO add exports_type for request
     match self.external_type.as_str() {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -10,6 +10,7 @@ use rspack_sources::Source;
 use rspack_util::ext::{AsAny, DynEq, DynHash};
 use rustc_hash::FxHashSet as HashSet;
 
+use crate::tree_shaking::visitor::OptimizeAnalyzeResult;
 use crate::{
   ChunkUkey, CodeGenerationResult, Compilation, CompilerContext, CompilerOptions, Context,
   ContextModule, DependencyTemplate, ExternalModule, ModuleDependency, ModuleType, NormalModule,
@@ -95,6 +96,7 @@ pub struct BuildResult {
   pub build_meta: BuildMeta,
   pub build_info: BuildInfo,
   pub dependencies: Vec<Box<dyn ModuleDependency>>,
+  pub analyze_result: OptimizeAnalyzeResult,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -141,6 +143,7 @@ pub trait Module: Debug + Send + Sync + AsAny + DynHash + DynEq + Identifiable {
         build_info,
         build_meta: Default::default(),
         dependencies: Vec::new(),
+        analyze_result: Default::default(),
       }
       .with_empty_diagnostic(),
     )

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -375,6 +375,7 @@ impl Module for NormalModule {
             build_info,
             build_meta: Default::default(),
             dependencies: Vec::new(),
+            analyze_result: Default::default(),
           }
           .with_diagnostic(e.into()),
         );
@@ -395,6 +396,7 @@ impl Module for NormalModule {
         ast_or_source,
         dependencies,
         presentational_dependencies,
+        analyze_result,
       },
       ds,
     ) = self
@@ -414,7 +416,6 @@ impl Module for NormalModule {
       })?
       .split_into_parts();
     diagnostics.extend(ds);
-
     // Only side effects used in code_generate can stay here
     // Other side effects should be set outside use_cache
     self.original_source = Some(original_source);
@@ -439,6 +440,7 @@ impl Module for NormalModule {
         build_info,
         build_meta,
         dependencies,
+        analyze_result,
       }
       .with_diagnostic(diagnostics),
     )

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -5,9 +5,10 @@ use rspack_loader_runner::ResourceData;
 use rspack_sources::BoxSource;
 
 use crate::{
-  AstOrSource, BuildInfo, BuildMeta, CodeGenerationData, Compilation, CompilerOptions,
-  DependencyTemplate, GenerationResult, GeneratorOptions, Module, ModuleDependency,
-  ModuleIdentifier, ModuleType, ParserOptions, RuntimeGlobals, SourceType,
+  tree_shaking::visitor::OptimizeAnalyzeResult, AstOrSource, BuildInfo, BuildMeta,
+  CodeGenerationData, Compilation, CompilerOptions, DependencyTemplate, GenerationResult,
+  GeneratorOptions, Module, ModuleDependency, ModuleIdentifier, ModuleType, ParserOptions,
+  RuntimeGlobals, SourceType,
 };
 
 #[derive(Debug)]
@@ -30,6 +31,7 @@ pub struct ParseResult {
   pub dependencies: Vec<Box<dyn ModuleDependency>>,
   pub presentational_dependencies: Vec<Box<dyn DependencyTemplate>>,
   pub ast_or_source: AstOrSource,
+  pub analyze_result: OptimizeAnalyzeResult,
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/tree_shaking/analyzer.rs
+++ b/crates/rspack_core/src/tree_shaking/analyzer.rs
@@ -1,5 +1,4 @@
 use super::visitor::OptimizeAnalyzeResult;
-use crate::Compilation;
 
 pub trait OptimizeAnalyzer {
   fn analyze(&self) -> OptimizeAnalyzeResult;

--- a/crates/rspack_core/src/tree_shaking/analyzer.rs
+++ b/crates/rspack_core/src/tree_shaking/analyzer.rs
@@ -2,5 +2,5 @@ use super::visitor::OptimizeAnalyzeResult;
 use crate::Compilation;
 
 pub trait OptimizeAnalyzer {
-  fn analyze(&self, compilation: &Compilation) -> OptimizeAnalyzeResult;
+  fn analyze(&self) -> OptimizeAnalyzeResult;
 }

--- a/crates/rspack_core/src/tree_shaking/asset_module.rs
+++ b/crates/rspack_core/src/tree_shaking/asset_module.rs
@@ -9,27 +9,12 @@ impl AssetModule {
   pub fn new(module_identifier: ModuleIdentifier) -> Self {
     Self { module_identifier }
   }
-
-  fn get_side_effects_from_config(&self, compilation: &Compilation) -> Option<SideEffectType> {
-    // sideEffects in module.rule has higher priority,
-    // we could early return if we match a rule.
-    if let Some(mgm) = compilation
-      .module_graph
-      .module_graph_module_by_identifier(&self.module_identifier)
-      && let Some(FactoryMeta { side_effects: Some(side_effects) }) = &mgm.factory_meta
-    {
-      return Some(SideEffectType::Configuration(*side_effects))
-    }
-    None
-  }
 }
 
 impl OptimizeAnalyzer for AssetModule {
-  fn analyze(&self, compilation: &Compilation) -> OptimizeAnalyzeResult {
+  fn analyze(&self) -> OptimizeAnalyzeResult {
     let mut result = OptimizeAnalyzeResult::default();
-    result.side_effects = self
-      .get_side_effects_from_config(compilation)
-      .unwrap_or(SideEffectType::Configuration(true));
+    result.side_effects = SideEffectType::Configuration(true);
     result.module_identifier = self.module_identifier;
     result
   }

--- a/crates/rspack_core/src/tree_shaking/asset_module.rs
+++ b/crates/rspack_core/src/tree_shaking/asset_module.rs
@@ -1,5 +1,5 @@
 use super::{analyzer::OptimizeAnalyzer, visitor::OptimizeAnalyzeResult, SideEffectType};
-use crate::{Compilation, FactoryMeta, ModuleIdentifier};
+use crate::ModuleIdentifier;
 
 pub struct AssetModule {
   module_identifier: ModuleIdentifier,

--- a/crates/rspack_core/src/tree_shaking/js_module.rs
+++ b/crates/rspack_core/src/tree_shaking/js_module.rs
@@ -3,13 +3,15 @@ use super::{
   visitor::{MarkInfo, ModuleRefAnalyze, OptimizeAnalyzeResult},
 };
 use crate::{
-  ast::javascript::Ast, Dependency, ModuleDependency, ModuleGraphModule, ModuleIdentifier,
+  ast::javascript::Ast, CompilerOptions, Dependency, ModuleDependency, ModuleGraphModule,
+  ModuleIdentifier,
 };
 
 pub struct JsModule<'b, 'a: 'b> {
   ast: &'a Ast,
   dependencies: &'b Vec<Box<dyn ModuleDependency>>,
   module_identifier: ModuleIdentifier,
+  compiler_options: &'a CompilerOptions,
 }
 
 impl<'a, 'b> JsModule<'b, 'a> {
@@ -17,17 +19,19 @@ impl<'a, 'b> JsModule<'b, 'a> {
     ast: &'a Ast,
     dependencies: &'b Vec<Box<dyn ModuleDependency>>,
     module_identifier: ModuleIdentifier,
+    compiler_options: &'a CompilerOptions,
   ) -> Self {
     Self {
       ast,
       dependencies,
       module_identifier,
+      compiler_options,
     }
   }
 }
 
 impl<'a, 'b> OptimizeAnalyzer for JsModule<'a, 'b> {
-  fn analyze(&self, compilation: &crate::Compilation) -> OptimizeAnalyzeResult {
+  fn analyze(&self) -> OptimizeAnalyzeResult {
     self.ast.visit(|program, context| {
       let top_level_mark = context.top_level_mark;
       let unresolved_mark = context.unresolved_mark;
@@ -41,7 +45,7 @@ impl<'a, 'b> OptimizeAnalyzer for JsModule<'a, 'b> {
         MarkInfo::new(top_level_mark, unresolved_mark),
         self.module_identifier,
         &self.dependencies,
-        &compilation.options,
+        &*self.compiler_options,
         program.comments.as_ref(),
         worker_syntax_list,
       );

--- a/crates/rspack_core/src/tree_shaking/js_module.rs
+++ b/crates/rspack_core/src/tree_shaking/js_module.rs
@@ -2,16 +2,27 @@ use super::{
   analyzer::OptimizeAnalyzer,
   visitor::{MarkInfo, ModuleRefAnalyze, OptimizeAnalyzeResult},
 };
-use crate::{ast::javascript::Ast, ModuleGraphModule, ModuleIdentifier};
+use crate::{
+  ast::javascript::Ast, Dependency, ModuleDependency, ModuleGraphModule, ModuleIdentifier,
+};
 
 pub struct JsModule<'b, 'a: 'b> {
   ast: &'a Ast,
-  mgm: &'b ModuleGraphModule,
+  dependencies: &'b Vec<Box<dyn ModuleDependency>>,
+  module_identifier: ModuleIdentifier,
 }
 
-impl<'a, 'b> JsModule<'a, 'b> {
-  pub fn new(ast: &'a Ast, mgm: &'b ModuleGraphModule) -> Self {
-    Self { ast, mgm }
+impl<'a, 'b> JsModule<'b, 'a> {
+  pub fn new(
+    ast: &'a Ast,
+    dependencies: &'b Vec<Box<dyn ModuleDependency>>,
+    module_identifier: ModuleIdentifier,
+  ) -> Self {
+    Self {
+      ast,
+      dependencies,
+      module_identifier,
+    }
   }
 }
 
@@ -28,8 +39,8 @@ impl<'a, 'b> OptimizeAnalyzer for JsModule<'a, 'b> {
 
       let mut analyzer = ModuleRefAnalyze::new(
         MarkInfo::new(top_level_mark, unresolved_mark),
-        self.mgm.module_identifier,
-        &self.mgm.factory_meta,
+        self.module_identifier,
+        &self.dependencies,
         &compilation.options,
         program.comments.as_ref(),
         worker_syntax_list,

--- a/crates/rspack_core/src/tree_shaking/js_module.rs
+++ b/crates/rspack_core/src/tree_shaking/js_module.rs
@@ -2,10 +2,7 @@ use super::{
   analyzer::OptimizeAnalyzer,
   visitor::{MarkInfo, ModuleRefAnalyze, OptimizeAnalyzeResult},
 };
-use crate::{
-  ast::javascript::Ast, CompilerOptions, Dependency, ModuleDependency, ModuleGraphModule,
-  ModuleIdentifier,
-};
+use crate::{ast::javascript::Ast, CompilerOptions, ModuleDependency, ModuleIdentifier};
 
 pub struct JsModule<'b, 'a: 'b> {
   ast: &'a Ast,
@@ -44,8 +41,8 @@ impl<'a, 'b> OptimizeAnalyzer for JsModule<'a, 'b> {
       let mut analyzer = ModuleRefAnalyze::new(
         MarkInfo::new(top_level_mark, unresolved_mark),
         self.module_identifier,
-        &self.dependencies,
-        &*self.compiler_options,
+        self.dependencies,
+        self.compiler_options,
         program.comments.as_ref(),
         worker_syntax_list,
       );

--- a/crates/rspack_core/src/tree_shaking/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/mod.rs
@@ -6,7 +6,7 @@ use swc_core::ecma::ast::ModuleItem;
 
 use self::visitor::{OptimizeAnalyzeResult, SymbolRef};
 
-pub(crate) mod analyzer;
+pub mod analyzer;
 pub mod asset_module;
 pub mod debug_helper;
 pub mod js_module;

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -1379,7 +1379,7 @@ async fn par_analyze_module(compilation: &mut Compilation) -> IdentifierMap<Opti
             // A module can missing its AST if the module is failed to build
             .and_then(|ast| ast.as_javascript())
           {
-            Some(ast) => JsModule::new(ast, *module_identifier).analyze(compilation),
+            Some(ast) => JsModule::new(ast, mgm).analyze(compilation),
             None => {
               return None;
             }

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -1307,9 +1307,9 @@ impl<'a> CodeSizeOptimizer<'a> {
 // };
 // }
 
-fn get_inherit_export_ref_graph<'a, 'b>(
-  analyze_result_map: &'a mut IdentifierMap<OptimizeAnalyzeResult>,
-  mg: &'b ModuleGraph,
+fn get_inherit_export_ref_graph(
+  analyze_result_map: &mut IdentifierMap<OptimizeAnalyzeResult>,
+  mg: &ModuleGraph,
 ) -> GraphMap<Identifier, (), Directed> {
   // calculate relation of module that has `export * from 'xxxx'`
   let inherit_export_ref_graph = create_inherit_graph(&*analyze_result_map, mg);

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -1,6 +1,4 @@
-use std::{
-  collections::hash_map::Entry, collections::VecDeque, hash::Hash, path::PathBuf, sync::Arc,
-};
+use std::{collections::hash_map::Entry, collections::VecDeque, hash::Hash, path::PathBuf};
 
 use bitflags::bitflags;
 use hashlink::{LinkedHashMap, LinkedHashSet};

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -656,15 +656,6 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
 
     let side_effects_option = self.options.optimization.side_effects;
     if side_effects_option.is_enable() {
-      // self.side_effects = self.get_side_effects_from_config().unwrap_or_else(|| {
-      //   if side_effects_option.is_true() {
-      //     SideEffectType::Analyze(self.has_side_effects_stmt)
-      //   } else {
-      //     // side_effects_option must be `flag` here
-      //     SideEffectType::Configuration(true)
-      //   }
-      // });
-
       self.side_effects = if side_effects_option.is_true() {
         SideEffectType::Analyze(self.has_side_effects_stmt)
       } else {

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -189,7 +189,7 @@ pub(crate) struct ModuleRefAnalyze<'a> {
   module_syntax: ModuleSyntax,
   pub(crate) bail_out_module_identifiers: HashMap<ModuleIdOrDepId, BailoutFlag>,
   pub(crate) side_effects: SideEffectType,
-  pub(crate) options: &'a Arc<CompilerOptions>,
+  pub(crate) options: &'a CompilerOptions,
   pub(crate) has_side_effects_stmt: bool,
   unresolved_ctxt: SyntaxContext,
   pub(crate) potential_top_level_mark: HashSet<Mark>,
@@ -258,7 +258,7 @@ impl<'a> ModuleRefAnalyze<'a> {
     mark_info: MarkInfo,
     module_identifier: ModuleIdentifier,
     dependencies: &'a Vec<Box<dyn ModuleDependency>>,
-    options: &'a Arc<CompilerOptions>,
+    options: &'a CompilerOptions,
     _comments: Option<&'a SwcComments>,
     worker_syntax_list: &'a WorkerSyntaxList,
   ) -> Self {
@@ -1664,7 +1664,7 @@ impl<'a> ModuleRefAnalyze<'a> {
 }
 
 /// The `allow(unused)` will be removed after the Tree shaking is finished
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 #[allow(unused)]
 pub struct OptimizeAnalyzeResult {
   pub top_level_mark: Mark,

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -64,7 +64,7 @@ impl SymbolRef {
     match self {
       SymbolRef::Declaration(_) => {}
       SymbolRef::Indirect(ref mut i) => {
-        if let Some(module_id) = mg.module_identifier_by_dependency_id(&i.dep_id) {
+        if i.src.is_empty() && let Some(module_id) = mg.module_identifier_by_dependency_id(&i.dep_id) {
           i.src = *module_id;
         }
       }

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -4,7 +4,6 @@ use std::{
 
 use bitflags::bitflags;
 use hashlink::{LinkedHashMap, LinkedHashSet};
-use rspack_identifier::{IdentifierLinkedMap, IdentifierMap};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use serde::Serialize;
 use swc_core::common::SyntaxContext;

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -6,6 +6,9 @@ use async_trait::async_trait;
 use rayon::prelude::*;
 use rspack_core::{
   rspack_sources::{BoxSource, RawSource, SourceExt},
+  tree_shaking::{
+    analyzer::OptimizeAnalyzer, asset_module::AssetModule, visitor::OptimizeAnalyzeResult,
+  },
   AssetGeneratorDataUrl, AssetParserDataUrl, AssetParserOptions, AstOrSource,
   BuildMetaDefaultObject, BuildMetaExportsType, CodeGenerationDataAssetInfo,
   CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, CompilerOptions, GenerateContext,
@@ -253,6 +256,8 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       build_meta,
       build_info,
       module_type,
+      compiler_options,
+      module_identifier,
       ..
     } = parse_context;
     build_info.strict = true;
@@ -284,6 +289,11 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         ))
       }
     };
+    let analyze_result = if compiler_options.builtins.tree_shaking.enable() {
+      AssetModule::new(module_identifier).analyze()
+    } else {
+      OptimizeAnalyzeResult::default()
+    };
 
     Ok(
       rspack_core::ParseResult {
@@ -291,7 +301,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         dependencies: vec![],
         ast_or_source: source.into(),
         presentational_dependencies: vec![],
-        analyze_result: Default::default(),
+        analyze_result,
       }
       .with_empty_diagnostic(),
     )

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -291,6 +291,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         dependencies: vec![],
         ast_or_source: source.into(),
         presentational_dependencies: vec![],
+        analyze_result: Default::default(),
       }
       .with_empty_diagnostic(),
     )

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -239,6 +239,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
         dependencies,
         presentational_dependencies: vec![],
         ast_or_source: AstOrSource::new(None, Some(new_source)),
+        analyze_result: Default::default(),
       }
       .with_diagnostic(diagnostic),
     )

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -131,7 +131,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         &scan_ast,
         &dependencies,
         module_identifier,
-        &compiler_options,
+        compiler_options,
       )
       .analyze()
     } else {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -1,6 +1,9 @@
 use rspack_core::rspack_sources::{
   RawSource, ReplaceSource, Source, SourceExt, SourceMap, SourceMapSource, WithoutOriginalOptions,
 };
+use rspack_core::tree_shaking::analyzer::OptimizeAnalyzer;
+use rspack_core::tree_shaking::js_module::JsModule;
+use rspack_core::tree_shaking::visitor::OptimizeAnalyzeResult;
 use rspack_core::{
   AstOrSource, GenerateContext, GenerationResult, Module, ModuleAst, ParseContext, ParseResult,
   ParserAndGenerator, SourceType, TemplateContext,
@@ -62,6 +65,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
             ast_or_source: RawSource::from(source.to_string()).boxed().into(),
             dependencies: vec![],
             presentational_dependencies: vec![],
+            analyze_result: Default::default(),
           }
           .with_diagnostic(e.into()),
         );
@@ -94,6 +98,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
             ast_or_source: RawSource::from(output.code.clone()).boxed().into(),
             dependencies: vec![],
             presentational_dependencies: vec![],
+            analyze_result: Default::default(),
           }
           .with_diagnostic(e.into()),
         );
@@ -121,6 +126,18 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       )
     });
 
+    let analyze_result = if compiler_options.builtins.tree_shaking.enable() {
+      JsModule::new(
+        &scan_ast,
+        &dependencies,
+        module_identifier,
+        &compiler_options,
+      )
+      .analyze()
+    } else {
+      OptimizeAnalyzeResult::default()
+    };
+
     let source = if let Some(map) = output.map {
       SourceMapSource::new(WithoutOriginalOptions {
         value: output.code,
@@ -137,6 +154,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         ast_or_source: AstOrSource::new(Some(ModuleAst::JavaScript(scan_ast)), Some(source)),
         dependencies,
         presentational_dependencies,
+        analyze_result,
       }
       .with_empty_diagnostic(),
     )

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -96,6 +96,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
         presentational_dependencies: vec![],
         dependencies: vec![],
         ast_or_source: box_source.into(),
+        analyze_result: Default::default(),
       }
       .with_diagnostic(diagnostics),
     )

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -95,6 +95,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
         dependencies,
         presentational_dependencies: vec![],
         ast_or_source: source.into(),
+        analyze_result: Default::default(),
       }
       .with_diagnostic(diagnostic),
     )


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. Close https://github.com/web-infra-dev/rspack/issues/3649
2. In the make phase, the module graph does not have detailed info on each module, we can't get the module id of each dependencies. So we use `""` by default, in analyze phase transform dependency id into module id. 

4. 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
1. Tests should pass.
<!-- Can you please describe how you tested the changes you made to the code? -->
