### PR TITLE
feat: initialize future flags

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -606,6 +606,7 @@ export interface RawExperiments {
   asyncWebAssembly: boolean
   newSplitChunks: boolean
   css: boolean
+  rspackFuture: RawRspackFuture
 }
 
 export interface RawExternalItem {
@@ -955,6 +956,10 @@ export interface RawResolveOptions {
   fullySpecified?: boolean
   exportsFields?: Array<string>
   extensionAlias?: Record<string, Array<string>>
+}
+
+export interface RawRspackFuture {
+
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_options/src/options/mod.rs
+++ b/crates/rspack_binding_options/src/options/mod.rs
@@ -100,6 +100,7 @@ impl RawOptionsApply for RawOptions {
       },
       async_web_assembly: self.experiments.async_web_assembly,
       new_split_chunks: self.experiments.new_split_chunks,
+      rspack_future: self.experiments.rspack_future.into(),
     };
     let optimization = IS_ENABLE_NEW_SPLIT_CHUNKS.set(&experiments.new_split_chunks, || {
       self.optimization.apply(plugins)

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -13,6 +13,7 @@ pub struct RawIncrementalRebuild {
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
+#[allow(clippy::empty_structs_with_brackets)]
 pub struct RawRspackFuture {}
 
 #[derive(Deserialize, Debug, Default)]

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -1,4 +1,5 @@
 use napi_derive::napi;
+use rspack_core::RspackFuture;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Default)]
@@ -12,10 +13,22 @@ pub struct RawIncrementalRebuild {
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
+pub struct RawRspackFuture {}
+
+#[derive(Deserialize, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+#[napi(object)]
 pub struct RawExperiments {
   pub lazy_compilation: bool,
   pub incremental_rebuild: RawIncrementalRebuild,
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
   pub css: bool,
+  pub rspack_future: RawRspackFuture,
+}
+
+impl From<RawRspackFuture> for RspackFuture {
+  fn from(_value: RawRspackFuture) -> Self {
+    Self {}
+  }
 }

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -22,9 +22,13 @@ impl IncrementalRebuildMakeState {
 }
 
 #[derive(Debug, Default)]
+pub struct RspackFuture {}
+
+#[derive(Debug, Default)]
 pub struct Experiments {
   pub lazy_compilation: bool,
   pub incremental_rebuild: IncrementalRebuild,
   pub async_web_assembly: bool,
   pub new_split_chunks: bool,
+  pub rspack_future: RspackFuture,
 }

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -22,6 +22,7 @@ impl IncrementalRebuildMakeState {
 }
 
 #[derive(Debug, Default)]
+#[allow(clippy::empty_structs_with_brackets)]
 pub struct RspackFuture {}
 
 #[derive(Debug, Default)]

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -634,14 +634,16 @@ function getRawExperiments(
 		incrementalRebuild,
 		asyncWebAssembly,
 		newSplitChunks,
-		css
+		css,
+		rspackFuture
 	} = experiments;
 	assert(
 		!isNil(lazyCompilation) &&
 			!isNil(incrementalRebuild) &&
 			!isNil(asyncWebAssembly) &&
 			!isNil(newSplitChunks) &&
-			!isNil(css)
+			!isNil(css) &&
+			!isNil(rspackFuture)
 	);
 
 	return {
@@ -649,7 +651,8 @@ function getRawExperiments(
 		incrementalRebuild: getRawIncrementalRebuild(incrementalRebuild),
 		asyncWebAssembly,
 		newSplitChunks,
-		css
+		css,
+		rspackFuture
 	};
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -158,6 +158,7 @@ const applyExperimentsDefaults = (
 	D(experiments, "asyncWebAssembly", false);
 	D(experiments, "newSplitChunks", true);
 	D(experiments, "css", true); // we not align with webpack about the default value for better DX
+	D(experiments, "rspackFuture", {});
 
 	if (typeof experiments.incrementalRebuild === "object") {
 		D(experiments.incrementalRebuild, "make", true);

--- a/packages/rspack/src/config/schema.js
+++ b/packages/rspack/src/config/schema.js
@@ -399,6 +399,13 @@ module.exports = {
 				css: {
 					description: "Enable native css support.",
 					type: "boolean"
+				},
+				rspackFuture: {
+					description:
+						"Enable default behavior in the future version of Rspack",
+					type: "object",
+					additionalProperties: false,
+					properties: {}
 				}
 			}
 		},

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -655,6 +655,7 @@ export interface IncrementalRebuildOptions {
 	make?: boolean;
 	emitAsset?: boolean;
 }
+export interface RspackFutureOptions {}
 // TODO: discuss with webpack, should move to css generator options
 // export interface CssExperimentOptions {
 // 	exportsOnly?: boolean;
@@ -674,6 +675,7 @@ export interface ExperimentsNormalized {
 	newSplitChunks?: boolean;
 	css?: boolean;
 	futureDefaults?: boolean;
+	rspackFuture?: RspackFutureOptions;
 }
 
 ///// Watch /////

--- a/packages/rspack/src/config/zod/experiments.ts
+++ b/packages/rspack/src/config/zod/experiments.ts
@@ -15,6 +15,7 @@ export function experiments() {
 		lazyCompilation: z.boolean().optional(),
 		outputModule: z.boolean().optional(),
 		newSplitChunks: z.boolean().optional(),
-		css: z.boolean().optional()
+		css: z.boolean().optional(),
+		rspackFuture: z.strictObject({}).optional()
 	});
 }

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -24,6 +24,7 @@ exports[`snapshots should have the correct base config 1`] = `
     },
     "lazyCompilation": false,
     "newSplitChunks": true,
+    "rspackFuture": {},
   },
   "externals": undefined,
   "externalsPresets": {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Initializes future flags. Rspack learned the technique for future flag from remix team.
Future flagging is fundamentally the same as other terms you may heard of like `feature-gates`, `feature-flags`.

Essentially, in Rspack, when it comes to adopting a deprecation or a newly added feature that differs from 
the behavior of the previous version, a new future flag is added.

For example:

```js
module.exports = {
  experiments: {
    rspackFuture: {
       disableTransformByDefault: true, // opt-in new deprecations
       newResolver: true
    }
  }
}
```

| Version |  Future flag | Deprecation message | Stability of the future behavior |
| - | - |  - | - |
| Current minor | Added (Default: _same as the old behavior_) | Added | ⚠️ (Not guaranteed)  |
| Next minor |  Still available (Default: _new behavior enabled_)  | Still available | ✅ |
| Minor after the next minor | Removed | Removed | ✅ |

When adopting a new breaking behavior in Rspack, three steps are included: 

1. In the current minor version, a breaking change is added with a new future flag. However, 
**for the default behavior, this flag is off**. You can adopt this feature by switching the flag.
At the same time, a deprecation message with regard to the breaking will also be added. 
2. In the next minor, the flag will be **turned on by default**. This is a **breaking change**. 
At this stage, you can still switch to the old implementation. This leaves people some time 
for adopting the new behavior later. For people who turned off the flag (which is enabled in this version), 
**a deprecation message will be used as a heads-up**.
3. In the minor version after that, the flag and its deprecation message will be **completely removed**.


In summary, developers have time of less than two releases to adopt to the new behavior.
This strategy is subject to change when it hits to our first major version.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Not necessary for now.

<!-- Can you please describe how you tested the changes you made to the code? -->
