### PR TITLE
refactor: add InitFragment trait

### DIFF
--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -2,13 +2,13 @@ use std::fmt::Debug;
 
 use rspack_sources::{BoxSource, ReplaceSource};
 
-use crate::{Compilation, InitFragment, Module, RuntimeGlobals};
+use crate::{BoxInitFragment, Compilation, Module, RuntimeGlobals};
 
 pub struct TemplateContext<'a> {
   pub compilation: &'a Compilation,
   pub module: &'a dyn Module,
   pub runtime_requirements: &'a mut RuntimeGlobals,
-  pub init_fragments: &'a mut Vec<InitFragment>,
+  pub init_fragments: &'a mut Vec<BoxInitFragment>,
 }
 
 pub type TemplateReplaceSource = ReplaceSource<BoxSource>;

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -3,8 +3,8 @@ use regex::Regex;
 use swc_core::ecma::atoms::JsWord;
 
 use crate::{
-  Compilation, DependencyId, ExportsType, FakeNamespaceObjectMode, InitFragment, InitFragmentStage,
-  ModuleGraph, ModuleIdentifier, RuntimeGlobals, TemplateContext,
+  Compilation, DependencyId, ExportsType, FakeNamespaceObjectMode, InitFragmentStage, ModuleGraph,
+  ModuleIdentifier, NormalInitFragment, RuntimeGlobals, TemplateContext,
 };
 
 pub fn export_from_import(
@@ -47,13 +47,13 @@ pub fn export_from_import(
         }
       } else if matches!(exports_type, ExportsType::DefaultOnly | ExportsType::DefaultWithNamed) {
         runtime_requirements.insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
-        init_fragments.push(InitFragment::new(
+        init_fragments.push(Box::new(NormalInitFragment::new(
           format!(
             "var {import_var}_namespace_cache;\n",
           ),
           InitFragmentStage::StageHarmonyExports,
           None,
-        ));
+        )));
         return format!("/*#__PURE__*/ ({import_var}_namespace_cache || ({import_var}_namespace_cache = {}({import_var}{})))", RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT, if matches!(exports_type, ExportsType::DefaultOnly) { "" } else { ", 2" });
       }
   }

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -10,7 +10,8 @@ use crate::{
   rspack_sources::{BoxSource, RawSource, Source, SourceExt},
   to_identifier, BuildContext, BuildInfo, BuildMetaExportsType, BuildResult, ChunkInitFragments,
   ChunkUkey, CodeGenerationDataUrl, CodeGenerationResult, Compilation, Context, ExternalType,
-  InitFragment, InitFragmentStage, LibIdentOptions, Module, ModuleType, RuntimeGlobals, SourceType,
+  InitFragmentStage, LibIdentOptions, Module, ModuleType, NormalInitFragment, RuntimeGlobals,
+  SourceType,
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -129,7 +130,7 @@ impl ExternalModule {
         if compilation.options.output.module {
           chunk_init_fragments
             .entry("external module node-commonjs".to_string())
-            .or_insert(InitFragment::new(
+            .or_insert(NormalInitFragment::new(
               "import { createRequire as __WEBPACK_EXTERNAL_createRequire } from 'module';\n"
                 .to_string(),
               InitFragmentStage::StageHarmonyImports,
@@ -171,7 +172,7 @@ impl ExternalModule {
           let identifier = to_identifier(id);
           chunk_init_fragments
             .entry(format!("external module import {identifier}"))
-            .or_insert(InitFragment::new(
+            .or_insert(NormalInitFragment::new(
               format!(
                 "import * as __WEBPACK_EXTERNAL_MODULE_{identifier}__ from '{}';\n",
                 self.request.as_str()

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -1,15 +1,24 @@
+use rspack_sources::{BoxSource, ConcatSource, RawSource, SourceExt};
+use rspack_util::ext::AsAny;
 use rustc_hash::FxHashMap as HashMap;
+use swc_core::ecma::atoms::JsWord;
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct InitFragment {
+use crate::{ExportsArgument, RuntimeGlobals};
+
+pub trait InitFragment: AsAny {}
+
+pub type BoxInitFragment = Box<dyn InitFragment>;
+
+#[derive(Debug, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
+pub struct NormalInitFragment {
   pub content: String,
   pub stage: InitFragmentStage,
-  pub end_content: Option<String>,
+  pub end_content: Option<Box<String>>,
 }
 
-impl InitFragment {
-  pub fn new(content: String, stage: InitFragmentStage, end_content: Option<String>) -> Self {
-    InitFragment {
+impl NormalInitFragment {
+  pub fn new(content: String, stage: InitFragmentStage, end_content: Option<Box<String>>) -> Self {
+    NormalInitFragment {
       content,
       stage,
       end_content,
@@ -17,7 +26,35 @@ impl InitFragment {
   }
 }
 
-#[derive(Debug, Copy, Clone, Hash, PartialEq, PartialOrd, Eq, Ord)]
+impl InitFragment for NormalInitFragment {}
+
+#[derive(Debug)]
+pub struct HarmonyExportInitFragment {
+  pub export_map: HashMap<JsWord, JsWord>,
+}
+
+impl InitFragment for HarmonyExportInitFragment {}
+
+macro_rules! impl_init_fragment_downcast_helpers {
+  ($ty:ty, $ident:ident) => {
+    impl dyn InitFragment + '_ {
+      ::paste::paste! {
+        pub fn [<as_ $ident>](&self) -> Option<& $ty> {
+          self.as_any().downcast_ref::<$ty>()
+        }
+
+        pub fn [<as_ $ident _mut>](&mut self) -> Option<&mut $ty> {
+          self.as_any_mut().downcast_mut::<$ty>()
+        }
+      }
+    }
+  };
+}
+
+impl_init_fragment_downcast_helpers!(NormalInitFragment, normal_init_fragment);
+impl_init_fragment_downcast_helpers!(HarmonyExportInitFragment, harmony_export_init_fragment);
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum InitFragmentStage {
   StageConstants,
   StageAsyncBoundary,
@@ -29,4 +66,79 @@ pub enum InitFragmentStage {
   StageAsyncHarmonyImports,
 }
 
-pub type ChunkInitFragments = HashMap<String, InitFragment>;
+pub type ChunkInitFragments = HashMap<String, NormalInitFragment>;
+
+pub fn render_init_fragments(
+  source: BoxSource,
+  fragments: &mut Vec<&mut NormalInitFragment>,
+) -> BoxSource {
+  // here use sort_by_key because need keep order equal stage fragments
+  fragments.sort_by_key(|m| m.stage);
+  // merge same init fragments
+  fragments.dedup();
+
+  let mut sources = vec![];
+
+  fragments.iter_mut().for_each(|f| {
+    sources.push(RawSource::from(std::mem::take(&mut f.content)).boxed());
+  });
+
+  sources.push(source);
+
+  fragments.iter_mut().rev().for_each(|f| {
+    if let Some(box end_content) = std::mem::take(&mut f.end_content) {
+      sources.push(RawSource::from(end_content).boxed());
+    }
+  });
+
+  ConcatSource::new(sources).boxed()
+}
+
+pub fn render_box_init_fragments(
+  mut fragments: Vec<BoxInitFragment>,
+  source: BoxSource,
+  exports_argument: ExportsArgument,
+  runtime_requirements: &mut RuntimeGlobals,
+) -> BoxSource {
+  let mut normal_init_fragments = vec![];
+
+  let mut harmony_export_init_fragments =
+    merge_harmony_export_init_fragments(&mut fragments, exports_argument, runtime_requirements);
+  if let Some(fragment) = harmony_export_init_fragments.as_mut() {
+    normal_init_fragments.push(fragment);
+  }
+
+  normal_init_fragments.extend(
+    fragments
+      .iter_mut()
+      .filter_map(|f| f.as_normal_init_fragment_mut())
+      .collect::<Vec<_>>(),
+  );
+  render_init_fragments(source, &mut normal_init_fragments)
+}
+
+fn merge_harmony_export_init_fragments(
+  fragments: &mut [BoxInitFragment],
+  exports_argument: ExportsArgument,
+  runtime_requirements: &mut RuntimeGlobals,
+) -> Option<NormalInitFragment> {
+  let mut export_map = HashMap::default();
+  fragments.iter_mut().for_each(|f| {
+    if let Some(f) = f.as_harmony_export_init_fragment_mut() {
+      export_map.extend(std::mem::take(&mut f.export_map))
+    }
+  });
+
+  if !export_map.is_empty() {
+    runtime_requirements.insert(RuntimeGlobals::EXPORTS);
+    runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
+
+    return Some(NormalInitFragment::new(
+      format!("{}({exports_argument}, {});\n", "", ""),
+      InitFragmentStage::StageHarmonyExports,
+      None,
+    ));
+  }
+
+  None
+}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  DependencyTemplate, InitFragment, InitFragmentStage, RuntimeGlobals, TemplateContext,
+  DependencyTemplate, InitFragmentStage, NormalInitFragment, RuntimeGlobals, TemplateContext,
   TemplateReplaceSource,
 };
 
@@ -39,7 +39,7 @@ impl DependencyTemplate for ModuleDecoratorDependency {
       .expect("should have mgm")
       .get_module_argument();
 
-    init_fragments.push(InitFragment::new(
+    init_fragments.push(Box::new(NormalInitFragment::new(
       format!(
         "/* module decorator */ {} = {}({});\n",
         module_argument,
@@ -48,6 +48,6 @@ impl DependencyTemplate for ModuleDecoratorDependency {
       ),
       InitFragmentStage::StageProvides,
       None,
-    ));
+    )));
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  DependencyTemplate, InitFragment, InitFragmentStage, RuntimeGlobals, TemplateContext,
+  DependencyTemplate, InitFragmentStage, NormalInitFragment, RuntimeGlobals, TemplateContext,
   TemplateReplaceSource,
 };
 
@@ -24,7 +24,7 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
     // TODO __esModule is used
     runtime_requirements.insert(RuntimeGlobals::MAKE_NAMESPACE_OBJECT);
     runtime_requirements.insert(RuntimeGlobals::EXPORTS);
-    init_fragments.push(InitFragment::new(
+    init_fragments.push(Box::new(NormalInitFragment::new(
       format!(
         "'use strict';\n{}({});\n", // todo remove strict
         RuntimeGlobals::MAKE_NAMESPACE_OBJECT,
@@ -36,12 +36,12 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
       ),
       InitFragmentStage::StageHarmonyExportsCompatibility,
       None,
-    ));
+    )));
 
     if compilation.module_graph.is_async(&module.identifier()) {
       runtime_requirements.insert(RuntimeGlobals::MODULE);
       runtime_requirements.insert(RuntimeGlobals::ASYNC_MODULE);
-      init_fragments.push(InitFragment::new(
+      init_fragments.push(Box::new(NormalInitFragment::new(
         format!(
           "{}({}, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) {{ try {{\n",
           RuntimeGlobals::ASYNC_MODULE,
@@ -52,8 +52,8 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
             .get_module_argument()
         ),
         InitFragmentStage::StageAsyncBoundary,
-        Some("\n__webpack_async_result__();\n} catch(e) { __webpack_async_result__(e); } });".to_string()),
-      ));
+        Some("\n__webpack_async_result__();\n} catch(e) { __webpack_async_result__(e); } });".to_string().into()),
+      )));
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   export_from_import, get_exports_type, ConnectionState, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, ErrorSpan, ExportsType, InitFragment,
-  InitFragmentStage, ModuleDependency, ModuleGraph, ModuleIdentifier, RuntimeGlobals,
+  DependencyId, DependencyTemplate, DependencyType, ErrorSpan, ExportsType, InitFragmentStage,
+  ModuleDependency, ModuleGraph, ModuleIdentifier, NormalInitFragment, RuntimeGlobals,
   TemplateContext, TemplateReplaceSource,
 };
 use rustc_hash::FxHashSet as HashSet;
@@ -90,7 +90,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
         .get_exports_argument();
       runtime_requirements.insert(RuntimeGlobals::EXPORTS);
       runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
-      init_fragments.push(InitFragment::new(
+      init_fragments.push(Box::new(NormalInitFragment::new(
         format!(
           "{}({exports_argument}, {});\n",
           RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
@@ -98,7 +98,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
         ),
         InitFragmentStage::StageHarmonyExports,
         None,
-      ));
+      )));
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   AsModuleDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ExportsSpec, InitFragment, InitFragmentStage, RuntimeGlobals, TemplateContext,
-  TemplateReplaceSource,
+  DependencyType, ExportsSpec, InitFragmentStage, NormalInitFragment, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -85,7 +85,7 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
         .collect::<Vec<_>>();
       if !exports.is_empty() {
         runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
-        init_fragments.push(InitFragment::new(
+        init_fragments.push(Box::new(NormalInitFragment::new(
           format!(
             "{}({exports_argument}, {});\n",
             RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
@@ -93,7 +93,7 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
           ),
           InitFragmentStage::StageHarmonyExports,
           None,
-        ));
+        )));
       } else {
         // dbg!(&used_exports);
         // dbg!(&self.exports);

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -2,8 +2,8 @@ use rspack_core::tree_shaking::symbol::{self, IndirectTopLevelSymbol};
 use rspack_core::tree_shaking::visitor::SymbolRef;
 use rspack_core::{
   import_statement, ConnectionState, Dependency, DependencyCategory, DependencyCondition,
-  DependencyId, DependencyTemplate, DependencyType, ErrorSpan, InitFragment, InitFragmentStage,
-  ModuleDependency, ModuleIdentifier, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  DependencyId, DependencyTemplate, DependencyType, ErrorSpan, InitFragmentStage, ModuleDependency,
+  ModuleIdentifier, NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 use rspack_core::{ExportsReferencedType, ModuleGraph, RuntimeSpec};
 use rustc_hash::FxHashSet as HashSet;
@@ -148,29 +148,29 @@ impl DependencyTemplate for HarmonyImportDependency {
       .module_graph
       .get_import_var(&module.identifier(), &self.request);
     if compilation.module_graph.is_async(ref_module) {
-      init_fragments.push(InitFragment::new(
+      init_fragments.push(Box::new(NormalInitFragment::new(
         content.0,
         InitFragmentStage::StageHarmonyImports,
         None,
-      ));
-      init_fragments.push(InitFragment::new(
+      )));
+      init_fragments.push(Box::new(NormalInitFragment::new(
         format!(
           "var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([{import_var}]);\n([{import_var}] = __webpack_async_dependencies__.then ? (await __webpack_async_dependencies__)() : __webpack_async_dependencies__);"
         ),
         InitFragmentStage::StageHarmonyImports,
         None,
-      ));
-      init_fragments.push(InitFragment::new(
+      )));
+      init_fragments.push(Box::new(NormalInitFragment::new(
         content.1,
         InitFragmentStage::StageAsyncHarmonyImports,
         None,
-      ));
+      )));
     } else {
-      init_fragments.push(InitFragment::new(
+      init_fragments.push(Box::new(NormalInitFragment::new(
         format!("{}{}", content.0, content.1),
         InitFragmentStage::StageHarmonyImports,
         None,
-      ));
+      )));
     }
     if self.export_all {
       runtime_requirements.insert(RuntimeGlobals::EXPORT_STAR);
@@ -179,7 +179,7 @@ impl DependencyTemplate for HarmonyImportDependency {
         .module_graph_module_by_identifier(&module.identifier())
         .expect("should have mgm")
         .get_exports_argument();
-      init_fragments.push(InitFragment::new(
+      init_fragments.push(Box::new(NormalInitFragment::new(
         format!(
           "{}.{}({import_var}, {exports_argument});\n",
           RuntimeGlobals::REQUIRE,
@@ -191,7 +191,7 @@ impl DependencyTemplate for HarmonyImportDependency {
           InitFragmentStage::StageHarmonyImports
         },
         None,
-      ));
+      )));
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -6,12 +6,11 @@ use rspack_core::tree_shaking::analyzer::OptimizeAnalyzer;
 use rspack_core::tree_shaking::js_module::JsModule;
 use rspack_core::tree_shaking::visitor::OptimizeAnalyzeResult;
 use rspack_core::{
-  GenerateContext, Module, ParseContext, ParseResult, ParserAndGenerator, SourceType,
-  TemplateContext,
+  render_box_init_fragments, GenerateContext, Module, ParseContext, ParseResult,
+  ParserAndGenerator, SourceType, TemplateContext,
 };
 use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 
-use crate::runtime::render_init_fragments;
 use crate::utils::syntax_by_module_type;
 use crate::visitors::{run_before_pass, scan_dependencies, swc_visitor::resolver};
 #[derive(Debug)]
@@ -204,7 +203,12 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
           .for_each(|dependency| dependency.apply(&mut source, &mut context));
       };
 
-      Ok(render_init_fragments(source.boxed(), &mut init_fragments))
+      Ok(render_box_init_fragments(
+        init_fragments,
+        source.boxed(),
+        mgm.get_exports_argument(),
+        generate_context.runtime_requirements,
+      ))
     } else {
       Err(internal_error!(
         "Unsupported source type {:?} for plugin JavaScript",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add add InitFragment trait, because need add `HarmonyExportInitFragment` for `HarmonyExportSpecifierDependency` codegen. The treeshaking need refactor `HarmonyExportSpecifierDependency` codegen.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Not need.
<!-- Can you please describe how you tested the changes you made to the code? -->
