### PR TITLE
fix: css loading module should render initial_chunk_ids

### DIFF
--- a/packages/rspack/tests/runtimeCases/runtime/split-css-chunk/index1.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-css-chunk/index1.js
@@ -7,3 +7,7 @@ it("should load css chunk", function (done) {
 		done();
 	});
 });
+
+import "./common.css";
+
+// ./common.css is initial chunks and also be async chunks.

--- a/packages/rspack/tests/runtimeCases/runtime/split-css-chunk/index2.js
+++ b/packages/rspack/tests/runtimeCases/runtime/split-css-chunk/index2.js
@@ -1,1 +1,3 @@
 import "./common";
+
+import("./other.css");


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`initial_chunk_ids_without_css` is render to `installedChunks`.
`initial_chunk_ids_with_css` is render to `loadCssChunkData`, it will be add to `installedChunks`
 so here direct use `initial_chunk_ids`.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added.
<!-- Can you please describe how you tested the changes you made to the code? -->
