### PR TITLE
feat: add logging when RSPACK_PROFILE enabled

### DIFF
--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -31,7 +31,11 @@ import {
 	experimental_cleanupGlobalTrace as cleanupGlobalTrace
 } from "@rspack/core";
 import path from "path";
-import { RspackJsCPUProfilePlugin, resolveProfile } from "./utils/profile";
+import {
+	RspackProfileJSCPUProfilePlugin,
+	RspackProfileLoggingPlugin,
+	resolveProfile
+} from "./utils/profile";
 
 type Command = "serve" | "build";
 
@@ -162,7 +166,11 @@ export class RspackCLI {
 							exitHook(cleanupGlobalTrace);
 						} else if (kind === "JSCPU") {
 							(item.plugins ??= []).push(
-								new RspackJsCPUProfilePlugin(value.output)
+								new RspackProfileJSCPUProfilePlugin(value.output)
+							);
+						} else if (kind === "LOGGING") {
+							(item.plugins ??= []).push(
+								new RspackProfileLoggingPlugin(value.output)
 							);
 						}
 					}

--- a/packages/rspack-cli/tests/build/profile/profile.test.ts
+++ b/packages/rspack-cli/tests/build/profile/profile.test.ts
@@ -4,16 +4,20 @@ import { resolve } from "path";
 
 const defaultTracePath = "./rspack.trace";
 const defaultJSCPUPath = "./rspack.jscpuprofile";
+const defaultLoggingPath = "./rspack.logging";
 const customTracePath = "./custom.trace";
 const customJSCPUPath = "./custom.jscpuprofile";
+const customLoggingPath = "./custom.logging";
 
 describe("profile", () => {
 	afterEach(() => {
 		[
 			defaultTracePath,
 			defaultJSCPUPath,
+			defaultLoggingPath,
 			customTracePath,
-			customJSCPUPath
+			customJSCPUPath,
+			customLoggingPath
 		].forEach(p => {
 			const pp = resolve(__dirname, p);
 			if (fs.existsSync(pp)) {
@@ -22,7 +26,7 @@ describe("profile", () => {
 		});
 	});
 
-	it("should store rust trace file and js cpu profile file when RSPACK_PROFILE=ALL enabled", async () => {
+	it("should store all profile files when RSPACK_PROFILE=ALL enabled", async () => {
 		const { exitCode } = await run(
 			__dirname,
 			[],
@@ -32,6 +36,7 @@ describe("profile", () => {
 		expect(exitCode).toBe(0);
 		expect(fs.existsSync(resolve(__dirname, defaultTracePath))).toBeTruthy();
 		expect(fs.existsSync(resolve(__dirname, defaultJSCPUPath))).toBeTruthy();
+		expect(fs.existsSync(resolve(__dirname, defaultLoggingPath))).toBeTruthy();
 	});
 
 	it("should store js cpu profile file when RSPACK_PROFILE=JSCPU enabled", async () => {
@@ -54,6 +59,17 @@ describe("profile", () => {
 		);
 		expect(exitCode).toBe(0);
 		expect(fs.existsSync(resolve(__dirname, defaultTracePath))).toBeTruthy();
+	});
+
+	it("should store logging file when RSPACK_PROFILE=LOGGING enabled", async () => {
+		const { exitCode } = await run(
+			__dirname,
+			[],
+			{},
+			{ RSPACK_PROFILE: "LOGGING" }
+		);
+		expect(exitCode).toBe(0);
+		expect(fs.existsSync(resolve(__dirname, defaultLoggingPath))).toBeTruthy();
 	});
 
 	it("should filter trace event when use RSPACK_PROFILE=[crate1,crate2]", async () => {
@@ -80,12 +96,13 @@ describe("profile", () => {
 			[],
 			{},
 			{
-				RSPACK_PROFILE: `TRACE=output=${customTracePath}|JSCPU=output=${customJSCPUPath}`
+				RSPACK_PROFILE: `TRACE=output=${customTracePath}|JSCPU=output=${customJSCPUPath}|LOGGING=output=${customLoggingPath}`
 			}
 		);
 		expect(exitCode).toBe(0);
 		expect(fs.existsSync(resolve(__dirname, customTracePath))).toBeTruthy();
 		expect(fs.existsSync(resolve(__dirname, customJSCPUPath))).toBeTruthy();
+		expect(fs.existsSync(resolve(__dirname, customLoggingPath))).toBeTruthy();
 	});
 
 	it("should be able to use logger trace layer and default output should be stdout", async () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

add `stats.logging` when RSPACK_PROFILE enabled

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

- updated `packages/rspack-cli/tests/build/profile/profile.test.ts`

<!-- Can you please describe how you tested the changes you made to the code? -->
