### PR TITLE
fix: passing option as `&str` caused memory leak in `builtin:swc-loader`

### DIFF
--- a/crates/node_binding/src/loader.rs
+++ b/crates/node_binding/src/loader.rs
@@ -6,8 +6,8 @@ use rspack_binding_options::{run_builtin_loader as run_builtin, JsLoaderContext}
 #[allow(unused)]
 pub async fn run_builtin_loader(
   builtin: String,
-  options: Option<&str>,
+  options: Option<String>,
   loader_context: JsLoaderContext,
 ) -> Result<JsLoaderContext> {
-  run_builtin(builtin, options, loader_context).await
+  run_builtin(builtin, options.as_deref(), loader_context).await
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use `String` instead of `&str` to workaround a memory leak issue.

```
thread 'tokio-runtime-worker' panicked at 'Could not parse builtin:swc-loader options:Some("�N�.\u{c7bda}�"),error: Error("expected value", line: 1, column: 1)', crates/rspack_binding_options/src/options/raw_module/mod.rs:42:11
```

Related: https://github.com/napi-rs/napi-rs/issues/1022

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
