### PR TITLE
feat: support option `resolveLoader`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -815,6 +815,7 @@ export interface RawOptions {
   context: string
   output: RawOutputOptions
   resolve: RawResolveOptions
+  resolveLoader: RawResolveOptions
   module: RawModuleOptions
   builtins: RawBuiltins
   externals?: Array<RawExternalItem>

--- a/crates/node_binding/src/plugins/loader.rs
+++ b/crates/node_binding/src/plugins/loader.rs
@@ -80,6 +80,7 @@ impl Plugin for JsLoaderResolver {
 
     match resolve_result {
       ResolveResult::Resource(resource) => {
+        // TODO: Should move this logic to `resolver`, since `resolve.alias` may contain query or fragment too. @Boshen
         let resource = resource.path.to_string_lossy().to_string() + rest.unwrap_or_default();
         Ok(Some(Arc::new(JsLoaderAdapter {
           identifier: resource.into(),

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -67,6 +67,7 @@ pub struct RawOptions {
   pub context: RawContext,
   pub output: RawOutputOptions,
   pub resolve: RawResolveOptions,
+  pub resolve_loader: RawResolveOptions,
   pub module: RawModuleOptions,
   pub builtins: RawBuiltins,
   pub externals: Option<Vec<RawExternalItem>>,
@@ -115,6 +116,7 @@ impl RawOptionsApply for RawOptions {
     }
     let output: OutputOptions = self.output.apply(plugins)?;
     let resolve = self.resolve.try_into()?;
+    let resolve_loader = self.resolve_loader.try_into()?;
     let devtool: Devtool = self.devtool.into();
     let mode = self.mode.unwrap_or_default().into();
     let module: ModuleOptions = self.module.apply(plugins)?;
@@ -253,6 +255,7 @@ impl RawOptionsApply for RawOptions {
       target,
       output,
       resolve,
+      resolve_loader,
       devtool,
       experiments,
       stats,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -443,6 +443,7 @@ impl Compilation {
           None,
           None,
           parent_module.and_then(|module| module.get_resolve_options().map(ToOwned::to_owned)),
+          self.options.resolve_loader.clone(),
           self.lazy_visit_modules.clone(),
           parent_module
             .and_then(|m| m.as_normal_module())
@@ -571,6 +572,7 @@ impl Compilation {
             None,
             None,
             task.resolve_options.clone(),
+            self.options.resolve_loader.clone(),
             self.lazy_visit_modules.clone(),
             module
               .as_normal_module()
@@ -860,6 +862,7 @@ impl Compilation {
     module_type: Option<ModuleType>,
     side_effects: Option<bool>,
     resolve_options: Option<Resolve>,
+    resolve_loader_options: Resolve,
     lazy_visit_modules: std::collections::HashSet<String>,
     issuer: Option<String>,
   ) {
@@ -873,6 +876,7 @@ impl Compilation {
       module_type,
       side_effects,
       resolve_options,
+      resolve_loader_options,
       lazy_visit_modules,
       resolver_factory: self.resolver_factory.clone(),
       options: self.options.clone(),

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -76,6 +76,7 @@ pub struct Compilation {
   logging: CompilationLogging,
   pub plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
+  pub loader_resolver_factory: Arc<ResolverFactory>,
   pub named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) named_chunk_groups: HashMap<String, ChunkGroupUkey>,
   pub entry_module_identifiers: IdentifierSet,
@@ -110,6 +111,7 @@ impl Compilation {
     module_graph: ModuleGraph,
     plugin_driver: SharedPluginDriver,
     resolver_factory: Arc<ResolverFactory>,
+    loader_resolver_factory: Arc<ResolverFactory>,
     cache: Arc<Cache>,
   ) -> Self {
     Self {
@@ -133,6 +135,7 @@ impl Compilation {
       logging: Default::default(),
       plugin_driver,
       resolver_factory,
+      loader_resolver_factory,
       named_chunks: Default::default(),
       named_chunk_groups: Default::default(),
       entry_module_identifiers: IdentifierSet::default(),
@@ -443,7 +446,6 @@ impl Compilation {
           None,
           None,
           parent_module.and_then(|module| module.get_resolve_options().map(ToOwned::to_owned)),
-          self.options.resolve_loader.clone(),
           self.lazy_visit_modules.clone(),
           parent_module
             .and_then(|m| m.as_normal_module())
@@ -572,7 +574,6 @@ impl Compilation {
             None,
             None,
             task.resolve_options.clone(),
-            self.options.resolve_loader.clone(),
             self.lazy_visit_modules.clone(),
             module
               .as_normal_module()
@@ -862,7 +863,6 @@ impl Compilation {
     module_type: Option<ModuleType>,
     side_effects: Option<bool>,
     resolve_options: Option<Resolve>,
-    resolve_loader_options: Resolve,
     lazy_visit_modules: std::collections::HashSet<String>,
     issuer: Option<String>,
   ) {
@@ -876,9 +876,9 @@ impl Compilation {
       module_type,
       side_effects,
       resolve_options,
-      resolve_loader_options,
       lazy_visit_modules,
       resolver_factory: self.resolver_factory.clone(),
+      loader_resolver_factory: self.loader_resolver_factory.clone(),
       options: self.options.clone(),
       plugin_driver: self.plugin_driver.clone(),
       cache: self.cache.clone(),

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -134,6 +134,7 @@ where
         Default::default(),
         self.plugin_driver.clone(),
         self.resolver_factory.clone(),
+        self.loader_resolver_factory.clone(),
         self.cache.clone(),
       );
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -37,6 +37,7 @@ where
   pub compilation: Compilation,
   pub plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
+  pub loader_resolver_factory: Arc<ResolverFactory>,
   pub cache: Arc<Cache>,
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
@@ -56,6 +57,7 @@ where
     let options = Arc::new(options);
 
     let resolver_factory = Arc::new(ResolverFactory::new(options.resolve.clone()));
+    let loader_resolver_factory = Arc::new(ResolverFactory::new(options.resolve_loader.clone()));
     let plugin_driver = Arc::new(PluginDriver::new(
       options.clone(),
       plugins,
@@ -70,11 +72,13 @@ where
         Default::default(),
         plugin_driver.clone(),
         resolver_factory.clone(),
+        loader_resolver_factory.clone(),
         cache.clone(),
       ),
       output_filesystem,
       plugin_driver,
       resolver_factory,
+      loader_resolver_factory,
       cache,
       emitted_asset_versions: Default::default(),
     }
@@ -99,6 +103,7 @@ where
         Default::default(),
         self.plugin_driver.clone(),
         self.resolver_factory.clone(),
+        self.loader_resolver_factory.clone(),
         self.cache.clone(),
       ),
     );

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -32,6 +32,7 @@ pub struct FactorizeTask {
   pub module_type: Option<ModuleType>,
   pub side_effects: Option<bool>,
   pub resolve_options: Option<Resolve>,
+  pub resolve_loader_options: Resolve,
   pub resolver_factory: Arc<ResolverFactory>,
   pub options: Arc<CompilerOptions>,
   pub lazy_visit_modules: std::collections::HashSet<String>,
@@ -76,6 +77,7 @@ impl WorkerTask for FactorizeTask {
         factory
           .create(ModuleFactoryCreateData {
             resolve_options: self.resolve_options,
+            resolve_loader_options: self.resolve_loader_options,
             context,
             dependency: dependency.clone(),
           })
@@ -99,6 +101,7 @@ impl WorkerTask for FactorizeTask {
         factory
           .create(ModuleFactoryCreateData {
             resolve_options: self.resolve_options,
+            resolve_loader_options: self.resolve_loader_options,
             context,
             dependency: dependency.clone(),
           })

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -32,8 +32,8 @@ pub struct FactorizeTask {
   pub module_type: Option<ModuleType>,
   pub side_effects: Option<bool>,
   pub resolve_options: Option<Resolve>,
-  pub resolve_loader_options: Resolve,
   pub resolver_factory: Arc<ResolverFactory>,
+  pub loader_resolver_factory: Arc<ResolverFactory>,
   pub options: Arc<CompilerOptions>,
   pub lazy_visit_modules: std::collections::HashSet<String>,
   pub plugin_driver: SharedPluginDriver,
@@ -77,7 +77,6 @@ impl WorkerTask for FactorizeTask {
         factory
           .create(ModuleFactoryCreateData {
             resolve_options: self.resolve_options,
-            resolve_loader_options: self.resolve_loader_options,
             context,
             dependency: dependency.clone(),
           })
@@ -94,14 +93,13 @@ impl WorkerTask for FactorizeTask {
             lazy_visit_modules: self.lazy_visit_modules,
             issuer: self.issuer,
           },
-          self.resolver_factory,
+          self.loader_resolver_factory,
           self.plugin_driver,
           self.cache,
         );
         factory
           .create(ModuleFactoryCreateData {
             resolve_options: self.resolve_options,
-            resolve_loader_options: self.resolve_loader_options,
             context,
             dependency: dependency.clone(),
           })

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -8,7 +8,6 @@ use crate::{BoxDependency, BoxModule, Context, FactoryMeta, Resolve};
 #[derive(Debug)]
 pub struct ModuleFactoryCreateData {
   pub resolve_options: Option<Resolve>,
-  pub resolve_loader_options: Resolve,
   pub context: Context,
   pub dependency: BoxDependency,
 }

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -8,6 +8,7 @@ use crate::{BoxDependency, BoxModule, Context, FactoryMeta, Resolve};
 #[derive(Debug)]
 pub struct ModuleFactoryCreateData {
   pub resolve_options: Option<Resolve>,
+  pub resolve_loader_options: Resolve,
   pub context: Context,
   pub dependency: BoxDependency,
 }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -557,7 +557,7 @@ impl NormalModuleFactory {
           .resolve_loader(
             compiler_options,
             context,
-            &loader_resolver,
+            loader_resolver,
             loader_request,
             loader_options,
           )

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -6,7 +6,7 @@ use rspack_error::{
   internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
 };
 use rspack_identifier::Identifiable;
-use rspack_loader_runner::{get_scheme, DescriptionData, Scheme};
+use rspack_loader_runner::{get_scheme, DescriptionData, Loader, Scheme};
 use sugar_path::{AsPath, SugarPath};
 use swc_core::common::Span;
 
@@ -14,8 +14,8 @@ use crate::{
   cache::Cache,
   module_rules_matcher, parse_resource, resolve, stringify_loaders_and_resource,
   tree_shaking::visitor::{get_side_effects_from_package_json, SideEffects},
-  BoxLoader, CompilerOptions, DependencyCategory, DependencyType, FactorizeArgs, FactoryMeta,
-  FuncUseCtx, GeneratorOptions, MissingModule, ModuleArgs, ModuleExt, ModuleFactory,
+  BoxLoader, CompilerContext, CompilerOptions, DependencyCategory, DependencyType, FactorizeArgs,
+  FactoryMeta, FuncUseCtx, GeneratorOptions, MissingModule, ModuleArgs, ModuleExt, ModuleFactory,
   ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleRule, ModuleRuleEnforce,
   ModuleRuleUse, ModuleRuleUseLoader, ModuleType, NormalModule, NormalModuleAfterResolveArgs,
   NormalModuleBeforeResolveArgs, ParserOptions, RawModule, Resolve, ResolveArgs, ResolveError,
@@ -26,7 +26,7 @@ use crate::{
 #[derive(Debug)]
 pub struct NormalModuleFactory {
   context: NormalModuleFactoryContext,
-  resolver_factory: Arc<ResolverFactory>,
+  loader_resolver_factory: Arc<ResolverFactory>,
   plugin_driver: SharedPluginDriver,
   cache: Arc<Cache>,
 }
@@ -55,13 +55,13 @@ static MATCH_RESOURCE_REGEX: Lazy<Regex> =
 impl NormalModuleFactory {
   pub fn new(
     context: NormalModuleFactoryContext,
-    resolver_factory: Arc<ResolverFactory>,
+    loader_resolver_factory: Arc<ResolverFactory>,
     plugin_driver: SharedPluginDriver,
     cache: Arc<Cache>,
   ) -> Self {
     Self {
       context,
-      resolver_factory,
+      loader_resolver_factory,
       plugin_driver,
       cache,
     }
@@ -145,13 +145,15 @@ impl NormalModuleFactory {
     Ok(None)
   }
 
-  fn get_loader_resolver(&self, loader_resolve_options: Option<Resolve>) -> Arc<Resolver> {
-    self.resolver_factory.get(ResolveOptionsWithDependencyType {
-      resolve_options: loader_resolve_options,
-      resolve_to_context: false,
-      dependency_type: DependencyType::CjsRequire,
-      dependency_category: DependencyCategory::CommonJS,
-    })
+  fn get_loader_resolver(&self) -> Arc<Resolver> {
+    self
+      .loader_resolver_factory
+      .get(ResolveOptionsWithDependencyType {
+        resolve_options: None,
+        resolve_to_context: false,
+        dependency_type: DependencyType::CjsRequire,
+        dependency_category: DependencyCategory::CommonJS,
+      })
   }
 
   pub async fn factorize_normal_module(
@@ -172,7 +174,7 @@ impl NormalModuleFactory {
     let context_scheme = get_scheme(data.context.as_ref());
     let context = data.context.as_path();
     let plugin_driver = &self.plugin_driver;
-    let loader_resolver = self.get_loader_resolver(Some(data.resolve_loader_options.clone()));
+    let loader_resolver = self.get_loader_resolver();
 
     let mut match_resource_data: Option<ResourceData> = None;
     let mut inline_loaders: Vec<ModuleRuleUseLoader> = vec![];
@@ -476,32 +478,94 @@ impl NormalModuleFactory {
         pre_loaders.len() + post_loaders.len() + normal_loaders.len() + inline_loaders.len(),
       );
 
-      all_loaders.extend(post_loaders);
-      if match_resource_data.is_some() {
-        all_loaders.extend(normal_loaders);
-        all_loaders.extend(inline_loaders);
-      } else {
-        all_loaders.extend(inline_loaders);
-        all_loaders.extend(normal_loaders);
+      for l in post_loaders {
+        all_loaders.push(
+          resolve_each(
+            plugin_driver,
+            &self.context.options,
+            self.context.options.context.as_ref(),
+            &loader_resolver,
+            &l.loader,
+            l.options.as_deref(),
+          )
+          .await?,
+        )
       }
-      all_loaders.extend(pre_loaders);
 
-      let mut loader = Vec::with_capacity(all_loaders.len());
-      for l in all_loaders {
-        loader.push(
-          plugin_driver
-            .resolve_loader(
-              &self.context.options,
-              context,
-              &loader_resolver,
-              &l.loader,
-              l.options.as_deref(),
-            )
-            .await?
-            .ok_or_else(|| internal_error!("Unable to resolve loader {}", &l.loader))?,
-        );
+      let mut resolved_inline_loaders = vec![];
+      let mut resolved_normal_loaders = vec![];
+
+      for l in inline_loaders {
+        resolved_inline_loaders.push(
+          resolve_each(
+            plugin_driver,
+            &self.context.options,
+            context,
+            &loader_resolver,
+            &l.loader,
+            l.options.as_deref(),
+          )
+          .await?,
+        )
       }
-      loader
+
+      for l in normal_loaders {
+        resolved_normal_loaders.push(
+          resolve_each(
+            plugin_driver,
+            &self.context.options,
+            self.context.options.context.as_ref(),
+            &loader_resolver,
+            &l.loader,
+            l.options.as_deref(),
+          )
+          .await?,
+        )
+      }
+
+      if match_resource_data.is_some() {
+        all_loaders.extend(resolved_normal_loaders);
+        all_loaders.extend(resolved_inline_loaders);
+      } else {
+        all_loaders.extend(resolved_inline_loaders);
+        all_loaders.extend(resolved_normal_loaders);
+      }
+
+      for l in pre_loaders {
+        all_loaders.push(
+          resolve_each(
+            plugin_driver,
+            &self.context.options,
+            self.context.options.context.as_ref(),
+            &loader_resolver,
+            &l.loader,
+            l.options.as_deref(),
+          )
+          .await?,
+        )
+      }
+
+      async fn resolve_each(
+        plugin_driver: &SharedPluginDriver,
+        compiler_options: &CompilerOptions,
+        context: &Path,
+        loader_resolver: &Resolver,
+        loader_request: &str,
+        loader_options: Option<&str>,
+      ) -> Result<Arc<dyn Loader<CompilerContext>>> {
+        plugin_driver
+          .resolve_loader(
+            compiler_options,
+            context,
+            &loader_resolver,
+            loader_request,
+            loader_options,
+          )
+          .await?
+          .ok_or_else(|| internal_error!("Unable to resolve loader {}", loader_request))
+      }
+
+      all_loaders
     };
 
     let request = if !loaders.is_empty() {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -172,7 +172,7 @@ impl NormalModuleFactory {
     let context_scheme = get_scheme(data.context.as_ref());
     let context = data.context.as_path();
     let plugin_driver = &self.plugin_driver;
-    let loader_resolver = self.get_loader_resolver(data.resolve_options.clone());
+    let loader_resolver = self.get_loader_resolver(Some(data.resolve_loader_options.clone()));
 
     let mut match_resource_data: Option<ResourceData> = None;
     let mut inline_loaders: Vec<ModuleRuleUseLoader> = vec![];

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -13,6 +13,7 @@ pub struct CompilerOptions {
   pub target: Target,
   pub mode: Mode,
   pub resolve: Resolve,
+  pub resolve_loader: Resolve,
   pub builtins: Builtins,
   pub module: ModuleOptions,
   pub devtool: Devtool,

--- a/crates/rspack_loader_sass/tests/fixtures.rs
+++ b/crates/rspack_loader_sass/tests/fixtures.rs
@@ -75,6 +75,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
         },
         target: rspack_core::Target::new(&vec![String::from("web")]).expect("TODO:"),
         resolve: rspack_core::Resolve::default(),
+        resolve_loader: rspack_core::Resolve::default(),
         builtins: Default::default(),
         module: Default::default(),
         stats: Default::default(),

--- a/crates/rspack_loader_swc/tests/fixtures.rs
+++ b/crates/rspack_loader_swc/tests/fixtures.rs
@@ -75,6 +75,7 @@ async fn loader_test(actual: impl AsRef<Path>, expected: impl AsRef<Path>) {
         },
         target: rspack_core::Target::new(&vec![String::from("web")]).expect("TODO:"),
         resolve: rspack_core::Resolve::default(),
+        resolve_loader: rspack_core::Resolve::default(),
         builtins: Default::default(),
         module: Default::default(),
         stats: Default::default(),

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -414,6 +414,7 @@ impl TestConfig {
         ),
         ..Default::default()
       },
+      resolve_loader: c::Resolve::default(),
       builtins: c::Builtins {
         define: self.builtins.define,
         provide: self.builtins.provide,

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -83,6 +83,7 @@ export const getRawOptions = (
 		context: options.context,
 		output: getRawOutput(options.output),
 		resolve: getRawResolve(options.resolve),
+		resolveLoader: getRawResolve(options.resolveLoader),
 		module: getRawModule(options.module, {
 			compiler,
 			devtool,

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -262,12 +262,6 @@ function resolveStringifyLoaders(
 	compiler: Compiler
 ) {
 	const obj = parsePathQueryFragment(use.loader);
-	// Do not handle builtin loader
-	if (!use.loader.startsWith(BUILTIN_LOADER_PREFIX)) {
-		obj.path = require.resolve(obj.path, {
-			paths: [compiler.context]
-		});
-	}
 	let ident: string | null = null;
 
 	if (use.options === null) obj.query = "";

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -122,6 +122,11 @@ export const applyRspackOptionsDefaults = (
 		options.resolve
 	);
 
+	options.resolveLoader = cleverMerge(
+		getResolveLoaderDefaults(),
+		options.resolveLoader
+	);
+
 	// TODO: refactor builtins
 	options.builtins = oldBuiltins.resolveBuiltinsOptions(options.builtins, {
 		contextPath: options.context!,
@@ -699,6 +704,18 @@ const applyOptimizationDefaults = (
 			}));
 		}
 	}
+};
+
+const getResolveLoaderDefaults = () => {
+	const resolveOptions: ResolveOptions = {
+		conditionNames: ["loader", "require", "node"],
+		exportsFields: ["exports"],
+		mainFields: ["loader", "main"],
+		extensions: [".js"],
+		mainFiles: ["index"]
+	};
+
+	return resolveOptions;
 };
 
 const getResolveDefaults = ({

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -157,6 +157,9 @@ export const getNormalizedRspackOptions = (
 		resolve: nestedConfig(config.resolve, resolve => ({
 			...resolve
 		})),
+		resolveLoader: nestedConfig(config.resolveLoader, resolve => ({
+			...resolve
+		})),
 		module: nestedConfig(config.module, module => ({
 			parser: keyedNestedConfig(
 				module.parser as Record<string, any>,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -36,6 +36,7 @@ export interface RspackOptionsNormalized {
 	entry: EntryNormalized;
 	output: OutputNormalized;
 	resolve: Resolve;
+	resolveLoader: Resolve;
 	module: ModuleOptionsNormalized;
 	target?: Target;
 	externals?: Externals;

--- a/packages/rspack/src/config/zod/index.ts
+++ b/packages/rspack/src/config/zod/index.ts
@@ -40,6 +40,7 @@ export function configSchema() {
 			snapshot: snapshot().optional(),
 			optimization: optimization().optional(),
 			resolve: resolve().optional(),
+			resolveLoader: resolve().optional(),
 			plugins: plugins().optional(),
 			// TODO(hyf0): what's the usage of this?
 			name: z.string().optional(),

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -698,10 +698,6 @@ function iteratePitchingLoaders(
 		return iteratePitchingLoaders(loaderContext, args, callback);
 	}
 
-	if (currentLoaderObject.path.includes("esm/index.js")) {
-		console.log(loaderContext);
-	}
-
 	// load loader module
 	loadLoader(currentLoaderObject, function (err: Error) {
 		if (err) {

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -698,6 +698,10 @@ function iteratePitchingLoaders(
 		return iteratePitchingLoaders(loaderContext, args, callback);
 	}
 
+	if (currentLoaderObject.path.includes("esm/index.js")) {
+		console.log(loaderContext);
+	}
+
 	// load loader module
 	loadLoader(currentLoaderObject, function (err: Error) {
 		if (err) {

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -418,6 +418,26 @@ exports[`snapshots should have the correct base config 1`] = `
       "node_modules",
     ],
   },
+  "resolveLoader": {
+    "conditionNames": [
+      "loader",
+      "require",
+      "node",
+    ],
+    "exportsFields": [
+      "exports",
+    ],
+    "extensions": [
+      ".js",
+    ],
+    "mainFields": [
+      "loader",
+      "main",
+    ],
+    "mainFiles": [
+      "index",
+    ],
+  },
   "snapshot": {
     "module": {
       "hash": false,

--- a/packages/rspack/tests/configCases/loader/additional-data/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/additional-data/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		rules: [
 			{
 				test: path.join(__dirname, "a.js"),
-				use: [{ loader: "loader-2.js" }, { loader: "./loader-1.js" }]
+				use: [{ loader: "./loader-2.js" }, { loader: "./loader-1.js" }]
 			}
 		]
 	}

--- a/packages/rspack/tests/configCases/loader/source-map/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/source-map/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 		rules: [
 			{
 				test: path.join(__dirname, "a.js"),
-				use: [{ loader: "loader-2.js" }, { loader: "./loader-1.js" }]
+				use: [{ loader: "./loader-2.js" }, { loader: "./loader-1.js" }]
 			}
 		]
 	}

--- a/webpack-test/configCases/loaders/issue-3320/deprecations.js
+++ b/webpack-test/configCases/loaders/issue-3320/deprecations.js
@@ -1,10 +1,11 @@
+// Does not support deprecation for Node
 module.exports = [
-	{
-		code: /DEP_WEBPACK_RULE_LOADER_OPTIONS_STRING/,
-		message: /Using a string as loader options is deprecated \(ruleSet\[1\]\.rules\[2\]\.options\)/
-	},
-	{
-		code: /DEP_WEBPACK_RULE_LOADER_OPTIONS_STRING/,
-		message: /Using a string as loader options is deprecated \(ruleSet\[1\]\.rules\[3\]\.use\[0\]\.options\)/
-	}
+	// {
+	// 	code: /DEP_WEBPACK_RULE_LOADER_OPTIONS_STRING/,
+	// 	message: /Using a string as loader options is deprecated \(ruleSet\[1\]\.rules\[2\]\.options\)/
+	// },
+	// {
+	// 	code: /DEP_WEBPACK_RULE_LOADER_OPTIONS_STRING/,
+	// 	message: /Using a string as loader options is deprecated \(ruleSet\[1\]\.rules\[3\]\.use\[0\]\.options\)/
+	// }
 ];

--- a/webpack-test/configCases/loaders/issue-3320/index.js
+++ b/webpack-test/configCases/loaders/issue-3320/index.js
@@ -1,9 +1,9 @@
 // Webpack supports this, but Rspack does not support `resolve.alias` with a custom query and fragment
-it.skip("should resolve aliased loader module with query", function() {
-	var foo = require('./a');
+// it.skip("should resolve aliased loader module with query", function() {
+// 	var foo = require('./a');
 
-	expect(foo).toBe("someMessage");
-});
+// 	expect(foo).toBe("someMessage");
+// });
 
 it("should favor explicit loader query over aliased query (options in rule)", function() {
 	var foo = require('./b');

--- a/webpack-test/configCases/loaders/issue-3320/index.js
+++ b/webpack-test/configCases/loaders/issue-3320/index.js
@@ -1,4 +1,5 @@
-it("should resolve aliased loader module with query", function() {
+// Webpack supports this, but Rspack does not support `resolve.alias` with a custom query and fragment
+it.skip("should resolve aliased loader module with query", function() {
 	var foo = require('./a');
 
 	expect(foo).toBe("someMessage");

--- a/webpack-test/configCases/loaders/issue-3320/test.filter.js
+++ b/webpack-test/configCases/loaders/issue-3320/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return "blocked by `resolveLoader` https://github.com/web-infra-dev/rspack/issues/3737"}
+module.exports = () => {return true}

--- a/webpack-test/scripts/test-metric.js
+++ b/webpack-test/scripts/test-metric.js
@@ -18,7 +18,10 @@ process.stdin.on("end", () => {
 
 	// "numFailedTestSuites": 0,
 	// "numFailedTests": 0,
-	const jsonObj = JSON.parse(data) || {};
+  let jsonObj = {}
+  try {
+    jsonObj = JSON.parse(data)
+  } catch(e) {}
 	if (isEmptyObject(jsonObj)) {
 		process.exit(-1);
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary


closes https://github.com/web-infra-dev/rspack/issues/3737

Added support for `resolveLoader`. However, nodejs-resolver does not support 
alias with a custom query or fragment, which results in the failure with the first webpack test case.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

See test changes and add back the first test once `resolve.alias` supports custom query and fragment.

<!-- Can you please describe how you tested the changes you made to the code? -->
