### PR TITLE
test: migrate inner-graph test

### DIFF
--- a/webpack-test/cases/inner-graph/circular/test.config.js
+++ b/webpack-test/cases/inner-graph/circular/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/circular/test.filter.js
+++ b/webpack-test/cases/inner-graph/circular/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/circular2/test.config.js
+++ b/webpack-test/cases/inner-graph/circular2/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/circular2/test.filter.js
+++ b/webpack-test/cases/inner-graph/circular2/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/class-dynamic-props/test.config.js
+++ b/webpack-test/cases/inner-graph/class-dynamic-props/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/class-dynamic-props/test.filter.js
+++ b/webpack-test/cases/inner-graph/class-dynamic-props/test.filter.js
@@ -5,6 +5,6 @@
 // 	return supportsClassFields();
 // };
 
-module.exports = () => {return 'this is wrong'}
+module.exports = () => {return 'need pure dependency'}
 
 

--- a/webpack-test/cases/inner-graph/class-dynamic-props/test.filter.js
+++ b/webpack-test/cases/inner-graph/class-dynamic-props/test.filter.js
@@ -1,12 +1,10 @@
 
-/*
-var supportsClassFields = require("../../../helpers/supportsClassFields");
+// var supportsClassFields = require("../../../helpers/supportsClassFields");
+//
+// module.exports = function (config) {
+// 	return supportsClassFields();
+// };
 
-module.exports = function (config) {
-	return supportsClassFields();
-};
+module.exports = () => {return 'this is wrong'}
 
-*/
-module.exports = () => {return false}
 
-							

--- a/webpack-test/cases/inner-graph/export-default-named/test.config.js
+++ b/webpack-test/cases/inner-graph/export-default-named/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/export-default-named/test.filter.js
+++ b/webpack-test/cases/inner-graph/export-default-named/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return 'result is wrong'}
 
-							
+

--- a/webpack-test/cases/inner-graph/export-default-named/test.filter.js
+++ b/webpack-test/cases/inner-graph/export-default-named/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return 'result is wrong'}
+module.exports = () => {return true}
 
 

--- a/webpack-test/cases/inner-graph/extend-class/test.config.js
+++ b/webpack-test/cases/inner-graph/extend-class/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/extend-class/test.filter.js
+++ b/webpack-test/cases/inner-graph/extend-class/test.filter.js
@@ -1,4 +1,3 @@
+module.exports = () => {return true}
 
-module.exports = () => {return false}
 
-							

--- a/webpack-test/cases/inner-graph/extend-class2/test.config.js
+++ b/webpack-test/cases/inner-graph/extend-class2/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/extend-class2/test.filter.js
+++ b/webpack-test/cases/inner-graph/extend-class2/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return 'result is wrong'}
 
-							
+

--- a/webpack-test/cases/inner-graph/extend-class2/test.filter.js
+++ b/webpack-test/cases/inner-graph/extend-class2/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return 'result is wrong'}
+module.exports = () => {return "need pure dependency"}
 
 

--- a/webpack-test/cases/inner-graph/no-side-effects/test.config.js
+++ b/webpack-test/cases/inner-graph/no-side-effects/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/no-side-effects/test.filter.js
+++ b/webpack-test/cases/inner-graph/no-side-effects/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/pure-in-removed/test.config.js
+++ b/webpack-test/cases/inner-graph/pure-in-removed/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/pure-in-removed/test.filter.js
+++ b/webpack-test/cases/inner-graph/pure-in-removed/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/reexport-namespace-and-default/test.config.js
+++ b/webpack-test/cases/inner-graph/reexport-namespace-and-default/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/reexport-namespace-and-default/test.filter.js
+++ b/webpack-test/cases/inner-graph/reexport-namespace-and-default/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/simple/test.config.js
+++ b/webpack-test/cases/inner-graph/simple/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/simple/test.filter.js
+++ b/webpack-test/cases/inner-graph/simple/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/static-of-class/test.config.js
+++ b/webpack-test/cases/inner-graph/static-of-class/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/static-of-class/test.filter.js
+++ b/webpack-test/cases/inner-graph/static-of-class/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/switch/test.config.js
+++ b/webpack-test/cases/inner-graph/switch/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/switch/test.filter.js
+++ b/webpack-test/cases/inner-graph/switch/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+

--- a/webpack-test/cases/inner-graph/try-globals/test.config.js
+++ b/webpack-test/cases/inner-graph/try-globals/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	builtins: {
+		treeShaking: true
+	}
+}

--- a/webpack-test/cases/inner-graph/try-globals/test.filter.js
+++ b/webpack-test/cases/inner-graph/try-globals/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return true}
 
-							
+


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. enable most of cases/inner-graph tests, the rest tests needs `pureExpressionDependency`
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
