### PR TITLE
fix: `require.context` should parse literals

### DIFF
--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(if_let_guard)]
 #![feature(let_chains)]
 #![feature(box_patterns)]
 #![recursion_limit = "256"]

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/require_context_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/require_context_scanner.rs
@@ -24,7 +24,7 @@ impl Visit for RequireContextScanner<'_> {
 
   fn visit_call_expr(&mut self, node: &CallExpr) {
     if is_require_context_call(node) && !node.args.is_empty() {
-      if let Some(Lit::Str(str)) = node.args.first().and_then(|x| x.expr.as_lit()) {
+      let mut analyze = |request: &str| {
         let recursive =
           if let Some(Lit::Bool(bool)) = node.args.get(1).and_then(|x| x.expr.as_lit()) {
             bool.value
@@ -64,11 +64,28 @@ impl Visit for RequireContextScanner<'_> {
               include: None,
               exclude: None,
               category: DependencyCategory::CommonJS,
-              request: str.value.to_string(),
+              request: request.to_string(),
               namespace_object: ContextNameSpaceObject::Unset,
             },
             Some(node.span.into()),
           )));
+      };
+
+      // Handle string evaluatables.
+      // For example: require.context("", ...), require.context(``, ...)
+      // https://github.com/webpack/webpack/blob/6be4065ade1e252c1d8dcba4af0f43e32af1bdc1/lib/dependencies/RequireContextDependencyParserPlugin.js#L47
+      // TODO: should've used expression evaluation to handle cases like `abc${"efg"}`, etc.
+      match node.args.first().map(|x| &*x.expr) {
+        Some(t) if let Some(Lit::Str(str)) = t.as_lit() => analyze(&str.value),
+        Some(t)
+          if let Some(tpl) = t.as_tpl()
+            && tpl.exprs.is_empty()
+            && tpl.quasis.len() == 1
+            && let Some(el) = tpl.quasis.first() =>
+        {
+          analyze(&el.raw)
+        }
+        _ => (),
       }
     } else {
       node.visit_children_with(self);

--- a/packages/rspack/tests/cases/context/issue-4663/assets/sample.js
+++ b/packages/rspack/tests/cases/context/issue-4663/assets/sample.js
@@ -1,0 +1,1 @@
+export const hello = "Hello, world!";

--- a/packages/rspack/tests/cases/context/issue-4663/index.js
+++ b/packages/rspack/tests/cases/context/issue-4663/index.js
@@ -1,0 +1,12 @@
+it("should evaluate `require.context` with template literals", () => {
+	const requireAssets = require.context(`./assets`, true, /\.js$/iu);
+	expect(requireAssets("./sample.js").hello).toBe("Hello, world!");
+});
+
+it("should evaluate `import.meta.webpackContext` with template literals", () => {
+	const requireAssets = import.meta.webpackContext(`./assets`, {
+		recursive: true,
+		regExp: /\.js$/iu
+	});
+	expect(requireAssets("./sample.js").hello).toBe("Hello, world!");
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

closes https://github.com/web-infra-dev/rspack/issues/4663

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
