### PR TITLE
chore(runtime-diff): alignment of startup chunk dependencies runtime module

### DIFF
--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -1,10 +1,12 @@
+use std::cmp::Ordering;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
-use rspack_database::DatabaseItem;
+use itertools::Itertools;
+use rspack_database::{DatabaseItem, Ukey};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use crate::ChunkGraph;
+use crate::{ChunkGraph, ChunkGroup};
 use crate::{ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, SourceType};
 use crate::{Compilation, EntryOptions, Filename, ModuleGraph, RuntimeSpec};
 
@@ -69,6 +71,37 @@ impl Chunk {
     }
   }
 
+  pub fn get_sorted_groups_iter(
+    &self,
+    chunk_group_by_ukey: &ChunkGroupByUkey,
+  ) -> impl Iterator<Item = &Ukey<ChunkGroup>> {
+    self
+      .groups
+      .iter()
+      .sorted_by(|ukey_a, ukey_b| {
+        let index_a = chunk_group_by_ukey
+          .get(ukey_a)
+          .expect("Group should exists")
+          .index;
+        let index_b = chunk_group_by_ukey
+          .get(ukey_b)
+          .expect("Group should exists")
+          .index;
+        // None should be greater than Some<_> to align with JavaScript
+        match index_a {
+          None => match index_b {
+            None => Ordering::Equal,
+            Some(_) => Ordering::Greater,
+          },
+          Some(index_a) => match index_b {
+            None => Ordering::Less,
+            Some(index_b) => index_a.cmp(&index_b),
+          },
+        }
+      })
+      .into_iter()
+  }
+
   pub fn get_entry_options<'a>(
     &self,
     chunk_group_by_ukey: &'a ChunkGroupByUkey,
@@ -88,13 +121,15 @@ impl Chunk {
   }
 
   pub fn split(&mut self, new_chunk: &mut Chunk, chunk_group_by_ukey: &mut ChunkGroupByUkey) {
-    self.groups.iter().for_each(|group| {
-      let group = chunk_group_by_ukey
-        .get_mut(group)
-        .expect("Group should exist");
-      group.insert_chunk(new_chunk.ukey, self.ukey);
-      new_chunk.add_group(group.ukey);
-    });
+    self
+      .get_sorted_groups_iter(chunk_group_by_ukey)
+      .for_each(|group| {
+        let group = chunk_group_by_ukey
+          .get_mut(group)
+          .expect("Group should exist");
+        group.insert_chunk(new_chunk.ukey, self.ukey);
+        new_chunk.add_group(group.ukey);
+      });
     new_chunk.id_name_hints.extend(self.id_name_hints.clone());
     new_chunk.runtime.extend(self.runtime.clone());
   }

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -75,31 +75,27 @@ impl Chunk {
     &self,
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> impl Iterator<Item = &Ukey<ChunkGroup>> {
-    self
-      .groups
-      .iter()
-      .sorted_by(|ukey_a, ukey_b| {
-        let index_a = chunk_group_by_ukey
-          .get(ukey_a)
-          .expect("Group should exists")
-          .index;
-        let index_b = chunk_group_by_ukey
-          .get(ukey_b)
-          .expect("Group should exists")
-          .index;
-        // None should be greater than Some<_> to align with JavaScript
-        match index_a {
-          None => match index_b {
-            None => Ordering::Equal,
-            Some(_) => Ordering::Greater,
-          },
-          Some(index_a) => match index_b {
-            None => Ordering::Less,
-            Some(index_b) => index_a.cmp(&index_b),
-          },
-        }
-      })
-      .into_iter()
+    self.groups.iter().sorted_by(|ukey_a, ukey_b| {
+      let index_a = chunk_group_by_ukey
+        .get(ukey_a)
+        .expect("Group should exists")
+        .index;
+      let index_b = chunk_group_by_ukey
+        .get(ukey_b)
+        .expect("Group should exists")
+        .index;
+      // None should be greater than Some<_> to align with JavaScript
+      match index_a {
+        None => match index_b {
+          None => Ordering::Equal,
+          Some(_) => Ordering::Greater,
+        },
+        Some(index_a) => match index_b {
+          None => Ordering::Less,
+          Some(index_b) => index_a.cmp(&index_b),
+        },
+      }
+    })
   }
 
   pub fn get_entry_options<'a>(

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -1,8 +1,9 @@
 //!  There are methods whose verb is `ChunkGraphChunk`
 
+use indexmap::IndexSet;
 use rspack_database::Database;
 use rspack_identifier::{IdentifierLinkedMap, IdentifierSet};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   find_graph_roots, merge_runtime, BoxModule, Chunk, ChunkByUkey, ChunkGroup, ChunkGroupByUkey,
@@ -402,8 +403,8 @@ impl ChunkGraph {
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> impl Iterator<Item = ChunkUkey> {
     let chunk = chunk_by_ukey.get(chunk_ukey).expect("should have chunk");
-    let mut set = HashSet::default();
-    for chunk_group_ukey in chunk.groups.iter() {
+    let mut set = IndexSet::new();
+    for chunk_group_ukey in chunk.get_sorted_groups_iter(chunk_group_by_ukey) {
       let chunk_group = chunk_group_by_ukey
         .get(chunk_group_ukey)
         .expect("should have chunk group");

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies.js
@@ -1,5 +1,0 @@
-var next = __webpack_require__.x;
-__webpack_require__.x = function() {
-    $ChunkIds$.map(__webpack_require__.e);
-    return next();
-};

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies_with_async.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/startup_chunk_dependencies_with_async.js
@@ -1,4 +1,0 @@
-var next = __webpack_require__.x;
-__webpack_require__.x = function() {
-    return Promise.all($ChunkIds$.map(__webpack_require__.e, __webpack_require__)).then(next);
-};

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -1,11 +1,12 @@
+use std::iter;
+
+use itertools::Itertools;
 use rspack_core::{
   impl_runtime_module,
   rspack_sources::{BoxSource, RawSource, SourceExt},
-  ChunkUkey, Compilation, RuntimeModule,
+  ChunkUkey, Compilation, RuntimeGlobals, RuntimeModule,
 };
 use rspack_identifier::Identifier;
-use rspack_plugin_javascript::runtime::stringify_chunks_to_array;
-use rustc_hash::FxHashSet as HashSet;
 
 #[derive(Debug, Eq)]
 pub struct StartupChunkDependenciesRuntimeModule {
@@ -45,13 +46,47 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
             .expect("Chunk not found");
           chunk.expect_id().to_string()
         })
-        .collect::<HashSet<_>>();
-      let source = if self.async_chunk_loading {
-        include_str!("runtime/startup_chunk_dependencies_with_async.js")
+        .collect::<Vec<_>>();
+
+      let body = if self.async_chunk_loading {
+        match chunk_ids.len() {
+          x if x == 1 => format!(
+            r#"return {}("{}").then(next);"#,
+            RuntimeGlobals::ENSURE_CHUNK,
+            chunk_ids.first().expect("Should has at least one chunk")
+          ),
+          x if x <= 2 => format!(
+            r#"return Promise.all([{}]).then(next);"#,
+            chunk_ids
+              .iter()
+              .map(|cid| format!(r#"{}("{}")"#, RuntimeGlobals::ENSURE_CHUNK, cid))
+              .join(",\n")
+          ),
+          _ => format!(
+            r#"return Promise.all({}.map({}, {})).then(next);"#,
+            serde_json::to_string(&chunk_ids).expect("Invalid json to string"),
+            RuntimeGlobals::ENSURE_CHUNK,
+            RuntimeGlobals::REQUIRE
+          ),
+        }
       } else {
-        include_str!("runtime/startup_chunk_dependencies.js")
+        chunk_ids
+          .iter()
+          .map(|cid| format!(r#"{}("{}");"#, RuntimeGlobals::ENSURE_CHUNK, cid))
+          .chain(iter::once("return next();".to_string()))
+          .join("\n")
       };
-      RawSource::from(source.replace("$ChunkIds$", &stringify_chunks_to_array(&chunk_ids))).boxed()
+
+      RawSource::from(format!(
+        r#"var next = {};
+        {} = function() {{
+          {}
+        }};"#,
+        RuntimeGlobals::STARTUP,
+        RuntimeGlobals::STARTUP,
+        body
+      ))
+      .boxed()
     } else {
       unreachable!("should have chunk for StartupChunkDependenciesRuntimeModule")
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -50,12 +50,12 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
 
       let body = if self.async_chunk_loading {
         match chunk_ids.len() {
-          x if x == 1 => format!(
+          1 => format!(
             r#"return {}("{}").then(next);"#,
             RuntimeGlobals::ENSURE_CHUNK,
             chunk_ids.first().expect("Should has at least one chunk")
           ),
-          x if x <= 2 => format!(
+          2 => format!(
             r#"return Promise.all([{}]).then(next);"#,
             chunk_ids
               .iter()

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/async.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/async.js
@@ -1,0 +1,2 @@
+import { value } from "./shared";
+export const result = value;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/index.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/index.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const vm = require("vm");
+const path = require("path");
+
+const requireAsync = file => {
+	return new Promise((resolve, reject) => {
+		fs.readFile(file, { encoding: "utf8" }, function (err, data) {
+			const sandbox = {
+				module: {
+					exports: {}
+				},
+				require: require,
+				__dirname: __dirname,
+				__filename: __filename
+			};
+			vm.runInNewContext(data, sandbox);
+			sandbox.module.exports.MyLib.then(resolve).catch(reject);
+		});
+	});
+};
+
+it("should work with chunkLoading=async-node and only one entrypoint chunk", async () => {
+	const chunk = await requireAsync(path.join(__dirname, "async.js"));
+	expect(chunk.result).toBe("1");
+});

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/lib-1.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/lib-1.js
@@ -1,0 +1,1 @@
+export default "1";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/other.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/other.js
@@ -1,0 +1,1 @@
+import xxx from "./shared";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/shared.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/shared.js
@@ -1,0 +1,2 @@
+import lib1 from "./lib-1";
+export const value = lib1;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/webpack.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-1/webpack.config.js
@@ -1,0 +1,29 @@
+module.exports = {
+	entry: {
+		main: "./index.js",
+		async: "./async.js",
+		other: "./other.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkLoading: "async-node",
+		library: {
+			name: "MyLib",
+			type: "commonjs-module"
+		}
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 0,
+			cacheGroups: {
+				lib1: {
+					test: /lib-1/,
+					name: "lib1",
+					chunks: "all",
+					priority: 3
+				}
+			}
+		}
+	},
+	target: "node"
+};

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/async.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/async.js
@@ -1,0 +1,2 @@
+import { value } from "./shared";
+export const result = value;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/index.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/index.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const vm = require("vm");
+const path = require("path");
+
+const requireAsync = file => {
+	return new Promise((resolve, reject) => {
+		fs.readFile(file, { encoding: "utf8" }, function (err, data) {
+			const sandbox = {
+				module: {
+					exports: {}
+				},
+				require: require,
+				__dirname: __dirname,
+				__filename: __filename
+			};
+			vm.runInNewContext(data, sandbox);
+			sandbox.module.exports.MyLib.then(resolve).catch(reject);
+		});
+	});
+};
+
+it("should work with chunkLoading=async-node and only two entrypoint chunks", async () => {
+	const chunk = await requireAsync(path.join(__dirname, "async.js"));
+	expect(chunk.result).toBe("12");
+});

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/lib-1.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/lib-1.js
@@ -1,0 +1,1 @@
+export default "1";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/lib-2.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/lib-2.js
@@ -1,0 +1,1 @@
+export default "2";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/other.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/other.js
@@ -1,0 +1,1 @@
+import xxx from "./shared";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/shared.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/shared.js
@@ -1,0 +1,3 @@
+import lib1 from "./lib-1";
+import lib2 from "./lib-2";
+export const value = lib1 + lib2;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/webpack.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-2/webpack.config.js
@@ -1,0 +1,35 @@
+module.exports = {
+	entry: {
+		main: "./index.js",
+		async: "./async.js",
+		other: "./other.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkLoading: "async-node",
+		library: {
+			name: "MyLib",
+			type: "commonjs-module"
+		}
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 0,
+			cacheGroups: {
+				lib1: {
+					test: /lib-1/,
+					name: "lib1",
+					chunks: "all",
+					priority: 3
+				},
+				lib2: {
+					test: /lib-2/,
+					name: "lib2",
+					chunks: "all",
+					priority: 2
+				}
+			}
+		}
+	},
+	target: "node"
+};

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/async.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/async.js
@@ -1,0 +1,2 @@
+import { value } from "./shared";
+export const result = value;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/index.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/index.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const vm = require("vm");
+const path = require("path");
+
+const requireAsync = file => {
+	return new Promise((resolve, reject) => {
+		fs.readFile(file, { encoding: "utf8" }, function (err, data) {
+			const sandbox = {
+				module: {
+					exports: {}
+				},
+				require: require,
+				__dirname: __dirname,
+				__filename: __filename
+			};
+			vm.runInNewContext(data, sandbox);
+			sandbox.module.exports.MyLib.then(resolve).catch(reject);
+		});
+	});
+};
+
+it("should work with chunkLoading=async-node and only three or more entrypoint chunks", async () => {
+	const chunk = await requireAsync(path.join(__dirname, "async.js"));
+	expect(chunk.result).toBe("123");
+});

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/lib-1.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/lib-1.js
@@ -1,0 +1,1 @@
+export default "1";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/lib-2.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/lib-2.js
@@ -1,0 +1,1 @@
+export default "2";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/lib-3.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/lib-3.js
@@ -1,0 +1,1 @@
+export default "3";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/other.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/other.js
@@ -1,0 +1,1 @@
+import xxx from "./shared";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/shared.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/shared.js
@@ -1,0 +1,4 @@
+import lib2 from "./lib-2";
+import lib1 from "./lib-1";
+import lib3 from "./lib-3";
+export const value = lib1 + lib2 + lib3;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/webpack.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-async-node-3/webpack.config.js
@@ -1,0 +1,41 @@
+module.exports = {
+	entry: {
+		main: "./index.js",
+		async: "./async.js",
+		other: "./other.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkLoading: "async-node",
+		library: {
+			name: "MyLib",
+			type: "commonjs-module"
+		}
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 0,
+			cacheGroups: {
+				lib1: {
+					test: /lib-1/,
+					name: "lib1",
+					chunks: "all",
+					priority: 3
+				},
+				lib2: {
+					test: /lib-2/,
+					name: "lib2",
+					chunks: "all",
+					priority: 2
+				},
+				lib3: {
+					test: /lib-3/,
+					name: "lib3",
+					chunks: "all",
+					priority: 1
+				}
+			}
+		}
+	},
+	target: "node"
+};

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/index.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/index.js
@@ -1,0 +1,4 @@
+import { value } from "./shared";
+it("should work with chunkLoading=require", function () {
+	expect(value).toBe("123");
+});

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/lib-1.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/lib-1.js
@@ -1,0 +1,1 @@
+export default "1";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/lib-2.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/lib-2.js
@@ -1,0 +1,1 @@
+export default "2";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/lib-3.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/lib-3.js
@@ -1,0 +1,1 @@
+export default "3";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/other.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/other.js
@@ -1,0 +1,1 @@
+import xxx from "./shared";

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/shared.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/shared.js
@@ -1,0 +1,4 @@
+import lib2 from "./lib-2";
+import lib1 from "./lib-1";
+import lib3 from "./lib-3";
+export const value = lib1 + lib2 + lib3;

--- a/packages/rspack/tests/configCases/chunk-loading/startup-require/webpack.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/startup-require/webpack.config.js
@@ -1,0 +1,36 @@
+module.exports = {
+	entry: {
+		main: "./index.js",
+		other: "./other.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkLoading: "require"
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 0,
+			cacheGroups: {
+				lib1: {
+					test: /lib-1/,
+					name: "lib1",
+					chunks: "all",
+					priority: 3
+				},
+				lib2: {
+					test: /lib-2/,
+					name: "lib2",
+					chunks: "all",
+					priority: 2
+				},
+				lib3: {
+					test: /lib-3/,
+					name: "lib3",
+					chunks: "all",
+					priority: 1
+				}
+			}
+		}
+	},
+	target: "node"
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/rspack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/rspack.config.js
@@ -1,0 +1,35 @@
+module.exports = {
+	entry: {
+		bundle: "./src/index.js",
+		another: "./src/another.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 10,
+			cacheGroups: {
+				lodash: {
+					test: /lodash/,
+					name: "lodash",
+					chunks: "all",
+					priority: 3
+				},
+				terser: {
+					test: /terser/,
+					name: "terser",
+					chunks: "all",
+					priority: 2
+				},
+				acorn: {
+					test: /acorn/,
+					name: "acorn",
+					chunks: "all",
+					priority: 1
+				}
+			}
+		}
+	},
+	target: "node"
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/src/another.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/src/another.js
@@ -1,0 +1,2 @@
+import "./shared";
+export default "another.js";

--- a/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/src/index.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/src/index.js
@@ -1,0 +1,2 @@
+import "./shared";
+export default "index.js";

--- a/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/src/shared.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/src/shared.js
@@ -1,0 +1,6 @@
+import _ from "lodash";
+import acorn from "acorn";
+import terser from "terser";
+console.log(_.VERSION);
+console.log(terser);
+console.log(acorn);

--- a/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/startup_chunk_dependencies"]
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/webpack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-startup-chunk-dependencies/webpack.config.js
@@ -1,0 +1,35 @@
+module.exports = {
+	entry: {
+		bundle: "./src/index.js",
+		another: "./src/another.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 10,
+			cacheGroups: {
+				lodash: {
+					test: /lodash/,
+					name: "lodash",
+					chunks: "all",
+					priority: 3
+				},
+				terser: {
+					test: /terser/,
+					name: "terser",
+					chunks: "all",
+					priority: 2
+				},
+				acorn: {
+					test: /acorn/,
+					name: "acorn",
+					chunks: "all",
+					priority: 1
+				}
+			}
+		}
+	},
+	target: "node"
+};


### PR DESCRIPTION
## Summary

Alignment of start up chunk dependencies runtime module

## Test Plan

- Add `packages/rspack/tests/configCases/chunk-loading/startup-require` to test sync entrypoint chunks
- Add `packages/rspack/tests/configCases/chunk-loading/startup-async-node-1` to test only one async entrypoint chunk
- Add `packages/rspack/tests/configCases/chunk-loading/startup-async-node-2` to test two async entrypoint chunks
- Add `packages/rspack/tests/configCases/chunk-loading/startup-async-node-3` to test three or more async entrypoint chunks

## Require Documentation?


- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
