### PR TITLE
fix: $RefreshReg$ is not defined error in node_modules

### DIFF
--- a/crates/rspack_loader_react_refresh/src/lib.rs
+++ b/crates/rspack_loader_react_refresh/src/lib.rs
@@ -32,6 +32,9 @@ impl Loader<LoaderRunnerContext> for ReactRefreshLoader {
     };
     let mut source = content.try_into_string()?;
     source += r#"
+function $RefreshSig$() {
+  return $ReactRefreshRuntime$.createSignatureFunctionForTransform();
+}
 function $RefreshReg$(type, id) {
   $ReactRefreshRuntime$.register(type, __webpack_module__.id + "_" + id);
 }

--- a/crates/rspack_swc_visitors/src/react.rs
+++ b/crates/rspack_swc_visitors/src/react.rs
@@ -102,6 +102,9 @@ pub fn fold_react_refresh(unresolved_mark: Mark) -> impl Fold {
 
 // $ReactRefreshRuntime$ is injected by provide
 //
+// function $RefreshSig$() {
+//   return $ReactRefreshRuntime$.createSignatureFunctionForTransform();
+// }
 // function $RefreshReg$(type, id) {
 //   $ReactRefreshRuntime$.register(type, __webpack_module__.id + "_" + id);
 // }
@@ -118,6 +121,27 @@ fn create_react_refresh_runtime_stmts(unresolved_mark: Mark) -> Vec<Stmt> {
   }
 
   vec![
+    FnDecl {
+      ident: quote_ident!("$RefreshSig$"),
+      declare: false,
+      function: Box::new(Function {
+        params: Vec::new(),
+        decorators: Vec::new(),
+        span: DUMMY_SP,
+        body: Some(BlockStmt {
+          span: DUMMY_SP,
+          stmts: vec![quote!(
+            "return $runtime.createSignatureFunctionForTransform();" as Stmt,
+            runtime = create_react_refresh_runtime_ident(unresolved_mark)
+          )],
+        }),
+        is_generator: false,
+        is_async: false,
+        type_params: None,
+        return_type: None,
+      }),
+    }
+    .into(),
     FnDecl {
       ident: quote_ident!("$RefreshReg$"),
       declare: false,

--- a/packages/playground/cases/react/basic-disableTransformByDefault/.gitignore
+++ b/packages/playground/cases/react/basic-disableTransformByDefault/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/playground/cases/react/basic-disableTransformByDefault/node_modules/foo/index.jsx
+++ b/packages/playground/cases/react/basic-disableTransformByDefault/node_modules/foo/index.jsx
@@ -1,0 +1,3 @@
+export default function Foo() {
+  return <div>foo</div>
+}

--- a/packages/playground/cases/react/basic-disableTransformByDefault/node_modules/foo/package.json
+++ b/packages/playground/cases/react/basic-disableTransformByDefault/node_modules/foo/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "foo",
+  "main": "./index.jsx"
+}

--- a/packages/playground/cases/react/basic-disableTransformByDefault/rspack.config.js
+++ b/packages/playground/cases/react/basic-disableTransformByDefault/rspack.config.js
@@ -35,6 +35,7 @@ module.exports = {
 			}
 		]
 	},
+	devtool: false,
 	plugins: [
 		new rspack.HtmlRspackPlugin({ template: "./src/index.html" }),
 		new ReactRefreshPlugin()

--- a/packages/playground/cases/react/basic-disableTransformByDefault/src/App.jsx
+++ b/packages/playground/cases/react/basic-disableTransformByDefault/src/App.jsx
@@ -4,6 +4,7 @@ import { ContextComponent } from './CountProvider'
 import { ReactRefreshFinder } from './ReactRefreshFinder'
 import { SameExportName as SameExportName1 } from './SameExportName1'
 import { SameExportName as SameExportName2 } from './SameExportName2'
+import ComponentInNodeModules from "foo"
 
 const Button = () => {
 	const [count, setCount] = React.useState(10)
@@ -25,6 +26,7 @@ export const App = () => {
 			<React.Suspense fallback={<div>loading...</div>}>
 				<LazyComponent />
 			</React.Suspense>
+			<ComponentInNodeModules />
 		</div>
 	)
 }

--- a/packages/rspack-plugin-react-refresh/client/reactRefreshEntry.js
+++ b/packages/rspack-plugin-react-refresh/client/reactRefreshEntry.js
@@ -40,8 +40,10 @@ if (process.env.NODE_ENV !== "production") {
 		// Only inject the runtime if it hasn't been injected
 		if (!safeThis[$RefreshInjected$]) {
 			RefreshRuntime.injectIntoGlobalHook(safeThis);
-			safeThis.$RefreshSig$ =
-				RefreshRuntime.createSignatureFunctionForTransform;
+
+			// Empty implementation to avoid "ReferenceError: variable is not defined" in module which didn't pass builtin:react-refresh-loader
+			safeThis.$RefreshSig$ = () => type => type;
+			safeThis.$RefreshReg$ = () => {};
 
 			// Mark the runtime as injected to prevent double-injection
 			safeThis[$RefreshInjected$] = true;

--- a/packages/rspack-plugin-react-refresh/tests/test.spec.ts
+++ b/packages/rspack-plugin-react-refresh/tests/test.spec.ts
@@ -72,7 +72,7 @@ describe("react-refresh-rspack-plugin", () => {
 			path.join(__dirname, "fixtures/default"),
 			{},
 			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
-				expect(vendor).not.toContain("$RefreshReg$");
+				expect(vendor).not.toContain("function $RefreshReg$");
 				done();
 			}
 		);
@@ -83,7 +83,7 @@ describe("react-refresh-rspack-plugin", () => {
 			path.join(__dirname, "fixtures/default"),
 			{},
 			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
-				expect(fixture).toContain("$RefreshReg$");
+				expect(fixture).toContain("function $RefreshReg$");
 				done();
 			}
 		);
@@ -97,7 +97,7 @@ describe("react-refresh-rspack-plugin", () => {
 				include: path.join(__dirname, "fixtures/node_modules/foo")
 			},
 			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
-				expect(vendor).toContain("$RefreshReg$");
+				expect(vendor).toContain("function $RefreshReg$");
 				done();
 			}
 		);
@@ -110,7 +110,7 @@ describe("react-refresh-rspack-plugin", () => {
 				exclude: path.join(__dirname, "fixtures/custom/index.js")
 			},
 			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
-				expect(fixture).not.toContain("$RefreshReg$");
+				expect(fixture).not.toContain("function $RefreshReg$");
 				done();
 			}
 		);
@@ -123,7 +123,7 @@ describe("react-refresh-rspack-plugin", () => {
 				exclude: null
 			},
 			(_, __, { reactRefresh, fixture, runtime, vendor }) => {
-				expect(reactRefresh).not.toContain("$RefreshReg$");
+				expect(reactRefresh).not.toContain("function $RefreshReg$");
 				done();
 			}
 		);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack-website/pull/479#discussion_r1335759431

webpack-plugin did the same, the loader will [inject runtime code](https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/0b960573797bf38926937994c481e4fec9ed8aa6/loader/index.js#L47), if a module doesn't have the injected runtime, it will use the empty implementation of `register` and `signature`, which equal to `$RefreshReg$` and `$RefreshSig$`

<img width="925" alt="Screenshot 2023-09-26 at 13 52 12" src="https://github.com/web-infra-dev/rspack/assets/42857895/ea0de86f-4ad3-41b5-8a0f-8918844094ed">


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

added

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
