### PR TITLE
feat: support `ident` for builtin loader

### DIFF
--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -362,14 +362,6 @@ impl Module for NormalModule {
     build_info.build_dependencies = loader_result.build_dependencies;
     build_info.asset_filenames = loader_result.asset_filenames;
 
-    if self
-      .resource_resolved_data()
-      .resource
-      .contains("builtin-loader-ident")
-    {
-      dbg!(&dependencies);
-    }
-
     Ok(
       BuildResult {
         build_info,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -222,6 +222,10 @@ impl NormalModule {
     &mut self.source
   }
 
+  pub fn loaders(&self) -> &[BoxLoader] {
+    &self.loaders
+  }
+
   pub fn loaders_mut_vec(&mut self) -> &mut Vec<BoxLoader> {
     &mut self.loaders
   }
@@ -357,6 +361,14 @@ impl Module for NormalModule {
     build_info.missing_dependencies = loader_result.missing_dependencies;
     build_info.build_dependencies = loader_result.build_dependencies;
     build_info.asset_filenames = loader_result.asset_filenames;
+
+    if self
+      .resource_resolved_data()
+      .resource
+      .contains("builtin-loader-ident")
+    {
+      dbg!(&dependencies);
+    }
 
     Ok(
       BuildResult {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -280,6 +280,11 @@ impl NormalModuleFactory {
             .filter(|item| !item.is_empty())
             .collect::<Vec<_>>()
         };
+
+        if dependency.request().contains("ruleSet[0].use[0]") {
+          dbg!(&raw_elements);
+        }
+
         request_without_match_resource = raw_elements
           .pop()
           .ok_or_else(|| internal_error!("Invalid request: {request_without_match_resource}"))?;
@@ -409,6 +414,10 @@ impl NormalModuleFactory {
         }
       }
     };
+
+    if dependency.request().contains("ruleSet[0].use[0]") {
+      dbg!(&resource_data);
+    }
     //TODO: with contextScheme
     let resolved_module_rules = self
       .calculate_module_rules(
@@ -433,8 +442,6 @@ impl NormalModuleFactory {
       }
     };
     let contains_inline = !inline_loaders.is_empty();
-
-    // dbg!(&user_request);
 
     let loaders: Vec<BoxLoader> = {
       let mut pre_loaders: Vec<ModuleRuleUseLoader> = vec![];

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -281,10 +281,6 @@ impl NormalModuleFactory {
             .collect::<Vec<_>>()
         };
 
-        if dependency.request().contains("ruleSet[0].use[0]") {
-          dbg!(&raw_elements);
-        }
-
         request_without_match_resource = raw_elements
           .pop()
           .ok_or_else(|| internal_error!("Invalid request: {request_without_match_resource}"))?;
@@ -415,9 +411,6 @@ impl NormalModuleFactory {
       }
     };
 
-    if dependency.request().contains("ruleSet[0].use[0]") {
-      dbg!(&resource_data);
-    }
     //TODO: with contextScheme
     let resolved_module_rules = self
       .calculate_module_rules(

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -216,14 +216,16 @@ async fn process_resource<C: Send>(loader_context: &mut LoaderContext<'_, C>) ->
   }
 
   if loader_context.content.is_none() {
-    let r = loader_context
-      .__resource_data
-      .resource_path
-      .to_string_lossy()
-      .to_string();
     let result = tokio::fs::read(&loader_context.__resource_data.resource_path)
       .await
-      .map_err(|e| internal_error!("{e}, failed to read {r}"))?;
+      .map_err(|e| {
+        let r = loader_context
+          .__resource_data
+          .resource_path
+          .to_string_lossy()
+          .to_string();
+        internal_error!("{e}, failed to read {r}")
+      })?;
     loader_context.content = Some(Content::from(result));
   }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -216,7 +216,14 @@ async fn process_resource<C: Send>(loader_context: &mut LoaderContext<'_, C>) ->
   }
 
   if loader_context.content.is_none() {
-    let result = tokio::fs::read(&loader_context.__resource_data.resource_path).await?;
+    let r = loader_context
+      .__resource_data
+      .resource_path
+      .to_string_lossy()
+      .to_string();
+    let result = tokio::fs::read(&loader_context.__resource_data.resource_path)
+      .await
+      .map_err(|e| internal_error!("{e}, failed to read {r}"))?;
     loader_context.content = Some(Content::from(result));
   }
 

--- a/crates/rspack_loader_runner/src/scheme.rs
+++ b/crates/rspack_loader_runner/src/scheme.rs
@@ -27,6 +27,8 @@ impl From<&str> for Scheme {
   fn from(value: &str) -> Self {
     match value {
       "" => Self::None,
+      // To avoid conflict with builtin loader protocol
+      "builtin" => Self::None,
       "data" => Self::Data,
       "file" => Self::File,
       "http" => Self::Http,

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -273,10 +273,9 @@ function resolveStringifyLoaders(
 	else if (typeof use.options === "object") obj.query = "??" + (ident = path);
 	else obj.query = "?" + JSON.stringify(use.options);
 
-	if (ident) {
-		if (typeof use.options === "object") {
-			compiler.ruleSet.references.set(ident, use.options);
-		}
+	if (use.options && typeof use.options === "object") {
+		if (!ident) ident = "[[missing ident]]";
+		compiler.ruleSet.references.set(ident, use.options);
 	}
 
 	return obj.path + obj.query + obj.fragment;

--- a/packages/rspack/tests/configCases/loader/builtin-loader-ident/index.js
+++ b/packages/rspack/tests/configCases/loader/builtin-loader-ident/index.js
@@ -1,4 +1,8 @@
 it("should use inline builtin loader with ident", () => {
-	const { lib } = require("builtin:swc-loader??builtin-swc-loader!./lib.ts");
-	// expect(lib).toBe("lib");
+	const {
+		lib,
+		foo
+	} = require("builtin:swc-loader??builtin-swc-loader!./lib.ts");
+	expect(lib).toBe("lib");
+	expect(foo("a")).toBe("a");
 });

--- a/packages/rspack/tests/configCases/loader/builtin-loader-ident/index.js
+++ b/packages/rspack/tests/configCases/loader/builtin-loader-ident/index.js
@@ -1,0 +1,4 @@
+it("should use inline builtin loader with ident", () => {
+	const { lib } = require("builtin:swc-loader??builtin-swc-loader!./lib.ts");
+	// expect(lib).toBe("lib");
+});

--- a/packages/rspack/tests/configCases/loader/builtin-loader-ident/lib.ts
+++ b/packages/rspack/tests/configCases/loader/builtin-loader-ident/lib.ts
@@ -1,0 +1,1 @@
+export const lib: string = "lib";

--- a/packages/rspack/tests/configCases/loader/builtin-loader-ident/lib.ts
+++ b/packages/rspack/tests/configCases/loader/builtin-loader-ident/lib.ts
@@ -1,1 +1,4 @@
 export const lib: string = "lib";
+export function foo<T>(val: T): T {
+	return val;
+}

--- a/packages/rspack/tests/configCases/loader/builtin-loader-ident/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/builtin-loader-ident/webpack.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								parser: {
+									syntax: "typescript"
+								}
+							}
+						},
+						ident: "builtin-swc-loader"
+					}
+				]
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support `ident` for builtin loader. You can now use `ident` as a way to pass options to builtin loaders. See test changes for details.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

See test changes.

<!-- Can you please describe how you tested the changes you made to the code? -->
