### PR TITLE
fix(rspack_loader_swc): Fail the build when jsc.target and env are used together for the SWC loader

### DIFF
--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -85,6 +85,15 @@ impl Loader<LoaderRunnerContext> for SwcLoader {
       ));
     }
 
+    if swc_options.config.jsc.target.is_some() && swc_options.config.env.is_some() {
+      loader_context.emit_diagnostic(Diagnostic::warn(
+        SWC_LOADER_IDENTIFIER.to_string(),
+        "`env` and `jsc.target` cannot be used together".to_string(),
+        0,
+        0,
+      ));
+    }
+
     GLOBALS.set(&Default::default(), || {
       try_with_handler(c.cm.clone(), Default::default(), |handler| {
         c.run(|| {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
This PR adds a check for `rspack_loader_swc` config so the user doesn't use both `env` and `jsc.target` at the same time. This is fixed in accordance with the official way its done under SWC here: https://github.com/swc-project/swc/pull/7704/files#diff-05ec577011f6096aac154c266838a96b40e857713f31a3441fc73baf1d90580eR376

Ticket: #4081
![Screenshot 2023-09-26 at 22 01 03](https://github.com/web-infra-dev/rspack/assets/40059557/607765d9-2879-4261-b68e-ea555077b88f)

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
- Go to `examples/builtin-swc-loader/rspack.config.js`
- Under the `builtin:swc-loader` loader options add `jsx.target: "es2016"` and `env.targets: "es2016"`
- Run the build ` pnpm --filter "./examples/builtin-swc-loader" build`
- Build should fail

## Require Documentation?
- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
