### PR TITLE
fix: fix module source-map

### DIFF
--- a/crates/rspack_plugin_javascript/src/ast/stringify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/stringify.rs
@@ -32,7 +32,7 @@ pub fn stringify(
       EsVersion::Es2022,
       SourceMapConfig {
         enable: devtool.source_map(),
-        inline_sources_content: !devtool.no_sources(),
+        inline_sources_content: true,
         emit_columns: !devtool.cheap(),
         names: Default::default(),
       },

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -1,6 +1,6 @@
 use rspack_core::rspack_sources::{
-  BoxSource, RawSource, ReplaceSource, Source, SourceExt, SourceMap, SourceMapSource,
-  WithoutOriginalOptions,
+  BoxSource, MapOptions, OriginalSource, RawSource, ReplaceSource, Source, SourceExt, SourceMap,
+  SourceMapSource, SourceMapSourceOptions,
 };
 use rspack_core::tree_shaking::analyzer::OptimizeAnalyzer;
 use rspack_core::tree_shaking::js_module::JsModule;
@@ -52,6 +52,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       compiler_options.builtins.decorator.is_some(),
       compiler_options.should_transform_by_default(),
     );
+    let use_source_map = compiler_options.devtool.enabled();
+    let use_simple_source_map = compiler_options.devtool.source_map();
+    let original_map = source.map(&MapOptions::new(!compiler_options.devtool.cheap()));
     let source = source.source();
     let mut ast = match crate::ast::parse(
       source.to_string(),
@@ -63,7 +66,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       Err(e) => {
         return Ok(
           ParseResult {
-            source: RawSource::from(source.to_string()).boxed(),
+            source: create_source(
+              source.to_string(),
+              resource_data.resource_path.to_string_lossy().to_string(),
+              use_simple_source_map,
+            ),
             dependencies: vec![],
             presentational_dependencies: vec![],
             analyze_result: Default::default(),
@@ -87,7 +94,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       crate::ast::stringify(&ast, &compiler_options.devtool, Some(true))?;
 
     ast = match crate::ast::parse(
-      output.code.clone(), // TODO avoid code clone
+      output.code.clone(),
       syntax,
       &resource_data.resource_path.to_string_lossy(),
       module_type,
@@ -96,7 +103,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       Err(e) => {
         return Ok(
           ParseResult {
-            source: RawSource::from(output.code.clone()).boxed(),
+            source: create_source(
+              source.to_string(),
+              resource_data.resource_path.to_string_lossy().to_string(),
+              use_simple_source_map,
+            ),
             dependencies: vec![],
             presentational_dependencies: vec![],
             analyze_result: Default::default(),
@@ -134,15 +145,27 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     };
 
     let source = if let Some(map) = output.map {
-      SourceMapSource::new(WithoutOriginalOptions {
+      SourceMapSource::new(SourceMapSourceOptions {
         value: output.code,
         name: resource_data.resource_path.to_string_lossy().to_string(),
         source_map: SourceMap::from_json(&map).map_err(|e| internal_error!(e.to_string()))?,
+        inner_source_map: use_source_map.then_some(original_map).flatten(),
+        remove_original_source: true,
+        ..Default::default()
       })
       .boxed()
+    } else if use_simple_source_map {
+      OriginalSource::new(output.code, resource_data.resource_path.to_string_lossy()).boxed()
     } else {
       RawSource::from(output.code).boxed()
     };
+
+    fn create_source(content: String, resource_path: String, devtool: bool) -> BoxSource {
+      if devtool {
+        return OriginalSource::new(content, resource_path).boxed();
+      }
+      RawSource::from(content).boxed()
+    }
 
     Ok(
       ParseResult {

--- a/examples/builtin-swc-loader/src/App.jsx
+++ b/examples/builtin-swc-loader/src/App.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 

--- a/examples/builtin-swc-loader/src/index.jsx
+++ b/examples/builtin-swc-loader/src/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';

--- a/packages/rspack/tests/configCases/source-map/source-map/App.jsx
+++ b/packages/rspack/tests/configCases/source-map/source-map/App.jsx
@@ -1,0 +1,3 @@
+export function App() {
+	return <div id="test">Hello Rspack!</div>;
+}

--- a/packages/rspack/tests/configCases/source-map/source-map/index.js
+++ b/packages/rspack/tests/configCases/source-map/source-map/index.js
@@ -1,0 +1,32 @@
+require("./App");
+
+it("should map to the original content if `module` enabled", async () => {
+	const path = require("path");
+	const fs = require("fs");
+	const sourceMap = require("source-map");
+
+	const source = fs.readFileSync(__filename + ".map", "utf-8");
+	const generated = fs.readFileSync(__filename, "utf-8");
+	const app = fs.readFileSync(path.resolve(__dirname, "../App.jsx"), "utf-8");
+	const map = JSON.parse(source);
+	const consumer = await new sourceMap.SourceMapConsumer(map);
+	expect(map.sources).toContain("./App.jsx");
+	expect(map.sourcesContent[1]).toEqual(app);
+	const STUB =
+		"\u0048\u0065\u006c\u006c\u006f\u0020\u0052\u0073\u0070\u0061\u0063\u006b\u0021";
+	const { line, column } = consumer.originalPositionFor(
+		positionFor(generated, STUB)
+	);
+	const { line: originalLine, column: originalColumn } = positionFor(app, STUB);
+	expect(line).toBe(originalLine);
+	expect(column).toBe(originalColumn);
+});
+
+const positionFor = (content, text) => {
+	let lines = content.split(/\r?\n/);
+	for (let i = 0; i < lines.length; i++) {
+		const column = lines[i].indexOf(text);
+		if (column >= 0) return { line: i + 1, column };
+	}
+	return null;
+};

--- a/packages/rspack/tests/configCases/source-map/source-map/webpack.config.js
+++ b/packages/rspack/tests/configCases/source-map/source-map/webpack.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+	devtool: "source-map",
+	externals: ["source-map"],
+	externalsType: "commonjs",
+	module: {
+		rules: [
+			{
+				test: /\.jsx$/,
+				loader: "builtin:swc-loader",
+				options: {
+					sourceMap: true,
+					jsc: {
+						parser: {
+							syntax: "ecmascript",
+							jsx: true
+						}
+					}
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Fixed a case where source-map cannot be mapped to original content, even if `"module"` is enabled.
- Aligned JavaScript source to Webpack

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

Added.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
