### PR TITLE
chore: better debugging

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
-    "recommendations": [
-        "streetsidesoftware.code-spell-checker",
-        "tamasfe.even-better-toml",
-        "rust-lang.rust-analyzer"
-    ]
+  "recommendations": [
+    "streetsidesoftware.code-spell-checker",
+    "tamasfe.even-better-toml",
+    "rust-lang.rust-analyzer",
+    "fabiospampinato.vscode-debug-launcher"
+  ]
 }

--- a/examples/basic/src/lib.js
+++ b/examples/basic/src/lib.js
@@ -1,1 +1,0 @@
-export const a = 3;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/jest": "29.1.0",
     "@types/node": "16",
     "@types/rimraf": "3.0.2",
+    "chalk": "^5.3.0",
     "commander": "10.0.1",
     "cross-env": "^7.0.3",
     "husky": "^7.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@types/rimraf':
         specifier: 3.0.2
         version: 3.0.2
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
       commander:
         specifier: 10.0.1
         version: 10.0.1
@@ -347,6 +350,9 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../../packages/rspack
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
 
   examples/basic-ts:
     dependencies:
@@ -14615,7 +14621,6 @@ packages:
     dependencies:
       webpack: 5.76.0(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack@5.76.0)
-    dev: true
 
   /@webpack-cli/info@1.5.0(webpack-cli@4.10.0):
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -14624,7 +14629,6 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0(webpack@5.76.0)
-    dev: true
 
   /@webpack-cli/serve@1.7.0(webpack-cli@4.10.0):
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -14636,7 +14640,6 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.10.0(webpack@5.76.0)
-    dev: true
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -16623,7 +16626,6 @@ packages:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
-    dev: true
 
   /clone-response@1.0.2:
     resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
@@ -18490,7 +18492,6 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -19273,7 +19274,6 @@ packages:
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
-    dev: true
 
   /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -20979,7 +20979,6 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
-    dev: true
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -21117,7 +21116,6 @@ packages:
   /interpret@2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
-    dev: true
 
   /interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -21481,7 +21479,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
-    dev: true
 
   /is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -21675,7 +21672,6 @@ packages:
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /isomorphic-fetch@2.2.1:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
@@ -22592,7 +22588,6 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -26706,7 +26701,6 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.2
-    dev: true
 
   /rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -26993,7 +26987,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
-    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -27002,7 +26995,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: true
 
   /resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -27739,7 +27731,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
-    dev: true
 
   /shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -29284,7 +29275,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.76.0
+      webpack: 5.76.0(webpack-cli@4.10.0)
 
   /terser-webpack-plugin@5.3.9(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
@@ -30886,7 +30877,6 @@ packages:
       rechoir: 0.7.1
       webpack: 5.76.0(webpack-cli@4.10.0)
       webpack-merge: 5.9.0
-    dev: true
 
   /webpack-dev-middleware@5.3.3:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -31161,7 +31151,6 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
-    dev: true
 
   /webpack-sources@2.3.1:
     resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
@@ -31276,7 +31265,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /webpack@5.80.0(esbuild@0.17.18):
     resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
@@ -31484,7 +31472,6 @@ packages:
 
   /wildcard@2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
-    dev: true
 
   /window-size@0.1.0:
     resolution: {integrity: sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,9 +350,6 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../../packages/rspack
-      chalk:
-        specifier: ^5.3.0
-        version: 5.3.0
 
   examples/basic-ts:
     dependencies:
@@ -14621,6 +14618,7 @@ packages:
     dependencies:
       webpack: 5.76.0(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack@5.76.0)
+    dev: true
 
   /@webpack-cli/info@1.5.0(webpack-cli@4.10.0):
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -14629,6 +14627,7 @@ packages:
     dependencies:
       envinfo: 7.8.1
       webpack-cli: 4.10.0(webpack@5.76.0)
+    dev: true
 
   /@webpack-cli/serve@1.7.0(webpack-cli@4.10.0):
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -14640,6 +14639,7 @@ packages:
         optional: true
     dependencies:
       webpack-cli: 4.10.0(webpack@5.76.0)
+    dev: true
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -16626,6 +16626,7 @@ packages:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+    dev: true
 
   /clone-response@1.0.2:
     resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
@@ -18492,6 +18493,7 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -19274,6 +19276,7 @@ packages:
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
+    dev: true
 
   /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
@@ -20979,6 +20982,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -21116,6 +21120,7 @@ packages:
   /interpret@2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
+    dev: true
 
   /interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
@@ -21479,6 +21484,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
+    dev: true
 
   /is-plain-object@5.0.0:
     resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
@@ -21672,6 +21678,7 @@ packages:
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /isomorphic-fetch@2.2.1:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
@@ -22588,6 +22595,7 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -26701,6 +26709,7 @@ packages:
     engines: {node: '>= 0.10'}
     dependencies:
       resolve: 1.22.2
+    dev: true
 
   /rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -26987,6 +26996,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -26995,6 +27005,7 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
 
   /resolve-pathname@3.0.0:
     resolution: {integrity: sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==}
@@ -27731,6 +27742,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
+    dev: true
 
   /shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -29275,7 +29287,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.76.0(webpack-cli@4.10.0)
+      webpack: 5.76.0
 
   /terser-webpack-plugin@5.3.9(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
@@ -30877,6 +30889,7 @@ packages:
       rechoir: 0.7.1
       webpack: 5.76.0(webpack-cli@4.10.0)
       webpack-merge: 5.9.0
+    dev: true
 
   /webpack-dev-middleware@5.3.3:
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
@@ -31151,6 +31164,7 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
+    dev: true
 
   /webpack-sources@2.3.1:
     resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
@@ -31265,6 +31279,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack@5.80.0(esbuild@0.17.18):
     resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
@@ -31472,6 +31487,7 @@ packages:
 
   /wildcard@2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+    dev: true
 
   /window-size@0.1.0:
     resolution: {integrity: sha512-1pTPQDKTdd61ozlKGNCjhNRd+KPmgLSGa3mZTHoOliaGcESD8G1PXhh7c1fgiPjVbNVfgy2Faw4BI8/m0cC8Mg==}

--- a/x.mjs
+++ b/x.mjs
@@ -158,7 +158,7 @@ rspackCommand
 	.option("-d, --debug", "Launch debugger in VSCode")
 	.action(async function ({ debug }) {
 		if (!debug) {
-			await $`npx rspack ${getVariadicArgs().toString()}`;
+			await $`npx rspack ${getVariadicArgs()}`;
 			return;
 		}
 		await launchRspackCli(getVariadicArgs());
@@ -185,7 +185,7 @@ jestCommand
 	.option("-d, --debug", "Launch debugger in VSCode")
 	.action(async ({ debug }) => {
 		if (!debug) {
-			await $`npx jest ${getVariadicArgs().toString()}`;
+			await $`npx jest ${getVariadicArgs()}`;
 			return;
 		}
 		await launchJestWithArgs(getVariadicArgs());
@@ -308,13 +308,7 @@ async function launchDebugger(launchConfig) {
 // Get args after `--`
 function getVariadicArgs() {
 	let idx = argv.findIndex(c => c === "--");
-	let args = idx === -1 ? [] : argv.slice(idx + 1);
-	Object.assign(args, {
-		toString() {
-			return this.join(" ");
-		}
-	});
-	return args;
+	return idx === -1 ? [] : argv.slice(idx + 1);
 }
 
 async function hasCommandCode() {

--- a/x.mjs
+++ b/x.mjs
@@ -282,8 +282,9 @@ async function launchJestWithArgs(additionalArgs) {
 }
 
 async function launchDebugger(launchConfig) {
-	if (!(await hasCommandCode())) return;
-	await hasLaunchExtensionInstalled();
+	if (!(await hasCommandCode()) || !(await hasLaunchExtensionInstalled())) {
+		return;
+	}
 	launchConfig = [
 		...launchConfig,
 		{
@@ -341,7 +342,7 @@ async function hasLaunchExtensionInstalled() {
 			console.error(stderr);
 			return false;
 		}
-		return stdout.includes("fabiospampinato.vscode-debug-launcher");
+		return stdout?.includes("fabiospampinato.vscode-debug-launcher");
 	} catch (p) {
 		console.error(
 			new Error(p.stderr || p.message, {

--- a/x.mjs
+++ b/x.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env zx
 
 import "zx/globals";
+import chalk from "chalk";
 import { Command } from "commander";
 import { version_handler } from "./scripts/release/version.mjs";
 import { publish_handler } from "./scripts/release/publish.mjs";
+const { yellow } = chalk;
+
 process.env.FORCE_COLOR = 3; // Fix zx losing color output in subprocesses
 
 const program = new Command();
@@ -143,12 +146,67 @@ testCommand
 		await $`pnpm --filter "webpack-test" test`;
 	});
 
-let versionCommand = program
+// x rspack / x rs
+const rspackCommand = program.command("rspack").alias("rs").description(`
+  $ x rspack -- [your-rspack-cli-args...]
+  $ x rspack --debug -- build
+  $ x rs -d -- build
+  $ x rsd -- build
+`);
+
+rspackCommand
+	.option("-d, --debug", "Launch debugger in VSCode")
+	.action(async function ({ debug }) {
+		if (!debug) {
+			await $`npx rspack ${getVariadicArgs().toString()}`;
+			return;
+		}
+		await launchRspackCli(getVariadicArgs());
+	});
+
+// x rsd
+program
+	.command("rspack-debug")
+	.alias("rsd")
+	.description("Alias for `x rspack --debug`")
+	.action(async function () {
+		await launchRspackCli(getVariadicArgs());
+	});
+
+// x jest / x j
+const jestCommand = program.command("jest").alias("j").description(`
+  $ x jest -- [your-jest-args...]
+  $ x jest --debug -- -t <test-name-pattern>
+  $ x j -d -- [test-path-pattern]
+  $ x jd -- [your-jest-args...]
+`);
+
+jestCommand
+	.option("-d, --debug", "Launch debugger in VSCode")
+	.action(async ({ debug }) => {
+		if (!debug) {
+			await $`npx jest ${getVariadicArgs().toString()}`;
+			return;
+		}
+		await launchJestWithArgs(getVariadicArgs());
+	});
+
+// x jd
+program
+	.command("jest-debug")
+	.alias("jd")
+	.description("Alias for `x jest --debug`")
+	.action(async function () {
+		await launchJestWithArgs(getVariadicArgs());
+	});
+
+program
 	.command("version")
 	.argument("<bump_version>", "bump version to (major|minor|patch|snapshot)")
 	.description("bump version")
 	.action(version_handler);
-let releaseCommand = program
+
+program
 	.command("publish")
 	.argument("<mode>", "publish mode (snapshot|stable)")
 	.requiredOption("--tag <char>", "publish tag")
@@ -167,3 +225,130 @@ if (argv[0] && /x.mjs/.test(argv[0])) {
 	argv = argv.slice(1);
 }
 program.parse(argv, { from: "user" });
+
+async function launchRspackCli(additionalArgs) {
+	let args = [
+		"--inspect-brk",
+		"${workspaceFolder}/packages/rspack-cli/bin/rspack",
+		...additionalArgs
+	];
+	let launch = [
+		{
+			name: "rust",
+			type: "lldb",
+			request: "launch",
+			sourceLanguages: ["rust"],
+			program: "node",
+			args,
+			env: process.env,
+			cwd: process.cwd()
+		}
+	];
+	console.info(`$ ${yellow("node")} ${args.join(" ")}`);
+	await launchDebugger(launch);
+}
+
+async function launchJestWithArgs(additionalArgs) {
+	let args = [
+		"--inspect-brk",
+		"--expose-gc",
+		"--max-old-space-size=8192",
+		"--experimental-vm-modules",
+		"${workspaceFolder}/node_modules/.bin/jest",
+		"--runInBand",
+		"--logHeapUsage"
+	];
+	if (additionalArgs) {
+		args.push(...additionalArgs);
+	}
+	let launch = [
+		{
+			name: "rust",
+			type: "lldb",
+			request: "launch",
+			sourceLanguages: ["rust"],
+			program: "node",
+			args,
+			env: {
+				NO_COLOR: JSON.stringify(1),
+				RSPACK_DEP_WARNINGS: JSON.stringify(false),
+				...process.env
+			},
+			cwd: process.cwd()
+		}
+	];
+	console.info(`$ ${yellow("node")} ${args.join(" ")}`);
+	await launchDebugger(launch);
+}
+
+async function launchDebugger(launchConfig) {
+	if (!(await hasCommandCode())) return;
+	await hasLaunchExtensionInstalled();
+	launchConfig = [
+		...launchConfig,
+		{
+			name: "node",
+			port: 9229,
+			request: "attach",
+			skipFiles: ["<node_internals>/**"],
+			sourceMaps: true,
+			continueOnAttach: true,
+			type: "node"
+		}
+	];
+	console.info(yellow("Initializing VSCode debugger..."));
+	await $`code --open-url ${launchConfig.map(
+		c =>
+			"vscode://fabiospampinato.vscode-debug-launcher/launch?args=" +
+			JSON.stringify(c)
+	)}`;
+}
+
+// Get args after `--`
+function getVariadicArgs() {
+	let idx = argv.findIndex(c => c === "--");
+	let args = idx === -1 ? [] : argv.slice(idx + 1);
+	Object.assign(args, {
+		toString() {
+			return this.join(" ");
+		}
+	});
+	return args;
+}
+
+async function hasCommandCode() {
+	let which = process.platform === "win32" ? "where.exe" : "which";
+	try {
+		let fs = await import("node:fs/promises");
+		let { stdout } = await $`${which} node`.quiet();
+		await fs.access(stdout.replace(/[\n\r]/g, ""));
+		return true;
+	} catch (p) {
+		console.error(
+			new Error(p.stderr || p.message, {
+				cause:
+					"Only Vscode has been supported by now. Did you forget to install 'code' command?"
+			})
+		);
+		return false;
+	}
+}
+
+async function hasLaunchExtensionInstalled() {
+	try {
+		let { stdout, stderr } = await $`code --list-extensions`.quiet();
+		if (stderr) {
+			console.error(stderr);
+			return false;
+		}
+		return stdout.includes("fabiospampinato.vscode-debug-launcher");
+	} catch (p) {
+		console.error(
+			new Error(p.stderr || p.message, {
+				cause:
+					"VSCode extension `fabiospampinato.vscode-debug-launcher` is required. https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-debug-launcher"
+			})
+		);
+		return false;
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Introduce a drop-in replacement for Rspack/Jest CLI to 
make debugging experience better on Rspack. 

**Commands**:

- x rspack / x rs: Normal rspack-cli commands
- x jest / x j: Normal jest-cli commands
- x rsd: Debugging command for rspack-cli with VSCode support
- x jd: Debugging command for jest-cli with VSCode support

New commands did almost nothing. Passing variadic arguments is supported with `--`. CLI arguments are directly passed to respect CLI.


**Examples**:

```bash
$ x rspack -- [your-rspack-cli-args...]
$ x rspack --debug -- build
$ x rs -d -- build
$ x rsd -- build
```

```bash
$ x jest -- [your-jest-args...]
$ x jest --debug -- -t <test-name-pattern>
$ x j -d -- [test-path-pattern]
$ x jd -- [your-jest-args...]
```


We only support vscode for now and [vscode-debug-launcher](https://marketplace.visualstudio.com/items?itemName=fabiospampinato.vscode-debug-launcher) needs to be installed for programmatically launching debug scripts.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
