### PR TITLE
fix: avoid double react refresh transform in rspack-dev-server

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -166,7 +166,21 @@ export class RspackDevServer extends WebpackDevServer {
 					// enable react.refresh by default
 					compiler.options.builtins.react.refresh ??= true;
 					if (compiler.options.builtins.react.refresh) {
-						new ReactRefreshPlugin().apply(compiler);
+						const runtimePaths = ReactRefreshPlugin.deprecated_runtimePaths;
+						new compiler.webpack.EntryPlugin(
+							compiler.context,
+							runtimePaths[0],
+							{
+								name: undefined
+							}
+						).apply(compiler);
+						new compiler.webpack.ProvidePlugin({
+							$ReactRefreshRuntime$: runtimePaths[1]
+						}).apply(compiler);
+						compiler.options.module.rules.unshift({
+							include: runtimePaths,
+							type: "js"
+						});
 					}
 				}
 			} else if (compiler.options.builtins.react.refresh) {

--- a/packages/rspack-plugin-react-refresh/src/index.js
+++ b/packages/rspack-plugin-react-refresh/src/index.js
@@ -18,9 +18,9 @@ const refreshRuntimeDirPath = path.dirname(
 	})
 );
 const runtimePaths = [
+	reactRefreshEntryPath,
 	reactRefreshPath,
 	refreshUtilsPath,
-	reactRefreshEntryPath,
 	refreshRuntimeDirPath
 ];
 
@@ -61,3 +61,5 @@ module.exports = class ReactRefreshRspackPlugin {
 		});
 	}
 };
+
+module.exports.deprecated_runtimePaths = runtimePaths;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

avoid builtin:react-refresh-loader and builtins.react.refresh transform at the same time

so builtin:react-refresh-loader and react-refresh-plugin should only used when `rspackFuture.disableTransformByDefault` enabled

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
