### PR TITLE
feat: expose `EntryPlugin`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -115,15 +115,15 @@ export interface BuiltinPlugin {
 }
 
 export const enum BuiltinPluginKind {
-  Define = 0,
-  Provide = 1,
-  Banner = 2,
-  Progress = 3,
-  Copy = 4,
-  Html = 5,
-  SwcJsMinimizer = 6,
-  SwcCssMinimizer = 7,
-  Entry = 8
+  Define = 'Define',
+  Provide = 'Provide',
+  Banner = 'Banner',
+  Progress = 'Progress',
+  Copy = 'Copy',
+  Html = 'Html',
+  SwcJsMinimizer = 'SwcJsMinimizer',
+  SwcCssMinimizer = 'SwcCssMinimizer',
+  Entry = 'Entry'
 }
 
 export function cleanupGlobalTrace(): void

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -122,7 +122,8 @@ export const enum BuiltinPluginKind {
   Copy = 4,
   Html = 5,
   SwcJsMinimizer = 6,
-  SwcCssMinimizer = 7
+  SwcCssMinimizer = 7,
+  Entry = 8
 }
 
 export function cleanupGlobalTrace(): void
@@ -579,14 +580,20 @@ export interface RawDevServer {
   hot: boolean
 }
 
-export interface RawEntryDescription {
-  import: Array<string>
+export interface RawEntryOptions {
+  name?: string
   runtime?: string
   chunkLoading?: string
   asyncChunks?: boolean
   publicPath?: string
   baseUri?: string
   filename?: string
+}
+
+export interface RawEntryPluginOptions {
+  context: string
+  entry: string
+  options: RawEntryOptions
 }
 
 export interface RawExperiments {
@@ -806,13 +813,6 @@ export interface RawOptimizationOptions {
 }
 
 export interface RawOptions {
-  entry: Record<string, RawEntryDescription>
-  /**
-   * Using this Vector to track the original order of user land entry configuration
-   * std::collection::HashMap does not guarantee the insertion order, for more details you could refer
-   * https://doc.rust-lang.org/std/collections/index.html#iterators:~:text=For%20unordered%20collections%20like%20HashMap%2C%20the%20items%20will%20be%20yielded%20in%20whatever%20order%20the%20internal%20representation%20made%20most%20convenient.%20This%20is%20great%20for%20reading%20through%20all%20the%20contents%20of%20the%20collection.
-   */
-  entryOrder: Array<string>
   mode?: undefined | 'production' | 'development' | 'none'
   target: Array<string>
   context: string

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
 };
 use crate::RawEntryPluginOptions;
 
-#[napi]
+#[napi(string_enum)]
 #[derive(Debug)]
 pub enum BuiltinPluginKind {
   Define,

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -17,6 +17,7 @@ use rspack_error::{Error, Result};
 use rspack_napi_shared::NapiResultExt;
 use rspack_plugin_banner::BannerPlugin;
 use rspack_plugin_copy::CopyPlugin;
+use rspack_plugin_entry::EntryPlugin;
 use rspack_plugin_html::HtmlPlugin;
 use rspack_plugin_progress::ProgressPlugin;
 use rspack_plugin_swc_css_minimizer::SwcCssMinimizerPlugin;
@@ -26,6 +27,7 @@ pub use self::{
   raw_banner::RawBannerConfig, raw_copy::RawCopyConfig, raw_html::RawHtmlPluginConfig,
   raw_progress::RawProgressPluginConfig, raw_swc_js_minimizer::RawMinification,
 };
+use crate::RawEntryPluginOptions;
 
 #[napi]
 #[derive(Debug)]
@@ -38,6 +40,7 @@ pub enum BuiltinPluginKind {
   Html,
   SwcJsMinimizer,
   SwcCssMinimizer,
+  Entry,
 }
 
 #[napi(object)]
@@ -74,6 +77,13 @@ impl TryFrom<BuiltinPlugin> for BoxPlugin {
       .boxed(),
       BuiltinPluginKind::Html => {
         HtmlPlugin::new(downcast_into::<RawHtmlPluginConfig>(value.options)?.into()).boxed()
+      }
+      BuiltinPluginKind::Entry => {
+        let plugin_options = downcast_into::<RawEntryPluginOptions>(value.options)?;
+        let context = plugin_options.context.into();
+        let entry_request = plugin_options.entry;
+        let options = plugin_options.options.into();
+        EntryPlugin::new(context, entry_request, options).boxed()
       }
     };
     Ok(plugin)

--- a/crates/rspack_binding_options/src/options/raw_entry.rs
+++ b/crates/rspack_binding_options/src/options/raw_entry.rs
@@ -1,15 +1,39 @@
 use napi_derive::napi;
+use rspack_core::EntryOptions;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
-pub struct RawEntryDescription {
-  pub import: Vec<String>,
+pub struct RawEntryPluginOptions {
+  pub context: String,
+  pub entry: String,
+  pub options: RawEntryOptions,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
+pub struct RawEntryOptions {
+  pub name: Option<String>,
   pub runtime: Option<String>,
   pub chunk_loading: Option<String>,
   pub async_chunks: Option<bool>,
   pub public_path: Option<String>,
   pub base_uri: Option<String>,
   pub filename: Option<String>,
+}
+
+impl From<RawEntryOptions> for EntryOptions {
+  fn from(value: RawEntryOptions) -> Self {
+    Self {
+      name: value.name,
+      runtime: value.runtime,
+      chunk_loading: value.chunk_loading.as_deref().map(Into::into),
+      async_chunks: value.async_chunks,
+      public_path: value.public_path.map(Into::into),
+      base_uri: value.base_uri,
+      filename: value.filename.map(Into::into),
+    }
+  }
 }

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -47,7 +47,11 @@ impl<'me> CodeSplitter<'me> {
 
     for (name, entry_data) in &compilation.entries {
       let options = &entry_data.options;
-      let dependencies = &entry_data.dependencies;
+      let dependencies = [
+        compilation.global_entry.dependencies.clone(),
+        entry_data.dependencies.clone(),
+      ]
+      .concat();
       let module_identifiers = dependencies
         .iter()
         .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -73,8 +73,9 @@ impl Chunk {
     chunk_group_by_ukey: &'a ChunkGroupByUkey,
   ) -> Option<&'a EntryOptions> {
     for group_ukey in &self.groups {
-      if let Some(group) = chunk_group_by_ukey.get(group_ukey) && group.kind.is_entrypoint() {
-        return group.options.entry_options.as_ref()
+      if let Some(group) = chunk_group_by_ukey.get(group_ukey)
+      && let Some(entry_options) = group.kind.get_entry_options() {
+        return Some(entry_options)
       }
     }
     None

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -168,7 +168,8 @@ impl Compilation {
     }
   }
 
-  pub fn add_entry(&mut self, entry: DependencyId, name: String, options: EntryOptions) {
+  pub fn add_entry(&mut self, entry: DependencyId, options: EntryOptions) {
+    let name = options.name.as_ref().cloned().unwrap_or_default();
     if let Some(data) = self.entries.get_mut(&name) {
       data.dependencies.push(entry);
     } else {

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -92,6 +92,7 @@ where
         new_compilation.make_failed_module =
           std::mem::take(&mut self.compilation.make_failed_module);
         new_compilation.entries = std::mem::take(&mut self.compilation.entries);
+        new_compilation.global_entry = std::mem::take(&mut self.compilation.global_entry);
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
         new_compilation.file_dependencies = std::mem::take(&mut self.compilation.file_dependencies);

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -1,18 +1,20 @@
 use crate::{
-  AsDependencyTemplate, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId, DependencyType,
+  ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct EntryDependency {
   id: DependencyId,
   request: String,
+  context: Context,
 }
 
 impl EntryDependency {
-  pub fn new(request: String) -> Self {
+  pub fn new(request: String, context: Context) -> Self {
     Self {
       request,
+      context,
       id: DependencyId::new(),
     }
   }
@@ -29,6 +31,10 @@ impl Dependency for EntryDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::Entry
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    Some(&self.context)
   }
 }
 

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -30,8 +30,8 @@ pub use dependency_template::*;
 use dyn_clone::{clone_trait_object, DynClone};
 
 use crate::{
-  ChunkGroupOptions, ConnectionState, Context, ContextMode, ContextOptions, ErrorSpan, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier, ReferencedExport, RuntimeSpec,
+  ChunkGroupOptionsKindRef, ConnectionState, Context, ContextMode, ContextOptions, ErrorSpan,
+  ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ReferencedExport, RuntimeSpec,
 };
 
 // Used to describe dependencies' types, see webpack's `type` getter in `Dependency`
@@ -358,7 +358,7 @@ pub trait ModuleDependency: Dependency {
   }
 
   // TODO: wired to place ChunkGroupOptions on dependency, should place on AsyncDependenciesBlock
-  fn group_options(&self) -> Option<&ChunkGroupOptions> {
+  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
     None
   }
 

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -3,9 +3,9 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   is_async_dependency, module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject,
-  BuildMetaExportsType, ChunkGraph, ChunkGroupOptions, DependencyId, ExportsArgument, ExportsInfo,
-  ExportsType, FactoryMeta, ModuleArgument, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  ModuleIssuer, ModuleProfile, ModuleSyntax, ModuleType,
+  BuildMetaExportsType, ChunkGraph, ChunkGroupOptionsKindRef, DependencyId, ExportsArgument,
+  ExportsInfo, ExportsType, FactoryMeta, ModuleArgument, ModuleGraph, ModuleGraphConnection,
+  ModuleIdentifier, ModuleIssuer, ModuleProfile, ModuleSyntax, ModuleType,
 };
 
 #[derive(Debug)]
@@ -138,7 +138,7 @@ impl ModuleGraphModule {
   pub fn dynamic_depended_modules<'a>(
     &self,
     module_graph: &'a ModuleGraph,
-  ) -> Vec<(&'a ModuleIdentifier, Option<&'a ChunkGroupOptions>)> {
+  ) -> Vec<(&'a ModuleIdentifier, Option<ChunkGroupOptionsKindRef<'a>>)> {
     self
       .dependencies
       .iter()

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -1,6 +1,6 @@
 use indexmap::IndexMap;
 
-use crate::{ChunkLoading, DependencyId, Filename, PublicPath};
+use crate::{ChunkLoading, DependencyId, EntryOptions, Filename, PublicPath};
 
 pub type Entry = IndexMap<String, EntryData>;
 
@@ -21,14 +21,4 @@ pub struct EntryDescription {
 pub struct EntryData {
   pub dependencies: Vec<DependencyId>,
   pub options: EntryOptions,
-}
-
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct EntryOptions {
-  pub runtime: Option<String>,
-  pub chunk_loading: Option<ChunkLoading>,
-  pub async_chunks: Option<bool>,
-  pub public_path: Option<PublicPath>,
-  pub base_uri: Option<String>,
-  pub filename: Option<Filename>,
 }

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -17,7 +17,7 @@ pub struct EntryDescription {
   pub filename: Option<Filename>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EntryData {
   pub dependencies: Vec<DependencyId>,
   pub options: EntryOptions,

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -1,23 +1,23 @@
 #![feature(let_chains)]
 
 use rspack_core::{
-  BoxDependency, Compilation, EntryDependency, EntryOptions, MakeParam, Plugin, PluginContext,
-  PluginMakeHookOutput,
+  BoxDependency, Compilation, Context, EntryDependency, EntryOptions, MakeParam, Plugin,
+  PluginContext, PluginMakeHookOutput,
 };
 
 #[derive(Debug)]
 pub struct EntryPlugin {
-  name: String,
   options: EntryOptions,
   entry_request: String,
+  context: Context,
 }
 
 impl EntryPlugin {
-  pub fn new(name: String, entry_request: String, options: EntryOptions) -> Self {
+  pub fn new(context: Context, entry_request: String, options: EntryOptions) -> Self {
     Self {
-      name,
       options,
       entry_request,
+      context,
     }
   }
 }
@@ -33,9 +33,12 @@ impl Plugin for EntryPlugin {
     if let Some(state) = compilation.options.get_incremental_rebuild_make_state() && !state.is_first() {
       return Ok(());
     }
-    let dependency: BoxDependency = Box::new(EntryDependency::new(self.entry_request.clone()));
+    let dependency: BoxDependency = Box::new(EntryDependency::new(
+      self.entry_request.clone(),
+      self.context.clone(),
+    ));
     let dependency_id = dependency.id();
-    compilation.add_entry(*dependency_id, self.name.clone(), self.options.clone());
+    compilation.add_entry(*dependency_id, self.options.clone());
     param.add_force_build_dependency(*dependency_id, None);
     compilation.module_graph.add_dependency(dependency);
     Ok(())

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   module_namespace_promise, ChunkGroupOptions, Dependency, DependencyCategory, DependencyId,
   DependencyTemplate, DependencyType, ErrorSpan, ExportsReferencedType, ModuleDependency,
-  ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource, ChunkGroupOptionsKindRef,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -66,8 +66,8 @@ impl ModuleDependency for ImportDependency {
     self.span.as_ref()
   }
 
-  fn group_options(&self) -> Option<&ChunkGroupOptions> {
-    Some(&self.group_options)
+  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
+    Some(ChunkGroupOptionsKindRef::Normal(&self.group_options))
   }
 
   fn set_request(&mut self, request: String) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  module_namespace_promise, ChunkGroupOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ExportsReferencedType, ModuleDependency,
-  ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource, ChunkGroupOptionsKindRef,
+  module_namespace_promise, ChunkGroupOptions, ChunkGroupOptionsKindRef, Dependency,
+  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ExportsReferencedType, ModuleDependency, ModuleGraph, ReferencedExport, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  ChunkGroupOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ErrorSpan, ExportsReferencedType, ModuleDependency, ModuleGraph, RuntimeGlobals,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  ChunkGroupOptionsKindRef, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, EntryOptions, ErrorSpan, ExportsReferencedType, ModuleDependency, ModuleGraph,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -11,7 +11,7 @@ pub struct WorkerDependency {
   id: DependencyId,
   request: String,
   span: Option<ErrorSpan>,
-  group_options: ChunkGroupOptions,
+  group_options: EntryOptions,
   public_path: String,
 }
 
@@ -22,7 +22,7 @@ impl WorkerDependency {
     request: String,
     public_path: String,
     span: Option<ErrorSpan>,
-    group_options: ChunkGroupOptions,
+    group_options: EntryOptions,
   ) -> Self {
     Self {
       start,
@@ -67,8 +67,8 @@ impl ModuleDependency for WorkerDependency {
     self.request = request;
   }
 
-  fn group_options(&self) -> Option<&ChunkGroupOptions> {
-    Some(&self.group_options)
+  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
+    Some(ChunkGroupOptionsKindRef::Entry(&self.group_options))
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -1,8 +1,8 @@
 use std::hash::Hash;
 
 use rspack_core::{
-  BoxDependency, BoxDependencyTemplate, ChunkGroupOptions, ConstDependency, EntryOptions,
-  ModuleIdentifier, OutputOptions, SpanExt,
+  BoxDependency, BoxDependencyTemplate, ConstDependency, EntryOptions, ModuleIdentifier,
+  OutputOptions, SpanExt,
 };
 use rspack_hash::RspackHash;
 use swc_core::common::Spanned;
@@ -64,16 +64,14 @@ impl<'a> WorkerScanner<'a> {
       parsed_path.value,
       self.output_options.worker_public_path.clone(),
       Some(new_expr.span.into()),
-      ChunkGroupOptions {
+      EntryOptions {
         name,
-        entry_options: Some(EntryOptions {
-          runtime: Some(runtime),
-          chunk_loading: Some(self.output_options.worker_chunk_loading.clone()),
-          async_chunks: None,
-          public_path: None,
-          base_uri: None,
-          filename: None,
-        }),
+        runtime: Some(runtime),
+        chunk_loading: Some(self.output_options.worker_chunk_loading.clone()),
+        async_chunks: None,
+        public_path: None,
+        base_uri: None,
+        filename: None,
       },
     )));
     if let Some(range) = range {

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -346,8 +346,10 @@ impl TestConfig {
 
     assert!(context.is_absolute());
 
+    let root = c::Context::new(context.to_string_lossy().to_string());
+
     let options = CompilerOptions {
-      context: c::Context::new(context.to_string_lossy().to_string()),
+      context: root.clone(),
       output: c::OutputOptions {
         clean: self.output.clean,
         filename: c::Filename::from_str(&self.output.filename).expect("Should exist"),
@@ -442,9 +444,10 @@ impl TestConfig {
       for request in &desc.import {
         plugins.push(
           rspack_plugin_entry::EntryPlugin::new(
-            name.clone(),
+            root.clone(),
             request.to_owned(),
             rspack_core::EntryOptions {
+              name: Some(name.clone()),
               runtime: Some("runtime".to_string()),
               chunk_loading: None,
               async_chunks: Some(true),

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -238,8 +238,10 @@ export class RspackDevServer extends WebpackDevServer {
 			additionalEntries.push(`${clientPath}?${webSocketURLStr}`);
 		}
 
-		for (const key in compiler.options.entry) {
-			compiler.options.entry[key].import.unshift(...additionalEntries);
+		for (const additionalEntry of additionalEntries) {
+			new compiler.webpack.EntryPlugin(compiler.context, additionalEntry, {
+				name: undefined
+			}).apply(compiler);
 		}
 	}
 

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -3,10 +3,12 @@
 exports[`normalize options snapshot additional entires should added 1`] = `
 {
   "main": [
+    "<prefix>/./placeholder.js",
+  ],
+  "undefined": [
     "<prefix>/rspack-dev-client/src/reactRefreshEntry.js",
     "<prefix>/webpack/hot/dev-server.js",
     "<prefix>/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-    "<prefix>/./placeholder.js",
   ],
 }
 `;
@@ -128,10 +130,12 @@ exports[`normalize options snapshot port string 1`] = `
 exports[`normalize options snapshot react-refresh client added when react/refresh enabled 1`] = `
 {
   "main": [
+    "<prefix>/./placeholder.js",
+  ],
+  "undefined": [
     "<prefix>/rspack-dev-client/src/reactRefreshEntry.js",
     "<prefix>/webpack/hot/dev-server.js",
     "<prefix>/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-    "<prefix>/./placeholder.js",
   ],
 }
 `;

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -46,29 +46,6 @@ import {
 	deprecated_resolveBuiltins
 } from "./builtin-plugin";
 
-class EntryPlugin {
-	constructor(
-		public context: string,
-		public entry: string,
-		public options: {
-			name?: string;
-			runtime?: string;
-		} = {}
-	) {}
-	apply(compiler: Compiler) {
-		const entry = this.context
-			? path.resolve(this.context, this.entry)
-			: this.entry;
-
-		compiler.options.entry = {
-			[this.options.name || "main"]: {
-				import: [entry],
-				runtime: this.options.runtime
-			}
-		};
-	}
-}
-
 class NodeTargetPlugin {
 	apply() {}
 }
@@ -159,7 +136,6 @@ class Compiler {
 		this.builtinPlugins = [];
 		// to workaround some plugin access webpack, we may change dev-server to avoid this hack in the future
 		this.webpack = {
-			EntryPlugin, // modernjs/server use this to inject dev-client
 			HotModuleReplacementPlugin, // modernjs/server will auto inject this plugin not set
 			NormalModule,
 			get sources(): typeof import("webpack-sources") {
@@ -183,6 +159,9 @@ class Compiler {
 			},
 			get ProvidePlugin() {
 				return require("./builtin-plugin").ProvidePlugin;
+			},
+			get EntryPlugin() {
+				return require("./builtin-plugin").EntryPlugin;
 			},
 			WebpackError: Error,
 			ModuleFilenameHelpers,

--- a/packages/rspack/src/builtin-plugin/EntryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EntryPlugin.ts
@@ -1,0 +1,41 @@
+import { RawEntryOptions, RawEntryPluginOptions } from "@rspack/binding";
+import { BuiltinPluginKind, create } from "./base";
+import { ChunkLoading, EntryRuntime, Filename, PublicPath } from "..";
+
+export type EntryOptions = {
+	name?: string;
+	runtime?: EntryRuntime;
+	chunkLoading?: ChunkLoading;
+	asyncChunks?: boolean;
+	publicPath?: PublicPath;
+	baseUri?: string;
+	filename?: Filename;
+};
+export const EntryPlugin = create(
+	BuiltinPluginKind.Entry,
+	(
+		context: string,
+		entry: string,
+		options: EntryOptions
+	): RawEntryPluginOptions => {
+		return {
+			context,
+			entry,
+			options: getRawEntryOptions(options)
+		};
+	}
+);
+
+function getRawEntryOptions(entry: EntryOptions): RawEntryOptions {
+	const runtime = entry.runtime;
+	const chunkLoading = entry.chunkLoading;
+	return {
+		name: entry.name,
+		publicPath: entry.publicPath,
+		baseUri: entry.baseUri,
+		runtime: runtime === false ? undefined : runtime,
+		chunkLoading: chunkLoading === false ? "false" : chunkLoading,
+		asyncChunks: entry.asyncChunks,
+		filename: entry.filename
+	};
+}

--- a/packages/rspack/src/builtin-plugin/base.ts
+++ b/packages/rspack/src/builtin-plugin/base.ts
@@ -3,15 +3,15 @@ import { Compiler } from "..";
 
 // TODO: workaround for https://github.com/napi-rs/napi-rs/pull/1690
 export enum BuiltinPluginKind {
-	Define = 0,
-	Provide = 1,
-	Banner = 2,
-	Progress = 3,
-	Copy = 4,
-	Html = 5,
-	SwcJsMinimizer = 6,
-	SwcCssMinimizer = 7,
-	Entry = 8
+	Define = "Define",
+	Provide = "Provide",
+	Banner = "Banner",
+	Progress = "Progress",
+	Copy = "Copy",
+	Html = "Html",
+	SwcJsMinimizer = "SwcJsMinimizer",
+	SwcCssMinimizer = "SwcCssMinimizer",
+	Entry = "Entry"
 }
 
 export abstract class RspackBuiltinPlugin {

--- a/packages/rspack/src/builtin-plugin/base.ts
+++ b/packages/rspack/src/builtin-plugin/base.ts
@@ -10,7 +10,8 @@ export enum BuiltinPluginKind {
 	Copy = 4,
 	Html = 5,
 	SwcJsMinimizer = 6,
-	SwcCssMinimizer = 7
+	SwcCssMinimizer = 7,
+	Entry = 8
 }
 
 export abstract class RspackBuiltinPlugin {

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -4,6 +4,7 @@ export * from "./DefinePlugin";
 export * from "./ProvidePlugin";
 export * from "./BannerPlugin";
 export * from "./ProgressPlugin";
+export * from "./EntryPlugin";
 
 export * from "./HtmlPlugin";
 export * from "./CopyPlugin";

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -74,10 +74,7 @@ export const getRawOptions = (
 		"context, devtool, cache should not be nil after defaults"
 	);
 	const devtool = options.devtool === false ? "" : options.devtool;
-	let rawEntry = getRawEntry(options.entry);
 	return {
-		entry: rawEntry,
-		entryOrder: Object.keys(rawEntry),
 		mode: options.mode,
 		target: getRawTarget(options.target),
 		context: options.context,
@@ -121,24 +118,6 @@ export const getRawOptions = (
 		builtins: options.builtins as any
 	};
 };
-
-function getRawEntry(entry: EntryNormalized): RawOptions["entry"] {
-	const raw: RawOptions["entry"] = {};
-	for (const key of Object.keys(entry)) {
-		const runtime = entry[key].runtime;
-		const chunkLoading = entry[key].chunkLoading;
-		raw[key] = {
-			import: entry[key].import!,
-			publicPath: entry[key].publicPath,
-			baseUri: entry[key].baseUri,
-			runtime: runtime === false ? undefined : runtime,
-			chunkLoading: chunkLoading === false ? "false" : chunkLoading,
-			asyncChunks: entry[key].asyncChunks,
-			filename: entry[key].filename
-		};
-	}
-	return raw;
-}
 
 function getRawTarget(target: Target | undefined): RawOptions["target"] {
 	if (!target) {

--- a/packages/rspack/src/index.ts
+++ b/packages/rspack/src/index.ts
@@ -29,7 +29,8 @@ export {
 	HtmlPlugin,
 	SwcJsMinimizerPlugin,
 	SwcCssMinimizerPlugin,
-	CopyPlugin
+	CopyPlugin,
+	EntryPlugin
 } from "./builtin-plugin";
 export type {
 	DefinePluginOptions,
@@ -38,7 +39,8 @@ export type {
 	BannerPluginOptions,
 	HtmlPluginOptions,
 	SwcJsMinimizerPluginOptions,
-	CopyPluginOptions
+	CopyPluginOptions,
+	EntryOptions
 } from "./builtin-plugin";
 
 export { Watching };

--- a/packages/rspack/src/lib/EntryOptionPlugin.ts
+++ b/packages/rspack/src/lib/EntryOptionPlugin.ts
@@ -1,0 +1,88 @@
+/**
+ * The following code is modified based on
+ * https://github.com/webpack/webpack/blob/4b4ca3b/lib/EntryOptionPlugin.js
+ *
+ * MIT Licensed
+ * Author Tobias Koppers @sokra
+ * Copyright (c) JS Foundation and other contributors
+ * https://github.com/webpack/webpack/blob/main/LICENSE
+ */
+
+import assert from "assert";
+import { Compiler, EntryDescriptionNormalized, EntryNormalized } from "..";
+import { EntryOptions, EntryPlugin } from "../builtin-plugin";
+
+export default class EntryOptionPlugin {
+	apply(compiler: Compiler) {
+		compiler.hooks.entryOption.tap("EntryOptionPlugin", (context, entry) => {
+			EntryOptionPlugin.applyEntryOption(compiler, context, entry);
+			return true;
+		});
+	}
+
+	static applyEntryOption(
+		compiler: Compiler,
+		context: string,
+		entry: EntryNormalized
+	) {
+		// TODO: dynamic entry is not supported yet
+		if (typeof entry === "function") {
+			// const DynamicEntryPlugin = require("./DynamicEntryPlugin");
+			// new DynamicEntryPlugin(context, entry).apply(compiler);
+		} else {
+			for (const name of Object.keys(entry)) {
+				const desc = entry[name];
+				const options = EntryOptionPlugin.entryDescriptionToOptions(
+					compiler,
+					name,
+					desc
+				);
+				assert(
+					desc.import !== undefined,
+					"desc.import should not be undefined when EntryOptionPlugin.applyEntryOption"
+				);
+				for (const entry of desc.import) {
+					new EntryPlugin(context, entry, options).apply(compiler);
+				}
+			}
+		}
+	}
+
+	static entryDescriptionToOptions(
+		compiler: Compiler,
+		name: string,
+		desc: EntryDescriptionNormalized
+	): EntryOptions {
+		const options = {
+			name,
+			filename: desc.filename,
+			runtime: desc.runtime,
+			// layer: desc.layer,
+			// dependOn: desc.dependOn,
+			baseUri: desc.baseUri,
+			publicPath: desc.publicPath,
+			chunkLoading: desc.chunkLoading,
+			asyncChunks: desc.asyncChunks
+			// wasmLoading: desc.wasmLoading,
+			// library: desc.library
+		};
+		// if (desc.layer !== undefined && !compiler.options.experiments.layers) {
+		// 	throw new Error(
+		// 		"'entryOptions.layer' is only allowed when 'experiments.layers' is enabled"
+		// 	);
+		// }
+		// if (desc.chunkLoading) {
+		// 	const EnableChunkLoadingPlugin = require("./javascript/EnableChunkLoadingPlugin");
+		// 	EnableChunkLoadingPlugin.checkEnabled(compiler, desc.chunkLoading);
+		// }
+		// if (desc.wasmLoading) {
+		// 	const EnableWasmLoadingPlugin = require("./wasm/EnableWasmLoadingPlugin");
+		// 	EnableWasmLoadingPlugin.checkEnabled(compiler, desc.wasmLoading);
+		// }
+		// if (desc.library) {
+		// 	const EnableLibraryPlugin = require("./library/EnableLibraryPlugin");
+		// 	EnableLibraryPlugin.checkEnabled(compiler, desc.library.type);
+		// }
+		return options;
+	}
+}

--- a/packages/rspack/src/lib/EntryOptionPlugin.ts
+++ b/packages/rspack/src/lib/EntryOptionPlugin.ts
@@ -39,7 +39,7 @@ export default class EntryOptionPlugin {
 				);
 				assert(
 					desc.import !== undefined,
-					"desc.import should not be undefined when EntryOptionPlugin.applyEntryOption"
+					"desc.import should not be `undefined` once `EntryOptionPlugin.applyEntryOption` is called"
 				);
 				for (const entry of desc.import) {
 					new EntryPlugin(context, entry, options).apply(compiler);

--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -83,7 +83,6 @@ function createCompiler(userOptions: RspackOptions): Compiler {
 	compiler.hooks.environment.call();
 	compiler.hooks.afterEnvironment.call();
 	new RspackOptionsApply().process(compiler.options, compiler);
-	compiler.hooks.entryOption.call(options.context, options.entry);
 	compiler.hooks.initialize.call();
 	return compiler;
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- refactor and expose EntryPlugin
- compilation.globalEntry for [the `name: undefined` to prepend entry case](https://github.com/web-infra-dev/rspack/pull/4073/files#diff-6195dbe0219b3b7ba39567cf6de6d629fb3a7b78c582c6b0b2957d1425105922R243)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

- no need

<!-- Can you please describe how you tested the changes you made to the code? -->
