### PR TITLE
perf: reduce memory size of const dependency and dependency type

### DIFF
--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -1,12 +1,10 @@
-use std::borrow::Cow;
-
 use crate::{DependencyTemplate, RuntimeGlobals, TemplateContext, TemplateReplaceSource};
 
 #[derive(Debug)]
 pub struct ConstDependency {
   pub start: u32,
   pub end: u32,
-  pub content: Cow<'static, str>,
+  pub content: Box<str>,
   pub runtime_requirements: Option<RuntimeGlobals>,
 }
 
@@ -14,7 +12,7 @@ impl ConstDependency {
   pub fn new(
     start: u32,
     end: u32,
-    content: Cow<'static, str>,
+    content: Box<str>,
     runtime_requirements: Option<RuntimeGlobals>,
   ) -> Self {
     Self {

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -18,7 +18,6 @@ pub use context_element_dependency::*;
 mod const_dependency;
 use std::{
   any::Any,
-  borrow::Cow,
   fmt::{Debug, Display},
   hash::Hash,
 };
@@ -85,7 +84,7 @@ pub enum DependencyType {
   WasmExportImported,
   /// static exports
   StaticExports,
-  Custom(Cow<'static, str>),
+  Custom(Box<str>), // TODO it will increase large layout size
 }
 
 impl Display for DependencyType {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Const Dependency size 56 -> 40, DependencyType 32 -> 24

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
