### PR TITLE
chore: upload artifact use RUNNER_LABELS

### DIFF
--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -62,4 +62,11 @@ runs:
 
         # TODO echo machine name as runner labels
         # echo "runner_labels=\"$(uname -n)\"" >> "$GITHUB_OUTPUT"
-        echo 'runner-labels="rspack-ci"' >> "$GITHUB_OUTPUT"
+        if [ -z "$RUNNER_LABELS" ]; then
+          # RUNNER_LABELS not exist
+          echo "self hosted runner must exist RUNNER_LABELS variable"
+          exit 1
+        fi
+
+        labelJson="[\"${RUNNER_LABELS//,/\",\"}\"]"
+        echo "runner-labels=$labelJson" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Upload artifact needs output current runner labels to keep download artifact working on same mechine

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
