### PR TITLE
feat: cjs analyze

### DIFF
--- a/crates/rspack/tests/fixtures/code-splitting/expected/main.js
+++ b/crates/rspack/tests/fixtures/code-splitting/expected/main.js
@@ -1,8 +1,8 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (__unused_webpack_module, exports, __webpack_require__) {
 console.log('hello, world');
-__webpack_require__.el(/* ./a */"./a.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./a */"./a.js", 23));
-__webpack_require__.el(/* ./b */"./b.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./b */"./b.js", 23));
+__webpack_require__.el(/* ./a */"./a.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./a */"./a.js", 21));
+__webpack_require__.el(/* ./b */"./b.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./b */"./b.js", 21));
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/samples/remove-parent-modules/self-import/expected/main.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/self-import/expected/main.js
@@ -1,6 +1,6 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (__unused_webpack_module, exports, __webpack_require__) {
-__webpack_require__.el(/* ./index */"./index.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./index */"./index.js", 23));
+__webpack_require__.el(/* ./index */"./index.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./index */"./index.js", 21));
 console.log('index');
 },
 

--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/expected/main.js
@@ -39,9 +39,8 @@ __webpack_require__.d(__webpack_exports__, {
   'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _zh_locale__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./zh_locale */"./zh_locale.js");
-/* harmony import */var _zh_locale__WEBPACK_IMPORTED_MODULE_0__default = /*#__PURE__*/__webpack_require__.n(_zh_locale__WEBPACK_IMPORTED_MODULE_0_);
 
-var __WEBPACK_DEFAULT_EXPORT__ = _zh_locale__WEBPACK_IMPORTED_MODULE_0__default;
+var __WEBPACK_DEFAULT_EXPORT__ = _zh_locale__WEBPACK_IMPORTED_MODULE_0_["default"];
 },
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/expected/main.js
@@ -2,10 +2,10 @@
 "./index.js": function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
+var _lib__WEBPACK_IMPORTED_MODULE_0__namespace_cache;
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
-/* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__default = /*#__PURE__*/__webpack_require__.n(_lib__WEBPACK_IMPORTED_MODULE_0_);
 
-_lib__WEBPACK_IMPORTED_MODULE_0_;
+/*#__PURE__*/ (_lib__WEBPACK_IMPORTED_MODULE_0__namespace_cache || (_lib__WEBPACK_IMPORTED_MODULE_0__namespace_cache = __webpack_require__.t(_lib__WEBPACK_IMPORTED_MODULE_0_, 2)));
 },
 "./lib.js": function (__unused_webpack_module, exports, __webpack_require__) {
 exports['a'] = 100000;

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -277,8 +277,6 @@ pub fn module_namespace_promise(
     _ => {
       if matches!(exports_type, ExportsType::Dynamic) {
         fake_type |= FakeNamespaceObjectMode::RETURN_VALUE;
-        // TODO should remove this after implement cjs analyze
-        fake_type |= FakeNamespaceObjectMode::MERGE_PROPERTIES;
       }
       if matches!(exports_type, ExportsType::DefaultWithNamed) {
         fake_type |= FakeNamespaceObjectMode::MERGE_PROPERTIES;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
@@ -5,12 +5,15 @@ use rspack_core::{
 use swc_core::{
   common::SyntaxContext,
   ecma::{
-    ast::{Expr, Ident, ModuleItem, Program},
+    ast::{
+      AssignExpr, CallExpr, Callee, Expr, ExprOrSpread, Ident, Lit, MemberExpr, ModuleItem,
+      ObjectLit, Pat, PatOrExpr, Program, Prop, PropName, PropOrSpread, UnaryOp,
+    },
     visit::{noop_visit_type, Visit, VisitWith},
   },
 };
 
-use super::expr_matcher;
+use super::{expr_matcher, is_require_call_expr};
 use crate::dependency::ModuleDecoratorDependency;
 
 pub struct CommonJsExportDependencyScanner<'a> {
@@ -19,6 +22,8 @@ pub struct CommonJsExportDependencyScanner<'a> {
   build_meta: &'a mut BuildMeta,
   module_type: ModuleType,
   is_harmony: bool,
+  parser_exports_state: &'a mut Option<bool>,
+  enter_call: u32,
 }
 
 impl<'a> CommonJsExportDependencyScanner<'a> {
@@ -27,6 +32,7 @@ impl<'a> CommonJsExportDependencyScanner<'a> {
     unresolved_ctxt: &'a SyntaxContext,
     build_meta: &'a mut BuildMeta,
     module_type: ModuleType,
+    parser_exports_state: &'a mut Option<bool>,
   ) -> Self {
     Self {
       presentational_dependencies,
@@ -34,6 +40,8 @@ impl<'a> CommonJsExportDependencyScanner<'a> {
       build_meta,
       module_type,
       is_harmony: false,
+      parser_exports_state,
+      enter_call: 0,
     }
   }
 }
@@ -59,7 +67,7 @@ impl Visit for CommonJsExportDependencyScanner<'_> {
       self
         .presentational_dependencies
         .push(Box::new(ModuleDecoratorDependency::new(decorator)));
-      bailout(self.build_meta);
+      self.bailout();
     }
   }
 
@@ -75,9 +83,185 @@ impl Visit for CommonJsExportDependencyScanner<'_> {
     }
     expr.visit_children_with(self);
   }
+
+  fn visit_assign_expr(&mut self, assign_expr: &AssignExpr) {
+    if let PatOrExpr::Pat(box Pat::Expr(box expr)) = &assign_expr.left {
+      // exports.__esModule = true;
+      // module.exports.__esModule = true;
+      // this.__esModule = true;
+      if expr_matcher::is_module_exports_esmodule(expr)
+        || expr_matcher::is_exports_esmodule(expr)
+        || expr_matcher::is_this_esmodule(expr)
+      {
+        self.enable();
+        self.check_namespace(&assign_expr.right);
+      }
+      // exports.xxx = 1;
+      if self.is_exports_member_expr_start(expr) {
+        self.enable();
+      }
+      if self.is_exports_expr(expr) {
+        self.enable();
+        if is_require_call_expr(&assign_expr.right, self.unresolved_ctxt) {
+          // exports = require('xx');
+          // module.exports = require('xx');
+          // this = require('xx');
+          // It's possible to reexport __esModule, so we must convert to a dynamic module
+          self.set_dynamic();
+        } else {
+          // exports = {};
+          // module.exports = {};
+          // this = {};
+          self.bailout();
+        }
+      }
+    }
+    // var a = exports;
+    // var a = module.exports;
+    // var a = this;
+    if self.is_exports_expr(&assign_expr.right) {
+      self.bailout();
+    }
+    assign_expr.visit_children_with(self);
+  }
+
+  fn visit_call_expr(&mut self, call_expr: &CallExpr) {
+    if let Callee::Expr(expr) = &call_expr.callee {
+      // Object.defineProperty(exports, "__esModule", { value: true });
+      // Object.defineProperty(module.exports, "__esModule", { value: true });
+      // Object.defineProperty(this, "__esModule", { value: true });
+      if expr_matcher::is_object_define_property(expr) && let Some(ExprOrSpread { expr, .. }) = call_expr.args.get(0) && let Some(ExprOrSpread { expr: box Expr::Lit(Lit::Str(str)), .. }) = call_expr.args.get(1) && &str.value == "__esModule" && let Some(value) = get_value_of_property_description(&call_expr.args.get(2)) &&  self.is_exports_expr(expr) {
+        self.enable();
+        self.check_namespace(value);
+      }
+      // exports()
+      // module.exports()
+      // this()
+      if self.is_exports_expr(expr) {
+        self.bailout();
+      }
+    }
+    self.enter_call += 1;
+    call_expr.visit_children_with(self);
+    self.enter_call -= 1;
+  }
 }
 
-fn bailout(build_meta: &mut BuildMeta) {
-  build_meta.exports_type = BuildMetaExportsType::Unset;
-  build_meta.default_object = BuildMetaDefaultObject::False;
+impl<'a> CommonJsExportDependencyScanner<'a> {
+  fn is_exports_member_expr_start(&self, mut expr: &Expr) -> bool {
+    loop {
+      match expr {
+        _ if self.is_exports_expr(expr) => return true,
+        Expr::Member(MemberExpr { obj, .. }) => expr = obj.as_ref(),
+        _ => return false,
+      }
+    }
+  }
+
+  fn is_exports_expr(&self, expr: &Expr) -> bool {
+    matches!(expr,  Expr::Ident(ident) if &ident.sym == "exports" && ident.span.ctxt == *self.unresolved_ctxt)
+      || expr_matcher::is_module_exports(expr)
+      || matches!(expr,  Expr::This(_) if  self.enter_call == 0)
+  }
+
+  fn check_namespace(&mut self, value_expr: &Expr) {
+    if matches!(self.parser_exports_state, Some(false)) || self.parser_exports_state.is_none() {
+      return;
+    }
+    if is_truthy_literal(value_expr) {
+      self.set_flagged();
+    } else {
+      self.set_dynamic();
+    }
+  }
+
+  // can't scan `__esModule` value
+  fn bailout(&mut self) {
+    if matches!(self.parser_exports_state, Some(true)) {
+      self.build_meta.exports_type = BuildMetaExportsType::Unset;
+      self.build_meta.default_object = BuildMetaDefaultObject::False;
+    }
+    *self.parser_exports_state = Some(false);
+  }
+
+  // `__esModule` is false
+  fn enable(&mut self) {
+    if matches!(self.parser_exports_state, Some(false)) || self.parser_exports_state.is_none() {
+      self.build_meta.exports_type = BuildMetaExportsType::Default;
+      self.build_meta.default_object = BuildMetaDefaultObject::Redirect;
+    }
+    *self.parser_exports_state = Some(true);
+  }
+
+  // `__esModule` is true
+  fn set_flagged(&mut self) {
+    if matches!(self.parser_exports_state, Some(false)) || self.parser_exports_state.is_none() {
+      return;
+    }
+    if matches!(self.build_meta.exports_type, BuildMetaExportsType::Dynamic) {
+      return;
+    }
+    self.build_meta.exports_type = BuildMetaExportsType::Flagged;
+  }
+
+  // `__esModule` is dynamic, eg `true && true`
+  fn set_dynamic(&mut self) {
+    if matches!(self.parser_exports_state, Some(false)) || self.parser_exports_state.is_none() {
+      return;
+    }
+    self.build_meta.exports_type = BuildMetaExportsType::Dynamic;
+  }
+}
+
+fn get_value_of_property_description<'a>(
+  expr_or_spread: &Option<&'a ExprOrSpread>,
+) -> Option<&'a Expr> {
+  if let Some(ExprOrSpread {
+    expr: box Expr::Object(ObjectLit { props, .. }),
+    ..
+  }) = expr_or_spread
+  {
+    for prop in props {
+      if let PropOrSpread::Prop(prop) = prop && let Prop::KeyValue(key_value_prop) = &**prop && let PropName::Ident(ident) = &key_value_prop.key && &ident.sym == "value" {
+        return Some(&key_value_prop.value);
+      }
+    }
+  }
+  None
+}
+
+fn is_truthy_literal(expr: &Expr) -> bool {
+  match expr {
+    Expr::Lit(lit) => is_lit_truthy_literal(lit),
+    Expr::Unary(unary) => {
+      if unary.op == UnaryOp::Bang {
+        return is_falsy_literal(&unary.arg);
+      }
+      false
+    }
+    _ => false,
+  }
+}
+
+fn is_falsy_literal(expr: &Expr) -> bool {
+  match expr {
+    Expr::Lit(lit) => !is_lit_truthy_literal(lit),
+    Expr::Unary(unary) => {
+      if unary.op == UnaryOp::Bang {
+        return is_truthy_literal(&unary.arg);
+      }
+      false
+    }
+    _ => false,
+  }
+}
+
+fn is_lit_truthy_literal(lit: &Lit) -> bool {
+  match lit {
+    Lit::Str(str) => !str.value.is_empty(),
+    Lit::Bool(bool) => bool.value,
+    Lit::Null(_) => false,
+    Lit::Num(num) => num.value != 0.0,
+    _ => true,
+  }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -6,10 +6,10 @@ use crate::dependency::HarmonyCompatibilityDependency;
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/HarmonyDetectionParserPlugin.js
 pub struct HarmonyDetectionScanner<'a> {
-  pub build_info: &'a mut BuildInfo,
-  pub build_meta: &'a mut BuildMeta,
-  pub module_type: &'a ModuleType,
-  pub code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
+  build_info: &'a mut BuildInfo,
+  build_meta: &'a mut BuildMeta,
+  module_type: &'a ModuleType,
+  code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
 }
 
 impl<'a> HarmonyDetectionScanner<'a> {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -74,7 +74,23 @@ pub(crate) mod expr_matcher {
     is_import_meta_webpack_hot_decline: "import.meta.webpackHot.decline",
     is_import_meta_url: "import.meta.url",
     is_import_meta: "import.meta",
+    is_exports_esmodule: "exports.__esModule",
+    is_this_esmodule: "this.__esModule",
+    is_module_exports_esmodule: "module.exports.__esModule",
+    is_object_define_property: "Object.defineProperty",
   });
+}
+
+pub fn is_require_call_expr(expr: &Expr, ctxt: &SyntaxContext) -> bool {
+  matches!(expr, Expr::Call(call_expr) if is_require_call(call_expr, ctxt))
+}
+
+pub fn is_require_call(node: &CallExpr, ctxt: &SyntaxContext) -> bool {
+  node
+    .callee
+    .as_expr()
+    .map(|expr| matches!(expr, box Expr::Ident(ident) if &ident.sym == "require" && ident.span.ctxt == *ctxt))
+    .unwrap_or_default()
 }
 
 pub fn is_require_context_call(node: &CallExpr) -> bool {

--- a/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
+++ b/crates/rspack_plugin_javascript/tests/fixtures/magic_comment/expected/main.js
@@ -1,13 +1,13 @@
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": function (__unused_webpack_module, exports, __webpack_require__) {
-__webpack_require__.el(/* ./normal */"./normal.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./normal */"./normal.js", 23));
-__webpack_require__.el(/* ./sub_fold */"./sub_fold.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./sub_fold */"./sub_fold.js", 23));
-__webpack_require__.el(/* ./single_quote */"./single_quote.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./single_quote */"./single_quote.js", 23));
-__webpack_require__.el(/* ./other */"./other.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./other */"./other.js", 23));
-__webpack_require__.el(/* ./user/1 */"./user/1.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./user/1 */"./user/1.js", 23));
-__webpack_require__.el(/* ./user/page/2 */"./user/page/2.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./user/page/2 */"./user/page/2.js", 23));
-__webpack_require__.el(/* ./user/page/3 */"./user/page/3.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./user/page/3 */"./user/page/3.js", 23));
-__webpack_require__.el(/* ./bug_only_single_quote.js */"./bug_only_single_quote.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./bug_only_single_quote.js */"./bug_only_single_quote.js", 23));
+__webpack_require__.el(/* ./normal */"./normal.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./normal */"./normal.js", 21));
+__webpack_require__.el(/* ./sub_fold */"./sub_fold.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./sub_fold */"./sub_fold.js", 21));
+__webpack_require__.el(/* ./single_quote */"./single_quote.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./single_quote */"./single_quote.js", 21));
+__webpack_require__.el(/* ./other */"./other.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./other */"./other.js", 21));
+__webpack_require__.el(/* ./user/1 */"./user/1.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./user/1 */"./user/1.js", 21));
+__webpack_require__.el(/* ./user/page/2 */"./user/page/2.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./user/page/2 */"./user/page/2.js", 21));
+__webpack_require__.el(/* ./user/page/3 */"./user/page/3.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./user/page/3 */"./user/page/3.js", 21));
+__webpack_require__.el(/* ./bug_only_single_quote.js */"./bug_only_single_quote.js").then(__webpack_require__.t.bind(__webpack_require__, /* ./bug_only_single_quote.js */"./bug_only_single_quote.js", 21));
 },
 
 },function(__webpack_require__) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Before we use `dynamic` as exports type for all commonjs, webpack is analzyed the commonjs and split to four state.

- Mark `dynamic` for dynamic `__esModule`
- Mark `flag` for `__esModule` value is true, the behavior is same as `namespace`(mark esm)
- Mark `undefined` for can't scanned `__esModule`
- Mark `default` for original commonjs

It will avoid use runtime to detect `__esModule` and make code faster.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

The webpack cjs analzye test is already migrated.
<!-- Can you please describe how you tested the changes you made to the code? -->
