### PR TITLE
fix: splitChunks.enforce, pass more webpack-tests

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_split_chunks.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks.rs
@@ -234,9 +234,11 @@ impl From<RawSplitChunksOptions> for new_split_chunks_plugin::PluginOptions {
                 &overall_max_initial_size
               });
 
-          let min_chunks = v
-            .min_chunks
-            .unwrap_or(if enforce { 1 } else { overall_min_chunks });
+          let min_chunks = if enforce {
+            1
+          } else {
+            v.min_chunks.unwrap_or(overall_min_chunks)
+          };
 
           let r#type = v
             .r#type

--- a/webpack-test/configCases/split-chunks-common/correct-order/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/correct-order/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => "https://github.com/web-infra-dev/rspack/issues/3562"
+module.exports = () => 'block: https://github.com/web-infra-dev/rspack/issues/3562'

--- a/webpack-test/configCases/split-chunks-common/extract-async-from-entry/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/extract-async-from-entry/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => true

--- a/webpack-test/configCases/split-chunks-common/hot-multi/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/hot-multi/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}

--- a/webpack-test/configCases/split-chunks-common/hot-multi/webpack.config.js
+++ b/webpack-test/configCases/split-chunks-common/hot-multi/webpack.config.js
@@ -1,5 +1,5 @@
 var HotModuleReplacementPlugin =
-	require("../../../../").HotModuleReplacementPlugin;
+	require("@rspack/core").HotModuleReplacementPlugin;
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {

--- a/webpack-test/configCases/split-chunks-common/hot/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/hot/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return false}
+module.exports = () => 'block: require.main https://github.com/web-infra-dev/rspack/issues/3562'

--- a/webpack-test/configCases/split-chunks-common/hot/webpack.config.js
+++ b/webpack-test/configCases/split-chunks-common/hot/webpack.config.js
@@ -1,5 +1,5 @@
 var HotModuleReplacementPlugin =
-	require("../../../../").HotModuleReplacementPlugin;
+	require("@rspack/core").HotModuleReplacementPlugin;
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: {

--- a/webpack-test/configCases/split-chunks-common/inverted-order/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/inverted-order/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => "https://github.com/web-infra-dev/rspack/issues/3562"
+module.exports = () => 'block: require.main https://github.com/web-infra-dev/rspack/issues/3562'

--- a/webpack-test/configCases/split-chunks-common/issue-12128/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/issue-12128/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => true

--- a/webpack-test/configCases/split-chunks-common/library/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/library/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => "https://github.com/web-infra-dev/rspack/issues/3564"
+module.exports = () => 'block: require.ensure https://github.com/web-infra-dev/rspack/issues/4304'

--- a/webpack-test/configCases/split-chunks-common/move-entry/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/move-entry/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => true

--- a/webpack-test/configCases/split-chunks-common/move-to-grandparent/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/move-to-grandparent/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => true

--- a/webpack-test/configCases/split-chunks-common/simple/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/simple/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => "https://github.com/web-infra-dev/rspack/issues/3562"
+module.exports = () => 'block: require.main https://github.com/web-infra-dev/rspack/issues/3562'

--- a/webpack-test/configCases/split-chunks-common/target-node/test.filter.js
+++ b/webpack-test/configCases/split-chunks-common/target-node/test.filter.js
@@ -1,1 +1,1 @@
-module.exports = () => {return "`splitChunks.name` doesn't support passing function"}
+module.exports = () => 'block: not support function type splitChunks.name https://github.com/web-infra-dev/rspack/issues/4333'


### PR DESCRIPTION
## Summary

- splitChunks.enforce should make minChunks to be 1
- pass more webpack-tests

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
