### PR TITLE
fix: use original value when `import.style` is object

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -24,7 +24,7 @@ mod plugins;
 use hook::*;
 // Napi macro registered this successfully
 #[allow(unused)]
-use loader::*;
+use loader::run_builtin_loader;
 use plugins::*;
 use rspack_binding_options::*;
 use rspack_binding_values::*;

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -1,25 +1,22 @@
 #![feature(let_chains)]
 
-use std::default::Default;
-
-use rspack_ast::RspackAst;
-use rspack_core::{rspack_sources::SourceMap, LoaderRunnerContext, Mode};
-use rspack_error::{internal_error, Diagnostic, Result};
-use rspack_loader_runner::{Identifiable, Identifier, Loader, LoaderContext};
-use rspack_plugin_javascript::{
-  ast::{self, SourceMapConfig},
-  TransformOutput,
-};
-use swc_config::{config_types::MergingOption, merge::Merge};
-use swc_core::base::config::{InputSourceMap, OutputCharset, TransformConfig};
-
 mod compiler;
 mod options;
 mod transformer;
 
+use std::default::Default;
+
 use compiler::{IntoJsAst, SwcCompiler};
 use options::SwcCompilerOptionsWithAdditional;
 pub use options::SwcLoaderJsOptions;
+use rspack_ast::RspackAst;
+use rspack_core::{rspack_sources::SourceMap, LoaderRunnerContext, Mode};
+use rspack_error::{internal_error, Diagnostic, Result};
+use rspack_loader_runner::{Identifiable, Identifier, Loader, LoaderContext};
+use rspack_plugin_javascript::ast::{self, SourceMapConfig};
+use rspack_plugin_javascript::TransformOutput;
+use swc_config::{config_types::MergingOption, merge::Merge};
+use swc_core::base::config::{InputSourceMap, OutputCharset, TransformConfig};
 
 #[derive(Debug)]
 pub struct SwcLoader {

--- a/crates/rspack_plugin_css/src/lib.rs
+++ b/crates/rspack_plugin_css/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(if_let_guard)]
 #![feature(box_patterns)]
 pub mod dependency;
-pub(crate) mod parser_and_generator;
+mod parser_and_generator;
 pub mod plugin;
 pub mod swc_css_compiler;
 mod utils;

--- a/packages/rspack/src/builtin-loader/swc/pluginImport.ts
+++ b/packages/rspack/src/builtin-loader/swc/pluginImport.ts
@@ -15,6 +15,10 @@ type PluginImportConfig = {
 
 type PluginImportOptions = PluginImportConfig[] | undefined;
 
+function isObject(val: any): boolean {
+	return Object.prototype.toString.call(val) === "[object Object]";
+}
+
 function resolvePluginImport(
 	pluginImport: PluginImportOptions
 ): RawPluginImportConfig[] | undefined {
@@ -33,6 +37,10 @@ function resolvePluginImport(
 		} else if (typeof config.style === "string") {
 			const isTpl = config.style.includes("{{");
 			rawConfig.style![isTpl ? "custom" : "css"] = config.style;
+		} else if (isObject(config.style)) {
+			// for child compiler
+			// see https://github.com/web-infra-dev/rspack/issues/4597
+			rawConfig.style = config.style;
 		}
 
 		// This option will overrides the behavior of style

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/.gitignore
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/.gitignore
@@ -1,0 +1,1 @@
+!node_modules/

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/diy.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/diy.js
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+	return source;
+};

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/button/index.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/button/index.js
@@ -1,0 +1,1 @@
+export default "button"

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/button/style/css.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/button/style/css.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/button/style/index.css
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/button/style/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: aquamarine;
+}

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/index.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/es/index.js
@@ -1,0 +1,1 @@
+import {default as Button} from './button';

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/package.json
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/node_modules/aaaaa/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "aaaaa",
+  "main": "es/index.js"
+}

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/rspack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/rspack.config.js
@@ -1,0 +1,46 @@
+const path = require("path");
+
+const config = {
+	module: {
+		rules: [
+			{
+				test: /\.(js|mjs|cjs|jsx)$/,
+				loader: path.join(__dirname, "diy.js")
+			},
+			{
+				test: /\.(js|mjs|cjs|jsx)$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							rspackExperiments: {
+								import: [
+									{
+										libraryName: "aaaaa",
+										libraryDirectory: "es",
+										style: "css"
+									}
+								]
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.make.tap("child", base => {
+					const child = base.createChildCompiler("child", {}, []);
+					child.runAsChild(() => {});
+				});
+			}
+		}
+	],
+	experiments: {
+		css: true
+	}
+};
+
+module.exports = config;

--- a/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/src/index.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/issue-4597/src/index.js
@@ -1,0 +1,8 @@
+import { Button } from "aaaaa";
+import fs from "fs";
+
+describe("should generate css successfully", () => {
+	const dir = fs.readdirSync(__dirname);
+	expect(dir).toStrictEqual(["main.css", "main.js"]);
+	expect(Button).toBe("button");
+});


### PR DESCRIPTION
Fixes #4597

#### Why does only the combination of **only** `htmlWebpackPlugin ` + `loader:diy.js` + `loader:builtin:swc_loader` yield an unexpected result?

This issue arises due to incorrect argument passing to ﻿`RawPluginImportConfig.style`. Currently, the ﻿`resolvePluginImport` does not handle the scenario where ﻿`RawPluginImportConfig.style` in the child compiler is an object due to normalization.


#### Why `loader:diy.js` + `loader:builtin:swc_loader` is ok

Since it does not involve a child compiler, it can utilize the arguments correctly.

#### Why `htmlWebpackPlugin` + `loader:builtin:swc_loader` is ok

Incorrect arguments were indeed generated. However, since only the builtin loader is present, it does not receive the incorrect arguments from the JavaScript side.

To address this, I've implemented a handler for the scenario where the type of ﻿`import.style` is an object. In such cases, we will use the original value.