### PR TITLE
feat: support `include` and `exclude` of react-refresh-rspack-plugin

### DIFF
--- a/packages/rspack-plugin-react-refresh/package.json
+++ b/packages/rspack-plugin-react-refresh/package.json
@@ -10,7 +10,7 @@
     "./react-refresh-entry": "./client/reactRefreshEntry.js"
   },
   "scripts": {
-    "test": "echo success"
+    "test": "jest --runInBand"
   },
   "files": [
     "client",
@@ -27,9 +27,12 @@
     "directory": "packages/rspack-plugin-react-refresh"
   },
   "dependencies": {
-    "@pmmmwh/react-refresh-webpack-plugin": "0.5.10"
+    "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
+    "schema-utils": "^4.0.0"
   },
   "devDependencies": {
+    "@rspack/core": "workspace:*",
+    "@rspack/plugin-react-refresh": "workspace:*",
     "react-refresh": "0.14.0"
   },
   "peerDependencies": {
@@ -39,5 +42,12 @@
     "react-refresh": {
       "optional": true
     }
+  },
+  "jest": {
+    "watchPathIgnorePatterns": [
+      "<rootDir>/dist",
+      "<rootDir>/tests/dist"
+    ],
+    "testEnvironment": "../../scripts/test/patch-node-env.cjs"
   }
 }

--- a/packages/rspack-plugin-react-refresh/src/options.js
+++ b/packages/rspack-plugin-react-refresh/src/options.js
@@ -1,0 +1,17 @@
+const d = (object, property, defaultValue) => {
+	if (
+		typeof object[property] === "undefined" &&
+		typeof defaultValue !== "undefined"
+	) {
+		object[property] = defaultValue;
+	}
+	return object[property];
+};
+
+const normalizeOptions = function (options) {
+	d(options, "exclude", /node_modules/i);
+	d(options, "include", /\.([cm]js|[jt]sx?|flow)$/i);
+	return options;
+};
+
+module.exports = { normalizeOptions };

--- a/packages/rspack-plugin-react-refresh/src/options.json
+++ b/packages/rspack-plugin-react-refresh/src/options.json
@@ -1,0 +1,33 @@
+{
+  "additionalProperties": false,
+  "type": "object",
+  "definitions": {
+    "Path": { "type": "string" },
+    "MatchCondition": {
+      "anyOf": [
+        { "instanceof": "RegExp" },
+        { "$ref": "#/definitions/Path" },
+        { "type": "null" }
+      ]
+    },
+    "MatchConditions": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/MatchCondition" },
+      "minItems": 1
+    }
+  },
+  "properties": {
+    "exclude": {
+      "anyOf": [
+        { "$ref": "#/definitions/MatchCondition" },
+        { "$ref": "#/definitions/MatchConditions" }
+      ]
+    },
+    "include": {
+      "anyOf": [
+        { "$ref": "#/definitions/MatchCondition" },
+        { "$ref": "#/definitions/MatchConditions" }
+      ]
+    }
+  }
+}

--- a/packages/rspack-plugin-react-refresh/tests/fixtures/.gitignore
+++ b/packages/rspack-plugin-react-refresh/tests/fixtures/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/rspack-plugin-react-refresh/tests/fixtures/custom/index.js
+++ b/packages/rspack-plugin-react-refresh/tests/fixtures/custom/index.js
@@ -1,0 +1,1 @@
+require("foo");

--- a/packages/rspack-plugin-react-refresh/tests/fixtures/default/index.js
+++ b/packages/rspack-plugin-react-refresh/tests/fixtures/default/index.js
@@ -1,0 +1,2 @@
+require("foo");
+module.exports = "default";

--- a/packages/rspack-plugin-react-refresh/tests/fixtures/node_modules/foo/index.js
+++ b/packages/rspack-plugin-react-refresh/tests/fixtures/node_modules/foo/index.js
@@ -1,0 +1,1 @@
+module.exports = "foo"

--- a/packages/rspack-plugin-react-refresh/tests/fixtures/node_modules/foo/package.json
+++ b/packages/rspack-plugin-react-refresh/tests/fixtures/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foo",
+  "main": "./index.js"
+}

--- a/packages/rspack-plugin-react-refresh/tests/test.spec.ts
+++ b/packages/rspack-plugin-react-refresh/tests/test.spec.ts
@@ -1,0 +1,131 @@
+const fs = require("fs");
+const path = require("path");
+const { rspack } = require("@rspack/core");
+const ReactRefreshPlugin = require("@rspack/plugin-react-refresh");
+
+const compileWithReactRefresh = (fixturePath, refreshOptions, callback) => {
+	let dist = path.join(fixturePath, "dist");
+	rspack(
+		{
+			mode: "development",
+			context: fixturePath,
+			entry: {
+				fixture: path.join(fixturePath, "index.js")
+			},
+			output: {
+				path: dist
+			},
+			plugins: [new ReactRefreshPlugin(refreshOptions)],
+			optimization: {
+				runtimeChunk: {
+					name: "runtime"
+				},
+				splitChunks: {
+					cacheGroups: {
+						reactRefresh: {
+							test: /[\\/](react-refresh|rspack-plugin-react-refresh\/client|react-refresh-webpack-plugin)[\\/]/,
+							name: "react-refresh",
+							chunks: "all",
+							priority: -1000
+						},
+						foo: {
+							test: /[\\/]node_modules[\\/]foo/,
+							name: "vendor",
+							chunks: "all",
+							priority: -500,
+							enforce: true
+						}
+					}
+				}
+			}
+		},
+		(error, stats) => {
+			expect(error).toBeFalsy();
+			const statsJson = stats.toJson({ all: true });
+			expect(statsJson.errors).toHaveLength(0);
+			expect(statsJson.warnings).toHaveLength(0);
+			callback(error, stats, {
+				reactRefresh: fs.readFileSync(
+					path.join(fixturePath, "dist", "react-refresh.js"),
+					"utf-8"
+				),
+				fixture: fs.readFileSync(
+					path.join(fixturePath, "dist", "fixture.js"),
+					"utf-8"
+				),
+				runtime: fs.readFileSync(
+					path.join(fixturePath, "dist", "runtime.js"),
+					"utf-8"
+				),
+				vendor: fs.readFileSync(
+					path.join(fixturePath, "dist", "vendor.js"),
+					"utf-8"
+				)
+			});
+		}
+	);
+};
+
+describe("react-refresh-rspack-plugin", () => {
+	it("should exclude node_modules when compiling with default options", done => {
+		compileWithReactRefresh(
+			path.join(__dirname, "fixtures/default"),
+			{},
+			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
+				expect(vendor).not.toContain("$RefreshReg$");
+				done();
+			}
+		);
+	});
+
+	it("should include non node_modules when compiling with default options", done => {
+		compileWithReactRefresh(
+			path.join(__dirname, "fixtures/default"),
+			{},
+			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
+				expect(fixture).toContain("$RefreshReg$");
+				done();
+			}
+		);
+	});
+
+	it("should include selected file when compiling", done => {
+		compileWithReactRefresh(
+			path.join(__dirname, "fixtures/custom"),
+			{
+				exclude: null,
+				include: [/node_modules\/foo/]
+			},
+			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
+				expect(vendor).toContain("$RefreshReg$");
+				done();
+			}
+		);
+	});
+
+	it("should exclude selected file when compiling", done => {
+		compileWithReactRefresh(
+			path.join(__dirname, "fixtures/custom"),
+			{
+				exclude: /custom\/index.js/
+			},
+			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
+				expect(fixture).not.toContain("$RefreshReg$");
+				done();
+			}
+		);
+	});
+
+	it("should always exclude react-refresh related modules", done => {
+		compileWithReactRefresh(
+			path.join(__dirname, "fixtures/custom"),
+			{
+				exclude: null
+			},
+			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
+				expect(reactRefresh).not.toContain("$RefreshReg$");
+				done();
+			}
+		);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1222,10 +1222,16 @@ importers:
   packages/rspack-plugin-react-refresh:
     specifiers:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10
+      '@rspack/core': workspace:*
+      '@rspack/plugin-react-refresh': workspace:*
       react-refresh: 0.14.0
+      schema-utils: ^4.0.0
     dependencies:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.10_react-refresh@0.14.0
+      schema-utils: 4.0.1
     devDependencies:
+      '@rspack/core': link:../rspack
+      '@rspack/plugin-react-refresh': 'link:'
       react-refresh: 0.14.0
 
   scripts:
@@ -3770,7 +3776,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.22.20:
@@ -3814,7 +3820,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-class-static-block/7.14.5:
@@ -3978,7 +3984,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-jsx/7.12.1_@babel+core@7.12.9:
@@ -4072,7 +4078,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3:
@@ -4107,7 +4113,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-numeric-separator/7.10.4:
@@ -4142,7 +4148,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread/7.8.3:
@@ -4186,7 +4192,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-optional-catch-binding/7.8.3:
@@ -4221,7 +4227,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-optional-chaining/7.8.3:
@@ -4256,7 +4262,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-private-property-in-object/7.14.5:
@@ -4324,7 +4330,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.22.20
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-typescript/7.20.0:
@@ -7315,7 +7321,7 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       callsites: 3.1.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
     dev: true
 
   /@jest/test-result/29.5.0:
@@ -7333,7 +7339,7 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dependencies:
       '@jest/test-result': 29.5.0
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       jest-haste-map: 29.5.0
       slash: 3.0.0
     dev: true
@@ -12514,6 +12520,7 @@ packages:
     dependencies:
       webpack: 5.76.0_webpack-cli@4.10.0
       webpack-cli: 4.10.0_webpack@5.76.0
+    dev: true
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -12522,6 +12529,7 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0_webpack@5.76.0
+    dev: true
 
   /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -12533,6 +12541,7 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.10.0_webpack@5.76.0
+    dev: true
 
   /@xtuc/ieee754/1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -13147,7 +13156,7 @@ packages:
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 29.5.0_@babel+core@7.22.20
       chalk: 4.1.2
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -14456,6 +14465,7 @@ packages:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+    dev: true
 
   /clone-response/1.0.2:
     resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
@@ -16243,6 +16253,7 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /err-code/2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -16948,6 +16959,7 @@ packages:
   /fastest-levenshtein/1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
+    dev: true
 
   /fastq/1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -18598,6 +18610,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash/0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -18735,6 +18748,7 @@ packages:
   /interpret/2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
+    dev: true
 
   /interpret/3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -19096,6 +19110,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
+    dev: true
 
   /is-plain-object/5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -19286,6 +19301,7 @@ packages:
   /isobject/3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /isomorphic-fetch/2.2.1:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
@@ -20067,7 +20083,7 @@ packages:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.11
+      graceful-fs: 4.2.10
 
   /jsonparse/1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
@@ -20196,6 +20212,7 @@ packages:
   /kind-of/6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /kleur/3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -24239,6 +24256,7 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.2
+    dev: true
 
   /rechoir/0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -24525,6 +24543,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -24533,6 +24552,7 @@ packages:
   /resolve-from/5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-pathname/3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -25237,6 +25257,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
+    dev: true
 
   /shallowequal/1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -26740,7 +26761,7 @@ packages:
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.76.0_webpack-cli@4.10.0
+      webpack: 5.76.0
 
   /terser/5.16.1:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
@@ -28194,6 +28215,7 @@ packages:
       rechoir: 0.7.1
       webpack: 5.76.0_webpack-cli@4.10.0
       webpack-merge: 5.9.0
+    dev: true
 
   /webpack-dev-middleware/5.3.3:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -28468,6 +28490,7 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
+    dev: true
 
   /webpack-sources/2.3.1:
     resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
@@ -28582,6 +28605,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.80.0_esbuild@0.17.18:
     resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
@@ -28749,6 +28773,7 @@ packages:
 
   /wildcard/2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+    dev: true
 
   /window-size/0.1.0:
     resolution: {integrity: sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Add `react-refresh-entry` to the loader excluding list
- Support passing `include` or `exclude` of plugin

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [X] Yes, the corresponding rspack-website PR is , let's create a page for rspack plugins first.
