### PR TITLE
fix: fix infinite while loop when entry name contains '/' like 'routes/index'

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,13 @@
     },
     {
       "type": "lldb",
+      "request": "attach",
+      "sourceLanguages": ["rust"],
+      "pid": "${command:pickMyProcess}",
+      "name": "debug-rust-attach"
+    },
+    {
+      "type": "lldb",
       "request": "launch",
       "sourceLanguages": ["rust"],
       "name": "debug-rust-basic",

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -224,15 +224,19 @@ pub fn generate_entry_startup(
   RawSource::from(source).boxed()
 }
 
+/**
+ * This is ported from https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/esm/ModuleChunkFormatPlugin.js#L98
+ */
 pub fn get_relative_path(base_chunk_output_name: &str, other_chunk_output_name: &str) -> String {
   let mut base_chunk_output_name_arr = base_chunk_output_name.split('/').collect::<Vec<_>>();
   base_chunk_output_name_arr.pop();
   let mut other_chunk_output_name_arr = other_chunk_output_name.split('/').collect::<Vec<_>>();
-  while !base_chunk_output_name_arr.is_empty() && !other_chunk_output_name_arr.is_empty() {
-    if base_chunk_output_name_arr[0] == other_chunk_output_name_arr[0] {
-      base_chunk_output_name_arr.remove(0);
-      other_chunk_output_name_arr.remove(0);
-    }
+  while !base_chunk_output_name_arr.is_empty()
+    && !other_chunk_output_name_arr.is_empty()
+    && base_chunk_output_name_arr[0] == other_chunk_output_name_arr[0]
+  {
+    base_chunk_output_name_arr.remove(0);
+    other_chunk_output_name_arr.remove(0);
   }
   let path = if base_chunk_output_name_arr.is_empty() {
     "./".to_string()


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
It seems when we ported get_relative_path we change the logic and cause infinite loop when entry key contains '/' like 'routes/_index'
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
No Need
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
