### PR TITLE
refactor: AsyncDependenciesBlock

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -73,7 +73,7 @@ impl<'me> CodeSplitter<'me> {
       compilation.chunk_graph.add_chunk(chunk.ukey);
 
       let mut entrypoint = ChunkGroup::new(
-        ChunkGroupKind::new_entrypoint(true, options.clone()),
+        ChunkGroupKind::new_entrypoint(true, Box::new(options.clone())),
         HashSet::from_iter([Arc::from(
           options.runtime.clone().unwrap_or_else(|| name.to_string()),
         )]),

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -7,8 +7,8 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::remove_parent_modules::RemoveParentModulesContext;
 use crate::{
-  ChunkGroup, ChunkGroupInfo, ChunkGroupKind, ChunkGroupOptions, ChunkGroupOptionsKindRef,
-  ChunkGroupUkey, ChunkLoading, ChunkUkey, Compilation, Logger, ModuleIdentifier, RuntimeSpec,
+  ChunkGroup, ChunkGroupInfo, ChunkGroupKind, ChunkGroupOptions, ChunkGroupUkey, ChunkLoading,
+  ChunkUkey, Compilation, GroupOptions, Logger, ModuleIdentifier, RuntimeSpec,
 };
 
 pub(super) struct CodeSplitter<'me> {
@@ -482,7 +482,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .insert(*module_identifier, chunk.ukey);
 
       let mut chunk_group = if let Some(kind) = group_options.as_ref()
-        && let &ChunkGroupOptionsKindRef::Entry(entry_options) = kind
+        && let GroupOptions::Entrypoint(entry_options) = kind
       {
         if let Some(filename) = &entry_options.filename {
           chunk.filename_template = Some(filename.clone());

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -303,17 +303,17 @@ impl ChunkGroupOptions {
   }
 }
 
-#[derive(Debug)]
-pub enum ChunkGroupOptionsKindRef<'a> {
-  Entry(&'a EntryOptions),
-  Normal(&'a ChunkGroupOptions),
+#[derive(Debug, Clone)]
+pub enum GroupOptions {
+  Entrypoint(EntryOptions),
+  ChunkGroup(ChunkGroupOptions),
 }
 
-impl ChunkGroupOptionsKindRef<'_> {
+impl GroupOptions {
   pub fn name(&self) -> Option<&str> {
     match self {
-      Self::Entry(e) => e.name.as_deref(),
-      Self::Normal(n) => n.name.as_deref(),
+      Self::Entrypoint(e) => e.name.as_deref(),
+      Self::ChunkGroup(n) => n.name.as_deref(),
     }
   }
 }

--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -253,11 +253,8 @@ pub enum ChunkGroupKind {
 }
 
 impl ChunkGroupKind {
-  pub fn new_entrypoint(initial: bool, options: EntryOptions) -> Self {
-    Self::Entrypoint {
-      initial,
-      options: Box::new(options),
-    }
+  pub fn new_entrypoint(initial: bool, options: Box<EntryOptions>) -> Self {
+    Self::Entrypoint { initial, options }
   }
 
   pub fn is_entrypoint(&self) -> bool {
@@ -305,7 +302,7 @@ impl ChunkGroupOptions {
 
 #[derive(Debug, Clone)]
 pub enum GroupOptions {
-  Entrypoint(EntryOptions),
+  Entrypoint(Box<EntryOptions>),
   ChunkGroup(ChunkGroupOptions),
 }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -781,7 +781,7 @@ impl Compilation {
               while let Some(mut block) = queue.pop() {
                 let dependencies = block.take_dependencies();
                 let blocks = block.take_blocks();
-                let block_id = block.identifier();
+                let block_id = block.id();
                 self.module_graph.add_block(block);
                 handle_block(
                   dependencies,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1,5 +1,4 @@
 use std::{
-  collections::VecDeque,
   fmt::Debug,
   hash::{BuildHasherDefault, Hash},
   path::PathBuf,
@@ -32,20 +31,20 @@ use super::{
 use crate::{
   build_chunk_graph::build_chunk_graph,
   cache::{use_code_splitting_cache, Cache, CodeSplittingCache},
-  is_source_equal, module_graph,
+  is_source_equal,
   tree_shaking::{optimizer, visitor::SymbolRef, BailoutFlag, OptimizeDependencyResult},
   AddQueue, AddTask, AddTaskResult, AdditionalChunkRuntimeRequirementsArgs,
   AdditionalModuleRequirementsArgs, AsyncDependenciesBlock, AsyncDependenciesBlockId,
   BoxDependency, BoxModule, BuildQueue, BuildTask, BuildTaskResult, CacheCount, CacheOptions,
-  Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroup, ChunkGroupByUkey, ChunkGroupUkey,
+  Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey,
   ChunkHashArgs, ChunkKind, ChunkUkey, CleanQueue, CleanTask, CleanTaskResult,
   CodeGenerationResult, CodeGenerationResults, CompilationLogger, CompilationLogging,
-  CompilerOptions, ContentHashArgs, DependenciesBlock, DependencyId, DependencyParents, Entry,
-  EntryData, EntryOptions, Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult,
-  Filename, Logger, Module, ModuleGraph, ModuleIdentifier, ModuleProfile, ModuleType, PathData,
-  ProcessAssetsArgs, ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask,
-  RenderManifestArgs, Resolve, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpec,
-  SharedPluginDriver, SourceType, Stats, TaskResult, WorkerTask,
+  CompilerOptions, ContentHashArgs, DependencyId, DependencyParents, Entry, EntryData,
+  EntryOptions, Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Logger,
+  Module, ModuleGraph, ModuleIdentifier, ModuleProfile, ModuleType, PathData, ProcessAssetsArgs,
+  ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs,
+  Resolve, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpec, SharedPluginDriver,
+  SourceType, Stats, TaskResult, WorkerTask,
 };
 use crate::{tree_shaking::visitor::OptimizeAnalyzeResult, Context};
 
@@ -757,7 +756,7 @@ impl Compilation {
                         .set_dependency_import_var(module.identifier(), dependency.request());
                     }
                     let dependency_id = *dependency.id();
-                    module.add_dependency(dependency_id);
+                    module.add_dependency_id(dependency_id);
                     all_dependencies.push(dependency_id);
                     module_graph.set_parents(
                       dependency_id,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1,4 +1,5 @@
 use std::{
+  collections::VecDeque,
   fmt::Debug,
   hash::{BuildHasherDefault, Hash},
   path::PathBuf,
@@ -17,7 +18,7 @@ use rspack_error::{
 };
 use rspack_futures::FuturesResults;
 use rspack_hash::{RspackHash, RspackHashDigest};
-use rspack_identifier::{IdentifierMap, IdentifierSet};
+use rspack_identifier::{Identifiable, IdentifierMap, IdentifierSet};
 use rspack_sources::{BoxSource, CachedSource, SourceExt};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 use swc_core::ecma::ast::ModuleItem;
@@ -31,19 +32,20 @@ use super::{
 use crate::{
   build_chunk_graph::build_chunk_graph,
   cache::{use_code_splitting_cache, Cache, CodeSplittingCache},
-  is_source_equal,
+  is_source_equal, module_graph,
   tree_shaking::{optimizer, visitor::SymbolRef, BailoutFlag, OptimizeDependencyResult},
   AddQueue, AddTask, AddTaskResult, AdditionalChunkRuntimeRequirementsArgs,
-  AdditionalModuleRequirementsArgs, BoxDependency, BoxModule, BuildQueue, BuildTask,
-  BuildTaskResult, CacheCount, CacheOptions, Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph,
-  ChunkGroupByUkey, ChunkGroupUkey, ChunkHashArgs, ChunkKind, ChunkUkey, CleanQueue, CleanTask,
-  CleanTaskResult, CodeGenerationResult, CodeGenerationResults, CompilationLogger,
-  CompilationLogging, CompilerOptions, ContentHashArgs, DependencyId, Entry, EntryData,
-  EntryOptions, Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult, Filename, Logger,
-  Module, ModuleGraph, ModuleIdentifier, ModuleProfile, ModuleType, PathData, ProcessAssetsArgs,
-  ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask, RenderManifestArgs,
-  Resolve, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpec, SharedPluginDriver,
-  SourceType, Stats, TaskResult, WorkerTask,
+  AdditionalModuleRequirementsArgs, AsyncDependenciesBlock, AsyncDependenciesBlockId,
+  BoxDependency, BoxModule, BuildQueue, BuildTask, BuildTaskResult, CacheCount, CacheOptions,
+  Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroup, ChunkGroupByUkey, ChunkGroupUkey,
+  ChunkHashArgs, ChunkKind, ChunkUkey, CleanQueue, CleanTask, CleanTaskResult,
+  CodeGenerationResult, CodeGenerationResults, CompilationLogger, CompilationLogging,
+  CompilerOptions, ContentHashArgs, DependenciesBlock, DependencyId, DependencyParents, Entry,
+  EntryData, EntryOptions, Entrypoint, FactorizeQueue, FactorizeTask, FactorizeTaskResult,
+  Filename, Logger, Module, ModuleGraph, ModuleIdentifier, ModuleProfile, ModuleType, PathData,
+  ProcessAssetsArgs, ProcessDependenciesQueue, ProcessDependenciesResult, ProcessDependenciesTask,
+  RenderManifestArgs, Resolve, ResolverFactory, RuntimeGlobals, RuntimeModule, RuntimeSpec,
+  SharedPluginDriver, SourceType, Stats, TaskResult, WorkerTask,
 };
 use crate::{tree_shaking::visitor::OptimizeAnalyzeResult, Context};
 
@@ -454,7 +456,7 @@ impl Compilation {
           &mut factorize_queue,
           parent_module_identifier,
           parent_module.and_then(|m| m.get_context()),
-          vec![dependency.clone()],
+          vec![id],
           parent_module_identifier.is_none(),
           None,
           None,
@@ -556,7 +558,8 @@ impl Compilation {
 
         let mut sorted_dependencies = HashMap::default();
 
-        task.dependencies.into_iter().for_each(|dependency| {
+        task.dependencies.into_iter().for_each(|dependency_id| {
+          let dependency = dependency_id.get_dependency(&self.module_graph);
           // only module dependency can put into resolve queue.
           if let Some(module_dependency) = dependency.as_module_dependency() {
             // TODO need implement more dependency `resource_identifier()`
@@ -575,9 +578,7 @@ impl Compilation {
             sorted_dependencies
               .entry(resource_identifier)
               .or_insert(vec![])
-              .push(dependency);
-          } else {
-            self.module_graph.add_dependency(dependency);
+              .push(dependency_id);
           }
         });
 
@@ -642,8 +643,7 @@ impl Compilation {
 
               tracing::trace!("Module created: {}", &module_identifier);
               if !diagnostics.is_empty() {
-                make_failed_dependencies
-                  .insert((*dependencies[0].id(), original_module_identifier));
+                make_failed_dependencies.insert((dependencies[0], original_module_identifier));
               }
 
               module_graph_module.set_issuer_if_unset(original_module_identifier);
@@ -702,7 +702,7 @@ impl Compilation {
             },
             Ok(TaskResult::Build(box task_result)) => {
               let BuildTaskResult {
-                module,
+                mut module,
                 build_result,
                 diagnostics,
                 current_profile,
@@ -743,14 +743,54 @@ impl Compilation {
                 .build_dependencies
                 .extend(build_result.build_info.build_dependencies.clone());
 
-              let mut dep_ids = vec![];
-              for dependency in build_result.dependencies.iter() {
-                if let Some(dependency) = dependency.as_module_dependency() {
-                  self
-                    .module_graph
-                    .set_dependency_import_var(module.identifier(), dependency.request());
-                }
-                dep_ids.push(*dependency.id());
+              let mut queue = vec![];
+              let mut all_dependencies = vec![];
+              let mut handle_block =
+                |dependencies: Vec<BoxDependency>,
+                 blocks: Vec<AsyncDependenciesBlock>,
+                 queue: &mut Vec<AsyncDependenciesBlock>,
+                 module_graph: &mut ModuleGraph,
+                 current_block: Option<AsyncDependenciesBlockId>| {
+                  for dependency in dependencies {
+                    if let Some(dependency) = dependency.as_module_dependency() {
+                      module_graph
+                        .set_dependency_import_var(module.identifier(), dependency.request());
+                    }
+                    let dependency_id = *dependency.id();
+                    module.add_dependency(dependency_id);
+                    all_dependencies.push(dependency_id);
+                    module_graph.set_parents(
+                      dependency_id,
+                      DependencyParents {
+                        block: current_block,
+                        module: module.identifier(),
+                      },
+                    );
+                    module_graph.add_dependency(dependency);
+                  }
+                  for block in blocks {
+                    queue.push(block);
+                  }
+                };
+              handle_block(
+                build_result.dependencies,
+                build_result.blocks,
+                &mut queue,
+                &mut self.module_graph,
+                None,
+              );
+              while let Some(mut block) = queue.pop() {
+                let dependencies = block.take_dependencies();
+                let blocks = block.take_blocks();
+                let block_id = block.identifier();
+                self.module_graph.add_block(block);
+                handle_block(
+                  dependencies,
+                  blocks,
+                  &mut queue,
+                  &mut self.module_graph,
+                  Some(block_id),
+                );
               }
 
               {
@@ -758,13 +798,13 @@ impl Compilation {
                   .module_graph
                   .module_graph_module_by_identifier_mut(&module.identifier())
                   .expect("Failed to get mgm");
-                mgm.dependencies = Box::new(dep_ids);
+                mgm.all_dependencies = Box::new(all_dependencies.clone());
                 if let Some(current_profile) = current_profile {
                   mgm.set_profile(current_profile);
                 }
               }
               process_dependencies_queue.add_task(ProcessDependenciesTask {
-                dependencies: build_result.dependencies,
+                dependencies: all_dependencies,
                 original_module_identifier: module.identifier(),
                 resolve_options: module.get_resolve_options(),
               });
@@ -922,7 +962,7 @@ impl Compilation {
     queue: &mut FactorizeQueue,
     original_module_identifier: Option<ModuleIdentifier>,
     original_module_context: Option<Box<Context>>,
-    dependencies: Vec<BoxDependency>,
+    dependencies: Vec<DependencyId>,
     is_entry: bool,
     module_type: Option<ModuleType>,
     side_effects: Option<bool>,
@@ -935,6 +975,7 @@ impl Compilation {
       original_module_identifier,
       issuer,
       original_module_context,
+      dependency: dependencies[0].get_dependency(&self.module_graph).clone(),
       dependencies,
       is_entry,
       module_type,

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -9,7 +9,7 @@ use crate::{
   ModuleProfile, ModuleType, NormalModuleFactory, NormalModuleFactoryContext, Resolve,
   ResolverFactory, SharedPluginDriver, WorkerQueue,
 };
-use crate::{ExportInfo, ExportsInfo, UsageState};
+use crate::{DependencyId, ExportInfo, ExportsInfo, UsageState};
 
 #[derive(Debug)]
 pub enum TaskResult {
@@ -28,7 +28,8 @@ pub struct FactorizeTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub original_module_context: Option<Box<Context>>,
   pub issuer: Option<Box<str>>,
-  pub dependencies: Vec<BoxDependency>,
+  pub dependency: BoxDependency,
+  pub dependencies: Vec<DependencyId>,
   pub is_entry: bool,
   pub module_type: Option<ModuleType>,
   pub side_effects: Option<bool>,
@@ -54,7 +55,7 @@ pub struct FactorizeTaskResult {
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub factory_result: ModuleFactoryResult,
   pub module_graph_module: Box<ModuleGraphModule>,
-  pub dependencies: Vec<BoxDependency>,
+  pub dependencies: Vec<DependencyId>,
   pub diagnostics: Vec<Diagnostic>,
   pub is_entry: bool,
   pub current_profile: Option<Box<ModuleProfile>>,
@@ -68,7 +69,7 @@ impl WorkerTask for FactorizeTask {
     if let Some(current_profile) = &self.current_profile {
       current_profile.mark_factory_start();
     }
-    let dependency = &self.dependencies[0];
+    let dependency = self.dependency;
 
     let context = if let Some(context) = dependency.get_context() {
       context
@@ -89,7 +90,7 @@ impl WorkerTask for FactorizeTask {
           .create(ModuleFactoryCreateData {
             resolve_options: self.resolve_options,
             context,
-            dependency: dependency.clone(),
+            dependency,
           })
           .await?
           .split_into_parts()
@@ -112,7 +113,7 @@ impl WorkerTask for FactorizeTask {
           .create(ModuleFactoryCreateData {
             resolve_options: self.resolve_options,
             context,
-            dependency: dependency.clone(),
+            dependency,
           })
           .await?
           .split_into_parts()
@@ -160,7 +161,7 @@ pub struct AddTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub module: Box<dyn Module>,
   pub module_graph_module: Box<ModuleGraphModule>,
-  pub dependencies: Vec<BoxDependency>,
+  pub dependencies: Vec<DependencyId>,
   pub is_entry: bool,
   pub current_profile: Option<Box<ModuleProfile>>,
 }
@@ -232,7 +233,7 @@ impl AddTask {
   fn set_resolved_module(
     module_graph: &mut ModuleGraph,
     original_module_identifier: Option<ModuleIdentifier>,
-    dependencies: Vec<BoxDependency>,
+    dependencies: Vec<DependencyId>,
     module_identifier: ModuleIdentifier,
   ) -> Result<()> {
     for dependency in dependencies {
@@ -339,7 +340,7 @@ pub type BuildQueue = WorkerQueue<BuildTask>;
 
 pub struct ProcessDependenciesTask {
   pub original_module_identifier: ModuleIdentifier,
-  pub dependencies: Vec<BoxDependency>,
+  pub dependencies: Vec<DependencyId>,
   pub resolve_options: Option<Box<Resolve>>,
 }
 

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -478,7 +478,7 @@ impl ContextModule {
 }
 
 impl DependenciesBlock for ContextModule {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
@@ -486,7 +486,7 @@ impl DependenciesBlock for ContextModule {
     &self.blocks
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependencies.push(dependency)
   }
 
@@ -732,7 +732,7 @@ impl ContextModule {
           .chunk_name
           .as_ref()
           .map(|name| {
-            let name = if !WEBPACK_CHUNK_NAME_PLACEHOLDER.is_match(&name) {
+            let name = if !WEBPACK_CHUNK_NAME_PLACEHOLDER.is_match(name) {
               Cow::Owned(format!("{name}[index]"))
             } else {
               Cow::Borrowed(name)

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -6,18 +6,18 @@ use rspack_identifier::{Identifiable, Identifier};
 use crate::{BoxDependency, DependencyId, GroupOptions};
 
 pub trait DependenciesBlock {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId);
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId);
 
   fn get_blocks(&self) -> &[AsyncDependenciesBlockId];
 
-  fn add_dependency(&mut self, dependency: DependencyId);
+  fn add_dependency_id(&mut self, dependency: DependencyId);
 
   fn get_dependencies(&self) -> &[DependencyId];
 }
 
 static ASYNC_DEPENDENCIES_BLOCK_ID: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
 
-fn get_async_dependencies_id() -> AsyncDependenciesBlockId {
+fn get_async_dependencies_block_id() -> AsyncDependenciesBlockId {
   AsyncDependenciesBlockId::from(
     ASYNC_DEPENDENCIES_BLOCK_ID
       .fetch_add(1, Ordering::Relaxed)
@@ -40,7 +40,7 @@ pub struct AsyncDependenciesBlock {
 impl Default for AsyncDependenciesBlock {
   fn default() -> Self {
     Self {
-      id: get_async_dependencies_id(),
+      id: get_async_dependencies_block_id(),
       group_options: Default::default(),
       blocks: Default::default(),
       block_ids: Default::default(),
@@ -85,7 +85,7 @@ impl Identifiable for AsyncDependenciesBlock {
 }
 
 impl DependenciesBlock for AsyncDependenciesBlock {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.block_ids.push(block)
   }
 
@@ -93,7 +93,7 @@ impl DependenciesBlock for AsyncDependenciesBlock {
     &self.block_ids
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependency_ids.push(dependency)
   }
 

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -18,14 +18,15 @@ pub trait DependenciesBlock {
 static ASYNC_DEPENDENCIES_BLOCK_ID: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
 
 fn get_async_dependencies_block_id() -> AsyncDependenciesBlockId {
-  AsyncDependenciesBlockId::from(
+  AsyncDependenciesBlockId(Identifier::from(
     ASYNC_DEPENDENCIES_BLOCK_ID
       .fetch_add(1, Ordering::Relaxed)
       .to_string(),
-  )
+  ))
 }
 
-pub type AsyncDependenciesBlockId = Identifier;
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct AsyncDependenciesBlockId(Identifier);
 
 #[derive(Debug, Clone)]
 pub struct AsyncDependenciesBlock {
@@ -51,6 +52,10 @@ impl Default for AsyncDependenciesBlock {
 }
 
 impl AsyncDependenciesBlock {
+  pub fn id(&self) -> AsyncDependenciesBlockId {
+    self.id
+  }
+
   pub fn set_group_options(&mut self, group_options: GroupOptions) {
     self.group_options = Some(group_options)
   }
@@ -80,7 +85,7 @@ impl AsyncDependenciesBlock {
 
 impl Identifiable for AsyncDependenciesBlock {
   fn identifier(&self) -> Identifier {
-    self.id
+    self.id.0
   }
 }
 

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -1,0 +1,103 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use once_cell::sync::Lazy;
+use rspack_identifier::{Identifiable, Identifier};
+
+use crate::{BoxDependency, DependencyId, GroupOptions};
+
+pub trait DependenciesBlock {
+  fn add_block(&mut self, block: AsyncDependenciesBlockId);
+
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId];
+
+  fn add_dependency(&mut self, dependency: DependencyId);
+
+  fn get_dependencies(&self) -> &[DependencyId];
+}
+
+static ASYNC_DEPENDENCIES_BLOCK_ID: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
+
+fn get_async_dependencies_id() -> AsyncDependenciesBlockId {
+  AsyncDependenciesBlockId::from(
+    ASYNC_DEPENDENCIES_BLOCK_ID
+      .fetch_add(1, Ordering::Relaxed)
+      .to_string(),
+  )
+}
+
+pub type AsyncDependenciesBlockId = Identifier;
+
+#[derive(Debug, Clone)]
+pub struct AsyncDependenciesBlock {
+  id: AsyncDependenciesBlockId,
+  group_options: Option<GroupOptions>,
+  blocks: Vec<AsyncDependenciesBlock>,
+  block_ids: Vec<AsyncDependenciesBlockId>,
+  dependency_ids: Vec<DependencyId>,
+  dependencies: Vec<BoxDependency>,
+}
+
+impl Default for AsyncDependenciesBlock {
+  fn default() -> Self {
+    Self {
+      id: get_async_dependencies_id(),
+      group_options: Default::default(),
+      blocks: Default::default(),
+      block_ids: Default::default(),
+      dependency_ids: Default::default(),
+      dependencies: Default::default(),
+    }
+  }
+}
+
+impl AsyncDependenciesBlock {
+  pub fn set_group_options(&mut self, group_options: GroupOptions) {
+    self.group_options = Some(group_options)
+  }
+
+  pub fn get_group_options(&self) -> Option<&GroupOptions> {
+    self.group_options.as_ref()
+  }
+
+  pub fn add_dependency(&mut self, dependency: BoxDependency) {
+    self.dependency_ids.push(*dependency.id());
+    self.dependencies.push(dependency);
+  }
+
+  pub fn take_dependencies(&mut self) -> Vec<BoxDependency> {
+    std::mem::take(&mut self.dependencies)
+  }
+
+  pub fn add_block(&mut self, block: AsyncDependenciesBlock) {
+    self.block_ids.push(block.id);
+    self.blocks.push(block);
+  }
+
+  pub fn take_blocks(&mut self) -> Vec<AsyncDependenciesBlock> {
+    std::mem::take(&mut self.blocks)
+  }
+}
+
+impl Identifiable for AsyncDependenciesBlock {
+  fn identifier(&self) -> Identifier {
+    self.id
+  }
+}
+
+impl DependenciesBlock for AsyncDependenciesBlock {
+  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+    self.block_ids.push(block)
+  }
+
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
+    &self.block_ids
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyId) {
+    self.dependency_ids.push(dependency)
+  }
+
+  fn get_dependencies(&self) -> &[DependencyId] {
+    &self.dependency_ids
+  }
+}

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -1,9 +1,9 @@
 use swc_core::ecma::atoms::JsWord;
 
 use crate::{
-  AsDependencyTemplate, ChunkGroupOptions, Context, ContextMode, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyType, ExtendedReferencedExport, ModuleDependency,
-  ModuleGraph, ReferencedExport, RuntimeSpec,
+  AsDependencyTemplate, Context, ContextMode, ContextOptions, Dependency, DependencyCategory,
+  DependencyId, DependencyType, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
+  ReferencedExport, RuntimeSpec,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -8,7 +8,6 @@ use crate::{
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct ContextElementDependency {
-  pub group_options: ChunkGroupOptions,
   pub id: DependencyId,
   // TODO remove this async dependency mark
   pub options: ContextOptions,

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -1,9 +1,9 @@
 use swc_core::ecma::atoms::JsWord;
 
 use crate::{
-  AsDependencyTemplate, ChunkGroupOptions, ChunkGroupOptionsKindRef, Context, ContextMode,
-  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyType,
-  ExtendedReferencedExport, ModuleDependency, ModuleGraph, ReferencedExport, RuntimeSpec,
+  AsDependencyTemplate, ChunkGroupOptions, Context, ContextMode, ContextOptions, Dependency,
+  DependencyCategory, DependencyId, DependencyType, ExtendedReferencedExport, ModuleDependency,
+  ModuleGraph, ReferencedExport, RuntimeSpec,
 };
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
@@ -80,10 +80,6 @@ impl ModuleDependency for ContextElementDependency {
     } else {
       vec![ExtendedReferencedExport::Array(vec![])]
     }
-  }
-
-  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
-    Some(ChunkGroupOptionsKindRef::Normal(&self.group_options))
   }
 }
 

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -31,7 +31,7 @@ pub use dependency_template::*;
 use dyn_clone::{clone_trait_object, DynClone};
 
 use crate::{
-  ConnectionState, Context, ContextMode, ContextOptions, DependencyExtraMeta, ErrorSpan,
+  ConnectionState, Context, ContextOptions, DependencyExtraMeta, ErrorSpan,
   ExtendedReferencedExport, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ReferencedExport,
   RuntimeSpec, UsedByExports,
 };

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -250,7 +250,7 @@ impl Identifiable for ExternalModule {
 }
 
 impl DependenciesBlock for ExternalModule {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
@@ -258,7 +258,7 @@ impl DependenciesBlock for ExternalModule {
     &self.blocks
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependencies.push(dependency)
   }
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -11,10 +11,11 @@ use serde::Serialize;
 use crate::{
   property_access,
   rspack_sources::{BoxSource, RawSource, Source, SourceExt},
-  to_identifier, BuildContext, BuildInfo, BuildMetaExportsType, BuildResult, ChunkInitFragments,
-  ChunkUkey, CodeGenerationDataUrl, CodeGenerationResult, Compilation, Context, ExternalType,
-  InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleType,
-  NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
+  to_identifier, AsyncDependenciesBlockId, BuildContext, BuildInfo, BuildMetaExportsType,
+  BuildResult, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl, CodeGenerationResult,
+  Compilation, Context, DependenciesBlock, DependencyId, ExternalType, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleType, NormalInitFragment,
+  RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -80,6 +81,8 @@ fn get_source_for_default_case(_optional: bool, request: &ExternalRequestValue) 
 
 #[derive(Debug)]
 pub struct ExternalModule {
+  dependencies: Vec<DependencyId>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   id: Identifier,
   pub request: ExternalRequest,
   external_type: ExternalType,
@@ -90,6 +93,8 @@ pub struct ExternalModule {
 impl ExternalModule {
   pub fn new(request: ExternalRequest, external_type: ExternalType, user_request: String) -> Self {
     Self {
+      dependencies: Vec::new(),
+      blocks: Vec::new(),
       id: Identifier::from(format!("external {external_type} {request:?}")),
       request,
       external_type,
@@ -244,6 +249,24 @@ impl Identifiable for ExternalModule {
   }
 }
 
+impl DependenciesBlock for ExternalModule {
+  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+    self.blocks.push(block)
+  }
+
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
+    &self.blocks
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyId) {
+    self.dependencies.push(dependency)
+  }
+
+  fn get_dependencies(&self) -> &[DependencyId] {
+    &self.dependencies
+  }
+}
+
 #[async_trait::async_trait]
 impl Module for ExternalModule {
   fn module_type(&self) -> &ModuleType {
@@ -305,6 +328,7 @@ impl Module for ExternalModule {
       build_info,
       build_meta: Default::default(),
       dependencies: Vec::new(),
+      blocks: Vec::new(),
       analyze_result: Default::default(),
     };
     // TODO add exports_type for request

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -6,6 +6,8 @@
 
 use std::sync::atomic::AtomicBool;
 use std::{fmt, sync::Arc};
+mod dependencies_block;
+pub use dependencies_block::{AsyncDependenciesBlock, AsyncDependenciesBlockId, DependenciesBlock};
 mod fake_namespace_object;
 pub use fake_namespace_object::*;
 mod module_profile;

--- a/crates/rspack_core/src/missing_module.rs
+++ b/crates/rspack_core/src/missing_module.rs
@@ -7,11 +7,14 @@ use rspack_sources::{RawSource, Source, SourceExt};
 use serde_json::json;
 
 use crate::{
-  CodeGenerationResult, Compilation, Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
+  AsyncDependenciesBlockId, CodeGenerationResult, Compilation, DependenciesBlock, DependencyId,
+  Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
 };
 
-#[derive(Debug, Eq)]
+#[derive(Debug)]
 pub struct MissingModule {
+  blocks: Vec<AsyncDependenciesBlockId>,
+  dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,
   readable_identifier: String,
   error_message: String,
@@ -24,10 +27,30 @@ impl MissingModule {
     error_message: String,
   ) -> Self {
     Self {
+      dependencies: Vec::new(),
+      blocks: Vec::new(),
       identifier,
       readable_identifier,
       error_message,
     }
+  }
+}
+
+impl DependenciesBlock for MissingModule {
+  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+    self.blocks.push(block)
+  }
+
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
+    &self.blocks
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyId) {
+    self.dependencies.push(dependency)
+  }
+
+  fn get_dependencies(&self) -> &[DependencyId] {
+    &self.dependencies
   }
 }
 
@@ -86,6 +109,8 @@ impl PartialEq for MissingModule {
     self.identifier == other.identifier
   }
 }
+
+impl Eq for MissingModule {}
 
 impl Hash for MissingModule {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/crates/rspack_core/src/missing_module.rs
+++ b/crates/rspack_core/src/missing_module.rs
@@ -37,7 +37,7 @@ impl MissingModule {
 }
 
 impl DependenciesBlock for MissingModule {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
@@ -45,7 +45,7 @@ impl DependenciesBlock for MissingModule {
     &self.blocks
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependencies.push(dependency)
   }
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -393,7 +393,7 @@ mod test {
       }
 
       impl DependenciesBlock for $ident {
-        fn add_block(&mut self, _: AsyncDependenciesBlockId) {
+        fn add_block_id(&mut self, _: AsyncDependenciesBlockId) {
           unreachable!()
         }
 
@@ -401,7 +401,7 @@ mod test {
           unreachable!()
         }
 
-        fn add_dependency(&mut self, _: DependencyId) {
+        fn add_dependency_id(&mut self, _: DependencyId) {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -760,7 +760,7 @@ mod test {
       }
 
       impl DependenciesBlock for $ident {
-        fn add_block(&mut self, _: AsyncDependenciesBlockId) {
+        fn add_block_id(&mut self, _: AsyncDependenciesBlockId) {
           unreachable!()
         }
 
@@ -768,7 +768,7 @@ mod test {
           unreachable!()
         }
 
-        fn add_dependency(&mut self, _: DependencyId) {
+        fn add_dependency_id(&mut self, _: DependencyId) {
           unreachable!()
         }
 
@@ -879,6 +879,7 @@ mod test {
     dep: BoxDependency,
   ) -> DependencyId {
     let dependency_id = *dep.id();
+    mg.add_dependency(dep);
     mg.dependency_id_to_module_identifier
       .insert(dependency_id, *to);
     if let Some(p_id) = from
@@ -886,7 +887,7 @@ mod test {
     {
       mgm.all_dependencies.push(dependency_id);
     }
-    mg.set_resolved_module(from.copied(), *dep.id(), *to)
+    mg.set_resolved_module(from.copied(), dependency_id, *to)
       .expect("failed to set resolved module");
 
     assert_eq!(

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -98,7 +98,7 @@ impl ModuleGraph {
   }
 
   pub fn add_block(&mut self, block: AsyncDependenciesBlock) {
-    self.blocks.insert(block.identifier(), block);
+    self.blocks.insert(block.id(), block);
   }
 
   pub fn set_parents(&mut self, dependency: DependencyId, parents: DependencyParents) {

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -4,11 +4,11 @@ use std::path::PathBuf;
 
 use rspack_error::{internal_error, Result};
 use rspack_hash::RspackHashDigest;
-use rspack_identifier::IdentifierMap;
+use rspack_identifier::{Identifiable, IdentifierMap};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::ecma::atoms::JsWord;
 
-use crate::IS_NEW_TREESHAKING;
+use crate::{AsyncDependenciesBlock, AsyncDependenciesBlockId, IS_NEW_TREESHAKING};
 mod connection;
 pub use connection::*;
 
@@ -22,6 +22,12 @@ use crate::{
 pub type ImportVarMap = HashMap<String /* request */, String /* import_var */>;
 
 #[derive(Debug, Default)]
+pub struct DependencyParents {
+  pub block: Option<AsyncDependenciesBlockId>,
+  pub module: ModuleIdentifier,
+}
+
+#[derive(Debug, Default)]
 pub struct ModuleGraph {
   dependency_id_to_module_identifier: HashMap<DependencyId, ModuleIdentifier>,
 
@@ -31,12 +37,16 @@ pub struct ModuleGraph {
   /// Module identifier to its module graph module
   pub module_identifier_to_module_graph_module: IdentifierMap<ModuleGraphModule>,
 
+  blocks: HashMap<AsyncDependenciesBlockId, AsyncDependenciesBlock>,
+
   dependency_id_to_connection_id: HashMap<DependencyId, ConnectionId>,
   connection_id_to_dependency_id: HashMap<ConnectionId, DependencyId>,
 
   /// Dependencies indexed by `DependencyId`
   /// None means the dependency has been removed
   dependencies: HashMap<DependencyId, BoxDependency>,
+
+  dependency_id_to_parents: HashMap<DependencyId, DependencyParents>,
 
   /// Dependencies indexed by `ConnectionId`
   /// None means the connection has been removed
@@ -87,6 +97,35 @@ impl ModuleGraph {
     }
   }
 
+  pub fn add_block(&mut self, block: AsyncDependenciesBlock) {
+    self.blocks.insert(block.identifier(), block);
+  }
+
+  pub fn set_parents(&mut self, dependency: DependencyId, parents: DependencyParents) {
+    self.dependency_id_to_parents.insert(dependency, parents);
+  }
+
+  pub fn get_parent_module(&self, dependency: &DependencyId) -> Option<ModuleIdentifier> {
+    self
+      .dependency_id_to_parents
+      .get(dependency)
+      .map(|p| p.module)
+  }
+
+  pub fn get_parent_block(&self, dependency: &DependencyId) -> Option<AsyncDependenciesBlockId> {
+    self
+      .dependency_id_to_parents
+      .get(dependency)
+      .and_then(|p| p.block)
+  }
+
+  pub fn block_by_id(
+    &self,
+    block_id: &AsyncDependenciesBlockId,
+  ) -> Option<&AsyncDependenciesBlock> {
+    self.blocks.get(block_id)
+  }
+
   pub fn add_dependency(&mut self, dependency: BoxDependency) {
     self.dependencies.insert(*dependency.id(), dependency);
   }
@@ -128,11 +167,11 @@ impl ModuleGraph {
   pub fn set_resolved_module(
     &mut self,
     original_module_identifier: Option<ModuleIdentifier>,
-    dependency: BoxDependency,
+    dependency_id: DependencyId,
     module_identifier: ModuleIdentifier,
   ) -> Result<()> {
+    let dependency = dependency_id.get_dependency(self);
     let is_module_dependency = dependency.as_module_dependency().is_some();
-    let dependency_id = *dependency.id();
     let condition = if IS_NEW_TREESHAKING.load(std::sync::atomic::Ordering::Relaxed) {
       dependency
         .as_module_dependency()
@@ -140,7 +179,6 @@ impl ModuleGraph {
     } else {
       None
     };
-    self.add_dependency(dependency);
     self
       .dependency_id_to_module_identifier
       .insert(dependency_id, module_identifier);
@@ -305,8 +343,8 @@ impl ModuleGraph {
     module_identifier: &ModuleIdentifier,
   ) -> Option<&[DependencyId]> {
     self
-      .module_graph_module_by_identifier(module_identifier)
-      .map(|mgm| mgm.dependencies.as_slice())
+      .module_by_identifier(module_identifier)
+      .map(|m| m.get_dependencies())
   }
 
   pub fn dependency_by_connection_id(
@@ -703,9 +741,10 @@ mod test {
   use rspack_sources::Source;
 
   use crate::{
-    BoxDependency, BuildContext, BuildResult, CodeGenerationResult, Compilation, Context,
-    Dependency, DependencyId, ExportInfo, ExportsInfo, Module, ModuleDependency, ModuleGraph,
-    ModuleGraphModule, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, UsageState,
+    AsyncDependenciesBlockId, BoxDependency, BuildContext, BuildResult, CodeGenerationResult,
+    Compilation, Context, DependenciesBlock, Dependency, DependencyId, ExportInfo, ExportsInfo,
+    Module, ModuleDependency, ModuleGraph, ModuleGraphModule, ModuleIdentifier, ModuleType,
+    RuntimeSpec, SourceType, UsageState,
   };
 
   // Define a detailed node type for `ModuleGraphModule`s
@@ -717,6 +756,24 @@ mod test {
       impl Identifiable for $ident {
         fn identifier(&self) -> ModuleIdentifier {
           (stringify!($ident).to_owned() + "__" + self.0).into()
+        }
+      }
+
+      impl DependenciesBlock for $ident {
+        fn add_block(&mut self, _: AsyncDependenciesBlockId) {
+          unreachable!()
+        }
+
+        fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
+          unreachable!()
+        }
+
+        fn add_dependency(&mut self, _: DependencyId) {
+          unreachable!()
+        }
+
+        fn get_dependencies(&self) -> &[DependencyId] {
+          unreachable!()
         }
       }
 
@@ -827,9 +884,9 @@ mod test {
     if let Some(p_id) = from
       && let Some(mgm) = mg.module_graph_module_by_identifier_mut(p_id)
     {
-      mgm.dependencies.push(dependency_id);
+      mgm.all_dependencies.push(dependency_id);
     }
-    mg.set_resolved_module(from.copied(), dep, *to)
+    mg.set_resolved_module(from.copied(), *dep.id(), *to)
       .expect("failed to set resolved module");
 
     assert_eq!(

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -2,12 +2,11 @@ use rspack_error::{internal_error, Result};
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  is_async_dependency, module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject,
-  BuildMetaExportsType, ChunkGraph, ChunkGroupOptionsKindRef, DependencyId, ExportsArgument,
-  ExportsType, FactoryMeta, ModuleArgument, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  ModuleIssuer, ModuleProfile, ModuleSyntax, ModuleType,
+  module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType,
+  ChunkGraph, DependencyId, ExportsArgument, ExportsType, FactoryMeta, ModuleArgument, ModuleGraph,
+  ModuleGraphConnection, ModuleIdentifier, ModuleIssuer, ModuleProfile, ModuleSyntax, ModuleType,
 };
-use crate::{ExportsInfoId, IS_NEW_TREESHAKING};
+use crate::{ExportsInfoId, GroupOptions, IS_NEW_TREESHAKING};
 
 #[derive(Debug)]
 pub struct ModuleGraphModule {
@@ -21,7 +20,8 @@ pub struct ModuleGraphModule {
   pub module_identifier: ModuleIdentifier,
   // TODO remove this since its included in module
   pub module_type: ModuleType,
-  pub dependencies: Box<Vec<DependencyId>>,
+  // TODO: remove this once we drop old treeshaking
+  pub all_dependencies: Box<Vec<DependencyId>>,
   pub(crate) pre_order_index: Option<u32>,
   pub post_order_index: Option<u32>,
   pub module_syntax: ModuleSyntax,
@@ -46,7 +46,7 @@ impl ModuleGraphModule {
       issuer: ModuleIssuer::Unset,
       // exec_order: usize::MAX,
       module_identifier,
-      dependencies: Default::default(),
+      all_dependencies: Default::default(),
       module_type,
       pre_order_index: None,
       post_order_index: None,
@@ -117,13 +117,6 @@ impl ModuleGraphModule {
     Ok(result)
   }
 
-  // pub fn dependencies(&mut self) -> Vec<&ModuleDependency> {
-  //   self
-  //     .outgoing_connections_unordered()
-  //     .map(|conn| &conn.dependency)
-  //     .collect()
-  // }
-
   pub fn depended_modules<'a>(&self, module_graph: &'a ModuleGraph) -> Vec<&'a ModuleIdentifier> {
     if IS_NEW_TREESHAKING.load(std::sync::atomic::Ordering::Relaxed) {
       self
@@ -152,7 +145,7 @@ impl ModuleGraphModule {
             .expect("should have id")
             .as_module_dependency()
           {
-            return !is_async_dependency(dep) && !dep.weak();
+            return module_graph.get_parent_block(id).is_none() && !dep.weak();
           }
           false
         })
@@ -160,7 +153,7 @@ impl ModuleGraphModule {
         .collect()
     } else {
       self
-        .dependencies
+        .all_dependencies
         .iter()
         .filter(|id| {
           if let Some(dep) = module_graph
@@ -168,7 +161,7 @@ impl ModuleGraphModule {
             .expect("should have id")
             .as_module_dependency()
           {
-            return !is_async_dependency(dep) && !dep.weak();
+            return module_graph.get_parent_block(id).is_none() && !dep.weak();
           }
           false
         })
@@ -181,23 +174,28 @@ impl ModuleGraphModule {
   pub fn dynamic_depended_modules<'a>(
     &self,
     module_graph: &'a ModuleGraph,
-  ) -> Vec<(&'a ModuleIdentifier, Option<ChunkGroupOptionsKindRef<'a>>)> {
+  ) -> Vec<(&'a ModuleIdentifier, Option<&'a GroupOptions>)> {
     self
-      .dependencies
+      .all_dependencies
       .iter()
       .filter_map(|id| {
-        let dep = module_graph
+        let Some(dep) = module_graph
           .dependency_by_id(id)
           .expect("should have id")
-          .as_module_dependency()?;
-        if !is_async_dependency(dep) {
+          .as_module_dependency()
+        else {
           return None;
-        }
+        };
+        let Some(block_id) = module_graph.get_parent_block(dep.id()) else {
+          return None;
+        };
         let module = module_graph
           .module_identifier_by_dependency_id(id)
           .expect("should have a module here");
-
-        Some((module, dep.group_options()))
+        let Some(block) = module_graph.block_by_id(&block_id) else {
+          return None;
+        };
+        Some((module, block.get_group_options()))
       })
       .collect()
   }
@@ -207,7 +205,7 @@ impl ModuleGraphModule {
     module_graph: &'a ModuleGraph,
   ) -> Vec<&'a ModuleIdentifier> {
     self
-      .dependencies
+      .all_dependencies
       .iter()
       .filter_map(|id| module_graph.module_identifier_by_dependency_id(id))
       .collect()

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -283,7 +283,7 @@ impl Identifiable for NormalModule {
 }
 
 impl DependenciesBlock for NormalModule {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
@@ -291,7 +291,7 @@ impl DependenciesBlock for NormalModule {
     &self.blocks
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependencies.push(dependency)
   }
 

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -5,12 +5,11 @@ use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_loader_runner::{AdditionalData, ResourceData};
 use rspack_sources::BoxSource;
 
-use crate::RuntimeSpec;
 use crate::{
-  tree_shaking::visitor::OptimizeAnalyzeResult, BoxDependency, BuildExtraDataType, BuildInfo,
-  BuildMeta, CodeGenerationData, Compilation, CompilerOptions, DependencyTemplate,
-  GeneratorOptions, Module, ModuleDependency, ModuleIdentifier, ModuleType, ParserOptions,
-  RuntimeGlobals, SourceType,
+  tree_shaking::visitor::OptimizeAnalyzeResult, AsyncDependenciesBlock, BoxDependency,
+  BuildExtraDataType, BuildInfo, BuildMeta, CodeGenerationData, Compilation, CompilerOptions,
+  DependencyTemplate, GeneratorOptions, Module, ModuleDependency, ModuleIdentifier, ModuleType,
+  ParserOptions, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
@@ -31,6 +30,7 @@ pub struct ParseContext<'a> {
 #[derive(Debug)]
 pub struct ParseResult {
   pub dependencies: Vec<BoxDependency>,
+  pub blocks: Vec<AsyncDependenciesBlock>,
   pub presentational_dependencies: Vec<Box<dyn DependencyTemplate>>,
   pub source: BoxSource,
   pub analyze_result: OptimizeAnalyzeResult,

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -50,7 +50,7 @@ impl Identifiable for RawModule {
 }
 
 impl DependenciesBlock for RawModule {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
@@ -58,7 +58,7 @@ impl DependenciesBlock for RawModule {
     &self.blocks
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependencies.push(dependency)
   }
 

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -7,12 +7,15 @@ use rspack_identifier::Identifiable;
 use rspack_sources::{BoxSource, RawSource, Source, SourceExt};
 
 use crate::{
-  BuildContext, BuildInfo, BuildResult, CodeGenerationResult, Context, Module, ModuleIdentifier,
+  dependencies_block::AsyncDependenciesBlockId, BuildContext, BuildInfo, BuildResult,
+  CodeGenerationResult, Context, DependenciesBlock, DependencyId, Module, ModuleIdentifier,
   ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
 pub struct RawModule {
+  blocks: Vec<AsyncDependenciesBlockId>,
+  dependencies: Vec<DependencyId>,
   source: BoxSource,
   identifier: ModuleIdentifier,
   readable_identifier: String,
@@ -29,6 +32,8 @@ impl RawModule {
     runtime_requirements: RuntimeGlobals,
   ) -> Self {
     Self {
+      blocks: Default::default(),
+      dependencies: Default::default(),
       // TODO: useSourceMap, etc...
       source: RawSource::from(source).boxed(),
       identifier,
@@ -41,6 +46,24 @@ impl RawModule {
 impl Identifiable for RawModule {
   fn identifier(&self) -> ModuleIdentifier {
     self.identifier
+  }
+}
+
+impl DependenciesBlock for RawModule {
+  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+    self.blocks.push(block)
+  }
+
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
+    &self.blocks
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyId) {
+    self.dependencies.push(dependency)
+  }
+
+  fn get_dependencies(&self) -> &[DependencyId] {
+    &self.dependencies
   }
 }
 

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -469,7 +469,7 @@ impl<'a> CodeSizeOptimizer<'a> {
             panic!("Failed to get ModuleGraphModule by module identifier {module_identifier}")
           });
         // reachable_dependency_identifier.extend(analyze_result.inherit_export_maps.keys());
-        for dependency_id in mgm.dependencies.iter() {
+        for dependency_id in mgm.all_dependencies.iter() {
           if self
             .compilation
             .module_graph
@@ -625,7 +625,7 @@ impl<'a> CodeSizeOptimizer<'a> {
       .module_graph_module_by_identifier(&cur)
       .unwrap_or_else(|| panic!("Failed to get mgm by module identifier {cur}"));
     let mut module_ident_list = vec![];
-    for dep in mgm.dependencies.iter() {
+    for dep in mgm.all_dependencies.iter() {
       if module_graph
         .dependency_by_id(dep)
         .expect("should have dependency")

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -307,6 +307,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
       rspack_core::ParseResult {
         // Assets do not have dependencies
         dependencies: vec![],
+        blocks: vec![],
         source,
         presentational_dependencies: vec![],
         analyze_result,

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -248,12 +248,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
           init_fragments: &mut init_fragments,
         };
 
-        let mgm = compilation
-          .module_graph
-          .module_graph_module_by_identifier(&module.identifier())
-          .expect("should have module graph module");
-
-        mgm.all_dependencies.iter().for_each(|id| {
+        module.get_dependencies().iter().for_each(|id| {
           if let Some(dependency) = compilation
             .module_graph
             .dependency_by_id(id)

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -219,6 +219,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
     Ok(
       ParseResult {
         dependencies,
+        blocks: vec![],
         presentational_dependencies: vec![],
         source: new_source,
         analyze_result: Default::default(),
@@ -252,7 +253,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
           .module_graph_module_by_identifier(&module.identifier())
           .expect("should have module graph module");
 
-        mgm.dependencies.iter().for_each(|id| {
+        mgm.all_dependencies.iter().for_each(|id| {
           if let Some(dependency) = compilation
             .module_graph
             .dependency_by_id(id)

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -129,7 +129,7 @@ pub fn css_modules_exports_to_string(
               .module_graph_module_by_identifier(&module.identifier())
               .and_then(|mgm| {
                 // workaround
-                mgm.dependencies.iter().find_map(|id| {
+                mgm.all_dependencies.iter().find_map(|id| {
                   let dependency = compilation
                     .module_graph
                     .dependency_by_id(id)

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -120,35 +120,30 @@ pub fn css_modules_exports_to_string(
   for (key, elements) in exports {
     let content = elements
       .iter()
-      .map(|(name, from)| {
-        match from {
-          None => name.to_owned(),
-          Some(from_name) => {
-            let from: &rspack_core::ModuleGraphModule = compilation
-              .module_graph
-              .module_graph_module_by_identifier(&module.identifier())
-              .and_then(|mgm| {
-                // workaround
-                mgm.all_dependencies.iter().find_map(|id| {
-                  let dependency = compilation
+      .map(|(name, from)| match from {
+        None => name.to_owned(),
+        Some(from_name) => {
+          let from = module
+            .get_dependencies()
+            .iter()
+            .find_map(|id| {
+              let dependency = compilation
+                .module_graph
+                .dependency_by_id(id)
+                .and_then(|d| d.as_module_dependency());
+              if let Some(dependency) = dependency {
+                if dependency.request() == from_name {
+                  return compilation
                     .module_graph
-                    .dependency_by_id(id)
-                    .and_then(|d| d.as_module_dependency());
-                  if let Some(dependency) = dependency {
-                    if dependency.request() == from_name {
-                      return compilation
-                        .module_graph
-                        .module_graph_module_by_dependency_id(id);
-                    }
-                  }
-                  None
-                })
-              })
-              .expect("should have css from module");
+                    .module_graph_module_by_dependency_id(id);
+                }
+              }
+              None
+            })
+            .expect("should have css from module");
 
-            let from = serde_json::to_string(from.id(&compilation.chunk_graph)).expect("TODO:");
-            format!("{}({from})[{name}]", RuntimeGlobals::REQUIRE)
-          }
+          let from = serde_json::to_string(from.id(&compilation.chunk_graph)).expect("TODO:");
+          format!("{}({from})[{name}]", RuntimeGlobals::REQUIRE)
         }
       })
       .collect::<Vec<_>>()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,5 +1,5 @@
+use rspack_core::Dependency;
 use rspack_core::{module_namespace_promise, DependencyType, ErrorSpan, ImportDependencyTrait};
-use rspack_core::{ChunkGroupOptions, Dependency};
 use rspack_core::{DependencyCategory, DependencyId, DependencyTemplate};
 use rspack_core::{ModuleDependency, TemplateContext, TemplateReplaceSource};
 use swc_core::ecma::atoms::JsWord;

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{module_namespace_promise, DependencyType, ErrorSpan, ImportDependencyTrait};
-use rspack_core::{ChunkGroupOptions, ChunkGroupOptionsKindRef, Dependency};
+use rspack_core::{ChunkGroupOptions, Dependency};
 use rspack_core::{DependencyCategory, DependencyId, DependencyTemplate};
 use rspack_core::{ModuleDependency, TemplateContext, TemplateReplaceSource};
 use swc_core::ecma::atoms::JsWord;
@@ -12,9 +12,6 @@ pub struct ImportDependency {
   request: JsWord,
   span: Option<ErrorSpan>,
   referenced_exports: Option<Vec<JsWord>>,
-  /// This is used to implement `webpackChunkName`, `webpackPrefetch` etc.
-  /// for example: `import(/* webpackChunkName: "my-chunk-name", webpackPrefetch: true */ './module')`
-  pub group_options: ChunkGroupOptions,
 }
 
 impl ImportDependency {
@@ -23,7 +20,6 @@ impl ImportDependency {
     end: u32,
     request: JsWord,
     span: Option<ErrorSpan>,
-    group_options: ChunkGroupOptions,
     referenced_exports: Option<Vec<JsWord>>,
   ) -> Self {
     Self {
@@ -33,7 +29,6 @@ impl ImportDependency {
       span,
       id: DependencyId::new(),
       referenced_exports,
-      group_options,
     }
   }
 }
@@ -67,10 +62,6 @@ impl ModuleDependency for ImportDependency {
 
   fn user_request(&self) -> &str {
     &self.request
-  }
-
-  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
-    Some(ChunkGroupOptionsKindRef::Normal(&self.group_options))
   }
 
   fn set_request(&mut self, request: String) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -1,8 +1,7 @@
 use rspack_core::{
-  module_namespace_promise, ChunkGroupOptions, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ExtendedReferencedExport, ImportDependencyTrait,
-  ModuleDependency, ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext,
-  TemplateReplaceSource,
+  module_namespace_promise, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ExtendedReferencedExport, ImportDependencyTrait, ModuleDependency,
+  ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -1,8 +1,8 @@
 use rspack_core::{
-  module_namespace_promise, ChunkGroupOptions, ChunkGroupOptionsKindRef, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ExtendedReferencedExport, ImportDependencyTrait, ModuleDependency, ModuleGraph, ReferencedExport,
-  RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_namespace_promise, ChunkGroupOptions, Dependency, DependencyCategory, DependencyId,
+  DependencyTemplate, DependencyType, ErrorSpan, ExtendedReferencedExport, ImportDependencyTrait,
+  ModuleDependency, ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -14,9 +14,6 @@ pub struct ImportEagerDependency {
   request: JsWord,
   span: Option<ErrorSpan>,
   referenced_exports: Option<Vec<JsWord>>,
-  /// This is used to implement `webpackChunkName`, `webpackPrefetch` etc.
-  /// for example: `import(/* webpackChunkName: "my-chunk-name", webpackPrefetch: true */ './module')`
-  pub group_options: ChunkGroupOptions,
 }
 
 impl ImportEagerDependency {
@@ -25,7 +22,6 @@ impl ImportEagerDependency {
     end: u32,
     request: JsWord,
     span: Option<ErrorSpan>,
-    group_options: ChunkGroupOptions,
     referenced_exports: Option<Vec<JsWord>>,
   ) -> Self {
     Self {
@@ -35,7 +31,6 @@ impl ImportEagerDependency {
       span,
       id: DependencyId::new(),
       referenced_exports,
-      group_options,
     }
   }
 }
@@ -69,10 +64,6 @@ impl ModuleDependency for ImportEagerDependency {
 
   fn user_request(&self) -> &str {
     &self.request
-  }
-
-  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
-    Some(ChunkGroupOptionsKindRef::Normal(&self.group_options))
   }
 
   fn set_request(&mut self, request: String) {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  ChunkGroupOptionsKindRef, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, EntryOptions, ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
-  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType, EntryOptions,
+  ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeGlobals, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -11,7 +11,6 @@ pub struct WorkerDependency {
   id: DependencyId,
   request: String,
   span: Option<ErrorSpan>,
-  group_options: EntryOptions,
   public_path: String,
 }
 
@@ -22,7 +21,6 @@ impl WorkerDependency {
     request: String,
     public_path: String,
     span: Option<ErrorSpan>,
-    group_options: EntryOptions,
   ) -> Self {
     Self {
       start,
@@ -30,7 +28,6 @@ impl WorkerDependency {
       id: DependencyId::new(),
       request,
       span,
-      group_options,
       public_path,
     }
   }
@@ -69,10 +66,6 @@ impl ModuleDependency for WorkerDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request;
-  }
-
-  fn group_options(&self) -> Option<ChunkGroupOptionsKindRef> {
-    Some(ChunkGroupOptionsKindRef::Entry(&self.group_options))
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType, EntryOptions,
-  ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeGlobals, RuntimeSpec,
+  Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeGlobals, RuntimeSpec,
   TemplateContext, TemplateReplaceSource,
 };
 

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -7,8 +7,8 @@ use rspack_core::tree_shaking::analyzer::OptimizeAnalyzer;
 use rspack_core::tree_shaking::js_module::JsModule;
 use rspack_core::tree_shaking::visitor::OptimizeAnalyzeResult;
 use rspack_core::{
-  render_init_fragments, GenerateContext, Module, ParseContext, ParseResult, ParserAndGenerator,
-  SourceType, TemplateContext,
+  render_init_fragments, DependenciesBlock, GenerateContext, Module, ParseContext, ParseResult,
+  ParserAndGenerator, SourceType, TemplateContext,
 };
 use rspack_error::{
   internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
@@ -167,7 +167,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     diagnostics.append(&mut warning_diagnostics);
 
     let analyze_result = if compiler_options.builtins.tree_shaking.enable() {
-      JsModule::new(&ast, &dependencies, module_identifier, compiler_options).analyze()
+      let mut all_dependencies = dependencies.clone();
+      for mut block in blocks.clone() {
+        all_dependencies.extend(block.take_dependencies());
+      }
+      JsModule::new(&ast, &all_dependencies, module_identifier, compiler_options).analyze()
     } else {
       OptimizeAnalyzeResult::default()
     };

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -114,6 +114,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
             use_simple_source_map,
           ),
           dependencies: vec![],
+          blocks: vec![],
           presentational_dependencies: vec![],
           analyze_result: Default::default(),
         }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -141,6 +141,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
     let ScanDependenciesResult {
       mut dependencies,
+      blocks,
       presentational_dependencies,
       mut rewrite_usage_span,
       import_map,
@@ -234,6 +235,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       ParseResult {
         source,
         dependencies,
+        blocks,
         presentational_dependencies,
         analyze_result,
       }
@@ -268,7 +270,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         .module_graph_module_by_identifier(&module.identifier())
         .expect("should have module graph module");
 
-      mgm.dependencies.iter().for_each(|id| {
+      mgm.all_dependencies.iter().for_each(|id| {
         if let Some(dependency) = compilation
           .module_graph
           .dependency_by_id(id)

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -2,9 +2,9 @@ use std::collections::hash_map::Entry;
 use std::collections::VecDeque;
 
 use rspack_core::{
-  BuildMetaExportsType, Compilation, DependencyId, ExportInfoProvided, ExportNameOrSpec,
-  ExportsInfoId, ExportsOfExportsSpec, ExportsSpec, ModuleGraph, ModuleGraphConnection,
-  ModuleIdentifier, Plugin,
+  BuildMetaExportsType, Compilation, DependenciesBlock, DependencyId, ExportInfoProvided,
+  ExportNameOrSpec, ExportsInfoId, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
+  ModuleGraphConnection, ModuleIdentifier, Plugin,
 };
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -60,7 +60,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
       self.current_module_id = module_id;
       let mut exports_specs_from_dependencies: HashMap<DependencyId, ExportsSpec> =
         HashMap::default();
-      self.process_dependencies_block(module_id, &mut exports_specs_from_dependencies);
+      self.process_dependencies_block(&module_id, &mut exports_specs_from_dependencies);
       let exports_info_id = self.mg.get_exports_info(&module_id).id;
       for (dep_id, exports_spec) in exports_specs_from_dependencies.into_iter() {
         self.process_exports_spec(dep_id, exports_spec, exports_info_id);
@@ -80,20 +80,31 @@ impl<'a> FlagDependencyExportsProxy<'a> {
   }
 
   pub fn process_dependencies_block(
-    &mut self,
-    mi: ModuleIdentifier,
+    &self,
+    module_identifier: &ModuleIdentifier,
     exports_specs_from_dependencies: &mut HashMap<DependencyId, ExportsSpec>,
   ) -> Option<()> {
-    let mgm = self.mg.module_graph_module_by_identifier(&mi)?;
-    // This clone is aiming to avoid use mut ref and immutable ref at the same time.
-    for ele in mgm.all_dependencies.clone().iter() {
+    let block = &**self.mg.module_by_identifier(module_identifier)?;
+    self.process_dependencies_block_inner(block, exports_specs_from_dependencies)
+  }
+
+  fn process_dependencies_block_inner<B: DependenciesBlock + ?Sized>(
+    &self,
+    block: &B,
+    exports_specs_from_dependencies: &mut HashMap<DependencyId, ExportsSpec>,
+  ) -> Option<()> {
+    for ele in block.get_dependencies().iter() {
       self.process_dependency(ele, exports_specs_from_dependencies);
+    }
+    for block_id in block.get_blocks() {
+      let block = self.mg.block_by_id(block_id)?;
+      self.process_dependencies_block_inner(block, exports_specs_from_dependencies);
     }
     None
   }
 
   pub fn process_dependency(
-    &mut self,
+    &self,
     dep_id: &DependencyId,
     exports_specs_from_dependencies: &mut HashMap<DependencyId, ExportsSpec>,
   ) -> Option<()> {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -86,7 +86,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
   ) -> Option<()> {
     let mgm = self.mg.module_graph_module_by_identifier(&mi)?;
     // This clone is aiming to avoid use mut ref and immutable ref at the same time.
-    for ele in mgm.dependencies.clone().iter() {
+    for ele in mgm.all_dependencies.clone().iter() {
       self.process_dependency(ele, exports_specs_from_dependencies);
     }
     None

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -85,7 +85,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
         .module_graph
         .module_graph_module_by_identifier(&module_id)
         .expect("should have module graph module");
-      let dep_id_list = mgm.dependencies.clone();
+      let dep_id_list = mgm.all_dependencies.clone();
       for dep_id in dep_id_list.into_iter() {
         let connection = self
           .compilation

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -66,7 +66,7 @@ impl<'a> WorkerScanner<'a> {
       Some(new_expr.span.into()),
     ));
     let mut block = AsyncDependenciesBlock::default();
-    block.set_group_options(GroupOptions::Entrypoint(EntryOptions {
+    block.set_group_options(GroupOptions::Entrypoint(Box::new(EntryOptions {
       name,
       runtime: Some(runtime),
       chunk_loading: Some(self.output_options.worker_chunk_loading.clone()),
@@ -75,7 +75,7 @@ impl<'a> WorkerScanner<'a> {
       base_uri: None,
       filename: None,
       library: None,
-    }));
+    })));
     block.add_dependency(dep);
     self.blocks.push(block);
 

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -102,6 +102,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
       rspack_core::ParseResult {
         presentational_dependencies: vec![],
         dependencies: vec![],
+        blocks: vec![],
         source: box_source,
         analyze_result: Default::default(),
       }

--- a/crates/rspack_plugin_runtime/src/lazy_compilation.rs
+++ b/crates/rspack_plugin_runtime/src/lazy_compilation.rs
@@ -20,7 +20,7 @@ pub struct LazyCompilationProxyModule {
 }
 
 impl DependenciesBlock for LazyCompilationProxyModule {
-  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
@@ -28,7 +28,7 @@ impl DependenciesBlock for LazyCompilationProxyModule {
     &self.blocks
   }
 
-  fn add_dependency(&mut self, dependency: DependencyId) {
+  fn add_dependency_id(&mut self, dependency: DependencyId) {
     self.dependencies.push(dependency)
   }
 

--- a/crates/rspack_plugin_runtime/src/lazy_compilation.rs
+++ b/crates/rspack_plugin_runtime/src/lazy_compilation.rs
@@ -4,8 +4,9 @@ use std::hash::Hash;
 use async_trait::async_trait;
 use rspack_core::{
   rspack_sources::{RawSource, Source, SourceExt},
-  Compilation, DependencyType, Module, ModuleArgs, ModuleType, Plugin, PluginContext,
-  PluginModuleHookOutput, RuntimeGlobals, RuntimeSpec, SourceType,
+  AsyncDependenciesBlockId, Compilation, DependenciesBlock, DependencyId, DependencyType, Module,
+  ModuleArgs, ModuleType, Plugin, PluginContext, PluginModuleHookOutput, RuntimeGlobals,
+  RuntimeSpec, SourceType,
 };
 use rspack_core::{CodeGenerationResult, Context, ModuleIdentifier};
 use rspack_error::Result;
@@ -13,7 +14,27 @@ use rspack_identifier::Identifiable;
 
 #[derive(Debug)]
 pub struct LazyCompilationProxyModule {
+  dependencies: Vec<DependencyId>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   pub module_identifier: ModuleIdentifier,
+}
+
+impl DependenciesBlock for LazyCompilationProxyModule {
+  fn add_block(&mut self, block: AsyncDependenciesBlockId) {
+    self.blocks.push(block)
+  }
+
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
+    &self.blocks
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyId) {
+    self.dependencies.push(dependency)
+  }
+
+  fn get_dependencies(&self) -> &[DependencyId] {
+    &self.dependencies
+  }
 }
 
 impl Module for LazyCompilationProxyModule {
@@ -106,6 +127,8 @@ impl Plugin for LazyCompilationPlugin {
     ) {
       return Ok(Some(Box::new(LazyCompilationProxyModule {
         module_identifier: args.indentfiler,
+        dependencies: Vec::new(),
+        blocks: Vec::new(),
       })));
     }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_macro.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_macro.rs
@@ -19,6 +19,24 @@ macro_rules! impl_runtime_module {
       }
     }
 
+    impl rspack_core::DependenciesBlock for $ident {
+      fn add_block(&mut self, _: rspack_core::AsyncDependenciesBlockId) {
+        unreachable!()
+      }
+
+      fn get_blocks(&self) -> &[rspack_core::AsyncDependenciesBlockId] {
+        unreachable!()
+      }
+
+      fn add_dependency(&mut self, _: rspack_core::DependencyId) {
+        unreachable!()
+      }
+
+      fn get_dependencies(&self) -> &[rspack_core::DependencyId] {
+        unreachable!()
+      }
+    }
+
     impl rspack_core::Module for $ident {
       fn module_type(&self) -> &rspack_core::ModuleType {
         &rspack_core::ModuleType::Runtime

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_macro.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_macro.rs
@@ -20,7 +20,7 @@ macro_rules! impl_runtime_module {
     }
 
     impl rspack_core::DependenciesBlock for $ident {
-      fn add_block(&mut self, _: rspack_core::AsyncDependenciesBlockId) {
+      fn add_block_id(&mut self, _: rspack_core::AsyncDependenciesBlockId) {
         unreachable!()
       }
 
@@ -28,7 +28,7 @@ macro_rules! impl_runtime_module {
         unreachable!()
       }
 
-      fn add_dependency(&mut self, _: rspack_core::DependencyId) {
+      fn add_dependency_id(&mut self, _: rspack_core::DependencyId) {
         unreachable!()
       }
 

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -150,48 +150,44 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
         let module_graph = &compilation.module_graph;
         let chunk_graph = &compilation.chunk_graph;
 
-        if let Some(dependencies) = module_graph
-          .module_graph_module_by_identifier(&module.identifier())
-          .map(|mgm| &mgm.all_dependencies)
-        {
-          dependencies
-            .iter()
-            .map(|id| module_graph.dependency_by_id(id).expect("should be ok"))
-            .filter(|dep| dep.dependency_type() == &WasmImport)
-            .map(|dep| {
-              (
-                dep,
-                module_graph.module_graph_module_by_dependency_id(dep.id()),
-              )
-            })
-            .for_each(|(dep, mgm)| {
-              if let Some(mgm) = mgm {
-                if !dep_modules.contains_key(&mgm.module_identifier) {
-                  let import_var = format!("WEBPACK_IMPORTED_MODULE_{}", dep_modules.len());
-                  let val = (import_var.clone(), mgm.id(chunk_graph));
+        module
+          .get_dependencies()
+          .iter()
+          .map(|id| module_graph.dependency_by_id(id).expect("should be ok"))
+          .filter(|dep| dep.dependency_type() == &WasmImport)
+          .map(|dep| {
+            (
+              dep,
+              module_graph.module_graph_module_by_dependency_id(dep.id()),
+            )
+          })
+          .for_each(|(dep, mgm)| {
+            if let Some(mgm) = mgm {
+              if !dep_modules.contains_key(&mgm.module_identifier) {
+                let import_var = format!("WEBPACK_IMPORTED_MODULE_{}", dep_modules.len());
+                let val = (import_var.clone(), mgm.id(chunk_graph));
 
-                  if matches!(module_graph.is_async(&mgm.module_identifier), Some(true)) {
-                    promises.push(import_var);
-                  }
-                  dep_modules.insert(mgm.module_identifier, val);
+                if matches!(module_graph.is_async(&mgm.module_identifier), Some(true)) {
+                  promises.push(import_var);
                 }
-
-                let dep = dep
-                  .as_any()
-                  .downcast_ref::<WasmImportDependency>()
-                  .expect("should be wasm import dependency");
-
-                let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
-                let request = dep.request();
-                let val = (mgm.module_identifier, dep_name);
-                if let Some(deps) = wasm_deps_by_request.get_mut(&request) {
-                  deps.push(val);
-                } else {
-                  wasm_deps_by_request.insert(request, vec![val]);
-                }
+                dep_modules.insert(mgm.module_identifier, val);
               }
-            })
-        }
+
+              let dep = dep
+                .as_any()
+                .downcast_ref::<WasmImportDependency>()
+                .expect("should be wasm import dependency");
+
+              let dep_name = serde_json::to_string(dep.name()).expect("should be ok.");
+              let request = dep.request();
+              let val = (mgm.module_identifier, dep_name);
+              if let Some(deps) = wasm_deps_by_request.get_mut(&request) {
+                deps.push(val);
+              } else {
+                wasm_deps_by_request.insert(request, vec![val]);
+              }
+            }
+          });
 
         let imports_code = dep_modules
           .iter()

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -94,6 +94,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
     Ok(
       ParseResult {
         dependencies,
+        blocks: vec![],
         presentational_dependencies: vec![],
         source,
         analyze_result: Default::default(),
@@ -151,7 +152,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
 
         if let Some(dependencies) = module_graph
           .module_graph_module_by_identifier(&module.identifier())
-          .map(|mgm| &mgm.dependencies)
+          .map(|mgm| &mgm.all_dependencies)
         {
           dependencies
             .iter()

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1168,7 +1168,7 @@ exports[`StatsTestCases should print correct stats for ignore-plugin 1`] = `
       "type": "module",
     },
     {
-      "identifier": "missing|<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh.js",
+      "identifier": "missing|<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh",
       "issuer": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: Some(RspackRegex("^//.///.*$|")), reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals", namespace_object: Unset, chunk_name: None }",
       "issuerName": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: Some(RspackRegex("^//.///.*$|")), reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals", namespace_object: Unset, chunk_name: None }",
       "issuerPath": [
@@ -1182,7 +1182,7 @@ exports[`StatsTestCases should print correct stats for ignore-plugin 1`] = `
         },
       ],
       "moduleType": "javascript/auto",
-      "name": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh.js (missing)",
+      "name": "<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh (missing)",
       "nameForCondition": undefined,
       "size": 160,
       "type": "module",
@@ -1227,7 +1227,7 @@ exports[`StatsTestCases should print correct stats for ignore-plugin 2`] = `
 "runtime modules 1 module
 ./index.js
 ./locals/en.js
-<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh.js (missing)
+<PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals/./zh (missing)
 <PROJECT_ROOT>/tests/statsCases/ignore-plugin/./globalIndex.js (missing)
 <PROJECT_ROOT>/tests/statsCases/ignore-plugin/locals|None|None|ContextOptions { mode: Sync, recursive: true, reg_exp: Some(RspackRegex("^//.///.*$|")), reg_str: "^//.///.*$", include: None, exclude: None, category: CommonJS, request: "./locals", namespace_object: Unset, chunk_name: None }"
 `;
@@ -3538,7 +3538,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "de66cb644888925a8f42",
+      "hash": "fdc023e1047f5aee231e",
       "logging": {},
       "modules": [
         {
@@ -3909,7 +3909,7 @@ import(/* webpackChunkName: "c" */ "./c");
   ],
   "errors": [],
   "errorsCount": 0,
-  "hash": "dd84ffabbcf23038f36e3e9b37b218ba7bc75de29efd38806ce66b6a9791de66cb644888925a8f42",
+  "hash": "dd84ffabbcf23038f36e3e9b37b218ba7bc75de29efd38806ce66b6a9791fdc023e1047f5aee231e",
   "warnings": [],
   "warningsCount": 0,
 }
@@ -4068,7 +4068,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/__webpack_require__.u {main}
-  4 chunks compiled successfully (de66cb644888925a8f42)"
+  4 chunks compiled successfully (fdc023e1047f5aee231e)"
 `;
 
 exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin-warn 1`] = `

--- a/packages/rspack/tests/cases/chunks/issue-4338/index.js
+++ b/packages/rspack/tests/cases/chunks/issue-4338/index.js
@@ -6,10 +6,10 @@ it("should has correctly output", () => {
 	const fs = require("fs");
 	const dir = fs.readdirSync(__dirname);
 	expect(dir).toStrictEqual([
+		"0.js",
 		"2.js",
-		"4.js",
+		"c0.js",
 		"c2.js",
-		"c4.js",
 		"main.js",
 		"one.js",
 		"two.js"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Currently, Rspack determines the code splitting point by matching DependencyType, but it can only indicate a one-to-one relationship, one dependency to one code splitting point. However, AsyncDependenciesBlock can indicate a one-to-many relationship, many dependency to one code splitting point, which will be used in scenarios like ContainerEntryModule, or lazy-once ContextModule.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
