### PR TITLE
feat(runtime): alignment of get_used_name of exports info

### DIFF
--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/new_treeshaking.snap
@@ -4,10 +4,11 @@ source: crates/rspack_testing/src/run_fixture.rs
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./zh_locale.js": (function (__unused_webpack_module, exports, __webpack_require__) {
+var __webpack_unused_export__;
 "use strict";
-Object.defineProperty(exports, "__esModule", ({
+__webpack_unused_export__ = ({
     value: true
-}));
+});
 exports["default"] = void 0;
 /* eslint-disable no-template-curly-in-string */ var _default = {};
 exports["default"] = _default;

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -350,7 +350,7 @@ impl ExportsInfoId {
         info.get_used_name(&name, runtime).map(UsedName::Str)
       }
       UsedName::Vec(names) => {
-        if names.len() == 0 {
+        if names.is_empty() {
           if self.is_used(runtime, mg) {
             Some(UsedName::Vec(names))
           } else {
@@ -373,11 +373,10 @@ impl ExportsInfoId {
               if info.exports_info.is_some()
                 && info.get_used(runtime) == UsageState::OnlyPropertiesUsed
               {
-                if let Some(nested) = info.exports_info.unwrap().get_used_name(
-                  mg,
-                  runtime,
-                  UsedName::Vec(remain_names.clone()),
-                ) {
+                if let Some(exports_info) = info.exports_info
+                  && let Some(nested) =
+                    exports_info.get_used_name(mg, runtime, UsedName::Vec(remain_names.clone()))
+                {
                   arr.extend(match nested {
                     UsedName::Str(name) => vec![name],
                     UsedName::Vec(names) => names,
@@ -996,19 +995,17 @@ impl ExportInfo {
         if matches!(usage, UsageState::Unused) {
           return None;
         }
-      } else {
-        if let Some(used_in_runtime) = &self.used_in_runtime {
-          if let Some(runtime) = runtime {
-            if runtime
-              .iter()
-              .all(|r| !used_in_runtime.contains_key(r.to_string().as_str()))
-            {
-              return None;
-            }
+      } else if let Some(used_in_runtime) = &self.used_in_runtime {
+        if let Some(runtime) = runtime {
+          if runtime
+            .iter()
+            .all(|r| !used_in_runtime.contains_key(r.to_string().as_str()))
+          {
+            return None;
           }
-        } else {
-          return None;
         }
+      } else {
+        return None;
       }
     }
     if let Some(used_name) = self.used_name.as_ref() {


### PR DESCRIPTION
## Summary

Alignment of get_used_name of exports_info and export_info. It not works because _globalUsed is UsageState::{Unknown}


## Test Plan



## Require Documentation?


- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
