### PR TITLE
fix: fix `Rule.oneOf` and `Rule.rules`

### DIFF
--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -121,18 +121,22 @@ pub async fn module_rule_matcher<'a>(
     }
   }
 
-  if let Some(one_of) = &module_rule.one_of {
-    for rule in one_of {
-      if module_rule_matcher(rule, resource_data, issuer, dependency, matched_rules).await? {
-        break;
-      }
-    }
-  }
-
   if let Some(rules) = &module_rule.rules {
     module_rules_matcher(rules, resource_data, issuer, dependency, matched_rules).await?;
   }
 
+  if let Some(one_of) = &module_rule.one_of {
+    let mut matched_once = false;
+    for rule in one_of {
+      if module_rule_matcher(rule, resource_data, issuer, dependency, matched_rules).await? {
+        matched_once = true;
+        break;
+      }
+    }
+    if !matched_once {
+      return Ok(false);
+    }
+  }
   matched_rules.push(module_rule);
   Ok(true)
 }

--- a/packages/rspack/tests/configCases/module/issue-4224/index.js
+++ b/packages/rspack/tests/configCases/module/issue-4224/index.js
@@ -1,0 +1,3 @@
+it("should generate asset/resource", () => {
+	expect(require("./index.scss").endsWith(".scss")).toBeTruthy();
+});

--- a/packages/rspack/tests/configCases/module/issue-4224/index.scss
+++ b/packages/rspack/tests/configCases/module/issue-4224/index.scss
@@ -1,0 +1,9 @@
+.a {
+	text-align: center;
+	line-height: 1.5;
+}
+
+.b {
+	font-size: 1.5rem;
+	background: #fafafa;
+}

--- a/packages/rspack/tests/configCases/module/issue-4224/webpack.config.js
+++ b/packages/rspack/tests/configCases/module/issue-4224/webpack.config.js
@@ -2,29 +2,33 @@ module.exports = {
 	module: {
 		rules: [
 			{
-				test: /\.s[ac]ss$/i,
 				oneOf: [
 					{
-						test: /\.module\.\w+$/i,
-						exclude: [/index\.scss$/],
-						use: [{ loader: "sass-loader" }],
-						type: "css/module"
+						test: /\.s[ac]ss$/i,
+						oneOf: [
+							{
+								test: /\.module\.\w+$/i,
+								exclude: [/index\.scss$/],
+								use: [{ loader: "sass-loader" }],
+								type: "css/module"
+							},
+							{
+								exclude: [/index\.scss$/],
+								use: [{ loader: "sass-loader" }],
+								type: "css"
+							}
+						]
 					},
 					{
-						exclude: [/index\.scss$/],
-						use: [{ loader: "sass-loader" }],
-						type: "css"
+						exclude: [
+							/\.(js|mjs|cjs|jsx)$/,
+							/\.(ts|mts|cts|tsx)$/,
+							/\.html$/,
+							/\.json$/
+						],
+						type: "asset/resource"
 					}
 				]
-			},
-			{
-				exclude: [
-					/\.(js|mjs|cjs|jsx)$/,
-					/\.(ts|mts|cts|tsx)$/,
-					/\.html$/,
-					/\.json$/
-				],
-				type: "asset/resource"
 			}
 		]
 	}

--- a/packages/rspack/tests/configCases/module/issue-4224/webpack.config.js
+++ b/packages/rspack/tests/configCases/module/issue-4224/webpack.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.s[ac]ss$/i,
+				oneOf: [
+					{
+						test: /\.module\.\w+$/i,
+						exclude: [/index\.scss$/],
+						use: [{ loader: "sass-loader" }],
+						type: "css/module"
+					},
+					{
+						exclude: [/index\.scss$/],
+						use: [{ loader: "sass-loader" }],
+						type: "css"
+					}
+				]
+			},
+			{
+				exclude: [
+					/\.(js|mjs|cjs|jsx)$/,
+					/\.(ts|mts|cts|tsx)$/,
+					/\.html$/,
+					/\.json$/
+				],
+				type: "asset/resource"
+			}
+		]
+	}
+};

--- a/packages/rspack/tests/configCases/module/one-of-nested/webpack.config.js
+++ b/packages/rspack/tests/configCases/module/one-of-nested/webpack.config.js
@@ -1,5 +1,3 @@
-const path = require("path");
-
 /**
  * @type {import('@rspack/core').RspackOptions}
  */

--- a/packages/rspack/tests/configCases/module/order-nested/index.js
+++ b/packages/rspack/tests/configCases/module/order-nested/index.js
@@ -1,0 +1,5 @@
+import { lib } from "./lib";
+
+it("should iterate `rules` first, then `oneOf`", () => {
+	expect(lib).toEqual("abc02");
+});

--- a/packages/rspack/tests/configCases/module/order-nested/lib.js
+++ b/packages/rspack/tests/configCases/module/order-nested/lib.js
@@ -1,0 +1,1 @@
+exports.lib = "abc";

--- a/packages/rspack/tests/configCases/module/order-nested/loader.js
+++ b/packages/rspack/tests/configCases/module/order-nested/loader.js
@@ -1,0 +1,4 @@
+module.exports = function (content) {
+	content += 'exports.lib += "0";\n';
+	this.callback(null, content);
+};

--- a/packages/rspack/tests/configCases/module/order-nested/loader1.js
+++ b/packages/rspack/tests/configCases/module/order-nested/loader1.js
@@ -1,0 +1,4 @@
+module.exports = function (content) {
+	content += 'exports.lib += "1";\n';
+	this.callback(null, content);
+};

--- a/packages/rspack/tests/configCases/module/order-nested/loader2.js
+++ b/packages/rspack/tests/configCases/module/order-nested/loader2.js
@@ -1,0 +1,4 @@
+module.exports = function (content) {
+	content += 'exports.lib += "2";\n';
+	this.callback(null, content);
+};

--- a/packages/rspack/tests/configCases/module/order-nested/webpack.config.js
+++ b/packages/rspack/tests/configCases/module/order-nested/webpack.config.js
@@ -7,20 +7,18 @@ module.exports = {
 		rules: [
 			{
 				test: /lib.js/,
-				use: ["./loader2.js"]
-			},
-			{
-				test: /lib.js/,
+				rules: [
+					{
+						use: ["./loader2.js"]
+					}
+				],
 				oneOf: [
 					{
-						resourceQuery: "/(__inline=false|url)/",
+						resourceQuery: /random-string/,
 						use: ["./loader1.js"]
 					},
 					{
 						use: ["./loader.js"]
-					},
-					{
-						use: ["./loader1.js"]
 					}
 				]
 			}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- `Rule.oneOf` should match at least one rule, otherwise the `effects` does not take affect.
- `Rule.rules` should run ahead of `Rule.oneOf`

Fixes https://github.com/web-infra-dev/rspack/issues/4224

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Added

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
