### PR TITLE
ci: disable most of the optimization.minimize in examples to speed up CI

### DIFF
--- a/examples/angular/rspack.config.js
+++ b/examples/angular/rspack.config.js
@@ -63,6 +63,7 @@ module.exports = {
 		asyncWebAssembly: true
 	},
 	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
 		runtimeChunk: false,
 		//swc has different behavior compare to terser,this lead output size inflate
 		minimizer: [

--- a/examples/cra-ts/rspack.config.js
+++ b/examples/cra-ts/rspack.config.js
@@ -12,6 +12,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/cra/rspack.config.js
+++ b/examples/cra/rspack.config.js
@@ -12,6 +12,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/extract-license/rspack.config.js
+++ b/examples/extract-license/rspack.config.js
@@ -5,6 +5,9 @@ const config = {
 	entry: {
 		main: "./src/index.js"
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/loader-compat/rspack.config.js
+++ b/examples/loader-compat/rspack.config.js
@@ -128,6 +128,9 @@ const config = {
 				}
 			}
 		]
-	}
+	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 };
 module.exports = config;

--- a/examples/plugin-compat/package.json
+++ b/examples/plugin-compat/package.json
@@ -13,7 +13,6 @@
   "license": "ISC",
   "devDependencies": {
     "@rspack/cli": "workspace:*",
-    "@rspack/plugin-minify": "workspace:*",
     "copy-webpack-plugin": "5.1.2",
     "fork-ts-checker-webpack-plugin": "8.0.0",
     "generate-package-json-webpack-plugin": "^2.6.0",

--- a/examples/plugin-compat/rspack.config.js
+++ b/examples/plugin-compat/rspack.config.js
@@ -1,10 +1,9 @@
-const rspack = require("@rspack/core");
 const BundleAnalyzerPlugin =
 	require("webpack-bundle-analyzer").BundleAnalyzerPlugin;
 const CopyPlugin = require("copy-webpack-plugin");
 const HtmlPlugin = require("html-webpack-plugin")
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
-const minifyPlugin = require("@rspack/plugin-minify");
+// const minifyPlugin = require("@rspack/plugin-minify");
 const manifestPlugin = require("rspack-manifest-plugin").WebpackManifestPlugin;
 const GeneratePackageJsonPlugin = require("generate-package-json-webpack-plugin");
 const licensePlugin = require("license-webpack-plugin");
@@ -20,14 +19,14 @@ const config = {
 		filename: "[contenthash:8].js"
 	},
 	optimization: {
-		minimize: true,
-		minimizer: [
-			new minifyPlugin({
-				minifier: "terser",
-				target: "es6",
-				css: true
-			})
-		]
+		minimize: false, // Disabling minification because it takes too long on CI
+		// minimizer: [
+			// new minifyPlugin({
+				// minifier: "terser",
+				// target: "es6",
+				// css: true
+			// })
+		// ]
 	},
 	plugins: [
 		new BundleAnalyzerPlugin({

--- a/examples/react-15-classic/rspack.config.js
+++ b/examples/react-15-classic/rspack.config.js
@@ -29,6 +29,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/react-15/rspack.config.js
+++ b/examples/react-15/rspack.config.js
@@ -12,6 +12,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/react-refresh-babel-loader/rspack.config.js
+++ b/examples/react-refresh-babel-loader/rspack.config.js
@@ -12,7 +12,10 @@ const config = {
 	},
 	mode: isProduction ? "production" : "development",
 	entry: { main: "./src/index.tsx" },
-	devtool: 'source-map',
+	devtool: false,
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	module: {
 		rules: [
 			{

--- a/examples/react-refresh/rspack.config.js
+++ b/examples/react-refresh/rspack.config.js
@@ -39,6 +39,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({ template: "./index.html" }),
 		new rspack.DefinePlugin({ "process.env.NODE_ENV": "'development'" }),

--- a/examples/react-storybook/rspack.config.js
+++ b/examples/react-storybook/rspack.config.js
@@ -13,6 +13,9 @@ module.exports = {
 			template: "./index.html"
 		})
 	],
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	module: {
 		rules: [
 			{

--- a/examples/react-with-less/rspack.config.js
+++ b/examples/react-with-less/rspack.config.js
@@ -16,6 +16,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/react-with-sass/rspack.config.js
+++ b/examples/react-with-sass/rspack.config.js
@@ -14,6 +14,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/solid/rspack.config.js
+++ b/examples/solid/rspack.config.js
@@ -33,6 +33,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/styled-components/rspack.config.js
+++ b/examples/styled-components/rspack.config.js
@@ -4,6 +4,9 @@ const config = {
 	entry: {
 		main: "./src/index.tsx"
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/svgr/rspack.config.js
+++ b/examples/svgr/rspack.config.js
@@ -12,6 +12,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/vue2-tsx/rspack.config.js
+++ b/examples/vue2-tsx/rspack.config.js
@@ -14,6 +14,10 @@ const config = defineConfig({
 
   experiments: { css: true },
 
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
+
   plugins: [
     new VueLoaderPlugin(),
     new HtmlRspackPlugin({

--- a/examples/vue3-jsx/rspack.config.js
+++ b/examples/vue3-jsx/rspack.config.js
@@ -24,6 +24,9 @@ const config = {
 			}
 		]
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"

--- a/examples/vue3-vanilla/rspack.config.js
+++ b/examples/vue3-vanilla/rspack.config.js
@@ -10,6 +10,9 @@ const config = {
 	devServer: {
 		historyApiFallback: true
 	},
+	optimization: {
+		minimize: false, // Disabling minification because it takes too long on CI
+	},
 	plugins: [
 		new VueLoaderPlugin(),
 		new rspack.HtmlRspackPlugin({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -719,9 +719,6 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../../packages/rspack
-      '@rspack/plugin-minify':
-        specifier: workspace:*
-        version: link:../../packages/rspack-plugin-minify
       copy-webpack-plugin:
         specifier: 5.1.2
         version: 5.1.2


### PR DESCRIPTION
I disabled most minifications based on the build timings that are > 10s on Mac from reading the raw logs:

![image](https://github.com/web-infra-dev/rspack/assets/1430279/593d75d5-543c-4df0-b5b0-eebfe9bbc6c1)
