### PR TITLE
chore: change nightly release notification to discord other than github issue

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -115,7 +115,8 @@ jobs:
                     "https://raw.githubusercontent.com/web-infra-dev/rspack-website/main/docs/public/logo.png",
                   embeds: [
                     {
-                      title: "nightly release failed"
+                      title: "nightly release failed",
+                      description: "See job:\n* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
                     }
                   ]
                 })

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -102,17 +102,23 @@ jobs:
         with:
           github-token: ${{ secrets.RSPACK_BOT_ACCESS_TOKEN }}
           script: |
-            const title = "Nightly Failed";
-            const body = "See job:\n* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}";
-
-            console.log(title);
-            console.log(body);
-
-            const result = await github.rest.issues.create({
-              owner: 'web-infra-dev',
-              repo: 'rspack',
-              title: title,
-              body: body,
-            });
-
-            console.log(result);
+            const res = await fetch(
+              '${{secrets.DISCORD_WEBHOOK_URL}}',
+              {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                  username: "nightly release",
+                  avatar_url:
+                    "https://raw.githubusercontent.com/web-infra-dev/rspack-website/main/docs/public/logo.png",
+                  embeds: [
+                    {
+                      title: "nightly release failed"
+                    }
+                  ]
+                })
+              }
+            );
+            console.log("res:", await res.text());


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
nightly failed message kinds of pollute github issue especially during holiday, so change it to discord

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
