### PR TITLE
feat: enable deprecation warnings by default

### DIFF
--- a/examples/angular/package.json
+++ b/examples/angular/package.json
@@ -38,6 +38,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.0.0",
     "typescript": "~4.9.4",
-    "webpack": "5.76.0"
+    "webpack": "5.76.0",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/angular/rspack.config.js
+++ b/examples/angular/rspack.config.js
@@ -1,17 +1,18 @@
 const { AngularWebpackPlugin } = require("@ngtools/webpack");
 const minifyPlugin = require("@rspack/plugin-minify");
+const rspack = require("@rspack/core");
 
 const {
-	DedupeModuleResolvePlugin,
+	DedupeModuleResolvePlugin
 } = require("@angular-devkit/build-angular/src/webpack/plugins/dedupe-module-resolve-plugin");
 const BundleAnalyzerPlugin =
 	require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 
 const {
-	NamedChunksPlugin,
+	NamedChunksPlugin
 } = require("@angular-devkit/build-angular/src/webpack/plugins/named-chunks-plugin");
 const {
-	OccurrencesPlugin,
+	OccurrencesPlugin
 } = require("@angular-devkit/build-angular/src/webpack/plugins/occurrences-plugin");
 const path = require("path");
 
@@ -25,7 +26,7 @@ class MyPlugin {
 				// TODO: This is just a workaround to support set `_module.factoryMeta.sideEffects` on loaderContext , because I am not sure If we should add a new hook that called anyway,
 				// This issue maybe addressed after discussing with rspack core member
 				normalModuleFactory.hooks.afterResolve.tap("MyPlugin", () => {});
-			},
+			}
 		);
 	}
 }
@@ -36,10 +37,10 @@ module.exports = {
 	target: ["web", "es2022"],
 	entry: {
 		polyfills: ["zone.js"],
-		main: ["./src/main.ts"],
+		main: ["./src/main.ts"]
 	},
 	resolve: {
-		extensions: [".ts", ".js"],
+		extensions: [".ts", ".js"]
 	},
 	output: {
 		uniqueName: "angular",
@@ -50,7 +51,7 @@ module.exports = {
 		filename: "[name].[contenthash:20].js",
 		chunkFilename: "[name].[contenthash:20].js",
 		crossOriginLoading: false,
-		trustedTypes: "angular#bundler",
+		trustedTypes: "angular#bundler"
 		// 'scriptType': 'module' // throws error
 	},
 	watch: false,
@@ -59,15 +60,15 @@ module.exports = {
 	experiments: {
 		// 'backCompat': false, // throws error
 		// 'syncWebAssembly': true, // throws error
-		asyncWebAssembly: true,
+		asyncWebAssembly: true
 	},
 	optimization: {
 		runtimeChunk: false,
 		//swc has different behavior compare to terser,this lead output size inflate
 		minimizer: [
 			new minifyPlugin({
-				minifier: "terser",
-			}),
+				minifier: "terser"
+			})
 		],
 		splitChunks: {
 			// 'maxAsyncRequests': null, // throws error
@@ -75,32 +76,24 @@ module.exports = {
 				default: {
 					chunks: "async",
 					minChunks: 2,
-					priority: 10,
+					priority: 10
 				},
 				common: {
 					name: "common",
 					chunks: "async",
 					minChunks: 2,
 					enforce: true,
-					priority: 5,
-				},
+					priority: 5
+				}
 				// 'vendors': false, // throws error
 				// 'defaultVendors': false // throws error
-			},
-		},
+			}
+		}
 	},
 	builtins: {
-		html: [
-			{
-				template: "./src/index.html",
-			},
-		],
 		codeGeneration: {
-			keepComments: true,
-		},
-		define: {
-			ngDevMode: false,
-		},
+			keepComments: true
+		}
 	},
 	module: {
 		parser: {
@@ -108,8 +101,8 @@ module.exports = {
 				requireContext: false,
 				// Disable auto URL asset module creation. This doesn't effect `new Worker(new URL(...))`
 				// https://webpack.js.org/guides/asset-modules/#url-assets
-				url: false,
-			},
+				url: false
+			}
 		},
 		rules: [
 			// {
@@ -126,28 +119,28 @@ module.exports = {
 			{
 				test: /\.?(svg|html)$/,
 				resourceQuery: /\?ngResource/,
-				type: "asset/source",
+				type: "asset/source"
 			},
 			{
 				test: /\.?(scss)$/,
 				resourceQuery: /\?ngResource/,
-				use: [{ loader: "raw-loader" }, { loader: "sass-loader" }],
+				use: [{ loader: "raw-loader" }, { loader: "sass-loader" }]
 			},
 			{ test: /[/\\]rxjs[/\\]add[/\\].+\.js$/, sideEffects: true },
 			{
 				test: /\.[cm]?[tj]sx?$/,
 				exclude: [
-					/[\\/]node_modules[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/,
+					/[\\/]node_modules[/\\](?:core-js|@babel|tslib|web-animations-js|web-streams-polyfill|whatwg-url)[/\\]/
 				],
 				use: [
 					{
 						loader: require.resolve(
-							"@angular-devkit/build-angular/src/babel/webpack-loader.js",
+							"@angular-devkit/build-angular/src/babel/webpack-loader.js"
 						),
 						options: {
 							cacheDirectory: path.join(
 								__dirname,
-								"/.angular/cache/15.2.4/babel-webpack",
+								"/.angular/cache/15.2.4/babel-webpack"
 							),
 							aot: true,
 							optimize: true,
@@ -176,27 +169,31 @@ module.exports = {
 								"safari 15.4",
 								"safari 15.2-15.3",
 								"safari 15.1",
-								"safari 15",
-							],
-						},
-					},
-				],
+								"safari 15"
+							]
+						}
+					}
+				]
 			},
 			{
 				test: /\.[cm]?tsx?$/,
 				use: [{ loader: require.resolve("@ngtools/webpack/src/ivy/index.js") }],
 				exclude: [
-					/[\\/]node_modules[/\\](?:css-loader|mini-css-extract-plugin|webpack-dev-server|webpack)[/\\]/,
-				],
-			},
-		],
+					/[\\/]node_modules[/\\](?:css-loader|mini-css-extract-plugin|webpack-dev-server|webpack)[/\\]/
+				]
+			}
+		]
 	},
 	plugins: [
 		// new DedupeModuleResolvePlugin(),
+		new rspack.HtmlRspackPlugin(),
+		new rspack.DefinePlugin({
+			ngDevMode: false
+		}),
 		new NamedChunksPlugin(),
 		new OccurrencesPlugin({
 			aot: true,
-			scriptsOptimization: false,
+			scriptsOptimization: false
 		}),
 		new MyPlugin(),
 		new AngularWebpackPlugin({
@@ -211,9 +208,9 @@ module.exports = {
 				sourceMap: false,
 				declaration: false,
 				declarationMap: false,
-				preserveSymlinks: false,
+				preserveSymlinks: false
 			},
-			inlineStyleFileExtension: "scss",
-		}),
-	],
+			inlineStyleFileExtension: "scss"
+		})
+	]
 };

--- a/examples/arco-pro/package.json
+++ b/examples/arco-pro/package.json
@@ -40,6 +40,7 @@
     "serve": "14.1.2",
     "@rspack/plugin-react-refresh": "workspace:*",
     "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*",
     "@rspack/plugin-html": "workspace:*",
     "@svgr/webpack": "^6.5.1",
     "@swc/core": "^1.3.14",

--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const rspack = require("@rspack/core");
 const ReactRefreshPlugin = require("@rspack/plugin-react-refresh");
 const { default: HtmlPlugin } = require("@rspack/plugin-html");
 
@@ -7,22 +8,13 @@ const prod = process.env.NODE_ENV === "production";
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
-	entry: { main: "./src/index.tsx" },
+	entry: "./src/index.tsx",
 	target: ["web", "es5"],
 	devServer: {
 		port: 5555,
 		webSocketServer: "sockjs",
 		historyApiFallback: true
 	},
-	mode: prod ? "production" : "development",
-	devtool: false,
-	builtins: {
-		progress: {},
-		treeShaking: true,
-		sideEffects: true,
-		noEmitAssets: false
-	},
-	cache: false,
 	module: {
 		rules: [
 			{
@@ -118,7 +110,8 @@ const config = {
 			template: path.join(__dirname, "index.html"),
 			favicon: path.join(__dirname, "public", "favicon.ico")
 		}),
-		new ReactRefreshPlugin()
+		new ReactRefreshPlugin(),
+		new rspack.ProgressPlugin()
 	],
 	infrastructureLogging: {
 		debug: false

--- a/examples/basic-ts/package.json
+++ b/examples/basic-ts/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/basic-ts/rspack.config.js
+++ b/examples/basic-ts/rspack.config.js
@@ -1,21 +1,16 @@
 const path = require("path");
+const rspack = require("@rspack/core");
 
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-	context: __dirname,
-	mode: "development",
-	entry: {
-		main: "./src/index.ts"
-	},
+	entry: "./src/index.ts",
 	resolve: {
 		tsConfigPath: path.resolve(__dirname, "tsconfig.json")
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/basic/rspack.config.js
+++ b/examples/basic/rspack.config.js
@@ -1,16 +1,11 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-	context: __dirname,
-	mode: "development",
-	entry: {
-		main: "./src/index.js"
-	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	entry: "./src/index.js",
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/builtin-swc-loader/package.json
+++ b/examples/builtin-swc-loader/package.json
@@ -13,8 +13,12 @@
   "license": "MIT",
   "dependencies": {
     "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-refresh": "0.14.0"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/builtin-swc-loader/rspack.config.js
+++ b/examples/builtin-swc-loader/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -39,13 +40,11 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
 	experiments: {
 		rspackFuture: {
 			disableTransformByDefault: true

--- a/examples/bundle-splitting/package.json
+++ b/examples/bundle-splitting/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/bundle-splitting/rspack.config.js
+++ b/examples/bundle-splitting/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	mode: "development",
@@ -5,9 +6,6 @@ const config = {
 		main: {
 			import: ["./index.js"]
 		}
-	},
-	output: {
-		publicPath: "http://localhost:3000"
 	},
 	module: {
 		rules: [],
@@ -30,11 +28,11 @@ const config = {
 			}
 		}
 	},
-	builtins: {
-		html: [{}],
-		define: {
+	plugins: [
+		new rspack.HtmlRspackPlugin(),
+		new rspack.DefinePlugin({
 			"process.env.NODE_ENV": "'development'"
-		}
-	}
+		})
+	]
 };
 module.exports = config;

--- a/examples/code-splitting/index.html
+++ b/examples/code-splitting/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/code-splitting/package.json
+++ b/examples/code-splitting/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/code-splitting/rspack.config.js
+++ b/examples/code-splitting/rspack.config.js
@@ -1,16 +1,15 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-	mode: "development",
 	entry: {
 		main: {
 			import: ["./index.js"]
 		}
 	},
-	builtins: {
-		html: [{}],
-		define: {
-			"process.env.NODE_ENV": "'development'"
-		}
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/cra-ts/package.json
+++ b/examples/cra-ts/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@rspack/core": "workspace:*"
   },
   "scripts": {
     "dev": "rspack serve",

--- a/examples/cra-ts/rspack.config.js
+++ b/examples/cra-ts/rspack.config.js
@@ -1,4 +1,4 @@
-const CopyPlugin = require("copy-webpack-plugin");
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -12,19 +12,17 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		copy: {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.CopyRspackPlugin({
 			patterns: [
 				{
 					from: "public"
 				}
 			]
-		}
-	}
+		})
+	]
 };
 module.exports = config;

--- a/examples/cra/package.json
+++ b/examples/cra/package.json
@@ -8,7 +8,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "@rspack/core": "workspace:*"
   },
   "scripts": {
     "dev": "rspack serve",

--- a/examples/cra/rspack.config.js
+++ b/examples/cra/rspack.config.js
@@ -1,4 +1,4 @@
-const CopyPlugin = require("copy-webpack-plugin");
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -12,19 +12,17 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		copy: {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.CopyRspackPlugin({
 			patterns: [
 				{
 					from: "public"
 				}
 			]
-		}
-	}
+		})
+	]
 };
 module.exports = config;

--- a/examples/emotion/package.json
+++ b/examples/emotion/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/emotion/rspack.config.js
+++ b/examples/emotion/rspack.config.js
@@ -1,15 +1,14 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
 		main: "./src/index.jsx"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
 	module: {
 		rules: [
 			{

--- a/examples/eslint/package.json
+++ b/examples/eslint/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "eslint-rspack-plugin": "^4.0.0-alpha",
-    "eslint": "8"
+    "eslint": "8",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/express/package.json
+++ b/examples/express/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "run-script-webpack-plugin": ""
+    "run-script-webpack-plugin": "",
+    "@rspack/core": "workspace:*"
   },
   "dependencies": {
     "express": "4.18.2"

--- a/examples/extract-license/package.json
+++ b/examples/extract-license/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/extract-license/rspack.config.js
+++ b/examples/extract-license/rspack.config.js
@@ -1,18 +1,17 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
 	entry: {
 		main: "./src/index.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		minifyOptions: {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.SwcJsMinimizerRspackPlugin({
 			extractComments: true
-		}
-	}
+		})
+	]
 };
 module.exports = config;

--- a/examples/library/package.json
+++ b/examples/library/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/loader-compat/package.json
+++ b/examples/loader-compat/package.json
@@ -36,6 +36,7 @@
     "ts-loader": "9.4.2",
     "image-webpack-loader": "8.1.0",
     "svg-react-loader": "0.4.6",
-    "node-loader": "2.0.0"
+    "node-loader": "2.0.0",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/loader-compat/rspack.config.js
+++ b/examples/loader-compat/rspack.config.js
@@ -108,23 +108,25 @@ const config = {
 				test: /\.png$/,
 				exclude: /h\.png$/,
 				use: ({ resource, realResource, resourceQuery, compiler, issuer }) => {
-					console.log('resource', resource)
-					console.log('issuer',issuer)
-					console.log('realResource', realResource);
-					console.log('resourceQuery', resourceQuery);
-					return [{
-						loader: "file-loader"
-					},
-					{
-						loader: "image-webpack-loader",
-						options: {
-							optipng: {
-								enabled: true
+					console.log("resource", resource);
+					console.log("issuer", issuer);
+					console.log("realResource", realResource);
+					console.log("resourceQuery", resourceQuery);
+					return [
+						{
+							loader: "file-loader"
+						},
+						{
+							loader: "image-webpack-loader",
+							options: {
+								optipng: {
+									enabled: true
+								}
 							}
 						}
-					}]
+					];
 				}
-}
+			}
 		]
 	}
 };

--- a/examples/monaco-editor-js/package.json
+++ b/examples/monaco-editor-js/package.json
@@ -11,5 +11,8 @@
   "dependencies": {
     "@rspack/cli": "workspace:*",
     "monaco-editor": "^0.39.0"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/monaco-editor-js/rspack.config.js
+++ b/examples/monaco-editor-js/rspack.config.js
@@ -1,23 +1,26 @@
-const path = require('path');
+const rspack = require("@rspack/core");
+const path = require("path");
 
 module.exports = {
 	entry: {
-		app: './index.js',
+		app: "./index.js"
 	},
 	output: {
-		globalObject: 'self',
-		filename: '[name].bundle.js',
-		path: path.resolve(__dirname, 'dist')
+		globalObject: "self",
+		filename: "[name].bundle.js",
+		path: path.resolve(__dirname, "dist")
 	},
 	module: {
 		rules: [
 			{
 				test: /\.ttf$/,
-				type: 'asset/resource',
+				type: "asset/resource"
 			}
 		]
 	},
-	builtins: {
-		html: [{ template: './index.html' }]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };

--- a/examples/monaco-editor-ts-react/package.json
+++ b/examples/monaco-editor-ts-react/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8",
-    "typescript": "^5.1.6"
+    "typescript": "^5.1.6",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/monaco-editor-ts-react/rspack.config.js
+++ b/examples/monaco-editor-ts-react/rspack.config.js
@@ -1,30 +1,33 @@
-const path = require('path');
+const rspack = require("@rspack/core");
+const path = require("path");
 
 module.exports = {
 	entry: {
-		app: './src/index.tsx',
+		app: "./src/index.tsx"
 	},
 	devServer: {
-		hot: true,
+		hot: true
 	},
 	resolve: {
-		extensions: ['*', '.js', '.jsx', '.tsx', '.ts'],
+		extensions: ["*", ".js", ".jsx", ".tsx", ".ts"],
 		tsConfigPath: path.resolve(__dirname, "tsconfig.json")
 	},
 	output: {
-		globalObject: 'self',
-		filename: '[name].bundle.js',
-		path: path.resolve(__dirname, 'dist')
+		globalObject: "self",
+		filename: "[name].bundle.js",
+		path: path.resolve(__dirname, "dist")
 	},
 	module: {
 		rules: [
 			{
 				test: /\.ttf$/,
-				type: 'asset/resource',
+				type: "asset/resource"
 			}
 		]
 	},
-	builtins: {
-		html: [{ template: './src/index.html' }]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./src/index.html"
+		})
+	]
 };

--- a/examples/multi-entry/package.json
+++ b/examples/multi-entry/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/multi-entry/rspack.config.js
+++ b/examples/multi-entry/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	mode: "development",
@@ -8,11 +9,6 @@ const config = {
 	output: {
 		publicPath: "http://localhost:3000"
 	},
-	builtins: {
-		html: [{}],
-		define: {
-			"process.env.NODE_ENV": "'development'"
-		}
-	}
+	plugins: [new rspack.HtmlRspackPlugin()]
 };
 module.exports = config;

--- a/examples/nestjs/package.json
+++ b/examples/nestjs/package.json
@@ -18,7 +18,8 @@
     "rxjs": "^7.5.5"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/node-globals-shim/package.json
+++ b/examples/node-globals-shim/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/node-globals-shim/rspack.config.js
+++ b/examples/node-globals-shim/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const path = require("path");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
@@ -5,15 +6,13 @@ const config = {
 	entry: {
 		main: "./src/index.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		provide: {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.ProvidePlugin({
 			process: path.resolve(__dirname, "./src/process-shim.js")
-		}
-	}
+		})
+	]
 };
 module.exports = config;

--- a/examples/node-polyfill/package.json
+++ b/examples/node-polyfill/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "@rspack/plugin-node-polyfill": "workspace:*"
+    "@rspack/plugin-node-polyfill": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/node-polyfill/rspack.config.js
+++ b/examples/node-polyfill/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const polyfillPlugin = require("@rspack/plugin-node-polyfill");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
@@ -5,13 +6,11 @@ const config = {
 	entry: {
 		main: "./src/index.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
-	plugins: [new polyfillPlugin()]
+	plugins: [
+		new polyfillPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/perfsee/package.json
+++ b/examples/perfsee/package.json
@@ -11,7 +11,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "@perfsee/webpack": "1.6.0"
+    "@perfsee/webpack": "1.6.0",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/perfsee/rspack.config.js
+++ b/examples/perfsee/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const { PerfseePlugin } = require("@perfsee/webpack");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
@@ -5,13 +6,11 @@ const config = {
 	entry: {
 		main: "./src/index.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
-	plugins: [new PerfseePlugin({})]
+	plugins: [
+		new PerfseePlugin({}),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -21,6 +21,7 @@
     "license-webpack-plugin": "^4.0.2",
     "rspack-manifest-plugin": "5.0.0-alpha0",
     "webpack-bundle-analyzer": "4.7.0",
-    "webpack-stats-plugin": "1.1.1"
+    "webpack-stats-plugin": "1.1.1",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const BundleAnalyzerPlugin =
 	require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const CopyPlugin = require("copy-webpack-plugin");

--- a/examples/polyfill/package.json
+++ b/examples/polyfill/package.json
@@ -12,7 +12,8 @@
     "core-js": "3.30.1"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/polyfill/rspack.config.js
+++ b/examples/polyfill/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const path = require("path");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
@@ -10,17 +11,27 @@ const config = {
 			"core-js": path.dirname(require.resolve("core-js"))
 		}
 	},
-	builtins: {
-		presetEnv: {
-			targets: ["> 0.01%", "not dead", "not op_mini all"],
-			mode: "usage",
-			coreJs: "3.26"
-		},
-		html: [
+	module: {
+		rules: [
 			{
-				template: "./index.html"
+				test: /\.js$/,
+				exclude: /node_modules/,
+				loader: "builtin:swc-loader",
+				options: {
+					sourceMap: true,
+					env: {
+						targets: ["> 0.01%", "not dead", "not op_mini all"],
+						mode: "usage",
+						coreJs: "3.26"
+					}
+				}
 			}
 		]
-	}
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/postcss-loader/package.json
+++ b/examples/postcss-loader/package.json
@@ -12,7 +12,8 @@
     "@rspack/cli": "workspace:*",
     "postcss-loader": "7.3.3",
     "autoprefixer": "10.4.15",
-    "postcss-plugin-px2rem": "0.8.1"
+    "postcss-plugin-px2rem": "0.8.1",
+    "@rspack/core": "workspace:*"
   },
   "browserslist": "last 4 version",
   "sideEffects": false,

--- a/examples/postcss-loader/rspack.config.js
+++ b/examples/postcss-loader/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
@@ -39,12 +40,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/postcss/package.json
+++ b/examples/postcss/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/postcss/rspack.config.js
+++ b/examples/postcss/rspack.config.js
@@ -1,12 +1,8 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	mode: "development",
 	entry: "./index.js",
-	builtins: {
-		html: [{}],
-		define: {
-			"process.env.NODE_ENV": "'development'"
-		}
-	}
+	plugins: [new rspack.HtmlRspackPlugin()]
 };
 module.exports = config;

--- a/examples/proxy/package.json
+++ b/examples/proxy/package.json
@@ -9,7 +9,8 @@
     "dev": "rspack serve"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/proxy/rspack.config.js
+++ b/examples/proxy/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const path = require("path");
 module.exports = (env, argv) => {
 	console.log("env:", env, argv);

--- a/examples/react-15-classic/package.json
+++ b/examples/react-15-classic/package.json
@@ -16,5 +16,8 @@
     "react": "15.0.0",
     "react-dom": "15.0.0",
     "react-refresh": "0.14.0"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/react-15-classic/rspack.config.js
+++ b/examples/react-15-classic/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -8,18 +9,30 @@ const config = {
 			{
 				test: /\.(png|svg|jpg)$/,
 				type: "asset/resource"
+			},
+			{
+				test: /\.jsx$/,
+				loader: "builtin:swc-loader",
+				options: {
+					jsc: {
+						parser: {
+							syntax: "ecmascript",
+							jsx: true
+						},
+						transform: {
+							react: {
+								runtime: "classic"
+							}
+						}
+					}
+				}
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		react: {
-			runtime: "classic"
-		}
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/react-15/package.json
+++ b/examples/react-15/package.json
@@ -16,5 +16,8 @@
     "react": "15.7.0",
     "react-dom": "15.7.0",
     "react-refresh": "0.14.0"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/react-15/rspack.config.js
+++ b/examples/react-15/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -11,12 +12,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/react-storybook/package.json
+++ b/examples/react-storybook/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "^18.0.8",
     "prop-types": "^15.8.1",
     "storybook": "^7.0.0",
-    "storybook-react-rspack": "7.0.0-rc.18"
+    "storybook-react-rspack": "7.0.0-rc.18",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/react-storybook/rspack.config.js
+++ b/examples/react-storybook/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 console.log("story:");
 /**
  * @type {import('@rspack/cli').Configuration}
@@ -7,13 +8,11 @@ module.exports = {
 	entry: {
 		main: "./src/main.jsx"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
 	module: {
 		rules: [
 			{

--- a/examples/react-with-less/package.json
+++ b/examples/react-with-less/package.json
@@ -17,5 +17,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "normalize.css": "8.0.1"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/react-with-less/rspack.config.js
+++ b/examples/react-with-less/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const path = require("path");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
@@ -5,16 +6,6 @@ const config = {
 	mode: "development",
 	entry: {
 		main: ["./src/index.jsx"]
-	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		define: {
-			"process.env.NODE_ENV": "'development'"
-		}
 	},
 	module: {
 		rules: [
@@ -25,6 +16,11 @@ const config = {
 			}
 		]
 	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
 	output: {
 		path: path.resolve(__dirname, "dist")
 	}

--- a/examples/react-with-sass/package.json
+++ b/examples/react-with-sass/package.json
@@ -16,5 +16,8 @@
     "react": "17.0.0",
     "react-dom": "17.0.0",
     "sass-loader": "^13.2.0"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/react-with-sass/rspack.config.js
+++ b/examples/react-with-sass/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	mode: "development",
@@ -13,12 +14,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,5 +16,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-refresh": "0.14.0"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/react/rspack.config.js
+++ b/examples/react/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -11,12 +12,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -18,5 +18,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
+  }
 }

--- a/examples/solid/rspack.config.js
+++ b/examples/solid/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
@@ -32,16 +33,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		react: {
-			refresh: false
-		}
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
-module.exports = config
-
+module.exports = config;

--- a/examples/stats/package.json
+++ b/examples/stats/package.json
@@ -9,7 +9,8 @@
     "build": "rspack build"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/stats/rspack.config.js
+++ b/examples/stats/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 class StatsPrinterTestPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("StatsPrinterTestPlugin", compilation => {
@@ -41,13 +42,11 @@ const config = {
 		main: "./src/index.js"
 	},
 	stats: true,
-	plugins: [new StatsPrinterTestPlugin()],
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new StatsPrinterTestPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/styled-components/package.json
+++ b/examples/styled-components/package.json
@@ -15,7 +15,8 @@
     "react-dom": "17"
   },
   "devDependencies": {
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/styled-components/rspack.config.js
+++ b/examples/styled-components/rspack.config.js
@@ -1,14 +1,13 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
 		main: "./src/index.tsx"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -14,7 +14,8 @@
     "svelte-preprocess": "^5.0.1",
     "tslib": "^2.5.0",
     "typescript": "5.0.2",
-    "webpack-bundle-analyzer": "4.6.1"
+    "webpack-bundle-analyzer": "4.6.1",
+    "@rspack/core": "workspace:*"
   },
   "scripts": {
     "build": "rspack build",

--- a/examples/svgr/package.json
+++ b/examples/svgr/package.json
@@ -16,6 +16,7 @@
     "react": "15",
     "react-dom": "15",
     "url-loader": "4.1.1",
-    "@svgr/webpack": "6.5.1"
+    "@svgr/webpack": "6.5.1",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/svgr/rspack.config.js
+++ b/examples/svgr/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -11,8 +12,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [{ template: "./index.html" }]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/tailwind-jit/package.json
+++ b/examples/tailwind-jit/package.json
@@ -13,7 +13,8 @@
     "tailwindcss": "3.3.1",
     "autoprefixer": "10.4.14",
     "postcss": "8.4.21",
-    "postcss-loader": "7.2.3"
+    "postcss-loader": "7.2.3",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/tailwind-jit/rspack.config.js
+++ b/examples/tailwind-jit/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
@@ -25,12 +26,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/examples/tailwind/package.json
+++ b/examples/tailwind/package.json
@@ -13,7 +13,8 @@
     "tailwindcss": "3.3.1",
     "autoprefixer": "10.4.14",
     "postcss": "8.4.21",
-    "postcss-loader": "7.2.3"
+    "postcss-loader": "7.2.3",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/tailwind/rspack.config.js
+++ b/examples/tailwind/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /**
  * @type {import('@rspack/cli').Configuration}
  */
@@ -27,11 +28,9 @@ module.exports = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };

--- a/examples/test.js
+++ b/examples/test.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+
+const migrate = dir => {
+	if (fs.statSync(dir).isFile() || dir.includes("node_modules")) return;
+	const source = JSON.parse(fs.readFileSync(`${dir}/package.json`, "utf-8"));
+	if (!source.devDependencies?.["@rspack/core"]) {
+		(source.devDependencies ||= {})["@rspack/core"] = "workspace:*";
+	}
+	fs.writeFileSync(`${dir}/package.json`, JSON.stringify(source, null, 2));
+	let config = fs.readFileSync(`${dir}/rspack.config.js`, "utf-8");
+	if (!config.includes(`const rspack = require("@rspack/core")`)) {
+		config = `const rspack = require("@rspack/core");\n` + config;
+		fs.writeFileSync(`${dir}/rspack.config.js`, config);
+	}
+};
+
+fs.readdirSync(__dirname).forEach(migrate);

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -15,7 +15,8 @@
     "@rspack/cli": "workspace:*",
     "less": "4.1.3",
     "less-loader": "^11.1.0",
-    "vue-loader": "^17.2.2"
+    "vue-loader": "^17.2.2",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/vue/rspack.config.js
+++ b/examples/vue/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const { VueLoaderPlugin } = require("vue-loader");
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -6,21 +7,19 @@ const config = {
 	entry: {
 		main: "./src/main.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		define: {
-			__VUE_OPTIONS_API__: JSON.stringify(true),
-			__VUE_PROD_DEVTOOLS__: JSON.stringify(false)
-		}
-	},
 	devServer: {
 		historyApiFallback: true
 	},
-	plugins: [new VueLoaderPlugin()],
+	plugins: [
+		new VueLoaderPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
+			__VUE_OPTIONS_API__: JSON.stringify(true),
+			__VUE_PROD_DEVTOOLS__: JSON.stringify(false)
+		})
+	],
 	module: {
 		rules: [
 			{

--- a/examples/vue2-ts/package.json
+++ b/examples/vue2-ts/package.json
@@ -15,7 +15,8 @@
     "less-loader": "^11.1.0",
     "vue": "2.7.14",
     "vue-loader": "^15.10.1",
-    "vue-style-loader": "^4.1.3"
+    "vue-style-loader": "^4.1.3",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/vue2-ts/rspack.config.js
+++ b/examples/vue2-ts/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const { VueLoaderPlugin } = require("vue-loader");
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -6,18 +7,16 @@ const config = {
 	entry: {
 		main: "./src/main.ts"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
 	devServer: {
 		historyApiFallback: true
 	},
 	devtool: false,
-	plugins: [new VueLoaderPlugin()],
+	plugins: [
+		new VueLoaderPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
 	resolve: {
 		extensions: [".vue", "..."]
 	},

--- a/examples/vue2/package.json
+++ b/examples/vue2/package.json
@@ -15,7 +15,8 @@
     "less-loader": "^11.1.0",
     "vue": "2.7.14",
     "vue-loader": "^15.11.0",
-    "vue-style-loader": "^4.1.3"
+    "vue-style-loader": "^4.1.3",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/vue2/rspack.config.js
+++ b/examples/vue2/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const { VueLoaderPlugin } = require("vue-loader");
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -6,18 +7,16 @@ const config = {
 	entry: {
 		main: "./src/main.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	},
 	devServer: {
 		historyApiFallback: true
 	},
 	devtool: false,
-	plugins: [new VueLoaderPlugin()],
+	plugins: [
+		new VueLoaderPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	],
 	module: {
 		rules: [
 			{

--- a/examples/vue3-jsx/package.json
+++ b/examples/vue3-jsx/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "7.21.0",
     "@rspack/cli": "workspace:*",
     "@vue/babel-plugin-jsx": "1.1.1",
-    "babel-loader": "9.1.2"
+    "babel-loader": "9.1.2",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/vue3-jsx/rspack.config.js
+++ b/examples/vue3-jsx/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
@@ -23,16 +24,14 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		define: {
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
 			__VUE_OPTIONS_API__: JSON.stringify(true),
 			__VUE_PROD_DEVTOOLS__: JSON.stringify(false)
-		}
-	}
+		})
+	]
 };
 module.exports = config;

--- a/examples/vue3-tsx/package.json
+++ b/examples/vue3-tsx/package.json
@@ -18,6 +18,7 @@
     "@vue/babel-plugin-jsx": "1.1.1",
     "babel-loader": "9.1.2",
     "typescript": "^5.1.3",
-    "vue-loader": "^17.2.2"
+    "vue-loader": "^17.2.2",
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/vue3-tsx/rspack.config.js
+++ b/examples/vue3-tsx/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const { VueLoaderPlugin } = require("vue-loader");
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -38,17 +39,15 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		define: {
+	plugins: [
+		new VueLoaderPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
 			__VUE_OPTIONS_API__: JSON.stringify(true),
 			__VUE_PROD_DEVTOOLS__: JSON.stringify(false)
-		}
-	},
-	plugins: [new VueLoaderPlugin()]
+		})
+	]
 };
 module.exports = config;

--- a/examples/vue3-vanilla/package.json
+++ b/examples/vue3-vanilla/package.json
@@ -17,7 +17,8 @@
     "less": "4.1.3",
     "less-loader": "^11.1.0",
     "style-loader": "^3.3.3",
-    "vue-loader": "^17.2.2"
+    "vue-loader": "^17.2.2",
+    "@rspack/core": "workspace:*"
   },
   "keywords": [],
   "author": "",

--- a/examples/vue3-vanilla/rspack.config.js
+++ b/examples/vue3-vanilla/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 const { VueLoaderPlugin } = require("vue-loader");
 
 /** @type {import('@rspack/cli').Configuration} */
@@ -6,21 +7,19 @@ const config = {
 	entry: {
 		main: "./src/main.js"
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		define: {
-			__VUE_OPTIONS_API__: JSON.stringify(true),
-			__VUE_PROD_DEVTOOLS__: JSON.stringify(false)
-		}
-	},
 	devServer: {
 		historyApiFallback: true
 	},
-	plugins: [new VueLoaderPlugin()],
+	plugins: [
+		new VueLoaderPlugin(),
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
+			__VUE_OPTIONS_API__: JSON.stringify(true),
+			__VUE_PROD_DEVTOOLS__: JSON.stringify(false)
+		})
+	],
 	module: {
 		rules: [
 			{

--- a/examples/wasm-simple/package.json
+++ b/examples/wasm-simple/package.json
@@ -10,5 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "@rspack/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/wasm-simple/rspack.config.js
+++ b/examples/wasm-simple/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	entry: {
@@ -10,8 +11,6 @@ const config = {
 	experiments: {
 		asyncWebAssembly: true
 	},
-	builtins: {
-		html: [{}]
-	}
+	plugins: [new rspack.HtmlRspackPlugin()]
 };
 module.exports = config;

--- a/examples/worker/package.json
+++ b/examples/worker/package.json
@@ -10,5 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "@rspack/cli": "workspace:*"
+  },
+  "devDependencies": {
+    "@rspack/core": "workspace:*"
   }
 }

--- a/examples/worker/rspack.config.js
+++ b/examples/worker/rspack.config.js
@@ -1,16 +1,15 @@
+const rspack = require("@rspack/core");
 const path = require("path");
 
 module.exports = {
 	entry: "./example.js",
 	context: __dirname,
 	output: {
-		path: path.join(__dirname, "dist"),
+		path: path.join(__dirname, "dist")
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		]
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };

--- a/examples/worklet/package.json
+++ b/examples/worklet/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {
     "esbuild": "0.19.3",
-    "@rspack/cli": "workspace:*"
+    "@rspack/cli": "workspace:*",
+    "@rspack/core": "workspace:*"
   },
   "sideEffects": false,
   "keywords": [],

--- a/examples/worklet/rspack.config.js
+++ b/examples/worklet/rspack.config.js
@@ -1,3 +1,4 @@
+const rspack = require("@rspack/core");
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
 	context: __dirname,
@@ -27,15 +28,10 @@ const config = {
 			}
 		]
 	},
-	builtins: {
-		html: [
-			{
-				template: "./index.html"
-			}
-		],
-		react: {
-			refresh: false
-		}
-	}
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		})
+	]
 };
 module.exports = config;

--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -24,6 +24,7 @@ import { normalizeEnv } from "./utils/options";
 import { loadRspackConfig } from "./utils/loadConfig";
 import findConfig from "./utils/findConfig";
 import type { RspackPluginInstance, RspackPluginFunction } from "@rspack/core";
+import * as rspackCore from "@rspack/core";
 import path from "path";
 
 type Command = "serve" | "build";
@@ -170,7 +171,22 @@ export class RspackCLI {
 			}
 			item.builtins = item.builtins || {};
 			if (isServe) {
-				item.builtins.progress = item.builtins.progress ?? true;
+				let installed = (item.plugins ||= []).find(
+					item => item instanceof rspackCore.ProgressPlugin
+				);
+				let o: rspackCore.ProgressPluginArgument | undefined;
+				if (
+					!installed &&
+					(o =
+						item.builtins.progress && typeof item.builtins.progress === "object"
+							? item.builtins.progress
+							: item.builtins.progress === true
+							? {}
+							: undefined)
+				) {
+					(item.plugins ||= []).push(new rspackCore.ProgressPlugin(o));
+				}
+				delete item.builtins.progress;
 			}
 
 			// no emit assets when run dev server, it will use node_binding api get file content
@@ -186,11 +202,14 @@ export class RspackCLI {
 
 			// When mode is set to 'none', optimization.nodeEnv defaults to false.
 			if (item.mode !== "none") {
-				item.builtins.define = {
-					// User defined `process.env.NODE_ENV` always has highest priority than default define
-					"process.env.NODE_ENV": JSON.stringify(item.mode),
-					...item.builtins.define
-				};
+				(item.plugins ||= []).push(
+					new rspackCore.DefinePlugin({
+						// User defined `process.env.NODE_ENV` always has highest priority than default define
+						"process.env.NODE_ENV": JSON.stringify(item.mode),
+						...item.builtins.define
+					})
+				);
+				delete item.builtins.define;
 			}
 
 			if (typeof item.stats === "undefined") {

--- a/packages/rspack-plugin-node-polyfill/src/index.js
+++ b/packages/rspack-plugin-node-polyfill/src/index.js
@@ -37,13 +37,7 @@ module.exports = class PolyfillBuiltinsPlugin {
 			process: [require.resolve("process/browser")]
 		};
 
-		compiler.options.builtins = {
-			...compiler.options.builtins,
-			provide: {
-				...provide,
-				...compiler.options.builtins?.provide
-			}
-		};
+		compiler.options.plugins.push(new compiler.webpack.ProvidePlugin(provide));
 		compiler.options.resolve.fallback = {
 			...PolyfilledBuiltinModules,
 			...compiler.options.resolve.fallback

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json",
     "dev": "tsc -w",
-    "test": "cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage"
+    "test": "cross-env NO_COLOR=1 RSPACK_DEP_WARNINGS=false node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage"
   },
   "files": [
     "dist"

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -114,6 +114,12 @@ export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
 }
 const getDeprecationStatus = () => {
 	const defaultEnableDeprecatedWarning = true;
+	if (
+		process.env.RSPACK_DEP_WARNINGS === "false" ||
+		process.env.RSPACK_DEP_WARNINGS === "0"
+	) {
+		return false;
+	}
 	return (
 		(process.env.RSPACK_DEP_WARNINGS ?? `${defaultEnableDeprecatedWarning}`) !==
 		"false"

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -113,10 +113,10 @@ export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
 	};
 }
 const getDeprecationStatus = () => {
-	const defaultEnableDeprecatedWarning = false;
+	const defaultEnableDeprecatedWarning = true;
 	return (
-		(process.env.RSPACK_BUILTINS_DEPRECATED ??
-			`${defaultEnableDeprecatedWarning}`) !== "false"
+		(process.env.RSPACK_DEP_WARNINGS ?? `${defaultEnableDeprecatedWarning}`) !==
+		"false"
 	);
 };
 const yellow = (content: string) =>
@@ -127,6 +127,12 @@ export const deprecatedWarn = (
 ) => {
 	if (enable) {
 		console.warn(yellow(content));
+		console.warn(
+			indent(
+				"Set env `RSPACK_DEP_WARNINGS` to 'false' to temporarily disable deprecation warnings.\n",
+				"    "
+			)
+		);
 	}
 };
 export const termlink = terminalLink;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,7 @@ importers:
       '@angular/router': ^16.0.0
       '@ngtools/webpack': ^16.0.0
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@rspack/plugin-minify': workspace:*
       html-webpack-plugin: ^5.5.0
       karma: ~6.4.0
@@ -145,6 +146,7 @@ importers:
       '@angular/compiler-cli': 16.0.0_scldldeidleauflck5yigfgo3u
       '@ngtools/webpack': 16.0.0_cgwpibwus2sfr6wgvih7aq35fm
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@rspack/plugin-minify': link:../../packages/rspack-plugin-minify
       html-webpack-plugin: 5.5.0_webpack@5.76.0
       karma: 6.4.2
@@ -163,6 +165,7 @@ importers:
       '@arco-themes/react-arco-pro': ^0.0.7
       '@loadable/component': ^5.15.2
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@rspack/plugin-html': workspace:*
       '@rspack/plugin-react-refresh': workspace:*
       '@svgr/webpack': ^6.5.1
@@ -222,6 +225,7 @@ importers:
       regenerator-runtime: 0.13.9
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@rspack/plugin-html': link:../../packages/rspack-plugin-html
       '@rspack/plugin-react-refresh': link:../../packages/rspack-plugin-react-refresh
       '@svgr/webpack': 6.5.1
@@ -239,26 +243,32 @@ importers:
   examples/basic:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/basic-ts:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       typescript: ^5.1.3
     dependencies:
       typescript: 5.1.3
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/builtin-swc-loader:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: 18.2.0
       react-dom: 18.2.0
       react-refresh: 0.14.0
     dependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-refresh: 0.14.0
@@ -266,18 +276,23 @@ importers:
   examples/bundle-splitting:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/code-splitting:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/cra:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: ^18.2.0
       react-dom: ^18.2.0
       web-vitals: ^2.1.4
@@ -286,11 +301,13 @@ importers:
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       web-vitals: 2.1.4
 
   examples/cra-ts:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: ^18.2.0
       react-dom: ^18.2.0
       web-vitals: ^2.1.4
@@ -299,6 +316,7 @@ importers:
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       web-vitals: 2.1.4
 
   examples/emotion:
@@ -306,6 +324,7 @@ importers:
       '@emotion/react': 11.10.6
       '@emotion/styled': 11.10.6
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: '17'
       react-dom: '17'
     dependencies:
@@ -315,39 +334,48 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/eslint:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       eslint: '8'
       eslint-rspack-plugin: ^4.0.0-alpha
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       eslint: 8.40.0
       eslint-rspack-plugin: 4.0.0-alpha_eslint@8.40.0
 
   examples/express:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       express: 4.18.2
       run-script-webpack-plugin: ''
     dependencies:
       express: 4.18.2
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       run-script-webpack-plugin: 0.2.0
 
   examples/extract-license:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/library:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/loader-compat:
     specifiers:
@@ -355,6 +383,7 @@ importers:
       '@mdx-js/loader': 2.2.1
       '@node-rs/crc32': 1.7.0
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13
       babel-loader: 9.1.2
@@ -381,6 +410,7 @@ importers:
       '@babel/preset-env': 7.20.2
       '@mdx-js/loader': 2.2.1
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@svgr/webpack': 6.5.1
       autoprefixer: 10.4.13
       babel-loader: 9.1.2
@@ -405,14 +435,18 @@ importers:
   examples/monaco-editor-js:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       monaco-editor: ^0.39.0
     dependencies:
       '@rspack/cli': link:../../packages/rspack-cli
       monaco-editor: 0.39.0
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/monaco-editor-ts-react:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@types/react': ^18.0.25
       '@types/react-dom': ^18.0.8
       monaco-editor: ^0.39.0
@@ -427,6 +461,7 @@ importers:
       react-dom: 18.0.0_react@18.0.0
       react-refresh: 0.13.0
     devDependencies:
+      '@rspack/core': link:../../packages/rspack
       '@types/react': 18.2.6
       '@types/react-dom': 18.2.4
       typescript: 5.1.6
@@ -434,8 +469,10 @@ importers:
   examples/multi-entry:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/nestjs:
     specifiers:
@@ -443,6 +480,7 @@ importers:
       '@nestjs/core': ^9.0.5
       '@nestjs/platform-express': ^9.0.0
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       reflect-metadata: ^0.1.13
       run-script-webpack-plugin: 0.2.0
       rxjs: ^7.5.5
@@ -455,32 +493,40 @@ importers:
       rxjs: 7.6.0
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/node-globals-shim:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/node-polyfill:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@rspack/plugin-node-polyfill': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@rspack/plugin-node-polyfill': link:../../packages/rspack-plugin-node-polyfill
 
   examples/perfsee:
     specifiers:
       '@perfsee/webpack': 1.6.0
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@perfsee/webpack': 1.6.0
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/plugin-compat:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@rspack/plugin-minify': workspace:*
       copy-webpack-plugin: 5.1.2
       fork-ts-checker-webpack-plugin: 8.0.0
@@ -492,6 +538,7 @@ importers:
       webpack-stats-plugin: 1.1.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@rspack/plugin-minify': link:../../packages/rspack-plugin-minify
       copy-webpack-plugin: 5.1.2
       fork-ts-checker-webpack-plugin: 8.0.0
@@ -505,26 +552,32 @@ importers:
   examples/polyfill:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       core-js: 3.30.1
     dependencies:
       core-js: 3.30.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/postcss:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/postcss-loader:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       autoprefixer: 10.4.15
       postcss-loader: 7.3.3
       postcss-plugin-px2rem: 0.8.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       autoprefixer: 10.4.15
       postcss-loader: 7.3.3
       postcss-plugin-px2rem: 0.8.1
@@ -532,12 +585,15 @@ importers:
   examples/proxy:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/react:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: 18.2.0
       react-dom: 18.2.0
       react-refresh: 0.14.0
@@ -546,10 +602,13 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-refresh: 0.14.0
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/react-15:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: 15.7.0
       react-dom: 15.7.0
       react-refresh: 0.14.0
@@ -558,10 +617,13 @@ importers:
       react: 15.7.0
       react-dom: 15.7.0_react@15.7.0
       react-refresh: 0.14.0
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/react-15-classic:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: 15.0.0
       react-dom: 15.0.0
       react-refresh: 0.14.0
@@ -570,6 +632,8 @@ importers:
       react: 15.0.0
       react-dom: 15.0.0_react@15.0.0
       react-refresh: 0.14.0
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/react-refresh:
     specifiers:
@@ -616,6 +680,7 @@ importers:
   examples/react-storybook:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@storybook/addon-essentials': ^7.0.0
       '@storybook/addon-interactions': ^7.0.0
       '@storybook/addon-links': ^7.0.0
@@ -634,6 +699,7 @@ importers:
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@storybook/addon-essentials': 7.0.15_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-interactions': 7.0.15_sfoxds7t5ydpegc3knd667wn6m
       '@storybook/addon-links': 7.0.15_sfoxds7t5ydpegc3knd667wn6m
@@ -649,6 +715,7 @@ importers:
   examples/react-with-less:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       less-loader: 11.1.0
       normalize.css: 8.0.1
       react: 17.0.0
@@ -659,10 +726,13 @@ importers:
       normalize.css: 8.0.1
       react: 17.0.0
       react-dom: 17.0.0_react@17.0.0
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/react-with-sass:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       react: 17.0.0
       react-dom: 17.0.0
       sass-loader: ^13.2.0
@@ -671,11 +741,14 @@ importers:
       react: 17.0.0
       react-dom: 17.0.0_react@17.0.0
       sass-loader: 13.2.0
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/solid:
     specifiers:
       '@babel/core': 7.20.12
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       babel-loader: 9.1.2
       babel-preset-solid: 1.6.9
       solid-js: 1.6.9
@@ -687,16 +760,21 @@ importers:
       babel-preset-solid: 1.6.9_@babel+core@7.20.12
       solid-js: 1.6.9
       solid-refresh: 0.5.2_solid-js@1.6.9
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/stats:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/styled-components:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@types/styled-components': 5.1.26
       react: '17'
       react-dom: '17'
@@ -708,10 +786,12 @@ importers:
       styled-components: 5.3.6_sfoxds7t5ydpegc3knd667wn6m
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
 
   examples/svelte:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@rspack/plugin-html': workspace:*
       '@tsconfig/svelte': ^3.0.0
       cross-env: ^7.0.3
@@ -725,6 +805,7 @@ importers:
       webpack-bundle-analyzer: 4.6.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@rspack/plugin-html': link:../../packages/rspack-plugin-html
       '@tsconfig/svelte': 3.0.0
       cross-env: 7.0.3
@@ -740,12 +821,14 @@ importers:
   examples/svgr:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@svgr/webpack': 6.5.1
       react: '15'
       react-dom: '15'
       url-loader: 4.1.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@svgr/webpack': 6.5.1
       react: 15.7.0
       react-dom: 15.7.0_react@15.7.0
@@ -754,12 +837,14 @@ importers:
   examples/tailwind:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       autoprefixer: 10.4.14
       postcss: 8.4.21
       postcss-loader: 7.2.3
       tailwindcss: 3.3.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       autoprefixer: 10.4.14_postcss@8.4.21
       postcss: 8.4.21
       postcss-loader: 7.2.3_postcss@8.4.21
@@ -768,12 +853,14 @@ importers:
   examples/tailwind-jit:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       autoprefixer: 10.4.14
       postcss: 8.4.21
       postcss-loader: 7.2.3
       tailwindcss: 3.3.1
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       autoprefixer: 10.4.14_postcss@8.4.21
       postcss: 8.4.21
       postcss-loader: 7.2.3_postcss@8.4.21
@@ -782,6 +869,7 @@ importers:
   examples/vue:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       less: 4.1.3
       less-loader: ^11.1.0
       vue: 3.2.47
@@ -790,6 +878,7 @@ importers:
       vue: 3.2.47
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       less: 4.1.3
       less-loader: 11.1.0_less@4.1.3
       vue-loader: 17.2.2_vue@3.2.47
@@ -797,6 +886,7 @@ importers:
   examples/vue2:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       css-loader: ^6.7.4
       less: 4.1.3
       less-loader: ^11.1.0
@@ -805,6 +895,7 @@ importers:
       vue-style-loader: ^4.1.3
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       css-loader: 6.7.4
       less: 4.1.3
       less-loader: 11.1.0_less@4.1.3
@@ -815,6 +906,7 @@ importers:
   examples/vue2-ts:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       css-loader: ^6.7.4
       less: 4.1.3
       less-loader: ^11.1.0
@@ -823,6 +915,7 @@ importers:
       vue-style-loader: ^4.1.3
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       css-loader: 6.8.1
       less: 4.1.3
       less-loader: 11.1.0_less@4.1.3
@@ -834,6 +927,7 @@ importers:
     specifiers:
       '@babel/core': 7.21.0
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@vue/babel-plugin-jsx': 1.1.1
       babel-loader: 9.1.2
       vue: 3.2.45
@@ -842,6 +936,7 @@ importers:
     devDependencies:
       '@babel/core': 7.21.0
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.21.0
       babel-loader: 9.1.2_@babel+core@7.21.0
 
@@ -850,6 +945,7 @@ importers:
       '@babel/core': 7.21.0
       '@babel/preset-typescript': ^7.22.5
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       '@vue/babel-plugin-jsx': 1.1.1
       babel-loader: 9.1.2
       typescript: ^5.1.3
@@ -861,6 +957,7 @@ importers:
       '@babel/core': 7.21.0
       '@babel/preset-typescript': 7.22.5_@babel+core@7.21.0
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       '@vue/babel-plugin-jsx': 1.1.1_@babel+core@7.21.0
       babel-loader: 9.1.2_@babel+core@7.21.0
       typescript: 5.1.3
@@ -869,6 +966,7 @@ importers:
   examples/vue3-vanilla:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       css-loader: ^6.8.1
       less: 4.1.3
       less-loader: ^11.1.0
@@ -879,6 +977,7 @@ importers:
       vue: 3.2.47
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       css-loader: 6.8.1
       less: 4.1.3
       less-loader: 11.1.0_less@4.1.3
@@ -888,21 +987,29 @@ importers:
   examples/wasm-simple:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     dependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/worker:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
     dependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+    devDependencies:
+      '@rspack/core': link:../../packages/rspack
 
   examples/worklet:
     specifiers:
       '@rspack/cli': workspace:*
+      '@rspack/core': workspace:*
       esbuild: 0.19.3
     devDependencies:
       '@rspack/cli': link:../../packages/rspack-cli
+      '@rspack/core': link:../../packages/rspack
       esbuild: 0.19.3
 
   npm/darwin-arm64:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Turn on deprecated warning as `builtin:swc-loader` performance is tested.

See: https://github.com/web-infra-dev/rspack/pull/4367

closes #4453

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
