### PR TITLE
fix(runtime): get export default when new class

### DIFF
--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -32,7 +32,14 @@ pub fn export_from_import(
     {
       match exports_type {
         ExportsType::Dynamic => {
-          return format!("{import_var}_default(){}", property_access(export_name, 1));
+          if is_call {
+            return format!("{import_var}_default(){}", property_access(export_name, 1));
+          } else {
+            return format!(
+              "({import_var}_default(){})",
+              property_access(export_name, 1)
+            );
+          }
         }
         ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
           export_name = export_name[1..].to_vec();

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -5484,7 +5484,7 @@ console.log(a);
   ],
   "errorsCount": 1,
   "filteredModules": undefined,
-  "hash": "70fb47b3fcabdfbd56a5",
+  "hash": "432c6329523a2019be22",
   "logging": {},
   "modules": [
     {
@@ -5679,7 +5679,7 @@ error[internal]: Export should be relative path and start with "./", but got ../
 
 
 
-Rspack compiled with 1 error (70fb47b3fcabdfbd56a5)"
+Rspack compiled with 1 error (432c6329523a2019be22)"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-modules 1`] = `


### PR DESCRIPTION
## Summary

Fix get export default when used in new expression. It needs to wrap the brackets when is_call is false

## Test Plan



## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
