### PR TITLE
perf: reduce ModuleGraphModule memory size

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -13,8 +13,8 @@ use crate::{
 
 pub(super) struct CodeSplitter<'me> {
   pub(super) compilation: &'me mut Compilation,
-  next_free_module_pre_order_index: usize,
-  next_free_module_post_order_index: usize,
+  next_free_module_pre_order_index: u32,
+  next_free_module_post_order_index: u32,
   queue: Vec<QueueItem>,
   queue_delayed: Vec<QueueItem>,
   split_point_modules: IdentifierSet,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -700,7 +700,7 @@ impl Compilation {
                   .module_graph
                   .module_graph_module_by_identifier_mut(&module.identifier())
                   .expect("Failed to get mgm");
-                mgm.dependencies = dep_ids;
+                mgm.dependencies = Box::new(dep_ids);
                 if let Some(current_profile) = current_profile {
                   mgm.set_profile(current_profile);
                 }

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -1,6 +1,6 @@
 mod entry;
 mod span;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
 
 pub use entry::*;
@@ -357,9 +357,9 @@ pub fn is_async_dependency(dep: &dyn ModuleDependency) -> bool {
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
-pub struct DependencyId(usize);
+pub struct DependencyId(u32);
 
-pub static DEPENDENCY_ID: Lazy<AtomicUsize> = Lazy::new(|| AtomicUsize::new(0));
+pub static DEPENDENCY_ID: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
 
 impl DependencyId {
   pub fn new() -> Self {
@@ -373,15 +373,15 @@ impl Default for DependencyId {
 }
 
 impl std::ops::Deref for DependencyId {
-  type Target = usize;
+  type Target = u32;
 
   fn deref(&self) -> &Self::Target {
     &self.0
   }
 }
 
-impl From<usize> for DependencyId {
-  fn from(id: usize) -> Self {
+impl From<u32> for DependencyId {
+  fn from(id: u32) -> Self {
     Self(id)
   }
 }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -325,7 +325,7 @@ impl ModuleGraph {
     removed
   }
 
-  pub fn get_pre_order_index(&self, module_identifier: &ModuleIdentifier) -> Option<usize> {
+  pub fn get_pre_order_index(&self, module_identifier: &ModuleIdentifier) -> Option<u32> {
     self
       .module_graph_module_by_identifier(module_identifier)
       .and_then(|mgm| mgm.pre_order_index)

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -20,15 +20,15 @@ pub struct ModuleGraphModule {
   pub module_identifier: ModuleIdentifier,
   // TODO remove this since its included in module
   pub module_type: ModuleType,
-  pub dependencies: Vec<DependencyId>,
-  pub(crate) pre_order_index: Option<usize>,
-  pub post_order_index: Option<usize>,
+  pub dependencies: Box<Vec<DependencyId>>,
+  pub(crate) pre_order_index: Option<u32>,
+  pub post_order_index: Option<u32>,
   pub module_syntax: ModuleSyntax,
   pub factory_meta: Option<FactoryMeta>,
   pub build_info: Option<BuildInfo>,
   pub build_meta: Option<BuildMeta>,
-  pub exports: ExportsInfo,
-  pub profile: Option<ModuleProfile>,
+  pub exports: Box<ExportsInfo>,
+  pub profile: Option<Box<ModuleProfile>>,
 }
 
 impl ModuleGraphModule {
@@ -48,7 +48,7 @@ impl ModuleGraphModule {
       factory_meta: None,
       build_info: None,
       build_meta: None,
-      exports: ExportsInfo::new(),
+      exports: Box::new(ExportsInfo::new()),
       profile: None,
     }
   }
@@ -175,11 +175,11 @@ impl ModuleGraphModule {
   }
 
   pub fn set_profile(&mut self, profile: ModuleProfile) {
-    self.profile = Some(profile);
+    self.profile = Some(Box::new(profile));
   }
 
   pub fn get_profile(&self) -> Option<&ModuleProfile> {
-    self.profile.as_ref()
+    self.profile.as_deref()
   }
 
   pub fn set_issuer_if_unset(&mut self, issuer: Option<ModuleIdentifier>) {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -10,9 +10,6 @@ pub struct ImportMetaHotAcceptDependency {
   request: JsWord,
   start: u32,
   end: u32,
-  category: &'static DependencyCategory,
-  dependency_type: &'static DependencyType,
-
   span: Option<ErrorSpan>,
 }
 
@@ -22,8 +19,6 @@ impl ImportMetaHotAcceptDependency {
       start,
       end,
       request,
-      category: &DependencyCategory::Esm,
-      dependency_type: &DependencyType::ImportMetaHotAccept,
       span,
       id: DependencyId::new(),
     }
@@ -36,11 +31,11 @@ impl Dependency for ImportMetaHotAcceptDependency {
   }
 
   fn category(&self) -> &DependencyCategory {
-    self.category
+    &DependencyCategory::Esm
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    self.dependency_type
+    &DependencyType::ImportMetaHotAccept
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -10,9 +10,6 @@ pub struct ImportMetaHotDeclineDependency {
   request: JsWord,
   start: u32,
   end: u32,
-  category: &'static DependencyCategory,
-  dependency_type: &'static DependencyType,
-
   span: Option<ErrorSpan>,
 }
 
@@ -22,8 +19,6 @@ impl ImportMetaHotDeclineDependency {
       start,
       end,
       request,
-      category: &DependencyCategory::Esm,
-      dependency_type: &DependencyType::ImportMetaHotDecline,
       span,
       id: DependencyId::new(),
     }
@@ -36,11 +31,11 @@ impl Dependency for ImportMetaHotDeclineDependency {
   }
 
   fn category(&self) -> &DependencyCategory {
-    self.category
+    &DependencyCategory::Esm
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    self.dependency_type
+    &DependencyType::ImportMetaHotDecline
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -10,9 +10,6 @@ pub struct ModuleHotAcceptDependency {
   request: JsWord,
   start: u32,
   end: u32,
-  category: &'static DependencyCategory,
-  dependency_type: &'static DependencyType,
-
   span: Option<ErrorSpan>,
 }
 
@@ -21,8 +18,6 @@ impl ModuleHotAcceptDependency {
     Self {
       id: DependencyId::new(),
       request,
-      category: &DependencyCategory::CommonJS,
-      dependency_type: &DependencyType::ModuleHotAccept,
       span,
       start,
       end,
@@ -36,11 +31,11 @@ impl Dependency for ModuleHotAcceptDependency {
   }
 
   fn category(&self) -> &DependencyCategory {
-    self.category
+    &DependencyCategory::CommonJS
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    self.dependency_type
+    &DependencyType::ModuleHotAccept
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -10,9 +10,6 @@ pub struct ModuleHotDeclineDependency {
   request: JsWord,
   start: u32,
   end: u32,
-  category: &'static DependencyCategory,
-  dependency_type: &'static DependencyType,
-
   span: Option<ErrorSpan>,
 }
 
@@ -21,8 +18,6 @@ impl ModuleHotDeclineDependency {
     Self {
       id: DependencyId::new(),
       request,
-      category: &DependencyCategory::CommonJS,
-      dependency_type: &DependencyType::ModuleHotDecline,
       span,
       start,
       end,
@@ -36,11 +31,11 @@ impl Dependency for ModuleHotDeclineDependency {
   }
 
   fn category(&self) -> &DependencyCategory {
-    self.category
+    &DependencyCategory::CommonJS
   }
 
   fn dependency_type(&self) -> &DependencyType {
-    self.dependency_type
+    &DependencyType::ModuleHotDecline
   }
 }
 

--- a/crates/rspack_util/src/comparators.rs
+++ b/crates/rspack_util/src/comparators.rs
@@ -13,7 +13,7 @@ pub fn compare_ids(a: &str, b: &str) -> Ordering {
   }
 }
 #[allow(clippy::comparison_chain)]
-pub fn compare_numbers(a: usize, b: usize) -> Ordering {
+pub fn compare_numbers(a: u32, b: u32) -> Ordering {
   if a < b {
     Ordering::Less
   } else if a > b {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- `DependencyId` size 16 -> 8, the `u32` is enough.
-  HMR Dependency size 56 -> 32
- `ModuleGraphModule` size 648 -> 336
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Not need.
<!-- Can you please describe how you tested the changes you made to the code? -->
