### PR TITLE
chore: alignment of async runtime module

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/async_module.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/async_module.js
@@ -8,41 +8,39 @@ var webpackExports =
 		: "__webpack_exports__";
 var webpackError =
 	typeof Symbol === "function" ? Symbol("webpack error") : "__webpack_error__";
-var resolveQueue = queue => {
+var resolveQueue = function (queue) {
 	if (queue && queue.d < 1) {
 		queue.d = 1;
-		queue.forEach(fn => fn.r--);
-		queue.forEach(fn => (fn.r-- ? fn.r++ : fn()));
+		queue.forEach(function (fn) { fn.r--; });
+		queue.forEach(function (fn) { fn.r-- ? fn.r++ : fn(); });
 	}
-};
-var wrapDeps = deps =>
-	deps.map(dep => {
+}
+var wrapDeps = function (deps) {
+	return deps.map(function (dep) {
 		if (dep !== null && typeof dep === "object") {
 			if (dep[webpackQueues]) return dep;
 			if (dep.then) {
 				var queue = [];
 				queue.d = 0;
-				dep.then(
-					r => {
-						obj[webpackExports] = r;
-						resolveQueue(queue);
-					},
-					e => {
-						obj[webpackError] = e;
-						resolveQueue(queue);
-					}
-				);
+				dep.then(function (r) {
+					obj[webpackExports] = r;
+					resolveQueue(queue);
+				}, function (e) {
+					obj[webpackError] = e;
+					resolveQueue(queue);
+				});
 				var obj = {};
-				obj[webpackQueues] = fn => fn(queue);
+				obj[webpackQueues] = function (fn) { fn(queue); };
 				return obj;
 			}
 		}
 		var ret = {};
-		ret[webpackQueues] = x => {};
+		ret[webpackQueues] = function () { };
 		ret[webpackExports] = dep;
 		return ret;
 	});
-__webpack_require__.a = (module, body, hasAwait) => {
+};
+__webpack_require__.a = function (module, body, hasAwait) {
 	var queue;
 	hasAwait && ((queue = []).d = -1);
 	var depQueues = new Set();
@@ -50,39 +48,29 @@ __webpack_require__.a = (module, body, hasAwait) => {
 	var currentDeps;
 	var outerResolve;
 	var reject;
-	var promise = new Promise((resolve, rej) => {
+	var promise = new Promise(function (resolve, rej) {
 		reject = rej;
 		outerResolve = resolve;
 	});
 	promise[webpackExports] = exports;
-	promise[webpackQueues] = fn => (
-		queue && fn(queue), depQueues.forEach(fn), promise["catch"](x => {})
-	);
+	promise[webpackQueues] = function (fn) { queue && fn(queue), depQueues.forEach(fn), promise["catch"](function () { }); };
 	module.exports = promise;
-	body(
-		deps => {
-			currentDeps = wrapDeps(deps);
-			var fn;
-			var getResult = () =>
-				currentDeps.map(d => {
-					if (d[webpackError]) throw d[webpackError];
-					return d[webpackExports];
-				});
-			var promise = new Promise(resolve => {
-				fn = () => resolve(getResult);
-				fn.r = 0;
-				var fnQueue = q =>
-					q !== queue &&
-					!depQueues.has(q) &&
-					(depQueues.add(q), q && !q.d && (fn.r++, q.push(fn)));
-				currentDeps.map(dep => dep[webpackQueues](fnQueue));
+	body(function (deps) {
+		currentDeps = wrapDeps(deps);
+		var fn;
+		var getResult = function () {
+			return currentDeps.map(function (d) {
+				if (d[webpackError]) throw d[webpackError];
+				return d[webpackExports];
 			});
-			return fn.r ? promise : getResult();
-		},
-		err => (
-			err ? reject((promise[webpackError] = err)) : outerResolve(exports),
-			resolveQueue(queue)
-		)
-	);
+		}
+		var promise = new Promise(function (resolve) {
+			fn = function () { resolve(getResult); };
+			fn.r = 0;
+			var fnQueue = function (q) { q !== queue && !depQueues.has(q) && (depQueues.add(q), q && !q.d && (fn.r++, q.push(fn))); };
+			currentDeps.map(function (dep) { dep[webpackQueues](fnQueue); });
+		});
+		return fn.r ? promise : getResult();
+	}, function (err) { (err ? reject(promise[webpackError] = err) : outerResolve(exports)), resolveQueue(queue); });
 	queue && queue.d < 0 && (queue.d = 0);
 };

--- a/packages/rspack/tests/runtimeDiffCases/runtime-async-module/src/a.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-async-module/src/a.js
@@ -1,0 +1,1 @@
+export default "123123";

--- a/packages/rspack/tests/runtimeDiffCases/runtime-async-module/src/index.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-async-module/src/index.js
@@ -1,0 +1,2 @@
+import a from "./a";
+await new Promise(r => setTimeout(() => r(a), 100));

--- a/packages/rspack/tests/runtimeDiffCases/runtime-async-module/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-async-module/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/async_module"]
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-async-module/webpack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-async-module/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	experiments: {
+		topLevelAwait: true
+	}
+};


### PR DESCRIPTION
## Summary

Alignment of async runtime module and adding the diff test cases:
- Convert the es6+ code to es5, just like the other runtime modules
- https://github.com/webpack/webpack/blob/v5.89.0/lib/runtime/AsyncModuleRuntimeModule.js#L104

## Test Plan


## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
