### PR TITLE
fix: use string as key for resolve.by_dependency

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_options/src/options/raw_resolve.rs
@@ -1,9 +1,7 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use napi_derive::napi;
-use rspack_core::{
-  Alias, AliasMap, ByDependency, DependencyCategory, Resolve, TsconfigOptions, TsconfigReferences,
-};
+use rspack_core::{Alias, AliasMap, ByDependency, Resolve, TsconfigOptions, TsconfigReferences};
 use serde::Deserialize;
 
 pub type AliasValue = serde_json::Value;
@@ -103,10 +101,7 @@ impl TryFrom<RawResolveOptions> for Resolve {
       .by_dependency
       .map(|i| {
         i.into_iter()
-          .map(|(k, v)| {
-            let v = v.try_into()?;
-            Ok((DependencyCategory::from(k.as_str()), v))
-          })
+          .map(|(k, v)| Ok((k.into(), v.try_into()?)))
           .collect::<Result<ByDependency, Self::Error>>()
       })
       .transpose()?;

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -155,18 +155,24 @@ impl From<&str> for DependencyCategory {
   }
 }
 
+impl DependencyCategory {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      DependencyCategory::Unknown => "unknown",
+      DependencyCategory::Esm => "esm",
+      DependencyCategory::CommonJS => "commonjs",
+      DependencyCategory::Url => "url",
+      DependencyCategory::CssImport => "css-import",
+      DependencyCategory::CssCompose => "css-compose",
+      DependencyCategory::Wasm => "wasm",
+      DependencyCategory::Worker => "worker",
+    }
+  }
+}
+
 impl Display for DependencyCategory {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    match self {
-      DependencyCategory::Unknown => write!(f, "unknown"),
-      DependencyCategory::Esm => write!(f, "esm"),
-      DependencyCategory::CommonJS => write!(f, "commonjs"),
-      DependencyCategory::Url => write!(f, "url"),
-      DependencyCategory::CssImport => write!(f, "css-import"),
-      DependencyCategory::CssCompose => write!(f, "css-compose"),
-      DependencyCategory::Wasm => write!(f, "wasm"),
-      DependencyCategory::Worker => write!(f, "worker"),
-    }
+    write!(f, "{}", self.as_str())
   }
 }
 

--- a/crates/rspack_core/src/options/resolve.rs
+++ b/crates/rspack_core/src/options/resolve.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf};
 
 use hashlink::LinkedHashMap;
 
@@ -115,11 +115,13 @@ impl Resolve {
   }
 }
 
-#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
-pub struct ByDependency(LinkedHashMap<DependencyCategory, Resolve>);
+type DependencyCategoryStr = Cow<'static, str>;
 
-impl FromIterator<(DependencyCategory, Resolve)> for ByDependency {
-  fn from_iter<I: IntoIterator<Item = (DependencyCategory, Resolve)>>(i: I) -> Self {
+#[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
+pub struct ByDependency(LinkedHashMap<DependencyCategoryStr, Resolve>);
+
+impl FromIterator<(DependencyCategoryStr, Resolve)> for ByDependency {
+  fn from_iter<I: IntoIterator<Item = (DependencyCategoryStr, Resolve)>>(i: I) -> Self {
     Self(LinkedHashMap::from_iter(i.into_iter()))
   }
 }
@@ -139,7 +141,7 @@ impl ByDependency {
   }
 
   pub fn get(&self, k: &DependencyCategory) -> Option<&Resolve> {
-    self.0.get(k)
+    self.0.get(k.as_str()).or_else(|| self.0.get("default"))
   }
 }
 

--- a/packages/rspack/src/config/README.md
+++ b/packages/rspack/src/config/README.md
@@ -1,3 +1,0 @@
-# How options is been processed in rspack?
-
-TODO

--- a/packages/rspack/tests/configCases/resolve/issue-4432/index.js
+++ b/packages/rspack/tests/configCases/resolve/issue-4432/index.js
@@ -1,0 +1,5 @@
+import value from "./package";
+
+it("should merge in the correct order", () => {
+	expect(value).toBe("custom");
+});

--- a/packages/rspack/tests/configCases/resolve/issue-4432/package/custom.js
+++ b/packages/rspack/tests/configCases/resolve/issue-4432/package/custom.js
@@ -1,0 +1,1 @@
+export default "custom";

--- a/packages/rspack/tests/configCases/resolve/issue-4432/package/package.json
+++ b/packages/rspack/tests/configCases/resolve/issue-4432/package/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "./main",
+  "module": "./module",
+  "custom": "./custom.js"
+}

--- a/packages/rspack/tests/configCases/resolve/issue-4432/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve/issue-4432/webpack.config.js
@@ -1,0 +1,10 @@
+/** @type {import('@rspack/cli').Configuration} */
+const config = {
+	entry: {
+		main: "./index.js"
+	},
+	resolve: {
+		mainFields: ["custom", "..."]
+	}
+};
+module.exports = config;


### PR DESCRIPTION
Fixes #4432


There has `undefined` and `default` field in `resolve.byDependency` in webpack, so let us change it to `Map<String, Resolve>`