### PR TITLE
refactor(rspack_loader_runner): remove nodejs_resolver dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,9 +1554,9 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nodejs-resolver"
-version = "0.0.88"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259edee7a18be2bdc9802f3357044a964d6e0624030201849ed734b8901a23b"
+checksum = "bfd06bcc5adab8de32fbbc8e975b364b537fd91e7ae5dfb9ae88fd15980c334b"
 dependencies = [
  "daachorse",
  "dashmap",
@@ -2458,13 +2458,13 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "derivative",
- "nodejs-resolver",
  "once_cell",
  "regex",
  "rspack_error",
  "rspack_identifier",
  "rspack_sources",
  "rustc-hash",
+ "serde_json",
  "similar-asserts",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ json               = { version = "0.12.4" }
 linked_hash_set    = { version = "0.1.4" }
 mimalloc-rust      = { version = "0.2" }
 mime_guess         = { version = "2.0.4" }
-nodejs-resolver    = { version = "0.0.88" }
+nodejs-resolver    = { version = "0.1.0" }
 once_cell          = { version = "1.18.0" }
 paste              = { version = "1.0" }
 pathdiff           = { version = "0.2.1" }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -6,7 +6,7 @@ use rspack_error::{
   internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
 };
 use rspack_identifier::Identifiable;
-use rspack_loader_runner::{get_scheme, Scheme};
+use rspack_loader_runner::{get_scheme, DescriptionData, Scheme};
 use sugar_path::{AsPath, SugarPath};
 use swc_core::common::Span;
 
@@ -306,10 +306,13 @@ impl NormalModuleFactory {
       match resource_data {
         Ok(ResolveResult::Resource(resource)) => {
           let uri = resource.join().display().to_string();
+          let description_data = resource.description.map(|d| {
+            DescriptionData::new(d.dir().as_ref().to_path_buf(), Arc::clone(d.data().raw()))
+          });
           ResourceData::new(uri, resource.path)
             .query_optional(resource.query)
             .fragment_optional(resource.fragment)
-            .description_optional(resource.description)
+            .description_optional(description_data)
         }
         Ok(ResolveResult::Ignored) => {
           let ident = format!("{}/{}", &data.context, request_without_match_resource);
@@ -608,8 +611,8 @@ impl NormalModuleFactory {
     }
     let resource_path = &resource_data.resource_path;
     let description = resource_data.resource_description.as_ref()?;
-    let package_path = description.dir().as_ref();
-    let side_effects = SideEffects::from_description(description)?;
+    let package_path = description.path();
+    let side_effects = SideEffects::from_description(description.json())?;
 
     let relative_path = resource_path.relative(package_path);
     side_effect_res = Some(get_side_effects_from_package_json(

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -1815,29 +1815,25 @@ pub enum SideEffects {
 }
 
 impl SideEffects {
-  pub fn from_description(description: &nodejs_resolver::DescriptionData) -> Option<Self> {
-    description
-      .data()
-      .raw()
-      .get("sideEffects")
-      .and_then(|value| {
-        if let Some(b) = value.as_bool() {
-          Some(SideEffects::Bool(b))
-        } else if let Some(s) = value.as_str() {
-          Some(SideEffects::String(s.to_owned()))
-        } else if let Some(vec) = value.as_array() {
-          let mut ans = vec![];
-          for value in vec {
-            if let Some(str) = value.as_str() {
-              ans.push(str.to_string());
-            } else {
-              return None;
-            }
+  pub fn from_description(description: &serde_json::Value) -> Option<Self> {
+    description.get("sideEffects").and_then(|value| {
+      if let Some(b) = value.as_bool() {
+        Some(SideEffects::Bool(b))
+      } else if let Some(s) = value.as_str() {
+        Some(SideEffects::String(s.to_owned()))
+      } else if let Some(vec) = value.as_array() {
+        let mut ans = vec![];
+        for value in vec {
+          if let Some(str) = value.as_str() {
+            ans.push(str.to_string());
+          } else {
+            return None;
           }
-          Some(SideEffects::Array(ans))
-        } else {
-          None
         }
-      })
+        Some(SideEffects::Array(ans))
+      } else {
+        None
+      }
+    })
   }
 }

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -103,12 +103,7 @@ pub async fn module_rule_matcher<'a>(
   if let Some(description_data) = &module_rule.description_data {
     if let Some(resource_description) = &resource_data.resource_description {
       for (k, matcher) in description_data {
-        if let Some(v) = resource_description
-          .data()
-          .raw()
-          .get(k)
-          .and_then(|v| v.as_str())
-        {
+        if let Some(v) = resource_description.json().get(k).and_then(|v| v.as_str()) {
           if !matcher.try_match(v).await? {
             return Ok(false);
           }

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -18,9 +18,9 @@ derivative      = { workspace = true }
 rustc-hash      = { workspace = true }
 tokio           = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot", "fs"] }
 
-nodejs-resolver   = { workspace = true }
 once_cell         = { workspace = true }
 regex             = { workspace = true }
 rspack_error      = { path = "../rspack_error" }
 rspack_identifier = { path = "../rspack_identifier" }
 rspack_sources    = { workspace = true }
+serde_json        = { workspace = true }

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -10,7 +10,7 @@ pub use content::Content;
 pub use loader::{DisplayWithSuffix, Loader};
 pub use plugin::LoaderRunnerPlugin;
 pub use rspack_identifier::{Identifiable, Identifier};
-pub use runner::{run_loaders, LoaderContext, ResourceData};
+pub use runner::{run_loaders, DescriptionData, LoaderContext, ResourceData};
 pub use scheme::{get_scheme, Scheme};
 
 pub const BUILTIN_LOADER_PREFIX: &str = "builtin:";

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use derivative::Derivative;
-use nodejs_resolver::DescriptionData;
 use once_cell::sync::OnceCell;
 use rspack_error::{
   internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
@@ -31,7 +30,7 @@ pub struct ResourceData {
   pub resource_query: Option<String>,
   /// Resource fragment with `#` prefix
   pub resource_fragment: Option<String>,
-  pub resource_description: Option<Arc<DescriptionData>>,
+  pub resource_description: Option<DescriptionData>,
   pub mimetype: Option<String>,
   pub parameters: Option<String>,
   pub encoding: Option<String>,
@@ -79,12 +78,12 @@ impl ResourceData {
     self
   }
 
-  pub fn description(mut self, v: Arc<DescriptionData>) -> Self {
+  pub fn description(mut self, v: DescriptionData) -> Self {
     self.resource_description = Some(v);
     self
   }
 
-  pub fn description_optional(mut self, v: Option<Arc<DescriptionData>>) -> Self {
+  pub fn description_optional(mut self, v: Option<DescriptionData>) -> Self {
     self.resource_description = v;
     self
   }
@@ -107,6 +106,31 @@ impl ResourceData {
   pub fn encoded_content(mut self, v: String) -> Self {
     self.encoded_content = Some(v);
     self
+  }
+}
+
+/// Used for [Rule.descriptionData](https://www.rspack.dev/config/module.html#ruledescriptiondata) and
+/// package.json.sideEffects in tree shaking.
+#[derive(Debug, Clone)]
+pub struct DescriptionData {
+  /// Path to package.json
+  path: PathBuf,
+
+  /// Raw package.json
+  json: Arc<serde_json::Value>,
+}
+
+impl DescriptionData {
+  pub fn new(path: PathBuf, json: Arc<serde_json::Value>) -> Self {
+    Self { path, json }
+  }
+
+  pub fn path(&self) -> &Path {
+    &self.path
+  }
+
+  pub fn json(&self) -> &serde_json::Value {
+    self.json.as_ref()
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR removes nodejs-resolver from rspack_loader_runner by directly using the serde_json::Value returned from the resolver.

We'll change the dependency once nodejs-resolver makes a new release for
* https://github.com/web-infra-dev/nodejs_resolver/pull/196

## Test Plan

CI passes.