### PR TITLE
fix: add the `./package.json` in the package.json's exports

### DIFF
--- a/packages/rspack-dev-client/package.json
+++ b/packages/rspack-dev-client/package.json
@@ -34,6 +34,7 @@
   },
   "exports": {
     "./react-refresh": "./src/reactRefresh.js",
-    "./react-refresh-entry": "./src/reactRefreshEntry.js"
+    "./react-refresh-entry": "./src/reactRefreshEntry.js",
+    "./package.json": "./package.json"
   }
 }

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -9,7 +9,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "rimraf dist/ && tsc -b tsconfig.build.json",

--- a/packages/rspack-plugin-html/package.json
+++ b/packages/rspack-plugin-html/package.json
@@ -9,7 +9,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc --build --force",

--- a/packages/rspack-plugin-minify/package.json
+++ b/packages/rspack-plugin-minify/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {},
   "files": [

--- a/packages/rspack-plugin-node-polyfill/package.json
+++ b/packages/rspack-plugin-node-polyfill/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "default": "./src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "test": "echo success"

--- a/packages/rspack-plugin-react-refresh/package.json
+++ b/packages/rspack-plugin-react-refresh/package.json
@@ -11,7 +11,8 @@
       "default": "./dist/index.js"
     },
     "./react-refresh": "./client/reactRefresh.js",
-    "./react-refresh-entry": "./client/reactRefreshEntry.js"
+    "./react-refresh-entry": "./client/reactRefreshEntry.js",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "rimraf dist/ && tsc -b ./tsconfig.build.json --force",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -10,7 +10,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json",


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
[Issue 4541](https://github.com/web-infra-dev/rspack/issues/4541)

add the `./package.json` in field `exports` of the related packages' `package.json` files to allow `package.json` file to be imported

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
