### PR TITLE
fix: compiler.webpack.ModuleFilenameHelpers type error

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "NodeNext",
+    "module": "CommonJS",
     "moduleResolution": "NodeNext",
     "target": "ES2018",
     "esModuleInterop": true,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Example:
Input:
``` typescript
import ModuleFilenameHelpers from "./lib/ModuleFilenameHelpers.js"

console.log(ModuleFilenameHelpers)
```
Ouput: (NodeNext)
``` typescript
const ModuleFilenameHelpers = require("./lib/ModuleFilenameHelpers.js")

// console undefined
console.log(ModuleFilenameHelpers.default)
```

Output: (CommonJS)
``` typescript
const ModuleFilenameHelpers = require("./lib/ModuleFilenameHelpers.js")

// console a object
console.log(ModuleFilenameHelpers)
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
