### PR TITLE
chore: run oxlint on all files during lint-staged (for now)

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,8 @@
+export default {
+  "*.rs": "rustfmt --edition 2021",
+  "packages/**/*.{ts,js}": "prettier --write",
+  "x.mjs": "prettier --write",
+  "crates/rspack_plugin_runtime/**/*.{ts,js}": "prettier --write",
+  "*.toml": "npx @taplo/cli format",
+  "**/*.{ts,js,mjs}": () => "oxlint ."
+}

--- a/package.json
+++ b/package.json
@@ -29,14 +29,6 @@
     "test:ci": "cross-env NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:example && pnpm run test:unit && pnpm test:webpack",
     "test:webpack": "pnpm --filter \"webpack-test\" test:metric"
   },
-  "lint-staged": {
-    "*.rs": "rustfmt --edition 2021",
-    "packages/**/*.{ts,js}": "prettier --write",
-    "x.mjs": "prettier --write",
-    "crates/rspack_plugin_runtime/**/*.{ts,js}": "prettier --write",
-    "*.toml": "npx @taplo/cli format",
-    "**/*.{ts,js,mjs}": "oxlint"
-  },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {


### PR DESCRIPTION
Currently when a specific file is passed to oxlint (e.g. `/pwd/to/test.js`), it will lint the file despite having it specified in `.eslintignore`, this makes lint-staged useless when an ignored file is committed.

oxlint has the same behavior as eslint.

This PR makes lint-staged to run on all changed files. The overhead is manageable because oxlint completes within a second.

See
* https://github.com/okonet/lint-staged#how-can-i-ignore-files-from-eslintignore
* https://github.com/okonet/lint-staged#example-run-tsc-on-changes-to-typescript-files-but-do-not-pass-any-filename-arguments

## Test Plan

I verified the behaviour we want: when an ignored file is commited, it does not get linted.