### PR TITLE
fix: missing rspack-only plugins on compiler.webpack

### DIFF
--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -203,6 +203,19 @@ class Compiler {
 				// get LazySet() {
 				// 	return require("./util/LazySet");
 				// }
+			},
+			// XxxRspackPlugin, Rspack-only plugins
+			get HtmlRspackPlugin() {
+				return require("./builtin-plugin").HtmlRspackPlugin;
+			},
+			get SwcJsMinimizerRspackPlugin() {
+				return require("./builtin-plugin").SwcJsMinimizerRspackPlugin;
+			},
+			get SwcCssMinimizerRspackPlugin() {
+				return require("./builtin-plugin").SwcCssMinimizerRspackPlugin;
+			},
+			get CopyRspackPlugin() {
+				return require("./builtin-plugin").CopyRspackPlugin;
 			}
 		};
 		this.root = this;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #4219 

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
