### PR TITLE
feat: add more context for error frame

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,8 +395,7 @@ dependencies = [
 [[package]]
 name = "codespan-reporting"
 version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+source = "git+https://github.com/brendanzab/codespan?branch=master#c84116f5a667bfce2aa1e045205c5832cfee1548"
 dependencies = [
  "termcolor",
  "unicode-width",

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -9,7 +9,7 @@ version    = "0.1.0"
 
 [dependencies]
 anyhow             = { workspace = true, features = ["backtrace"] }
-codespan-reporting = "0.11.1"
+codespan-reporting = { git = "https://github.com/brendanzab/codespan", branch = "master" }
 futures            = { workspace = true }
 rspack_util        = { path = "../rspack_util" }
 sugar_path         = { workspace = true }

--- a/crates/rspack_error/src/emitter.rs
+++ b/crates/rspack_error/src/emitter.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use anyhow::Context;
 use codespan_reporting::diagnostic::{Diagnostic, Label, Severity};
 use codespan_reporting::files::SimpleFiles;
-use codespan_reporting::term;
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
+use codespan_reporting::term::{self, Config};
 use sugar_path::SugarPath;
 use termcolor::{Buffer, Color, ColorSpec, StandardStreamLock, WriteColor};
 
@@ -192,7 +192,11 @@ fn emit_diagnostic<T: Write + WriteColor>(
       )
       .with_message(&diagnostic.message)]);
 
-    let config = codespan_reporting::term::Config::default();
+    let config = Config {
+      before_label_lines: 4,
+      after_label_lines: 4,
+      ..Config::default()
+    };
 
     term::emit(writer, &config, files, &diagnostic).expect("TODO:");
   } else {

--- a/crates/rspack_error/tests/fixtures/char-based-offset-error-span/fixtures__char-based-offset-error-span.snap
+++ b/crates/rspack_error/tests/fixtures/char-based-offset-error-span/fixtures__char-based-offset-error-span.snap
@@ -1,12 +1,17 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 41
 expression: char-based-offset-error-span
 ---
 error[scss]: Sass Error
   ┌─ tests/fixtures/char-based-offset-error-span/index.scss:5:10
   │
+1 │ // 一些中文注释
+2 │ // 一些 emoji：👏 👏 👏
+3 │ // a̐éö̲
+4 │ .wrong {
 5 │   wrong: $wrong;
   │          ^^^^^^ Undefined variable.
+6 │ }
+7 │ 
 
 

--- a/crates/rspack_error/tests/fixtures/html_syntax_error/fixtures__html_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/html_syntax_error/fixtures__html_syntax_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 38
 expression: html_syntax_error
 ---
 error[html]: HTML parsing error
@@ -8,10 +7,12 @@ error[html]: HTML parsing error
   │
 1 │ <head>
   │ ^^^^^^ Start tag seen without seeing a doctype first, expected "<!DOCTYPE html>"
+2 │   </something>
 
 error[html]: HTML parsing error
   ┌─ tests/fixtures/html_syntax_error/index.html:2:3
   │
+1 │ <head>
 2 │   </something>
   │   ^^^^^^^^^^^^ Stray end tag "something"
 

--- a/crates/rspack_error/tests/fixtures/js_syntax_error/fixtures__js_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/js_syntax_error/fixtures__js_syntax_error.snap
@@ -5,12 +5,21 @@ expression: js_syntax_error
 error[javascript]: JavaScript parsing error
   ┌─ tests/fixtures/js_syntax_error/index.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/fixtures/js_syntax_error/index.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 

--- a/crates/rspack_error/tests/fixtures/jsx_syntax_error/fixtures__jsx_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/jsx_syntax_error/fixtures__jsx_syntax_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 39
 expression: jsx_syntax_error
 ---
 error[jsx]: JSX parsing error
@@ -8,10 +7,12 @@ error[jsx]: JSX parsing error
   │
 1 │ let a = <test>/test>;
   │                    ^ Unexpected token. Did you mean `{'>'}` or `&gt;`?
+2 │ 
 
 error[jsx]: JSX parsing error
   ┌─ tests/fixtures/jsx_syntax_error/index.jsx:2:1
   │
+1 │ let a = <test>/test>;
 2 │ 
   │ ^ Unexpected eof
 

--- a/crates/rspack_error/tests/fixtures/recoverable_syntax_error/fixtures__recoverable_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/recoverable_syntax_error/fixtures__recoverable_syntax_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 38
 expression: recoverable_syntax_error
 ---
 error[tsx]: TSX parsing error
@@ -8,11 +7,13 @@ error[tsx]: TSX parsing error
   │
 1 │ let c = <test>() => {}</test>;
   │                       ^ Expected a semicolon
+2 │ 
 
 error[tsx]: TSX parsing error
   ┌─ tests/fixtures/recoverable_syntax_error/index.tsx:1:24
   │
 1 │ let c = <test>() => {}</test>;
   │                        ^ Expression expected
+2 │ 
 
 

--- a/crates/rspack_error/tests/fixtures/sass-warnings/fixtures__sass-warnings.snap
+++ b/crates/rspack_error/tests/fixtures/sass-warnings/fixtures__sass-warnings.snap
@@ -1,16 +1,17 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 41
 expression: sass-warnings
 ---
 warning[scss]: Sass Warning
   ┌─ tests/fixtures/sass-warnings/index.scss:2:11
   │
+1 │ .c {
 2 │   width: (12px/4px);
   │           ^^^^^^^^ Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
 
 Recommendation: math.div(12px, 4px) or calc(12px / 4px)
 
 More info and automated migrator: https://sass-lang.com/d/slash-div
+3 │ }
 
 

--- a/crates/rspack_error/tests/fixtures/ts_syntax_error/fixtures__ts_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/ts_syntax_error/fixtures__ts_syntax_error.snap
@@ -1,12 +1,16 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 38
 expression: ts_syntax_error
 ---
 error[typescript]: Typescript parsing error
   ┌─ tests/fixtures/ts_syntax_error/index.ts:5:5
   │
+1 │ const CONST = 9000 % 2;
+2 │ const enum D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
 5 │     g = CONST
   │     ^ Expected ',', got 'g'
+6 │ }
 
 

--- a/crates/rspack_error/tests/fixtures/tsx_syntax_error/fixtures__tsx_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/tsx_syntax_error/fixtures__tsx_syntax_error.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 38
 expression: tsx_syntax_error
 ---
 error[tsx]: TSX parsing error
@@ -8,5 +7,6 @@ error[tsx]: TSX parsing error
   │
 1 │ let c = <test>/test>;
   │          ^^^^ Unexpected token `test`. Expected jsx identifier
+2 │ 
 
 

--- a/crates/rspack_error/tests/out_of_order/multi_json_syntax_error/fixtures__multi_json_syntax_error.snap
+++ b/crates/rspack_error/tests/out_of_order/multi_json_syntax_error/fixtures__multi_json_syntax_error.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/rspack_error/tests/fixtures.rs
-assertion_line: 63
 expression: multi_json_syntax_error
 ---
 error[json]: Json parsing error
   ┌─ tests/out_of_order/multi_json_syntax_error/a.json:3:1
   │
+1 │ {
+2 │   "a"
 3 │ }
   │ ^ Unexpected character }
 

--- a/crates/rspack_error/tests/out_of_order/multiple_file_syntax_error/fixtures__multiple_file_syntax_error.snap
+++ b/crates/rspack_error/tests/out_of_order/multiple_file_syntax_error/fixtures__multiple_file_syntax_error.snap
@@ -5,84 +5,147 @@ expression: multiple_file_syntax_error
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/a.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/a.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/b.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/b.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/c.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/c.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/d.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/d.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/e.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/e.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/f.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/f.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/g.js:2:10
   │
+1 │ const CONST = 9000 % 2;
 2 │ const  D {
   │          ^ Expected a semicolon
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
+6 │ }
 
 error[javascript]: JavaScript parsing error
   ┌─ tests/out_of_order/multiple_file_syntax_error/g.js:6:1
   │
+2 │ const  D {
+3 │     // Comma is required, but parser can recover because of the newline.
+4 │     d = 10
+5 │     g = CONST
 6 │ }
   │ ^ Expression expected
 

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -198,8 +198,13 @@ describe("Stats", () => {
 		error[javascript]: JavaScript parsing error
 		  ┌─ tests/fixtures/b.js:6:1
 		  │
+		2 │     return "This is b";
+		3 │ };
+		4 │ 
+		5 │ // Test CJS top-level return
 		6 │ return;
 		  │ ^^^^^^^ Return statement is not allowed here
+		7 │ 
 
 
 

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -718,6 +718,7 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
   │
 1 │ let let = let;
   │     ^^^ \`let\` cannot be used as an identifier in strict mode
+2 │ 
 
 ",
       "message": "\`let\` cannot be used as an identifier in strict mode",
@@ -729,6 +730,7 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
   │
 1 │ let let = let;
   │           ^^^ \`let\` cannot be used as an identifier in strict mode
+2 │ 
 
 ",
       "message": "\`let\` cannot be used as an identifier in strict mode",
@@ -747,6 +749,7 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
   │
 1 │ let let = let;
   │     ^^^ \`let\` cannot be used as an identifier in strict mode
+2 │ 
 
 
 
@@ -755,6 +758,7 @@ error[javascript]: JavaScript parsing error
   │
 1 │ let let = let;
   │           ^^^ \`let\` cannot be used as an identifier in strict mode
+2 │ 
 
 
 
@@ -935,6 +939,10 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
   │
 1 │ const a {}
   │         ^ Expected a semicolon
+2 │ (function() {
+3 │ var __webpack_modules__ = {
+4 │ "10": function (__unused_webpack_module, exports, __webpack_require__) {
+5 │ console.log(0);
 
 ",
       "message": "Expected a semicolon",
@@ -953,6 +961,10 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 2`]
   │
 1 │ const a {}
   │         ^ Expected a semicolon
+2 │ (function() {
+3 │ var __webpack_modules__ = {
+4 │ "10": function (__unused_webpack_module, exports, __webpack_require__) {
+5 │ console.log(0);
 
 
 
@@ -1021,6 +1033,7 @@ exports[`StatsTestCases should print correct stats for normal-errors 1`] = `
   │
 1 │ import "not-exist";
   │ ^^^^^^^^^^^^^^^^^^^ Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
+2 │ 
 
 ",
       "message": "Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js",
@@ -1039,6 +1052,7 @@ exports[`StatsTestCases should print correct stats for normal-errors 2`] = `
   │
 1 │ import "not-exist";
   │ ^^^^^^^^^^^^^^^^^^^ Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
+2 │ 
 
 
 
@@ -1633,8 +1647,16 @@ exports[`StatsTestCases should print correct stats for parse-error 1`] = `
       "formatted": "error[javascript]: JavaScript parsing error
   ┌─ tests/statsCases/parse-error/b.js:6:8
   │
+2 │ code
+3 │ which
+4 │ includes
+5 │ a
 6 │ parser )
   │        ^ Expected ';', '}' or <eof>
+7 │ error
+8 │ in
+9 │ some
+10 │ line
 
 ",
       "message": "Expected ';', '}' or <eof>",
@@ -1651,8 +1673,16 @@ exports[`StatsTestCases should print correct stats for parse-error 2`] = `
 "error[javascript]: JavaScript parsing error
   ┌─ tests/statsCases/parse-error/b.js:6:8
   │
+2 │ code
+3 │ which
+4 │ includes
+5 │ a
 6 │ parser )
   │        ^ Expected ';', '}' or <eof>
+7 │ error
+8 │ in
+9 │ some
+10 │ line
 
 
 
@@ -1842,6 +1872,8 @@ console.log(a);
   │
 1 │ import { a } from "cycle-alias/a";
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias
+2 │ console.log(a);
+3 │ 
 
 ",
       "message": "Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias",
@@ -1946,6 +1978,8 @@ error[internal]: Resolve error
   │
 1 │ import { a } from "cycle-alias/a";
   │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias
+2 │ console.log(a);
+3 │ 
 
 
 
@@ -2727,10 +2761,14 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
       "formatted": "warning[internal]: Resolve error
   ┌─ tests/statsCases/try-require--module/index.js:2:5
   │  
+1 │   try {
 2 │       require('./missing-module')
   │ ╭────────^
 3 │ │ } catch (e) {
   │ ╰──^ Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js
+4 │   
+5 │   }
+6 │   
 
 ",
       "message": "Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js",
@@ -2744,10 +2782,14 @@ exports[`StatsTestCases should print correct stats for try-require--module 2`] =
 "warning[internal]: Resolve error
   ┌─ tests/statsCases/try-require--module/index.js:2:5
   │  
+1 │   try {
 2 │       require('./missing-module')
   │ ╭────────^
 3 │ │ } catch (e) {
   │ ╰──^ Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js
+4 │   
+5 │   }
+6 │   
 
 
 
@@ -2763,10 +2805,14 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
       "formatted": "warning[internal]: Resolve error
   ┌─ tests/statsCases/try-require-resolve-module/index.js:2:5
   │  
+1 │   try {
 2 │       require.resolve('./missing-module')
   │ ╭────────^
 3 │ │ } catch (e) {
   │ ╰──^ Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js
+4 │   
+5 │   }
+6 │   
 
 ",
       "message": "Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js",
@@ -2780,10 +2826,14 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
 "warning[internal]: Resolve error
   ┌─ tests/statsCases/try-require-resolve-module/index.js:2:5
   │  
+1 │   try {
 2 │       require.resolve('./missing-module')
   │ ╭────────^
 3 │ │ } catch (e) {
   │ ╰──^ Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js
+4 │   
+5 │   }
+6 │   
 
 
 
@@ -2799,10 +2849,14 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
       "formatted": "warning[internal]: Resolve error
   ┌─ tests/statsCases/try-require-resolve-weak-module/index.js:2:5
   │  
+1 │   try {
 2 │       require.resolveWeak('./missing-module')
   │ ╭────────^
 3 │ │ } catch (e) {
   │ ╰──^ Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js
+4 │   
+5 │   }
+6 │   
 
 ",
       "message": "Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js",
@@ -2816,10 +2870,14 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
 "warning[internal]: Resolve error
   ┌─ tests/statsCases/try-require-resolve-weak-module/index.js:2:5
   │  
+1 │   try {
 2 │       require.resolveWeak('./missing-module')
   │ ╭────────^
 3 │ │ } catch (e) {
   │ ╰──^ Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js
+4 │   
+5 │   }
+6 │   
 
 
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. Now the error frame can display () 4 lines of source code above where the error happen, and 4 lines below error happen.  
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
