### PR TITLE
feat: add some exports info api

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -375,13 +375,6 @@ export interface JsStatsWarning {
   formatted: string
 }
 
-export interface NodeFS {
-  writeFile: (...args: any[]) => any
-  removeFile: (...args: any[]) => any
-  mkdir: (...args: any[]) => any
-  mkdirp: (...args: any[]) => any
-}
-
 export interface PathData {
   filename?: string
   hash?: string
@@ -974,13 +967,5 @@ export interface RawStyleConfig {
 
 export interface RawTrustedTypes {
   policyName?: string
-}
-
-export interface ThreadsafeNodeFS {
-  writeFile: (...args: any[]) => any
-  removeFile: (...args: any[]) => any
-  mkdir: (...args: any[]) => any
-  mkdirp: (...args: any[]) => any
-  removeDirAll: (...args: any[]) => any
 }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -35,8 +35,8 @@ use crate::{
   BoxModuleDependency, BuildQueue, BuildTask, BuildTaskResult, Chunk, ChunkByUkey,
   ChunkContentHash, ChunkGraph, ChunkGroup, ChunkGroupUkey, ChunkHashArgs, ChunkKind, ChunkUkey,
   CleanQueue, CleanTask, CleanTaskResult, CodeGenerationResult, CodeGenerationResults,
-  CompilerOptions, ContentHashArgs, DependencyId, Entry, EntryData, EntryOptions, Entrypoint,
-  FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Module, ModuleGraph,
+  CompilerOptions, ContentHashArgs, DependencyId, DependencyType, Entry, EntryData, EntryOptions,
+  Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Module, ModuleGraph,
   ModuleIdentifier, ModuleType, PathData, ProcessAssetsArgs, ProcessDependenciesQueue,
   ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs, Resolve, ResolverFactory,
   RuntimeGlobals, RuntimeModule, RuntimeSpec, SharedPluginDriver, SourceType, Stats, TaskResult,
@@ -512,6 +512,8 @@ impl Compilation {
             .dependency_by_id(&id)
             .expect("dependency expected");
 
+          // TODO here should be implement `sortedDependencies` by `dependency.getResourceIdentifier()`,
+          // see https://github.com/webpack/webpack/blob/main/lib/Compilation.js#L1621
           self.handle_module_creation(
             &mut factorize_queue,
             Some(task.original_module_identifier),

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -35,8 +35,8 @@ use crate::{
   BoxModuleDependency, BuildQueue, BuildTask, BuildTaskResult, Chunk, ChunkByUkey,
   ChunkContentHash, ChunkGraph, ChunkGroup, ChunkGroupUkey, ChunkHashArgs, ChunkKind, ChunkUkey,
   CleanQueue, CleanTask, CleanTaskResult, CodeGenerationResult, CodeGenerationResults,
-  CompilerOptions, ContentHashArgs, DependencyId, DependencyType, Entry, EntryData, EntryOptions,
-  Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Module, ModuleGraph,
+  CompilerOptions, ContentHashArgs, DependencyId, Entry, EntryData, EntryOptions, Entrypoint,
+  FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Module, ModuleGraph,
   ModuleIdentifier, ModuleType, PathData, ProcessAssetsArgs, ProcessDependenciesQueue,
   ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs, Resolve, ResolverFactory,
   RuntimeGlobals, RuntimeModule, RuntimeSpec, SharedPluginDriver, SourceType, Stats, TaskResult,
@@ -501,24 +501,41 @@ impl Compilation {
       while let Some(task) = process_dependencies_queue.get_task() {
         active_task_count += 1;
 
+        let original_module_identifier = &task.original_module_identifier;
+        let module = self
+          .module_graph
+          .module_by_identifier(original_module_identifier)
+          .expect("Module expected");
+
+        let mut sorted_dependencies = HashMap::default();
+
         task.dependencies.into_iter().for_each(|id| {
-          let original_module_identifier = &task.original_module_identifier;
-          let module = self
-            .module_graph
-            .module_by_identifier(original_module_identifier)
-            .expect("Module expected");
           let dependency = self
             .module_graph
             .dependency_by_id(&id)
             .expect("dependency expected");
 
-          // TODO here should be implement `sortedDependencies` by `dependency.getResourceIdentifier()`,
-          // see https://github.com/webpack/webpack/blob/main/lib/Compilation.js#L1621
+          // TODO need implement more dependency `resource_identifier()`
+          // https://github.com/webpack/webpack/blob/main/lib/Compilation.js#L1621
+          let resource_identifier =
+            if let Some(resource_identifier) = dependency.resource_identifier() {
+              resource_identifier.to_string()
+            } else {
+              format!("{}|{}", dependency.dependency_type(), dependency.request())
+            };
+
+          sorted_dependencies
+            .entry(resource_identifier)
+            .or_insert(vec![])
+            .push(dependency.clone());
+        });
+
+        for dependencies in sorted_dependencies.into_values() {
           self.handle_module_creation(
             &mut factorize_queue,
             Some(task.original_module_identifier),
             module.get_context().cloned(),
-            vec![dependency.clone()],
+            dependencies,
             false,
             None,
             None,
@@ -529,7 +546,7 @@ impl Compilation {
               .and_then(|module| module.name_for_condition())
               .map(|issuer| issuer.to_string()),
           );
-        });
+        }
 
         result_tx
           .send(Ok(TaskResult::ProcessDependencies(

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -446,6 +446,11 @@ impl ContextModule {
                   category: options.context_options.category,
                   context: options.resource.clone().into(),
                   options: options.context_options.clone(),
+                  resource_identifier: format!(
+                    "context{}|{}",
+                    &options.resource,
+                    path.to_string_lossy()
+                  ),
                 }));
               }
             })
@@ -574,4 +579,8 @@ fn alternative_requests(
   }
 
   items
+}
+
+pub fn create_resource_identifier_for_context_dependency(options: &ContextOptions) -> String {
+  format!("{options}")
 }

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -12,6 +12,7 @@ pub struct ContextElementDependency {
   pub user_request: String,
   pub category: DependencyCategory,
   pub context: Context,
+  pub resource_identifier: String,
 }
 
 impl Dependency for ContextElementDependency {
@@ -25,6 +26,10 @@ impl Dependency for ContextElementDependency {
 
   fn get_context(&self) -> Option<&Context> {
     Some(&self.context)
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
   }
 }
 

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -208,10 +208,12 @@ impl<T: ModuleDependency> AsModuleDependency for T {
   }
 }
 
+pub type DependencyConditionFn =
+  Box<dyn Fn(&ModuleGraphConnection, &RuntimeSpec, &ModuleGraph) -> ConnectionState>;
 pub enum DependencyCondition {
   Nil,
   False,
-  Fn(Box<dyn Fn(&ModuleGraphConnection, &RuntimeSpec, &ModuleGraph) -> ConnectionState>),
+  Fn(DependencyConditionFn),
 }
 
 pub trait ModuleDependency: Dependency {

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -15,8 +15,8 @@ use crate::RuntimeSpec;
 pub struct ExportsInfo {
   exports: HashMap<JsWord, ExportInfo>,
   other_exports_info: ExportInfo,
-  side_effects_only_info: ExportInfo,
-  exports_are_ordered: bool,
+  _side_effects_only_info: ExportInfo,
+  _exports_are_ordered: bool,
   redirect_to: Option<Box<ExportsInfo>>,
 }
 
@@ -25,8 +25,8 @@ impl ExportsInfo {
     Self {
       exports: HashMap::default(),
       other_exports_info: ExportInfo::new("null"),
-      side_effects_only_info: ExportInfo::new("*side effects only*"),
-      exports_are_ordered: false,
+      _side_effects_only_info: ExportInfo::new("*side effects only*"),
+      _exports_are_ordered: false,
       redirect_to: None,
     }
   }
@@ -61,12 +61,18 @@ impl ExportsInfo {
 
   pub fn get_read_only_export_info(&self, name: &JsWord) -> &ExportInfo {
     if let Some(info) = self.exports.get(name) {
-      &info
+      info
     } else if let Some(redirect_to) = &self.redirect_to {
       redirect_to.get_read_only_export_info(name)
     } else {
       &self.other_exports_info
     }
+  }
+}
+
+impl Default for ExportsInfo {
+  fn default() -> Self {
+    Self::new()
   }
 }
 
@@ -77,14 +83,14 @@ pub enum UsedName {
 
 #[derive(Debug)]
 pub struct ExportInfo {
-  name: &'static str,
+  _name: &'static str,
   module_identifier: Option<ModuleIdentifier>,
 }
 
 impl ExportInfo {
-  pub fn new(name: &'static str) -> Self {
+  pub fn new(_name: &'static str) -> Self {
     Self {
-      name,
+      _name,
       module_identifier: None,
     }
   }
@@ -110,17 +116,12 @@ pub enum UsageState {
   Used,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub enum UsedByExports {
   Set(HashSet<JsWord>),
   Bool(bool),
+  #[default]
   Nil,
-}
-
-impl Default for UsedByExports {
-  fn default() -> Self {
-    UsedByExports::Nil
-  }
 }
 
 pub fn get_dependency_used_by_exports_condition(
@@ -131,7 +132,7 @@ pub fn get_dependency_used_by_exports_condition(
   match used_by_exports {
     UsedByExports::Set(used_by_exports) => {
       let module_identifier = module_graph
-        .parent_module_by_dependency_id(&dependency_id)
+        .parent_module_by_dependency_id(dependency_id)
         .expect("should have parent module");
       let used_by_exports = Arc::new(used_by_exports.clone());
       DependencyCondition::Fn(Box::new(move |_, runtime, module_graph| {
@@ -158,21 +159,21 @@ pub fn get_dependency_used_by_exports_condition(
 }
 
 pub struct ReferencedExport {
-  name: Vec<JsWord>,
-  can_mangle: bool,
+  _name: Vec<JsWord>,
+  _can_mangle: bool,
 }
 
 impl ReferencedExport {
-  pub fn new(name: Vec<JsWord>, can_mangle: bool) -> Self {
-    Self { name, can_mangle }
+  pub fn new(_name: Vec<JsWord>, _can_mangle: bool) -> Self {
+    Self { _name, _can_mangle }
   }
 }
 
 impl Default for ReferencedExport {
   fn default() -> Self {
     Self {
-      name: vec![],
-      can_mangle: true,
+      _name: vec![],
+      _can_mangle: true,
     }
   }
 }

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+
+use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::FxHashSet as HashSet;
+use swc_core::ecma::atoms::JsWord;
+
+use crate::ConnectionState;
+use crate::DependencyCondition;
+use crate::DependencyId;
+use crate::ModuleGraph;
+use crate::ModuleIdentifier;
+use crate::RuntimeSpec;
+
+#[derive(Debug)]
+pub struct ExportsInfo {
+  exports: HashMap<JsWord, ExportInfo>,
+  other_exports_info: ExportInfo,
+  side_effects_only_info: ExportInfo,
+  exports_are_ordered: bool,
+  redirect_to: Option<Box<ExportsInfo>>,
+}
+
+impl ExportsInfo {
+  pub fn new() -> Self {
+    Self {
+      exports: HashMap::default(),
+      other_exports_info: ExportInfo::new("null"),
+      side_effects_only_info: ExportInfo::new("*side effects only*"),
+      exports_are_ordered: false,
+      redirect_to: None,
+    }
+  }
+
+  pub fn get_used(
+    &self,
+    name: UsedName,
+    runtime: &RuntimeSpec,
+    module_graph: &ModuleGraph,
+  ) -> UsageState {
+    match &name {
+      UsedName::Str(value) => {
+        let info = self.get_read_only_export_info(value);
+        info.get_used(runtime)
+      }
+      UsedName::Vec(value) => {
+        if value.is_empty() {
+          return self.other_exports_info.get_used(runtime);
+        }
+        let info = self.get_read_only_export_info(&value[0]);
+        if let Some(exports_info) = info.get_exports_info(module_graph) {
+          return exports_info.get_used(
+            UsedName::Vec(value.iter().skip(1).cloned().collect::<Vec<_>>()),
+            runtime,
+            module_graph,
+          );
+        }
+        info.get_used(runtime)
+      }
+    }
+  }
+
+  pub fn get_read_only_export_info(&self, name: &JsWord) -> &ExportInfo {
+    if let Some(info) = self.exports.get(name) {
+      &info
+    } else if let Some(redirect_to) = &self.redirect_to {
+      redirect_to.get_read_only_export_info(name)
+    } else {
+      &self.other_exports_info
+    }
+  }
+}
+
+pub enum UsedName {
+  Str(JsWord),
+  Vec(Vec<JsWord>),
+}
+
+#[derive(Debug)]
+pub struct ExportInfo {
+  name: &'static str,
+  module_identifier: Option<ModuleIdentifier>,
+}
+
+impl ExportInfo {
+  pub fn new(name: &'static str) -> Self {
+    Self {
+      name,
+      module_identifier: None,
+    }
+  }
+
+  // TODO
+  pub fn get_used(&self, _runtime: &RuntimeSpec) -> UsageState {
+    UsageState::Unused
+  }
+
+  pub fn get_exports_info<'a>(&self, module_graph: &'a ModuleGraph) -> Option<&'a ExportsInfo> {
+    self
+      .module_identifier
+      .map(|id| module_graph.get_exports_info(&id))
+  }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum UsageState {
+  Unused,
+  OnlyPropertiesUsed,
+  NoInfo,
+  Unknown,
+  Used,
+}
+
+#[derive(Debug, Clone)]
+pub enum UsedByExports {
+  Set(HashSet<JsWord>),
+  Bool(bool),
+  Nil,
+}
+
+impl Default for UsedByExports {
+  fn default() -> Self {
+    UsedByExports::Nil
+  }
+}
+
+pub fn get_dependency_used_by_exports_condition(
+  dependency_id: &DependencyId,
+  used_by_exports: &UsedByExports,
+  module_graph: &ModuleGraph,
+) -> DependencyCondition {
+  match used_by_exports {
+    UsedByExports::Set(used_by_exports) => {
+      let module_identifier = module_graph
+        .parent_module_by_dependency_id(&dependency_id)
+        .expect("should have parent module");
+      let used_by_exports = Arc::new(used_by_exports.clone());
+      DependencyCondition::Fn(Box::new(move |_, runtime, module_graph| {
+        let exports_info = module_graph.get_exports_info(&module_identifier);
+        for export_name in used_by_exports.iter() {
+          if exports_info.get_used(UsedName::Str(export_name.clone()), runtime, module_graph)
+            != UsageState::Unused
+          {
+            return ConnectionState::Bool(true);
+          }
+        }
+        ConnectionState::Bool(false)
+      }))
+    }
+    UsedByExports::Bool(bool) => {
+      if *bool {
+        DependencyCondition::Nil
+      } else {
+        DependencyCondition::False
+      }
+    }
+    UsedByExports::Nil => DependencyCondition::Nil,
+  }
+}
+
+pub struct ReferencedExport {
+  name: Vec<JsWord>,
+  can_mangle: bool,
+}
+
+impl ReferencedExport {
+  pub fn new(name: Vec<JsWord>, can_mangle: bool) -> Self {
+    Self { name, can_mangle }
+  }
+}
+
+impl Default for ReferencedExport {
+  fn default() -> Self {
+    Self {
+      name: vec![],
+      can_mangle: true,
+    }
+  }
+}

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -15,6 +15,8 @@ pub use missing_module::*;
 mod normal_module;
 mod raw_module;
 pub use raw_module::*;
+mod exports_info;
+pub use exports_info::*;
 pub mod module;
 pub mod parser_and_generator;
 pub use module::*;

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -88,7 +88,7 @@ impl ModuleGraphConnection {
     match dependency.get_condition(module_graph) {
       DependencyCondition::Nil => ConnectionState::Bool(false),
       DependencyCondition::False => ConnectionState::Bool(true),
-      DependencyCondition::Fn(f) => f(&self, runtime, module_graph),
+      DependencyCondition::Fn(f) => f(self, runtime, module_graph),
     }
   }
 }

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -1,4 +1,4 @@
-use crate::{DependencyId, ModuleIdentifier};
+use crate::{DependencyCondition, DependencyId, ModuleGraph, ModuleIdentifier, RuntimeSpec};
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ConnectionId(usize);
@@ -27,6 +27,8 @@ pub struct ModuleGraphConnection {
 
   /// The referencing dependency id
   pub dependency_id: DependencyId,
+
+  active: Option<bool>,
 }
 
 impl ModuleGraphConnection {
@@ -39,6 +41,74 @@ impl ModuleGraphConnection {
       original_module_identifier,
       module_identifier,
       dependency_id,
+      active: None,
     }
+  }
+
+  pub fn set_active(&mut self, value: bool) {
+    self.active = Some(value);
+  }
+
+  pub fn is_active(&self, module_graph: &ModuleGraph, runtime: &RuntimeSpec) -> bool {
+    if let Some(value) = self.active {
+      return value;
+    }
+    self
+      .get_condition_state(module_graph, runtime)
+      .is_not_false()
+  }
+
+  pub fn is_target_active(&self, module_graph: &ModuleGraph, runtime: &RuntimeSpec) -> bool {
+    if let Some(value) = self.active {
+      return value;
+    }
+    self.get_condition_state(module_graph, runtime).is_true()
+  }
+
+  pub fn get_active_state(
+    &self,
+    module_graph: &ModuleGraph,
+    runtime: &RuntimeSpec,
+  ) -> ConnectionState {
+    if let Some(value) = self.active {
+      return ConnectionState::Bool(value);
+    }
+    self.get_condition_state(module_graph, runtime)
+  }
+
+  // Here avoid move condition, so use dependency id to search
+  pub fn get_condition_state(
+    &self,
+    module_graph: &ModuleGraph,
+    runtime: &RuntimeSpec,
+  ) -> ConnectionState {
+    let dependency = module_graph
+      .dependency_by_id(&self.dependency_id)
+      .expect("should have dependency");
+    match dependency.get_condition(module_graph) {
+      DependencyCondition::Nil => ConnectionState::Bool(false),
+      DependencyCondition::False => ConnectionState::Bool(true),
+      DependencyCondition::Fn(f) => f(&self, runtime, module_graph),
+    }
+  }
+}
+
+pub enum ConnectionState {
+  Bool(bool),
+}
+
+impl ConnectionState {
+  pub fn is_true(&self) -> bool {
+    match self {
+      ConnectionState::Bool(bool) => *bool,
+    }
+    // other should return false
+  }
+
+  pub fn is_not_false(&self) -> bool {
+    match self {
+      ConnectionState::Bool(bool) => *bool,
+    }
+    // other should return false
   }
 }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -8,11 +8,11 @@ use rspack_identifier::IdentifierMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 mod connection;
-pub use connection::{ConnectionId, ModuleGraphConnection};
+pub use connection::{ConnectionId, ConnectionState, ModuleGraphConnection};
 
 use crate::{
   to_identifier, BoxModule, BoxModuleDependency, BuildDependency, BuildInfo, BuildMeta,
-  DependencyId, Module, ModuleGraphModule, ModuleIdentifier,
+  DependencyId, ExportsInfo, Module, ModuleGraphModule, ModuleIdentifier,
 };
 
 // TODO Here request can be used JsWord
@@ -494,6 +494,13 @@ impl ModuleGraph {
       .expect("should have module import var")
       .get(request)
       .unwrap_or_else(|| panic!("should have import var for {module_identifier} {request}"))
+  }
+
+  pub fn get_exports_info(&self, module_identifier: &ModuleIdentifier) -> &ExportsInfo {
+    let mgm = self
+      .module_graph_module_by_identifier(module_identifier)
+      .expect("should have mgm");
+    &mgm.exports
   }
 }
 

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -3,9 +3,9 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   is_async_dependency, module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject,
-  BuildMetaExportsType, ChunkGraph, ChunkGroupOptions, DependencyId, ExportsType, FactoryMeta,
-  ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleIssuer,
-  ModuleSyntax, ModuleType,
+  BuildMetaExportsType, ChunkGraph, ChunkGroupOptions, DependencyId, ExportsInfo, ExportsType,
+  FactoryMeta, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
+  ModuleIssuer, ModuleSyntax, ModuleType,
 };
 
 #[derive(Debug)]
@@ -27,6 +27,7 @@ pub struct ModuleGraphModule {
   pub factory_meta: Option<FactoryMeta>,
   pub build_info: Option<BuildInfo>,
   pub build_meta: Option<BuildMeta>,
+  pub exports: ExportsInfo,
 }
 
 impl ModuleGraphModule {
@@ -46,6 +47,7 @@ impl ModuleGraphModule {
       factory_meta: None,
       build_info: None,
       build_meta: None,
+      exports: ExportsInfo::new(),
     }
   }
 

--- a/crates/rspack_core/src/tree_shaking/symbol/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/symbol/mod.rs
@@ -181,13 +181,19 @@ impl StarSymbol {
   }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
+#[derive(Debug, Clone, Eq, Hash, Serialize)]
 pub struct IndirectTopLevelSymbol {
   pub src: Identifier,
   pub ty: IndirectType,
   // module identifier of module that import me, only used for debugging
   pub importer: Identifier,
   pub dep_id: DependencyId,
+}
+
+impl PartialEq for IndirectTopLevelSymbol {
+  fn eq(&self, other: &Self) -> bool {
+    self.src == other.src && self.ty == other.ty && self.importer == other.importer
+  }
 }
 
 impl IndirectTopLevelSymbol {

--- a/crates/rspack_core/src/tree_shaking/symbol/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/symbol/mod.rs
@@ -181,19 +181,13 @@ impl StarSymbol {
   }
 }
 
-#[derive(Debug, Clone, Eq, Hash, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
 pub struct IndirectTopLevelSymbol {
   pub src: Identifier,
   pub ty: IndirectType,
   // module identifier of module that import me, only used for debugging
   pub importer: Identifier,
   pub dep_id: DependencyId,
-}
-
-impl PartialEq for IndirectTopLevelSymbol {
-  fn eq(&self, other: &Self) -> bool {
-    self.src == other.src && self.ty == other.ty && self.importer == other.importer
-  }
 }
 
 impl IndirectTopLevelSymbol {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
   module_id, ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  DependencyType, ErrorSpan, ExportsReferencedType, ModuleDependency, ModuleGraph, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -80,6 +81,14 @@ impl ModuleDependency for RequireResolveDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request;
+  }
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &ModuleGraph,
+    _runtime: &RuntimeSpec,
+  ) -> ExportsReferencedType {
+    ExportsReferencedType::No
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  module_id_expr, normalize_context, ContextOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  create_resource_identifier_for_context_dependency, module_id_expr, normalize_context,
+  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
+  ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -12,6 +12,7 @@ pub struct CommonJsRequireContextDependency {
   pub id: DependencyId,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
+  resource_identifier: String,
 }
 
 impl CommonJsRequireContextDependency {
@@ -22,6 +23,7 @@ impl CommonJsRequireContextDependency {
     options: ContextOptions,
     span: Option<ErrorSpan>,
   ) -> Self {
+    let resource_identifier = create_resource_identifier_for_context_dependency(&options);
     Self {
       callee_start,
       callee_end,
@@ -29,6 +31,7 @@ impl CommonJsRequireContextDependency {
       options,
       span,
       id: DependencyId::new(),
+      resource_identifier,
     }
   }
 }
@@ -40,6 +43,10 @@ impl Dependency for CommonJsRequireContextDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::CommonJSRequireContext
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  module_id_expr, normalize_context, ContextOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  create_resource_identifier_for_context_dependency, module_id_expr, normalize_context,
+  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
+  ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -12,6 +12,7 @@ pub struct ImportContextDependency {
   pub id: DependencyId,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
+  resource_identifier: String,
 }
 
 impl ImportContextDependency {
@@ -22,6 +23,7 @@ impl ImportContextDependency {
     options: ContextOptions,
     span: Option<ErrorSpan>,
   ) -> Self {
+    let resource_identifier = create_resource_identifier_for_context_dependency(&options);
     Self {
       callee_start,
       callee_end,
@@ -29,6 +31,7 @@ impl ImportContextDependency {
       options,
       span,
       id: DependencyId::new(),
+      resource_identifier,
     }
   }
 }
@@ -40,6 +43,10 @@ impl Dependency for ImportContextDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::ImportContext
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -23,7 +23,7 @@ impl RequireContextDependency {
       options,
       span,
       id: DependencyId::new(),
-      resource_identifier: resource_identifier,
+      resource_identifier,
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  module_id_expr, ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  create_resource_identifier_for_context_dependency, module_id_expr, ContextOptions, Dependency,
+  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -11,16 +11,19 @@ pub struct RequireContextDependency {
   pub id: DependencyId,
   pub options: ContextOptions,
   span: Option<ErrorSpan>,
+  resource_identifier: String,
 }
 
 impl RequireContextDependency {
   pub fn new(start: u32, end: u32, options: ContextOptions, span: Option<ErrorSpan>) -> Self {
+    let resource_identifier = create_resource_identifier_for_context_dependency(&options);
     Self {
       start,
       end,
       options,
       span,
       id: DependencyId::new(),
+      resource_identifier: resource_identifier,
     }
   }
 }
@@ -32,6 +35,10 @@ impl Dependency for RequireContextDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::RequireContext
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -24,6 +24,7 @@ pub struct HarmonyImportDependency {
   pub specifiers: Vec<Specifier>,
   pub dependency_type: DependencyType,
   pub export_all: bool,
+  resource_identifier: String,
 }
 
 impl HarmonyImportDependency {
@@ -34,6 +35,7 @@ impl HarmonyImportDependency {
     dependency_type: DependencyType,
     export_all: bool,
   ) -> Self {
+    let resource_identifier = format!("{}|{}", DependencyCategory::Esm, &request);
     Self {
       request,
       span,
@@ -41,6 +43,7 @@ impl HarmonyImportDependency {
       specifiers,
       dependency_type,
       export_all,
+      resource_identifier,
     }
   }
 }
@@ -197,6 +200,10 @@ impl Dependency for HarmonyImportDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &self.dependency_type
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -1,8 +1,9 @@
 use rspack_core::tree_shaking::symbol::IndirectTopLevelSymbol;
 use rspack_core::{
   import_statement, tree_shaking::symbol, tree_shaking::visitor::SymbolRef, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan, InitFragment,
-  InitFragmentStage, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ExportsReferencedType, InitFragment, InitFragmentStage, ModuleDependency, ModuleGraph,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -27,7 +28,6 @@ pub struct HarmonyImportDependency {
 
 impl HarmonyImportDependency {
   pub fn new(
-    id: DependencyId,
     request: JsWord,
     span: Option<ErrorSpan>,
     specifiers: Vec<Specifier>,
@@ -37,7 +37,7 @@ impl HarmonyImportDependency {
     Self {
       request,
       span,
-      id,
+      id: DependencyId::new(),
       specifiers,
       dependency_type,
       export_all,
@@ -223,5 +223,13 @@ impl ModuleDependency for HarmonyImportDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request.into();
+  }
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &ModuleGraph,
+    _runtime: &RuntimeSpec,
+  ) -> ExportsReferencedType {
+    ExportsReferencedType::No
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -77,20 +77,20 @@ impl HarmonyImportSpecifierDependency {
     match &self.specifier {
       Specifier::Namespace(_) => true,
       Specifier::Default(local) => {
-        compilation.used_symbol_ref.iter().find(|symbol| {
+        compilation.used_symbol_ref.iter().any(|symbol| {
           matches!(
             symbol,
             SymbolRef::Indirect(indirect) if indirect.src == reference_mgm.module_identifier && indirect.ty == symbol::IndirectType::ImportDefault(local.clone()) && indirect.importer() == module.identifier()
           )
-        }).is_some()
+        })
       }
       Specifier::Named(local, imported) => {
-        compilation.used_symbol_ref.iter().find(|symbol| {
+        compilation.used_symbol_ref.iter().any(|symbol| {
           matches!(
             symbol,
             SymbolRef::Indirect(indirect) if indirect.src == reference_mgm.module_identifier && indirect.ty == symbol::IndirectType::Import(local.clone(), imported.clone()) && indirect.importer() == module.identifier()
           )
-        }).is_some()
+        })
       }
     }
   }
@@ -114,12 +114,10 @@ impl HarmonyImportSpecifierDependency {
           })
           .collect(),
       )
+    } else if let Some(v) = ids {
+      ExportsReferencedType::Value(vec![ReferencedExport::new(v.clone(), true)])
     } else {
-      if let Some(v) = ids {
-        ExportsReferencedType::Value(vec![ReferencedExport::new(v.clone(), true)])
-      } else {
-        ExportsReferencedType::Object
-      }
+      ExportsReferencedType::Object
     }
   }
 }
@@ -176,7 +174,7 @@ impl ModuleDependency for HarmonyImportSpecifierDependency {
       return self.get_referenced_exports_in_destructuring(None);
     }
     // TODO
-    return self.get_referenced_exports_in_destructuring(Some(&self.ids));
+    self.get_referenced_exports_in_destructuring(Some(&self.ids))
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,6 +1,8 @@
 use rspack_core::{
-  module_id, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  get_dependency_used_by_exports_condition, module_id, Dependency, DependencyCategory,
+  DependencyCondition, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ModuleDependency, ModuleGraph, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  UsedByExports,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -11,6 +13,7 @@ pub struct URLDependency {
   id: DependencyId,
   request: JsWord,
   span: Option<ErrorSpan>,
+  used_by_exports: UsedByExports,
 }
 
 impl URLDependency {
@@ -21,6 +24,7 @@ impl URLDependency {
       id: DependencyId::new(),
       request,
       span,
+      used_by_exports: UsedByExports::default(),
     }
   }
 }
@@ -58,6 +62,10 @@ impl ModuleDependency for URLDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request.into();
+  }
+
+  fn get_condition(&self, module_graph: &ModuleGraph) -> DependencyCondition {
+    get_dependency_used_by_exports_condition(&self.id, &self.used_by_exports, module_graph)
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   ChunkGroupOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  DependencyType, ErrorSpan, ExportsReferencedType, ModuleDependency, ModuleGraph, RuntimeGlobals,
+  RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -73,6 +73,14 @@ impl ModuleDependency for WorkerDependency {
 
   fn group_options(&self) -> Option<&ChunkGroupOptions> {
     Some(&self.group_options)
+  }
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &ModuleGraph,
+    _runtime: &RuntimeSpec,
+  ) -> ExportsReferencedType {
+    ExportsReferencedType::No
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use rspack_core::{
-  tree_shaking::symbol::DEFAULT_JS_WORD, ConstDependency, DependencyId, DependencyTemplate,
-  DependencyType, ModuleDependency, ModuleIdentifier, SpanExt,
+  tree_shaking::symbol::DEFAULT_JS_WORD, ConstDependency, DependencyTemplate, DependencyType,
+  ModuleDependency, ModuleIdentifier, SpanExt,
 };
 use rustc_hash::FxHashMap;
 use swc_core::{

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -483,32 +483,6 @@ exports[`StatsTestCases should print correct stats for ignore-plugin 1`] = `
       "chunks": [
         "main",
       ],
-      "id": "665",
-      "identifier": "missing|<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh",
-      "issuer": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: RspackRegex { algo: Regress(Regex { cr: CompiledRegex { insns: [StartOfLine, ByteSeq2([46, 47]), Loop1CharBody { min_iters: 0, max_iters: 18446744073709551615, greedy: true }, MatchAnyExceptLineTerminator, EndOfLine, Goal], brackets: [], start_pred: Arbitrary, loops: 0, groups: 0, named_group_indices: {}, flags: Flags { icase: false, multiline: false, dot_all: false, no_opt: false, unicode: false } } }) }, reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals" }",
-      "issuerId": "941",
-      "issuerName": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: RspackRegex { algo: Regress(Regex { cr: CompiledRegex { insns: [StartOfLine, ByteSeq2([46, 47]), Loop1CharBody { min_iters: 0, max_iters: 18446744073709551615, greedy: true }, MatchAnyExceptLineTerminator, EndOfLine, Goal], brackets: [], start_pred: Arbitrary, loops: 0, groups: 0, named_group_indices: {}, flags: Flags { icase: false, multiline: false, dot_all: false, no_opt: false, unicode: false } } }) }, reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals" }",
-      "issuerPath": [
-        {
-          "id": "10",
-          "identifier": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/index.js",
-          "name": "./index.js",
-        },
-        {
-          "id": "941",
-          "identifier": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: RspackRegex { algo: Regress(Regex { cr: CompiledRegex { insns: [StartOfLine, ByteSeq2([46, 47]), Loop1CharBody { min_iters: 0, max_iters: 18446744073709551615, greedy: true }, MatchAnyExceptLineTerminator, EndOfLine, Goal], brackets: [], start_pred: Arbitrary, loops: 0, groups: 0, named_group_indices: {}, flags: Flags { icase: false, multiline: false, dot_all: false, no_opt: false, unicode: false } } }) }, reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals" }",
-          "name": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: RspackRegex { algo: Regress(Regex { cr: CompiledRegex { insns: [StartOfLine, ByteSeq2([46, 47]), Loop1CharBody { min_iters: 0, max_iters: 18446744073709551615, greedy: true }, MatchAnyExceptLineTerminator, EndOfLine, Goal], brackets: [], start_pred: Arbitrary, loops: 0, groups: 0, named_group_indices: {}, flags: Flags { icase: false, multiline: false, dot_all: false, no_opt: false, unicode: false } } }) }, reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals" }",
-        },
-      ],
-      "moduleType": "javascript/auto",
-      "name": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh (missing)",
-      "size": 160,
-      "type": "module",
-    },
-    {
-      "chunks": [
-        "main",
-      ],
       "id": "136",
       "identifier": "missing|<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh.js",
       "issuer": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: RspackRegex { algo: Regress(Regex { cr: CompiledRegex { insns: [StartOfLine, ByteSeq2([46, 47]), Loop1CharBody { min_iters: 0, max_iters: 18446744073709551615, greedy: true }, MatchAnyExceptLineTerminator, EndOfLine, Goal], brackets: [], start_pred: Arbitrary, loops: 0, groups: 0, named_group_indices: {}, flags: Flags { icase: false, multiline: false, dot_all: false, no_opt: false, unicode: false } } }) }, reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals" }",
@@ -580,7 +554,6 @@ exports[`StatsTestCases should print correct stats for ignore-plugin 1`] = `
 exports[`StatsTestCases should print correct stats for ignore-plugin 2`] = `
 "./index.js [10] {main}
 ./locals/en.js [208] {main}
-<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh (missing) [665] {main}
 <PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh.js (missing) [136] {main}
 <PROJECT_ROOT>/tests/statsCases/ignore-plugin/./globalIndex.js (missing) [239] {main}
 <PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: RspackRegex { algo: Regress(Regex { cr: CompiledRegex { insns: [StartOfLine, ByteSeq2([46, 47]), Loop1CharBody { min_iters: 0, max_iters: 18446744073709551615, greedy: true }, MatchAnyExceptLineTerminator, EndOfLine, Goal], brackets: [], start_pred: Arbitrary, loops: 0, groups: 0, named_group_indices: {}, flags: Flags { icase: false, multiline: false, dot_all: false, no_opt: false, unicode: false } } }) }, reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals" } [941] {main}"

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1494,6 +1494,13 @@ console.log(a);
               "type": "esm import",
               "userRequest": "cycle-alias/a",
             },
+            {
+              "moduleId": "10",
+              "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js",
+              "moduleName": "./index.js",
+              "type": "esm import specifier",
+              "userRequest": "cycle-alias/a",
+            },
           ],
           "size": 160,
           "type": "module",
@@ -1588,6 +1595,13 @@ console.log(a);
           "type": "esm import",
           "userRequest": "cycle-alias/a",
         },
+        {
+          "moduleId": "10",
+          "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js",
+          "moduleName": "./index.js",
+          "type": "esm import specifier",
+          "userRequest": "cycle-alias/a",
+        },
       ],
       "size": 160,
       "type": "module",
@@ -1624,10 +1638,12 @@ chunk {main} bundle.js (main) [entry]
     entry ./index
   <PROJECT_ROOT>/tests/statsCases/resolve-overflow/cycle-alias/a (missing) [280] {main}
     esm import cycle-alias/a [10]
+    esm import specifier cycle-alias/a [10]
 ./index.js [10] {main}
   entry ./index
 <PROJECT_ROOT>/tests/statsCases/resolve-overflow/cycle-alias/a (missing) [280] {main}
   esm import cycle-alias/a [10]
+  esm import specifier cycle-alias/a [10]
 
 error[internal]: Resolve error
   ┌─ tests/statsCases/resolve-overflow/index.js:1:1
@@ -1724,6 +1740,13 @@ console.log(a);
               "type": "esm import",
               "userRequest": "pkg-a",
             },
+            {
+              "moduleId": "10",
+              "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/index.js",
+              "moduleName": "./index.js",
+              "type": "esm import specifier",
+              "userRequest": "pkg-a",
+            },
           ],
           "size": 160,
           "type": "module",
@@ -1813,6 +1836,13 @@ console.log(a);
           "type": "esm import",
           "userRequest": "pkg-a",
         },
+        {
+          "moduleId": "10",
+          "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/index.js",
+          "moduleName": "./index.js",
+          "type": "esm import specifier",
+          "userRequest": "pkg-a",
+        },
       ],
       "size": 160,
       "type": "module",
@@ -1849,10 +1879,12 @@ chunk {main} bundle.js (main) [entry]
     entry ./index
   <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/pkg-a (missing) [788] {main}
     esm import pkg-a [10]
+    esm import specifier pkg-a [10]
 ./index.js [10] {main}
   entry ./index
 <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/pkg-a (missing) [788] {main}
   esm import pkg-a [10]
+  esm import specifier pkg-a [10]
 
 Export should be relative path and start with "./", but got ../../index.js
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- add exports info api
- add `dependency.resource_identifier()` to merge equal requests, and implement https://github.com/webpack/webpack/blob/main/lib/Compilation.js#L1621
- add `HarmonyImportSpecifierDependency` to dependency instead of  presentational_dependencies

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

It's unnecessary at now,because exports info  is not enabled

<!-- Can you please describe how you tested the changes you made to the code? -->
