### PR TITLE
ci: only run `merge_group` tests on check being requested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       debug_enabled:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

I have no idea why every merge queue event is triggered on the main branch: 
<img width="545" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/64a936e8-5619-40c0-9d8a-96fa00110fd2">

However, it seems to me we can trigger the workflow only if checking is requested.  Action type `destroyed` is not what we should care about I guess. Please check on this @jerrykingxyz 
https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=destroyed#merge_group

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
