### PR TITLE
fix: merge disableReactRefreshByDefault to disableTransformByDefault

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -160,15 +160,14 @@ export class RspackDevServer extends WebpackDevServer {
 				// enable react.development by default
 				compiler.options.builtins.react ??= {};
 				compiler.options.builtins.react.development ??= true;
-				// enable react.refresh is rspackFuture.disableReactRefreshByDefault is enabled
 				if (
-					!compiler.options.experiments.rspackFuture
-						.disableReactRefreshByDefault
+					!compiler.options.experiments.rspackFuture.disableTransformByDefault
 				) {
+					// enable react.refresh by default if rspackFuture.disableTransformByDefault is not enabled
 					compiler.options.builtins.react.refresh ??= true;
-				}
-				if (compiler.options.builtins.react.refresh) {
-					new ReactRefreshPlugin().apply(compiler);
+					if (compiler.options.builtins.react.refresh) {
+						new ReactRefreshPlugin().apply(compiler);
+					}
 				}
 			} else if (compiler.options.builtins.react.refresh) {
 				if (mode === "production") {

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -157,13 +157,13 @@ export class RspackDevServer extends WebpackDevServer {
 				// enable hot by default
 				compiler.options.devServer ??= {};
 				compiler.options.devServer.hot = true;
-				// enable react.development by default
-				compiler.options.builtins.react ??= {};
-				compiler.options.builtins.react.development ??= true;
 				if (
 					!compiler.options.experiments.rspackFuture.disableTransformByDefault
 				) {
-					// enable react.refresh by default if rspackFuture.disableTransformByDefault is not enabled
+					compiler.options.builtins.react ??= {};
+					// enable react.development by default
+					compiler.options.builtins.react.development ??= true;
+					// enable react.refresh by default
 					compiler.options.builtins.react.refresh ??= true;
 					if (compiler.options.builtins.react.refresh) {
 						new ReactRefreshPlugin().apply(compiler);

--- a/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
+++ b/packages/rspack-dev-server/tests/__snapshots__/normalizeOptions.test.ts.snap
@@ -140,43 +140,6 @@ exports[`normalize options snapshot react-refresh client added when react/refres
 }
 `;
 
-exports[`normalize options snapshot shouldn't have reactRefreshEntry.js by default when rspackFuture.disableReactRefreshByDefault is enabled 1`] = `
-{
-  "main": [
-    "<prefix>/./placeholder.js",
-  ],
-  "undefined": [
-    "<prefix>/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-    "<prefix>/webpack/hot/dev-server.js",
-  ],
-}
-`;
-
-exports[`normalize options snapshot shouldn't have reactRefreshEntry.js by default when rspackFuture.disableReactRefreshByDefault is enabled 2`] = `
-{
-  "main": [
-    "<prefix>/./placeholder.js",
-  ],
-  "undefined": [
-    "<prefix>/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-    "<prefix>/webpack/hot/dev-server.js",
-  ],
-}
-`;
-
-exports[`normalize options snapshot shouldn't have reactRefreshEntry.js by default when rspackFuture.disableReactRefreshByDefault is enabled 3`] = `
-{
-  "main": [
-    "<prefix>/./placeholder.js",
-  ],
-  "undefined": [
-    "<prefix>/rspack-plugin-react-refresh/client/reactRefreshEntry.js",
-    "<prefix>/webpack-dev-server/client/index.js?protocol=ws%3A&hostname=0.0.0.0&&pathname=%2Fws&logging=info&overlay=true&reconnect=10&hot=true&live-reload=true",
-    "<prefix>/webpack/hot/dev-server.js",
-  ],
-}
-`;
-
 exports[`normalize options snapshot shouldn't have reactRefreshEntry.js when react.refresh is false 1`] = `
 {
   "main": [

--- a/packages/rspack-dev-server/tests/normalizeOptions.test.ts
+++ b/packages/rspack-dev-server/tests/normalizeOptions.test.ts
@@ -1,6 +1,7 @@
 import { RspackOptions, rspack } from "@rspack/core";
 import { RspackDevServer, Configuration } from "@rspack/dev-server";
 import { createCompiler } from "@rspack/core";
+import ReactRefreshPlugin from "@rspack/plugin-react-refresh";
 import serializer from "jest-serializer-path";
 expect.addSnapshotSerializer(serializer);
 
@@ -24,86 +25,71 @@ describe("normalize options snapshot", () => {
 	});
 
 	it("additional entires should added", async () => {
-		await matchAdditionEntries(
-			{},
-			{
-				entry: ["something"]
-			}
-		);
+		expect(
+			await getAdditionEntries({}, { entry: ["something"] })
+		).toMatchSnapshot();
 	});
 
 	it("react-refresh client added when react/refresh enabled", async () => {
-		await matchAdditionEntries(
-			{},
-			{
-				entry: ["something"],
-				builtins: {
-					react: {
-						refresh: true
+		expect(
+			await getAdditionEntries(
+				{},
+				{
+					entry: ["something"],
+					builtins: {
+						react: {
+							refresh: true
+						}
 					}
 				}
-			}
-		);
+			)
+		).toMatchSnapshot();
 	});
 
 	it("shouldn't have reactRefreshEntry.js when react.refresh is false", async () => {
-		await matchAdditionEntries(
-			{},
-			{
-				entry: ["something"],
-				builtins: {
-					react: {
-						refresh: false
+		expect(
+			await getAdditionEntries(
+				{},
+				{
+					entry: ["something"],
+					builtins: {
+						react: {
+							refresh: false
+						}
 					}
 				}
-			}
-		);
+			)
+		).toMatchSnapshot();
 	});
 
 	it("shouldn't have reactRefreshEntry.js by default when rspackFuture.disableReactRefreshByDefault is enabled", async () => {
-		await matchAdditionEntries(
+		const reactRefreshEntry =
+			"<prefix>/rspack-plugin-react-refresh/client/reactRefreshEntry.js";
+		const entries1 = await getAdditionEntries(
 			{},
 			{
 				entry: ["something"],
 				experiments: {
 					rspackFuture: {
-						disableReactRefreshByDefault: true
+						disableTransformByDefault: true
 					}
 				}
 			}
 		);
-		await matchAdditionEntries(
+		expect(entries1["undefined"]).not.toContain(reactRefreshEntry);
+		const entries2 = await getAdditionEntries(
 			{},
 			{
 				entry: ["something"],
-				builtins: {
-					react: {
-						refresh: false
-					}
-				},
+				plugins: [new ReactRefreshPlugin()],
 				experiments: {
 					rspackFuture: {
-						disableReactRefreshByDefault: true
+						disableTransformByDefault: true
 					}
 				}
 			}
 		);
-		await matchAdditionEntries(
-			{},
-			{
-				entry: ["something"],
-				builtins: {
-					react: {
-						refresh: true
-					}
-				},
-				experiments: {
-					rspackFuture: {
-						disableReactRefreshByDefault: true
-					}
-				}
-			}
-		);
+		expect(entries2["undefined"]).toContain(reactRefreshEntry);
 	});
 
 	it("react.development and react.refresh should be true by default when hot enabled", async () => {
@@ -170,7 +156,7 @@ async function match(config: RspackOptions) {
 	await server.stop();
 }
 
-async function matchAdditionEntries(
+async function getAdditionEntries(
 	serverConfig: Configuration,
 	config: RspackOptions
 ) {
@@ -208,6 +194,6 @@ async function matchAdditionEntries(
 			return [key, replaced];
 		})
 	);
-	expect(value).toMatchSnapshot();
 	await server.stop();
+	return value;
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -178,7 +178,6 @@ const applyExperimentsDefaults = (
 		D(experiments.rspackFuture, "newResolver", false);
 		D(experiments.rspackFuture, "newTreeshaking", false);
 		D(experiments.rspackFuture, "disableTransformByDefault", false);
-		D(experiments.rspackFuture, "disableReactRefreshByDefault", false);
 	}
 };
 

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -937,8 +937,7 @@ export type IncrementalRebuildOptions = z.infer<
 const rspackFutureOptions = z.strictObject({
 	newResolver: z.boolean().optional(),
 	newTreeshaking: z.boolean().optional(),
-	disableTransformByDefault: z.boolean().optional(),
-	disableReactRefreshByDefault: z.boolean().optional()
+	disableTransformByDefault: z.boolean().optional()
 });
 export type RspackFutureOptions = z.infer<typeof rspackFutureOptions>;
 

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -25,7 +25,6 @@ exports[`snapshots should have the correct base config 1`] = `
     "lazyCompilation": false,
     "newSplitChunks": true,
     "rspackFuture": {
-      "disableReactRefreshByDefault": false,
       "disableTransformByDefault": false,
       "newResolver": false,
       "newTreeshaking": false,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

move to disableTransformByDefault since this actually depend on disableTransformByDefault

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [x] Yes, the corresponding rspack-website PR is \_\_
