### PR TITLE
perf: pass `SyntaxContext` by copy

### DIFF
--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -114,7 +114,7 @@ pub fn get_callexpr_literal_args(e: &CallExpr) -> String {
   }
 }
 
-pub fn is_require_literal_expr(e: &CallExpr, unresolved_ctxt: &SyntaxContext) -> bool {
+pub fn is_require_literal_expr(e: &CallExpr, unresolved_ctxt: SyntaxContext) -> bool {
   if e.args.len() == 1 {
     let res = !get_callexpr_literal_args(e).is_empty();
 
@@ -127,7 +127,7 @@ pub fn is_require_literal_expr(e: &CallExpr, unresolved_ctxt: &SyntaxContext) ->
               sym,
               span: Span { ctxt, .. },
               ..
-            }) if sym == "require" && ctxt == unresolved_ctxt
+            }) if sym == "require" && *ctxt == unresolved_ctxt
           )
         }
         _ => false,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -22,7 +22,7 @@ pub const WEBPACK_BASE_URI: &str = "__webpack_base_uri__";
 pub const NON_WEBPACK_REQUIRE: &str = "__non_webpack_require__";
 
 pub struct ApiScanner<'a> {
-  pub unresolved_ctxt: &'a SyntaxContext,
+  pub unresolved_ctxt: SyntaxContext,
   pub module: bool,
   pub build_info: &'a mut BuildInfo,
   pub enter_assign: bool,
@@ -32,7 +32,7 @@ pub struct ApiScanner<'a> {
 
 impl<'a> ApiScanner<'a> {
   pub fn new(
-    unresolved_ctxt: &'a SyntaxContext,
+    unresolved_ctxt: SyntaxContext,
     resource_data: &'a ResourceData,
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     module: bool,
@@ -79,7 +79,7 @@ impl Visit for ApiScanner<'_> {
   }
 
   fn visit_ident(&mut self, ident: &Ident) {
-    if ident.span.ctxt != *self.unresolved_ctxt {
+    if ident.span.ctxt != self.unresolved_ctxt {
       return;
     }
     match ident.sym.as_ref() as &str {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
@@ -18,7 +18,7 @@ use crate::dependency::ModuleDecoratorDependency;
 
 pub struct CommonJsExportDependencyScanner<'a> {
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  unresolved_ctxt: &'a SyntaxContext,
+  unresolved_ctxt: SyntaxContext,
   build_meta: &'a mut BuildMeta,
   module_type: ModuleType,
   is_harmony: bool,
@@ -31,7 +31,7 @@ pub struct CommonJsExportDependencyScanner<'a> {
 impl<'a> CommonJsExportDependencyScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-    unresolved_ctxt: &'a SyntaxContext,
+    unresolved_ctxt: SyntaxContext,
     build_meta: &'a mut BuildMeta,
     module_type: ModuleType,
     parser_exports_state: &'a mut Option<bool>,
@@ -71,7 +71,7 @@ impl Visit for CommonJsExportDependencyScanner<'_> {
   }
 
   fn visit_ident(&mut self, ident: &Ident) {
-    if &ident.sym == "module" && ident.span.ctxt == *self.unresolved_ctxt {
+    if &ident.sym == "module" && ident.span.ctxt == self.unresolved_ctxt {
       // here should use, but scanner is not one pass, so here use extra `visit_program` to calculate is_harmony
       // matches!( self.build_meta.exports_type, BuildMetaExportsType::Namespace)
       let decorator = if self.is_harmony {
@@ -210,13 +210,13 @@ impl<'a> CommonJsExportDependencyScanner<'a> {
   }
 
   fn is_exports_or_module_exports_or_this_expr(&self, expr: &Expr) -> bool {
-    matches!(expr,  Expr::Ident(ident) if &ident.sym == "exports" && ident.span.ctxt == *self.unresolved_ctxt)
+    matches!(expr,  Expr::Ident(ident) if &ident.sym == "exports" && ident.span.ctxt == self.unresolved_ctxt)
       || expr_matcher::is_module_exports(expr)
       || matches!(expr,  Expr::This(_) if  self.enter_call == 0)
   }
 
   fn is_exports_expr(&self, expr: &Expr) -> bool {
-    matches!(expr,  Expr::Ident(ident) if &ident.sym == "exports" && ident.span.ctxt == *self.unresolved_ctxt)
+    matches!(expr,  Expr::Ident(ident) if &ident.sym == "exports" && ident.span.ctxt == self.unresolved_ctxt)
   }
 
   fn check_namespace(&mut self, top_level: bool, value_expr: Option<&Expr>) {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -15,7 +15,7 @@ use crate::dependency::{CommonJsRequireDependency, RequireResolveDependency};
 pub struct CommonJsImportDependencyScanner<'a> {
   dependencies: &'a mut Vec<BoxDependency>,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  unresolved_ctxt: &'a SyntaxContext,
+  unresolved_ctxt: SyntaxContext,
   in_try: bool,
   in_if: bool,
 }
@@ -24,7 +24,7 @@ impl<'a> CommonJsImportDependencyScanner<'a> {
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-    unresolved_ctxt: &'a SyntaxContext,
+    unresolved_ctxt: SyntaxContext,
   ) -> Self {
     Self {
       dependencies,
@@ -82,7 +82,7 @@ impl Visit for CommonJsImportDependencyScanner<'_> {
   fn visit_call_expr(&mut self, call_expr: &CallExpr) {
     if let Callee::Expr(expr) = &call_expr.callee {
       if let Expr::Ident(ident) = &**expr {
-        if "require".eq(&ident.sym) && ident.span.ctxt == *self.unresolved_ctxt {
+        if "require".eq(&ident.sym) && ident.span.ctxt == self.unresolved_ctxt {
           {
             if let Some(expr) = call_expr.args.first()
               && call_expr.args.len() == 1

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -6,7 +6,7 @@ use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 use super::expr_matcher;
 
 pub struct CommonJsScanner<'a> {
-  unresolved_ctxt: &'a SyntaxContext,
+  unresolved_ctxt: SyntaxContext,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   has_module_ident: bool,
 }
@@ -14,7 +14,7 @@ pub struct CommonJsScanner<'a> {
 impl<'a> CommonJsScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-    unresolved_ctxt: &'a SyntaxContext,
+    unresolved_ctxt: SyntaxContext,
   ) -> Self {
     Self {
       presentational_dependencies,
@@ -31,7 +31,7 @@ impl Visit for CommonJsScanner<'_> {
     if self.has_module_ident {
       return;
     }
-    if &ident.sym == "module" && ident.span.ctxt == *self.unresolved_ctxt {
+    if &ident.sym == "module" && ident.span.ctxt == self.unresolved_ctxt {
       self
         .presentational_dependencies
         .push(Box::new(RuntimeRequirementsDependency::new(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -82,7 +82,7 @@ pub fn scan_dependencies(
 
   let mut rewrite_usage_span = HashMap::default();
   program.visit_with(&mut ApiScanner::new(
-    &unresolved_ctxt,
+    unresolved_ctxt,
     resource_data,
     &mut presentational_dependencies,
     compiler_options.output.module,
@@ -91,7 +91,7 @@ pub fn scan_dependencies(
 
   program.visit_with(&mut CompatibilityScanner::new(
     &mut presentational_dependencies,
-    &unresolved_ctxt,
+    unresolved_ctxt,
   ));
   program.visit_with(&mut ExportInfoApiScanner::new(
     &mut presentational_dependencies,
@@ -103,17 +103,17 @@ pub fn scan_dependencies(
   program.visit_with(&mut CommonJsImportDependencyScanner::new(
     &mut dependencies,
     &mut presentational_dependencies,
-    &unresolved_ctxt,
+    unresolved_ctxt,
   ));
   if module_type.is_js_auto() || module_type.is_js_dynamic() {
     program.visit_with(&mut CommonJsScanner::new(
       &mut presentational_dependencies,
-      &unresolved_ctxt,
+      unresolved_ctxt,
     ));
     program.visit_with(&mut RequireContextScanner::new(&mut dependencies));
     program.visit_with(&mut CommonJsExportDependencyScanner::new(
       &mut presentational_dependencies,
-      &unresolved_ctxt,
+      unresolved_ctxt,
       build_meta,
       *module_type,
       &mut parser_exports_state,
@@ -121,7 +121,7 @@ pub fn scan_dependencies(
     if let Some(node_option) = &compiler_options.node {
       program.visit_with(&mut NodeStuffScanner::new(
         &mut presentational_dependencies,
-        &unresolved_ctxt,
+        unresolved_ctxt,
         compiler_options,
         node_option,
         resource_data,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
@@ -13,7 +13,7 @@ const GLOBAL: &str = "global";
 
 pub struct NodeStuffScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  pub unresolved_ctxt: &'a SyntaxContext,
+  pub unresolved_ctxt: SyntaxContext,
   pub compiler_options: &'a CompilerOptions,
   pub node_option: &'a NodeOption,
   pub resource_data: &'a ResourceData,
@@ -22,7 +22,7 @@ pub struct NodeStuffScanner<'a> {
 impl<'a> NodeStuffScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-    unresolved_ctxt: &'a SyntaxContext,
+    unresolved_ctxt: SyntaxContext,
     compiler_options: &'a CompilerOptions,
     node_option: &'a NodeOption,
     resource_data: &'a ResourceData,
@@ -41,7 +41,7 @@ impl Visit for NodeStuffScanner<'_> {
   noop_visit_type!();
 
   fn visit_ident(&mut self, ident: &Ident) {
-    if ident.span.ctxt == *self.unresolved_ctxt {
+    if ident.span.ctxt == self.unresolved_ctxt {
       match ident.sym.as_ref() as &str {
         DIR_NAME => {
           let dirname = match self.node_option.dirname.as_str() {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -104,15 +104,15 @@ pub(crate) mod expr_matcher {
   });
 }
 
-pub fn is_require_call_expr(expr: &Expr, ctxt: &SyntaxContext) -> bool {
+pub fn is_require_call_expr(expr: &Expr, ctxt: SyntaxContext) -> bool {
   matches!(expr, Expr::Call(call_expr) if is_require_call(call_expr, ctxt))
 }
 
-pub fn is_require_call(node: &CallExpr, ctxt: &SyntaxContext) -> bool {
+pub fn is_require_call(node: &CallExpr, ctxt: SyntaxContext) -> bool {
   node
     .callee
     .as_expr()
-    .map(|expr| matches!(expr, box Expr::Ident(ident) if &ident.sym == "require" && ident.span.ctxt == *ctxt))
+    .map(|expr| matches!(expr, box Expr::Ident(ident) if &ident.sym == "require" && ident.span.ctxt == ctxt))
     .unwrap_or_default()
 }
 
@@ -255,16 +255,16 @@ fn test() {
   }));
 }
 
-pub fn is_unresolved_member_object_ident(expr: &Expr, unresolved_ctxt: &SyntaxContext) -> bool {
+pub fn is_unresolved_member_object_ident(expr: &Expr, unresolved_ctxt: SyntaxContext) -> bool {
   if let Expr::Member(member) = expr {
     if let Expr::Ident(ident) = &*member.obj {
-      return ident.span.ctxt == *unresolved_ctxt;
+      return ident.span.ctxt == unresolved_ctxt;
     };
   }
   false
 }
 
-pub fn is_unresolved_require(expr: &Expr, unresolved_ctxt: &SyntaxContext) -> bool {
+pub fn is_unresolved_require(expr: &Expr, unresolved_ctxt: SyntaxContext) -> bool {
   let ident = match expr {
     Expr::Ident(ident) => Some(ident),
     Expr::Member(mem) => mem.obj.as_ident(),
@@ -274,5 +274,5 @@ pub fn is_unresolved_require(expr: &Expr, unresolved_ctxt: &SyntaxContext) -> bo
     unreachable!("please don't use this fn in other case");
   };
   assert!(ident.sym.eq("require"));
-  ident.span.ctxt == *unresolved_ctxt
+  ident.span.ctxt == unresolved_ctxt
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`SyntaxContext` is just a u32 and is cheaper to copy than pass by reference.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
