### PR TITLE
chore: disable sync document when closed merge request

### DIFF
--- a/.github/workflows/need-doc.yml
+++ b/.github/workflows/need-doc.yml
@@ -4,7 +4,7 @@ name: Need Documentation
 
 on:
   pull_request:
-    types: [closed, labeled]
+    types: [labeled]
 
 jobs:
   check_label:
@@ -15,7 +15,7 @@ jobs:
   doc:
     name: Need Documentation
     runs-on: ubuntu-latest
-    if: ${{ (github.event.pull_request.merged == true || github.event.label.name == 'need documentation') && contains(github.event.pull_request.labels.*.name, 'need documentation') }}
+    if: ${{ (github.event.label.name == 'need documentation') && contains(github.event.pull_request.labels.*.name, 'need documentation') }}
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
we already sync the document issue to website when we add label, so no need to add duplicate one when we close merge request
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
