### PR TITLE
feat: support resolving builtin loaders in Rust tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,11 +2914,14 @@ dependencies = [
 name = "rspack_testing"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "cargo-rst",
  "rspack_binding_options",
  "rspack_core",
+ "rspack_error",
  "rspack_fs",
  "rspack_ids",
+ "rspack_loader_runner",
  "rspack_loader_sass",
  "rspack_loader_swc",
  "rspack_plugin_asset",

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -98,7 +98,7 @@ async fn run(relative_path: &str, #[cfg(feature = "tracing")] layer: Layer) {
   compiler
     .build()
     .await
-    .unwrap_or_else(|e| panic!("{e:?}, failed to compile in fixtrue {bundle_dir:?}"));
+    .unwrap_or_else(|e| panic!("{e:?}, failed to compile in fixture {bundle_dir:?}"));
   println!("{:?}", start.elapsed());
   #[cfg(feature = "hmr")]
   {

--- a/crates/rspack/benches/main.rs
+++ b/crates/rspack/benches/main.rs
@@ -26,7 +26,7 @@ async fn bench(cur_dir: &PathBuf) {
   compiler
     .build()
     .await
-    .unwrap_or_else(|_| panic!("failed to compile in fixtrue {cur_dir:?}"));
+    .unwrap_or_else(|_| panic!("failed to compile in fixture {cur_dir:?}"));
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/crates/rspack/tests/fixtures.rs
+++ b/crates/rspack/tests/fixtures.rs
@@ -8,11 +8,6 @@ fn rspack(fixture_path: PathBuf) {
   test_fixture(&fixture_path);
 }
 
-#[fixture("tests/fixtures/code-splitting")]
-fn rspack2(fixture_path: PathBuf) {
-  test_fixture(&fixture_path);
-}
-
 #[fixture("tests/samples/**/test.config.json")]
 fn samples(fixture_path: PathBuf) {
   test_fixture(fixture_path.parent().expect("should exist"));

--- a/crates/rspack_error/tests/fixtures.rs
+++ b/crates/rspack_error/tests/fixtures.rs
@@ -16,7 +16,7 @@ pub async fn test_fixture<F: FnOnce(&Stats, Settings) -> rspack_error::Result<()
   compiler
     .build()
     .await
-    .unwrap_or_else(|_| panic!("failed to compile in fixtrue {fixture_path:?}"));
+    .unwrap_or_else(|e| panic!("{e}, failed to compile in fixture {fixture_path:?}"));
   let stats = compiler.compilation.get_stats();
   let mut settings = Settings::clone_current();
   settings.remove_snapshot_suffix();
@@ -24,10 +24,7 @@ pub async fn test_fixture<F: FnOnce(&Stats, Settings) -> rspack_error::Result<()
   f(&stats, settings)
 }
 
-#[fixture(
-  "tests/fixtures/*",
-  exclude("export_star_error", "char-based-offset-error-span", "sass-warnings")
-)]
+#[fixture("tests/fixtures/*", exclude("export_star_error"))]
 fn custom(fixture_path: PathBuf) {
   test_fixture(&fixture_path, |stats, settings| {
     let dirname = fixture_path

--- a/crates/rspack_error/tests/fixtures/char-based-offset-error-span/test.config.json
+++ b/crates/rspack_error/tests/fixtures/char-based-offset-error-span/test.config.json
@@ -6,7 +6,7 @@
 					"type": "regexp",
 					"matcher": "\\.s[ac]ss$"
 				},
-				"use": [{ "builtinLoader": "builtin:sass-loader" }],
+				"use": [{ "loader": "builtin:sass-loader" }],
 				"type": "css"
 			}
 		]

--- a/crates/rspack_error/tests/fixtures/sass-warnings/test.config.json
+++ b/crates/rspack_error/tests/fixtures/sass-warnings/test.config.json
@@ -6,7 +6,7 @@
 					"type": "regexp",
 					"matcher": "\\.s[ac]ss$"
 				},
-				"use": [{ "builtinLoader": "builtin:sass-loader" }],
+				"use": [{ "loader": "builtin:sass-loader" }],
 				"type": "css"
 			}
 		]

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   SideEffectOption,
 };
 use rspack_loader_sass::{SassLoader, SassLoaderOptions};
-// use rspack_testing::{fixture, test_fixture};
+use rspack_testing::{fixture, test_fixture};
 use sass_embedded::Url;
 
 // UPDATE_SASS_LOADER_TEST=1 cargo test --package rspack_loader_sass test_fn_name -- --exact --nocapture
@@ -110,7 +110,7 @@ async fn rspack_importer() {
   loader_test("scss/language.scss", "expected/rspack_importer.css").await;
 }
 
-// #[fixture("tests/fixtures/*")]
-// fn sass(fixture_path: PathBuf) {
-//   test_fixture(&fixture_path);
-// }
+#[fixture("tests/fixtures/*")]
+fn sass(fixture_path: PathBuf) {
+  test_fixture(&fixture_path);
+}

--- a/crates/rspack_loader_sass/tests/fixtures/rspack_importer/test.config.json
+++ b/crates/rspack_loader_sass/tests/fixtures/rspack_importer/test.config.json
@@ -6,7 +6,7 @@
 					"type": "regexp",
 					"matcher": "\\.s[ac]ss$"
 				},
-				"use": [{ "builtinLoader": "builtin:sass-loader" }],
+				"use": [{ "loader": "builtin:sass-loader" }],
 				"type": "css"
 			}
 		]

--- a/crates/rspack_loader_swc/tests/fixtures.rs
+++ b/crates/rspack_loader_swc/tests/fixtures.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   SideEffectOption,
 };
 use rspack_loader_swc::{SwcLoader, SwcLoaderJsOptions};
-// use rspack_testing::{fixture, test_fixture};
+use rspack_testing::{fixture, test_fixture};
 use serde_json::json;
 use swc_core::base::config::PluginConfig;
 
@@ -110,7 +110,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
 //   loader_test("swc-plugin/index.js", "swc-plugin/expected/index.js").await;
 // }
 
-// #[fixture("tests/fixtures/*")]
-// fn swc(fixture_path: PathBuf) {
-//   test_fixture(&fixture_path);
-// }
+#[fixture("tests/fixtures/*")]
+fn swc(fixture_path: PathBuf) {
+  test_fixture(&fixture_path);
+}

--- a/crates/rspack_loader_swc/tests/fixtures/esm/test.config.json
+++ b/crates/rspack_loader_swc/tests/fixtures/esm/test.config.json
@@ -8,7 +8,7 @@
         },
         "use": [
           {
-            "builtinLoader": "builtin:swc-loader",
+            "loader": "builtin:swc-loader",
             "options": " {\n              \"jsc\": {\n                \"target\": \"es2015\",\n                \"parser\": {\n                  \"syntax\": \"ecmascript\",\n                  \"jsx\": true,\n                  \"dynamicImport\": true,\n                  \"classProperty\": true,\n                  \"exportNamespaceFrom\": true,\n                  \"exportDefaultFrom\": true\n                }\n              }\n            }"
           }
         ],

--- a/crates/rspack_loader_swc/tests/fixtures/ts/test.config.json
+++ b/crates/rspack_loader_swc/tests/fixtures/ts/test.config.json
@@ -8,7 +8,7 @@
         },
         "use": [
           {
-            "builtinLoader": "builtin:swc-loader",
+            "loader": "builtin:swc-loader",
             "options": " {\n              \"jsc\": {\n                \"target\": \"es2015\",\n                \"parser\": {\n                  \"syntax\": \"typescript\",\n                  \"tsx\": true,\n                  \"dynamicImport\": true,\n                  \"classProperty\": true,\n                  \"exportNamespaceFrom\": true,\n                  \"exportDefaultFrom\": true\n                }\n              }\n            }"
           }
         ],

--- a/crates/rspack_testing/Cargo.toml
+++ b/crates/rspack_testing/Cargo.toml
@@ -16,8 +16,10 @@ test  = false
 [dependencies]
 rspack_binding_options                  = { path = "../rspack_binding_options" }
 rspack_core                             = { path = "../rspack_core" }
+rspack_error                            = { path = "../rspack_error" }
 rspack_fs                               = { path = "../rspack_fs", features = ["async", "rspack-error"] }
 rspack_ids                              = { path = "../rspack_ids" }
+rspack_loader_runner                    = { path = "../rspack_loader_runner" }
 rspack_loader_sass                      = { path = "../rspack_loader_sass" }
 rspack_loader_swc                       = { path = "../rspack_loader_swc" }
 rspack_plugin_asset                     = { path = "../rspack_plugin_asset" }
@@ -36,6 +38,7 @@ rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }
 rspack_regex                            = { path = "../rspack_regex" }
 rspack_tracing                          = { path = "../rspack_tracing" }
 
+async-trait    = { workspace = true }
 cargo-rst      = { path = "../cargo-rst" }
 schemars       = { workspace = true }
 serde          = { workspace = true }

--- a/crates/rspack_testing/examples/build-cli.rs
+++ b/crates/rspack_testing/examples/build-cli.rs
@@ -41,12 +41,12 @@ async fn main() {
   compiler
     .build()
     .await
-    .unwrap_or_else(|e| panic!("failed to compile in fixtrue {config:?}, {e:#?}"));
+    .unwrap_or_else(|e| panic!("failed to compile in fixture {config:?}, {e:#?}"));
   let stats = compiler.compilation.get_stats();
   let errors = stats.get_errors();
   if !errors.is_empty() {
     eprintln!(
-      "Failed to compile in fixtrue {:?}, errors: {:?}",
+      "Failed to compile in fixture {:?}, errors: {:?}",
       config,
       stats
         .emit_diagnostics_string(true)

--- a/crates/rspack_testing/src/lib.rs
+++ b/crates/rspack_testing/src/lib.rs
@@ -1,4 +1,5 @@
 mod eval_raw;
+mod loader;
 mod run_fixture;
 mod test_config;
 pub use eval_raw::evaluate_to_json;

--- a/crates/rspack_testing/src/loader.rs
+++ b/crates/rspack_testing/src/loader.rs
@@ -1,0 +1,64 @@
+use std::{fmt::Debug, path::Path, sync::Arc};
+
+use rspack_core::{
+  BoxLoader, CompilerOptions, NormalModule, Plugin, Resolver, BUILTIN_LOADER_PREFIX,
+};
+use rspack_error::{internal_error, Result};
+use rspack_loader_sass::SASS_LOADER_IDENTIFIER;
+use rspack_loader_swc::SWC_LOADER_IDENTIFIER;
+
+#[derive(Debug)]
+pub struct BuiltinLoaderResolver;
+
+fn get_builtin_loader(builtin: &str, options: Option<&str>) -> BoxLoader {
+  if builtin.starts_with(SASS_LOADER_IDENTIFIER) {
+    return Arc::new(rspack_loader_sass::SassLoader::new(
+      serde_json::from_str(options.unwrap_or("{}")).unwrap_or_else(|e| {
+        panic!("Could not parse builtin:sass-loader options: {options:?}, error: {e:?}")
+      }),
+    ));
+  }
+
+  if builtin.starts_with(SWC_LOADER_IDENTIFIER) {
+    return Arc::new(rspack_loader_swc::SwcLoader::new(
+      serde_json::from_str(options.unwrap_or("{}")).unwrap_or_else(|e| {
+        panic!("Could not parse builtin:swc-loader options:{options:?},error: {e:?}")
+      }),
+      Some(builtin.into()),
+    ));
+  }
+
+  unreachable!("Unexpected builtin loader: {builtin}")
+}
+
+#[async_trait::async_trait]
+impl Plugin for BuiltinLoaderResolver {
+  async fn before_loaders(&self, module: &mut NormalModule) -> Result<()> {
+    let contains_inline = module.contains_inline_loader();
+
+    if contains_inline {
+      return Err(internal_error!(
+        "Inline loaders are not supported for builtin loaders"
+      ));
+    }
+
+    Ok(())
+  }
+
+  async fn resolve_loader(
+    &self,
+    _compiler_options: &CompilerOptions,
+    _context: &Path,
+    _resolver: &Resolver,
+    loader_request: &str,
+    loader_options: Option<&str>,
+  ) -> Result<Option<BoxLoader>> {
+    if loader_request.starts_with(BUILTIN_LOADER_PREFIX) {
+      return Ok(Some(get_builtin_loader(loader_request, loader_options)));
+    }
+
+    Err(internal_error!(
+      "JS loaders are not supported in Rust tests: {loader_request}"
+    ))
+  }
+}

--- a/crates/rspack_testing/src/run_fixture.rs
+++ b/crates/rspack_testing/src/run_fixture.rs
@@ -36,7 +36,7 @@ pub async fn test_fixture(fixture_path: &Path) -> Compiler<AsyncNativeFileSystem
   compiler
     .build()
     .await
-    .unwrap_or_else(|e| panic!("failed to compile in fixtrue {fixture_path:?}, {e:#?}"));
+    .unwrap_or_else(|e| panic!("failed to compile in fixture {fixture_path:?}, {e:#?}"));
   let stats = compiler.compilation.get_stats();
   let output_name = make_relative_from(&compiler.options.output.path, fixture_path);
   let rst = RstBuilder::default()
@@ -48,7 +48,7 @@ pub async fn test_fixture(fixture_path: &Path) -> Compiler<AsyncNativeFileSystem
   let errors = stats.get_errors();
   if !warnings.is_empty() && errors.is_empty() {
     println!(
-      "Warning to compile in fixtrue {:?}, warnings: {:?}",
+      "Warning to compile in fixture {:?}, warnings: {:?}",
       fixture_path,
       stats
         .emit_diagnostics_string(true)
@@ -57,7 +57,7 @@ pub async fn test_fixture(fixture_path: &Path) -> Compiler<AsyncNativeFileSystem
   }
   if !errors.is_empty() {
     panic!(
-      "Failed to compile in fixtrue {:?}, errors: {:?}",
+      "Failed to compile in fixture {:?}, errors: {:?}",
       fixture_path,
       stats
         .emit_diagnostics_string(true)
@@ -107,7 +107,7 @@ pub async fn test_rebuild_fixture(
   compiler
     .build()
     .await
-    .unwrap_or_else(|e| panic!("failed to compile in fixtrue {fixture_path:?}, {e:#?}"));
+    .unwrap_or_else(|e| panic!("failed to compile in fixture {fixture_path:?}, {e:#?}"));
 
   let mut files_map: HashMap<String, FsOptionEnum> = HashMap::new();
   let changed_files: HashSet<String> =
@@ -189,7 +189,7 @@ pub async fn test_rebuild_fixture(
   let errors = stats.get_errors();
   if !errors.is_empty() {
     panic!(
-      "Failed to compile in fixtrue {:?}, errors: {:?}",
+      "Failed to compile in fixture {:?}, errors: {:?}",
       fixture_path,
       stats
         .emit_diagnostics_string(true)

--- a/crates/rspack_testing/test.config.scheme.json
+++ b/crates/rspack_testing/test.config.scheme.json
@@ -407,10 +407,10 @@
     "ModuleRuleUse": {
       "type": "object",
       "required": [
-        "builtinLoader"
+        "loader"
       ],
       "properties": {
-        "builtinLoader": {
+        "loader": {
           "type": "string"
         },
         "options": {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Adds support for resolving builtin loaders in Rust tests.
Changed Rust test option field `Rule.use.builtinLoader` -> `Rule.use.loader`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Turned on a few tests. See Git Diff.

<!-- Can you please describe how you tested the changes you made to the code? -->
