### PR TITLE
feat: support `Compiler.compile`

### DIFF
--- a/packages/rspack/src/util/assertNotNil.ts
+++ b/packages/rspack/src/util/assertNotNil.ts
@@ -1,0 +1,5 @@
+export function assertNotNill(value: any): asserts value {
+	if (value == null) {
+		throw Error(`${value} should not be undefined or null`);
+	}
+}

--- a/packages/rspack/tests/configCases/hooks/issue-4395/index.js
+++ b/packages/rspack/tests/configCases/hooks/issue-4395/index.js
@@ -1,0 +1,7 @@
+const path = require("path");
+const fs = require("fs");
+
+it("should compile successfully", () => {
+	const exist = fs.existsSync(path.resolve(__dirname, "./temp"));
+	expect(exist).toBeTruthy();
+});

--- a/packages/rspack/tests/configCases/hooks/issue-4395/rspack.config.js
+++ b/packages/rspack/tests/configCases/hooks/issue-4395/rspack.config.js
@@ -1,0 +1,38 @@
+const path = require("path");
+const fs = require("fs");
+
+const config = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.make.tap("child", base => {
+					const child = base.createChildCompiler("child", {}, []);
+					child.runAsChild(() => {});
+				});
+			}
+		},
+		{
+			apply(compiler) {
+				let count = 0;
+				const add = () => {
+					count += 1;
+				};
+				const sub = () => {
+					count -= 1;
+				};
+				compiler.hooks.thisCompilation.tap("mock-plugin", compilation => {
+					compilation.hooks.processAssets.tap("mock-plugin", () => {
+						sub();
+						if (count === 0) {
+							const temp = path.resolve(__dirname, "dist/temp");
+							fs.writeFileSync(temp, "");
+						}
+					});
+				});
+				compiler.hooks.run.tap("mock-plugin", add);
+			}
+		}
+	]
+};
+
+module.exports = config;


### PR DESCRIPTION
Fixes #4395

utilize `﻿compile` instead of `﻿run` within ﻿`runAsChild`