### PR TITLE
fix: use indirect call for TaggedTpl

### DIFF
--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -61,11 +61,12 @@ pub fn export_from_import(
 
   if !export_name.is_empty() {
     // TODO check used
-    let access = format!("{import_var}{}", property_access(&export_name, 0));
+    let property = property_access(&export_name, 0);
     if is_call && !call_context {
-      return format!("(0, {access})");
+      format!("(0, {import_var}{property})")
+    } else {
+      format!("{import_var}{property}")
     }
-    access
   } else {
     import_var.to_string()
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -27,6 +27,7 @@ impl Dependency for HarmonyExportSpecifierDependency {
   fn dependency_debug_name(&self) -> &'static str {
     "HarmonyExportSpecifierDependency"
   }
+
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -4,18 +4,13 @@ use rspack_core::{
   ConstDependency, DependencyType, SpanExt,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
-use swc_core::{
-  common::Span,
-  ecma::{
-    ast::{
-      AssignExpr, AssignOp, Callee, ExportAll, ExportSpecifier, Expr, Id, Ident, ImportDecl,
-      ImportSpecifier, Lit, MemberExpr, MemberProp, ModuleExportName, NamedExport, Pat, PatOrExpr,
-      Program, Prop,
-    },
-    atoms::JsWord,
-    visit::{noop_visit_type, Visit, VisitWith},
-  },
-};
+use swc_core::atoms::JsWord;
+use swc_core::common::Span;
+use swc_core::ecma::ast::{AssignExpr, AssignOp, MemberExpr, MemberProp};
+use swc_core::ecma::ast::{Callee, ExportAll, ExportSpecifier, Expr, Id, TaggedTpl};
+use swc_core::ecma::ast::{Ident, ImportDecl, Pat, PatOrExpr, Program, Prop};
+use swc_core::ecma::ast::{ImportSpecifier, Lit, ModuleExportName, NamedExport};
+use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use super::{collect_destructuring_assignment_properties, ExtraSpanInfo};
 use crate::dependency::{
@@ -469,6 +464,12 @@ impl Visit for HarmonyImportRefDependencyScanner<'_> {
   fn visit_callee(&mut self, callee: &Callee) {
     self.enter_callee = true;
     callee.visit_children_with(self);
+    self.enter_callee = false;
+  }
+
+  fn visit_tagged_tpl(&mut self, n: &TaggedTpl) {
+    self.enter_callee = true;
+    n.visit_children_with(self);
     self.enter_callee = false;
   }
 

--- a/packages/rspack/tests/cases/indirect-call/call/dep.js
+++ b/packages/rspack/tests/cases/indirect-call/call/dep.js
@@ -1,0 +1,3 @@
+export default function dep() {
+	return this;
+}

--- a/packages/rspack/tests/cases/indirect-call/call/index.js
+++ b/packages/rspack/tests/cases/indirect-call/call/index.js
@@ -1,0 +1,10 @@
+import a from "./dep.js";
+
+const global = a();
+
+it("should generate indirect call", () => {
+	expect(a()).toBeUndefined();
+	expect(a()).toBeUndefined();
+	expect(a()).toBeUndefined();
+	expect(global).toBeUndefined();
+});

--- a/packages/rspack/tests/cases/indirect-call/tagged-template-expression/dep.js
+++ b/packages/rspack/tests/cases/indirect-call/tagged-template-expression/dep.js
@@ -1,0 +1,3 @@
+export default function dep() {
+	return this;
+}

--- a/packages/rspack/tests/cases/indirect-call/tagged-template-expression/dep1.js
+++ b/packages/rspack/tests/cases/indirect-call/tagged-template-expression/dep1.js
@@ -1,0 +1,5 @@
+export default function dep() {
+	return () => {
+		return this;
+	};
+}

--- a/packages/rspack/tests/cases/indirect-call/tagged-template-expression/index.js
+++ b/packages/rspack/tests/cases/indirect-call/tagged-template-expression/index.js
@@ -1,0 +1,12 @@
+import a from "./dep.js";
+import b from "./dep1.js";
+
+const global = a``;
+
+it("should generate indirect call", () => {
+	expect(a``).toBeUndefined();
+	expect(a`${{ a }}`).toBeUndefined();
+	expect(a``).toBeUndefined();
+	expect(b()``).toBeUndefined();
+	expect(global).toBeUndefined();
+});


### PR DESCRIPTION
Fixes #4380

The ﻿`TaggedTemplate` should be marked with ﻿`enter_call`. Consequently, it will generate an indirect call in the form of `﻿(0, xxxx)()`.
