### PR TITLE
refactor: css-import span should be calculated with at-rule

### DIFF
--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -66,12 +66,6 @@ impl DependencyTemplate for CssImportDependency {
     source: &mut TemplateReplaceSource,
     _code_generatable_context: &mut TemplateContext,
   ) {
-    source.replace(
-      self.start - 8, /* @import */
-      // Semicolon should be available and guarantee, or it's a syntax error.
-      self.end + 1, /* ; */
-      "",
-      None,
-    );
+    source.replace(self.start, self.end, "", None);
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Css-import replacement was originally implemented with dependency template. 
The implementation is supposed to remove the css-import statement in order to do module concatenation.
This PR refactors the current span calculation workaround into a more reasonable way which leverages the at-rule span.

closes #3813
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

This is a refactor, so tests has been added before(using snapshots).

<!-- Can you please describe how you tested the changes you made to the code? -->
