### PR TITLE
fix: improve interoperability of rules with side-effects

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -761,6 +761,12 @@ export interface RawModuleOptions {
 }
 
 export interface RawModuleRule {
+  /**
+   * A conditional match matching an absolute path + query + fragment
+   * This one is reserved as our escape hatch for those who
+   * relies on some single-thread runtime behaviors.
+   */
+  rspackResource?: RawRuleSetCondition
   /** A condition matcher matching an absolute path. */
   test?: RawRuleSetCondition
   include?: RawRuleSetCondition

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -249,9 +249,10 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct RawModuleRule {
-  /// A conditional match matching an absolute path + query + fragment
-  /// This one is reserved as our escape hatch for those who
-  /// relies on some single-thread runtime behaviors.
+  /// A conditional match matching an absolute path + query + fragment.
+  /// Note:
+  ///   This is a custom matching rule not initially designed by webpack.
+  ///   Only for single-threaded environment interoperation purpose.
   pub rspack_resource: Option<RawRuleSetCondition>,
   /// A condition matcher matching an absolute path.
   pub test: Option<RawRuleSetCondition>,

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -249,6 +249,10 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct RawModuleRule {
+  /// A conditional match matching an absolute path + query + fragment
+  /// This one is reserved as our escape hatch for those who
+  /// relies on some single-thread runtime behaviors.
+  pub rspack_resource: Option<RawRuleSetCondition>,
   /// A condition matcher matching an absolute path.
   pub test: Option<RawRuleSetCondition>,
   pub include: Option<RawRuleSetCondition>,
@@ -639,6 +643,7 @@ impl RawOptionsApply for RawModuleRule {
       .unwrap_or_default();
 
     Ok(ModuleRule {
+      rspack_resource: self.rspack_resource.map(|raw| raw.try_into()).transpose()?,
       test: self.test.map(|raw| raw.try_into()).transpose()?,
       include: self.include.map(|raw| raw.try_into()).transpose()?,
       exclude: self.exclude.map(|raw| raw.try_into()).transpose()?,

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -279,9 +279,10 @@ pub type FnUse =
 #[derive(Derivative, Default)]
 #[derivative(Debug)]
 pub struct ModuleRule {
-  /// A conditional match matching an absolute path + query + fragment
-  /// This one is reserved as our escape hatch for those who
-  /// relies on some single-thread runtime behaviors.
+  /// A conditional match matching an absolute path + query + fragment.
+  /// Note:
+  ///   This is a custom matching rule not initially designed by webpack.
+  ///   Only for single-threaded environment interoperation purpose.
   pub rspack_resource: Option<RuleSetCondition>,
   /// A condition matcher matching an absolute path.
   pub test: Option<RuleSetCondition>,

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -279,6 +279,10 @@ pub type FnUse =
 #[derive(Derivative, Default)]
 #[derivative(Debug)]
 pub struct ModuleRule {
+  /// A conditional match matching an absolute path + query + fragment
+  /// This one is reserved as our escape hatch for those who
+  /// relies on some single-thread runtime behaviors.
+  pub rspack_resource: Option<RuleSetCondition>,
   /// A condition matcher matching an absolute path.
   pub test: Option<RuleSetCondition>,
   pub include: Option<RuleSetCondition>,

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -26,6 +26,11 @@ pub async fn module_rule_matcher<'a>(
   dependency: &DependencyCategory,
   matched_rules: &mut Vec<&'a ModuleRule>,
 ) -> Result<bool> {
+  if let Some(test_rule) = &module_rule.rspack_resource
+    && !test_rule.try_match(&resource_data.resource).await? {
+    return Ok(false)
+  }
+
   // Include all modules that pass test assertion. If you supply a Rule.test option, you cannot also supply a `Rule.resource`.
   // See: https://webpack.js.org/configuration/module/#ruletest
   if let Some(test_rule) = &module_rule.test

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -400,7 +400,8 @@ const getRawModuleRule = (
 		enforce: rule.enforce
 	};
 
-	// Function calls may contain side-effects.
+	// Function calls may contain side-effects when interoperating with single-threaded environment.
+	// In order to mitigate the issue, Rspack tries to merge these calls together.
 	// See: https://github.com/web-infra-dev/rspack/issues/4003#issuecomment-1689662380
 	if (
 		typeof rule.test === "function" ||

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -350,7 +350,7 @@ export type RuleSetConditions = RuleSetCondition[];
 export interface RuleSetLogicalConditions {
 	and?: RuleSetConditions;
 	or?: RuleSetConditions;
-	not?: RuleSetCondition;
+	not?: RuleSetConditions;
 }
 export type RuleSetUse =
 	| RuleSetUseItem[]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fixes https://github.com/web-infra-dev/rspack/issues/4112
Fixes https://github.com/web-infra-dev/rspack/issues/4003

This PR fixes the issue on the Rspack side to provide a better interoperability
with JavaScript runtime. However, **leveraging the order of each rule being called
is, to me, not a good choice to make**, but webpack does not provide a good alternative 
for us to match `resourcePath` and `resourceQuery` at the same time,
which is a bummer for implementations in a multi-threaded environment. 
Nevertheless, it's reasonable for vue-loader or some other loaders to choose as 
they do not have another choice to make.

See: https://github.com/web-infra-dev/rspack/issues/4003#issuecomment-1689662380


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Tested locally on the reproduction demos.

<!-- Can you please describe how you tested the changes you made to the code? -->
