### PR TITLE
chore: support run ci with forked repo PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     name: Rust check
     needs: rust_changes
     if: ${{ needs.rust_changes.outputs.changed == 'true' }}
-    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS) }}
+    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v3
 
@@ -148,7 +148,7 @@ jobs:
     name: Rust test
     needs: rust_changes
     if: ${{ needs.rust_changes.outputs.changed == 'true' }}
-    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS) }}
+    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -41,7 +41,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ${{ contains(inputs.target, 'linux') && fromJSON(vars.LINUX_RUNNER_LABELS) || contains(inputs.target, 'windows') && fromJSON(vars.WINDOWS_RUNNER_LABELS) || contains(inputs.target, 'apple') && fromJSON(vars.MACOS_RUNNER_LABELS) }}
+    runs-on: ${{ contains(inputs.target, 'linux') && fromJSON(vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"') || contains(inputs.target, 'windows') && fromJSON(vars.WINDOWS_RUNNER_LABELS || '"windows-latest"') || contains(inputs.target, 'apple') && fromJSON(vars.MACOS_RUNNER_LABELS || '"macos-latest"') }}
     defaults:
       run:
         shell: bash
@@ -172,7 +172,7 @@ jobs:
     name: E2E Testing
     needs: build
     if: inputs.target == 'x86_64-unknown-linux-gnu' && inputs.test
-    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS) }}
+    runs-on: ${{ fromJSON(vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"') }}
     container:
       image: mcr.microsoft.com/playwright:v1.35.0-jammy
     steps:
@@ -198,7 +198,7 @@ jobs:
   test:
     needs: build
     if: inputs.test
-    runs-on: ${{ contains(inputs.target, 'linux') && fromJSON(vars.LINUX_RUNNER_LABELS) || contains(inputs.target, 'windows') && fromJSON(vars.WINDOWS_RUNNER_LABELS) || contains(inputs.target, 'apple') && fromJSON(vars.MACOS_RUNNER_LABELS) }}
+    runs-on: ${{ contains(inputs.target, 'linux') && fromJSON(vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"') || contains(inputs.target, 'windows') && fromJSON(vars.WINDOWS_RUNNER_LABELS || '"windows-latest"') || contains(inputs.target, 'apple') && fromJSON(vars.MACOS_RUNNER_LABELS || '"macos-latest"') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

forked repo can not access global variable in ci, this pr will make it fallback to github action.

I will try to extract the logic for calculating runner labels in another PR

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
