### PR TITLE
chore: only remove android sdk

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -80,6 +80,14 @@ jobs:
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
+          # just remove android sdk seems enough for use, save us some time
+          android: true
+          dotnet: false
+          haskell: false
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
       - name: Pnpm Cache
         uses: ./.github/actions/pnpm-cache
         with:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
remove android sdk save 15GB which seems big enough for use, let's save some time for free-disk-cache itself
reduce 3min -> 1min, seems not bad
## Test Plan
No Need
## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
