### PR TITLE
chore: takedown down monaco-editor example build in ci

### DIFF
--- a/examples/monaco-editor-js/package.json
+++ b/examples/monaco-editor-js/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "rspack serve",
-    "build": "rspack build"
+    "build:local": "rspack build"
   },
   "license": "MIT",
   "dependencies": {

--- a/examples/monaco-editor-ts-react/package.json
+++ b/examples/monaco-editor-ts-react/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "rspack serve",
-    "build": "rspack build"
+    "build:local": "rspack build"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
monaco-editor-example takes too long to build in ci, let's save our ci time by remove it in ci
![img_v2_4d769250-4806-449c-9f06-c750778c847g](https://github.com/web-infra-dev/rspack/assets/8898718/89ca9a4e-c268-4d57-ac1b-25452f8c991a)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
