### PR TITLE
feat: support configuration.profile

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -348,6 +348,11 @@ export interface JsStatsLogging {
   trace?: Array<string>
 }
 
+export interface JsStatsMillisecond {
+  secs: number
+  subsecMillis: number
+}
+
 export interface JsStatsModule {
   type: string
   moduleType: string
@@ -363,12 +368,19 @@ export interface JsStatsModule {
   reasons?: Array<JsStatsModuleReason>
   assets?: Array<string>
   source?: string | Buffer
+  profile?: JsStatsModuleProfile
 }
 
 export interface JsStatsModuleIssuer {
   identifier: string
   name: string
   id?: string
+}
+
+export interface JsStatsModuleProfile {
+  factory: JsStatsMillisecond
+  integration: JsStatsMillisecond
+  building: JsStatsMillisecond
 }
 
 export interface JsStatsModuleReason {
@@ -801,6 +813,7 @@ export interface RawOptions {
   cache: RawCacheOptions
   experiments: RawExperiments
   node?: RawNodeOption
+  profile: boolean
 }
 
 export interface RawOutputOptions {

--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -204,6 +204,7 @@ pub struct JsStatsModule {
   pub reasons: Option<Vec<JsStatsModuleReason>>,
   pub assets: Option<Vec<String>>,
   pub source: Option<Either<String, Buffer>>,
+  pub profile: Option<JsStatsModuleProfile>,
 }
 
 impl TryFrom<rspack_core::StatsModule<'_>> for JsStatsModule {
@@ -241,7 +242,40 @@ impl TryFrom<rspack_core::StatsModule<'_>> for JsStatsModule {
         .map(|i| i.into_iter().map(Into::into).collect()),
       assets: stats.assets,
       source,
+      profile: stats.profile.map(|p| p.into()),
     })
+  }
+}
+
+#[napi(object)]
+pub struct JsStatsModuleProfile {
+  pub factory: JsStatsMillisecond,
+  pub integration: JsStatsMillisecond,
+  pub building: JsStatsMillisecond,
+}
+
+impl From<rspack_core::StatsModuleProfile> for JsStatsModuleProfile {
+  fn from(value: rspack_core::StatsModuleProfile) -> Self {
+    Self {
+      factory: value.factory.into(),
+      integration: value.integration.into(),
+      building: value.building.into(),
+    }
+  }
+}
+
+#[napi(object)]
+pub struct JsStatsMillisecond {
+  pub secs: u32,
+  pub subsec_millis: u32,
+}
+
+impl From<rspack_core::StatsMillisecond> for JsStatsMillisecond {
+  fn from(value: rspack_core::StatsMillisecond) -> Self {
+    Self {
+      secs: value.secs as u32,
+      subsec_millis: value.subsec_millis,
+    }
   }
 }
 

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -85,6 +85,7 @@ pub struct RawOptions {
   pub cache: RawCacheOptions,
   pub experiments: RawExperiments,
   pub node: Option<RawNodeOption>,
+  pub profile: bool,
 }
 
 impl RawOptionsApply for RawOptions {
@@ -266,6 +267,7 @@ impl RawOptionsApply for RawOptions {
       node,
       dev_server,
       builtins,
+      profile: self.profile,
     })
   }
 }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -6,6 +6,8 @@
 use std::{fmt, sync::Arc};
 mod fake_namespace_object;
 pub use fake_namespace_object::*;
+mod module_profile;
+pub use module_profile::*;
 use rspack_database::Database;
 pub mod external_module;
 pub use external_module::*;

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -12,7 +12,7 @@ pub use connection::{ConnectionId, ConnectionState, ModuleGraphConnection};
 
 use crate::{
   to_identifier, BoxModule, BoxModuleDependency, BuildDependency, BuildInfo, BuildMeta,
-  DependencyId, ExportsInfo, Module, ModuleGraphModule, ModuleIdentifier,
+  DependencyId, ExportsInfo, Module, ModuleGraphModule, ModuleIdentifier, ModuleProfile,
 };
 
 // TODO Here request can be used JsWord
@@ -361,6 +361,12 @@ impl ModuleGraph {
           .collect()
       })
       .unwrap_or_default()
+  }
+
+  pub fn get_profile(&self, module: &BoxModule) -> Option<&ModuleProfile> {
+    self
+      .module_graph_module_by_identifier(&module.identifier())
+      .and_then(|mgm| mgm.get_profile())
   }
 
   /// Remove a connection and return connection origin module identifier and dependency

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -5,7 +5,7 @@ use crate::{
   is_async_dependency, module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject,
   BuildMetaExportsType, ChunkGraph, ChunkGroupOptions, DependencyId, ExportsInfo, ExportsType,
   FactoryMeta, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  ModuleIssuer, ModuleSyntax, ModuleType,
+  ModuleIssuer, ModuleProfile, ModuleSyntax, ModuleType,
 };
 
 #[derive(Debug)]
@@ -28,6 +28,7 @@ pub struct ModuleGraphModule {
   pub build_info: Option<BuildInfo>,
   pub build_meta: Option<BuildMeta>,
   pub exports: ExportsInfo,
+  pub profile: Option<ModuleProfile>,
 }
 
 impl ModuleGraphModule {
@@ -48,6 +49,7 @@ impl ModuleGraphModule {
       build_info: None,
       build_meta: None,
       exports: ExportsInfo::new(),
+      profile: None,
     }
   }
 
@@ -158,6 +160,14 @@ impl ModuleGraphModule {
       .iter()
       .filter_map(|id| module_graph.module_identifier_by_dependency_id(id))
       .collect()
+  }
+
+  pub fn set_profile(&mut self, profile: ModuleProfile) {
+    self.profile = Some(profile);
+  }
+
+  pub fn get_profile(&self) -> Option<&ModuleProfile> {
+    self.profile.as_ref()
   }
 
   pub fn set_issuer_if_unset(&mut self, issuer: Option<ModuleIdentifier>) {

--- a/crates/rspack_core/src/module_profile.rs
+++ b/crates/rspack_core/src/module_profile.rs
@@ -1,0 +1,165 @@
+use std::time::{Duration, Instant};
+
+use once_cell::sync::OnceCell;
+
+#[derive(Debug, Default)]
+pub struct TimeRange {
+  start: OnceCell<Instant>,
+  end: OnceCell<Instant>,
+}
+
+impl TimeRange {
+  pub fn with_value(start: Instant, end: Instant) -> Self {
+    Self {
+      start: OnceCell::with_value(start),
+      end: OnceCell::with_value(end),
+    }
+  }
+
+  pub fn duration(&self) -> Option<Duration> {
+    if let Some(end) = self.end.get() && let Some(start) = self.start.get() {
+      Some(end.duration_since(*start))
+    } else {
+      None
+    }
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct ModulePhaseProfile {
+  range: TimeRange,
+  parallelism_factor: OnceCell<u16>,
+}
+
+impl ModulePhaseProfile {
+  pub fn duration(&self) -> Option<Duration> {
+    self.range.duration()
+  }
+
+  pub fn set_parallelism_factor(&self, factor: u16) {
+    self
+      .parallelism_factor
+      .set(factor)
+      .expect("should only call once");
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct ModuleProfile {
+  pub factory: ModulePhaseProfile,
+  // pub restoring: ModulePhaseProfile,
+  pub integration: ModulePhaseProfile,
+  pub building: ModulePhaseProfile,
+  // pub storing: ModulePhaseProfile,
+
+  // pub additional_factory_times: Vec<TimeRange>,
+  // pub additional_factories: Duration,
+  // pub additional_factories_parallelism_factor: u16,
+}
+
+impl ModuleProfile {
+  pub fn mark_factory_start(&self) {
+    self
+      .factory
+      .range
+      .start
+      .set(Instant::now())
+      .expect("should only call once");
+  }
+
+  pub fn mark_factory_end(&self) {
+    self
+      .factory
+      .range
+      .end
+      .set(Instant::now())
+      .expect("should only call once");
+  }
+
+  // TODO: restore module to cache is not implemented yet
+  // pub fn mark_restoring_start(&self) {
+  //   self
+  //     .restoring
+  //     .range
+  //     .start
+  //     .set(Instant::now())
+  //     .expect("should only call once");
+  // }
+
+  // pub fn mark_restoring_end(&self) {
+  //   self
+  //     .restoring
+  //     .range
+  //     .end
+  //     .set(Instant::now())
+  //     .expect("should only call once");
+  // }
+
+  pub fn mark_integration_start(&self) {
+    self
+      .integration
+      .range
+      .start
+      .set(Instant::now())
+      .expect("should only call once");
+  }
+
+  pub fn mark_integration_end(&self) {
+    self
+      .integration
+      .range
+      .end
+      .set(Instant::now())
+      .expect("should only call once");
+  }
+
+  pub fn mark_building_start(&self) {
+    self
+      .building
+      .range
+      .start
+      .set(Instant::now())
+      .expect("should only call once");
+  }
+
+  pub fn mark_building_end(&self) {
+    self
+      .building
+      .range
+      .end
+      .set(Instant::now())
+      .expect("should only call once");
+  }
+
+  // TODO: store module to cache is not implemented yet
+  // pub fn mark_storing_start(&self) {
+  //   self
+  //     .storing
+  //     .range
+  //     .start
+  //     .set(Instant::now())
+  //     .expect("should only call once");
+  // }
+
+  // pub fn mark_storing_end(&self) {
+  //   self
+  //     .storing
+  //     .range
+  //     .end
+  //     .set(Instant::now())
+  //     .expect("should only call once");
+  // }
+
+  // pub fn merge(&mut self, other: Self) {
+  //   self.additional_factories += other.factory.duration().expect("should have duration");
+  //   self.additional_factory_times.push(TimeRange::with_value(
+  //     *other
+  //       .factory
+  //       .range
+  //       .start
+  //       .get()
+  //       .expect("should have duration"),
+  //     *other.factory.range.end.get().expect("should have duration"),
+  //   ));
+  // }
+}

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -22,6 +22,7 @@ pub struct CompilerOptions {
   pub experiments: Experiments,
   pub node: Option<NodeOption>,
   pub optimization: Optimization,
+  pub profile: bool,
 }
 
 impl CompilerOptions {

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -425,6 +425,18 @@ impl Stats<'_> {
 
     // TODO: a placeholder for concatenation modules
     let modules = nested_modules.then(Vec::new);
+    let profile = if let Some(p) = mgm.get_profile()
+    && let Some(factory) = p.factory.duration()
+    && let Some(integration) = p.integration.duration()
+    && let Some(building) = p.building.duration() {
+      Some(StatsModuleProfile {
+        factory: StatsMillisecond::new(factory.as_secs(), factory.subsec_millis()),
+        integration: StatsMillisecond::new(integration.as_secs(), integration.subsec_millis()),
+        building: StatsMillisecond::new(building.as_secs(), building.subsec_millis()),
+      })
+    } else {
+      None
+    };
 
     Ok(StatsModule {
       r#type: "module",
@@ -448,6 +460,7 @@ impl Stats<'_> {
       assets,
       modules,
       source: source.then(|| module.original_source()).flatten(),
+      profile,
     })
   }
 
@@ -559,6 +572,14 @@ pub struct StatsModule<'a> {
   pub assets: Option<Vec<String>>,
   pub modules: Option<Vec<StatsModule<'a>>>,
   pub source: Option<&'a dyn Source>,
+  pub profile: Option<StatsModuleProfile>,
+}
+
+#[derive(Debug)]
+pub struct StatsModuleProfile {
+  pub factory: StatsMillisecond,
+  pub integration: StatsMillisecond,
+  pub building: StatsMillisecond,
 }
 
 #[derive(Debug)]
@@ -605,4 +626,19 @@ pub struct StatsModuleReason {
   pub module_id: Option<String>,
   pub r#type: Option<String>,
   pub user_request: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct StatsMillisecond {
+  pub secs: u64,
+  pub subsec_millis: u32,
+}
+
+impl StatsMillisecond {
+  pub fn new(secs: u64, subsec_millis: u32) -> Self {
+    Self {
+      secs,
+      subsec_millis,
+    }
+  }
 }

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -87,6 +87,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
           remove_empty_chunks: true,
           side_effects: SideEffectOption::False,
         },
+        profile: false,
       }),
       resolver_factory: Default::default(),
     },

--- a/crates/rspack_loader_swc/tests/fixtures.rs
+++ b/crates/rspack_loader_swc/tests/fixtures.rs
@@ -87,6 +87,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
           remove_empty_chunks: true,
           side_effects: SideEffectOption::False,
         },
+        profile: false,
       }),
       resolver_factory: Default::default(),
     },

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -498,6 +498,7 @@ impl TestConfig {
         remove_empty_chunks: self.optimization.remove_empty_chunks,
         side_effects: c::SideEffectOption::from(self.optimization.side_effects.as_str()),
       },
+      profile: false,
     };
     let mut plugins = Vec::new();
     for (name, desc) in &self.entry {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -115,6 +115,7 @@ export const getRawOptions = (
 		},
 		experiments: getRawExperiments(options.experiments),
 		node: getRawNode(options.node),
+		profile: options.profile!,
 		// TODO: refactor builtins
 		builtins: options.builtins as any
 	};

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -69,6 +69,7 @@ export const applyRspackOptionsDefaults = (
 
 	F(options, "devtool", () => false as const);
 	D(options, "watch", false);
+	D(options, "profile", false);
 
 	const futureDefaults = options.experiments.futureDefaults ?? false;
 	F(options, "cache", () => development);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -242,6 +242,7 @@ export const getNormalizedRspackOptions = (
 		watch: config.watch,
 		watchOptions: cloneObject(config.watchOptions),
 		devServer: config.devServer,
+		profile: config.profile,
 		builtins: nestedConfig(config.builtins, builtins => ({
 			...builtins
 		}))

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -53,8 +53,9 @@ export interface RspackOptionsNormalized {
 	watch?: Watch;
 	watchOptions: WatchOptions;
 	devServer?: DevServer;
-	builtins: Builtins;
 	ignoreWarnings?: IgnoreWarningsNormalized;
+	profile?: Profile;
+	builtins: Builtins;
 }
 
 ///// Name /////
@@ -679,6 +680,9 @@ export type IgnoreWarningsNormalized = ((
 	warning: Error,
 	compilation: Compilation
 ) => boolean)[];
+
+///// Profile /////
+export type Profile = boolean;
 
 ///// Builtins /////
 export type Builtins = oldBuiltins.Builtins;

--- a/packages/rspack/src/config/zod/index.ts
+++ b/packages/rspack/src/config/zod/index.ts
@@ -47,7 +47,8 @@ export function configSchema() {
 			devServer: z.object({}).optional(),
 			output: output().optional(),
 			builtins: builtins().optional(),
-			module: z.any().optional()
+			module: z.any().optional(),
+			profile: z.boolean().optional()
 		})
 		.strict();
 }

--- a/packages/rspack/src/stats/statsFactoryUtils.ts
+++ b/packages/rspack/src/stats/statsFactoryUtils.ts
@@ -21,7 +21,18 @@ export type StatsAsset = KnownStatsAsset & Record<string, any>;
 
 export type StatsChunk = KnownStatsChunk & Record<string, any>;
 
-export type KnownStatsModule = binding.JsStatsModule;
+export type KnownStatsModule = binding.JsStatsModule & {
+	profile?: StatsProfile;
+};
+
+export type StatsProfile = KnownStatsProfile & Record<string, any>;
+
+export type KnownStatsProfile = {
+	total: number;
+	resolving: number;
+	integration: number;
+	building: number;
+};
 
 export type StatsModule = KnownStatsModule & Record<string, any>;
 
@@ -122,9 +133,10 @@ export type SimpleExtractors = {
 	// 	},
 	// 	StatsChunkGroup
 	// >;
-	// module: ExtractorsByOption<Module, StatsModule>;
+	module: ExtractorsByOption<binding.JsStatsModule, StatsModule>;
 	// module$visible: ExtractorsByOption<Module, StatsModule>;
 	// moduleIssuer: ExtractorsByOption<Module, StatsModuleIssuer>;
+	profile: ExtractorsByOption<binding.JsStatsModuleProfile, StatsProfile>;
 	// moduleReason: ExtractorsByOption<ModuleGraphConnection, StatsModuleReason>;
 	chunk: ExtractorsByOption<StatsChunk, KnownStatsChunk>;
 	// chunkOrigin: ExtractorsByOption<OriginRecord, StatsChunkOrigin>;
@@ -503,3 +515,7 @@ export const mergeToObject = (
 
 	return obj;
 };
+
+export function resolveStatsMillisecond(s: binding.JsStatsMillisecond) {
+	return s.secs * 1000 + s.subsecMillis;
+}

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -292,19 +292,23 @@ describe("Stats", () => {
 			entry: "./fixtures/abc",
 			profile: true
 		});
-		expect(stats?.toString({ all: false, modules: true }).replace(/\\/g, "/"))
-			.toMatchInlineSnapshot(`
+		expect(
+			stats
+				?.toString({ all: false, modules: true })
+				.replace(/\\/g, "/")
+				.replace(/\d+ ms/g, "X ms")
+		).toMatchInlineSnapshot(`
 		"./fixtures/a.js [876] {main}
 		  [222] ->
-		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)
+		  X ms (resolving: X ms, integration: X ms, building: X ms)
 		./fixtures/b.js [211] {main}
 		  [222] ->
-		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)
+		  X ms (resolving: X ms, integration: X ms, building: X ms)
 		./fixtures/c.js [537] {main}
 		  [222] ->
-		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)
+		  X ms (resolving: X ms, integration: X ms, building: X ms)
 		./fixtures/abc.js [222] {main}
-		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)"
+		  X ms (resolving: X ms, integration: X ms, building: X ms)"
 	`);
 	});
 });

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -108,6 +108,7 @@ describe("Stats", () => {
 		  },
 		  "errors": [],
 		  "errorsCount": 0,
+		  "filteredModules": undefined,
 		  "hash": "f9f4e86a4560388a500c",
 		  "logging": {},
 		  "modules": [
@@ -282,6 +283,28 @@ describe("Stats", () => {
 		<t> extend chunkGroup runtime: X ms
 		<t> remove parent modules: X ms
 		"
+	`);
+	});
+
+	it("should have module profile when profile is true", async () => {
+		const stats = await compile({
+			context: __dirname,
+			entry: "./fixtures/abc",
+			profile: true
+		});
+		expect(stats?.toString({ all: false, modules: true }).replace(/\\/g, "/"))
+			.toMatchInlineSnapshot(`
+		"./fixtures/a.js [876] {main}
+		  [222] ->
+		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)
+		./fixtures/b.js [211] {main}
+		  [222] ->
+		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)
+		./fixtures/c.js [537] {main}
+		  [222] ->
+		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)
+		./fixtures/abc.js [222] {main}
+		  0 ms (resolving: 0 ms, integration: 0 ms, building: 0 ms)"
 	`);
 	});
 });

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -287,6 +287,7 @@ exports[`snapshots should have the correct base config 1`] = `
     "workerWasmLoading": "fetch",
   },
   "plugins": [],
+  "profile": false,
   "resolve": {
     "browserField": true,
     "byDependency": {

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -178,6 +178,7 @@ import rawModule from './raw.png'",
   },
   "errors": [],
   "errorsCount": 0,
+  "filteredModules": undefined,
   "hash": "c2196d4a6876028f1c57",
   "logging": {},
   "modules": [
@@ -472,6 +473,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
+  "filteredModules": undefined,
   "hash": "d96303f50e05d7754f6d",
   "logging": {},
   "modules": [
@@ -653,6 +655,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
+  "filteredModules": undefined,
   "hash": "fd7b7cf5b2803b0b7113",
   "logging": {},
   "modules": [
@@ -771,6 +774,7 @@ rspack compiled with 2 errors"
 
 exports[`StatsTestCases should print correct stats for ignore-plugin 1`] = `
 {
+  "filteredModules": undefined,
   "modules": [
     {
       "chunks": [
@@ -1750,6 +1754,7 @@ rspack compiled with 1 error"
 
 exports[`StatsTestCases should print correct stats for reasons 1`] = `
 {
+  "filteredModules": undefined,
   "modules": [
     {
       "chunks": [
@@ -1947,6 +1952,7 @@ console.log(a);
     },
   ],
   "errorsCount": 1,
+  "filteredModules": undefined,
   "hash": "9a30ab81da0d81699cd4",
   "logging": {},
   "modules": [
@@ -2193,6 +2199,7 @@ console.log(a);
     },
   ],
   "errorsCount": 1,
+  "filteredModules": undefined,
   "hash": "dfcb34e009aa1d3ba1c6",
   "logging": {},
   "modules": [
@@ -2386,6 +2393,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
+  "filteredModules": undefined,
   "hash": "92d29d02b4c2bff57ea2",
   "logging": {},
   "modules": [
@@ -2593,6 +2601,7 @@ import rawModule from './raw.png'",
   },
   "errors": [],
   "errorsCount": 0,
+  "filteredModules": undefined,
   "hash": "f8f56b80d711a8ab4dbc",
   "logging": {},
   "modules": [
@@ -2797,6 +2806,7 @@ exports[`StatsTestCases should print correct stats for stats-hooks 1`] = `
   },
   "errors": [],
   "errorsCount": 0,
+  "filteredModules": undefined,
   "hash": "92d29d02b4c2bff57ea2",
   "logging": {},
   "modules": [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

enable to add module profile info in `stats.module[]`, only contain factory, building, and integration time consuming, storing and restoring are related to mem cache, and we haven't implement it yet

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

- add in `Stats.test.ts`

<!-- Can you please describe how you tested the changes you made to the code? -->
