### PR TITLE
fix: patch `sendStats` of webpack-dev-server

### DIFF
--- a/packages/rspack-dev-server/src/patch.ts
+++ b/packages/rspack-dev-server/src/patch.ts
@@ -7,6 +7,8 @@ function restoreDevServerPatch() {
 	WebpackDevServer.prototype.sendStats = old;
 }
 
+// Patch webpack-dev-server to prevent it from failing to send stats.
+// See https://github.com/web-infra-dev/rspack/pull/4028 for details.
 function applyDevServerPatch() {
 	if (old) return restoreDevServerPatch;
 

--- a/packages/rspack-dev-server/src/patch.ts
+++ b/packages/rspack-dev-server/src/patch.ts
@@ -1,0 +1,32 @@
+import WebpackDevServer from "webpack-dev-server";
+
+let old: InstanceType<typeof WebpackDevServer>["sendStats"] | undefined;
+
+function restoreDevServerPatch() {
+	// @ts-expect-error private API
+	WebpackDevServer.prototype.sendStats = old;
+}
+
+function applyDevServerPatch() {
+	if (old) return restoreDevServerPatch;
+
+	// @ts-expect-error private API
+	old = WebpackDevServer.prototype.sendStats;
+
+	// @ts-expect-error private API
+	WebpackDevServer.prototype.sendStats = function sendStats__rspack_patched(
+		...args
+	) {
+		let stats = args[1];
+
+		if (!stats) {
+			return;
+		}
+
+		return old.apply(this, args);
+	};
+
+	return restoreDevServerPatch;
+}
+
+export { applyDevServerPatch };

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -16,8 +16,11 @@ import fs from "fs";
 import WebpackDevServer from "webpack-dev-server";
 import type { ResolvedDevServer, DevServer } from "./config";
 import { getRspackMemoryAssets } from "./middleware";
+import { applyDevServerPatch } from "./patch";
 // @ts-expect-error
 import { runtimePathRegexp } from "@rspack/dev-client/runtime-path-regexp";
+
+applyDevServerPatch();
 
 export class RspackDevServer extends WebpackDevServer {
 	/**

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -41,9 +41,8 @@ export class Stats {
 		const statsFactory = this.compilation.createStatsFactory(options);
 
 		// FIXME: This is a really ugly workaround for avoid panic for accessing previous compilation.
-		// webpack-dev-server and Modern.js dev server will detect whether the returned stats is available.
+		// Modern.js dev server will detect whether the returned stats is available.
 		// So this does not do harm to these frameworks.
-		// webpack-dev-server: https://github.com/webpack/webpack-dev-server/blob/540c43852ea33f9cb18820e1cef05d5ddb86cc3e/lib/Server.js#L3222
 		// Modern.js: https://github.com/web-infra-dev/modern.js/blob/63f916f882f7d16096949e264e119218c0ab8d7d/packages/server/server/src/dev-tools/dev-middleware/socketServer.ts#L172
 		let stats: StatsCompilation | null = null;
 		try {
@@ -69,9 +68,8 @@ export class Stats {
 		const statsPrinter = this.compilation.createStatsPrinter(options);
 
 		// FIXME: This is a really ugly workaround for avoid panic for accessing previous compilation.
-		// webpack-dev-server and Modern.js dev server will detect whether the returned stats is available.
+		// Modern.js dev server will detect whether the returned stats is available.
 		// So this does not do harm to these frameworks.
-		// webpack-dev-server: https://github.com/webpack/webpack-dev-server/blob/540c43852ea33f9cb18820e1cef05d5ddb86cc3e/lib/Server.js#L3222
 		// Modern.js: https://github.com/web-infra-dev/modern.js/blob/63f916f882f7d16096949e264e119218c0ab8d7d/packages/server/server/src/dev-tools/dev-middleware/socketServer.ts#L172
 		let stats: StatsCompilation | null = null;
 		try {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Patch webpack-dev-server to prevent it from reading empty stats (to whom using rspack-dev-server).
Continue: https://github.com/web-infra-dev/rspack/pull/4028

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Blocked by https://github.com/web-infra-dev/rspack/issues/4120

<!-- Can you please describe how you tested the changes you made to the code? -->
