### PR TITLE
perf(@rspack/core): remove schema-utils

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -73,7 +73,6 @@
     "json-parse-even-better-errors": "^3.0.0",
     "neo-async": "2.6.2",
     "react-refresh": "0.14.0",
-    "schema-utils": "^4.0.0",
     "tapable": "2.2.1",
     "terminal-link": "^2.1.1",
     "watchpack": "^2.4.0",

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -106,6 +106,9 @@ export interface LoaderContext<OptionsType = {}> {
 	loaders: LoaderObject[];
 	mode?: Mode;
 	hot?: boolean;
+	/**
+	 * @param schema Considering performance, Rspack does not perform the schema validation. If your loader requires schema validation, please call scheme-utils or zod on your own.
+	 */
 	getOptions(schema?: any): OptionsType;
 	resolve(
 		context: string,

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -107,7 +107,7 @@ export interface LoaderContext<OptionsType = {}> {
 	mode?: Mode;
 	hot?: boolean;
 	/**
-	 * @param schema Considering performance, Rspack does not perform the schema validation. If your loader requires schema validation, please call scheme-utils or zod on your own.
+	 * @param schema To provide the best performance, Rspack does not perform the schema validation. If your loader requires schema validation, please call scheme-utils or zod on your own.
 	 */
 	getOptions(schema?: any): OptionsType;
 	resolve(

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -508,7 +508,7 @@ export async function runLoaders(
 	};
 	loaderContext._compiler = compiler;
 	loaderContext._compilation = compiler.compilation;
-	loaderContext.getOptions = function (schema) {
+	loaderContext.getOptions = function () {
 		const loader = getCurrentLoader(loaderContext);
 		let options = loader?.options;
 
@@ -530,19 +530,6 @@ export async function runLoaders(
 			options = {};
 		}
 
-		if (schema) {
-			let name = "Loader";
-			let baseDataPath = "options";
-			let match;
-			if (schema.title && (match = /^(.+) (.+)$/.exec(schema.title))) {
-				[, name, baseDataPath] = match;
-			}
-			const { validate } = require("schema-utils");
-			validate(schema, options, {
-				name,
-				baseDataPath
-			});
-		}
 		return options;
 	};
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1492,9 +1492,6 @@ importers:
       react-refresh:
         specifier: 0.14.0
         version: 0.14.0
-      schema-utils:
-        specifier: ^4.0.0
-        version: 4.0.0
       tapable:
         specifier: 2.2.1
         version: 2.2.1
@@ -2271,7 +2268,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       jsonc-parser: 3.2.0
       rxjs: 7.8.1
       source-map: 0.7.4
@@ -2287,7 +2284,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       chokidar: 3.5.3
       jsonc-parser: 3.2.0
       rxjs: 7.8.1
@@ -14815,8 +14812,10 @@ packages:
       ajv: 6.12.6
     dev: true
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -27499,7 +27498,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   /schema-utils@4.0.1:
@@ -27508,7 +27507,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
 
   /scroll-into-view-if-needed@2.2.20:


### PR DESCRIPTION
## Summary

Remove schema-utils from `@rspack/core` to improve the start up performance and reduce npm dependencies.

resolve https://github.com/web-infra-dev/rspack/issues/4588

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
