### PR TITLE
feat(rspack_core): add oxc_resolver (turned off by default)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,7 +140,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -151,7 +151,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -174,7 +174,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -565,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed5fff0d93c7559121e9c72bf9c242295869396255071ff2cb1617147b608c5"
 dependencies = [
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.0"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",
@@ -737,7 +737,7 @@ checksum = "eecf8589574ce9b895052fa12d69af7a233f99e6107f5cb8dd1044f2a17bfdcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -856,7 +856,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1109,6 +1109,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1157,7 +1158,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1674,6 +1675,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "oxc_resolver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0cba9c2dd86cc336814aa1b2fb2e3c1bdee5cbf411debb736ab582856f249db"
+dependencies = [
+ "dashmap",
+ "dunce",
+ "indexmap 2.0.0",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,7 +1811,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1880,7 +1898,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1931,7 +1949,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2327,6 +2345,7 @@ dependencies = [
  "mime_guess",
  "nodejs-resolver",
  "once_cell",
+ "oxc_resolver",
  "paste",
  "petgraph",
  "rayon",
@@ -3152,9 +3171,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -3182,13 +3201,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3204,9 +3223,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -3365,7 +3384,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3416,7 +3435,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3599,7 +3618,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3677,7 +3696,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3831,7 +3850,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3984,7 +4003,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4080,7 +4099,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4272,7 +4291,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4350,7 +4369,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4429,7 +4448,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4470,7 +4489,7 @@ checksum = "ff9719b6085dd2824fd61938a881937be14b08f95e2d27c64c825a9f65e052ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4494,7 +4513,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4510,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4552,7 +4571,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4577,22 +4596,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4710,7 +4729,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4733,7 +4752,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4985,7 +5004,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -5007,7 +5026,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -959,7 +959,7 @@ export interface RawResolveOptions {
 }
 
 export interface RawRspackFuture {
-
+  newResolver: boolean
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -13,8 +13,9 @@ pub struct RawIncrementalRebuild {
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
-#[allow(clippy::empty_structs_with_brackets)]
-pub struct RawRspackFuture {}
+pub struct RawRspackFuture {
+  pub new_resolver: bool,
+}
 
 #[derive(Deserialize, Debug, Default)]
 #[serde(rename_all = "camelCase")]
@@ -29,7 +30,9 @@ pub struct RawExperiments {
 }
 
 impl From<RawRspackFuture> for RspackFuture {
-  fn from(_value: RawRspackFuture) -> Self {
-    Self {}
+  fn from(value: RawRspackFuture) -> Self {
+    Self {
+      new_resolver: value.new_resolver,
+    }
   }
 }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -23,6 +23,7 @@ itertools = { workspace = true }
 mime_guess = { workspace = true }
 nodejs-resolver = { version = "0.1.0" }
 once_cell = { workspace = true }
+oxc_resolver = { version = "0.1.0" }
 paste = { workspace = true }
 petgraph = { version = "0.6.3", features = ["serde-1"] }
 rayon = { workspace = true }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -53,8 +53,12 @@ where
     plugins: Vec<Box<dyn Plugin>>,
     output_filesystem: T,
   ) -> Self {
-    let resolver_factory = Arc::new(ResolverFactory::new(options.resolve.clone()));
-    let loader_resolver_factory = Arc::new(ResolverFactory::new(options.resolve_loader.clone()));
+    let new_resolver = options.experiments.rspack_future.new_resolver;
+    let resolver_factory = Arc::new(ResolverFactory::new(new_resolver, options.resolve.clone()));
+    let loader_resolver_factory = Arc::new(ResolverFactory::new(
+      new_resolver,
+      options.resolve_loader.clone(),
+    ));
     let (plugin_driver, options) = PluginDriver::new(options, plugins, resolver_factory.clone());
     let cache = Arc::new(Cache::new(options.clone()));
 

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -23,7 +23,9 @@ impl IncrementalRebuildMakeState {
 
 #[derive(Debug, Default)]
 #[allow(clippy::empty_structs_with_brackets)]
-pub struct RspackFuture {}
+pub struct RspackFuture {
+  pub new_resolver: bool,
+}
 
 #[derive(Debug, Default)]
 pub struct Experiments {

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -22,7 +22,6 @@ impl IncrementalRebuildMakeState {
 }
 
 #[derive(Debug, Default)]
-#[allow(clippy::empty_structs_with_brackets)]
 pub struct RspackFuture {
   pub new_resolver: bool,
 }

--- a/crates/rspack_core/src/resolver/factory.rs
+++ b/crates/rspack_core/src/resolver/factory.rs
@@ -26,7 +26,7 @@ pub struct ResolverFactory {
 
 impl Default for ResolverFactory {
   fn default() -> Self {
-    Self::new(Resolve::default())
+    Self::new(false, Resolve::default())
   }
 }
 
@@ -35,10 +35,10 @@ impl ResolverFactory {
     self.resolver.clear_cache();
   }
 
-  pub fn new(options: Resolve) -> Self {
+  pub fn new(new_resolver: bool, options: Resolve) -> Self {
     Self {
       base_options: options.clone(),
-      resolver: Resolver::new(options),
+      resolver: Resolver::new(new_resolver, options),
       resolvers: Default::default(),
     }
   }

--- a/crates/rspack_core/src/resolver/factory.rs
+++ b/crates/rspack_core/src/resolver/factory.rs
@@ -36,10 +36,9 @@ impl ResolverFactory {
   }
 
   pub fn new(options: Resolve) -> Self {
-    let resolver = Resolver::new(options.clone());
     Self {
-      resolver,
-      base_options: options,
+      base_options: options.clone(),
+      resolver: Resolver::new(options),
       resolvers: Default::default(),
     }
   }

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -1,7 +1,7 @@
 mod factory;
 mod resolver_impl;
 
-use std::path::PathBuf;
+use std::{fmt, path::PathBuf};
 
 use rspack_error::Error;
 use rspack_loader_runner::DescriptionData;
@@ -11,7 +11,7 @@ pub use self::resolver_impl::{ResolveInnerOptions, Resolver};
 use crate::{ResolveArgs, SharedPluginDriver};
 
 /// A successful path resolution or an ignored path.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum ResolveResult {
   Resource(Resource),
   Ignored,
@@ -20,13 +20,26 @@ pub enum ResolveResult {
 /// A successful path resolution.
 ///
 /// Contains the raw `package.json` value if there is one.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Resource {
   pub path: PathBuf,
   pub query: Option<String>,
   pub fragment: Option<String>,
   pub description_data: Option<DescriptionData>,
 }
+
+impl fmt::Debug for Resource {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    write!(f, "{:?}", self.full_path())
+  }
+}
+
+impl PartialEq for Resource {
+  fn eq(&self, other: &Self) -> bool {
+    self.path == other.path && self.query == other.query && self.fragment == other.fragment
+  }
+}
+impl Eq for Resource {}
 
 impl Resource {
   /// Get the full path with query and fragment attached.
@@ -43,7 +56,15 @@ impl Resource {
 }
 
 /// A runtime error message and an error for rspack stats.
+#[derive(Debug)]
 pub struct ResolveError(pub String, pub Error);
+
+impl PartialEq for ResolveError {
+  fn eq(&self, other: &Self) -> bool {
+    self.0 == other.0
+  }
+}
+impl Eq for ResolveError {}
 
 /// Main entry point for module resolution.
 pub async fn resolve(
@@ -52,21 +73,24 @@ pub async fn resolve(
 ) -> Result<ResolveResult, ResolveError> {
   let mut args = args;
 
-  let resolver = plugin_driver
-    .resolver_factory
-    .get(ResolveOptionsWithDependencyType {
-      resolve_options: args.resolve_options.take(),
-      resolve_to_context: args.resolve_to_context,
-      dependency_type: args.dependency_type.clone(),
-      dependency_category: *args.dependency_category,
-    });
+  let dep = ResolveOptionsWithDependencyType {
+    resolve_options: args.resolve_options.take(),
+    resolve_to_context: args.resolve_to_context,
+    dependency_type: args.dependency_type.clone(),
+    dependency_category: *args.dependency_category,
+  };
 
-  let base_dir = args.context.as_ref();
-  let result = resolver.resolve(base_dir, args.specifier);
+  let base_dir = args.context.clone();
+  let base_dir = base_dir.as_ref();
+
+  let resolver = plugin_driver.resolver_factory.get(dep);
+  let result = resolver
+    .resolve(base_dir, args.specifier)
+    .map_err(|error| error.into_resolve_error(&args, plugin_driver));
 
   let (file_dependencies, missing_dependencies) = resolver.dependencies();
   args.file_dependencies.extend(file_dependencies);
   args.missing_dependencies.extend(missing_dependencies);
 
-  result.map_err(|error| error.into_resolve_error(args, plugin_driver))
+  result
 }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -87,8 +87,8 @@ pub enum Resolver {
 }
 
 impl Resolver {
-  pub fn new(options: Resolve) -> Self {
-    if std::env::var("OXC_RESOLVER").is_ok() {
+  pub fn new(new_resolver: bool, options: Resolve) -> Self {
+    if new_resolver {
       Self::new_oxc_resolver(options)
     } else {
       Self::new_nodejs_resolver(options)

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -1,4 +1,5 @@
 use std::{
+  fmt,
   path::{Path, PathBuf},
   sync::Arc,
 };
@@ -16,14 +17,28 @@ use crate::{
 #[derive(Debug)]
 pub enum ResolveInnerError {
   NodejsResolver(nodejs_resolver::Error),
-  // OxcResolver(oxc_resolver::ResolveError),
+  OxcResolver(oxc_resolver::ResolveError),
 }
 
 /// Proxy to [nodejs_resolver::Options] or [oxc_resolver::ResolveOptions]
-#[derive(Debug)]
 pub enum ResolveInnerOptions<'a> {
   NodejsResolver(&'a nodejs_resolver::Options),
-  // OxcResolver(&'a oxc_resolver::ResolveOptions),
+  OxcResolver(&'a oxc_resolver::ResolveOptions),
+}
+
+impl<'a> fmt::Debug for ResolveInnerOptions<'a> {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      Self::NodejsResolver(options) => {
+        let mut options = (*options).clone();
+        options.external_cache = None;
+        write!(f, "{:?}", options)
+      }
+      Self::OxcResolver(options) => {
+        write!(f, "{:?}", options)
+      }
+    }
+  }
 }
 
 impl<'a> ResolveInnerOptions<'a> {
@@ -33,31 +48,31 @@ impl<'a> ResolveInnerOptions<'a> {
         options.enforce_extension,
         nodejs_resolver::EnforceExtension::Enabled
       ),
-      // Self::OxcResolver(options) => matches!(
-      // options.enforce_extension,
-      // oxc_resolver::EnforceExtension::Enabled
-      // ),
+      Self::OxcResolver(options) => matches!(
+        options.enforce_extension,
+        oxc_resolver::EnforceExtension::Enabled
+      ),
     }
   }
 
   pub fn extensions(&self) -> impl Iterator<Item = &String> {
     match self {
       Self::NodejsResolver(options) => options.extensions.iter(),
-      // Self::OxcResolver(options) => options.extensions.iter(),
+      Self::OxcResolver(options) => options.extensions.iter(),
     }
   }
 
   pub fn main_files(&self) -> impl Iterator<Item = &String> {
     match self {
       Self::NodejsResolver(options) => options.main_files.iter(),
-      // Self::OxcResolver(options) => options.main_files.iter(),
+      Self::OxcResolver(options) => options.main_files.iter(),
     }
   }
 
   pub fn modules(&self) -> impl Iterator<Item = &String> {
     match self {
       Self::NodejsResolver(options) => options.modules.iter(),
-      // Self::OxcResolver(options) => options.modules.iter(),
+      Self::OxcResolver(options) => options.modules.iter(),
     }
   }
 }
@@ -68,12 +83,16 @@ impl<'a> ResolveInnerOptions<'a> {
 #[derive(Debug)]
 pub enum Resolver {
   NodejsResolver(nodejs_resolver::Resolver, Arc<nodejs_resolver::Cache>),
-  // OxcResolver(oxc_resolver::Resolver),
+  OxcResolver(oxc_resolver::Resolver),
 }
 
 impl Resolver {
   pub fn new(options: Resolve) -> Self {
-    Self::new_nodejs_resolver(options)
+    if std::env::var("OXC_RESOLVER").is_ok() {
+      Self::new_oxc_resolver(options)
+    } else {
+      Self::new_nodejs_resolver(options)
+    }
   }
 
   fn new_nodejs_resolver(options: Resolve) -> Self {
@@ -84,11 +103,17 @@ impl Resolver {
     Self::NodejsResolver(resolver, cache)
   }
 
+  fn new_oxc_resolver(options: Resolve) -> Self {
+    let options = to_oxc_resolver_options(options, false, DependencyCategory::Unknown);
+    let resolver = oxc_resolver::Resolver::new(options);
+    Self::OxcResolver(resolver)
+  }
+
   /// Clear cache for all resolver instances
   pub fn clear_cache(&self) {
     match self {
       Self::NodejsResolver(_, cache) => cache.entries.clear(),
-      // Self::OxcResolver(resolver) => resolver.clear_cache(),
+      Self::OxcResolver(resolver) => resolver.clear_cache(),
     }
   }
 
@@ -108,9 +133,16 @@ impl Resolver {
         );
         let resolver = nodejs_resolver::Resolver::new(options);
         Self::NodejsResolver(resolver, cache.clone())
-      } /* Self::OxcResolver(_resolver) => {
-         * unimplemented!()
-         * } */
+      }
+      Self::OxcResolver(resolver) => {
+        let options = to_oxc_resolver_options(
+          options,
+          options_with_dependency_type.resolve_to_context,
+          options_with_dependency_type.dependency_category,
+        );
+        let resolver = resolver.clone_with_options(options);
+        Self::OxcResolver(resolver)
+      }
     }
   }
 
@@ -125,7 +157,7 @@ impl Resolver {
   pub fn options(&self) -> ResolveInnerOptions<'_> {
     match self {
       Self::NodejsResolver(resolver, _) => ResolveInnerOptions::NodejsResolver(&resolver.options),
-      // Self::OxcResolver(resolver) => ResolveInnerOptions::OxcResolver(resolver.options()),
+      Self::OxcResolver(resolver) => ResolveInnerOptions::OxcResolver(resolver.options()),
     }
   }
 
@@ -146,9 +178,20 @@ impl Resolver {
           nodejs_resolver::ResolveResult::Ignored => ResolveResult::Ignored,
         })
         .map_err(ResolveInnerError::NodejsResolver),
-      // Self::OxcResolver(_resolver) => {
-      // unimplemented!()
-      // }
+      Self::OxcResolver(resolver) => match resolver.resolve(path, request) {
+        Ok(r) => Ok(ResolveResult::Resource(Resource {
+          path: r.path().to_path_buf(),
+          query: r.query().map(ToString::to_string),
+          fragment: r.fragment().map(ToString::to_string),
+          description_data: r
+            .package_json()
+            .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(&d.raw_json))),
+        })),
+        Err(error) if matches!(error, oxc_resolver::ResolveError::Ignored(_)) => {
+          Ok(ResolveResult::Ignored)
+        }
+        Err(error) => Err(ResolveInnerError::OxcResolver(error)),
+      },
     }
   }
 }
@@ -156,14 +199,12 @@ impl Resolver {
 impl ResolveInnerError {
   pub fn into_resolve_error(
     self,
-    args: ResolveArgs<'_>,
+    args: &ResolveArgs<'_>,
     plugin_driver: &SharedPluginDriver,
   ) -> ResolveError {
     match self {
       Self::NodejsResolver(error) => map_nodejs_resolver_error(error, args, plugin_driver),
-      // Self::OxcResolver(_error) => {
-      // unimplemented!()
-      // }
+      Self::OxcResolver(error) => map_oxc_resolver_error(error, args, plugin_driver),
     }
   }
 }
@@ -231,13 +272,109 @@ fn to_nodejs_resolver_options(
   }
 }
 
+fn to_oxc_resolver_options(
+  options: Resolve,
+  resolve_to_context: bool,
+  dependency_type: DependencyCategory,
+) -> oxc_resolver::ResolveOptions {
+  let options = options.merge_by_dependency(dependency_type);
+  let tsconfig = options.tsconfig;
+  let enforce_extension = oxc_resolver::EnforceExtension::Auto;
+  let description_files = vec!["package.json".to_string()];
+  let extensions = options.extensions.unwrap_or_else(|| {
+    vec![".tsx", ".ts", ".jsx", ".js", ".mjs", ".json"]
+      .into_iter()
+      .map(|s| s.to_string())
+      .collect()
+  });
+  let alias = options
+    .alias
+    .unwrap_or_default()
+    .into_iter()
+    .map(|(key, value)| {
+      let value = value
+        .into_iter()
+        .map(|x| match x {
+          nodejs_resolver::AliasMap::Target(target) => oxc_resolver::AliasValue::Path(target),
+          nodejs_resolver::AliasMap::Ignored => oxc_resolver::AliasValue::Ignore,
+        })
+        .collect();
+      (key, value)
+    })
+    .collect();
+  let prefer_relative = options.prefer_relative.unwrap_or(false);
+  let symlinks = options.symlinks.unwrap_or(true);
+  let main_files = options
+    .main_files
+    .unwrap_or_else(|| vec![String::from("index")]);
+  let main_fields = options
+    .main_fields
+    .unwrap_or_else(|| vec![String::from("module"), String::from("main")]);
+  let alias_fields = (if options.browser_field.unwrap_or(true) {
+    vec!["browser".to_string()]
+  } else {
+    vec![]
+  })
+  .into_iter()
+  .map(|x| vec![x])
+  .collect();
+  let condition_names = options
+    .condition_names
+    .unwrap_or_else(|| vec!["module".to_string(), "import".to_string()]);
+  let modules = options
+    .modules
+    .unwrap_or_else(|| vec!["node_modules".to_string()]);
+  let fallback = options
+    .fallback
+    .unwrap_or_default()
+    .into_iter()
+    .map(|(key, value)| {
+      let value = value
+        .into_iter()
+        .map(|x| match x {
+          nodejs_resolver::AliasMap::Target(target) => oxc_resolver::AliasValue::Path(target),
+          nodejs_resolver::AliasMap::Ignored => oxc_resolver::AliasValue::Ignore,
+        })
+        .collect();
+      (key, value)
+    })
+    .collect();
+  let fully_specified = options.fully_specified.unwrap_or_default();
+  let exports_fields = options
+    .exports_field
+    .unwrap_or_else(|| vec![vec!["exports".to_string()]]);
+  let extension_alias = options.extension_alias.unwrap_or_default();
+  oxc_resolver::ResolveOptions {
+    fallback,
+    modules,
+    extensions,
+    enforce_extension,
+    alias,
+    prefer_relative,
+    symlinks,
+    alias_fields,
+    description_files,
+    main_files,
+    main_fields,
+    condition_names,
+    tsconfig,
+    resolve_to_context,
+    fully_specified,
+    exports_fields,
+    extension_alias,
+    // not supported by rspack yet
+    prefer_absolute: false,
+    restrictions: vec![],
+    roots: vec![],
+    builtin_modules: false,
+  }
+}
+
 fn map_nodejs_resolver_error(
   error: nodejs_resolver::Error,
-  args: ResolveArgs<'_>,
+  args: &ResolveArgs<'_>,
   plugin_driver: &SharedPluginDriver,
 ) -> ResolveError {
-  let base_dir: &Path = args.context.as_ref();
-  let importer = args.importer.map(|i| i.as_str());
   match error {
     nodejs_resolver::Error::Io(error) => {
       ResolveError(error.to_string(), Error::Io { source: error })
@@ -262,68 +399,104 @@ fn map_nodejs_resolver_error(
       internal_error!("{} is not a tsconfig", path.display()),
     ),
     _ => {
-      if let Some(importer) = &importer {
-        let span = args.span.unwrap_or_default();
-        // Use relative path in runtime for stable hashing
-        let (runtime_message, internal_message) = if let nodejs_resolver::Error::Overflow = error {
-          (
-            format!(
-              "Can't resolve {:?} in {} , maybe it had cycle alias",
-              args.specifier,
-              Path::new(&importer)
-                .relative(&plugin_driver.options.context)
-                .display()
-            ),
-            format!(
-              "Can't resolve {:?} in {} , maybe it had cycle alias",
-              args.specifier, importer
-            ),
-          )
-        } else {
-          (
-            format!(
-              "Failed to resolve {} in {}",
-              args.specifier,
-              base_dir.display()
-            ),
-            format!("Failed to resolve {} in {}", args.specifier, importer),
-          )
-        };
-        ResolveError(
-          runtime_message,
-          TraceableError::from_real_file_path(
-            Path::new(
-              importer
-                .split_once('|')
-                .map(|(_, path)| path)
-                .unwrap_or(importer),
-            ),
-            span.start as usize,
-            span.end as usize,
-            "Resolve error".to_string(),
-            internal_message.clone(),
-          )
-          .map(|e| {
-            if args.optional {
-              Error::TraceableError(e.with_severity(Severity::Warn))
-            } else {
-              Error::TraceableError(e)
-            }
-          })
-          .unwrap_or_else(|_| {
-            if args.optional {
-              Error::InternalError(InternalError::new(internal_message, Severity::Warn))
-            } else {
-              internal_error!(internal_message)
-            }
-          }),
-        )
-      } else {
-        ResolveError(
-          format!("Failed to resolve {} in project root", args.specifier),
-          internal_error!("Failed to resolve {} in project root", args.specifier),
-        )
-      }
+      let is_recursion = matches!(error, nodejs_resolver::Error::Overflow);
+      map_resolver_error(is_recursion, args, plugin_driver)
     }
+  }
+}
+
+fn map_oxc_resolver_error(
+  error: oxc_resolver::ResolveError,
+  args: &ResolveArgs<'_>,
+  plugin_driver: &SharedPluginDriver,
+) -> ResolveError {
+  match error {
+    oxc_resolver::ResolveError::InvalidPackageTarget(specifier) => {
+      let message = format!(
+        "Export should be relative path and start with \"./\", but got {}",
+        specifier
+      );
+      ResolveError(
+        message.clone(),
+        Error::Anyhow {
+          source: anyhow::Error::msg(message),
+        },
+      )
+    }
+    _ => {
+      let is_recursion = matches!(error, oxc_resolver::ResolveError::Recursion);
+      map_resolver_error(is_recursion, args, plugin_driver)
+    }
+  }
+}
+
+fn map_resolver_error(
+  is_recursion: bool,
+  args: &ResolveArgs<'_>,
+  plugin_driver: &SharedPluginDriver,
+) -> ResolveError {
+  let base_dir: &Path = args.context.as_ref();
+  let importer = args.importer.map(|i| i.as_str());
+  if let Some(importer) = &importer {
+    let span = args.span.unwrap_or_default();
+    // Use relative path in runtime for stable hashing
+    let (runtime_message, internal_message) = if is_recursion {
+      (
+        format!(
+          "Can't resolve {:?} in {} , maybe it had cycle alias",
+          args.specifier,
+          Path::new(importer)
+            .relative(&plugin_driver.options.context)
+            .display()
+        ),
+        format!(
+          "Can't resolve {:?} in {} , maybe it had cycle alias",
+          args.specifier, importer
+        ),
+      )
+    } else {
+      (
+        format!(
+          "Failed to resolve {} in {}",
+          args.specifier,
+          base_dir.display()
+        ),
+        format!("Failed to resolve {} in {}", args.specifier, importer),
+      )
+    };
+    ResolveError(
+      runtime_message,
+      TraceableError::from_real_file_path(
+        Path::new(
+          importer
+            .split_once('|')
+            .map(|(_, path)| path)
+            .unwrap_or(importer),
+        ),
+        span.start as usize,
+        span.end as usize,
+        "Resolve error".to_string(),
+        internal_message.clone(),
+      )
+      .map(|e| {
+        if args.optional {
+          Error::TraceableError(e.with_severity(Severity::Warn))
+        } else {
+          Error::TraceableError(e)
+        }
+      })
+      .unwrap_or_else(|_| {
+        if args.optional {
+          Error::InternalError(InternalError::new(internal_message, Severity::Warn))
+        } else {
+          internal_error!(internal_message)
+        }
+      }),
+    )
+  } else {
+    ResolveError(
+      format!("Failed to resolve {} in project root", args.specifier),
+      internal_error!("Failed to resolve {} in project root", args.specifier),
+    )
   }
 }

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -652,7 +652,9 @@ function getRawExperiments(
 		asyncWebAssembly,
 		newSplitChunks,
 		css,
-		rspackFuture
+		rspackFuture: {
+			newResolver: rspackFuture.newResolver ?? false
+		}
 	};
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -655,7 +655,9 @@ export interface IncrementalRebuildOptions {
 	make?: boolean;
 	emitAsset?: boolean;
 }
-export interface RspackFutureOptions {}
+export interface RspackFutureOptions {
+	newResolver?: boolean;
+}
 // TODO: discuss with webpack, should move to css generator options
 // export interface CssExperimentOptions {
 // 	exportsOnly?: boolean;

--- a/packages/rspack/src/config/zod/experiments.ts
+++ b/packages/rspack/src/config/zod/experiments.ts
@@ -16,6 +16,10 @@ export function experiments() {
 		outputModule: z.boolean().optional(),
 		newSplitChunks: z.boolean().optional(),
 		css: z.boolean().optional(),
-		rspackFuture: z.strictObject({}).optional()
+		rspackFuture: z
+			.strictObject({
+				newResolver: z.boolean().optional()
+			})
+			.optional()
 	});
 }

--- a/packages/rspack/tests/configCases/resolve-new/alias/.gitignore
+++ b/packages/rspack/tests/configCases/resolve-new/alias/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/resolve-new/alias/a.js
+++ b/packages/rspack/tests/configCases/resolve-new/alias/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/configCases/resolve-new/alias/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/alias/index.js
@@ -1,0 +1,11 @@
+import value from "@b";
+import value2 from "xx";
+import value3 from "alias";
+import value4 from "ignored";
+
+it("alias should work", () => {
+	expect(value).toBe("a");
+	expect(value2).toBe("a");
+	expect(value3).toBe("a");
+	expect(value4).toStrictEqual({});
+});

--- a/packages/rspack/tests/configCases/resolve-new/alias/node_modules/alias/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/alias/node_modules/alias/index.js
@@ -1,0 +1,1 @@
+module.exports = require('@b');

--- a/packages/rspack/tests/configCases/resolve-new/alias/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/alias/webpack.config.js
@@ -1,0 +1,28 @@
+const path = require("path");
+module.exports = {
+	entry: "./index.js",
+	resolve: {
+		alias: {
+			"@b": path.resolve(__dirname, "./a"),
+			xx: path.resolve(__dirname, "./a"),
+			ignored: path.resolve(__dirname, "./a")
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				resolve: {
+					alias: {
+						ignored: false
+					}
+				}
+			}
+		]
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/by-dependency/baz.js
+++ b/packages/rspack/tests/configCases/resolve-new/by-dependency/baz.js
@@ -1,0 +1,1 @@
+export default "baz";

--- a/packages/rspack/tests/configCases/resolve-new/by-dependency/foo.bar
+++ b/packages/rspack/tests/configCases/resolve-new/by-dependency/foo.bar
@@ -1,0 +1,1 @@
+export default 'foo';

--- a/packages/rspack/tests/configCases/resolve-new/by-dependency/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/by-dependency/index.js
@@ -1,0 +1,10 @@
+import foo from "./foo";
+import baz from "./baz";
+
+it("should resolve 'foo.bar', byDependency '.bar' extension works", function () {
+	expect(foo).toBe("foo");
+});
+
+it("should resolve 'baz.js', byDependency '...' extensions works", function () {
+	expect(baz).toBe("baz");
+});

--- a/packages/rspack/tests/configCases/resolve-new/by-dependency/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/by-dependency/webpack.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	mode: "development",
+	resolve: {
+		byDependency: {
+			esm: {
+				extensions: [".bar", "..."]
+			}
+		}
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/.gitignore
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/index.js
@@ -1,0 +1,13 @@
+import esmImport from "exports-conditional";
+import esmImport2 from "exports-conditional-2";
+
+const cjsImport = require("exports-conditional");
+const cjsImport2 = require("exports-conditional-2");
+
+it("conditional exports should works", () => {
+	expect(esmImport).toBe("esm");
+	expect(cjsImport).toBe("cjs");
+
+	expect(esmImport2).toBe("esm");
+	expect(cjsImport2).toBe("cjs");
+});

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional-2/lib.cjs
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional-2/lib.cjs
@@ -1,0 +1,1 @@
+module.exports = "cjs"

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional-2/lib.js
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional-2/lib.js
@@ -1,0 +1,1 @@
+export default "esm"

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional-2/package.json
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional-2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "exports-conditional-2",
+  "version": "1.0.0",
+  "exports": {
+    "import": "./lib.js",
+    "require": "./lib.cjs"
+  },
+  "type": "module",
+  "sideEffects": false
+}

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional/lib.cjs
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional/lib.cjs
@@ -1,0 +1,1 @@
+module.exports = "cjs"

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional/lib.mjs
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional/lib.mjs
@@ -1,0 +1,1 @@
+export default "esm"

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional/package.json
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/node_modules/exports-conditional/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "exports-conditional",
+  "version": "1.0.0",
+  "exports": {
+    "import": "./lib.mjs",
+    "require": "./lib.cjs"
+  },
+  "sideEffects": false
+}

--- a/packages/rspack/tests/configCases/resolve-new/condition-exports/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/condition-exports/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	entry: "./index.js",
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/conditions/.gitignore
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/resolve-new/conditions/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/index.js
@@ -1,0 +1,9 @@
+import mappedValue from "exports-field/dist/main";
+import entryValue from "exports-field";
+
+it("conditionNames should works", () => {
+	expect(mappedValue).toBe("lib/lib2/main");
+	expect(entryValue).toBe("x");
+	const pkgValue = require("exports-field/package.json");
+	expect(pkgValue.name).toBe("exports-field");
+});

--- a/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/lib/lib2/main.js
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/lib/lib2/main.js
@@ -1,0 +1,1 @@
+module.exports = "lib/lib2/main";

--- a/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/lib/main.js
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/lib/main.js
@@ -1,0 +1,1 @@
+module.exports = "lib/main";

--- a/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/package.json
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "exports-field",
+  "version": "1.0.0",
+  "main": "./main.js",
+  "exports": {
+    ".": "./x.js",
+    "./dist/": {
+      "pack": [
+        "./lib/lib2/",
+        "./lib/"
+      ],
+      "node": "./lib/",
+      "default": "./lib/"
+    },
+    "./dist/a.js": "./../../a.js",
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false
+}

--- a/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/x.js
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/node_modules/exports-field/x.js
@@ -1,0 +1,1 @@
+module.exports = "x"

--- a/packages/rspack/tests/configCases/resolve-new/conditions/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/conditions/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	entry: "./index.js",
+	resolve: {
+		conditionNames: ["pack"]
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/exports-fields/.gitignore
+++ b/packages/rspack/tests/configCases/resolve-new/exports-fields/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack/tests/configCases/resolve-new/exports-fields/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/exports-fields/index.js
@@ -1,0 +1,4 @@
+it("should resolve both alternatives", () => {
+	const b = require("exports-field");
+	expect(b).toBe("b");
+});

--- a/packages/rspack/tests/configCases/resolve-new/exports-fields/node_modules/exports-field/b.js
+++ b/packages/rspack/tests/configCases/resolve-new/exports-fields/node_modules/exports-field/b.js
@@ -1,0 +1,1 @@
+module.exports = 'b'

--- a/packages/rspack/tests/configCases/resolve-new/exports-fields/node_modules/exports-field/package.json
+++ b/packages/rspack/tests/configCases/resolve-new/exports-fields/node_modules/exports-field/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "exports-field",
+  "version": "1.0.0",
+  "b": "./b.js"
+}

--- a/packages/rspack/tests/configCases/resolve-new/exports-fields/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/exports-fields/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	entry: "./index.js",
+	resolve: {
+		exportsFields: ["a", "b"]
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/extension-alias/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/extension-alias/index.js
@@ -1,0 +1,5 @@
+import value from "./src/index.mjs";
+
+it("extension-alias should work", () => {
+	expect(value).toBe("in ts");
+});

--- a/packages/rspack/tests/configCases/resolve-new/extension-alias/src/index.mts
+++ b/packages/rspack/tests/configCases/resolve-new/extension-alias/src/index.mts
@@ -1,0 +1,1 @@
+module.exports = "in ts"

--- a/packages/rspack/tests/configCases/resolve-new/extension-alias/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/extension-alias/webpack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	entry: "./index.js",
+	resolve: {
+		extensionAlias: {
+			".mjs": [".mts"]
+		}
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/fallback/#/a.js
+++ b/packages/rspack/tests/configCases/resolve-new/fallback/#/a.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/packages/rspack/tests/configCases/resolve-new/fallback/a/1.js
+++ b/packages/rspack/tests/configCases/resolve-new/fallback/a/1.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/packages/rspack/tests/configCases/resolve-new/fallback/a/2.js
+++ b/packages/rspack/tests/configCases/resolve-new/fallback/a/2.js
@@ -1,0 +1,1 @@
+module.exports = "not 2";

--- a/packages/rspack/tests/configCases/resolve-new/fallback/b/2.js
+++ b/packages/rspack/tests/configCases/resolve-new/fallback/b/2.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/packages/rspack/tests/configCases/resolve-new/fallback/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/fallback/index.js
@@ -1,0 +1,14 @@
+it("ignores the fallback if an existing module is present", () => {
+	const two = require("./b/2");
+	expect(two).toBe(2);
+});
+
+it("can fallback if the module does not exist", () => {
+	const one = require("./b/1");
+	expect(one).toBe(1);
+});
+
+it("# alias should work", () => {
+	const one = require("#/a");
+	expect(one).toBe(1);
+});

--- a/packages/rspack/tests/configCases/resolve-new/fallback/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/fallback/webpack.config.js
@@ -1,0 +1,17 @@
+const path = require("path");
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {
+		alias: {
+			"#": path.resolve(__dirname, "#")
+		},
+		fallback: {
+			"./b": path.resolve(__dirname, "a")
+		}
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/modules/a/foo/a.js
+++ b/packages/rspack/tests/configCases/resolve-new/modules/a/foo/a.js
@@ -1,0 +1,1 @@
+export default "a";

--- a/packages/rspack/tests/configCases/resolve-new/modules/a/foo/package.json
+++ b/packages/rspack/tests/configCases/resolve-new/modules/a/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "a-foo",
+  "version": "1.0.0",
+  "module": "./a.js"
+}

--- a/packages/rspack/tests/configCases/resolve-new/modules/b/foo/b.js
+++ b/packages/rspack/tests/configCases/resolve-new/modules/b/foo/b.js
@@ -1,0 +1,1 @@
+export default "b";

--- a/packages/rspack/tests/configCases/resolve-new/modules/b/foo/package.json
+++ b/packages/rspack/tests/configCases/resolve-new/modules/b/foo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "b-foo",
+  "version": "1.0.0",
+  "module": "./b.js"
+}

--- a/packages/rspack/tests/configCases/resolve-new/modules/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/modules/index.js
@@ -1,0 +1,7 @@
+import a from "foo/a";
+import b from "foo/b";
+
+it("resolve modules should work fine", async () => {
+	expect(a).toEqual("a");
+	expect(b).toEqual("b");
+});

--- a/packages/rspack/tests/configCases/resolve-new/modules/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/modules/webpack.config.js
@@ -1,0 +1,12 @@
+const path = require("path");
+
+module.exports = {
+	resolve: {
+		modules: [path.resolve(__dirname, "a"), path.resolve(__dirname, "b")]
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/multi-alias/a/1.js
+++ b/packages/rspack/tests/configCases/resolve-new/multi-alias/a/1.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/packages/rspack/tests/configCases/resolve-new/multi-alias/b/2.js
+++ b/packages/rspack/tests/configCases/resolve-new/multi-alias/b/2.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/packages/rspack/tests/configCases/resolve-new/multi-alias/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/multi-alias/index.js
@@ -1,0 +1,6 @@
+it("should resolve both alternatives", () => {
+	const one = require("_/1");
+	const two = require("_/2");
+	expect(one).toBe(1);
+	expect(two).toBe(2);
+});

--- a/packages/rspack/tests/configCases/resolve-new/multi-alias/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/multi-alias/webpack.config.js
@@ -1,0 +1,14 @@
+const path = require("path");
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	resolve: {
+		alias: {
+			_: [path.resolve(__dirname, "a"), path.resolve(__dirname, "b")]
+		}
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/bar.mjs
+++ b/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/bar.mjs
@@ -1,0 +1,1 @@
+export default 'bar'

--- a/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/baz.js
+++ b/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/baz.js
@@ -1,0 +1,1 @@
+export default "baz";

--- a/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/foo.bar
+++ b/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/foo.bar
@@ -1,0 +1,3 @@
+import bar from './bar'
+
+export default bar;

--- a/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/index.js
@@ -1,0 +1,10 @@
+import foo from "./foo";
+import baz from "./baz";
+
+it("should resolve 'foo.bar', byDependency '.bar' extension works", function () {
+	expect(foo).toBe("bar");
+});
+
+it("should resolve 'baz.js', byDependency '...' extensions works", function () {
+	expect(baz).toBe("baz");
+});

--- a/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/nested-by-dependency/webpack.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+	mode: "development",
+	resolve: {
+		byDependency: {
+			esm: {
+				extensions: [".bar", "..."] // enable resolve .bar
+			}
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.bar$/,
+				resolve: {
+					byDependency: {
+						// dependencyType of import is esm
+						esm: {
+							extensions: [".mjs", "..."], // enable resolve .mjs in .bar
+							fullySpecified: false // resolve .mjs without fullySpecified in .bar
+						}
+					}
+				}
+			}
+		]
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};

--- a/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/index.js
+++ b/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/index.js
@@ -1,0 +1,19 @@
+import fakeValue from "fake";
+import fileValue from "@/file";
+import baseUrlFileValue from "src/file";
+import fileValueWithQuery1 from "@/file?a=b";
+import fileValueWithQuery2 from "@/file?a=c";
+
+it("should require real files by alias tsconfig paths", () => {
+	expect(fakeValue).toEqual("real");
+	expect(fileValue).toStrictEqual({});
+});
+
+it("absolute path relative base url should works", () => {
+	expect(baseUrlFileValue).toStrictEqual({});
+	expect(baseUrlFileValue === fileValue).toBe(true);
+	expect(fileValueWithQuery1).toStrictEqual({});
+	expect(fileValueWithQuery2).toStrictEqual({});
+	expect(fileValueWithQuery1 !== fileValueWithQuery2).toBe(true);
+	expect(fileValueWithQuery1 !== baseUrlFileValue).toBe(true);
+});

--- a/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/real.js
+++ b/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/real.js
@@ -1,0 +1,1 @@
+module.exports = "real";

--- a/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/src/file.js
+++ b/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/src/file.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/tsconfig.json
+++ b/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "fake": ["./real.js"],
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve-new/tsconfig-paths-map/webpack.config.js
@@ -1,0 +1,15 @@
+const path = require("path");
+
+module.exports = {
+	entry: {
+		main: "./index.js"
+	},
+	resolve: {
+		tsConfigPath: path.resolve(__dirname, "./tsconfig.json")
+	},
+	experiments: {
+		rspackFuture: {
+			newResolver: true
+		}
+	}
+};


### PR DESCRIPTION
## Summary

This PR adds oxc_resolver to rspack_core. The resolver can be enabled by `experiments.newResolver`.

The next step is to switch the CI to use the new resolver, then eventually have it turned on by default.

I also plan to add `tracing` capabilities for debugging the resolver.

## Test Plan

* CI should pass because this is turned off by default
* I have tested the resolver on 3 internal projects and verified results against `nodejs_resolver`