### PR TITLE
feat(rspack_core): oxc_resolver v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,9 +1716,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "oxc_resolver"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0cba9c2dd86cc336814aa1b2fb2e3c1bdee5cbf411debb736ab582856f249db"
+checksum = "9657cba6ac0894a8acf3aca5b9a4b7668ce8486042588cf2bf0f34eb5f37ebc6"
 dependencies = [
  "dashmap",
  "dunce",
@@ -1729,6 +1729,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3357,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -22,7 +22,7 @@ itertools = { workspace = true }
 mime_guess = { workspace = true }
 nodejs-resolver = { version = "0.1.0" }
 once_cell = { workspace = true }
-oxc_resolver = { version = "0.1.0" }
+oxc_resolver = { version = "0.2.0", features = ["tracing-subscriber"] }
 paste = { workspace = true }
 petgraph = { version = "0.6.3", features = ["serde-1"] }
 rayon = { workspace = true }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -423,6 +423,10 @@ fn map_oxc_resolver_error(
         },
       )
     }
+    oxc_resolver::ResolveError::TsconfigNotFound(path) => ResolveError(
+      format!("{} is not a tsconfig", path.display()),
+      internal_error!("{} is not a tsconfig", path.display()),
+    ),
     _ => {
       let is_recursion = matches!(error, oxc_resolver::ResolveError::Recursion);
       map_resolver_error(is_recursion, args, plugin_driver)


### PR DESCRIPTION
## Summary

This release of the oxc resolver contains the following features:

* Automatic tsconfig project references path resolution.
  * When `tsconfig.json#references` is specified, their respective `tsconfig.json#compilerOptions.paths` is used for resolving path alias within that project.
  * See https://www.typescriptlang.org/docs/handbook/project-references.html
* Tracing capabilities via `OXC_RESOLVER=DEBUG` / `OXC_RESOLVER=ERROR` and `OXC_RESOLVER=TRACE` environment variables
* Tons of performance improvements
  * node_modules lookups are cached
  * symlink resolutions are cached
  * total number of path hashes are reduce by half
  * removed searching inside non-existent directories for scoped packages. Previously `node_modules/@scope/package/index.js` is searched when `node_modules/@scope` does not exist. It is now skipped.

## Highlight

You may start using the future flag

```javascript
  experiments: {
    rspackFuture: {
      newResolver: true
    }
  },
```

and

```javascript
  resolve: {
    tsConfigPath: path.resolve(__dirname, 'tsconfig.json')
  }
```

To test out automatic tsconfig project references path resolution.



## Test Plan

I manually tested this on two of the largest internal projects and made sure everything got resolved correctly.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_

Let's not list this on the website until we are confident that `oxc_resolver` has covered more use cases by testing it internally, since I expect other bugs.
