### PR TITLE
fix(4314): remove help info print when throw error

### DIFF
--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -94,6 +94,7 @@ export class RspackCLI {
 			);
 		}
 
+		this.program.showHelpOnFail(false);
 		this.program.usage("[options]");
 		this.program.scriptName("rspack");
 		this.program.strictCommands(true).strict(true);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

GitHub Issue: #4314 

This bug is exactly caused by the internal bug in "yargs". when we use .command method in yargs, if the async handler function we pass in throws an error, it will result in an unexpected "--help" command execution.

I also propose an issue for "yargs", maybe they will fix this bug.
about the bug detail you can see [yargs issue 2368](https://github.com/yargs/yargs/issues/2368)

For rspack, I wrap the handler code with a "try-catch" block to catch the error we throw. In the catch block, we should exit the process by calling "process.exit()" ourselves instead of throwing an error, which prevents the internal bug in "yargs".

Why don't use "try-catch" block wrap `await this.program.parseAsync(hideBin(argv));`?

I have tried this, but it doesn't work, It may be because the handler function is called asynchronously, so the error it throws cannot be captured by the outer "try-catch" block.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
make sure "a.js" is a file not exist, run `rspack build -c a.js`
it is expected that only error info is outputted,without "--help" info.
## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
