### PR TITLE
fix(typing): fix ExternalObject type argument not found

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -34,7 +34,7 @@ export class JsCompilation {
   getMissingDependencies(): Array<string>
   getBuildDependencies(): Array<string>
   pushDiagnostic(severity: "error" | "warning", title: string, message: string): void
-  pushNativeDiagnostics(diagnostics: ExternalObject<Array<Diagnostic>>): void
+  pushNativeDiagnostics(diagnostics: ExternalObject<'Diagnostic[]'>): void
   getStats(): JsStats
   getAssetPath(filename: string, data: PathData): string
   getAssetPathWithInfo(filename: string, data: PathData): PathWithInfo
@@ -307,17 +307,17 @@ export interface JsLoaderContext {
    * Internal additional data, contains more than `String`
    * @internal
    */
-  additionalDataExternal: ExternalObject<AdditionalData>
+  additionalDataExternal: ExternalObject<'AdditionalData'>
   /**
    * Internal loader context
    * @internal
    */
-  contextExternal: ExternalObject<LoaderRunnerContext>
+  contextExternal: ExternalObject<'LoaderRunnerContext'>
   /**
    * Internal loader diagnostic
    * @internal
    */
-  diagnosticsExternal: ExternalObject<Array<Diagnostic>>
+  diagnosticsExternal: ExternalObject<'Diagnostic[]'>
 }
 
 export interface JsModule {
@@ -662,7 +662,7 @@ export interface RawExternalItemFnCtx {
 
 export interface RawExternalItemFnResult {
   externalType?: string
-  result?: RawExternalItemValue
+  result?: string | boolean | string[] | Record<string, string[]>
 }
 
 export interface RawExternalsPluginOptions {

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -51,6 +51,8 @@ impl From<RawExternalItemValueWrapper> for ExternalItemValue {
 #[napi(object)]
 pub struct RawExternalItemFnResult {
   pub external_type: Option<String>,
+  // sadly, napi.rs does not support type alias at the moment. Need to add Either here
+  #[napi(ts_type = "string | boolean | string[] | Record<string, string[]>")]
   pub result: Option<RawExternalItemValue>,
 }
 

--- a/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
@@ -253,12 +253,15 @@ pub struct JsLoaderContext {
   pub loader_index_from_js: Option<u32>,
   /// Internal additional data, contains more than `String`
   /// @internal
+  #[napi(ts_type = "ExternalObject<'AdditionalData'>")]
   pub additional_data_external: External<AdditionalData>,
   /// Internal loader context
   /// @internal
+  #[napi(ts_type = "ExternalObject<'LoaderRunnerContext'>")]
   pub context_external: External<rspack_core::LoaderRunnerContext>,
   /// Internal loader diagnostic
   /// @internal
+  #[napi(ts_type = "ExternalObject<'Diagnostic[]'>")]
   pub diagnostics_external: External<Vec<Diagnostic>>,
 }
 

--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -321,7 +321,7 @@ impl JsCompilation {
     self.inner.push_diagnostic(diagnostic);
   }
 
-  #[napi]
+  #[napi(ts_args_type = r#"diagnostics: ExternalObject<'Diagnostic[]'>"#)]
   pub fn push_native_diagnostics(&mut self, mut diagnostics: External<Vec<Diagnostic>>) {
     while let Some(diagnostic) = diagnostics.pop() {
       self.inner.push_diagnostic(diagnostic);


### PR DESCRIPTION
part of #4640

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
This is part of #4640. Currently the rspack.d.ts has several type errors due to ExternalObject.
I am not 100% sure if this is a correct direction to fix/work around. Appreciate @Brooooooklyn 's feedback.

This pull request avoid un-generated identifiers by using string literal. 
It will still work because either the API is internal or is used as an opaque token. 

With this, we are one step forward toward removing skipLibCheck flag. cc @xiaoxiangmoe 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

I used `tsc` to check the lib is type-error-free.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
