### PR TITLE
feat: deprecate `builtin:sass-loader`

### DIFF
--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -176,7 +176,10 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.define = ${JSON.stringify(
 				builtins.define
-			)}' has been deprecated, please migrate to rspack.DefinePlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.DefinePlugin",
+				"https://www.rspack.dev/config/plugins.html#defineplugin"
+			)}`
 		);
 		new DefinePlugin(builtins.define).apply(compiler);
 	}
@@ -184,7 +187,10 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.provide = ${JSON.stringify(
 				builtins.provide
-			)}' has been deprecated, please migrate to rspack.ProvidePlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.ProvidePlugin",
+				"https://www.rspack.dev/config/plugins.html#provideplugin"
+			)}`
 		);
 		new ProvidePlugin(builtins.provide).apply(compiler);
 	}
@@ -192,7 +198,10 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.progress = ${JSON.stringify(
 				builtins.progress
-			)}' has been deprecated, please migrate to rspack.ProgressPlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.ProgressPlugin",
+				"https://www.rspack.dev/config/plugins.html#progressplugin"
+			)}`
 		);
 		const progress = builtins.progress === true ? {} : builtins.progress;
 		new ProgressPlugin(progress).apply(compiler);
@@ -201,7 +210,10 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.banner = ${JSON.stringify(
 				builtins.banner
-			)}' has been deprecated, please migrate to rspack.BannerPlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.BannerPlugin",
+				"https://www.rspack.dev/config/plugins.html#bannerplugin"
+			)}`
 		);
 		if (Array.isArray(builtins.banner)) {
 			for (const banner of builtins.banner) {
@@ -216,7 +228,10 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.html = ${JSON.stringify(
 				builtins.html
-			)}' has been deprecated, please migrate to rspack.HtmlPlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.HtmlRspackPlugin",
+				"https://www.rspack.dev/config/plugins.html#htmlrspackplugin"
+			)}`
 		);
 		for (const html of builtins.html) {
 			new HtmlRspackPlugin(html).apply(compiler);
@@ -226,7 +241,10 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.copy = ${JSON.stringify(
 				builtins.copy
-			)}' has been deprecated, please migrate to rspack.CopyPlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.CopyRspackPlugin",
+				"https://www.rspack.dev/config/plugins.html#copyrspackplugin"
+			)}`
 		);
 		new CopyRspackPlugin(builtins.copy).apply(compiler);
 	}
@@ -234,7 +252,13 @@ export function deprecated_resolveBuiltins(
 		deprecatedWarn(
 			`'builtins.minifyOptions = ${JSON.stringify(
 				builtins.minifyOptions
-			)}' has been deprecated, please migrate to rspack.SwcJsMinimizerPlugin and rspack.SwcCssMinimizerPlugin`
+			)}' has been deprecated, please migrate to ${termlink(
+				"rspack.SwcJsMinimizerRspackPlugin",
+				"https://www.rspack.dev/config/plugins.html#SwcJsMinimizerRspackPlugin"
+			)} and ${termlink(
+				"rspack.SwcCssMinimizerRspackPlugin",
+				"https://www.rspack.dev/config/plugins.html#SwcCssMinimizerRspackPlugin"
+			)}`
 		);
 	}
 	const disableMinify =

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -271,7 +271,7 @@ function getBuiltinLoaderOptions(
 ): RuleSetLoaderWithOptions["options"] {
 	if (identifier.startsWith(`${BUILTIN_LOADER_PREFIX}sass-loader`)) {
 		deprecatedWarn(
-			`'builtin:sass-loader' have been deprecated, please migrate to ${termlink(
+			`'builtin:sass-loader' has been deprecated, please migrate to ${termlink(
 				"sass-loader",
 				"https://github.com/webpack-contrib/sass-loader"
 			)}`

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -17,7 +17,7 @@ import {
 	RuleSetLoaderWithOptions
 } from "./zod";
 import { parsePathQueryFragment } from "../loader-runner";
-import { isNil } from "../util";
+import { deprecatedWarn, isNil, termlink } from "../util";
 import {
 	resolveEmotion,
 	resolvePluginImport,
@@ -270,6 +270,12 @@ function getBuiltinLoaderOptions(
 	options: ComposeJsUseOptions
 ): RuleSetLoaderWithOptions["options"] {
 	if (identifier.startsWith(`${BUILTIN_LOADER_PREFIX}sass-loader`)) {
+		deprecatedWarn(
+			`'builtin:sass-loader' have been deprecated, please migrate to ${termlink(
+				"sass-loader",
+				"https://github.com/webpack-contrib/sass-loader"
+			)}`
+		);
 		return getSassLoaderOptions(o, options);
 	}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Prepare for deprecation for `builtin:sass-loader` in 0.4.0.
See: https://github.com/web-infra-dev/rspack/pull/4041

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
