### PR TITLE
fix: import/export with string literal

### DIFF
--- a/crates/rspack/tests/fixtures/dynamic-import/snapshot/output.snap
+++ b/crates/rspack/tests/fixtures/dynamic-import/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 'a';
 },
@@ -21,7 +21,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return b; }
+  b: function() { return b; }
 });
  const b = "b";
 },

--- a/crates/rspack/tests/fixtures/simple-with-query/snapshot/output.snap
+++ b/crates/rspack/tests/fixtures/simple-with-query/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 3;
 },
@@ -26,7 +26,7 @@ console.log("hello, world");
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 3;
 },

--- a/crates/rspack/tests/tree-shaking/array-side-effects/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/array-side-effects/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'app': function() { return app; }
+  app: function() { return app; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -25,7 +25,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'result': function() { return result; }
+  result: function() { return result; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/assign-with-side-effects/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/assign-with-side-effects/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'app': function() { return app; }
+  app: function() { return app; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -25,7 +25,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'result': function() { return result; }
+  result: function() { return result; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/basic/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/basic/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'answer': function() { return answer; }
+  answer: function() { return answer; }
 });
  const answer = 103330;
 },
@@ -39,7 +39,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'myanswer': function() { return myanswer; }
+  myanswer: function() { return myanswer; }
 });
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./answer */"./answer.js");
 

--- a/crates/rspack/tests/tree-shaking/bb/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/bb/snapshot/output.snap
@@ -19,7 +19,7 @@ _b_js__WEBPACK_IMPORTED_MODULE_0_.d;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'd': function() { return d; }
+  d: function() { return d; }
 });
  const d = 3;
  const c = 100;
@@ -28,7 +28,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'ccc': function() { return ccc; }
+  ccc: function() { return ccc; }
 });
  const ccc = 30;
 },

--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/output.snap
@@ -16,7 +16,7 @@ exports["default"] = _default;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'locales': function() { return locales; }
+  locales: function() { return locales; }
 });
 /* harmony import */var _locale_zh__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ../locale_zh */"./locale_zh.ts");
 
@@ -29,7 +29,7 @@ const locales = {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'test': function() { return test; }
+  test: function() { return test; }
 });
 /* harmony import */var _antd_index__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./antd/index */"./antd/index.ts");
 
@@ -40,7 +40,7 @@ _antd_index__WEBPACK_IMPORTED_MODULE_0_.locales.zh_CN;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _zh_locale__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./zh_locale */"./zh_locale.js");
 

--- a/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'answer': function() { return answer; }
+  answer: function() { return answer; }
 });
 
  const answer = 42;
@@ -16,7 +16,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'myanswer': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_.myanswer; }
+  myanswer: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_.myanswer; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -33,7 +33,7 @@ __webpack_require__(/* ./answer */"./answer.js");
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'myanswer': function() { return myanswer; }
+  myanswer: function() { return myanswer; }
 });
  const myanswer = 'anyser';
 },

--- a/crates/rspack/tests/tree-shaking/class-extend/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/class-extend/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'v': function() { return v; }
+  v: function() { return v; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -31,7 +31,7 @@ _app__WEBPACK_IMPORTED_MODULE_0_.v;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'value': function() { return value; }
+  value: function() { return value; }
 });
  class Lib {
 }

--- a/crates/rspack/tests/tree-shaking/context-module/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/context-module/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'value': function() { return value; }
+  value: function() { return value; }
 });
  const value = "dynamic";
 },
@@ -15,7 +15,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'value': function() { return value; }
+  value: function() { return value; }
 });
  const value = "dynamic";
 },

--- a/crates/rspack/tests/tree-shaking/cyclic-reference-export-all/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/cyclic-reference-export-all/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _containers__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./containers */"./src/containers/index.js");
 
@@ -30,7 +30,7 @@ __webpack_require__.es(_platform_container__WEBPACK_IMPORTED_MODULE_0_, __webpac
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'containers': function() { return _containers__WEBPACK_IMPORTED_MODULE_0_; }
+  containers: function() { return _containers__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _containers__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./containers */"./src/containers/containers.js");
 
@@ -40,8 +40,8 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'usePlatform': function() { return usePlatform; },
-  'PlatformProvider': function() { return PlatformProvider; }
+  usePlatform: function() { return usePlatform; },
+  PlatformProvider: function() { return PlatformProvider; }
 });
  const usePlatform = 3;
  const PlatformProvider = 1000;

--- a/crates/rspack/tests/tree-shaking/default_export/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/default_export/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'answer': function() { return answer; }
+  answer: function() { return answer; }
 });
  const answer = 103330; // export default answer;
 },
@@ -15,8 +15,8 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'render': function() { return render; },
-  'default': function() { return result; }
+  render: function() { return render; },
+  "default": function() { return result; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -39,8 +39,8 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'secret': function() { return secret; },
-  'myanswer': function() { return myanswer; }
+  secret: function() { return secret; },
+  myanswer: function() { return myanswer; }
 });
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./answer */"./answer.js");
 

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/snapshot/output.snap
@@ -12,7 +12,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./bar */"./bar.js");
 __webpack_require__.es(_bar__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/snapshot/output.snap
@@ -12,7 +12,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 'baz';
 },
@@ -20,7 +20,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return _baz__WEBPACK_IMPORTED_MODULE_0_.a; }
+  a: function() { return _baz__WEBPACK_IMPORTED_MODULE_0_.a; }
 });
 /* harmony import */var _baz__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./baz */"./baz.js");
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./bar */"./bar.js");

--- a/crates/rspack/tests/tree-shaking/export-imported-import-all-as/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/export-imported-import-all-as/snapshot/output.snap
@@ -21,7 +21,7 @@ _answer__WEBPACK_IMPORTED_MODULE_0_.filter;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'filter': function() { return _test_js__WEBPACK_IMPORTED_MODULE_0_; }
+  filter: function() { return _test_js__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _test_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./test.js */"./test.js");
  const a = 3;
@@ -32,7 +32,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'result': function() { return result; }
+  result: function() { return result; }
 });
  const result = "";
 },

--- a/crates/rspack/tests/tree-shaking/export-named-decl-as/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/export-named-decl-as/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'formatNumber': function() { return _plugin_formatNumber__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  formatNumber: function() { return _plugin_formatNumber__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _plugin_formatNumber__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./plugin/formatNumber */"./src/plugin/formatNumber.js");
 
@@ -24,7 +24,7 @@ console.log(_answer__WEBPACK_IMPORTED_MODULE_0_);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return formatNumber_default; }
+  "default": function() { return formatNumber_default; }
 });
 function formatNumber(config) {}
 const plugin = (cls)=>{

--- a/crates/rspack/tests/tree-shaking/export-star-chain/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/export-star-chain/snapshot/output.snap
@@ -15,7 +15,7 @@ __webpack_require__.es(_something__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'red': function() { return red; }
+  red: function() { return red; }
 });
  const red = 'red';
 },
@@ -23,7 +23,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'blue': function() { return blue; }
+  blue: function() { return blue; }
 });
  const blue = 'blue';
 },
@@ -51,7 +51,7 @@ __webpack_require__.es(_c__WEBPACK_IMPORTED_MODULE_2_, __webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'result': function() { return result; }
+  result: function() { return result; }
 });
  const result = 'ssss';
 },
@@ -74,7 +74,7 @@ _export__WEBPACK_IMPORTED_MODULE_0_.Something;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Something': function() { return Something; }
+  Something: function() { return Something; }
 });
  class Something {
 }
@@ -83,7 +83,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Colors': function() { return _colors_index__WEBPACK_IMPORTED_MODULE_0_; }
+  Colors: function() { return _colors_index__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _colors_index__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ../colors/index */"./colors/index.js");
 /* harmony import */var _Something__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./Something */"./something/Something.js");

--- a/crates/rspack/tests/tree-shaking/export_star/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/export_star/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'bar': function() { return _foo__WEBPACK_IMPORTED_MODULE_0_; }
+  bar: function() { return _foo__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./foo */"./foo.js");
 /* harmony import */var _result__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./result */"./result.js");
@@ -20,7 +20,7 @@ __webpack_require__.es(_result__WEBPACK_IMPORTED_MODULE_1_, __webpack_exports__)
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./bar */"./bar.js");
 __webpack_require__.es(_bar__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);
@@ -43,7 +43,7 @@ _foo__WEBPACK_IMPORTED_MODULE_0_.bar.a;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'c': function() { return c; }
+  c: function() { return c; }
 });
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./foo */"./foo.js");
 __webpack_require__.es(_foo__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);

--- a/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return b; }
+  b: function() { return b; }
 });
 /* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./foo.js */"./foo.js");
 __webpack_require__.es(_foo_js__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-required/snapshot/output.snap
@@ -40,8 +40,8 @@ module.exports = result;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  '_class_call_check': function() { return _class_call_check; },
-  '_': function() { return _class_call_check; }
+  _class_call_check: function() { return _class_call_check; },
+  _: function() { return _class_call_check; }
 });
  function _class_call_check(instance, Constructor) {
     if (!(instance instanceof Constructor)) throw new TypeError("Cannot call a class as a function");
@@ -52,8 +52,8 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  '_create_class': function() { return _create_class; },
-  '_': function() { return _create_class; }
+  _create_class: function() { return _create_class; },
+  _: function() { return _create_class; }
 });
 function _defineProperties(target, props) {
     for(var i = 0; i < props.length; i++){

--- a/crates/rspack/tests/tree-shaking/import-as-default/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/import-as-default/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 var a = 1;
 var __WEBPACK_DEFAULT_EXPORT__ = a;

--- a/crates/rspack/tests/tree-shaking/import-export-all-as-a-empty-module/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/import-export-all-as-a-empty-module/snapshot/output.snap
@@ -7,8 +7,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'aaa': function() { return _app__WEBPACK_IMPORTED_MODULE_1_; },
-  'routes': function() { return routes; }
+  aaa: function() { return _app__WEBPACK_IMPORTED_MODULE_1_; },
+  routes: function() { return routes; }
 });
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./answer */"./answer.js");
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0__default = /*#__PURE__*/__webpack_require__.n(_answer__WEBPACK_IMPORTED_MODULE_0_);

--- a/crates/rspack/tests/tree-shaking/import-star-as-and-export/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/import-star-as-and-export/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'app': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_; }
+  app: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -24,7 +24,7 @@ _app__WEBPACK_IMPORTED_MODULE_0_.app;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 20000;
 },

--- a/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return Something; }
+  "default": function() { return Something; }
 });
 class Something {
 }
@@ -16,7 +16,7 @@ class Something {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Sider': function() { return _Something__WEBPACK_IMPORTED_MODULE_1_["default"]; }
+  Sider: function() { return _Something__WEBPACK_IMPORTED_MODULE_1_["default"]; }
 });
 /* harmony import */var _Something__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./Something */"./Something.js");
 

--- a/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'c': function() { return c; }
+  c: function() { return c; }
 });
  const c = 'a';
 },
@@ -21,7 +21,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./foo */"./foo.js");
 __webpack_require__.es(_foo__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);
@@ -35,7 +35,7 @@ __webpack_require__.es(_bar__WEBPACK_IMPORTED_MODULE_1_, __webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return b; }
+  b: function() { return b; }
 });
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a.js */"./a.js");
 __webpack_require__.es(_a_js__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);

--- a/crates/rspack/tests/tree-shaking/issues_3198/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/issues_3198/snapshot/output.snap
@@ -14,7 +14,7 @@ _test__WEBPACK_IMPORTED_MODULE_0_.obj.test = 1;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'obj': function() { return obj; }
+  obj: function() { return obj; }
 });
  const obj = {};
 },

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable1/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable1/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'defaults': function() { return defaults; }
+  defaults: function() { return defaults; }
 });
  const defaults = {
     test: 1000
@@ -17,7 +17,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Something': function() { return Something; }
+  Something: function() { return Something; }
 });
 /* harmony import */var _Layout__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./Layout */"./Layout.js");
 

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable2/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable2/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'defaults': function() { return defaults; }
+  defaults: function() { return defaults; }
 });
  const defaults = {
     test: 1000
@@ -17,7 +17,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Something': function() { return Something; }
+  Something: function() { return Something; }
 });
 /* harmony import */var _Layout__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./Layout */"./Layout.js");
 

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects1/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects1/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 3;
 },

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects2/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects2/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 3;
 },

--- a/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return Layout; }
+  "default": function() { return Layout; }
 });
 function Layout() {}
 },
@@ -15,7 +15,7 @@ function Layout() {}
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'something': function() { return something; }
+  something: function() { return something; }
 });
  function something() {}
 },
@@ -23,7 +23,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'cccc': function() { return cccc; }
+  cccc: function() { return cccc; }
 });
  function cccc() {}
 },
@@ -31,7 +31,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'cccc': function() { return _c__WEBPACK_IMPORTED_MODULE_2_.cccc; }
+  cccc: function() { return _c__WEBPACK_IMPORTED_MODULE_2_.cccc; }
 });
 /* harmony import */var _Layout__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./Layout */"./Layout.js");
 /* harmony import */var _Something__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./Something */"./Something.js");

--- a/crates/rspack/tests/tree-shaking/named_export_alias/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/named_export_alias/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'something': function() { return something; }
+  something: function() { return something; }
 });
  function something() {}
 },
@@ -15,7 +15,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return a; }
+  "default": function() { return a; }
 });
 /* harmony import */var _Something__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./Something */"./Something.js");
 

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = {
     a: ''
@@ -17,7 +17,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return b; }
+  b: function() { return b; }
 });
  const b = {
     b: ""
@@ -27,8 +27,8 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return _a__WEBPACK_IMPORTED_MODULE_0_.a; },
-  'b': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.b; }
+  a: function() { return _a__WEBPACK_IMPORTED_MODULE_0_.a; },
+  b: function() { return _b__WEBPACK_IMPORTED_MODULE_1_.b; }
 });
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a */"./a.js");
 /* harmony import */var _b__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./b */"./b.js");
@@ -53,7 +53,7 @@ console.log(_lib__WEBPACK_IMPORTED_MODULE_0_.getDocPermissionTextSendMe);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'getDocPermissionTextSendMe': function() { return getDocPermissionTextSendMe; }
+  getDocPermissionTextSendMe: function() { return getDocPermissionTextSendMe; }
 });
 /* harmony import */var _enum_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./enum.js */"./enum.js");
 

--- a/crates/rspack/tests/tree-shaking/nested-import-3/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/nested-import-3/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 103330;
  const b = 103330;

--- a/crates/rspack/tests/tree-shaking/nested-import-4/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/nested-import-4/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 103330;
  const b = 103330;
@@ -23,7 +23,7 @@ _lib__WEBPACK_IMPORTED_MODULE_0_.Lib.a;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Lib': function() { return _answer__WEBPACK_IMPORTED_MODULE_0_; }
+  Lib: function() { return _answer__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./answer */"./answer.js");
 

--- a/crates/rspack/tests/tree-shaking/prune-bailout-module/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/prune-bailout-module/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 var __WEBPACK_DEFAULT_EXPORT__ = 300;
 },
@@ -22,7 +22,7 @@ _lib__WEBPACK_IMPORTED_MODULE_0_.a;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return _a_js__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  a: function() { return _a_js__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a.js */"./a.js");
 

--- a/crates/rspack/tests/tree-shaking/react-redux-like/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/react-redux-like/snapshot/output.snap
@@ -7,8 +7,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Provider': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; },
-  'useSelector': function() { return _selector_js__WEBPACK_IMPORTED_MODULE_1_["default"]; }
+  Provider: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; },
+  useSelector: function() { return _selector_js__WEBPACK_IMPORTED_MODULE_1_["default"]; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 /* harmony import */var _selector_js__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./selector.js */"./selector.js");
@@ -37,7 +37,7 @@ _foo__WEBPACK_IMPORTED_MODULE_0_.useSelector;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 function Provider() {}
 var __WEBPACK_DEFAULT_EXPORT__ = Provider;
@@ -46,7 +46,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = Provider;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return useSelector; }
+  "default": function() { return useSelector; }
 });
 function useSelector() {
     return "";

--- a/crates/rspack/tests/tree-shaking/reexport-all-as-multi-level-nested/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/reexport-all-as-multi-level-nested/snapshot/output.snap
@@ -7,8 +7,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; },
-  'aa': function() { return _aa__WEBPACK_IMPORTED_MODULE_0_; }
+  a: function() { return a; },
+  aa: function() { return _aa__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _aa__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./aa */"./package/autogen/aa.js");
 
@@ -20,7 +20,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'aa': function() { return aa; }
+  aa: function() { return aa; }
 });
  const aa = 3;
  const cc = 3;
@@ -29,7 +29,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return _a__WEBPACK_IMPORTED_MODULE_0_; }
+  a: function() { return _a__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a */"./package/autogen/a.js");
 

--- a/crates/rspack/tests/tree-shaking/reexport-all-as/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/reexport-all-as/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  function a() {}
  function dddd() {}
@@ -16,7 +16,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return _a__WEBPACK_IMPORTED_MODULE_0_; }
+  a: function() { return _a__WEBPACK_IMPORTED_MODULE_0_; }
 });
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a */"./package/autogen/a.js");
 

--- a/crates/rspack/tests/tree-shaking/reexport_default_as/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/reexport_default_as/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return test; }
+  "default": function() { return test; }
 });
 function test() {}
 },
@@ -15,7 +15,7 @@ function test() {}
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Select': function() { return _bar__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  Select: function() { return _bar__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./bar */"./bar.js");
 

--- a/crates/rspack/tests/tree-shaking/reexport_entry_elimination/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/reexport_entry_elimination/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return _b_js__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  b: function() { return _b_js__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _b_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./b.js */"./b.js");
 
@@ -17,7 +17,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _c_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./c.js */"./c.js");
 
@@ -27,7 +27,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = 2000 + _c_js__WEBPACK_IMPORTED_MODULE_0_["defau
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 var __WEBPACK_DEFAULT_EXPORT__ = 10;
 },

--- a/crates/rspack/tests/tree-shaking/rename-export-from-import/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rename-export-from-import/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'q': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_.question; }
+  q: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_.question; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -24,7 +24,7 @@ _app__WEBPACK_IMPORTED_MODULE_0_.q;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'question': function() { return question; }
+  question: function() { return question; }
 });
  const answer = "1";
  const question = "2";

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/snapshot/output.snap
@@ -7,8 +7,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; },
-  'bar': function() { return bar; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; },
+  bar: function() { return bar; }
 });
 var foo = function() {
     return 42;

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 var Foo = function() {
     console.log("side effect");

--- a/crates/rspack/tests/tree-shaking/rollup-unused-called-import/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-called-import/snapshot/output.snap
@@ -14,7 +14,7 @@ function __WEBPACK_DEFAULT_EXPORT__(){
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _dead__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./dead */"./dead.js");
 

--- a/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'foo': function() { return foo; }
+  foo: function() { return foo; }
 });
  var foo = {
     value: 1

--- a/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/snapshot/output.snap
@@ -26,8 +26,8 @@ console.log(getClass().name);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'bar': function() { return bar; },
-  'baz': function() { return Baz; }
+  bar: function() { return bar; },
+  baz: function() { return Baz; }
 });
  function foo() {
     console.log("outer foo");

--- a/crates/rspack/tests/tree-shaking/rollup-unused-var/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-var/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'foo': function() { return foo; }
+  foo: function() { return foo; }
 });
 var foo = "lol";
 var bar = "wut";

--- a/crates/rspack/tests/tree-shaking/side-effects-analyzed/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-analyzed/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'something': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  something: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -24,7 +24,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/side-effects-export-default-expr/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-export-default-expr/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return b; }
+  b: function() { return b; }
 });
 
 var __WEBPACK_DEFAULT_EXPORT__ = /* "./lib" unused */null;

--- a/crates/rspack/tests/tree-shaking/side-effects-flagged-only/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-flagged-only/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'something': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  something: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 /* harmony import */var _src_a__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./src/a */"./src/a.js");
@@ -25,7 +25,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/side-effects-prune/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-prune/snapshot/output.snap
@@ -24,7 +24,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'something': function() { return something; }
+  something: function() { return something; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/side-effects-two/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-two/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'something': function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
+  something: function() { return _lib__WEBPACK_IMPORTED_MODULE_0_["default"]; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -26,7 +26,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/snapshot/output.snap
@@ -15,8 +15,8 @@ console.log(_maths_js__WEBPACK_IMPORTED_MODULE_0_.square);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'xxx': function() { return _test_js__WEBPACK_IMPORTED_MODULE_0_; },
-  'square': function() { return square; }
+  xxx: function() { return _test_js__WEBPACK_IMPORTED_MODULE_0_; },
+  square: function() { return square; }
 });
 /* harmony import */var _test_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./test.js */"./test.js");
 // maths.js
@@ -37,7 +37,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'test': function() { return test; }
+  test: function() { return test; }
 });
  function test() {}
  function ccc() {}

--- a/crates/rspack/tests/tree-shaking/static-class/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/static-class/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 /* harmony import */var _b_js__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./b.js */"./b.js");
 
@@ -28,7 +28,7 @@ class Result {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'bb': function() { return bb; }
+  bb: function() { return bb; }
 });
  const bb = 2;
  const cc = 3;

--- a/crates/rspack/tests/tree-shaking/transitive-bailout/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/transitive-bailout/snapshot/output.snap
@@ -7,8 +7,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; },
-  'b': function() { return b; }
+  a: function() { return a; },
+  b: function() { return b; }
 });
  const a = 3;
  const b = 3;

--- a/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 /* harmony import */var _side_effects_js__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./side-effects.js */"./side-effects.js");
 /* harmony import */var _side_effects_js__WEBPACK_IMPORTED_MODULE_1__default = /*#__PURE__*/__webpack_require__.n(_side_effects_js__WEBPACK_IMPORTED_MODULE_1_);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'b': function() { return b; }
+  b: function() { return b; }
 });
  const b = 3;
 },
@@ -15,7 +15,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 3;
 },

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return test; }
+  "default": function() { return test; }
 });
 function test() {}
 },
@@ -21,7 +21,7 @@ function test() {}
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 __webpack_require__.el(/* ./bar */"./bar.js").then(__webpack_require__.bind(__webpack_require__, /* ./bar */"./bar.js")).then((mod)=>{
     console.log(mod);

--- a/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _test__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./test */"./test.js");
 
@@ -20,7 +20,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = myanswer;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 function test() {}
 var __WEBPACK_DEFAULT_EXPORT__ = test;
@@ -35,7 +35,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = test;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'answer': function() { return answer; }
+  answer: function() { return answer; }
 });
  const answer = 30;
 },

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  '_': function() { return _async_to_generator; }
+  _: function() { return _async_to_generator; }
 });
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
     try {
@@ -41,7 +41,7 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  '_': function() { return tslib__WEBPACK_IMPORTED_MODULE_0_.__generator; }
+  _: function() { return tslib__WEBPACK_IMPORTED_MODULE_0_.__generator; }
 });
 /* harmony import */var tslib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* tslib */"../../../../../node_modules/tslib/tslib.es6.js");
 
@@ -50,7 +50,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  '__generator': function() { return __generator; }
+  __generator: function() { return __generator; }
 });
 /******************************************************************************
 Copyright (c) Microsoft Corporation.
@@ -483,7 +483,7 @@ var __setModuleDefault = Object.create ? function(o, v) {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'test': function() { return test; }
+  test: function() { return test; }
 });
 /* harmony import */var _swc_helpers_async_to_generator__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* @swc/helpers/_/_async_to_generator */"../../../../../node_modules/@swc/helpers/esm/_async_to_generator.js");
 /* harmony import */var _swc_helpers_ts_generator__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* @swc/helpers/_/_ts_generator */"../../../../../node_modules/@swc/helpers/esm/_ts_generator.js");

--- a/crates/rspack/tests/tree-shaking/var-function-expr/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/var-function-expr/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'app': function() { return app; }
+  app: function() { return app; }
 });
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./lib */"./lib.js");
 
@@ -31,8 +31,8 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'result': function() { return result; },
-  'something': function() { return something; }
+  result: function() { return result; },
+  something: function() { return something; }
 });
  const secret = "888";
  const result = 20000;

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return abc; }
+  "default": function() { return abc; }
 });
 /* harmony import */var _dep_a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./dep?a */"./dep.js?a");
 
@@ -38,7 +38,7 @@ abc();
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return def; }
+  "default": function() { return def; }
 });
 /* harmony import */var _dep_d__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./dep?d */"./dep.js?d");
 
@@ -52,8 +52,8 @@ class def {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return x; },
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  x: function() { return x; },
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const x = "x";
 var __WEBPACK_DEFAULT_EXPORT__ = true;
@@ -62,7 +62,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = true;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const x = "x";
 var __WEBPACK_DEFAULT_EXPORT__ = false;
@@ -71,8 +71,8 @@ var __WEBPACK_DEFAULT_EXPORT__ = false;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return x; },
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  x: function() { return x; },
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const x = "x";
 var __WEBPACK_DEFAULT_EXPORT__ = true;
@@ -81,8 +81,8 @@ var __WEBPACK_DEFAULT_EXPORT__ = true;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return x; },
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  x: function() { return x; },
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const x = "x";
 var __WEBPACK_DEFAULT_EXPORT__ = true;
@@ -91,7 +91,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = true;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const x = "x";
 var __WEBPACK_DEFAULT_EXPORT__ = false;
@@ -100,8 +100,8 @@ var __WEBPACK_DEFAULT_EXPORT__ = false;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return x; },
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  x: function() { return x; },
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
  const x = "x";
 var __WEBPACK_DEFAULT_EXPORT__ = true;

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/snapshot/output.snap
@@ -18,7 +18,7 @@ __webpack_require__.r(__webpack_exports__);
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'test': function() { return test; }
+  test: function() { return test; }
 });
 /* harmony import */var _module__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./module */"./module.js");
 
@@ -41,7 +41,7 @@ it("should generate correct code when pure expressions are in dead branches", ()
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _some_module__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./some-module */"./some-module.js");
 
@@ -82,9 +82,9 @@ var __WEBPACK_DEFAULT_EXPORT__ = doSomething;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'Block': function() { return Block; },
-  'Inline': function() { return Inline; },
-  'Document': function() { return Document; }
+  Block: function() { return Block; },
+  Inline: function() { return Inline; },
+  Document: function() { return Document; }
 });
 class Block {
     static doSomething() {}

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/snapshot/output.snap
@@ -34,11 +34,11 @@ it("export should be unused when only unused functions use it", ()=>{
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'A': function() { return A; },
-  'B': function() { return B; },
-  'exportAUsed': function() { return exportAUsed; },
-  'exportBUsed': function() { return exportBUsed; },
-  'exportCUsed': function() { return exportCUsed; }
+  A: function() { return A; },
+  B: function() { return B; },
+  exportAUsed: function() { return exportAUsed; },
+  exportBUsed: function() { return exportBUsed; },
+  exportCUsed: function() { return exportCUsed; }
 });
  function A(s) {
     return s + "A";
@@ -57,7 +57,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'y': function() { return y; }
+  y: function() { return y; }
 });
 /* harmony import */var _inner__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./inner */"./inner.js");
 

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/snapshot/output.snap
@@ -43,11 +43,11 @@ it("should be able to handle circular referenced", ()=>{
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return x; },
-  'y': function() { return y; },
-  'z': function() { return z; },
-  'a': function() { return a; },
-  'f3': function() { return f3; }
+  x: function() { return x; },
+  y: function() { return y; },
+  z: function() { return z; },
+  a: function() { return a; },
+  f3: function() { return f3; }
 });
 function x() {
     return [

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/snapshot/output.snap
@@ -12,8 +12,8 @@ it("should be able to load package without side effects where modules are unused
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; },
-  'test': function() { return test; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; },
+  test: function() { return test; }
 });
 /* harmony import */var _package__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./package */"./package/index.js");
 
@@ -24,7 +24,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = _package__WEBPACK_IMPORTED_MODULE_0_.a;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 
  function a() {

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/snapshot/output.snap
@@ -20,8 +20,8 @@ it("should not threat globals as pure", ()=>{
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'ok': function() { return ok; },
-  'ok2': function() { return ok2; }
+  ok: function() { return ok; },
+  ok2: function() { return ok2; }
 });
 try {
     var x = NOT_DEFINED;

--- a/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/snapshot/output.snap
@@ -29,7 +29,7 @@ it("default export should be used", ()=>{
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'mod': function() { return mod; }
+  mod: function() { return mod; }
 });
 /* harmony import */var _package1_script__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./package1/script */"./package1/script.js");
 /* harmony import */var _package2_script__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./package2/script */"./package2/script.js");
@@ -41,7 +41,7 @@ __webpack_require__.d(__webpack_exports__, {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'exportDefaultUsed': function() { return exportDefaultUsed; }
+  exportDefaultUsed: function() { return exportDefaultUsed; }
 });
 /* harmony import */var _script1__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./script1 */"./package1/script1.js");
 __webpack_require__.es(_script1__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);
@@ -62,7 +62,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = 1;
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'exportDefaultUsed': function() { return exportDefaultUsed; }
+  exportDefaultUsed: function() { return exportDefaultUsed; }
 });
 
 function __WEBPACK_DEFAULT_EXPORT__(){
@@ -75,8 +75,8 @@ function __WEBPACK_DEFAULT_EXPORT__(){
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; },
-  'exportDefaultUsed': function() { return exportDefaultUsed; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; },
+  exportDefaultUsed: function() { return exportDefaultUsed; }
 });
 /* harmony import */var _script1__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./script1 */"./package2/script1.js");
 __webpack_require__.es(_script1__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);
@@ -89,7 +89,7 @@ var __WEBPACK_DEFAULT_EXPORT__ = _script1__WEBPACK_IMPORTED_MODULE_0_["default"]
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 var __WEBPACK_DEFAULT_EXPORT__ = 1;
 },

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./tracker */"../node_modules/pmodule/tracker.js");
 var a = "a";
@@ -21,8 +21,8 @@ var c = "c";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'z': function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; },
-  'x': function() { return x; }
+  z: function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; },
+  x: function() { return x; }
 });
 /* harmony import */var _c__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./c */"../node_modules/pmodule/c.js");
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./tracker */"../node_modules/pmodule/tracker.js");
@@ -37,7 +37,7 @@ var y = "y";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'z': function() { return z; }
+  z: function() { return z; }
 });
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./tracker */"../node_modules/pmodule/tracker.js");
 var z = "z";
@@ -49,9 +49,9 @@ var z = "z";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.x; },
-  'z': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; },
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  x: function() { return _b__WEBPACK_IMPORTED_MODULE_1_.x; },
+  z: function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; },
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./a */"../node_modules/pmodule/a.js");
 __webpack_require__.es(_a__WEBPACK_IMPORTED_MODULE_0_, __webpack_exports__);
@@ -67,8 +67,8 @@ var __WEBPACK_DEFAULT_EXPORT__ = "def";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'track': function() { return track; },
-  'log': function() { return log; }
+  track: function() { return track; },
+  log: function() { return log; }
 });
  function track(file) {
     log.push(file);

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/snapshot/output.snap
@@ -7,8 +7,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'z': function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; },
-  'x': function() { return x; }
+  z: function() { return _c__WEBPACK_IMPORTED_MODULE_0_.z; },
+  x: function() { return x; }
 });
 /* harmony import */var _c__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./c */"../node_modules/pmodule/c.js");
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./tracker */"../node_modules/pmodule/tracker.js");
@@ -23,7 +23,7 @@ var y = "y";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'z': function() { return z; }
+  z: function() { return z; }
 });
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./tracker */"../node_modules/pmodule/tracker.js");
 var z = "z";
@@ -35,9 +35,9 @@ var z = "z";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'x': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.x; },
-  'z': function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; },
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  x: function() { return _b__WEBPACK_IMPORTED_MODULE_1_.x; },
+  z: function() { return _b__WEBPACK_IMPORTED_MODULE_1_.z; },
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 /* harmony import */var _b__WEBPACK_IMPORTED_MODULE_1_ = __webpack_require__(/* ./b */"../node_modules/pmodule/b.js");
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_2_ = __webpack_require__(/* ./tracker */"../node_modules/pmodule/tracker.js");
@@ -51,8 +51,8 @@ var __WEBPACK_DEFAULT_EXPORT__ = "def";
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'track': function() { return track; },
-  'log': function() { return log; }
+  track: function() { return track; },
+  log: function() { return log; }
 });
  function track(file) {
     log.push(file);

--- a/crates/rspack/tests/tree-shaking/with-assets/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/with-assets/snapshot/output.snap
@@ -7,7 +7,7 @@ source: crates/rspack_testing/src/run_fixture.rs
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'a': function() { return a; }
+  a: function() { return a; }
 });
  const a = 3;
 },

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -6,6 +6,9 @@ use rustc_hash::FxHashMap as HashMap;
 mod identifier;
 pub use identifier::*;
 
+mod property_name;
+pub use property_name::*;
+
 mod property_access;
 pub use property_access::*;
 

--- a/crates/rspack_core/src/utils/property_name.rs
+++ b/crates/rspack_core/src/utils/property_name.rs
@@ -69,6 +69,6 @@ pub fn property_name(prop: &str) -> Result<Cow<str>> {
   } else {
     serde_json::to_string(prop)
       .map_err(|e| internal_error!(e.to_string()))
-      .map(|s| Cow::from(s))
+      .map(Cow::from)
   }
 }

--- a/crates/rspack_core/src/utils/property_name.rs
+++ b/crates/rspack_core/src/utils/property_name.rs
@@ -1,0 +1,74 @@
+use std::borrow::Cow;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rspack_error::{internal_error, Result};
+use rustc_hash::FxHashSet as HashSet;
+
+pub static SAFE_IDENTIFIER: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^[_a-zA-Z$][_a-zA-Z$0-9]*$").expect("Invalid regexp"));
+pub static RESERVED_IDENTIFIER: Lazy<HashSet<&str>> = Lazy::new(|| {
+  HashSet::from_iter([
+    "break",
+    "case",
+    "catch",
+    "class",
+    "const",
+    "continue",
+    "debugger",
+    "default",
+    "delete",
+    "do",
+    "else",
+    "export",
+    "extends",
+    "finally",
+    "for",
+    "function",
+    "if",
+    "import",
+    "in",
+    "instanceof",
+    "new",
+    "return",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "try",
+    "typeof",
+    "var",
+    "void",
+    "while",
+    "with",
+    "enum",
+    // strict mode
+    "implements",
+    "interface",
+    "let",
+    "package",
+    "private",
+    "protected",
+    "public",
+    "static",
+    "yield",
+    "yield",
+    // module code
+    "await",
+    // skip future reserved keywords defined under ES1 till ES3
+    // additional
+    "null",
+    "true",
+    "false",
+  ])
+});
+
+pub fn property_name(prop: &str) -> Result<Cow<str>> {
+  if SAFE_IDENTIFIER.is_match(prop) && !RESERVED_IDENTIFIER.contains(prop) {
+    Ok(Cow::from(prop))
+  } else {
+    serde_json::to_string(prop)
+      .map_err(|e| internal_error!(e.to_string()))
+      .map(|s| Cow::from(s))
+  }
+}

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -273,11 +273,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
           .for_each(|dependency| dependency.apply(&mut source, &mut context));
       };
 
-      Ok(render_init_fragments(
-        source.boxed(),
-        init_fragments,
-        generate_context,
-      ))
+      render_init_fragments(source.boxed(), init_fragments, generate_context)
     } else {
       Err(internal_error!(
         "Unsupported source type {:?} for plugin JavaScript",

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -322,7 +322,7 @@ impl JsPlugin {
       final_source,
       chunk_init_fragments,
       &mut ChunkRenderContext {},
-    );
+    )?;
     if let Some(source) = compilation.plugin_driver.render(RenderArgs {
       compilation,
       chunk: &args.chunk_ukey,
@@ -353,7 +353,7 @@ impl JsPlugin {
       .await?
       .expect("should run render_chunk hook");
     let final_source =
-      render_init_fragments(source, chunk_init_fragments, &mut ChunkRenderContext {});
+      render_init_fragments(source, chunk_init_fragments, &mut ChunkRenderContext {})?;
     if let Some(source) = compilation.plugin_driver.render(RenderArgs {
       compilation,
       chunk: &args.chunk_ukey,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -184,7 +184,8 @@ impl Visit for HarmonyImportDependencyScanner<'_> {
           n.local.sym.clone(),
           match &n.imported {
             Some(ModuleExportName::Ident(ident)) => Some(ident.sym.clone()),
-            _ => None,
+            Some(ModuleExportName::Str(str)) => Some(str.value.clone()),
+            None => None,
           },
         );
         self.import_map.insert(
@@ -194,7 +195,8 @@ impl Visit for HarmonyImportDependencyScanner<'_> {
             specifier.clone(),
             Some(match &n.imported {
               Some(ModuleExportName::Ident(ident)) => ident.sym.clone(),
-              _ => n.local.sym.clone(),
+              Some(ModuleExportName::Str(str)) => str.value.clone(),
+              None => n.local.sym.clone(),
             }),
             self.last_harmony_import_order,
           ),
@@ -274,9 +276,9 @@ impl Visit for HarmonyImportDependencyScanner<'_> {
               specifiers.push(Specifier::Named(
                 orig.sym.clone(),
                 match &named.exported {
+                  Some(ModuleExportName::Str(export)) => Some(export.value.clone()),
                   Some(ModuleExportName::Ident(export)) => Some(export.sym.clone()),
                   None => None,
-                  _ => unreachable!(),
                 },
               ));
             }

--- a/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/snapshot/output.snap
+++ b/crates/rspack_plugin_javascript/tests/fixtures/builtins/define/snapshot/output.snap
@@ -258,9 +258,9 @@ console.log(console.log(console.log)); // TODO: recursive
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; },
-  'DO_NOT_CONVERTED7': function() { return DO_NOT_CONVERTED7; },
-  'DO_NOT_CONVERTED9': function() { return DO_NOT_CONVERTED9; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; },
+  DO_NOT_CONVERTED7: function() { return DO_NOT_CONVERTED7; },
+  DO_NOT_CONVERTED9: function() { return DO_NOT_CONVERTED9; }
 });
 const DO_NOT_CONVERTED7 = 402;
 const DO_NOT_CONVERTED9 = 403;

--- a/crates/rspack_plugin_javascript/tests/fixtures/provide/snapshot/output.snap
+++ b/crates/rspack_plugin_javascript/tests/fixtures/provide/snapshot/output.snap
@@ -21,7 +21,7 @@ function a() {
 'use strict';
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'default': function() { return __WEBPACK_DEFAULT_EXPORT__; }
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
 });
 const lib = {
     get: ()=>{

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -41,7 +41,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
     // TODO default_object is not align with webpack
     build_meta.default_object = BuildMetaDefaultObject::RedirectWarn;
     let source = box_source.source();
-    let strip_bom_source = source.strip_prefix("\u{feff}");
+    let strip_bom_source = source.strip_prefix('\u{feff}');
     let need_strip_bom = strip_bom_source.is_some();
 
     let parse_result = json::parse(strip_bom_source.unwrap_or(&source)).map_err(|e| {

--- a/crates/rspack_plugin_wasm/tests/fixtures/imports-multiple/snapshot/output.snap
+++ b/crates/rspack_plugin_wasm/tests/fixtures/imports-multiple/snapshot/output.snap
@@ -26,8 +26,8 @@ var __webpack_exports__ = (__webpack_exec__("./index.js"));
 __webpack_require__.a(module, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'result': function() { return result; },
-  'getNumber': function() { return getNumber; }
+  result: function() { return result; },
+  getNumber: function() { return getNumber; }
 });
 /* harmony import */var _wasm_wasm__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./wasm.wasm */"./wasm.wasm");
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_wasm_wasm__WEBPACK_IMPORTED_MODULE_0_]);
@@ -44,7 +44,7 @@ __webpack_async_result__();
 __webpack_require__.a(module, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) { try {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  'getNumber': function() { return getNumber; }
+  getNumber: function() { return getNumber; }
 });
 /* harmony import */var _wasm_wasm__WEBPACK_IMPORTED_MODULE_0_ = __webpack_require__(/* ./wasm.wasm */"./wasm.wasm");
 var __webpack_async_dependencies__ = __webpack_handle_async_dependencies__([_wasm_wasm__WEBPACK_IMPORTED_MODULE_0_]);

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -503,7 +503,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "627ffdc10e023d4d79a6",
+  "hash": "3290e10b2fba8a8bd75a",
   "logging": {},
   "modules": [
     {
@@ -606,7 +606,7 @@ chunk {main} main.xxxx.js (main) >{dynamic_js}< [entry]
   entry ./index
 ./dynamic.js [426] {dynamic_js}
   dynamic import ./dynamic [10]
-Rspack compiled successfully (627ffdc10e023d4d79a6)"
+Rspack compiled successfully (3290e10b2fba8a8bd75a)"
 `;
 
 exports[`StatsTestCases should print correct stats for hot+production 1`] = `
@@ -2502,7 +2502,7 @@ exports[`StatsTestCases should print correct stats for simple 1`] = `
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "86603a19716580fa0e3f",
+  "hash": "21b6a905e9c471003723",
   "logging": {},
   "modules": [
     {
@@ -2565,7 +2565,7 @@ chunk {main} bundle.js (main) [entry]
     entry ./index
 ./index.js [10] {main}
   entry ./index
-Rspack compiled successfully (86603a19716580fa0e3f)"
+Rspack compiled successfully (21b6a905e9c471003723)"
 `;
 
 exports[`StatsTestCases should print correct stats for simple-module-source 1`] = `
@@ -2951,7 +2951,7 @@ exports[`StatsTestCases should print correct stats for stats-hooks 1`] = `
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "86603a19716580fa0e3f",
+  "hash": "21b6a905e9c471003723",
   "logging": {},
   "modules": [
     {
@@ -3008,7 +3008,7 @@ exports[`StatsTestCases should print correct stats for stats-hooks 2`] = `
 asset bundle.js 589 bytes [emitted111] (name: main) [testA: aaaaaa]
 Entrypoint main 589 bytes = bundle.js
 ./index.js
-Rspack compiled successfully (86603a19716580fa0e3f)"
+Rspack compiled successfully (21b6a905e9c471003723)"
 `;
 
 exports[`StatsTestCases should print correct stats for try-require--module 1`] = `

--- a/webpack-test/cases/parsing/amd-rename/test.filter.js
+++ b/webpack-test/cases/parsing/amd-rename/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/api/test.filter.js
+++ b/webpack-test/cases/parsing/api/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/asi/test.filter.js
+++ b/webpack-test/cases/parsing/asi/test.filter.js
@@ -1,4 +1,5 @@
+const { FilteredStatus } = require("../../../lib/util/filterUtil")
 
-module.exports = () => {return false}
+module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4419"]}
 
 							

--- a/webpack-test/cases/parsing/bom/test.filter.js
+++ b/webpack-test/cases/parsing/bom/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/browserify/test.filter.js
+++ b/webpack-test/cases/parsing/browserify/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/chunks/test.filter.js
+++ b/webpack-test/cases/parsing/chunks/test.filter.js
@@ -1,3 +1,4 @@
+const { FilteredStatus } = require("../../../lib/util/filterUtil")
 
 /*
 var supportsES6 = require("../../../helpers/supportsES6");
@@ -7,6 +8,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4304"]}
 
 							

--- a/webpack-test/cases/parsing/comment-in-import/test.filter.js
+++ b/webpack-test/cases/parsing/comment-in-import/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/complex-require/test.filter.js
+++ b/webpack-test/cases/parsing/complex-require/test.filter.js
@@ -1,3 +1,4 @@
+const { FilteredStatus } = require("../../../lib/util/filterUtil")
 
 /*
 var supportsTemplateStrings = require("../../../helpers/supportsTemplateStrings");
@@ -7,6 +8,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4420, https://github.com/web-infra-dev/rspack/issues/4304, https://github.com/web-infra-dev/rspack/issues/4313"]}
 
 							

--- a/webpack-test/cases/parsing/context/test.filter.js
+++ b/webpack-test/cases/parsing/context/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/3346"}
 
 							

--- a/webpack-test/cases/parsing/declared-api/test.filter.js
+++ b/webpack-test/cases/parsing/declared-api/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/es2020/test.filter.js
+++ b/webpack-test/cases/parsing/es2020/test.filter.js
@@ -7,6 +7,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4421"}
 
 							

--- a/webpack-test/cases/parsing/es2022/test.filter.js
+++ b/webpack-test/cases/parsing/es2022/test.filter.js
@@ -1,6 +1,4 @@
-
-/*
-module.exports = function(config) {
+module.exports = function (config) {
 	// terser doesn't support static {}
 	if (config.mode === "production") return false;
 
@@ -11,8 +9,3 @@ module.exports = function(config) {
 		return false;
 	}
 };
-
-*/
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/es6.nominimize/test.filter.js
+++ b/webpack-test/cases/parsing/es6.nominimize/test.filter.js
@@ -7,6 +7,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4304"}
 
 							

--- a/webpack-test/cases/parsing/evaluate-nullish/test.filter.js
+++ b/webpack-test/cases/parsing/evaluate-nullish/test.filter.js
@@ -7,6 +7,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4424"}
 
 							

--- a/webpack-test/cases/parsing/evaluate/test.filter.js
+++ b/webpack-test/cases/parsing/evaluate/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4424"}
 
 							

--- a/webpack-test/cases/parsing/extract-amd.nominimize/test.filter.js
+++ b/webpack-test/cases/parsing/extract-amd.nominimize/test.filter.js
@@ -7,6 +7,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/extract-amd/test.filter.js
+++ b/webpack-test/cases/parsing/extract-amd/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/extract-require/test.filter.js
+++ b/webpack-test/cases/parsing/extract-require/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4424"}
 
 							

--- a/webpack-test/cases/parsing/harmony-deep-exports/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-deep-exports/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4426, https://github.com/web-infra-dev/rspack/issues/4325"}
 
 							

--- a/webpack-test/cases/parsing/harmony-duplicate-export/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-duplicate-export/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4325"}
 
 							

--- a/webpack-test/cases/parsing/harmony-edge-cases/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-edge-cases/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/harmony-export-import-specifier/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-export-import-specifier/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4426"}
 
 							

--- a/webpack-test/cases/parsing/harmony-export-precedence/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-export-precedence/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4323"}
 
 							

--- a/webpack-test/cases/parsing/harmony-info/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-info/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4323"}
 
 							

--- a/webpack-test/cases/parsing/harmony-injecting-order/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-injecting-order/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/harmony-module-optimization/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-module-optimization/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/harmony-reexport/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-reexport/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "new treeshaking re-implementation"}
 
 							

--- a/webpack-test/cases/parsing/harmony-star-conflict/test.filter.js
+++ b/webpack-test/cases/parsing/harmony-star-conflict/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4118, https://github.com/web-infra-dev/rspack/issues/4323"}
 
 							

--- a/webpack-test/cases/parsing/harmony/node_modules/abc.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/abc.js
@@ -1,0 +1,9 @@
+export var a = "a";
+export var b = "b";
+export {c} from "./abc_c";
+
+import * as temp from "./abc_c";
+export {temp as d};
+
+import {c} from "./abc_c";
+export {c as e};

--- a/webpack-test/cases/parsing/harmony/node_modules/abc_c.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/abc_c.js
@@ -1,0 +1,1 @@
+export var c = "c";

--- a/webpack-test/cases/parsing/harmony/node_modules/circularEven.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/circularEven.js
@@ -1,0 +1,8 @@
+import { odd } from "circularOdd";
+
+export default odd(3);
+
+export function even(n) {
+	if(n == 0) return true;
+	return odd(n - 1);
+}

--- a/webpack-test/cases/parsing/harmony/node_modules/circularOdd.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/circularOdd.js
@@ -1,0 +1,6 @@
+import { even } from "circularEven";
+
+export function odd(n) {
+	if(n == 0) return false;
+	return even(n - 1);
+}

--- a/webpack-test/cases/parsing/harmony/node_modules/commonjs-trans.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/commonjs-trans.js
@@ -1,0 +1,7 @@
+exports.__esModule = true;
+
+exports.default = function Thing() {
+	this.value = "thing";
+};
+
+exports.Other = "other";

--- a/webpack-test/cases/parsing/harmony/node_modules/commonjs.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/commonjs.js
@@ -1,0 +1,5 @@
+module.exports = function Thing() {
+	return "thing";
+}
+
+module.exports.Other = "other";

--- a/webpack-test/cases/parsing/harmony/node_modules/def.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/def.js
@@ -1,0 +1,1 @@
+export default "def";

--- a/webpack-test/cases/parsing/harmony/node_modules/exportKinds.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/exportKinds.js
@@ -1,0 +1,7 @@
+export function fn() {
+	return "fn";
+}
+export var one = "one", two = "two";
+
+export var test1 = fn();
+export var test2 = two;

--- a/webpack-test/cases/parsing/harmony/node_modules/exports-specifier.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/exports-specifier.js
@@ -1,0 +1,2 @@
+var specA = 1, b = 2;
+export { specA, b as specB }

--- a/webpack-test/cases/parsing/harmony/node_modules/reexport.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/reexport.js
@@ -1,0 +1,3 @@
+export * from "abc";
+export { one as o, two } from "exportKinds";
+export { default as def } from "commonjs";

--- a/webpack-test/cases/parsing/harmony/node_modules/reexport2.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/reexport2.js
@@ -1,0 +1,2 @@
+"use strict";
+export * from "abc";

--- a/webpack-test/cases/parsing/harmony/node_modules/unused.js
+++ b/webpack-test/cases/parsing/harmony/node_modules/unused.js
@@ -1,0 +1,5 @@
+export var a = "a";
+var b = "b";
+export {b as d};
+export {c as e} from "./abc_c";
+export * from "./abc";

--- a/webpack-test/cases/parsing/harmony/test.filter.js
+++ b/webpack-test/cases/parsing/harmony/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return false}
-
-							

--- a/webpack-test/cases/parsing/hashbang/test.filter.js
+++ b/webpack-test/cases/parsing/hashbang/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4427"}
 
 							

--- a/webpack-test/cases/parsing/issue-345/test.filter.js
+++ b/webpack-test/cases/parsing/issue-345/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/issue-387/test.filter.js
+++ b/webpack-test/cases/parsing/issue-387/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313"}
 
 							

--- a/webpack-test/cases/parsing/issue-627/test.filter.js
+++ b/webpack-test/cases/parsing/issue-627/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4429"}
 
 							

--- a/webpack-test/cases/parsing/issue-758/test.filter.js
+++ b/webpack-test/cases/parsing/issue-758/test.filter.js
@@ -1,4 +1,4 @@
 
-module.exports = () => {return false}
+module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4313, https://github.com/web-infra-dev/rspack/issues/4304"}
 
 							


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

```js
// a.js
export {a as "\0 a"}

// index.js
import {"\0 a" as a} from "./a"
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
