### PR TITLE
Update reactRefreshEntry.js Make dev-server compatible with globalThis

### DIFF
--- a/packages/rspack-dev-client/src/reactRefreshEntry.js
+++ b/packages/rspack-dev-client/src/reactRefreshEntry.js
@@ -1,4 +1,10 @@
 const RefreshRuntime = require("react-refresh/runtime");
 
-RefreshRuntime.injectIntoGlobalHook(globalThis);
-globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+let _globalThis;
+try {
+	_globalThis = globalThis;
+} catch(e) {
+	_globalThis = window;
+}
+RefreshRuntime.injectIntoGlobalHook(_globalThis);
+_globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;


### PR DESCRIPTION
Make dev-server compatible with globalThis

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Make dev-server compatible in chrome 49;
Only this line in dev-client, make the web project not been opend in chrome 49.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

I changed the code in my project/node_modules/@rspack/dev-client/src/reactRefreshEntry.js.
and my web project  worked.
