### PR TITLE
feat: handle `react-refresh` resolving in `@rspack/plugin-react-refresh`

### DIFF
--- a/packages/rspack-plugin-react-refresh/src/index.js
+++ b/packages/rspack-plugin-react-refresh/src/index.js
@@ -44,6 +44,10 @@ module.exports = class ReactRefreshRspackPlugin {
 		 */
 		this.options = normalizeOptions(options);
 	}
+
+	/**
+	 * @param {import("@rspack/core").Compiler} compiler
+	 */
 	apply(compiler) {
 		new compiler.webpack.EntryPlugin(compiler.context, reactRefreshEntryPath, {
 			name: undefined
@@ -59,6 +63,12 @@ module.exports = class ReactRefreshRspackPlugin {
 			},
 			use: "builtin:react-refresh-loader"
 		});
+
+		const refreshPath = path.dirname(require.resolve("react-refresh"));
+		compiler.options.resolve.alias = {
+			"react-refresh": refreshPath,
+			...compiler.options.resolve.alias
+		};
 	}
 };
 

--- a/packages/rspack/src/web/ResolveSwcPlugin.ts
+++ b/packages/rspack/src/web/ResolveSwcPlugin.ts
@@ -13,6 +13,8 @@ export class ResolveSwcPlugin {
 		// redirect @swc/helpers to rspack, so user don't have to manual install it
 		compiler.options.resolve.alias = {
 			"@swc/helpers": swcPath,
+			// TODO: DEPRECATED: remove in v0.5.0.
+			// it's moved to `@rspack/plugin-react-refresh`, but it still required for `builtins.react` for now.
 			"react-refresh": refreshPath,
 			...compiler.options.resolve.alias
 		};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

CI passes. Should be working if `react-refresh` is removed from the package.

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
