### PR TITLE
fix: align stats.modulesSpace default behaivor with webpack

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -301,6 +301,9 @@ export class Compilation {
 			.concat(optionsOrFallback(options.loggingDebug, []))
 			.map(normalizeFilter);
 
+		options.modulesSpace =
+			options.modulesSpace || (context.forToString ? 15 : Infinity);
+
 		return options;
 	}
 

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -116,7 +116,8 @@ function presetToOptions(name?: boolean | string): StatsOptions {
 			};
 		case "verbose":
 			return {
-				all: true
+				all: true,
+				modulesSpace: Infinity
 			};
 		case "errors-only":
 			return {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -610,6 +610,7 @@ export interface StatsOptions {
 	timings?: boolean;
 	builtAt?: boolean;
 	moduleAssets?: boolean;
+	modulesSpace?: number;
 	nestedModules?: boolean;
 	source?: boolean;
 	logging?: ("none" | "error" | "warn" | "info" | "log" | "verbose") | boolean;

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -613,10 +613,7 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 				options.source!
 			);
 			const groupedModules = factory.create(`${type}.modules`, array, context);
-			const limited = spaceLimited(
-				groupedModules,
-				15 /* options.modulesSpace */
-			);
+			const limited = spaceLimited(groupedModules, options.modulesSpace!);
 			object.modules = limited.children;
 			object.filteredModules = limited.filteredChildren;
 		},

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -202,11 +202,11 @@ describe("Stats", () => {
 		  │
 		2 │     return "This is b";
 		3 │ };
-		4 │ 
+		4 │
 		5 │ // Test CJS top-level return
 		6 │ return;
 		  │ ^^^^^^^ Return statement is not allowed here
-		7 │ 
+		7 │
 
 
 
@@ -237,7 +237,7 @@ describe("Stats", () => {
 				version: false,
 				modulesSpace: 3
 			}).modules?.length
-			// 3 -1 （max - filteredChildrenLineReserved）
+			// 2 = 3 - 1 = max - filteredChildrenLineReserved
 		).toBe(2);
 	});
 

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -202,11 +202,11 @@ describe("Stats", () => {
 		  │
 		2 │     return "This is b";
 		3 │ };
-		4 │
+		4 │ 
 		5 │ // Test CJS top-level return
 		6 │ return;
 		  │ ^^^^^^^ Return statement is not allowed here
-		7 │
+		7 │ 
 
 
 

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -202,16 +202,43 @@ describe("Stats", () => {
 		  │
 		2 │     return "This is b";
 		3 │ };
-		4 │ 
+		4 │
 		5 │ // Test CJS top-level return
 		6 │ return;
 		  │ ^^^^^^^ Return statement is not allowed here
-		7 │ 
+		7 │
 
 
 
 		rspack compiled with 1 error (27ec1c09308b67dcfd6f)"
 	`);
+	});
+
+	it("should output the specified number of modules when set stats.modulesSpace", async () => {
+		const stats = await compile({
+			context: __dirname,
+			entry: "./fixtures/abc"
+		});
+
+		expect(
+			stats?.toJson({
+				all: true,
+				timings: false,
+				builtAt: false,
+				version: false
+			}).modules?.length
+		).toBe(4);
+
+		expect(
+			stats?.toJson({
+				all: true,
+				timings: false,
+				builtAt: false,
+				version: false,
+				modulesSpace: 3
+			}).modules?.length
+			// 3 -1 （max - filteredChildrenLineReserved）
+		).toBe(2);
 	});
 
 	it("should have time log when logging verbose", async () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
