### PR TITLE
chore: use self hosted ci

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -13,6 +13,11 @@ inputs:
     default: 'release'
     required: false
     type: string
+  options:
+    description: 'Options for docker'
+    default: ""
+    required: false
+    type: string
   pre:
     required: false
     default: ""
@@ -26,21 +31,23 @@ runs:
   using: composite
   steps:
     - name: Docker Build ${{ inputs.target }}
-      uses: addnab/docker-run-action@v3
-      with:
-        image: ${{ inputs.image }}
-        options: >
-          --privileged
-          --user 0:0
-          -v ${{ github.workspace }}/.cargo/git/db:/usr/local/cargo/git/db
-          -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache
-          -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index
-          -v ${{ github.workspace }}:/build
-          -w /build
-        run: |
+      shell: bash
+      run: |
+        code="
           set -e
           ${{ inputs.pre }}
           rustup target add ${{ inputs.target }}
           corepack enable
           RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
           ${{ inputs.post }}
+        "
+        docker run \
+          --rm \
+          --privileged \
+          --user 0:0 \
+          ${{ inputs.options }} \
+          -v ${{ github.workspace }}:/build \
+          -w /build \
+          -i \
+          ${{ inputs.image }} \
+          bash -c "$code"

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -12,6 +12,9 @@ inputs:
     required: false
     type: boolean
 
+env:
+  IS_GITHUB_RUNNER: startsWith(runner.name, 'GitHub Actions')
+
 runs:
   using: composite
   steps:
@@ -24,6 +27,8 @@ runs:
     # Uses `packageManagement` field from package.json
     - name: Install pnpm
       uses: pnpm/action-setup@v2
+      with:
+        dest: ${{ runner.tool_cache }}/pnpm
 
     - name: Get pnpm store directory
       id: pnpm-cache
@@ -32,6 +37,7 @@ runs:
 
     - name: Restore pnpm cache
       id: restore
+      if: ${{ env.IS_GITHUB_RUNNER }}
       uses: actions/cache/restore@v3
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
@@ -45,7 +51,7 @@ runs:
 
     - name: Save pnpm cache
       uses: actions/cache/save@v3
-      if: ${{ inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
+      if: ${{ env.IS_GITHUB_RUNNER && inputs.save-if == 'true' && steps.restore.outputs.cache-hit != 'true' }}
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: node-cache-${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/actions/rustup/action.yml
+++ b/.github/actions/rustup/action.yml
@@ -30,6 +30,9 @@ inputs:
     required: false
     type: string
 
+env:
+  IS_GITHUB_RUNNER: startsWith(runner.name, 'GitHub Actions')
+
 runs:
   using: composite
   steps:
@@ -77,6 +80,7 @@ runs:
 
     - name: Cache on ${{ github.ref_name }}
       uses: Swatinem/rust-cache@v2
+      if: ${{ env.IS_GITHUB_RUNNER }}
       with:
         shared-key: ${{ inputs.shared-key }}
         save-if: ${{ inputs.save-cache == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     name: Rust check
     needs: rust_changes
     if: ${{ needs.rust_changes.outputs.changed == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS) }}
     steps:
       - uses: actions/checkout@v3
 
@@ -148,7 +148,7 @@ jobs:
     name: Rust test
     needs: rust_changes
     if: ${{ needs.rust_changes.outputs.changed == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS) }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -39,30 +39,9 @@ on:
         type: string
 
 jobs:
-  select:
-    name: Select Host
-    runs-on: ubuntu-latest
-    outputs:
-      host: ${{ steps.run.outputs.host }}
-    steps:
-      - name: Choose Target for ${{ inputs.target }}
-        id: run
-        shell: bash
-        run: |
-          if [[ "${{ contains(inputs.target, 'linux') }}" == "true" ]]; then
-            echo "host=ubuntu-latest" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ contains(inputs.target, 'windows') }}" == "true" ]]; then
-            echo "host=windows-latest" >> "$GITHUB_OUTPUT"
-          fi
-          if [[ "${{ contains(inputs.target, 'apple') }}" == "true" ]]; then
-            echo "host=macos-latest" >> "$GITHUB_OUTPUT"
-          fi
-
   build:
     name: Build
-    needs: select
-    runs-on: ${{ needs.select.outputs.host }}
+    runs-on: ${{ contains(inputs.target, 'linux') && fromJSON(vars.LINUX_RUNNER_LABELS) || contains(inputs.target, 'windows') && fromJSON(vars.WINDOWS_RUNNER_LABELS) || contains(inputs.target, 'apple') && fromJSON(vars.MACOS_RUNNER_LABELS) }}
     defaults:
       run:
         shell: bash
@@ -76,7 +55,7 @@ jobs:
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: free-disk-cache
-        if: ${{ contains(inputs.target, 'linux') }}
+        if: ${{ startsWith(runner.name, 'GitHub Actions') && contains(inputs.target, 'linux') }}
         uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: false
@@ -121,6 +100,7 @@ jobs:
           target: ${{ inputs.target }}
           profile: ${{ inputs.profile }}
           pre: unset CC_x86_64_unknown_linux_gnu && unset CC # for jemallocator to compile
+          options: -v $HOME/.cargo:/usr/local/cargo -v $HOME/.rustup:/usr/local/rustup
 
       - name: Build aarch64-unknown-linux-gnu in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-gnu' }}
@@ -130,6 +110,7 @@ jobs:
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
           profile: ${{ inputs.profile }}
           pre: export JEMALLOC_SYS_WITH_LG_PAGE=16 && export CC_aarch64_unknown_linux_gnu=/usr/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc # for jemallocator to compile
+          options: -v $HOME/.cargo:/usr/local/cargo -v $HOME/.rustup:/usr/local/rustup
 
       - name: Build x86_64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'x86_64-unknown-linux-musl' }}
@@ -138,6 +119,7 @@ jobs:
           target: ${{ inputs.target }}
           image: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
           profile: ${{ inputs.profile }}
+          options: -v $HOME/.cargo/git/db:/root/.cargo/git/db -v $HOME/.cargo/registry/cache:/root/.cargo/registry/cache -v $HOME/.cargo/registry/index:/root/.cargo/registry/index
 
       - name: Build aarch64-unknown-linux-musl in Docker
         if: ${{ inputs.target == 'aarch64-unknown-linux-musl' }}
@@ -148,6 +130,7 @@ jobs:
           profile: ${{ inputs.profile }}
           pre: |
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+          options: -v $HOME/.cargo/git/db:/root/.cargo/git/db -v $HOME/.cargo/registry/cache:/root/.cargo/registry/cache -v $HOME/.cargo/registry/index:/root/.cargo/registry/index
 
       # Windows
 
@@ -187,9 +170,9 @@ jobs:
 
   e2e:
     name: E2E Testing
-    needs: [select, build]
+    needs: build
     if: inputs.target == 'x86_64-unknown-linux-gnu' && inputs.test
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS) }}
     container:
       image: mcr.microsoft.com/playwright:v1.35.0-jammy
     steps:
@@ -213,9 +196,9 @@ jobs:
           pnpm run test:e2e
 
   test:
-    needs: [select, build]
+    needs: build
     if: inputs.test
-    runs-on: ${{ needs.select.outputs.host }}
+    runs-on: ${{ contains(inputs.target, 'linux') && fromJSON(vars.LINUX_RUNNER_LABELS) || contains(inputs.target, 'windows') && fromJSON(vars.WINDOWS_RUNNER_LABELS) || contains(inputs.target, 'apple') && fromJSON(vars.MACOS_RUNNER_LABELS) }}
     timeout-minutes: 30
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix build cache not work in CI and support use self hosted runner. Some CI data are as follows:

* github action - https://github.com/web-infra-dev/rspack/actions/runs/6558444654
* pr with self hosted - https://github.com/web-infra-dev/rspack/actions/runs/6559111173

| | github action | pr with self hosted |
|--|--|--|
| build rspack |  23m4s | 5m46s |
| build job |  27m56s | 9m42s |
| rust test | 6m37s | 3m13s |
| nodejs test | 7m12s | 5m43s |
| one time CI | 39m14s | 15m46s |


This new runner can be toggled by the CI action variables `LINUX_RUNNER_LABELS`. See https://github.com/web-infra-dev/rspack/settings/variables/actions (permission required).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

No

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
