### PR TITLE
refactor: remove ctxt of variable in import map

### DIFF
--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -800,7 +800,7 @@ impl<'a> CodeSizeOptimizer<'a> {
         // one for `app.js`, one for `lib.js`
         // the binding in `app.js` used for shake the `export {xxx}`
         // In other words, we need two binding for supporting indirect redirect.
-        if let Some(import_symbol_ref) = module_result.import_map.get(symbol.id()) {
+        if let Some(import_symbol_ref) = module_result.import_map.get(&symbol.id().atom) {
           self
             .symbol_graph
             .add_edge(&current_symbol_ref, import_symbol_ref);
@@ -1209,7 +1209,7 @@ impl<'a> CodeSizeOptimizer<'a> {
       SymbolRef::Url { .. } | SymbolRef::Worker { .. } => {}
       SymbolRef::Usage(ref binding, ref member_chain, ref src) => {
         let analyze_result = analyze_map.get(src).expect("Should have analyze result");
-        if let Some(import_symbol_ref) = analyze_result.import_map.get(binding) {
+        if let Some(import_symbol_ref) = analyze_result.import_map.get(&binding.atom) {
           self
             .symbol_graph
             .add_edge(&current_symbol_ref, import_symbol_ref);

--- a/crates/rspack_core/src/tree_shaking/symbol/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/symbol/mod.rs
@@ -360,7 +360,7 @@ impl PartialEq for SymbolExt {
 /// We use [Part::MemberExpr] to represent namespace access
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum Part {
-  Id(BetterId),
+  TopLevelId(BetterId),
   MemberExpr { object: BetterId, property: JsWord },
   Url(JsWord),
   Worker(JsWord),
@@ -372,7 +372,7 @@ impl Part {
   /// [`Id`]: BetterIdOrMemExpr::Id
   #[must_use]
   pub fn is_id(&self) -> bool {
-    matches!(self, Self::Id(..))
+    matches!(self, Self::TopLevelId(..))
   }
 
   /// Returns `true` if the better id or mem expr is [`MemberExpr`].
@@ -385,7 +385,7 @@ impl Part {
 
   pub fn get_id(&self) -> Option<&BetterId> {
     match self {
-      Part::Id(id) => Some(id),
+      Part::TopLevelId(id) => Some(id),
       Part::MemberExpr { object, .. } => Some(object),
       Part::Url(_) | Part::Worker(_) => None,
     }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. `ctxt` in import map is useless in the rest of stage, so removed it.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
