### PR TITLE
chore: replace querystring with fast-querystring in @rspack/core deps

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -70,7 +70,7 @@
     "graceful-fs": "4.2.10",
     "json-parse-even-better-errors": "^3.0.0",
     "neo-async": "2.6.2",
-    "querystring": "^0.2.1",
+    "fast-querystring": "1.1.2",
     "react-refresh": "0.14.0",
     "schema-utils": "^4.0.0",
     "tapable": "2.2.1",

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -521,10 +521,8 @@ export async function runLoaders(
 					throw new Error(`Cannot parse string options: ${e.message}`);
 				}
 			} else {
-				const querystring = require("querystring");
-				options = querystring.parse(options, "&", "=", {
-					maxKeys: 0
-				});
+				const querystring = require("fast-querystring");
+				options = querystring.parse(options);
 			}
 		}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -1443,6 +1447,9 @@ importers:
       enhanced-resolve:
         specifier: 5.12.0
         version: 5.12.0
+      fast-querystring:
+        specifier: 1.1.2
+        version: 1.1.2
       graceful-fs:
         specifier: 4.2.10
         version: 4.2.10
@@ -1452,9 +1459,6 @@ importers:
       neo-async:
         specifier: 2.6.2
         version: 2.6.2
-      querystring:
-        specifier: ^0.2.1
-        version: 0.2.1
       react-refresh:
         specifier: 0.14.0
         version: 0.14.0
@@ -19055,6 +19059,10 @@ packages:
       - supports-color
     dev: true
 
+  /fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+    dev: false
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -19078,6 +19086,12 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
+
+  /fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+    dev: false
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -25904,12 +25918,6 @@ packages:
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
     dev: false
 
-  /querystring@0.2.1:
-    resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
-    engines: {node: '>=0.4.x'}
-    deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
-    dev: false
-
   /queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -31581,7 +31589,3 @@ packages:
       which: 3.0.0
       yaml: 2.2.2
     dev: false
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false


### PR DESCRIPTION
close https://github.com/web-infra-dev/rspack/issues/4526 

I just found an alternative npm package named fast-querystring. According its readme description(https://www.npmjs.com/package/fast-querystring), it's a fast choice.

But I'm curious about where to locate the test case file?

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

remove old deps & update new one

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No