### PR TITLE
test: add test cases for #4643

### DIFF
--- a/packages/rspack/tests/cases/parsing/issue-4643/a.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/cases/parsing/issue-4643/b.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/b.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+	return "b";
+};

--- a/packages/rspack/tests/cases/parsing/issue-4643/c.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/c.js
@@ -1,0 +1,7 @@
+function c() {}
+
+c.prototype.value = function () {
+	return "c";
+};
+
+module.exports = c;

--- a/packages/rspack/tests/cases/parsing/issue-4643/index.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/index.js
@@ -1,0 +1,20 @@
+import a from "./a";
+import b from "./b";
+import c from "./c";
+
+it("should handle default exports when used as value", function () {
+	expect(a).toBe("a");
+});
+
+it("should handle default exports when used as function", function () {
+	expect(b()).toBe("b");
+});
+
+it("should handle default exports when used as class", function () {
+	let ins = new c();
+	expect(ins.value()).toBe("c");
+});
+
+it("should handle default exports when used as class method callee", function () {
+	expect(new c().value()).toBe("c");
+});


### PR DESCRIPTION
## Summary

Adding test cases for #4643, affected #4607 and #4639, which has been reverted. 
These test cases will be used when is_call is fixed 

## Test Plan

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
