### PR TITLE
feat: implement HarmonyExportSpecifierDependency get_exports

### DIFF
--- a/crates/rspack/tests/tree-shaking/import-export-all-as-a-empty-module/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/import-export-all-as-a-empty-module/expected/main.js
@@ -3,9 +3,7 @@
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'aaa': function() { return _app__WEBPACK_IMPORTED_MODULE_1_; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'aaa': function() { return _app__WEBPACK_IMPORTED_MODULE_1_; },
   'routes': function() { return routes; }
 });
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./answer */"./answer.js");

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/expected/main.js
@@ -23,9 +23,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return _a__WEBPACK_IMPORTED_MODULE_0_.a; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'a': function() { return _a__WEBPACK_IMPORTED_MODULE_0_.a; },
   'b': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.b; }
 });
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a */"./a.js");

--- a/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/react-redux-like/expected/main.js
@@ -3,9 +3,7 @@
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Provider': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'Provider': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; },
   'useSelector': function() { return _selector_js__WEBPACK_IMPORTED_MODULE_1_["default"]; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");

--- a/crates/rspack/tests/tree-shaking/reexport-all-as-multi-level-nested/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/reexport-all-as-multi-level-nested/expected/main.js
@@ -3,10 +3,8 @@
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
+  'a': function() { return a; },
   'aa': function() { return _aa__WEBPACK_IMPORTED_MODULE_0_; }
-});
-__webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
 });
 /* harmony import */var _aa__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./aa */"./package/autogen/aa.js");
 

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/expected/main.js
@@ -11,9 +11,7 @@ console.log(_maths_js__WEBPACK_IMPORTED_MODULE_0_.square);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'xxx': function() { return _test_js__WEBPACK_IMPORTED_MODULE_0_; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'xxx': function() { return _test_js__WEBPACK_IMPORTED_MODULE_0_; },
   'square': function() { return square; }
 });
 /* harmony import */var _test_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./test.js */"./test.js");

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/expected/main.js
@@ -17,9 +17,7 @@ var c = "c";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'z': function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'z': function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; },
   'x': function() { return x; }
 });
 /* harmony import */var _c__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./c */"../node_modules/pmodule/c.js");
@@ -48,9 +46,7 @@ var z = "z";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   'x': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.x; },
-  'z': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'z': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; },
   'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a */"../node_modules/pmodule/a.js");

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/expected/main.js
@@ -3,9 +3,7 @@
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'z': function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'z': function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; },
   'x': function() { return x; }
 });
 /* harmony import */var _c__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./c */"../node_modules/pmodule/c.js");
@@ -34,9 +32,7 @@ var z = "z";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   'x': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.x; },
-  'z': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; }
-});
-__webpack_require__.d(__webpack_exports__, {
+  'z': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; },
   'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _b__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./b */"../node_modules/pmodule/b.js");

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -532,12 +532,6 @@ impl Compilation {
       while let Some(task) = process_dependencies_queue.get_task() {
         active_task_count += 1;
 
-        let original_module_identifier = &task.original_module_identifier;
-        let module = self
-          .module_graph
-          .module_by_identifier(original_module_identifier)
-          .expect("Module expected");
-
         let mut sorted_dependencies = HashMap::default();
 
         task.dependencies.into_iter().for_each(|dependency| {
@@ -560,8 +554,16 @@ impl Compilation {
               .entry(resource_identifier)
               .or_insert(vec![])
               .push(dependency);
+          } else {
+            self.module_graph.add_dependency(dependency);
           }
         });
+
+        let original_module_identifier = &task.original_module_identifier;
+        let module = self
+          .module_graph
+          .module_by_identifier(original_module_identifier)
+          .expect("Module expected");
 
         for dependencies in sorted_dependencies.into_values() {
           self.handle_module_creation(

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -241,8 +241,8 @@ pub struct ExportsSpec {
   pub can_mangle: Option<bool>,
   pub terminal_binding: Option<bool>,
   pub from: Option<ModuleGraphConnection>,
-  pub dependencies: Vec<ModuleIdentifier>,
-  pub hide_export: Vec<JsWord>,
+  pub dependencies: Option<Vec<ModuleIdentifier>>,
+  pub hide_export: Option<Vec<JsWord>>,
 }
 
 pub enum ExportsReferencedType {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
@@ -12,14 +12,14 @@ pub struct AnonymousFunctionRangeInfo {
 }
 
 #[derive(Debug)]
-pub struct HarmonyExpressionHeaderDependency {
+pub struct HarmonyExportExpressionDependency {
   pub start: u32,
   pub end: u32,
   pub declaration: bool,
   pub function: Option<AnonymousFunctionRangeInfo>,
 }
 
-impl HarmonyExpressionHeaderDependency {
+impl HarmonyExportExpressionDependency {
   pub fn new(
     start: u32,
     end: u32,
@@ -35,7 +35,7 @@ impl HarmonyExpressionHeaderDependency {
   }
 }
 
-impl DependencyTemplate for HarmonyExpressionHeaderDependency {
+impl DependencyTemplate for HarmonyExportExpressionDependency {
   fn apply(
     &self,
     source: &mut TemplateReplaceSource,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   AsModuleDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ExportsSpec, InitFragmentStage, NormalInitFragment, RuntimeGlobals,
+  DependencyType, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, HarmonyExportInitFragment,
   TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
@@ -9,14 +9,14 @@ use swc_core::ecma::atoms::JsWord;
 #[derive(Debug, Clone)]
 pub struct HarmonyExportSpecifierDependency {
   id: DependencyId,
-  exports: Vec<(JsWord, JsWord)>,
+  export: (JsWord, JsWord),
 }
 
 impl HarmonyExportSpecifierDependency {
-  pub fn new(exports: Vec<(JsWord, JsWord)>) -> Self {
+  pub fn new(export: (JsWord, JsWord)) -> Self {
     Self {
       id: DependencyId::new(),
-      exports,
+      export,
     }
   }
 }
@@ -35,7 +35,15 @@ impl Dependency for HarmonyExportSpecifierDependency {
   }
 
   fn get_exports(&self) -> Option<ExportsSpec> {
-    None
+    Some(ExportsSpec {
+      exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::String(self.export.0.clone())]),
+      priority: Some(1),
+      can_mangle: None,
+      terminal_binding: Some(true),
+      from: None,
+      dependencies: None,
+      hide_export: None,
+    })
   }
 }
 
@@ -48,67 +56,25 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
     code_generatable_context: &mut TemplateContext,
   ) {
     let TemplateContext {
-      runtime_requirements,
       init_fragments,
       compilation,
       module,
       ..
     } = code_generatable_context;
-    let exports_argument = compilation
-      .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
-      .expect("should have mgm")
-      .get_exports_argument();
-    runtime_requirements.insert(RuntimeGlobals::EXPORTS);
 
-    if !self.exports.is_empty() {
-      let used_exports = if compilation.options.builtins.tree_shaking.is_true() {
-        Some(
-          compilation
-            .module_graph
-            .get_exports_info(&module.identifier())
-            .get_used_exports(),
-        )
-      } else {
-        None
-      };
-      let exports = self
-        .exports
-        .clone()
-        .into_iter()
-        .filter(|s| {
-          if let Some(export_map) = &used_exports {
-            return export_map.contains(&s.0);
-          }
-          true
-        })
-        .collect::<Vec<_>>();
-      if !exports.is_empty() {
-        runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
-        init_fragments.push(Box::new(NormalInitFragment::new(
-          format!(
-            "{}({exports_argument}, {});\n",
-            RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
-            format_exports(&exports)
-          ),
-          InitFragmentStage::StageHarmonyExports,
-          None,
-        )));
-      } else {
-        // dbg!(&used_exports);
-        // dbg!(&self.exports);
-      }
+    let used = if compilation.options.builtins.tree_shaking.is_true() {
+      compilation
+        .module_graph
+        .get_exports_info(&module.identifier())
+        .get_used_exports()
+        .contains(&self.export.0)
+    } else {
+      true
+    };
+    if used {
+      init_fragments.push(Box::new(HarmonyExportInitFragment::new(
+        self.export.clone(),
+      )));
     }
   }
-}
-
-pub fn format_exports(exports: &[(JsWord, JsWord)]) -> String {
-  format!(
-    "{{\n  {}\n}}",
-    exports
-      .iter()
-      .map(|s| format!("'{}': function() {{ return {}; }}", s.0, s.1))
-      .collect::<Vec<_>>()
-      .join(",\n  ")
-  )
 }

--- a/crates/rspack_plugin_javascript/src/plugin/provided_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/provided_exports_plugin.rs
@@ -92,8 +92,8 @@ impl<'a> ProvidedExportsPlugin<'a> {
     let global_priority = &exports_spec.priority;
     let global_terminal_binding = exports_spec.terminal_binding.unwrap_or(false);
     let _export_dependencies = &exports_spec.dependencies;
-    if !exports_spec.hide_export.is_empty() {
-      for name in exports_spec.hide_export.iter() {
+    if let Some(hide_export) = exports_spec.hide_export {
+      for name in hide_export.iter() {
         let export_info = exports_info.export_info_mut(name);
         export_info.unuset_target(&dep_id);
       }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The pr add `HarmonyExportSpecifierDependency` `get_exports` implement to support treeshaking, and also merge `HarmonyExportInitFragment` to generate one `webpack_require.d`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Not need.
<!-- Can you please describe how you tested the changes you made to the code? -->
