### PR TITLE
fix uniqueName Acquisition method

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -437,9 +437,6 @@ const applyOutputDefaults = (
 		if (libraryName) return libraryName;
 		const pkgPath = path.resolve(context, "package.json");
 		try {
-			if (output?.library?.name) {
-				return output.library.name;
-			}
 			const packageInfo = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
 			return packageInfo.name || "";
 		} catch (e: any) {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -23,6 +23,8 @@ import type {
 	ExternalsPresets,
 	InfrastructureLogging,
 	JavascriptParserOptions,
+	Library,
+	LibraryOptions,
 	Mode,
 	ModuleOptions,
 	Node,
@@ -403,16 +405,14 @@ const applyOutputDefaults = (
 		futureDefaults: boolean;
 	}
 ) => {
-
-
-	const getLibraryName = (library:string | string[]| Record<string,any>):string => {
+	const getLibraryName = (library: Library): string => {
 		const libraryName =
 			typeof library === "object" &&
 			library &&
 			!Array.isArray(library) &&
 			"type" in library
 				? library.name
-				: /** @type {LibraryName} */ (library);
+				: library;
 		if (Array.isArray(libraryName)) {
 			return libraryName.join(".");
 		} else if (typeof libraryName === "object") {
@@ -422,8 +422,6 @@ const applyOutputDefaults = (
 		}
 		return "";
 	};
-
-
 	F(output, "uniqueName", () => {
 		const libraryName = getLibraryName(output.library).replace(
 			/^\[(\\*[\w:]+\\*)\](\.)|(\.)\[(\\*[\w:]+\\*)\](?=\.|$)|\[(\\*[\w:]+\\*)\]/g,

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -124,6 +124,9 @@ const libraryOptions = z.strictObject({
 });
 export type LibraryOptions = z.infer<typeof libraryOptions>;
 
+const library = libraryName.or(libraryOptions).optional();
+export type Library = z.infer<typeof library>;
+
 const filenameTemplate = z.string();
 export type FilenameTemplate = z.infer<typeof filenameTemplate>;
 
@@ -277,7 +280,7 @@ const output = z.strictObject({
 	uniqueName: uniqueName.optional(),
 	chunkLoadingGlobal: chunkLoadingGlobal.optional(),
 	enabledLibraryTypes: enabledLibraryTypes.optional(),
-	library: libraryName.or(libraryOptions).optional(),
+	library: library.optional(),
 	libraryExport: libraryExport.optional(),
 	libraryTarget: libraryType.optional(),
 	umdNamedDefine: umdNamedDefine.optional(),

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -378,10 +378,16 @@ describe("snapshots", () => {
 		+ Received
 
 		@@ ... @@
+		-     "chunkLoadingGlobal": "webpackChunk_rspack_core",
+		+     "chunkLoadingGlobal": "webpackChunkmyLib_awesome",
+		@@ ... @@
 		-     "enabledLibraryTypes": Array [],
 		+     "enabledLibraryTypes": Array [
 		+       "var",
 		+     ],
+		@@ ... @@
+		-     "hotUpdateGlobal": "webpackHotUpdate_rspack_core",
+		+     "hotUpdateGlobal": "webpackHotUpdatemyLib_awesome",
 		@@ ... @@
 		-     "library": undefined,
 		+     "library": Object {
@@ -395,6 +401,9 @@ describe("snapshots", () => {
 		+       "type": "var",
 		+       "umdNamedDefine": undefined,
 		+     },
+		@@ ... @@
+		-     "uniqueName": "@rspack/core",
+		+     "uniqueName": "myLib.awesome",
 	`)
 	);
 	test(
@@ -410,10 +419,16 @@ describe("snapshots", () => {
 			+ Received
 
 			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunk_rspack_core",
+			+     "chunkLoadingGlobal": "webpackChunkmyLib",
+			@@ ... @@
 			-     "enabledLibraryTypes": Array [],
 			+     "enabledLibraryTypes": Array [
 			+       "var",
 			+     ],
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdate_rspack_core",
+			+     "hotUpdateGlobal": "webpackHotUpdatemyLib",
 			@@ ... @@
 			-     "library": undefined,
 			+     "library": Object {
@@ -427,6 +442,9 @@ describe("snapshots", () => {
 			+       "type": "var",
 			+       "umdNamedDefine": undefined,
 			+     },
+			@@ ... @@
+			-     "uniqueName": "@rspack/core",
+			+     "uniqueName": "myLib",
 		`)
 	);
 	test(
@@ -445,10 +463,16 @@ describe("snapshots", () => {
 			+ Received
 
 			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunk_rspack_core",
+			+     "chunkLoadingGlobal": "webpackChunkmyLib_lib",
+			@@ ... @@
 			-     "enabledLibraryTypes": Array [],
 			+     "enabledLibraryTypes": Array [
 			+       "var",
 			+     ],
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdate_rspack_core",
+			+     "hotUpdateGlobal": "webpackHotUpdatemyLib_lib",
 			@@ ... @@
 			-     "library": undefined,
 			+     "library": Object {
@@ -463,6 +487,9 @@ describe("snapshots", () => {
 			+       "type": "var",
 			+       "umdNamedDefine": undefined,
 			+     },
+			@@ ... @@
+			-     "uniqueName": "@rspack/core",
+			+     "uniqueName": "myLib.lib",
 		`)
 	);
 	test(
@@ -483,10 +510,16 @@ describe("snapshots", () => {
 			+ Received
 
 			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunk_rspack_core",
+			+     "chunkLoadingGlobal": "webpackChunkmyLib",
+			@@ ... @@
 			-     "enabledLibraryTypes": Array [],
 			+     "enabledLibraryTypes": Array [
 			+       "var",
 			+     ],
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdate_rspack_core",
+			+     "hotUpdateGlobal": "webpackHotUpdatemyLib",
 			@@ ... @@
 			-     "library": undefined,
 			+     "library": Object {
@@ -502,6 +535,9 @@ describe("snapshots", () => {
 			+       "type": "var",
 			+       "umdNamedDefine": undefined,
 			+     },
+			@@ ... @@
+			-     "uniqueName": "@rspack/core",
+			+     "uniqueName": "myLib",
 		`)
 	);
 	test(
@@ -522,10 +558,16 @@ describe("snapshots", () => {
 			+ Received
 
 			@@ ... @@
+			-     "chunkLoadingGlobal": "webpackChunk_rspack_core",
+			+     "chunkLoadingGlobal": "webpackChunk_name_my_name_Lib_name_",
+			@@ ... @@
 			-     "enabledLibraryTypes": Array [],
 			+     "enabledLibraryTypes": Array [
 			+       "var",
 			+     ],
+			@@ ... @@
+			-     "hotUpdateGlobal": "webpackHotUpdate_rspack_core",
+			+     "hotUpdateGlobal": "webpackHotUpdate_name_my_name_Lib_name_",
 			@@ ... @@
 			-     "library": undefined,
 			+     "library": Object {
@@ -542,6 +584,9 @@ describe("snapshots", () => {
 			+       "type": "var",
 			+       "umdNamedDefine": undefined,
 			+     },
+			@@ ... @@
+			-     "uniqueName": "@rspack/core",
+			+     "uniqueName": "[name].my[name]Lib.[name]",
 		`)
 	);
 	test("target node", { target: "node" }, e =>


### PR DESCRIPTION
 
## Summary

see [webpack-outputuniquename](https://webpack.js.org/configuration/output/#outputuniquename)

Webpack prefers to take `output.library.name` first, and only if the user has not configured it, will it take the `name` from `package.json`.

## Test Plan

copy by [webpack defaults config](https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/config/defaults.js#L804)

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_

see [rspack-outputuniquename-doc](https://www.rspack.dev/config/output.html#outputuniquename) , In fact, this is how he described it.
