### PR TITLE
chore: add oxlint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+crates/rspack/tests
+crates/rspack_error/tests
+crates/rspack_plugin_css/webpack_css_cases_to_be_migrated
+packages/playground/fixtures
+packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
+packages/rspack/tests
+webpack-examples
+webpack-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,27 @@ jobs:
         with:
           files: .
 
+  oxlint:
+    name: Lint JS
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            src:
+              - '**/*.{ts,js,mjs}'
+
+      - name: Pnpm Cache
+        if: steps.changes.outputs.src == 'true'
+        uses: ./.github/actions/pnpm-cache
+
+      - name: oxlint
+        if: steps.changes.outputs.src == 'true'
+        run: pnpm run lint:js
+
   rust_changes:
     name: Rust Changes
     runs-on: ubuntu-latest

--- a/examples/loader-compat/rspack.config.js
+++ b/examples/loader-compat/rspack.config.js
@@ -90,7 +90,7 @@ const config = {
 				type: "javascript/auto"
 			},
 			{
-				test: /\h.png$/,
+				test: /h\.png$/,
 				use: ["file-loader"]
 			},
 			{
@@ -106,7 +106,7 @@ const config = {
 			},
 			{
 				test: /\.png$/,
-				exclude: /\h.png$/,
+				exclude: /h\.png$/,
 				use: ({ resource, realResource, resourceQuery, compiler, issuer }) => {
 					console.log('resource', resource)
 					console.log('issuer',issuer)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format:js": "npx prettier \"packages/**/*.{ts,js}\" \"crates/rspack_plugin_runtime/**/*.{ts,js}\" --check --write",
     "format-ci:toml": "npx @taplo/cli format --check '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "format:toml": "npx @taplo/cli format '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
-    "lint:js": "npx prettier \"packages/**/*.{ts,js}\" --check",
+    "lint:js": "oxlint .",
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:release": "pnpm --filter @rspack/binding run build:release",
@@ -34,7 +34,8 @@
     "packages/**/*.{ts,js}": "prettier --write",
     "x.mjs": "prettier --write",
     "crates/rspack_plugin_runtime/**/*.{ts,js}": "prettier --write",
-    "*.toml": "npx @taplo/cli format"
+    "*.toml": "npx @taplo/cli format",
+    "**/*.{ts,js,mjs}": "oxlint"
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
@@ -56,6 +57,7 @@
     "jest-environment-node": "29.5.0",
     "lint-staged": "^12.5.0",
     "npm-run-all": "4.1.5",
+    "oxlint": "0.0.10",
     "prettier": "2.5.1",
     "rimraf": "3.0.2",
     "ts-jest": "29.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ importers:
       jest-environment-node: 29.5.0
       lint-staged: ^12.5.0
       npm-run-all: 4.1.5
+      oxlint: 0.0.10
       prettier: 2.5.1
       rimraf: 3.0.2
       sass-embedded-darwin-arm64: 1.58.3
@@ -53,6 +54,7 @@ importers:
       jest-environment-node: 29.5.0
       lint-staged: 12.5.0
       npm-run-all: 4.1.5
+      oxlint: 0.0.10
       prettier: 2.5.1
       rimraf: 3.0.2
       ts-jest: 29.1.0_44ttdtjaknnkcgzh5px4h2qxl4
@@ -7583,6 +7585,54 @@ packages:
     dependencies:
       '@octokit/openapi-types': 17.1.0
     dev: true
+
+  /@oxlint/darwin-arm64/0.0.10:
+    resolution: {integrity: sha512-OCZODSvvN6tf1ynSU7x6sgdOdNbkmAHANcgpRvHAx2jpIwmD3K4rY1dCeMly2QDbmhiMyUH0yxq2P3ob03ot9g==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxlint/darwin-x64/0.0.10:
+    resolution: {integrity: sha512-ZZZz0NDowShzYv4EK0yigsNpAh2PUjXBEkTIEQb6O/vUYtGovsOxIHPqN0qazG5QHjIAivDh7TF7qSNN4gkqBQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxlint/linux-arm64/0.0.10:
+    resolution: {integrity: sha512-Prvc1FItOByDZzE+i5nAo2QT2L7tujONJC0sO2raLASkjb8z9Ct3GMd4QieU/620+gtrG7aVaCPjsj5Uy9QFRA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxlint/linux-x64/0.0.10:
+    resolution: {integrity: sha512-a1dy65CU3Oxv4foR8HQRb83IYKOt9SEFYOZAtTSjDmmlHxtZpC4QZG2pAEqmBypzL7lTbbBTojWDWb8BXJEICA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxlint/win32-arm64/0.0.10:
+    resolution: {integrity: sha512-Dq8HE54Rb2R37ruIine9NhNpZrC7ZlKd+6Eo0Z/6w5ZvbFF1ZB+eOiMthu1DKY8cbwOP7qnn2xzm1rSttW4T/A==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@oxlint/win32-x64/0.0.10:
+    resolution: {integrity: sha512-Xt1GUWY+t/Ik9vwMYrQ3Y6yJM24OhqcKk92Xy7fteom40lnAag5dijWXCKjt7Yx4skB924sdBWoWSPfql6zChw==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@perfsee/bundle-analyzer/1.6.0:
     resolution: {integrity: sha512-RdOzu04TNW5YPaxPUmIqmd6QeINJT8h8tZPnjHdDqdoaogWi+yUoOjzke02dedKDxcZvqWuiiRuE4iGlPOUcJQ==}
@@ -21800,6 +21850,19 @@ packages:
       type-fest: 0.11.0
     dev: true
     optional: true
+
+  /oxlint/0.0.10:
+    resolution: {integrity: sha512-iYvSfGEoNhNHidGD4e3pEZjYdxW4SWWAMgbgqFNqgWl5nqk5TMy2x0x6WB2HaY++xKNE0m/6FYbp19FNJY2Imw==}
+    engines: {node: '>=14.*'}
+    hasBin: true
+    optionalDependencies:
+      '@oxlint/darwin-arm64': 0.0.10
+      '@oxlint/darwin-x64': 0.0.10
+      '@oxlint/linux-arm64': 0.0.10
+      '@oxlint/linux-x64': 0.0.10
+      '@oxlint/win32-arm64': 0.0.10
+      '@oxlint/win32-x64': 0.0.10
+    dev: true
 
   /p-cancelable/0.3.0:
     resolution: {integrity: sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Let's lint the codebase with oxlint :-)

## Test Plan

* running `pnpm run lint:js` succeeds
* The new CI job "Lint js" passes https://github.com/web-infra-dev/rspack/actions/runs/5924295664/job/16061553616

<img width="519" alt="image" src="https://github.com/web-infra-dev/rspack/assets/1430279/b6aa6db1-1c8c-4aed-b2ac-653707fe6ab0">

* for lint-staged, I modified a file and made sure it got triggered and reported errors

<img width="769" alt="image" src="https://github.com/web-infra-dev/rspack/assets/1430279/f0c50203-a86a-4211-906f-59db44933bfb">


Running locally:

```
rspack  oxlint ❯ pnpm run lint:js

> monorepo@0.2.12 lint:js /Users/bytedance/github/rspack
> oxlint .

Finished in 1011ms on 827 files with 56 rules using 12 threads.
Found 0 warnings and 0 errors.```