### PR TITLE
chore: remove benchmark test on merge_group

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,6 @@
 name: Benchmark
 
 on:
-  merge_group:
   issue_comment:
     types: [created]
 
@@ -13,7 +12,7 @@ concurrency:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    if: github.event_name == 'merge_group' || github.event.issue.pull_request && startsWith(github.event.comment.body, '!bench')
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '!bench')
     steps:
       - uses: actions/github-script@v6
         with:
@@ -81,6 +80,6 @@ jobs:
               ref: 'main',
               inputs: {
                 prNumber: '' + prData.num,
-                reportComment: `${{ github.event_name }}` == `merge_group` ? "false" : "true"
+                reportComment: "true"
               }
             })


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
Running benchmarks in merge_group and pr is very different, I will add a github action to run benchmarks on merge_group

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
