### PR TITLE
revert: apply entry and externals eagerly

### DIFF
--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -343,7 +343,7 @@ class Compiler {
 			) {
 				new HttpExternalsPlugin(!!options.experiments.css).apply(this);
 			}
-			new EntryOptionPlugin().apply(this);
+			EntryOptionPlugin.applyEntryOption(this, this.context, options.entry);
 		}
 		// TODO: remove this when drop support for builtins options
 		options.builtins = deprecated_resolveBuiltins(

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -306,7 +306,7 @@ class Compiler {
 
 		const options = this.options;
 		// TODO: remove this in v0.4
-		{
+		if (this.parentCompilation === undefined) {
 			if (options.externals) {
 				assert(
 					options.externalsType,

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -39,42 +39,42 @@ export class RspackOptionsApply {
 		compiler.name = options.name;
 		compiler.outputFileSystem = fs;
 
-		if (options.externals) {
-			assert(
-				options.externalsType,
-				"options.externalsType should have value after `applyRspackOptionsDefaults`"
-			);
-			new ExternalsPlugin(options.externalsType, options.externals).apply(
-				compiler
-			);
-		}
+		// if (options.externals) {
+		// 	assert(
+		// 		options.externalsType,
+		// 		"options.externalsType should have value after `applyRspackOptionsDefaults`"
+		// 	);
+		// 	new ExternalsPlugin(options.externalsType, options.externals).apply(
+		// 		compiler
+		// 	);
+		// }
 
-		if (options.externalsPresets.node) {
-			new NodeTargetPlugin().apply(compiler);
-		}
-		if (options.externalsPresets.electronMain) {
-			new ElectronTargetPlugin("main").apply(compiler);
-		}
-		if (options.externalsPresets.electronPreload) {
-			new ElectronTargetPlugin("preload").apply(compiler);
-		}
-		if (options.externalsPresets.electronRenderer) {
-			new ElectronTargetPlugin("renderer").apply(compiler);
-		}
-		if (
-			options.externalsPresets.electron &&
-			!options.externalsPresets.electronMain &&
-			!options.externalsPresets.electronPreload &&
-			!options.externalsPresets.electronRenderer
-		) {
-			new ElectronTargetPlugin().apply(compiler);
-		}
-		if (
-			options.externalsPresets.web ||
-			(options.externalsPresets.node && options.experiments.css)
-		) {
-			new HttpExternalsPlugin(!!options.experiments.css).apply(compiler);
-		}
+		// if (options.externalsPresets.node) {
+		// 	new NodeTargetPlugin().apply(compiler);
+		// }
+		// if (options.externalsPresets.electronMain) {
+		// 	new ElectronTargetPlugin("main").apply(compiler);
+		// }
+		// if (options.externalsPresets.electronPreload) {
+		// 	new ElectronTargetPlugin("preload").apply(compiler);
+		// }
+		// if (options.externalsPresets.electronRenderer) {
+		// 	new ElectronTargetPlugin("renderer").apply(compiler);
+		// }
+		// if (
+		// 	options.externalsPresets.electron &&
+		// 	!options.externalsPresets.electronMain &&
+		// 	!options.externalsPresets.electronPreload &&
+		// 	!options.externalsPresets.electronRenderer
+		// ) {
+		// 	new ElectronTargetPlugin().apply(compiler);
+		// }
+		// if (
+		// 	options.externalsPresets.web ||
+		// 	(options.externalsPresets.node && options.experiments.css)
+		// ) {
+		// 	new HttpExternalsPlugin(!!options.experiments.css).apply(compiler);
+		// }
 
 		const runtimeChunk = options.optimization
 			.runtimeChunk as OptimizationRuntimeChunkNormalized;
@@ -85,7 +85,7 @@ export class RspackOptionsApply {
 				}
 			});
 		}
-		new EntryOptionPlugin().apply(compiler);
+		// new EntryOptionPlugin().apply(compiler);
 		assert(
 			options.context,
 			"options.context should have value after `applyRspackOptionsDefaults`"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

eagerly apply entry and externals is a break change, so revert it before we release a patch version

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
- eco-ci should pass
<!-- Can you please describe how you tested the changes you made to the code? -->
