### PR TITLE
fix: remove `react` from `rspackExperiments` of `builtin:swc-loader`

### DIFF
--- a/crates/rspack_loader_swc/src/options.rs
+++ b/crates/rspack_loader_swc/src/options.rs
@@ -1,6 +1,5 @@
 use rspack_swc_visitors::{
-  EmotionOptions, ImportOptions, RawEmotionOptions, RawImportOptions, RawReactOptions,
-  RawRelayOptions, ReactOptions, RelayOptions,
+  EmotionOptions, ImportOptions, RawEmotionOptions, RawImportOptions, RawRelayOptions, RelayOptions,
 };
 use serde::Deserialize;
 use swc_config::config_types::BoolConfig;
@@ -13,7 +12,6 @@ use swc_core::base::config::{
 #[serde(rename_all = "camelCase", default)]
 pub struct RawRspackExperiments {
   pub relay: Option<RawRelayOptions>,
-  pub react: Option<RawReactOptions>,
   pub import: Option<Vec<RawImportOptions>>,
   pub emotion: Option<RawEmotionOptions>,
 }
@@ -21,7 +19,6 @@ pub struct RawRspackExperiments {
 #[derive(Default, Debug)]
 pub(crate) struct RspackExperiments {
   pub(crate) relay: Option<RelayOptions>,
-  pub(crate) react: Option<ReactOptions>,
   pub(crate) import: Option<Vec<ImportOptions>>,
   pub(crate) emotion: Option<EmotionOptions>,
 }
@@ -30,7 +27,6 @@ impl From<RawRspackExperiments> for RspackExperiments {
   fn from(value: RawRspackExperiments) -> Self {
     Self {
       relay: value.relay.map(|v| v.into()),
-      react: value.react.map(|v| v.into()),
       import: value
         .import
         .map(|i| i.into_iter().map(|v| v.into()).collect()),

--- a/crates/rspack_loader_swc/src/transformer.rs
+++ b/crates/rspack_loader_swc/src/transformer.rs
@@ -4,10 +4,7 @@ use std::sync::Arc;
 use either::Either;
 use rspack_core::CompilerOptions;
 use swc_core::common::{chain, comments::Comments, Mark, SourceMap};
-use swc_core::ecma::{
-  transforms::base::pass::{noop, Optional},
-  visit::Fold,
-};
+use swc_core::ecma::{transforms::base::pass::noop, visit::Fold};
 
 use crate::options::RspackExperiments;
 
@@ -33,7 +30,7 @@ pub(crate) fn transform<'a>(
   resource_path: &'a Path,
   rspack_options: &'a CompilerOptions,
   comments: Option<&'a dyn Comments>,
-  top_level_mark: Mark,
+  _top_level_mark: Mark,
   unresolved_mark: Mark,
   cm: Arc<SourceMap>,
   content_hash: Option<u32>,
@@ -42,17 +39,6 @@ pub(crate) fn transform<'a>(
   use rspack_swc_visitors::EmotionOptions;
 
   chain!(
-    either!(rspack_experiments.react, |options| {
-      rspack_swc_visitors::react(top_level_mark, comments, &cm, options, unresolved_mark)
-    }),
-    Optional::new(
-      rspack_swc_visitors::fold_react_refresh(unresolved_mark),
-      rspack_experiments
-        .react
-        .as_ref()
-        .and_then(|v| v.refresh)
-        .unwrap_or_default()
-    ),
     either!(rspack_experiments.emotion, |options: &EmotionOptions| {
       // SAFETY: Source content hash should always available if emotion is turned on.
       let content_hash = content_hash.expect("Content hash should be available");

--- a/packages/rspack/tests/configCases/builtin-swc-loader/react-refresh-false/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/react-refresh-false/webpack.config.js
@@ -5,11 +5,12 @@ module.exports = {
 				test: /\.js$/,
 				loader: "builtin:swc-loader",
 				options: {
-					rspackExperiments: {
-						react: {
-							refresh: false
-						}
-					}
+					// TODO: add back this until `@rspack/plugin-react-refresh` is finished
+					// rspackExperiments: {
+					// 	react: {
+					// 		refresh: false
+					// 	}
+					// }
 				}
 			}
 		]

--- a/packages/rspack/tests/configCases/builtin-swc-loader/react-runtime-classic/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/react-runtime-classic/webpack.config.js
@@ -5,9 +5,11 @@ module.exports = {
 				test: /\.js$/,
 				loader: "builtin:swc-loader",
 				options: {
-					rspackExperiments: {
-						react: {
-							runtime: "classic"
+					jsc: {
+						transform: {
+							react: {
+								runtime: "classic"
+							}
 						}
 					}
 				}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`rspackExperiments.react.refresh` is quite different from the original `jsc.transform.react.refresh`. So, at the time of implementing this feature, 
this option was migrated to `rspackExperiments`. However, this would add some problem.
Since the `rspackExperiments.react.refresh` does two things.
1. Apply `react-refresh/babel`
2. Apply `react-refresh-webpack-plugin/loader`

The second one should respect the bail-out path provided by user and the path of `react-refresh` and `react-refresh-webpack-plugin/client/ReactUtils` and something like this,
which cannot be decided directly from user when writing the configuration. So we decide to remove this and respect to swc-loader's original `jsc.transform.react` and not including the `react-refresh-webpack-plugin/loader` transformations.

`@rspack/plugin-react-refresh` plugin haven't finished yet. So this is only a part of the `react-refresh` implementation for Rspack under `rspackFuture.disableTransformByDefault`.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Updated.
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
