### PR TITLE
chore: support passing refs to ecosystem-ci

### DIFF
--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-latest
-    if: github.repository == 'web-infra-dev/rspack' && github.event.issue.pull_request && startsWith(github.event.comment.body, '!eco-ci')
+    if: github.repository == 'web-infra-dev/rspack' && github.event.issue.pull_request && contains(github.event.comment.body, '!eco-ci')
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -69,9 +69,16 @@ jobs:
           result-encoding: string
           script: |
             const comment = process.env.COMMENT.trim()
+            const command = comment.split('\n')[0]
             const prData = ${{ steps.get-pr-data.outputs.result }}
 
-            const suite = comment.split('\n')[0].replace(/^!eco-ci/, '').trim()
+            const {
+              MODERN_REF: modernRef,
+              RSPRESS_REF: rspressRef,
+              RSBUILD_REF: rsbuildRef
+            } = parseEnv(command.split(/\s/))
+
+            const suite = command.replace(/^.*?!eco-ci/, '').trim()
 
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
@@ -82,6 +89,31 @@ jobs:
                 prNumber: '' + prData.num,
                 branchName: prData.branchName,
                 repo: prData.repo,
-                suite: suite === '' ? '-' : suite
+                suite: suite === '' ? '-' : suite,
+                modernRef,
+                rspressRef,
+                rsbuildRef
               }
             })
+
+            function parseEnv(args) {
+              const envSetterRegex = /(\w+)=('(.*)'|"(.*)"|(.*))/
+              const envSetters = {}
+              for (let i = 0; i < args.length; i++) {
+                const match = envSetterRegex.exec(args[i])
+                if (match) {
+                  let value
+
+                  if (typeof match[3] !== 'undefined') {
+                    value = match[3]
+                  } else if (typeof match[4] === 'undefined') {
+                    value = match[5]
+                  } else {
+                    value = match[4]
+                  }
+
+                  envSetters[match[1]] = value
+                }
+              }
+              return envSetters   
+            }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support three ref types for rspack-ecosystem-ci:

- MODERN_REF: branch name to test against modern
- RSPRESS_REF: branch name to test against rspress
- RSBUILD_REF: branch name to test against rsbuild

```
MODERN_REF=<your-test-ref> !eco-ci modern
MODERN_REF=<your-test-ref> RSBUILD_REF=<your-test-ref> !eco-ci
RSPRESS_REF=<your-test-ref> !eco-ci
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
