### PR TITLE
fix: `builtin:swc-loader` does not report error correctly

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
@@ -298,7 +298,7 @@ impl TryFrom<&rspack_core::LoaderContext<'_, rspack_core::LoaderRunnerContext>>
       current_loader: cx.current_loader().to_string(),
       is_pitching: true,
       context: External::new(cx.context.clone()),
-      diagnostics: External::new(cx.diagnostics.clone()),
+      diagnostics: External::new(cx.__diagnostics.clone()),
     })
   }
 }
@@ -358,8 +358,7 @@ pub async fn run_builtin_loader(
     ),
     asset_filenames: HashSet::from_iter(loader_context.asset_filenames.into_iter()),
     // Initialize with no diagnostic
-    diagnostics: vec![],
-
+    __diagnostics: vec![],
     __resource_data: &ResourceData::new(Default::default(), Default::default()),
     __loader_items: LoaderItemList(list),
     __loader_index: 0,

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -167,13 +167,22 @@ pub struct LoaderContext<'c, C> {
 
   pub asset_filenames: HashSet<String>,
 
+  // Only used for cross-crate accessing.
+  // This field should not be accessed in builtin loaders.
   pub __loader_index: usize,
+  // Only used for cross-crate accessing.
+  // This field should not be accessed in builtin loaders.
   pub __loader_items: LoaderItemList<'c, C>,
+  // Only used for cross-crate accessing.
+  // This field should not be accessed in builtin loaders.
   #[derivative(Debug = "ignore")]
   pub __plugins: &'c [Box<dyn LoaderRunnerPlugin>],
+  // Only used for cross-crate accessing.
+  // This field should not be accessed in builtin loaders.
   pub __resource_data: &'c ResourceData,
-
-  pub diagnostics: Vec<Diagnostic>,
+  // Only used for cross-crate accessing.
+  // This field should not be accessed in builtin loaders.
+  pub __diagnostics: Vec<Diagnostic>,
 }
 
 impl<'c, C> LoaderContext<'c, C> {
@@ -202,6 +211,11 @@ impl<'c, C> LoaderContext<'c, C> {
 
   pub fn loader_index(&self) -> usize {
     self.__loader_index
+  }
+
+  /// Emit a diagnostic, it can be a `warning` or `error`.
+  pub fn emit_diagnostic(&mut self, diagnostic: Diagnostic) {
+    self.__diagnostics.push(diagnostic)
   }
 }
 
@@ -276,7 +290,7 @@ async fn create_loader_context<'c, C: 'c>(
     __loader_items: LoaderItemList(__loader_items),
     __plugins: plugins,
     __resource_data: resource_data,
-    diagnostics: vec![],
+    __diagnostics: vec![],
   };
 
   Ok(loader_context)
@@ -377,7 +391,7 @@ impl<C> TryFrom<LoaderContext<'_, C>> for TWithDiagnosticArray<LoaderResult> {
         source_map: loader_context.source_map,
         additional_data: loader_context.additional_data,
       }
-      .with_diagnostic(loader_context.diagnostics),
+      .with_diagnostic(loader_context.__diagnostics),
     )
   }
 }

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -507,7 +507,7 @@ impl Loader<LoaderRunnerContext> for SassLoader {
     loader_context.content = Some(result.css.into());
     loader_context.source_map = source_map;
     loader_context
-      .diagnostics
+      .__diagnostics
       .append(&mut rx.into_iter().flatten().collect_vec());
     Ok(())
   }

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -506,9 +506,9 @@ impl Loader<LoaderRunnerContext> for SassLoader {
 
     loader_context.content = Some(result.css.into());
     loader_context.source_map = source_map;
-    loader_context
-      .__diagnostics
-      .append(&mut rx.into_iter().flatten().collect_vec());
+    rx.into_iter().flatten().for_each(|d| {
+      loader_context.emit_diagnostic(d);
+    });
     Ok(())
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prepare": "is-ci || husky install",
     "pnpm:devPreinstall": "is-ci || node ./scripts/doctor.js",
     "test:example": "pnpm --filter \"example-*\" build",
-    "test:unit": "pnpm --filter \"@rspack/*\" test",
+    "test:unit": "NO_COLOR=1 pnpm --filter \"@rspack/*\" test",
     "test:e2e": "pnpm --filter \"@rspack-e2e/*\" test",
     "test:ci": "cross-env NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:example && pnpm run test:unit && pnpm test:webpack",
     "test:webpack": "pnpm --filter \"webpack-test\" test:metric"

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1752,6 +1752,50 @@ exports[`StatsTestCases should print correct stats for parse-error 2`] = `
 rspack compiled with 1 error"
 `;
 
+exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-loader 1`] = `
+{
+  "errors": [
+    {
+      "formatted": "error[internal]: 
+  [38;2;255;30;30m×[0m Expected '{', got 'error'
+   ╭─[[38;2;92;157;255;1;4m<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts[0m:1:1]
+ [2m1[0m │ export error;
+   · [38;2;246;87;248m       ─────[0m
+   ╰────
+
+
+",
+      "message": "
+  [38;2;255;30;30m×[0m Expected '{', got 'error'
+   ╭─[[38;2;92;157;255;1;4m<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts[0m:1:1]
+ [2m1[0m │ export error;
+   · [38;2;246;87;248m       ─────[0m
+   ╰────
+",
+      "title": "",
+    },
+  ],
+  "errorsCount": 1,
+  "logging": {},
+  "warnings": [],
+  "warningsCount": 0,
+}
+`;
+
+exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-loader 2`] = `
+"error[internal]: 
+  [38;2;255;30;30m×[0m Expected '{', got 'error'
+   ╭─[[38;2;92;157;255;1;4m<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts[0m:1:1]
+ [2m1[0m │ export error;
+   · [38;2;246;87;248m       ─────[0m
+   ╰────
+
+
+
+
+rspack compiled with 1 error"
+`;
+
 exports[`StatsTestCases should print correct stats for reasons 1`] = `
 {
   "filteredModules": undefined,

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1757,20 +1757,20 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
   "errors": [
     {
       "formatted": "error[internal]: 
-  [38;2;255;30;30m×[0m Expected '{', got 'error'
-   ╭─[[38;2;92;157;255;1;4m<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts[0m:1:1]
- [2m1[0m │ export error;
-   · [38;2;246;87;248m       ─────[0m
-   ╰────
+  x Expected '{', got 'error'
+   ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
+ 1 | export error;
+   :        ^^^^^
+   \`----
 
 
 ",
       "message": "
-  [38;2;255;30;30m×[0m Expected '{', got 'error'
-   ╭─[[38;2;92;157;255;1;4m<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts[0m:1:1]
- [2m1[0m │ export error;
-   · [38;2;246;87;248m       ─────[0m
-   ╰────
+  x Expected '{', got 'error'
+   ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
+ 1 | export error;
+   :        ^^^^^
+   \`----
 ",
       "title": "",
     },
@@ -1784,11 +1784,11 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
 
 exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-loader 2`] = `
 "error[internal]: 
-  [38;2;255;30;30m×[0m Expected '{', got 'error'
-   ╭─[[38;2;92;157;255;1;4m<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts[0m:1:1]
- [2m1[0m │ export error;
-   · [38;2;246;87;248m       ─────[0m
-   ╰────
+  x Expected '{', got 'error'
+   ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
+ 1 | export error;
+   :        ^^^^^
+   \`----
 
 
 

--- a/packages/rspack/tests/statsCases/parse-error-builtin-swc-loader/index.ts
+++ b/packages/rspack/tests/statsCases/parse-error-builtin-swc-loader/index.ts
@@ -1,0 +1,1 @@
+export error;

--- a/packages/rspack/tests/statsCases/parse-error-builtin-swc-loader/webpack.config.js
+++ b/packages/rspack/tests/statsCases/parse-error-builtin-swc-loader/webpack.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+	stats: "errors-warnings",
+	module: {
+		rules: [
+			{
+				test: /\.ts$/,
+				loader: "builtin:swc-loader",
+				options: {
+					jsc: {
+						parser: {
+							syntax: "typescript"
+						}
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Continue https://github.com/web-infra-dev/rspack/pull/4082

In webpack, `emitWarning` or `emitError` can be used to create some additional error on the compilation. 

In Rspack, we have the `loader_context.diagnostics` field to represent this behavior. But this one has been misused in builtin-loaders. In order to make error report successfully and treat the loader error as the module build error, I changed it to returning a `Err`. 

But still, there's some misalignment in the `ModuleBuildError`, I will create a new issue to indicate this problem.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added.

<!-- Can you please describe how you tested the changes you made to the code? -->
