### PR TITLE
fix: make builtin plugins class name consistent with webpack

### DIFF
--- a/packages/rspack/src/builtin-plugin/base.ts
+++ b/packages/rspack/src/builtin-plugin/base.ts
@@ -39,7 +39,7 @@ export function create<T extends any[], R>(
 	name: BuiltinPluginName,
 	resolve: (...args: T) => R
 ) {
-	return class Plugin extends RspackBuiltinPlugin {
+	class Plugin extends RspackBuiltinPlugin {
 		name = name;
 		_options: R;
 
@@ -56,5 +56,11 @@ export function create<T extends any[], R>(
 				options: this._options
 			};
 		}
-	};
+	}
+
+	// Make the plugin class name consistent with webpack
+	// https://stackoverflow.com/a/46132163
+	Object.defineProperty(Plugin, "name", { value: name });
+
+	return Plugin;
 }

--- a/packages/rspack/tests/builtinPlugin.test.ts
+++ b/packages/rspack/tests/builtinPlugin.test.ts
@@ -1,0 +1,6 @@
+import { DefinePlugin, ProvidePlugin } from "../src";
+
+test("Should provide builtin plugins with correct class name", () => {
+	expect(new DefinePlugin({}).constructor.name).toEqual("DefinePlugin");
+	expect(new ProvidePlugin({}).constructor.name).toEqual("ProvidePlugin");
+});


### PR DESCRIPTION
## Summary

Make builtin plugins class name consistent with webpack.

```js
// before
import { DefinePlugin, ProvidePlugin } from '@rspack/core';

console.log(new DefinePlugin({}).constructor.name); // -> 'Plugin'
console.log(new ProvidePlugin({}).constructor.name); // -> 'Plugin'

// after
import { DefinePlugin, ProvidePlugin } from '@rspack/core';

console.log(new DefinePlugin({}).constructor.name); // -> 'DefinePlugin'
console.log(new ProvidePlugin({}).constructor.name); // -> 'ProvidePlugin'
```

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
