### PR TITLE
perf: reduce task structs memory size

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -526,7 +526,7 @@ impl From<FuncUseCtx> for RawFuncUseCtx {
       resource: value.resource,
       real_resource: value.real_resource,
       resource_query: value.resource_query,
-      issuer: value.issuer,
+      issuer: value.issuer.map(|s| s.to_string()),
     }
   }
 }

--- a/crates/rspack_core/src/compiler/resolver.rs
+++ b/crates/rspack_core/src/compiler/resolver.rs
@@ -22,7 +22,7 @@ pub struct ResolverFactory {
 
 #[derive(Debug, Hash, Eq, PartialEq, Clone)]
 pub struct ResolveOptionsWithDependencyType {
-  pub resolve_options: Option<Resolve>,
+  pub resolve_options: Option<Box<Resolve>>,
   pub resolve_to_context: bool,
   pub dependency_type: DependencyType,
   pub dependency_category: DependencyCategory,
@@ -60,7 +60,7 @@ impl ResolverFactory {
     } else {
       let base_options = self.base_options.clone();
       let merged_options = match &options.resolve_options {
-        Some(o) => base_options.merge(o.clone()),
+        Some(o) => base_options.merge(*o.clone()),
         None => base_options,
       };
       let normalized = merged_options.to_inner_options(

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -124,7 +124,7 @@ pub struct ContextModuleOptions {
   pub resource_query: Option<String>,
   pub resource_fragment: Option<String>,
   pub context_options: ContextOptions,
-  pub resolve_options: Option<Resolve>,
+  pub resolve_options: Option<Box<Resolve>>,
 }
 
 impl Display for ContextModuleOptions {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -177,7 +177,7 @@ pub trait Module: Debug + Send + Sync + AsAny + DynHash + DynEq + Identifiable {
   fn code_generation(&self, _compilation: &Compilation) -> Result<CodeGenerationResult>;
 
   /// Name matched against bundle-splitting conditions.
-  fn name_for_condition(&self) -> Option<Cow<str>> {
+  fn name_for_condition(&self) -> Option<Box<str>> {
     // Align with https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/Module.js#L852
     None
   }
@@ -207,11 +207,11 @@ pub trait Module: Debug + Send + Sync + AsAny + DynHash + DynEq + Identifiable {
   /// Resolve options matched by module rules.
   /// e.g `javascript/esm` may have special resolving options like `fullySpecified`.
   /// `css` and `css/module` may have special resolving options like `preferRelative`.
-  fn get_resolve_options(&self) -> Option<&Resolve> {
+  fn get_resolve_options(&self) -> Option<Box<Resolve>> {
     None
   }
 
-  fn get_context(&self) -> Option<&Context> {
+  fn get_context(&self) -> Option<Box<Context>> {
     None
   }
 

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -7,7 +7,7 @@ use crate::{BoxDependency, BoxModule, Context, FactoryMeta, Resolve};
 
 #[derive(Debug)]
 pub struct ModuleFactoryCreateData {
-  pub resolve_options: Option<Resolve>,
+  pub resolve_options: Option<Box<Resolve>>,
   pub context: Context,
   pub dependency: BoxDependency,
 }

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -174,8 +174,8 @@ impl ModuleGraphModule {
       .collect()
   }
 
-  pub fn set_profile(&mut self, profile: ModuleProfile) {
-    self.profile = Some(Box::new(profile));
+  pub fn set_profile(&mut self, profile: Box<ModuleProfile>) {
+    self.profile = Some(profile);
   }
 
   pub fn get_profile(&self) -> Option<&ModuleProfile> {

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -77,7 +77,7 @@ impl ModuleIssuer {
 pub struct NormalModule {
   id: ModuleIdentifier,
   /// Context of this module
-  context: Context,
+  context: Box<Context>,
   /// Request with loaders from config
   request: String,
   /// Request intended by user (without loaders from config)
@@ -104,7 +104,7 @@ pub struct NormalModule {
   source: NormalModuleSource,
 
   /// Resolve options derived from [Rule.resolve]
-  resolve_options: Option<Resolve>,
+  resolve_options: Option<Box<Resolve>>,
   /// Parser options derived from [Rule.parser]
   parser_options: Option<ParserOptions>,
   /// Generator options derived from [Rule.generator]
@@ -157,7 +157,7 @@ impl NormalModule {
     generator_options: Option<GeneratorOptions>,
     match_resource: Option<ResourceData>,
     resource_data: ResourceData,
-    resolve_options: Option<Resolve>,
+    resolve_options: Option<Box<Resolve>>,
     loaders: Vec<BoxLoader>,
     options: Arc<CompilerOptions>,
     contains_inline_loader: bool,
@@ -170,7 +170,7 @@ impl NormalModule {
     };
     Self {
       id: ModuleIdentifier::from(identifier),
-      context: get_context(&resource_data),
+      context: Box::new(get_context(&resource_data)),
       request,
       user_request,
       raw_request,
@@ -417,7 +417,7 @@ impl Module for NormalModule {
     }
   }
 
-  fn name_for_condition(&self) -> Option<Cow<str>> {
+  fn name_for_condition(&self) -> Option<Box<str>> {
     // Align with https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/NormalModule.js#L375
     let resource = self.resource_data.resource.as_str();
     let idx = resource.find('?');
@@ -433,8 +433,8 @@ impl Module for NormalModule {
     Some(Cow::Owned(contextify(options.context, self.user_request())))
   }
 
-  fn get_resolve_options(&self) -> Option<&Resolve> {
-    self.resolve_options.as_ref()
+  fn get_resolve_options(&self) -> Option<Box<Resolve>> {
+    self.resolve_options.clone()
   }
 
   fn get_code_generation_dependencies(&self) -> Option<&[Box<dyn ModuleDependency>]> {
@@ -453,8 +453,8 @@ impl Module for NormalModule {
     }
   }
 
-  fn get_context(&self) -> Option<&Context> {
-    Some(&self.context)
+  fn get_context(&self) -> Option<Box<Context>> {
+    Some(self.context.clone())
   }
 
   // Port from https://github.com/webpack/webpack/blob/main/lib/NormalModule.js#L1120

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -660,11 +660,11 @@ impl NormalModuleFactory {
     Ok(rules)
   }
 
-  fn calculate_resolve_options(&self, module_rules: &[&ModuleRule]) -> Option<Resolve> {
+  fn calculate_resolve_options(&self, module_rules: &[&ModuleRule]) -> Option<Box<Resolve>> {
     let mut resolved = None;
     module_rules.iter().for_each(|rule| {
       if let Some(resolve) = rule.resolve.as_ref() {
-        resolved = Some(resolve.to_owned());
+        resolved = Some(Box::new(resolve.to_owned()));
       }
     });
     resolved
@@ -777,7 +777,7 @@ pub struct NormalModuleFactoryContext {
   pub side_effects: Option<bool>,
   pub options: Arc<CompilerOptions>,
   pub lazy_visit_modules: std::collections::HashSet<String>,
-  pub issuer: Option<String>,
+  pub issuer: Option<Box<str>>,
 }
 
 /// Using `u32` instead of `usize` to reduce memory usage,

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -291,7 +291,7 @@ pub struct FuncUseCtx {
   pub resource: Option<String>,
   pub real_resource: Option<String>,
   pub resource_query: Option<String>,
-  pub issuer: Option<String>,
+  pub issuer: Option<Box<str>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -122,7 +122,7 @@ pub struct ResolveArgs<'a> {
   pub dependency_type: &'a DependencyType,
   pub dependency_category: &'a DependencyCategory,
   pub span: Option<ErrorSpan>,
-  pub resolve_options: Option<Resolve>,
+  pub resolve_options: Option<Box<Resolve>>,
   pub resolve_to_context: bool,
   pub optional: bool,
   pub file_dependencies: &'a mut HashSet<PathBuf>,

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -391,7 +391,7 @@ impl Stats<'_> {
             }
           })
           .collect();
-        reasons.sort_unstable_by(|a, b| a.module_identifier.cmp(&b.module_identifier));
+        reasons.sort_unstable();
         Ok(reasons)
       })
       .transpose()?;
@@ -620,7 +620,7 @@ pub struct StatsModuleIssuer {
   pub id: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StatsModuleReason {
   pub module_identifier: Option<String>,
   pub module_name: Option<String>,

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -114,7 +114,7 @@ struct RspackImporter {
 impl RspackImporter {
   pub fn new(include_paths: Vec<PathBuf>, factory: Arc<ResolverFactory>) -> Self {
     let sass_module_resolve = factory.get(ResolveOptionsWithDependencyType {
-      resolve_options: Some(Resolve {
+      resolve_options: Some(Box::new(Resolve {
         extensions: Some(vec![
           ".sass".to_owned(),
           ".scss".to_owned(),
@@ -126,13 +126,13 @@ impl RspackImporter {
         main_fields: Some(Vec::new()),
         // TODO: add restrictions field when resolver supports it.
         ..Default::default()
-      }),
+      })),
       resolve_to_context: false,
       dependency_type: DependencyType::Unknown,
       dependency_category: DependencyCategory::Unknown,
     });
     let sass_import_resolve = factory.get(ResolveOptionsWithDependencyType {
-      resolve_options: Some(Resolve {
+      resolve_options: Some(Box::new(Resolve {
         extensions: Some(vec![
           ".sass".to_owned(),
           ".scss".to_owned(),
@@ -148,13 +148,13 @@ impl RspackImporter {
         ]),
         main_fields: Some(Vec::new()),
         ..Default::default()
-      }),
+      })),
       resolve_to_context: false,
       dependency_type: DependencyType::Unknown,
       dependency_category: DependencyCategory::Unknown,
     });
     let rspack_module_resolve = factory.get(ResolveOptionsWithDependencyType {
-      resolve_options: Some(Resolve {
+      resolve_options: Some(Box::new(Resolve {
         // TODO: add dependencyType.
         condition_names: Some(vec!["sass".to_owned(), "style".to_owned()]),
         main_fields: Some(vec![
@@ -175,13 +175,13 @@ impl RspackImporter {
         ]),
         prefer_relative: Some(true),
         ..Default::default()
-      }),
+      })),
       resolve_to_context: false,
       dependency_type: DependencyType::Unknown,
       dependency_category: DependencyCategory::Unknown,
     });
     let rspack_import_resolve = factory.get(ResolveOptionsWithDependencyType {
-      resolve_options: Some(Resolve {
+      resolve_options: Some(Box::new(Resolve {
         condition_names: Some(vec!["sass".to_owned(), "style".to_owned()]),
         main_fields: Some(vec![
           "sass".to_owned(),
@@ -203,7 +203,7 @@ impl RspackImporter {
         ]),
         prefer_relative: Some(true),
         ..Default::default()
-      }),
+      })),
       resolve_to_context: false,
       dependency_type: DependencyType::Unknown,
       dependency_category: DependencyCategory::Unknown,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`TaskResult` size 392 -> 16
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
Not need.
<!-- Can you please describe how you tested the changes you made to the code? -->
