### PR TITLE
fix: variable undefined with multiple same import

### DIFF
--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -44,7 +44,7 @@ pub enum DependencyType {
   ExportInfoApi,
   Entry,
   // Harmony import
-  EsmImport,
+  EsmImport(/* HarmonyImportSideEffectDependency.span */ ErrorSpan), /* TODO: remove span after old tree shaking is removed */
   EsmImportSpecifier,
   // Harmony export
   EsmExport,
@@ -96,7 +96,7 @@ impl Display for DependencyType {
     match self {
       DependencyType::Unknown => write!(f, "unknown"),
       DependencyType::Entry => write!(f, "entry"),
-      DependencyType::EsmImport => write!(f, "esm import"),
+      DependencyType::EsmImport(_) => write!(f, "esm import"),
       DependencyType::EsmExport => write!(f, "esm export"),
       DependencyType::EsmExportSpecifier => write!(f, "esm export specifier"),
       DependencyType::EsmExportImportedSpecifier => write!(f, "esm export import specifier"),

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -24,7 +24,7 @@ use super::{
 use crate::needs_refactor::WorkerSyntaxList;
 use crate::{
   extract_member_expression_chain, BoxDependency, CompilerOptions, DependencyId, DependencyType,
-  FactoryMeta, ModuleGraph, ModuleIdentifier, ModuleSyntax,
+  ErrorSpan, FactoryMeta, ModuleGraph, ModuleIdentifier, ModuleSyntax,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -764,7 +764,10 @@ impl<'a> Visit for ModuleRefAnalyze<'a> {
         match decl {
           ModuleDecl::Import(import) => {
             let src = &import.src.value;
-            let dep_id = match self.resolve_module_identifier(src, &DependencyType::EsmImport) {
+            let dep_id = match self.resolve_module_identifier(
+              src,
+              &DependencyType::EsmImport(ErrorSpan::from(import.span)),
+            ) {
               Some(module_identifier) => module_identifier,
               None => {
                 // TODO: Ignore for now because swc helper interference.

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -100,7 +100,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
       .filter(|specifier| {
         let is_import = matches!(
           module_dependency.dependency_type(),
-          DependencyType::EsmImport
+          DependencyType::EsmImport(_)
         );
         if is_import && !ref_mgm.module_type.is_js_like() {
           return true;
@@ -125,7 +125,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
           Specifier::Named(local, imported) => {
             let symbol = if matches!(
               module_dependency.dependency_type(),
-              DependencyType::EsmImport
+              DependencyType::EsmImport(_)
             ) {
               SymbolRef::Indirect(IndirectTopLevelSymbol {
                 src: ref_mgm.module_identifier,

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -44,8 +44,8 @@ impl Plugin for InferAsyncModulesPlugin {
           .incoming_connections_unordered(module_graph)?
           .filter(|con| {
             if let Some(dep) = module_graph.dependency_by_id(&con.dependency_id) {
-              *dep.dependency_type() == DependencyType::EsmImport
-                || *dep.dependency_type() == DependencyType::EsmExport
+              matches!(dep.dependency_type(), DependencyType::EsmImport(_))
+                || matches!(dep.dependency_type(), DependencyType::EsmExport)
             } else {
               false
             }

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -44,8 +44,10 @@ impl Plugin for InferAsyncModulesPlugin {
           .incoming_connections_unordered(module_graph)?
           .filter(|con| {
             if let Some(dep) = module_graph.dependency_by_id(&con.dependency_id) {
-              matches!(dep.dependency_type(), DependencyType::EsmImport(_))
-                || matches!(dep.dependency_type(), DependencyType::EsmExport)
+              matches!(
+                dep.dependency_type(),
+                DependencyType::EsmImport(_) | DependencyType::EsmExport
+              )
             } else {
               false
             }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -237,7 +237,7 @@ impl Visit for HarmonyImportDependencyScanner<'_> {
 
     let key = (
       import_decl.src.value.clone(),
-      DependencyType::EsmImport,
+      DependencyType::EsmImport(import_decl.span.into()),
       self.last_harmony_import_order,
     );
     if let Some(importer_info) = self.imports.get_mut(&key) {

--- a/packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect/index.js
+++ b/packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect/index.js
@@ -1,0 +1,10 @@
+import { a } from "./lib";
+import { b } from "./lib";
+
+if (process.env.NODE_ENV !== "production") {
+	a;
+}
+
+it("should works", () => {
+	expect(b).toBe(43);
+});

--- a/packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect/lib.js
+++ b/packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect/lib.js
@@ -1,0 +1,2 @@
+export const a = 42;
+export const b = 43;

--- a/packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect/webpack.config.js
+++ b/packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect/webpack.config.js
@@ -1,0 +1,17 @@
+const { DefinePlugin } = require("@rspack/core");
+
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	context: __dirname,
+	builtins: {
+		treeShaking: true
+	},
+	optimization: {
+		sideEffects: true
+	},
+	plugins: [
+		new DefinePlugin({
+			"process.env.NODE_ENV": JSON.stringify("production")
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

checkout added test case

after we introduce [source_order](https://github.com/web-infra-dev/rspack/pull/4262) for new tree shaking implementation, HarmonyImportSideEffectDependency will be duplicated, and merged by InitFragment, this is aligned behavior with webpack, before it won't be duplicated

```js
// before:
import {a} from "./lib" // => Dependency(100 /* dependency_id */, "./lib")
import {b} from "./lib" // => Dependency(100 /* dependency_id */, "./lib")

```

```js
// after:
import {a} from "./lib" // => Dependency(100 /*dependency_id*/, "./lib", 0 /* source_order */)
import {b} from "./lib" // => Dependency(101 /*dependency_id*/, "./lib", 1 /* source_order */)
```

but in the old tree shaking implementation will find dependency by its request and dependency_type, so when we want to find `Dependency(101)`, we actually will find `Dependency(100)`, if `Dependency(100)` is unused, then we won't generate the code, so `Dependency(101)` will be removed mistakenly


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

- packages/rspack/tests/configCases/tree-shaking/multiple-same-import-side-effect

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
