### PR TITLE
chore(runtime-diff): alignment of get trusted type policy runtime module

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   rspack_sources::{BoxSource, RawSource, SourceExt},
-  Compilation, RuntimeModule,
+  Compilation, RuntimeGlobals, RuntimeModule,
 };
 use rspack_identifier::Identifier;
 
@@ -9,12 +9,16 @@ use crate::impl_runtime_module;
 #[derive(Debug, Eq)]
 pub struct GetTrustedTypesPolicyRuntimeModule {
   id: Identifier,
+  create_script: bool,
+  create_script_url: bool,
 }
 
-impl Default for GetTrustedTypesPolicyRuntimeModule {
-  fn default() -> Self {
+impl GetTrustedTypesPolicyRuntimeModule {
+  pub fn new(runtime_requirements: &RuntimeGlobals) -> Self {
     Self {
       id: Identifier::from("webpack/runtime/get_trusted_types_policy"),
+      create_script: runtime_requirements.contains(RuntimeGlobals::CREATE_SCRIPT),
+      create_script_url: runtime_requirements.contains(RuntimeGlobals::CREATE_SCRIPT_URL),
     }
   }
 }
@@ -31,11 +35,35 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
       .trusted_types
       .as_ref()
       .expect("should have trusted_types");
-    RawSource::from(include_str!("runtime/get_trusted_types_policy.js").replace(
+
+    let mut result = include_str!("runtime/get_trusted_types_policy.js").replace(
       "$policyName$",
       &trusted_types.policy_name.clone().unwrap_or_default(),
-    ))
-    .boxed()
+    );
+    let mut policy_content: Vec<String> = Vec::new();
+    println!("{} {}", self.create_script, self.create_script_url);
+    if self.create_script {
+      policy_content.push(
+        r#"
+        createScript: function (script) {
+          return script;
+        }
+        "#
+        .to_string(),
+      );
+    }
+    if self.create_script_url {
+      policy_content.push(
+        r#"
+        createScriptURL: function (url) {
+          return url;
+        }
+        "#
+        .to_string(),
+      );
+    }
+    result = result.replace("$policyContent$", policy_content.join(",").as_ref());
+    RawSource::from(result).boxed()
   }
 }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -41,7 +41,6 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
       &trusted_types.policy_name.clone().unwrap_or_default(),
     );
     let mut policy_content: Vec<String> = Vec::new();
-    println!("{} {}", self.create_script, self.create_script_url);
     if self.create_script {
       policy_content.push(
         r#"

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_trusted_types_policy.rs
@@ -61,7 +61,7 @@ impl RuntimeModule for GetTrustedTypesPolicyRuntimeModule {
         .to_string(),
       );
     }
-    result = result.replace("$policyContent$", policy_content.join(",").as_ref());
+    result = result.replace("$policyContent$", policy_content.join(",\n").as_ref());
     RawSource::from(result).boxed()
   }
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_trusted_types_policy.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/get_trusted_types_policy.js
@@ -3,17 +3,11 @@ __webpack_require__.tt = function () {
     // Create Trusted Type policy if Trusted Types are available and the policy doesn't exist yet.
     if (policy === undefined) {
         policy = {
-            createScript: function (script) {
-                return script;
-            },
-            createScriptURL: function (url) {
-                return url;
-            }
+            $policyContent$
         };
-    }
-
-    if (typeof trustedTypes !== "undefined" && trustedTypes.createPolicy) {
-        policy = trustedTypes.createPolicy('$policyName$', policy);
+        if (typeof trustedTypes !== "undefined" && trustedTypes.createPolicy) {
+            policy = trustedTypes.createPolicy("$policyName$", policy);
+        }
     }
     return policy;
 }

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -227,8 +227,10 @@ impl Plugin for RuntimePlugin {
         }
         RuntimeGlobals::DEFINE_PROPERTY_GETTERS => compilation
           .add_runtime_module(chunk, DefinePropertyGettersRuntimeModule::default().boxed()),
-        RuntimeGlobals::GET_TRUSTED_TYPES_POLICY => compilation
-          .add_runtime_module(chunk, GetTrustedTypesPolicyRuntimeModule::default().boxed()),
+        RuntimeGlobals::GET_TRUSTED_TYPES_POLICY => compilation.add_runtime_module(
+          chunk,
+          GetTrustedTypesPolicyRuntimeModule::new(&runtime_requirements).boxed(),
+        ),
         RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT => compilation.add_runtime_module(
           chunk,
           CreateFakeNamespaceObjectRuntimeModule::default().boxed(),

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -229,7 +229,7 @@ impl Plugin for RuntimePlugin {
           .add_runtime_module(chunk, DefinePropertyGettersRuntimeModule::default().boxed()),
         RuntimeGlobals::GET_TRUSTED_TYPES_POLICY => compilation.add_runtime_module(
           chunk,
-          GetTrustedTypesPolicyRuntimeModule::new(&runtime_requirements).boxed(),
+          GetTrustedTypesPolicyRuntimeModule::new(runtime_requirements).boxed(),
         ),
         RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT => compilation.add_runtime_module(
           chunk,

--- a/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/rspack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/rspack.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	entry: {
+		bundle: {
+			import: "./src/index",
+			chunkLoading: "import-scripts"
+		}
+	},
+	output: {
+		trustedTypes: {
+			policyName: "my-application#webpack"
+		}
+	},
+	target: "web"
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/src/chunk.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/src/chunk.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/src/index.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/src/index.js
@@ -1,0 +1,1 @@
+import(/* webpackChunkName: "chunk" */ "./chunk");

--- a/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/get_trusted_types_policy"]
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/webpack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-get-trusted-types-policy/webpack.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+	entry: {
+		bundle: {
+			import: "./src/index",
+			chunkLoading: "import-scripts"
+		}
+	},
+	output: {
+		trustedTypes: {
+			policyName: "my-application#webpack"
+		}
+	},
+	target: "web"
+};


### PR DESCRIPTION
## Summary

Alignment of get trusted type policy runtime module.
- Adding logic of generating code by runtime requirements

> output.trustedTypes.onPolicyCreationFailure is not supported in Rspack yet

## Test Plan


## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
