### PR TITLE
fix: fix a panic issue of `get_hash` if assertion is failed

### DIFF
--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -498,7 +498,7 @@ impl JsStats {
       .collect()
   }
 
-  #[napi]
+  #[napi(catch_unwind)]
   pub fn get_hash(&self) -> String {
     self
       .inner


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fixed a panic issue for node binding.

Note:
For developers who are writing NAPI-RS bindings, returning a `Result` or annotate `#[napi(catch_unwind)]` is acceptable unless you can be sure 100% that `expect` is working or it will cause a runtime panic

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Not necessary.

<!-- Can you please describe how you tested the changes you made to the code? -->
