### PR TITLE
fix: 🐛 export default expr codegen should keep expr lead commen

### DIFF
--- a/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/new_treeshaking.snap
@@ -14,7 +14,7 @@ function res() {
     answer;
 }
  const a = 3;
-var __WEBPACK_DEFAULT_EXPORT__ = (/* unused pure expression or super */ null && (res()));
+var __WEBPACK_DEFAULT_EXPORT__ = /*#__PURE__*/ (/* unused pure expression or super */ null && (res()));
 }),
 "./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/output.snap
@@ -23,7 +23,7 @@ function res() {
     _answer__WEBPACK_IMPORTED_MODULE_0__.answer;
 }
  const a = 3;
-var __WEBPACK_DEFAULT_EXPORT__ = res();
+var __WEBPACK_DEFAULT_EXPORT__ = /*#__PURE__*/ res();
 }),
 "./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";

--- a/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/snap.diff
+++ b/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/snap.diff
@@ -25,8 +25,8 @@
 +    answer;
  }
   const a = 3;
--var __WEBPACK_DEFAULT_EXPORT__ = res();
-+var __WEBPACK_DEFAULT_EXPORT__ = (/* unused pure expression or super */ null && (res()));
+-var __WEBPACK_DEFAULT_EXPORT__ = /*#__PURE__*/ res();
++var __WEBPACK_DEFAULT_EXPORT__ = /*#__PURE__*/ (/* unused pure expression or super */ null && (res()));
  }),
  "./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
  "use strict";

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -154,12 +154,14 @@ pub fn scan_dependencies(
       build_info,
       &mut rewrite_usage_span,
     ));
+    let comments = program.comments.as_ref();
     program.visit_with(&mut HarmonyExportDependencyScanner::new(
       &mut dependencies,
       &mut presentational_dependencies,
       &mut import_map,
       build_info,
       &mut rewrite_usage_span,
+      comments,
     ));
 
     if build_meta.esm {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
