### PR TITLE
fix: add workaround for accessing previous stats

### DIFF
--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -40,10 +40,19 @@ export class Stats {
 
 		const statsFactory = this.compilation.createStatsFactory(options);
 
-		return statsFactory.create("compilation", this.compilation, {
-			compilation: this.compilation,
-			_inner: this.#inner
-		});
+		// FIXME: This is a really ugly workaround for
+		let stats: StatsCompilation | null = null;
+		try {
+			stats = statsFactory.create("compilation", this.compilation, {
+				compilation: this.compilation,
+				_inner: this.#inner
+			});
+		} catch (e) {
+			console.warn(
+				"Failed to get stats. Are you trying to access the previous stats in future compilations?"
+			);
+		}
+		return stats as StatsCompilation;
 	}
 
 	toString(opts?: StatsValue) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In the previous implementation, `Stats` will be converted eagerly from compilation to `JsStats` 
and this cause a severe performance impact on large applications. So https://github.com/web-infra-dev/rspack/pull/4029 reverts this.
However, at the same time, we still have to deal with the problem that the previous PR fixed.
`webpack-dev-server` and other implementations alike will try to access the previous 
compilation stats unintentionally. In JavaScript, this does not create a problem, however, 
in the world of Rust, the reference of compilation will be dropped as the next compilation starts.
The core part of this is that `Stats` is depending on that reference to generate the stats, which 
results in `get_hash` a failure on the JS side.

So here comes the workaround for that problem:

This is a really ugly workaround for avoid panic for accessing previous compilation.
webpack-dev-server and Modern.js dev server will detect whether the returned stats is available.
So this does not do harm to these frameworks.
webpack-dev-server: https://github.com/webpack/webpack-dev-server/blob/540c43852ea33f9cb18820e1cef05d5ddb86cc3e/lib/Server.js#L3222
Modern.js: https://github.com/web-infra-dev/modern.js/blob/63f916f882f7d16096949e264e119218c0ab8d7d/packages/server/server/src/dev-tools/dev-middleware/socketServer.ts#L172

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Tested in the internal project.

<!-- Can you please describe how you tested the changes you made to the code? -->
