### PR TITLE
fix: require.context should not fail when using `endWith` algo (#4557)

### DIFF
--- a/crates/rspack_regex/src/algo.rs
+++ b/crates/rspack_regex/src/algo.rs
@@ -100,14 +100,14 @@ impl Algo {
   pub(crate) fn global(&self) -> bool {
     match self {
       Algo::Regress(reg) => reg.flags.contains('g'),
-      Algo::EndWith { .. } => unreachable!(),
+      Algo::EndWith { .. } => false,
     }
   }
 
   pub(crate) fn sticky(&self) -> bool {
     match self {
       Algo::Regress(reg) => reg.flags.contains('y'),
-      Algo::EndWith { .. } => unreachable!(),
+      Algo::EndWith { .. } => false,
     }
   }
 }

--- a/packages/rspack/tests/cases/context/issue-4557/folder/my-story.js
+++ b/packages/rspack/tests/cases/context/issue-4557/folder/my-story.js
@@ -1,0 +1,1 @@
+function test() {}

--- a/packages/rspack/tests/cases/context/issue-4557/index.js
+++ b/packages/rspack/tests/cases/context/issue-4557/index.js
@@ -1,0 +1,7 @@
+it("ensure that require context is created correctly", function () {
+	const pageObjectContext = require.context("./folder", true, /-story$/);
+	expect(pageObjectContext(`./my-story`)).toBeDefined();
+	expect(() => {
+		pageObjectContext(`./my-other-story`);
+	}).toThrowError(/Cannot find module/);
+});


### PR DESCRIPTION
## Summary
Fix [Panic in require.context regex](https://github.com/web-infra-dev/rspack/issues/4557) (#4557)
Regexes using `endWith` algorithm should return `false` when checking for sticky or global flag.

## Test Plan

Added test case

Verified that without the fix, it fails with the following error:
```
  ● cases › context › issue-4557 › issue-4557 should compile

    error[internal]: internal error: entered unreachable code

      This is not expected, please file an issue at https://github.com/web-infra-dev/rspack/issues.
         0: <unknown>
         1: <unknown>
         2: <unknown>
         3: <unknown>
         4: <unknown>
         5: <unknown>
         6: <unknown>
         7: <unknown>
         8: <unknown>
         9: <unknown>
        10: <unknown>
        11: <unknown>

  ● cases › context › issue-4557 › issue-4557 should load the compiled test
```

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
