### PR TITLE
fix(core): fix missing source_info in esm module error

### DIFF
--- a/crates/rspack_core/src/utils/hooks.rs
+++ b/crates/rspack_core/src/utils/hooks.rs
@@ -91,7 +91,12 @@ pub async fn resolve(
         ResolveError(
           runtime_message,
           TraceableError::from_real_file_path(
-            Path::new(importer),
+            Path::new(
+              importer
+                .split_once('|')
+                .map(|(_, path)| path)
+                .unwrap_or(importer),
+            ),
             span.start as usize,
             span.end as usize,
             "Resolve error".to_string(),

--- a/packages/rspack/tests/Errors.test.ts
+++ b/packages/rspack/tests/Errors.test.ts
@@ -142,9 +142,9 @@ it("should emit warnings for resolve failure in esm", async () => {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "formatted": "error[internal]: Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n = Did you mean './answer.js'?\\n     BREAKING CHANGE: The request './answer' failed to resolve only because it was resolved as fully specified\\n     (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"').\\n     The extension in the request is mandatory for it to be fully specified.\\n     Add the extension to the request.\\n\\n",
+		      "formatted": "error[internal]: Resolve error\\n  ┌─ tests/fixtures/errors/resolve-fail-esm/index.js:1:1\\n  │\\n1 │ import { answer } from './answer'\\n  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n  │\\n  = Did you mean './answer.js'?\\n      BREAKING CHANGE: The request './answer' failed to resolve only because it was resolved as fully specified\\n      (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '\\"type\\": \\"module\\"').\\n      The extension in the request is mandatory for it to be fully specified.\\n      Add the extension to the request.\\n\\n",
 		      "message": "Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js",
-		      "title": "",
+		      "title": "Resolve error",
 		    },
 		  ],
 		  "warnings": Array [],


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fixs #3891, esm error missing due to importer contains "javascript/esm" which cause fs.readfile failed
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
No Test Needed
<!-- Can you please describe how you tested the changes you made to the code? -->
