### PR TITLE
fix: make dev-server compatible with globalThis

### DIFF
--- a/packages/rspack-dev-client/src/reactRefreshEntry.js
+++ b/packages/rspack-dev-client/src/reactRefreshEntry.js
@@ -1,10 +1,4 @@
 const RefreshRuntime = require("react-refresh/runtime");
 
-let _globalThis;
-try {
-	_globalThis = globalThis;
-} catch (e) {
-	_globalThis = self;
-}
-RefreshRuntime.injectIntoGlobalHook(_globalThis);
-_globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+RefreshRuntime.injectIntoGlobalHook(self);
+self.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;

--- a/packages/rspack-dev-client/src/reactRefreshEntry.js
+++ b/packages/rspack-dev-client/src/reactRefreshEntry.js
@@ -1,4 +1,10 @@
 const RefreshRuntime = require("react-refresh/runtime");
 
-RefreshRuntime.injectIntoGlobalHook(globalThis);
-globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;
+let _globalThis;
+try {
+	_globalThis = globalThis;
+} catch (e) {
+	_globalThis = self;
+}
+RefreshRuntime.injectIntoGlobalHook(_globalThis);
+_globalThis.$RefreshSig$ = RefreshRuntime.createSignatureFunctionForTransform;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
Make dev-server compatible in chrome 49;
Only this line in dev-client, make the web project not been opened in chrome 49.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
I changed the code in my project/node_modules/@rspack/dev-client/src/reactRefreshEntry.js.
and my web project worked.