### PR TITLE
perf(@rspack/core): remove util dependency

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -75,7 +75,6 @@
     "schema-utils": "^4.0.0",
     "tapable": "2.2.1",
     "terminal-link": "^2.1.1",
-    "util": "0.12.5",
     "watchpack": "^2.4.0",
     "webpack-sources": "3.2.3",
     "zod": "^3.21.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1467,9 +1467,6 @@ importers:
       terminal-link:
         specifier: ^2.1.1
         version: 2.1.1
-      util:
-        specifier: 0.12.5
-        version: 0.12.5
       watchpack:
         specifier: ^2.4.0
         version: 2.4.0


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`util` is a built module of Node.js, so `@rspack/core` do not need to declare the `util` as a dependecy.

https://nodejs.org/api/util.html

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
