### PR TITLE
fix: fix filenames with multiple bytes in match-resource

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -240,7 +240,7 @@ impl NormalModuleFactory {
 
             match request_without_match_resource
               .char_indices()
-              .nth(whole_matched.len())
+              .nth(whole_matched.chars().count())
             {
               Some((pos, _)) => &request_without_match_resource[pos..],
               None => {

--- a/packages/rspack/tests/configCases/loader/issue-4630/index.js
+++ b/packages/rspack/tests/configCases/loader/issue-4630/index.js
@@ -1,0 +1,9 @@
+it("should able to handle filenames with multiple bytes with inline-match-resource", () => {
+	expect(require("./你好世界.js!=!./你好世界.js")).toBe("你好世界");
+	expect(require("./こんにちは世界.js!=!./こんにちは世界.js")).toBe(
+		"こんにちは世界"
+	);
+	expect(require("./반갑구나세상아.js!=!./반갑구나세상아.js")).toBe(
+		"반갑구나,세상아"
+	);
+});

--- a/packages/rspack/tests/configCases/loader/issue-4630/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/issue-4630/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	context: __dirname
+};

--- a/packages/rspack/tests/configCases/loader/issue-4630/こんにちは世界.js
+++ b/packages/rspack/tests/configCases/loader/issue-4630/こんにちは世界.js
@@ -1,0 +1,1 @@
+module.exports = "こんにちは世界";

--- a/packages/rspack/tests/configCases/loader/issue-4630/你好世界.js
+++ b/packages/rspack/tests/configCases/loader/issue-4630/你好世界.js
@@ -1,0 +1,1 @@
+module.exports = "你好世界";

--- a/packages/rspack/tests/configCases/loader/issue-4630/반갑구나세상아.js
+++ b/packages/rspack/tests/configCases/loader/issue-4630/반갑구나세상아.js
@@ -1,0 +1,1 @@
+module.exports = "반갑구나,세상아";

--- a/x.mjs
+++ b/x.mjs
@@ -2,11 +2,14 @@
 
 import "zx/globals";
 import chalk from "chalk";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { Command } from "commander";
 import { version_handler } from "./scripts/release/version.mjs";
 import { publish_handler } from "./scripts/release/publish.mjs";
 const { yellow } = chalk;
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 process.env.FORCE_COLOR = 3; // Fix zx losing color output in subprocesses
 
 const program = new Command();
@@ -229,7 +232,7 @@ program.parse(argv, { from: "user" });
 async function launchRspackCli(additionalArgs) {
 	let args = [
 		"--inspect-brk",
-		"${workspaceFolder}/packages/rspack-cli/bin/rspack",
+		path.join(__dirname, "/packages/rspack-cli/bin/rspack"),
 		...additionalArgs
 	];
 	let launch = [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

closes https://github.com/web-infra-dev/rspack/issues/4630

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
