### PR TITLE
feat(core): add cache hits info to stats

### DIFF
--- a/crates/node_binding/src/js_values/stats.rs
+++ b/crates/node_binding/src/js_values/stats.rs
@@ -143,6 +143,22 @@ impl From<(String, rspack_core::LogType)> for JsStatsLogging {
         args: Some(vec![message]),
         trace: None,
       },
+      rspack_core::LogType::Cache { label, hit, total } => Self {
+        name: value.0,
+        r#type: "cache".to_string(),
+        args: Some(vec![format!(
+          "{}: {:.1}% ({}/{})",
+          label,
+          if total == 0 {
+            0 as f32
+          } else {
+            hit as f32 / total as f32 * 100_f32
+          },
+          hit,
+          total,
+        )]),
+        trace: None,
+      },
     }
   }
 }

--- a/crates/rspack_core/src/cache/occasion/code_generate.rs
+++ b/crates/rspack_core/src/cache/occasion/code_generate.rs
@@ -21,14 +21,14 @@ impl CodeGenerateOccasion {
     module: &'a BoxModule,
     compilation: &Compilation,
     generator: G,
-  ) -> Result<CodeGenerationResult>
+  ) -> Result<(CodeGenerationResult, bool)>
   where
     G: Fn(&'a BoxModule) -> Result<CodeGenerationResult>,
   {
     let storage = match &self.storage {
       Some(s) => s,
       // no cache return directly
-      None => return generator(module),
+      None => return Ok((generator(module)?, false)),
     };
 
     let mut cache_id = None;
@@ -44,7 +44,7 @@ impl CodeGenerateOccasion {
 
       // currently no need to separate module hash by runtime
       if let Some(data) = storage.get(&id) {
-        return Ok(data);
+        return Ok((data, true));
       }
 
       if matches!(normal_module.source(), NormalModuleSource::Unbuild) {
@@ -59,6 +59,6 @@ impl CodeGenerateOccasion {
     if let Some(id) = cache_id {
       storage.set(id, data.clone());
     }
-    Ok(data)
+    Ok((data, false))
   }
 }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -35,15 +35,15 @@ use crate::{
   is_source_equal,
   tree_shaking::{optimizer, visitor::SymbolRef, BailoutFlag, OptimizeDependencyResult},
   AddQueue, AddTask, AddTaskResult, AdditionalChunkRuntimeRequirementsArgs, BoxDependency,
-  BoxModule, BuildQueue, BuildTask, BuildTaskResult, Chunk, ChunkByUkey, ChunkContentHash,
-  ChunkGraph, ChunkGroup, ChunkGroupUkey, ChunkHashArgs, ChunkKind, ChunkUkey, CleanQueue,
-  CleanTask, CleanTaskResult, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
-  CompilationLogging, CompilerOptions, ContentHashArgs, DependencyId, Entry, EntryData,
-  EntryOptions, Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Logger,
-  Module, ModuleGraph, ModuleIdentifier, ModuleProfile, ModuleType, PathData, ProcessAssetsArgs,
-  ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs,
-  Resolve, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpec, SharedPluginDriver,
-  SourceType, Stats, TaskResult, WorkerTask,
+  BoxModule, BuildQueue, BuildTask, BuildTaskResult, CacheCount, CacheOptions, Chunk, ChunkByUkey,
+  ChunkContentHash, ChunkGraph, ChunkGroup, ChunkGroupUkey, ChunkHashArgs, ChunkKind, ChunkUkey,
+  CleanQueue, CleanTask, CleanTaskResult, CodeGenerationResult, CodeGenerationResults,
+  CompilationLogger, CompilationLogging, CompilerOptions, ContentHashArgs, DependencyId, Entry,
+  EntryData, EntryOptions, Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult,
+  Filename, Logger, Module, ModuleGraph, ModuleIdentifier, ModuleProfile, ModuleType, PathData,
+  ProcessAssetsArgs, ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask,
+  RenderManifestArgs, Resolve, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpec,
+  SharedPluginDriver, SourceType, Stats, TaskResult, WorkerTask,
 };
 use crate::{tree_shaking::visitor::OptimizeAnalyzeResult, Context};
 
@@ -343,7 +343,7 @@ impl Compilation {
 
   #[instrument(name = "compilation:make", skip_all)]
   pub async fn make(&mut self, mut param: MakeParam) -> Result<()> {
-    let logger = self.get_logger("rspack.Compiler");
+    let logger = self.get_logger("rspack.Compilation");
     let start = logger.time("make hook");
     if let Some(e) = self
       .plugin_driver
@@ -387,7 +387,7 @@ impl Compilation {
   }
 
   async fn update_module_graph(&mut self, params: Vec<MakeParam>) -> Result<()> {
-    let logger = self.get_logger("rspack.Compiler");
+    let logger = self.get_logger("rspack.Compilation");
     let deps_builder = RebuildDepsBuilder::new(params, &self.module_graph);
     let mut origin_module_deps = HashMap::default();
 
@@ -469,6 +469,15 @@ impl Compilation {
     let mut process_deps_time = logger.time_aggregate("module process dependencies task");
     let mut factorize_time = logger.time_aggregate("module factorize task");
     let mut build_time = logger.time_aggregate("module build task");
+
+    let mut build_cache_counter = None;
+    let mut factorize_cache_counter = None;
+
+    if !(matches!(self.options.cache, CacheOptions::Disabled)) {
+      build_cache_counter = Some(logger.cache("module build cache"));
+      factorize_cache_counter = Some(logger.cache("module factorize cache"));
+    }
+
     tokio::task::block_in_place(|| loop {
       let start = factorize_time.start();
       while let Some(task) = factorize_queue.get_task() {
@@ -617,7 +626,17 @@ impl Compilation {
                 dependencies,
                 current_profile,
                 exports_info_related,
+                from_cache,
               } = task_result;
+
+              if let Some(counter) = &mut factorize_cache_counter {
+                if from_cache {
+                  counter.hit();
+                } else {
+                  counter.miss();
+                }
+              }
+
               let module_identifier = factory_result.module.identifier();
 
               tracing::trace!("Module created: {}", &module_identifier);
@@ -686,7 +705,17 @@ impl Compilation {
                 build_result,
                 diagnostics,
                 current_profile,
+                from_cache,
               } = task_result;
+
+              if let Some(counter) = &mut build_cache_counter {
+                if from_cache {
+                  counter.hit();
+                } else {
+                  counter.miss();
+                }
+              }
+
               if self.options.builtins.tree_shaking.enable() {
                 self
                   .optimize_analyze_result_map
@@ -777,6 +806,13 @@ impl Compilation {
     logger.time_aggregate_end(process_deps_time);
     logger.time_aggregate_end(factorize_time);
     logger.time_aggregate_end(build_time);
+
+    if let Some(counter) = build_cache_counter {
+      logger.cache_end(counter);
+    }
+    if let Some(counter) = factorize_cache_counter {
+      logger.cache_end(counter);
+    }
 
     // TODO @jerrykingxyz make update_module_graph a pure function
     self
@@ -913,8 +949,15 @@ impl Compilation {
 
   #[instrument(name = "compilation:code_generation", skip(self))]
   async fn code_generation(&mut self) -> Result<()> {
+    let logger = self.get_logger("rspack.Compilation");
+    let mut codegen_cache_counter = match self.options.cache {
+      CacheOptions::Disabled => None,
+      _ => Some(logger.cache("module code generation cache")),
+    };
+
     fn run_iteration(
       compilation: &mut Compilation,
+      codegen_cache_counter: &mut Option<CacheCount>,
       filter_op: impl Fn(&(&ModuleIdentifier, &Box<dyn Module>)) -> bool + Sync + Send,
     ) -> Result<()> {
       let results = compilation
@@ -935,39 +978,52 @@ impl Compilation {
             .use_cache(module, compilation, |module| {
               module.code_generation(compilation)
             })
-            .map(|result| (*module_identifier, result))
+            .map(|(result, from_cache)| (*module_identifier, result, from_cache))
         })
-        .collect::<Result<Vec<(ModuleIdentifier, CodeGenerationResult)>>>()?;
+        .collect::<Result<Vec<(ModuleIdentifier, CodeGenerationResult, bool)>>>()?;
 
-      results.into_iter().for_each(|(module_identifier, result)| {
-        compilation.code_generated_modules.insert(module_identifier);
+      results
+        .into_iter()
+        .for_each(|(module_identifier, result, from_cache)| {
+          if let Some(counter) = codegen_cache_counter {
+            if from_cache {
+              counter.hit();
+            } else {
+              counter.miss();
+            }
+          }
+          compilation.code_generated_modules.insert(module_identifier);
 
-        let runtimes = compilation
-          .chunk_graph
-          .get_module_runtimes(module_identifier, &compilation.chunk_by_ukey);
+          let runtimes = compilation
+            .chunk_graph
+            .get_module_runtimes(module_identifier, &compilation.chunk_by_ukey);
 
-        compilation
-          .code_generation_results
-          .module_generation_result_map
-          .insert(module_identifier, result);
-        for runtime in runtimes.values() {
-          compilation.code_generation_results.add(
-            module_identifier,
-            runtime.clone(),
-            module_identifier,
-          );
-        }
-      });
+          compilation
+            .code_generation_results
+            .module_generation_result_map
+            .insert(module_identifier, result);
+          for runtime in runtimes.values() {
+            compilation.code_generation_results.add(
+              module_identifier,
+              runtime.clone(),
+              module_identifier,
+            );
+          }
+        });
       Ok(())
     }
 
-    run_iteration(self, |(_, module)| {
+    run_iteration(self, &mut codegen_cache_counter, |(_, module)| {
       module.get_code_generation_dependencies().is_none()
     })?;
 
-    run_iteration(self, |(_, module)| {
+    run_iteration(self, &mut codegen_cache_counter, |(_, module)| {
       module.get_code_generation_dependencies().is_some()
     })?;
+
+    if let Some(counter) = codegen_cache_counter {
+      logger.cache_end(counter);
+    }
 
     Ok(())
   }

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -59,6 +59,7 @@ pub struct FactorizeTaskResult {
   pub is_entry: bool,
   pub current_profile: Option<Box<ModuleProfile>>,
   pub exports_info_related: ExportsInfoRelated,
+  pub from_cache: bool,
 }
 
 #[async_trait::async_trait]
@@ -134,6 +135,7 @@ impl WorkerTask for FactorizeTask {
     Ok(TaskResult::Factorize(Box::new(FactorizeTaskResult {
       is_entry: self.is_entry,
       original_module_identifier: self.original_module_identifier,
+      from_cache: result.from_cache,
       factory_result: result,
       module_graph_module: Box::new(mgm),
       dependencies: self.dependencies,
@@ -257,6 +259,7 @@ pub struct BuildTaskResult {
   pub build_result: Box<BuildResult>,
   pub diagnostics: Vec<Diagnostic>,
   pub current_profile: Option<Box<ModuleProfile>>,
+  pub from_cache: bool,
 }
 
 #[async_trait::async_trait]
@@ -320,6 +323,7 @@ impl WorkerTask for BuildTask {
         build_result: Box::new(build_result),
         diagnostics,
         current_profile: self.current_profile,
+        from_cache: is_cache_valid,
       }))
     })
   }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -102,11 +102,16 @@ impl ContextModuleFactory {
     };
     let plugin_driver = &self.plugin_driver;
 
-    let resource_data = self
+    let (resource_data, from_cache) = match self
       .cache
       .resolve_module_occasion
       .use_cache(resolve_args, |args| resolve(args, plugin_driver))
-      .await;
+      .await
+    {
+      Ok(result) => result,
+      Err(err) => (Err(err), false),
+    };
+
     let module = match resource_data {
       Ok(ResolveResult::Resource(resource)) => Box::new(ContextModule::new(
         ContextModuleOptions {
@@ -154,6 +159,7 @@ impl ContextModuleFactory {
         missing_dependencies,
         context_dependencies,
         factory_meta,
+        from_cache,
       }
       .with_empty_diagnostic(),
     )

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -19,6 +19,7 @@ pub struct ModuleFactoryResult {
   pub context_dependencies: HashSet<PathBuf>,
   pub missing_dependencies: HashSet<PathBuf>,
   pub factory_meta: FactoryMeta,
+  pub from_cache: bool,
 }
 
 impl ModuleFactoryResult {
@@ -29,6 +30,7 @@ impl ModuleFactoryResult {
       context_dependencies: Default::default(),
       missing_dependencies: Default::default(),
       factory_meta: Default::default(),
+      from_cache: false,
     }
   }
 
@@ -66,6 +68,11 @@ impl ModuleFactoryResult {
 
   pub fn factory_meta(mut self, factory_meta: FactoryMeta) -> Self {
     self.factory_meta = factory_meta;
+    self
+  }
+
+  pub fn from_cache(mut self, from_cache: bool) -> Self {
+    self.from_cache = from_cache;
     self
   }
 }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -183,16 +183,19 @@ impl NormalModuleFactory {
     let mut no_pre_post_auto_loaders = false;
 
     // with scheme, windows absolute path is considered scheme by `url`
-    let resource_data = if scheme != Scheme::None
+    let (resource_data, from_cache) = if scheme != Scheme::None
       && !Path::is_absolute(Path::new(request_without_match_resource))
     {
       // resource with scheme
-      plugin_driver
-        .normal_module_factory_resolve_for_scheme(ResourceData::new(
-          request_without_match_resource.to_string(),
-          "".into(),
-        ))
-        .await?
+      (
+        plugin_driver
+          .normal_module_factory_resolve_for_scheme(ResourceData::new(
+            request_without_match_resource.to_string(),
+            "".into(),
+          ))
+          .await?,
+        false,
+      )
     }
     // TODO: resource within scheme, call resolveInScheme hook
     else {
@@ -313,18 +316,25 @@ impl NormalModuleFactory {
       };
 
       // default resolve
-      let resource_data = self
+      let (resource_data, from_cache) = match self
         .cache
         .resolve_module_occasion
         .use_cache(resolve_args, |args| resolve(args, plugin_driver))
-        .await;
+        .await
+      {
+        Ok(result) => result,
+        Err(err) => (Err(err), false),
+      };
       match resource_data {
         Ok(ResolveResult::Resource(resource)) => {
           let uri = resource.full_path().display().to_string();
-          ResourceData::new(uri, resource.path)
-            .query_optional(resource.query)
-            .fragment_optional(resource.fragment)
-            .description_optional(resource.description_data)
+          (
+            ResourceData::new(uri, resource.path)
+              .query_optional(resource.query)
+              .fragment_optional(resource.fragment)
+              .description_optional(resource.description_data),
+            from_cache,
+          )
         }
         Ok(ResolveResult::Ignored) => {
           let ident = format!("{}/{}", &data.context, request_without_match_resource);
@@ -340,7 +350,9 @@ impl NormalModuleFactory {
           self.context.module_type = Some(*raw_module.module_type());
 
           return Ok(Some(
-            ModuleFactoryResult::new(raw_module).with_empty_diagnostic(),
+            ModuleFactoryResult::new(raw_module)
+              .from_cache(from_cache)
+              .with_empty_diagnostic(),
           ));
         }
         Err(ResolveError(runtime_error, internal_error)) => {
@@ -350,6 +362,7 @@ impl NormalModuleFactory {
           let mut missing_dependencies = Default::default();
           let diagnostics: Vec<Diagnostic> = internal_error.into();
           let mut diagnostic = diagnostics[0].clone();
+          let mut from_cache_result = from_cache;
           if !data
             .resolve_options
             .as_ref()
@@ -373,11 +386,16 @@ impl NormalModuleFactory {
               missing_dependencies: &mut missing_dependencies,
               file_dependencies: &mut file_dependencies,
             };
-            let resource_data = self
+            let (resource_data, from_cache) = match self
               .cache
               .resolve_module_occasion
               .use_cache(new_args, |args| resolve(args, plugin_driver))
-              .await;
+              .await
+            {
+              Ok(result) => result,
+              Err(err) => (Err(err), false),
+            };
+            from_cache_result = from_cache;
             if let Ok(ResolveResult::Resource(resource)) = resource_data {
               // TODO: Here windows resolver will return normalized path.
               // eg. D:\a\rspack\rspack\packages\rspack\tests\fixtures\errors\resolve-fail-esm\answer.js
@@ -402,7 +420,9 @@ impl NormalModuleFactory {
           .boxed();
           self.context.module_type = Some(*missing_module.module_type());
           return Ok(Some(
-            ModuleFactoryResult::new(missing_module).with_diagnostic(vec![diagnostic]),
+            ModuleFactoryResult::new(missing_module)
+              .from_cache(from_cache_result)
+              .with_diagnostic(vec![diagnostic]),
           ));
         }
       }
@@ -636,6 +656,7 @@ impl NormalModuleFactory {
         .file_dependencies(file_dependencies)
         .missing_dependencies(missing_dependencies)
         .factory_meta(factory_meta)
+        .from_cache(from_cache)
         .with_empty_diagnostic(),
     ))
   }

--- a/packages/rspack/src/logging/Logger.ts
+++ b/packages/rspack/src/logging/Logger.ts
@@ -27,7 +27,8 @@ export const LogType = Object.freeze({
 	time: /** @type {"time"} */ "time", // name, time as [seconds, nanoseconds]
 
 	clear: /** @type {"clear"} */ "clear", // no arguments
-	status: /** @type {"status"} */ "status" // message, arguments
+	status: /** @type {"status"} */ "status", // message, arguments
+	cache: /** @type {"cache"} */ "cache" // [hit, total]
 });
 
 export function getLogTypeBitFlag(type: LogTypeEnum) {

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -416,7 +416,8 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 						LogType.profileEnd,
 						LogType.time,
 						LogType.status,
-						LogType.clear
+						LogType.clear,
+						LogType.cache
 					]);
 					collapsedGroups = true;
 				} else if (logging === "log" || logging === true) {

--- a/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
@@ -609,6 +609,8 @@ const SIMPLE_PRINTERS: Record<
 		mapLines(message, x => `</p> ${magenta(x)}`),
 	"loggingEntry(time).loggingEntry.message": (message, { magenta }) =>
 		mapLines(message, x => `<t> ${magenta(x)}`),
+	"loggingEntry(cache).loggingEntry.message": (message, { magenta }) =>
+		mapLines(message, x => `<c> ${magenta(x)}`),
 	"loggingEntry(group).loggingEntry.message": (message, { cyan }) =>
 		mapLines(message, x => `<-> ${cyan(x)}`),
 	"loggingEntry(groupCollapsed).loggingEntry.message": (message, { cyan }) =>

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -1,5 +1,6 @@
 import * as util from "util";
-import { rspack, RspackOptions } from "../src";
+import path from "path";
+import { rspack, RspackOptions, Stats } from "../src";
 import serializer from "jest-serializer-path";
 
 expect.addSnapshotSerializer(serializer);
@@ -253,6 +254,11 @@ describe("Stats", () => {
 				.replace(/\d+ ms/g, "X ms")
 		).toMatchInlineSnapshot(`
 		"LOG from rspack.Compilation
+		<t> make hook: X ms
+		<t> module add task: X ms
+		<t> module process dependencies task: X ms
+		<t> module factorize task: X ms
+		<t> module build task: X ms
 		<t> finish modules: X ms
 		<t> optimize dependencies: X ms
 		<t> create chunks: X ms
@@ -272,11 +278,6 @@ describe("Stats", () => {
 		<t> process assets: X ms
 
 		LOG from rspack.Compiler
-		<t> make hook: X ms
-		<t> module add task: X ms
-		<t> module process dependencies task: X ms
-		<t> module factorize task: X ms
-		<t> module build task: X ms
 		<t> make: X ms
 		<t> finish make hook: X ms
 		<t> finish compilation: X ms
@@ -333,5 +334,119 @@ describe("Stats", () => {
 		./fixtures/abc.js [222] {main}
 		  X ms (resolving: X ms, integration: X ms, building: X ms)"
 	`);
+	});
+
+	it("should have cache hits log when logging verbose and cache is enabled", async () => {
+		const compiler = rspack({
+			context: __dirname,
+			entry: "./fixtures/abc",
+			cache: true,
+			experiments: {
+				incrementalRebuild: false
+			}
+		});
+		await new Promise<void>((resolve, reject) => {
+			compiler.build(err => {
+				if (err) {
+					return reject(err);
+				}
+				resolve();
+			});
+		});
+		const stats = await new Promise<string>((resolve, reject) => {
+			compiler.rebuild(
+				new Set([path.join(__dirname, "./fixtures/a")]),
+				new Set(),
+				err => {
+					if (err) {
+						return reject(err);
+					}
+					const stats = new Stats(compiler.compilation).toString({
+						all: false,
+						logging: "verbose"
+					});
+					resolve(stats);
+				}
+			);
+		});
+		expect(stats).toContain("module build cache: 100.0% (4/4)");
+		expect(stats).toContain("module factorize cache: 100.0% (5/5)");
+		expect(stats).toContain("module code generation cache: 100.0% (4/4)");
+	});
+
+	it("should not have any cache hits log when cache is disabled", async () => {
+		const compiler = rspack({
+			context: __dirname,
+			entry: "./fixtures/abc",
+			cache: false,
+			experiments: {
+				incrementalRebuild: false
+			}
+		});
+		await new Promise<void>((resolve, reject) => {
+			compiler.build(err => {
+				if (err) {
+					return reject(err);
+				}
+				resolve();
+			});
+		});
+		const stats = await new Promise<string>((resolve, reject) => {
+			compiler.rebuild(
+				new Set([path.join(__dirname, "./fixtures/a")]),
+				new Set(),
+				err => {
+					if (err) {
+						return reject(err);
+					}
+					const stats = new Stats(compiler.compilation).toString({
+						all: false,
+						logging: "verbose"
+					});
+					resolve(stats);
+				}
+			);
+		});
+		expect(stats).not.toContain("module build cache");
+		expect(stats).not.toContain("module factorize cache");
+		expect(stats).not.toContain("module code generation cache");
+	});
+
+	it("should have any cache hits log of modules in incremental rebuild mode", async () => {
+		const compiler = rspack({
+			context: __dirname,
+			entry: "./fixtures/abc",
+			cache: true,
+			experiments: {
+				incrementalRebuild: true
+			}
+		});
+		await new Promise<void>((resolve, reject) => {
+			compiler.build(err => {
+				if (err) {
+					return reject(err);
+				}
+				resolve();
+			});
+		});
+		const stats = await new Promise<string>((resolve, reject) => {
+			compiler.rebuild(
+				new Set([path.join(__dirname, "./fixtures/a")]),
+				new Set(),
+				err => {
+					if (err) {
+						return reject(err);
+					}
+					const stats = new Stats(compiler.compilation).toString({
+						all: false,
+						logging: "verbose"
+					});
+					resolve(stats);
+				}
+			);
+		});
+		expect(stats).toContain("module build cache: 100.0% (1/1)");
+		expect(stats).toContain("module factorize cache: 100.0% (1/1)");
+		expect(stats).toContain("module code generation cache: 100.0% (4/4)");
 	});
 });


### PR DESCRIPTION

## Summary

Add cache hits info to stats for benchmark and debugging the cache

## Test Plan

- Adding cases in Stats.test.ts, should include the outputs of cache hits info when stats.logging=verbose, and should not have any outputs when the cache is disabled

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
