### PR TITLE
fix(typing): fix packages/rspack-cli ts-expect-error

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -22,15 +22,16 @@ export class BuildCommand implements RspackCommand {
 				}),
 			async options => {
 				const logger = cli.getLogger();
-				// @ts-expect-error
-				let createJsonStringifyStream;
+				let createJsonStringifyStream: typeof import("@discoveryjs/json-ext").stringifyStream;
 				if (options.json) {
 					const jsonExt = await import("@discoveryjs/json-ext");
 					createJsonStringifyStream = jsonExt.default.stringifyStream;
 				}
 
-				// @ts-expect-error
-				const callback = (error, stats: Stats | MultiStats) => {
+				const errorHandler = (
+					error: Error | null,
+					stats: Stats | MultiStats | undefined
+				) => {
 					if (error) {
 						logger.error(error);
 						process.exit(2);
@@ -47,15 +48,11 @@ export class BuildCommand implements RspackCommand {
 									compiler.options ? compiler.options.stats : undefined
 								)
 						  }
-						: // @ts-expect-error
-						compiler.options
-						? // @ts-expect-error
-						  compiler.options.stats
+						: compiler.options
+						? compiler.options.stats
 						: undefined;
-					// @ts-expect-error
 					if (options.json && createJsonStringifyStream) {
-						// @ts-expect-error
-						const handleWriteError = error => {
+						const handleWriteError = (error: Error) => {
 							logger.error(error);
 							process.exit(2);
 						};
@@ -89,11 +86,6 @@ export class BuildCommand implements RspackCommand {
 				};
 
 				const rspackOptions = { ...options, argv: { ...options } };
-
-				// @ts-expect-error
-				const errorHandler = (err, Stats) => {
-					callback(err, Stats);
-				};
 
 				const compiler = await cli.createCompiler(
 					rspackOptions,

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -48,7 +48,7 @@ export type LoadedRspackConfig =
 	| MultiRspackOptions
 	| ((
 			env: Record<string, any>,
-			argv: Record<string, any>
+			argv?: Record<string, any>
 	  ) => RspackOptions | MultiRspackOptions);
 
 export async function loadRspackConfig(

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -82,16 +82,13 @@ export const previewOptions = (yargs: yargs.Argv) => {
 		});
 };
 
-// @ts-expect-error
-export function normalizeEnv(argv) {
-	// @ts-expect-error
-	function parseValue(previous, value) {
+export function normalizeEnv(argv: yargs.Arguments) {
+	function parseValue(previous: Record<string, unknown>, value: string) {
 		const [allKeys, val] = value.split(/=(.+)/, 2);
 		const splitKeys = allKeys.split(/\.(?!$)/);
 
 		let prevRef = previous;
 
-		// @ts-expect-error
 		splitKeys.forEach((someKey, index) => {
 			// https://github.com/webpack/webpack-cli/issues/3284
 			if (someKey.endsWith("=")) {

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -38,7 +38,8 @@ import { URLSearchParams } from "url";
 import {
 	experimental_registerGlobalTrace as registerGlobalTrace,
 	experimental_cleanupGlobalTrace as cleanupGlobalTrace,
-	RspackOptions
+	RspackOptions,
+	type Compiler
 } from "@rspack/core";
 
 type JSCPUProfileOptionsOutput = string;
@@ -167,16 +168,14 @@ function resolveLoggingOptions(value: string): LoggingOptions {
 class RspackProfileJSCPUProfilePlugin {
 	constructor(private output: string) {}
 
-	// @ts-expect-error
-	apply(compiler) {
+	apply(compiler: Compiler) {
 		const session = new inspector.Session();
 		session.connect();
 		session.post("Profiler.enable");
 		session.post("Profiler.start");
 		compiler.hooks.done.tapAsync(
 			RspackProfileJSCPUProfilePlugin.name,
-			// @ts-expect-error
-			(stats, callback) => {
+			(_stats, callback) => {
 				if (compiler.watchMode) return callback();
 				session.post("Profiler.stop", (error, param) => {
 					if (error) {
@@ -194,11 +193,9 @@ class RspackProfileJSCPUProfilePlugin {
 class RspackProfileLoggingPlugin {
 	constructor(private output: string) {}
 
-	// @ts-expect-error
-	apply(compiler) {
+	apply(compiler: Compiler) {
 		compiler.hooks.done.tapAsync(
 			RspackProfileLoggingPlugin.name,
-			// @ts-expect-error
 			(stats, callback) => {
 				if (compiler.watchMode) return callback();
 				const logging = stats.toJson({


### PR DESCRIPTION
part of #4640

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
This fixes all ts-expect-error in packages/rspack-cli.  Errors are most related to 
* nullable config. 
* unannotated callback
* not importing types

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->
`tsc --noEmit`

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
