### PR TITLE
fix: rspack builtin.html.meta.* support Record<string, string>

### DIFF
--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -32,6 +32,11 @@ export const HtmlRspackPlugin = create(
 					name: key,
 					content: value
 				};
+			} else {
+				meta[key] = {
+					name: key,
+					...value
+				};
 			}
 		}
 		const scriptLoading = c.scriptLoading ?? "defer";

--- a/packages/rspack/tests/configCases/builtins/html-meta/index.js
+++ b/packages/rspack/tests/configCases/builtins/html-meta/index.js
@@ -9,4 +9,5 @@ it("html meta", () => {
 			'<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />'
 		)
 	).toBe(true);
+	expect(htmlContent.includes('<meta a="b" name="test" />')).toBe(true);
 });

--- a/packages/rspack/tests/configCases/builtins/html-meta/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/html-meta/webpack.config.js
@@ -3,7 +3,10 @@ module.exports = {
 		html: [
 			{
 				meta: {
-					viewport: "width=device-width, initial-scale=1, shrink-to-fit=no"
+					viewport: "width=device-width, initial-scale=1, shrink-to-fit=no",
+					test: {
+						a: "b"
+					}
 				}
 			}
 		]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

rspack will ignore the builtins.html.meta value set to `Record<string, Record<string, string>>`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
updated the builtins.html test cases to cover this.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
