### PR TITLE
feat: support `ContextDependency`

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -428,7 +428,7 @@ impl From<RawGeneratorOptions> for GeneratorOptions {
       ),
       "unknown" => Self::Unknown,
       _ => panic!(
-        "Failed to resolve the RawGeneratorOptions.type {}. Expected type is \"asset\", \"asset/inline\", \"asset/resource\", \"unknown\".",
+        r#"Failed to resolve the RawGeneratorOptions.type {}. Expected type is "asset", "asset/inline", "asset/resource", "unknown"."#,
         value.r#type
       ),
     }

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -49,6 +49,19 @@ pub enum ContextMode {
   LazyOnce,
 }
 
+impl ContextMode {
+  pub fn as_str(&self) -> &str {
+    match self {
+      ContextMode::Sync => "sync",
+      ContextMode::Eager => "eager",
+      ContextMode::Weak => "weak",
+      ContextMode::Lazy => "lazy",
+      ContextMode::LazyOnce => "lazy-once",
+      ContextMode::AsyncWeak => "async-weak",
+    }
+  }
+}
+
 impl From<&str> for ContextMode {
   fn from(value: &str) -> Self {
     match value {
@@ -57,6 +70,7 @@ impl From<&str> for ContextMode {
       "weak" => ContextMode::Weak,
       "lazy" => ContextMode::Lazy,
       "lazy-once" => ContextMode::LazyOnce,
+      "async-weak" => ContextMode::AsyncWeak,
       // TODO should give warning
       _ => panic!("unknown context mode"),
     }
@@ -104,23 +118,6 @@ pub struct ContextOptions {
   pub request: String,
   pub namespace_object: ContextNameSpaceObject,
   pub chunk_name: Option<String>,
-}
-
-impl Display for ContextOptions {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(
-      f,
-      "({:?}, {}, {},  {:?}, {:?},  {:?}, {}, {:?})",
-      self.mode,
-      self.recursive,
-      self.reg_str,
-      self.include,
-      self.exclude,
-      self.category,
-      self.request,
-      self.namespace_object
-    )
-  }
 }
 
 impl PartialEq for ContextOptions {
@@ -305,13 +302,17 @@ impl ContextModule {
           .module_graph
           .module_identifier_by_dependency_id(dependency)
         {
-          if let Some(dependency) = compilation
-            .module_graph
-            .dependency_by_id(dependency)
-            .and_then(|d| d.as_module_dependency())
-          {
+          let dep = compilation.module_graph.dependency_by_id(dependency);
+          let request = if let Some(d) = dep.and_then(|d| d.as_module_dependency()) {
+            Some(d.user_request().to_string())
+          } else {
+            dep
+              .and_then(|d| d.as_context_dependency())
+              .map(|d| d.request().to_string())
+          };
+          if let Some(request) = request {
             map.insert(
-              dependency.user_request().to_string(),
+              request,
               if let Some(module_id) = compilation.chunk_graph.get_module_id(*module_identifier) {
                 format!("\"{module_id}\"")
               } else {
@@ -683,7 +684,7 @@ impl ContextModule {
     Ok(())
   }
 
-  pub fn resolve_dependencies(
+  fn resolve_dependencies(
     &self,
     build_context: BuildContext<'_>,
   ) -> Result<TWithDiagnosticArray<BuildResult>> {
@@ -861,8 +862,4 @@ fn alternative_requests(
   }
 
   items
-}
-
-pub fn create_resource_identifier_for_context_dependency(options: &ContextOptions) -> String {
-  format!("{options}")
 }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -37,13 +37,13 @@ impl ContextModuleFactory {
     }
   }
 
-  pub async fn before_resolve(
+  async fn before_resolve(
     &mut self,
     data: &mut ModuleFactoryCreateData,
   ) -> Result<Option<TWithDiagnosticArray<ModuleFactoryResult>>> {
     let dependency = data
       .dependency
-      .as_module_dependency_mut()
+      .as_context_dependency_mut()
       .expect("should be module dependency");
     let mut before_resolve_args = NormalModuleBeforeResolveArgs {
       request: dependency.request().to_string(),
@@ -74,14 +74,14 @@ impl ContextModuleFactory {
     Ok(None)
   }
 
-  pub async fn resolve(
+  async fn resolve(
     &self,
     data: ModuleFactoryCreateData,
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>> {
     let dependency = data
       .dependency
-      .as_module_dependency()
-      .expect("should be module dependency");
+      .as_context_dependency()
+      .expect("should be context dependency");
     let factory_meta = Default::default();
     let mut file_dependencies = Default::default();
     let mut missing_dependencies = Default::default();
@@ -119,14 +119,13 @@ impl ContextModuleFactory {
           resource_query: resource.query,
           resource_fragment: resource.fragment,
           resolve_options: data.resolve_options,
-          context_options: dependency.options().expect("should has options").clone(),
+          context_options: dependency.options().clone(),
         },
         plugin_driver.resolver_factory.clone(),
       )) as BoxModule,
       Ok(ResolveResult::Ignored) => {
         let ident = format!("{}/{}", data.context, specifier);
         let module_identifier = ModuleIdentifier::from(format!("ignored|{ident}"));
-
         let raw_module = RawModule::new(
           "/* (ignored) */".to_owned(),
           module_identifier,
@@ -134,7 +133,6 @@ impl ContextModuleFactory {
           Default::default(),
         )
         .boxed();
-
         return Ok(ModuleFactoryResult::new(raw_module).with_empty_diagnostic());
       }
       Err(ResolveError(runtime_error, internal_error)) => {

--- a/crates/rspack_core/src/dependency/context_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_dependency.rs
@@ -1,0 +1,29 @@
+use crate::{ContextOptions, Dependency};
+
+pub trait ContextDependency: Dependency {
+  fn request(&self) -> &str;
+  fn options(&self) -> &ContextOptions;
+  fn get_context(&self) -> Option<&str>;
+  fn resource_identifier(&self) -> &str;
+  fn set_request(&mut self, request: String);
+}
+
+pub trait AsContextDependency {
+  fn as_context_dependency(&self) -> Option<&dyn ContextDependency> {
+    None
+  }
+
+  fn as_context_dependency_mut(&mut self) -> Option<&mut dyn ContextDependency> {
+    None
+  }
+}
+
+impl<T: ContextDependency> AsContextDependency for T {
+  fn as_context_dependency(&self) -> Option<&dyn ContextDependency> {
+    Some(self)
+  }
+
+  fn as_context_dependency_mut(&mut self) -> Option<&mut dyn ContextDependency> {
+    Some(self)
+  }
+}

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -1,10 +1,10 @@
 use swc_core::ecma::atoms::JsWord;
 
-use crate::{
-  AsDependencyTemplate, Context, ContextMode, ContextOptions, Dependency, DependencyCategory,
-  DependencyId, DependencyType, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
-  ReferencedExport, RuntimeSpec,
-};
+use crate::{AsContextDependency, AsDependencyTemplate, Context};
+use crate::{ContextMode, ContextOptions, Dependency};
+use crate::{DependencyCategory, DependencyId, DependencyType};
+use crate::{ExtendedReferencedExport, ModuleDependency};
+use crate::{ModuleGraph, ReferencedExport, RuntimeSpec};
 
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub struct ContextElementDependency {
@@ -39,6 +39,10 @@ impl Dependency for ContextElementDependency {
   fn get_context(&self) -> Option<&Context> {
     Some(&self.context)
   }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
+  }
 }
 
 impl ModuleDependency for ContextElementDependency {
@@ -57,16 +61,8 @@ impl ModuleDependency for ContextElementDependency {
     )
   }
 
-  fn options(&self) -> Option<&ContextOptions> {
-    Some(&self.options)
-  }
-
   fn set_request(&mut self, request: String) {
     self.request = request;
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
   }
 
   fn get_referenced_exports(
@@ -83,3 +79,4 @@ impl ModuleDependency for ContextElementDependency {
 }
 
 impl AsDependencyTemplate for ContextElementDependency {}
+impl AsContextDependency for ContextElementDependency {}

--- a/crates/rspack_core/src/dependency/dependency_category.rs
+++ b/crates/rspack_core/src/dependency/dependency_category.rs
@@ -1,0 +1,52 @@
+use std::fmt::{Debug, Display};
+use std::hash::Hash;
+
+#[derive(Default, Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum DependencyCategory {
+  #[default]
+  Unknown,
+  Esm,
+  CommonJS,
+  Url,
+  CssImport,
+  CssCompose,
+  Wasm,
+  Worker,
+}
+
+impl From<&str> for DependencyCategory {
+  fn from(value: &str) -> Self {
+    match value {
+      "esm" => Self::Esm,
+      "commonjs" => Self::CommonJS,
+      "url" => Self::Url,
+      "wasm" => Self::Wasm,
+      "css-import" => Self::CssImport,
+      "css-compose" => Self::CssCompose,
+      "worker" => Self::Worker,
+      "unknown" => Self::Unknown,
+      _ => unimplemented!("DependencyCategory {}", value),
+    }
+  }
+}
+
+impl DependencyCategory {
+  pub fn as_str(&self) -> &'static str {
+    match self {
+      DependencyCategory::Unknown => "unknown",
+      DependencyCategory::Esm => "esm",
+      DependencyCategory::CommonJS => "commonjs",
+      DependencyCategory::Url => "url",
+      DependencyCategory::CssImport => "css-import",
+      DependencyCategory::CssCompose => "css-compose",
+      DependencyCategory::Wasm => "wasm",
+      DependencyCategory::Worker => "worker",
+    }
+  }
+}
+
+impl Display for DependencyCategory {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.as_str())
+  }
+}

--- a/crates/rspack_core/src/dependency/dependency_id.rs
+++ b/crates/rspack_core/src/dependency/dependency_id.rs
@@ -1,0 +1,62 @@
+use std::sync::atomic::Ordering::Relaxed;
+use std::{collections::hash_map::Entry, sync::atomic::AtomicU32};
+
+use serde::Serialize;
+use swc_core::ecma::atoms::JsWord;
+
+use crate::{BoxDependency, DependencyExtraMeta, ModuleGraph};
+
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+pub struct DependencyId(u32);
+
+pub static DEPENDENCY_ID: AtomicU32 = AtomicU32::new(0);
+
+impl DependencyId {
+  pub fn get_dependency<'a>(&self, mg: &'a ModuleGraph) -> &'a BoxDependency {
+    mg.dependency_by_id(self).expect("should have dependency")
+  }
+
+  pub fn new() -> Self {
+    Self(DEPENDENCY_ID.fetch_add(1, Relaxed))
+  }
+
+  pub fn set_ids(&self, ids: Vec<JsWord>, mg: &mut ModuleGraph) {
+    match mg.dep_meta_map.entry(*self) {
+      Entry::Occupied(mut occ) => {
+        occ.get_mut().ids = ids;
+      }
+      Entry::Vacant(vac) => {
+        vac.insert(DependencyExtraMeta { ids });
+      }
+    };
+  }
+
+  /// # Panic
+  /// This method will panic if one of following condition is true:
+  /// * current dependency id is not belongs to `HarmonyImportSpecifierDependency` or  `HarmonyExportImportedSpecifierDependency`
+  /// * current id is not in `ModuleGraph`
+  pub fn get_ids(&self, mg: &ModuleGraph) -> Vec<JsWord> {
+    let dep = mg.dependency_by_id(self).expect("should have dep");
+    dep.get_ids(mg)
+  }
+}
+
+impl Default for DependencyId {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl std::ops::Deref for DependencyId {
+  type Target = u32;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl From<u32> for DependencyId {
+  fn from(id: u32) -> Self {
+    Self(id)
+  }
+}

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -1,0 +1,97 @@
+use std::{any::Any, fmt::Debug};
+
+use dyn_clone::{clone_trait_object, DynClone};
+use rspack_util::ext::AsAny;
+use rustc_hash::FxHashSet as HashSet;
+use swc_core::{common::Span, ecma::atoms::JsWord};
+
+use super::dependency_template::AsDependencyTemplate;
+use super::module_dependency::*;
+use super::ExportsSpec;
+use super::{DependencyCategory, DependencyId, DependencyType};
+use crate::AsContextDependency;
+use crate::{ConnectionState, Context, ErrorSpan, ModuleGraph, ModuleIdentifier, UsedByExports};
+
+pub trait Dependency:
+  AsDependencyTemplate
+  + AsContextDependency
+  + AsModuleDependency
+  + AsAny
+  + DynClone
+  + Send
+  + Sync
+  + Debug
+{
+  /// name of the original struct or enum
+  fn dependency_debug_name(&self) -> &'static str;
+
+  fn id(&self) -> &DependencyId;
+
+  fn category(&self) -> &DependencyCategory {
+    &DependencyCategory::Unknown
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    &DependencyType::Unknown
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    None
+  }
+
+  fn get_exports(&self, _mg: &ModuleGraph) -> Option<ExportsSpec> {
+    None
+  }
+
+  fn set_used_by_exports(&mut self, _used_by_exports: Option<UsedByExports>) {}
+
+  fn get_module_evaluation_side_effects_state(
+    &self,
+    _module_graph: &ModuleGraph,
+    _module_chain: &mut HashSet<ModuleIdentifier>,
+  ) -> ConnectionState {
+    ConnectionState::Bool(true)
+  }
+
+  fn span(&self) -> Option<ErrorSpan> {
+    None
+  }
+
+  /// `Span` used for Dependency search in `on_usage` in `InnerGraph`
+  fn span_for_on_usage_search(&self) -> Option<ErrorSpan> {
+    self.span()
+  }
+
+  fn is_span_equal(&self, other: &Span) -> bool {
+    if let Some(err_span) = self.span_for_on_usage_search() {
+      let other = ErrorSpan::from(*other);
+      other == err_span
+    } else {
+      false
+    }
+  }
+
+  // For now only `HarmonyImportSpecifierDependency` and
+  // `HarmonyExportImportedSpecifierDependency` can use this method
+  fn get_ids(&self, _mg: &ModuleGraph) -> Vec<JsWord> {
+    unreachable!()
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    None
+  }
+}
+
+impl dyn Dependency + '_ {
+  pub fn downcast_ref<D: Any>(&self) -> Option<&D> {
+    self.as_any().downcast_ref::<D>()
+  }
+
+  pub fn downcast_mut<D: Any>(&mut self) -> Option<&mut D> {
+    self.as_any_mut().downcast_mut::<D>()
+  }
+}
+
+clone_trait_object!(Dependency);
+
+pub type BoxDependency = Box<dyn Dependency>;

--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -1,0 +1,109 @@
+use std::borrow::Cow;
+use std::fmt::{Debug, Display};
+
+use crate::ErrorSpan;
+
+// Used to describe dependencies' types, see webpack's `type` getter in `Dependency`
+// Note: This is almost the same with the old `ResolveKind`
+#[derive(Default, Clone, PartialEq, Eq, Hash, Debug)]
+pub enum DependencyType {
+  #[default]
+  Unknown,
+  ExportInfoApi,
+  Entry,
+  // Harmony import
+  EsmImport(/* HarmonyImportSideEffectDependency.span */ ErrorSpan), /* TODO: remove span after old tree shaking is removed */
+  EsmImportSpecifier,
+  // Harmony export
+  EsmExport(ErrorSpan),
+  EsmExportImportedSpecifier,
+  EsmExportSpecifier,
+  // import()
+  DynamicImport,
+  // import() eager
+  DynamicImportEager,
+  // cjs require
+  CjsRequire,
+  // new URL("./foo", import.meta.url)
+  NewUrl,
+  // new Worker()
+  NewWorker,
+  // import.meta.webpackHot.accept
+  ImportMetaHotAccept,
+  // import.meta.webpackHot.decline
+  ImportMetaHotDecline,
+  // module.hot.accept
+  ModuleHotAccept,
+  // module.hot.decline
+  ModuleHotDecline,
+  // css url()
+  CssUrl,
+  // css @import
+  CssImport,
+  // css modules compose
+  CssCompose,
+  // context element
+  ContextElement,
+  // import context
+  ImportContext,
+  // import.meta.webpackContext
+  ImportMetaContext,
+  // commonjs require context
+  CommonJSRequireContext,
+  // require.context
+  RequireContext,
+  // require.resolve
+  RequireResolve,
+  /// wasm import
+  WasmImport,
+  /// wasm export import
+  WasmExportImported,
+  /// static exports
+  StaticExports,
+  Custom(Box<str>), // TODO it will increase large layout size
+}
+
+impl DependencyType {
+  pub fn as_str(&self) -> Cow<str> {
+    match self {
+      DependencyType::Unknown => Cow::Borrowed("unknown"),
+      DependencyType::Entry => Cow::Borrowed("entry"),
+      DependencyType::EsmImport(_) => Cow::Borrowed("esm import"),
+      DependencyType::EsmExport(_) => Cow::Borrowed("esm export"),
+      DependencyType::EsmExportSpecifier => Cow::Borrowed("esm export specifier"),
+      DependencyType::EsmExportImportedSpecifier => Cow::Borrowed("esm export import specifier"),
+      DependencyType::EsmImportSpecifier => Cow::Borrowed("esm import specifier"),
+      DependencyType::DynamicImport => Cow::Borrowed("dynamic import"),
+      DependencyType::CjsRequire => Cow::Borrowed("cjs require"),
+      DependencyType::NewUrl => Cow::Borrowed("new URL()"),
+      DependencyType::NewWorker => Cow::Borrowed("new Worker()"),
+      DependencyType::ImportMetaHotAccept => Cow::Borrowed("import.meta.webpackHot.accept"),
+      DependencyType::ImportMetaHotDecline => Cow::Borrowed("import.meta.webpackHot.decline"),
+      DependencyType::ModuleHotAccept => Cow::Borrowed("module.hot.accept"),
+      DependencyType::ModuleHotDecline => Cow::Borrowed("module.hot.decline"),
+      DependencyType::CssUrl => Cow::Borrowed("css url"),
+      DependencyType::CssImport => Cow::Borrowed("css import"),
+      DependencyType::CssCompose => Cow::Borrowed("css compose"),
+      DependencyType::ContextElement => Cow::Borrowed("context element"),
+      // TODO: mode
+      DependencyType::ImportContext => Cow::Borrowed("import context"),
+      DependencyType::DynamicImportEager => Cow::Borrowed("import() eager"),
+      DependencyType::CommonJSRequireContext => Cow::Borrowed("commonjs require context"),
+      DependencyType::RequireContext => Cow::Borrowed("require.context"),
+      DependencyType::RequireResolve => Cow::Borrowed("require.resolve"),
+      DependencyType::WasmImport => Cow::Borrowed("wasm import"),
+      DependencyType::WasmExportImported => Cow::Borrowed("wasm export imported"),
+      DependencyType::StaticExports => Cow::Borrowed("static exports"),
+      DependencyType::Custom(ty) => Cow::Owned(format!("custom {ty}")),
+      DependencyType::ExportInfoApi => Cow::Borrowed("export info api"),
+      // TODO: mode
+      DependencyType::ImportMetaContext => Cow::Borrowed("import.meta context"),
+    }
+  }
+}
+
+impl Display for DependencyType {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.as_str())
+  }
+}

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -1,6 +1,6 @@
 use crate::{
-  AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId, DependencyType,
-  ModuleDependency,
+  AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ModuleDependency,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
@@ -57,3 +57,4 @@ impl ModuleDependency for EntryDependency {
 }
 
 impl AsDependencyTemplate for EntryDependency {}
+impl AsContextDependency for EntryDependency {}

--- a/crates/rspack_core/src/dependency/import_dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/import_dependency_trait.rs
@@ -1,0 +1,20 @@
+use swc_core::ecma::atoms::JsWord;
+
+use crate::{ExtendedReferencedExport, ModuleDependency};
+use crate::{ModuleGraph, ReferencedExport, RuntimeSpec};
+
+pub trait ImportDependencyTrait: ModuleDependency {
+  fn referenced_exports(&self) -> Option<&Vec<JsWord>>;
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &ModuleGraph,
+    _runtime: Option<&RuntimeSpec>,
+  ) -> Vec<ExtendedReferencedExport> {
+    if let Some(referenced_exports) = self.referenced_exports() {
+      vec![ReferencedExport::new(referenced_exports.clone(), false).into()]
+    } else {
+      vec![ExtendedReferencedExport::Array(vec![])]
+    }
+  }
+}

--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -1,254 +1,39 @@
-mod entry;
-mod span;
-use std::borrow::Cow;
-use std::sync::atomic::Ordering::Relaxed;
-use std::{collections::hash_map::Entry, sync::atomic::AtomicU32};
-
-pub use entry::*;
-use once_cell::sync::Lazy;
-use rspack_util::ext::AsAny;
-use rustc_hash::FxHashSet as HashSet;
-use serde::Serialize;
-pub use span::SpanExt;
-mod runtime_template;
-pub use runtime_template::*;
-mod runtime_requirements_dependency;
-pub use runtime_requirements_dependency::RuntimeRequirementsDependency;
-mod context_element_dependency;
-mod dependency_macro;
-pub use context_element_dependency::*;
-use swc_core::{common::Span, ecma::atoms::JsWord};
 mod const_dependency;
-use std::{
-  any::Any,
-  fmt::{Debug, Display},
-  hash::Hash,
-};
+mod context_dependency;
+mod context_element_dependency;
+mod dependency_category;
+mod dependency_id;
+mod dependency_macro;
+mod dependency_template;
+mod dependency_trait;
+mod dependency_type;
+mod entry;
+mod import_dependency_trait;
+mod module_dependency;
+mod runtime_requirements_dependency;
+mod runtime_template;
+mod span;
 
 pub use const_dependency::ConstDependency;
-mod dependency_template;
+pub use context_dependency::{AsContextDependency, ContextDependency};
+pub use context_element_dependency::ContextElementDependency;
+pub use dependency_category::DependencyCategory;
+pub use dependency_id::*;
 pub use dependency_template::*;
-use dyn_clone::{clone_trait_object, DynClone};
+pub use dependency_trait::*;
+pub use dependency_type::DependencyType;
+pub use entry::*;
+pub use import_dependency_trait::ImportDependencyTrait;
+pub use module_dependency::*;
+pub use runtime_requirements_dependency::RuntimeRequirementsDependency;
+pub use runtime_template::*;
+pub use span::SpanExt;
+use swc_core::ecma::atoms::JsWord;
 
 use crate::{
-  ConnectionState, Context, ContextOptions, DependencyExtraMeta, ErrorSpan,
-  ExtendedReferencedExport, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ReferencedExport,
-  RuntimeSpec, UsedByExports,
+  ConnectionState, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ReferencedExport,
+  RuntimeSpec,
 };
-
-// Used to describe dependencies' types, see webpack's `type` getter in `Dependency`
-// Note: This is almost the same with the old `ResolveKind`
-#[derive(Default, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum DependencyType {
-  #[default]
-  Unknown,
-  ExportInfoApi,
-  Entry,
-  // Harmony import
-  EsmImport(/* HarmonyImportSideEffectDependency.span */ ErrorSpan), /* TODO: remove span after old tree shaking is removed */
-  EsmImportSpecifier,
-  // Harmony export
-  EsmExport(ErrorSpan),
-  EsmExportImportedSpecifier,
-  EsmExportSpecifier,
-  // import()
-  DynamicImport,
-  // import() eager
-  DynamicImportEager,
-  // cjs require
-  CjsRequire,
-  // new URL("./foo", import.meta.url)
-  NewUrl,
-  // new Worker()
-  NewWorker,
-  // import.meta.webpackHot.accept
-  ImportMetaHotAccept,
-  // import.meta.webpackHot.decline
-  ImportMetaHotDecline,
-  // module.hot.accept
-  ModuleHotAccept,
-  // module.hot.decline
-  ModuleHotDecline,
-  // css url()
-  CssUrl,
-  // css @import
-  CssImport,
-  // css modules compose
-  CssCompose,
-  // context element
-  ContextElement,
-  // import context
-  ImportContext,
-  // import.meta.webpackContext
-  ImportMetaContext,
-  // commonjs require context
-  CommonJSRequireContext,
-  // require.context
-  RequireContext,
-  // require.resolve
-  RequireResolve,
-  /// wasm import
-  WasmImport,
-  /// wasm export import
-  WasmExportImported,
-  /// static exports
-  StaticExports,
-  Custom(Box<str>), // TODO it will increase large layout size
-}
-
-impl DependencyType {
-  pub fn as_str(&self) -> Cow<str> {
-    match self {
-      DependencyType::Unknown => Cow::Borrowed("unknown"),
-      DependencyType::Entry => Cow::Borrowed("entry"),
-      DependencyType::EsmImport(_) => Cow::Borrowed("esm import"),
-      DependencyType::EsmExport(_) => Cow::Borrowed("esm export"),
-      DependencyType::EsmExportSpecifier => Cow::Borrowed("esm export specifier"),
-      DependencyType::EsmExportImportedSpecifier => Cow::Borrowed("esm export import specifier"),
-      DependencyType::EsmImportSpecifier => Cow::Borrowed("esm import specifier"),
-      DependencyType::DynamicImport => Cow::Borrowed("dynamic import"),
-      DependencyType::CjsRequire => Cow::Borrowed("cjs require"),
-      DependencyType::NewUrl => Cow::Borrowed("new URL()"),
-      DependencyType::NewWorker => Cow::Borrowed("new Worker()"),
-      DependencyType::ImportMetaHotAccept => Cow::Borrowed("import.meta.webpackHot.accept"),
-      DependencyType::ImportMetaHotDecline => Cow::Borrowed("import.meta.webpackHot.decline"),
-      DependencyType::ModuleHotAccept => Cow::Borrowed("module.hot.accept"),
-      DependencyType::ModuleHotDecline => Cow::Borrowed("module.hot.decline"),
-      DependencyType::CssUrl => Cow::Borrowed("css url"),
-      DependencyType::CssImport => Cow::Borrowed("css import"),
-      DependencyType::CssCompose => Cow::Borrowed("css compose"),
-      DependencyType::ContextElement => Cow::Borrowed("context element"),
-      // TODO: mode
-      DependencyType::ImportContext => Cow::Borrowed("import context"),
-      DependencyType::DynamicImportEager => Cow::Borrowed("import() eager"),
-      DependencyType::CommonJSRequireContext => Cow::Borrowed("commonjs require context"),
-      DependencyType::RequireContext => Cow::Borrowed("require.context"),
-      DependencyType::RequireResolve => Cow::Borrowed("require.resolve"),
-      DependencyType::WasmImport => Cow::Borrowed("wasm import"),
-      DependencyType::WasmExportImported => Cow::Borrowed("wasm export imported"),
-      DependencyType::StaticExports => Cow::Borrowed("static exports"),
-      DependencyType::Custom(ty) => Cow::Owned(format!("custom {ty}")),
-      DependencyType::ExportInfoApi => Cow::Borrowed("export info api"),
-      // TODO: mode
-      DependencyType::ImportMetaContext => Cow::Borrowed("import.meta context"),
-    }
-  }
-}
-
-impl Display for DependencyType {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.as_str())
-  }
-}
-
-#[derive(Default, Copy, Clone, PartialEq, Eq, Hash, Debug)]
-pub enum DependencyCategory {
-  #[default]
-  Unknown,
-  Esm,
-  CommonJS,
-  Url,
-  CssImport,
-  CssCompose,
-  Wasm,
-  Worker,
-}
-
-impl From<&str> for DependencyCategory {
-  fn from(value: &str) -> Self {
-    match value {
-      "esm" => Self::Esm,
-      "commonjs" => Self::CommonJS,
-      "url" => Self::Url,
-      "wasm" => Self::Wasm,
-      "css-import" => Self::CssImport,
-      "css-compose" => Self::CssCompose,
-      "worker" => Self::Worker,
-      "unknown" => Self::Unknown,
-      _ => unimplemented!("DependencyCategory {}", value),
-    }
-  }
-}
-
-impl DependencyCategory {
-  pub fn as_str(&self) -> &'static str {
-    match self {
-      DependencyCategory::Unknown => "unknown",
-      DependencyCategory::Esm => "esm",
-      DependencyCategory::CommonJS => "commonjs",
-      DependencyCategory::Url => "url",
-      DependencyCategory::CssImport => "css-import",
-      DependencyCategory::CssCompose => "css-compose",
-      DependencyCategory::Wasm => "wasm",
-      DependencyCategory::Worker => "worker",
-    }
-  }
-}
-
-impl Display for DependencyCategory {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}", self.as_str())
-  }
-}
-
-pub trait Dependency:
-  AsDependencyTemplate + AsModuleDependency + AsAny + DynClone + Send + Sync + Debug
-{
-  /// name of the original struct or enum
-  fn dependency_debug_name(&self) -> &'static str;
-
-  fn id(&self) -> &DependencyId;
-
-  fn category(&self) -> &DependencyCategory {
-    &DependencyCategory::Unknown
-  }
-
-  fn dependency_type(&self) -> &DependencyType {
-    &DependencyType::Unknown
-  }
-
-  fn get_context(&self) -> Option<&Context> {
-    None
-  }
-
-  fn get_exports(&self, _mg: &ModuleGraph) -> Option<ExportsSpec> {
-    None
-  }
-
-  fn set_used_by_exports(&mut self, _used_by_exports: Option<UsedByExports>) {}
-
-  fn get_module_evaluation_side_effects_state(
-    &self,
-    _module_graph: &ModuleGraph,
-    _module_chain: &mut HashSet<ModuleIdentifier>,
-  ) -> ConnectionState {
-    ConnectionState::Bool(true)
-  }
-
-  fn span(&self) -> Option<ErrorSpan> {
-    None
-  }
-
-  /// `Span` used for Dependency search in `on_usage` in `InnerGraph`
-  fn span_for_on_usage_search(&self) -> Option<ErrorSpan> {
-    self.span()
-  }
-
-  fn is_span_equal(&self, other: &Span) -> bool {
-    if let Some(err_span) = self.span_for_on_usage_search() {
-      let other = ErrorSpan::from(*other);
-      other == err_span
-    } else {
-      false
-    }
-  }
-
-  // For now only `HarmonyImportSpecifierDependency` and
-  // `HarmonyExportImportedSpecifierDependency` can use this method
-  fn get_ids(&self, _mg: &ModuleGraph) -> Vec<JsWord> {
-    unreachable!()
-  }
-}
 
 #[derive(Debug, Default)]
 pub struct ExportSpec {
@@ -342,26 +127,6 @@ impl From<Vec<ReferencedExport>> for ExportsReferencedType {
   }
 }
 
-pub trait AsModuleDependency {
-  fn as_module_dependency(&self) -> Option<&dyn ModuleDependency> {
-    None
-  }
-
-  fn as_module_dependency_mut(&mut self) -> Option<&mut dyn ModuleDependency> {
-    None
-  }
-}
-
-impl<T: ModuleDependency> AsModuleDependency for T {
-  fn as_module_dependency(&self) -> Option<&dyn ModuleDependency> {
-    Some(self)
-  }
-
-  fn as_module_dependency_mut(&mut self) -> Option<&mut dyn ModuleDependency> {
-    Some(self)
-  }
-}
-
 pub type DependencyConditionFn = Box<dyn Function>;
 
 pub trait Function:
@@ -396,137 +161,13 @@ pub enum DependencyCondition {
   Fn(DependencyConditionFn),
 }
 
-impl Debug for DependencyCondition {
+impl std::fmt::Debug for DependencyCondition {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
       // Self::Nil => write!(f, "Nil"),
       Self::False => write!(f, "False"),
       Self::Fn(_) => write!(f, "Fn"),
     }
-  }
-}
-
-pub trait ModuleDependency: Dependency {
-  fn request(&self) -> &str;
-  fn user_request(&self) -> &str;
-  fn weak(&self) -> bool {
-    false
-  }
-  fn set_request(&mut self, request: String);
-
-  // TODO should split to `ModuleDependency` and `ContextDependency`
-  fn options(&self) -> Option<&ContextOptions> {
-    None
-  }
-
-  fn get_optional(&self) -> bool {
-    false
-  }
-
-  fn get_condition(&self) -> Option<DependencyCondition> {
-    None
-  }
-
-  fn get_referenced_exports(
-    &self,
-    _module_graph: &ModuleGraph,
-    _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
-    vec![ExtendedReferencedExport::Array(vec![])]
-  }
-
-  // an identifier to merge equal requests
-  fn resource_identifier(&self) -> Option<&str> {
-    None
-  }
-
-  fn is_export_all(&self) -> Option<bool> {
-    None
-  }
-}
-
-pub trait ImportDependencyTrait: ModuleDependency {
-  fn referenced_exports(&self) -> Option<&Vec<JsWord>>;
-
-  fn get_referenced_exports(
-    &self,
-    _module_graph: &ModuleGraph,
-    _runtime: Option<&RuntimeSpec>,
-  ) -> Vec<ExtendedReferencedExport> {
-    if let Some(referenced_exports) = self.referenced_exports() {
-      vec![ReferencedExport::new(referenced_exports.clone(), false).into()]
-    } else {
-      vec![ExtendedReferencedExport::Array(vec![])]
-    }
-  }
-}
-
-impl dyn Dependency + '_ {
-  pub fn downcast_ref<D: Any>(&self) -> Option<&D> {
-    self.as_any().downcast_ref::<D>()
-  }
-
-  pub fn downcast_mut<D: Any>(&mut self) -> Option<&mut D> {
-    self.as_any_mut().downcast_mut::<D>()
-  }
-}
-
-clone_trait_object!(Dependency);
-clone_trait_object!(ModuleDependency);
-
-pub type BoxModuleDependency = Box<dyn ModuleDependency>;
-pub type BoxDependency = Box<dyn Dependency>;
-
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
-pub struct DependencyId(u32);
-
-pub static DEPENDENCY_ID: Lazy<AtomicU32> = Lazy::new(|| AtomicU32::new(0));
-
-impl DependencyId {
-  pub fn get_dependency<'a>(&self, mg: &'a ModuleGraph) -> &'a BoxDependency {
-    mg.dependency_by_id(self).expect("should have dependency")
-  }
-
-  pub fn new() -> Self {
-    Self(DEPENDENCY_ID.fetch_add(1, Relaxed))
-  }
-
-  pub fn set_ids(&self, ids: Vec<JsWord>, mg: &mut ModuleGraph) {
-    match mg.dep_meta_map.entry(*self) {
-      Entry::Occupied(mut occ) => {
-        occ.get_mut().ids = ids;
-      }
-      Entry::Vacant(vac) => {
-        vac.insert(DependencyExtraMeta { ids });
-      }
-    };
-  }
-  /// # Panic
-  /// This method will panic if one of following condition is true:
-  /// * current dependency id is not belongs to `HarmonyImportSpecifierDependency` or  `HarmonyExportImportedSpecifierDependency`
-  /// * current id is not in `ModuleGraph`
-  pub fn get_ids(&self, mg: &ModuleGraph) -> Vec<JsWord> {
-    let dep = mg.dependency_by_id(self).expect("should have dep");
-    dep.get_ids(mg)
-  }
-}
-impl Default for DependencyId {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
-impl std::ops::Deref for DependencyId {
-  type Target = u32;
-
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
-}
-
-impl From<u32> for DependencyId {
-  fn from(id: u32) -> Self {
-    Self(id)
   }
 }
 

--- a/crates/rspack_core/src/dependency/module_dependency.rs
+++ b/crates/rspack_core/src/dependency/module_dependency.rs
@@ -1,0 +1,55 @@
+use dyn_clone::clone_trait_object;
+
+use super::Dependency;
+use crate::{DependencyCondition, ExtendedReferencedExport, ModuleGraph, RuntimeSpec};
+
+pub trait ModuleDependency: Dependency {
+  fn request(&self) -> &str;
+  fn user_request(&self) -> &str;
+  fn weak(&self) -> bool {
+    false
+  }
+  fn set_request(&mut self, request: String);
+
+  fn get_optional(&self) -> bool {
+    false
+  }
+
+  fn get_condition(&self) -> Option<DependencyCondition> {
+    None
+  }
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &ModuleGraph,
+    _runtime: Option<&RuntimeSpec>,
+  ) -> Vec<ExtendedReferencedExport> {
+    vec![ExtendedReferencedExport::Array(vec![])]
+  }
+
+  fn is_export_all(&self) -> Option<bool> {
+    None
+  }
+}
+
+clone_trait_object!(ModuleDependency);
+
+pub trait AsModuleDependency {
+  fn as_module_dependency(&self) -> Option<&dyn ModuleDependency> {
+    None
+  }
+
+  fn as_module_dependency_mut(&mut self) -> Option<&mut dyn ModuleDependency> {
+    None
+  }
+}
+
+impl<T: ModuleDependency> AsModuleDependency for T {
+  fn as_module_dependency(&self) -> Option<&dyn ModuleDependency> {
+    Some(self)
+  }
+
+  fn as_module_dependency_mut(&mut self) -> Option<&mut dyn ModuleDependency> {
+    Some(self)
+  }
+}

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -84,5 +84,3 @@ pub trait ModuleFactory {
     data: ModuleFactoryCreateData,
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>>;
 }
-
-pub type BoxModuleFactory = Box<dyn ModuleFactory>;

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -74,10 +74,6 @@ impl ModuleGraph {
     &self.module_identifier_to_module
   }
 
-  pub fn modules_mut(&mut self) -> &mut IdentifierMap<BoxModule> {
-    &mut self.module_identifier_to_module
-  }
-
   pub fn module_graph_modules(&self) -> &IdentifierMap<ModuleGraphModule> {
     &self.module_identifier_to_module_graph_module
   }
@@ -134,13 +130,6 @@ impl ModuleGraph {
     self.dependencies.get(dependency_id)
   }
 
-  pub fn dependency_by_id_mut(
-    &mut self,
-    dependency_id: &DependencyId,
-  ) -> Option<&mut BoxDependency> {
-    self.dependencies.get_mut(dependency_id)
-  }
-
   fn remove_dependency(&mut self, dependency_id: &DependencyId) {
     self.dependencies.remove(dependency_id);
   }
@@ -171,7 +160,8 @@ impl ModuleGraph {
     module_identifier: ModuleIdentifier,
   ) -> Result<()> {
     let dependency = dependency_id.get_dependency(self);
-    let is_module_dependency = dependency.as_module_dependency().is_some();
+    let is_module_dependency =
+      dependency.as_module_dependency().is_some() || dependency.as_context_dependency().is_some();
     let condition = if IS_NEW_TREESHAKING.load(std::sync::atomic::Ordering::Relaxed) {
       dependency
         .as_module_dependency()
@@ -849,6 +839,7 @@ mod test {
       }
 
       impl crate::AsDependencyTemplate for $ident {}
+      impl crate::AsContextDependency for $ident {}
     };
   }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -67,7 +67,7 @@ impl NormalModuleFactory {
     }
   }
 
-  pub async fn before_resolve(
+  async fn before_resolve(
     &mut self,
     data: &mut ModuleFactoryCreateData,
   ) -> Result<Option<TWithDiagnosticArray<ModuleFactoryResult>>> {
@@ -106,7 +106,7 @@ impl NormalModuleFactory {
     Ok(None)
   }
 
-  pub async fn after_resolve(
+  async fn after_resolve(
     &mut self,
     data: &ModuleFactoryCreateData,
     factory_result: &ModuleFactoryResult,
@@ -750,7 +750,7 @@ impl NormalModuleFactory {
     (resolved_parser, resolved_generator)
   }
 
-  pub fn calculate_module_type(
+  fn calculate_module_type(
     &self,
     module_rules: &[&ModuleRule],
     default_module_type: Option<ModuleType>,
@@ -766,7 +766,7 @@ impl NormalModuleFactory {
     resolved_module_type
   }
 
-  pub async fn factorize(
+  async fn factorize(
     &mut self,
     data: &mut ModuleFactoryCreateData,
   ) -> Result<TWithDiagnosticArray<ModuleFactoryResult>> {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -125,7 +125,7 @@ impl GeneratorOptions {
     maybe.filter(|_| matches!(module_type, ModuleType::Asset))
   }
 
-  pub fn get_asset_inline(&self, module_type: &ModuleType) -> Option<&AssetInlineGeneratorOptions> {
+  fn get_asset_inline(&self, module_type: &ModuleType) -> Option<&AssetInlineGeneratorOptions> {
     let maybe = match self {
       Self::AssetInline(i) => Some(i),
       _ => None,
@@ -133,10 +133,7 @@ impl GeneratorOptions {
     maybe.filter(|_| matches!(module_type, ModuleType::AssetInline))
   }
 
-  pub fn get_asset_resource(
-    &self,
-    module_type: &ModuleType,
-  ) -> Option<&AssetResourceGeneratorOptions> {
+  fn get_asset_resource(&self, module_type: &ModuleType) -> Option<&AssetResourceGeneratorOptions> {
     let maybe = match self {
       Self::AssetResource(i) => Some(i),
       _ => None,

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -395,12 +395,21 @@ impl Stats<'_> {
             let dependency = self
               .compilation
               .module_graph
-              .dependency_by_id(&connection.dependency_id)
-              .and_then(|d| d.as_module_dependency());
-
-            let r#type = dependency.map(|d| d.dependency_type().to_string());
-
-            let user_request = dependency.map(|d| d.user_request().to_string());
+              .dependency_by_id(&connection.dependency_id);
+            let (r#type, user_request) =
+              if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
+                (
+                  Some(d.dependency_type().to_string()),
+                  Some(d.user_request().to_string()),
+                )
+              } else if let Some(d) = dependency.and_then(|d| d.as_context_dependency()) {
+                (
+                  Some(d.dependency_type().to_string()),
+                  Some(d.request().to_string()),
+                )
+              } else {
+                (None, None)
+              };
             StatsModuleReason {
               module_identifier: connection.original_module_identifier.map(|i| i.to_string()),
               module_name,

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -470,14 +470,12 @@ impl<'a> CodeSizeOptimizer<'a> {
           });
         // reachable_dependency_identifier.extend(analyze_result.inherit_export_maps.keys());
         for dependency_id in mgm.all_dependencies.iter() {
-          if self
+          let dep = self
             .compilation
             .module_graph
             .dependency_by_id(dependency_id)
-            .expect("should have dependency")
-            .as_module_dependency()
-            .is_none()
-          {
+            .expect("should have dependency");
+          if dep.as_module_dependency().is_none() && dep.as_context_dependency().is_none() {
             continue;
           }
           let module_identifier = match self
@@ -626,11 +624,10 @@ impl<'a> CodeSizeOptimizer<'a> {
       .unwrap_or_else(|| panic!("Failed to get mgm by module identifier {cur}"));
     let mut module_ident_list = vec![];
     for dep in mgm.all_dependencies.iter() {
-      if module_graph
+      let dependency = module_graph
         .dependency_by_id(dep)
-        .expect("should have dependency")
-        .as_module_dependency()
-        .is_none()
+        .expect("should have dependency");
+      if dependency.as_module_dependency().is_none() && dependency.as_context_dependency().is_none()
       {
         continue;
       }

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -1659,6 +1659,11 @@ impl<'a> ModuleRefAnalyze<'a> {
         && dependency_type == dep.dependency_type()
       {
         Some(*dep.id())
+      } else if let Some(dep) = dep.as_context_dependency()
+        && dep.request() == src
+        && dependency_type == dep.dependency_type()
+      {
+        Some(*dep.id())
       } else {
         None
       }

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  AsDependencyTemplate, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ModuleDependency,
+  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ModuleDependency,
 };
 
 #[derive(Debug, Clone)]
@@ -57,3 +57,4 @@ impl ModuleDependency for CssComposeDependency {
 }
 
 impl AsDependencyTemplate for CssComposeDependency {}
+impl AsContextDependency for CssComposeDependency {}

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ModuleDependency, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -69,3 +69,5 @@ impl DependencyTemplate for CssImportDependency {
     source.replace(self.start, self.end, "", None);
   }
 }
+
+impl AsContextDependency for CssImportDependency {}

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -1,9 +1,9 @@
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use rspack_core::{
-  CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, Dependency, DependencyCategory,
-  DependencyId, DependencyTemplate, DependencyType, ErrorSpan, ModuleDependency, ModuleIdentifier,
-  PublicPath, TemplateContext, TemplateReplaceSource,
+  AsContextDependency, CodeGenerationDataFilename, CodeGenerationDataUrl, Compilation, Dependency,
+  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ModuleDependency, ModuleIdentifier, PublicPath, TemplateContext, TemplateReplaceSource,
 };
 
 use crate::utils::AUTO_PUBLIC_PATH_PLACEHOLDER;
@@ -107,6 +107,8 @@ impl DependencyTemplate for CssUrlDependency {
     }
   }
 }
+
+impl AsContextDependency for CssUrlDependency {}
 
 static WHITE_OR_BRACKET_REGEX: Lazy<Regex> =
   Lazy::new(|| Regex::new(r#"[\n\t ()'"\\]"#).expect("Invalid Regexp"));

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -127,16 +127,20 @@ pub fn css_modules_exports_to_string(
             .get_dependencies()
             .iter()
             .find_map(|id| {
-              let dependency = compilation
-                .module_graph
-                .dependency_by_id(id)
-                .and_then(|d| d.as_module_dependency());
-              if let Some(dependency) = dependency {
-                if dependency.request() == from_name {
-                  return compilation
-                    .module_graph
-                    .module_graph_module_by_dependency_id(id);
-                }
+              let dependency = compilation.module_graph.dependency_by_id(id);
+              let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
+                Some(d.request())
+              } else {
+                dependency
+                  .and_then(|d| d.as_context_dependency())
+                  .map(|d| d.request())
+              };
+              if let Some(request) = request
+                && request == from_name
+              {
+                return compilation
+                  .module_graph
+                  .module_graph_module_by_dependency_id(id);
               }
               None
             })

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -1,0 +1,242 @@
+use rspack_core::{
+  property_access, AsContextDependency, AsModuleDependency, Dependency, DependencyCategory,
+  DependencyId, DependencyTemplate, DependencyType, ExportNameOrSpec, ExportsOfExportsSpec,
+  ExportsSpec, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleGraph,
+  NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedName,
+};
+
+#[derive(Debug, Clone)]
+pub enum ExportsBase {
+  Exports,
+  ModuleExports,
+  This,
+  DefinePropertyExports,
+  DefinePropertyModuleExports,
+  DefinePropertyThis,
+}
+
+impl ExportsBase {
+  pub fn is_exports(&self) -> bool {
+    matches!(self, Self::Exports | Self::DefinePropertyExports)
+  }
+
+  pub fn is_module_exports(&self) -> bool {
+    matches!(
+      self,
+      Self::ModuleExports | Self::DefinePropertyModuleExports
+    )
+  }
+
+  pub fn is_this(&self) -> bool {
+    matches!(self, Self::This | Self::DefinePropertyThis)
+  }
+
+  pub fn is_expression(&self) -> bool {
+    matches!(self, Self::Exports | Self::ModuleExports | Self::This)
+  }
+
+  pub fn is_define_property(&self) -> bool {
+    matches!(
+      self,
+      Self::DefinePropertyExports | Self::DefinePropertyModuleExports | Self::DefinePropertyThis
+    )
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct CommonJsExportsDependency {
+  id: DependencyId,
+  range: (u32, u32),
+  value_range: Option<(u32, u32)>,
+  base: ExportsBase,
+  names: UsedName,
+}
+
+impl CommonJsExportsDependency {
+  pub fn new(
+    range: (u32, u32),
+    value_range: Option<(u32, u32)>,
+    base: ExportsBase,
+    names: UsedName,
+  ) -> Self {
+    Self {
+      id: DependencyId::new(),
+      range,
+      value_range,
+      base,
+      names,
+    }
+  }
+}
+
+impl Dependency for CommonJsExportsDependency {
+  fn dependency_debug_name(&self) -> &'static str {
+    "CommonJsExportsDependency"
+  }
+
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  fn category(&self) -> &DependencyCategory {
+    &DependencyCategory::CommonJS
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    &DependencyType::CjsExports
+  }
+
+  fn get_exports(&self, _mg: &ModuleGraph) -> Option<ExportsSpec> {
+    Some(ExportsSpec {
+      exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::String(match &self.names {
+        UsedName::Str(name) => name.clone(),
+        UsedName::Vec(names) => names[0].clone(),
+      })]),
+      priority: None,
+      can_mangle: Some(false), // in webpack, object own property may not be mangled
+      terminal_binding: None,
+      from: None,
+      dependencies: None,
+      hide_export: None,
+      exclude_exports: None,
+    })
+  }
+
+  fn get_module_evaluation_side_effects_state(
+    &self,
+    _module_graph: &rspack_core::ModuleGraph,
+    _module_chain: &mut rustc_hash::FxHashSet<rspack_core::ModuleIdentifier>,
+  ) -> rspack_core::ConnectionState {
+    rspack_core::ConnectionState::Bool(false)
+  }
+}
+
+impl AsModuleDependency for CommonJsExportsDependency {}
+
+impl DependencyTemplate for CommonJsExportsDependency {
+  fn apply(
+    &self,
+    source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    let TemplateContext {
+      compilation,
+      module,
+      runtime,
+      init_fragments,
+      runtime_requirements,
+      ..
+    } = code_generatable_context;
+
+    let mgm = compilation
+      .module_graph
+      .module_graph_module_by_identifier(&module.identifier())
+      .expect("should have mgm");
+
+    let used = compilation
+      .module_graph
+      .get_exports_info(&module.identifier())
+      .id
+      .get_used_name(&compilation.module_graph, *runtime, self.names.clone());
+
+    let exports_argument = mgm.get_exports_argument();
+    let module_argument = mgm.get_module_argument();
+
+    let base = if self.base.is_exports() {
+      runtime_requirements.insert(RuntimeGlobals::EXPORTS);
+      exports_argument.to_string()
+    } else if self.base.is_module_exports() {
+      runtime_requirements.insert(RuntimeGlobals::MODULE);
+      format!("{}.exports", module_argument)
+    } else if self.base.is_this() {
+      runtime_requirements.insert(RuntimeGlobals::THIS_AS_EXPORTS);
+      "this".to_string()
+    } else {
+      panic!("Unexpected base type");
+    };
+
+    if self.base.is_expression() {
+      if let Some(used) = used {
+        source.replace(
+          self.range.0,
+          self.range.1,
+          &format!(
+            "{}{}",
+            base,
+            property_access(
+              match used {
+                UsedName::Str(name) => vec![name].into_iter(),
+                UsedName::Vec(names) => names.into_iter(),
+              },
+              0
+            )
+          ),
+          None,
+        )
+      } else {
+        init_fragments.push(
+          NormalInitFragment::new(
+            "var __webpack_unused_export__;\n".to_string(),
+            InitFragmentStage::StageConstants,
+            0,
+            InitFragmentKey::unique(),
+            None,
+          )
+          .boxed(),
+        );
+        source.replace(
+          self.range.0,
+          self.range.1,
+          "__webpack_unused_export__",
+          None,
+        );
+      }
+    } else if self.base.is_define_property() {
+      if let Some(value_range) = self.value_range {
+        if let Some(used) = used {
+          if let UsedName::Vec(used) = used {
+            source.replace(
+              self.range.0,
+              value_range.0,
+              &format!(
+                "Object.defineProperty({}{}, {}, (",
+                base,
+                property_access(used[0..used.len() - 1].iter(), 0),
+                serde_json::to_string(&used.last())
+                  .expect("Unexpected render define property base")
+              ),
+              None,
+            );
+            source.replace(value_range.1, self.range.1, "))", None);
+          } else {
+            panic!("Unexpected base type");
+          }
+        } else {
+          init_fragments.push(
+            NormalInitFragment::new(
+              "var __webpack_unused_export__;\n".to_string(),
+              InitFragmentStage::StageConstants,
+              0,
+              InitFragmentKey::unique(),
+              None,
+            )
+            .boxed(),
+          );
+          source.replace(
+            self.range.0,
+            value_range.0,
+            "__webpack_unused_export__ = (",
+            None,
+          );
+          source.replace(value_range.1, self.range.1, ")", None);
+        }
+      } else {
+        panic!("Define property need value range");
+      }
+    } else {
+      panic!("Unexpected base type");
+    }
+  }
+}
+
+impl AsContextDependency for CommonJsExportsDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -1,7 +1,7 @@
-use rspack_core::{
-  module_id, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
-};
+use rspack_core::{module_id, AsContextDependency, Dependency, DependencyCategory};
+use rspack_core::{DependencyId, DependencyTemplate};
+use rspack_core::{DependencyType, ErrorSpan, ModuleDependency, RuntimeGlobals};
+use rspack_core::{TemplateContext, TemplateReplaceSource};
 use swc_core::ecma::atoms::JsWord;
 
 // Webpack RequireHeaderDependency + CommonJsRequireDependency
@@ -100,3 +100,5 @@ impl DependencyTemplate for CommonJsRequireDependency {
     );
   }
 }
+
+impl AsContextDependency for CommonJsRequireDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  module_id, ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
   DependencyType, ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeSpec,
   TemplateContext, TemplateReplaceSource,
 };
@@ -71,10 +71,6 @@ impl ModuleDependency for RequireResolveDependency {
     self.weak
   }
 
-  fn options(&self) -> Option<&ContextOptions> {
-    None
-  }
-
   fn get_optional(&self) -> bool {
     self.optional
   }
@@ -112,3 +108,5 @@ impl DependencyTemplate for RequireResolveDependency {
     );
   }
 }
+
+impl AsContextDependency for RequireResolveDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/context_dependency.rs
@@ -1,5 +1,0 @@
-use rspack_core::Dependency;
-
-pub trait ContextDependencyTrait: Dependency {
-  fn chunk_name(&self) -> Option<&str>;
-}

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -1,18 +1,17 @@
-use rspack_core::{
-  create_resource_identifier_for_context_dependency, module_id_expr, normalize_context,
-  ContextOptions, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
-};
+use rspack_core::{module_id_expr, AsModuleDependency, ContextDependency};
+use rspack_core::{normalize_context, DependencyCategory, DependencyId, DependencyTemplate};
+use rspack_core::{ContextOptions, Dependency, TemplateReplaceSource};
+use rspack_core::{DependencyType, ErrorSpan, RuntimeGlobals, TemplateContext};
 
-use super::ContextDependencyTrait;
+use super::create_resource_identifier_for_context_dependency;
 
 #[derive(Debug, Clone)]
 pub struct ImportContextDependency {
   callee_start: u32,
   callee_end: u32,
   args_end: u32,
-  pub id: DependencyId,
-  pub options: ContextOptions,
+  id: DependencyId,
+  options: ContextOptions,
   span: Option<ErrorSpan>,
   resource_identifier: String,
 }
@@ -25,7 +24,7 @@ impl ImportContextDependency {
     options: ContextOptions,
     span: Option<ErrorSpan>,
   ) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(&options);
+    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
     Self {
       callee_start,
       callee_end,
@@ -60,31 +59,25 @@ impl Dependency for ImportContextDependency {
   }
 }
 
-impl ModuleDependency for ImportContextDependency {
+impl ContextDependency for ImportContextDependency {
+  fn options(&self) -> &ContextOptions {
+    &self.options
+  }
+
   fn request(&self) -> &str {
     &self.options.request
   }
 
-  fn user_request(&self) -> &str {
-    &self.options.request
+  fn get_context(&self) -> Option<&str> {
+    None
   }
 
-  fn options(&self) -> Option<&ContextOptions> {
-    Some(&self.options)
+  fn resource_identifier(&self) -> &str {
+    &self.resource_identifier
   }
 
   fn set_request(&mut self, request: String) {
     self.options.request = request;
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
-  }
-}
-
-impl ContextDependencyTrait for ImportContextDependency {
-  fn chunk_name(&self) -> Option<&str> {
-    self.options.chunk_name.as_deref()
   }
 }
 
@@ -123,3 +116,5 @@ impl DependencyTemplate for ImportContextDependency {
     }
   }
 }
+
+impl AsModuleDependency for ImportContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -1,22 +1,23 @@
-use rspack_core::{
-  create_resource_identifier_for_context_dependency, module_id_expr, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
-};
+use rspack_core::{module_id_expr, AsModuleDependency, ContextDependency};
+use rspack_core::{ContextOptions, Dependency, DependencyCategory, DependencyId};
+use rspack_core::{DependencyTemplate, DependencyType, ErrorSpan, RuntimeGlobals};
+use rspack_core::{TemplateContext, TemplateReplaceSource};
+
+use super::create_resource_identifier_for_context_dependency;
 
 #[derive(Debug, Clone)]
 pub struct ImportMetaContextDependency {
   start: u32,
   end: u32,
-  pub id: DependencyId,
-  pub options: ContextOptions,
+  id: DependencyId,
+  options: ContextOptions,
   span: Option<ErrorSpan>,
   resource_identifier: String,
 }
 
 impl ImportMetaContextDependency {
   pub fn new(start: u32, end: u32, options: ContextOptions, span: Option<ErrorSpan>) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(&options);
+    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
     Self {
       start,
       end,
@@ -50,25 +51,25 @@ impl Dependency for ImportMetaContextDependency {
   }
 }
 
-impl ModuleDependency for ImportMetaContextDependency {
+impl ContextDependency for ImportMetaContextDependency {
   fn request(&self) -> &str {
     &self.options.request
   }
 
-  fn user_request(&self) -> &str {
-    &self.options.request
+  fn options(&self) -> &ContextOptions {
+    &self.options
   }
 
-  fn options(&self) -> Option<&ContextOptions> {
-    Some(&self.options)
+  fn get_context(&self) -> Option<&str> {
+    None
+  }
+
+  fn resource_identifier(&self) -> &str {
+    &self.resource_identifier
   }
 
   fn set_request(&mut self, request: String) {
     self.options.request = request;
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
   }
 }
 
@@ -96,3 +97,5 @@ impl DependencyTemplate for ImportMetaContextDependency {
     );
   }
 }
+
+impl AsModuleDependency for ImportMetaContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/mod.rs
@@ -1,11 +1,33 @@
 mod common_js_require_context_dependency;
-mod context_dependency;
 mod import_context_dependency;
 mod import_meta_context_dependency;
 mod require_context_dependency;
 
 pub use common_js_require_context_dependency::CommonJsRequireContextDependency;
-pub use context_dependency::ContextDependencyTrait;
 pub use import_context_dependency::ImportContextDependency;
 pub use import_meta_context_dependency::ImportMetaContextDependency;
 pub use require_context_dependency::RequireContextDependency;
+use rspack_core::ContextOptions;
+use rspack_regex::regexp_as_str;
+
+fn create_resource_identifier_for_context_dependency(
+  context: Option<&str>,
+  options: &ContextOptions,
+) -> String {
+  let context = context.unwrap_or_default();
+  let request = &options.request;
+  let recursive = options.recursive.to_string();
+  let regexp = options
+    .reg_exp
+    .as_ref()
+    .map(regexp_as_str)
+    .unwrap_or_default();
+  let include = options.include.as_deref().unwrap_or_default();
+  let exclude = options.exclude.as_deref().unwrap_or_default();
+  let mode = options.mode.as_str();
+  // TODO: need `RawChunkGroupOptions`
+  let id = format!(
+    "context{context}|ctx request{request} {recursive} `{regexp} {include} {exclude} ``{mode} `"
+  );
+  id
+}

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -1,22 +1,23 @@
-use rspack_core::{
-  create_resource_identifier_for_context_dependency, module_id_expr, ContextOptions, Dependency,
-  DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
-};
+use rspack_core::{module_id_expr, AsModuleDependency, ContextDependency};
+use rspack_core::{ContextOptions, Dependency, DependencyCategory, DependencyId};
+use rspack_core::{DependencyTemplate, DependencyType, ErrorSpan, RuntimeGlobals};
+use rspack_core::{TemplateContext, TemplateReplaceSource};
+
+use super::create_resource_identifier_for_context_dependency;
 
 #[derive(Debug, Clone)]
 pub struct RequireContextDependency {
   start: u32,
   end: u32,
-  pub id: DependencyId,
-  pub options: ContextOptions,
+  id: DependencyId,
+  options: ContextOptions,
   span: Option<ErrorSpan>,
   resource_identifier: String,
 }
 
 impl RequireContextDependency {
   pub fn new(start: u32, end: u32, options: ContextOptions, span: Option<ErrorSpan>) -> Self {
-    let resource_identifier = create_resource_identifier_for_context_dependency(&options);
+    let resource_identifier = create_resource_identifier_for_context_dependency(None, &options);
     Self {
       start,
       end,
@@ -50,25 +51,25 @@ impl Dependency for RequireContextDependency {
   }
 }
 
-impl ModuleDependency for RequireContextDependency {
+impl ContextDependency for RequireContextDependency {
   fn request(&self) -> &str {
     &self.options.request
   }
 
-  fn user_request(&self) -> &str {
-    &self.options.request
+  fn options(&self) -> &ContextOptions {
+    &self.options
   }
 
-  fn options(&self) -> Option<&ContextOptions> {
-    Some(&self.options)
+  fn get_context(&self) -> Option<&str> {
+    None
+  }
+
+  fn resource_identifier(&self) -> &str {
+    &self.resource_identifier
   }
 
   fn set_request(&mut self, request: String) {
     self.options.request = request;
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
   }
 }
 
@@ -96,3 +97,5 @@ impl DependencyTemplate for RequireContextDependency {
     );
   }
 }
+
+impl AsModuleDependency for RequireContextDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
@@ -1,7 +1,6 @@
-use rspack_core::{
-  AsModuleDependency, Dependency, DependencyId, DependencyTemplate, ModuleDependency,
-  TemplateContext, TemplateReplaceSource,
-};
+use rspack_core::{AsContextDependency, AsModuleDependency, Dependency};
+use rspack_core::{DependencyId, DependencyTemplate};
+use rspack_core::{TemplateContext, TemplateReplaceSource};
 
 pub const DEFAULT_EXPORT: &str = "__WEBPACK_DEFAULT_EXPORT__";
 // pub const NAMESPACE_OBJECT_EXPORT: &'static str = "__WEBPACK_NAMESPACE_OBJECT__";
@@ -57,15 +56,7 @@ impl Dependency for HarmonyExportExpressionDependency {
   }
 }
 
-impl AsModuleDependency for HarmonyExportExpressionDependency {
-  fn as_module_dependency(&self) -> Option<&dyn ModuleDependency> {
-    None
-  }
-
-  fn as_module_dependency_mut(&mut self) -> Option<&mut dyn ModuleDependency> {
-    None
-  }
-}
+impl AsModuleDependency for HarmonyExportExpressionDependency {}
 
 impl DependencyTemplate for HarmonyExportExpressionDependency {
   fn apply(
@@ -108,3 +99,5 @@ impl DependencyTemplate for HarmonyExportExpressionDependency {
     }
   }
 }
+
+impl AsContextDependency for HarmonyExportExpressionDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -1,12 +1,12 @@
 use linked_hash_set::LinkedHashSet;
 use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, export_from_import,
-  get_exports_type, process_export_info, ConnectionState, Dependency, DependencyCategory,
-  DependencyCondition, DependencyId, DependencyTemplate, DependencyType, ExportInfoId,
-  ExportInfoProvided, ExportNameOrSpec, ExportSpec, ExportsInfoId, ExportsOfExportsSpec,
-  ExportsSpec, ExportsType, ExtendedReferencedExport, HarmonyExportInitFragment, ModuleDependency,
-  ModuleGraph, ModuleIdentifier, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState,
-  UsedName,
+  get_exports_type, process_export_info, AsContextDependency, ConnectionState, Dependency,
+  DependencyCategory, DependencyCondition, DependencyId, DependencyTemplate, DependencyType,
+  ExportInfoId, ExportInfoProvided, ExportNameOrSpec, ExportSpec, ExportsInfoId,
+  ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
+  HarmonyExportInitFragment, ModuleDependency, ModuleGraph, ModuleIdentifier, RuntimeSpec,
+  TemplateContext, TemplateReplaceSource, UsageState, UsedName,
 };
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::ecma::atoms::JsWord;
@@ -736,6 +736,10 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
   fn dependency_debug_name(&self) -> &'static str {
     "HarmonyExportImportedSpecifierDependency"
   }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
+  }
 }
 
 impl ModuleDependency for HarmonyExportImportedSpecifierDependency {
@@ -749,10 +753,6 @@ impl ModuleDependency for HarmonyExportImportedSpecifierDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request.into();
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
   }
 
   fn is_export_all(&self) -> Option<bool> {
@@ -850,6 +850,8 @@ impl ModuleDependency for HarmonyExportImportedSpecifierDependency {
     }
   }
 }
+
+impl AsContextDependency for HarmonyExportImportedSpecifierDependency {}
 
 #[allow(unused)]
 #[derive(Debug, PartialEq, Eq)]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  AsModuleDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, HarmonyExportInitFragment,
-  ModuleGraph, TemplateContext, TemplateReplaceSource, UsedName,
+  AsContextDependency, AsModuleDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyTemplate, DependencyType, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec,
+  HarmonyExportInitFragment, ModuleGraph, TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -116,3 +116,5 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
     }
   }
 }
+
+impl AsContextDependency for HarmonyExportSpecifierDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -1,10 +1,11 @@
 use rspack_core::tree_shaking::symbol::{self, IndirectTopLevelSymbol};
 use rspack_core::tree_shaking::visitor::SymbolRef;
 use rspack_core::{
-  import_statement, AwaitDependenciesInitFragment, ConnectionState, Dependency, DependencyCategory,
-  DependencyCondition, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ExtendedReferencedExport, InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleDependency,
-  ModuleIdentifier, NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  import_statement, AsContextDependency, AwaitDependenciesInitFragment, ConnectionState,
+  Dependency, DependencyCategory, DependencyCondition, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ExtendedReferencedExport, InitFragmentExt, InitFragmentKey,
+  InitFragmentStage, ModuleDependency, ModuleIdentifier, NormalInitFragment, RuntimeGlobals,
+  TemplateContext, TemplateReplaceSource,
 };
 use rspack_core::{ModuleGraph, RuntimeSpec};
 use rustc_hash::FxHashSet as HashSet;
@@ -264,6 +265,10 @@ impl Dependency for HarmonyImportSideEffectDependency {
       ConnectionState::Bool(true)
     }
   }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
+  }
 }
 
 impl ModuleDependency for HarmonyImportSideEffectDependency {
@@ -281,10 +286,6 @@ impl ModuleDependency for HarmonyImportSideEffectDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request.into();
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
   }
 
   fn get_referenced_exports(
@@ -326,3 +327,5 @@ impl DependencyTemplate for HarmonyImportSideEffectDependency {
     );
   }
 }
+
+impl AsContextDependency for HarmonyImportSideEffectDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -1,11 +1,11 @@
 use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, export_from_import,
   get_dependency_used_by_exports_condition, get_exports_type,
-  tree_shaking::symbol::DEFAULT_JS_WORD, Compilation, ConnectionState, Dependency,
-  DependencyCategory, DependencyCondition, DependencyId, DependencyTemplate, DependencyType,
-  ExportsType, ExtendedReferencedExport, ModuleDependency, ModuleGraph, ModuleGraphModule,
-  ModuleIdentifier, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource,
-  UsedByExports,
+  tree_shaking::symbol::DEFAULT_JS_WORD, AsContextDependency, Compilation, ConnectionState,
+  Dependency, DependencyCategory, DependencyCondition, DependencyId, DependencyTemplate,
+  DependencyType, ExportsType, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
+  ModuleGraphModule, ModuleIdentifier, ReferencedExport, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource, UsedByExports,
 };
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::{common::Span, ecma::atoms::JsWord};
@@ -237,6 +237,10 @@ impl Dependency for HarmonyImportSpecifierDependency {
   fn dependency_debug_name(&self) -> &'static str {
     "HarmonyImportSpecifierDependency"
   }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some(&self.resource_identifier)
+  }
 }
 
 impl ModuleDependency for HarmonyImportSpecifierDependency {
@@ -250,10 +254,6 @@ impl ModuleDependency for HarmonyImportSpecifierDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request.into();
-  }
-
-  fn resource_identifier(&self) -> Option<&str> {
-    Some(&self.resource_identifier)
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
@@ -312,3 +312,5 @@ impl ModuleDependency for HarmonyImportSpecifierDependency {
     self.get_referenced_exports_in_destructuring(Some(&ids))
   }
 }
+
+impl AsContextDependency for HarmonyImportSpecifierDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,5 +1,5 @@
-use rspack_core::Dependency;
 use rspack_core::{module_namespace_promise, DependencyType, ErrorSpan, ImportDependencyTrait};
+use rspack_core::{AsContextDependency, Dependency};
 use rspack_core::{DependencyCategory, DependencyId, DependencyTemplate};
 use rspack_core::{ModuleDependency, TemplateContext, TemplateReplaceSource};
 use swc_core::ecma::atoms::JsWord;
@@ -97,3 +97,5 @@ impl DependencyTemplate for ImportDependency {
     );
   }
 }
+
+impl AsContextDependency for ImportDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  module_namespace_promise, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ErrorSpan, ExtendedReferencedExport, ImportDependencyTrait, ModuleDependency,
-  ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  module_namespace_promise, AsContextDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyTemplate, DependencyType, ErrorSpan, ExtendedReferencedExport, ImportDependencyTrait,
+  ModuleDependency, ModuleGraph, ReferencedExport, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -110,3 +111,5 @@ impl DependencyTemplate for ImportEagerDependency {
     );
   }
 }
+
+impl AsContextDependency for ImportEagerDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
@@ -32,12 +32,16 @@ impl DependencyTemplate for HarmonyAcceptDependency {
     let mut content = String::default();
 
     self.dependency_ids.iter().for_each(|id| {
-      if let Some(dependency) = compilation
-        .module_graph
-        .dependency_by_id(id)
-        .and_then(|d| d.as_module_dependency())
-      {
-        let stmts = import_statement(code_generatable_context, id, dependency.request(), true);
+      let dependency = compilation.module_graph.dependency_by_id(id);
+      let request = if let Some(dependency) = dependency.and_then(|d| d.as_module_dependency()) {
+        Some(dependency.request())
+      } else {
+        dependency
+          .and_then(|d| d.as_context_dependency())
+          .map(|d| d.request())
+      };
+      if let Some(request) = request {
+        let stmts = import_statement(code_generatable_context, id, request, true);
         content.push_str(stmts.0.as_str());
         content.push_str(stmts.1.as_str());
       }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  module_id, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -81,3 +81,5 @@ impl DependencyTemplate for ImportMetaHotAcceptDependency {
     );
   }
 }
+
+impl AsContextDependency for ImportMetaHotAcceptDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  module_id, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -81,3 +81,5 @@ impl DependencyTemplate for ImportMetaHotDeclineDependency {
     );
   }
 }
+
+impl AsContextDependency for ImportMetaHotDeclineDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  module_id, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -81,3 +81,5 @@ impl DependencyTemplate for ModuleHotAcceptDependency {
     );
   }
 }
+
+impl AsContextDependency for ModuleHotAcceptDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  module_id, Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
+  module_id, AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -81,3 +81,5 @@ impl DependencyTemplate for ModuleHotDeclineDependency {
     );
   }
 }
+
+impl AsContextDependency for ModuleHotDeclineDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
-  AsModuleDependency, ConnectionState, Dependency, DependencyId, DependencyTemplate, ModuleGraph,
-  ModuleIdentifier, TemplateContext, TemplateReplaceSource, UsageState, UsedByExports, UsedName,
+  AsContextDependency, AsModuleDependency, ConnectionState, Dependency, DependencyId,
+  DependencyTemplate, ModuleGraph, ModuleIdentifier, TemplateContext, TemplateReplaceSource,
+  UsageState, UsedByExports, UsedName,
 };
 use rustc_hash::FxHashSet as HashSet;
 #[derive(Debug, Clone)]
@@ -45,15 +46,7 @@ impl Dependency for PureExpressionDependency {
   }
 }
 
-impl AsModuleDependency for PureExpressionDependency {
-  fn as_module_dependency(&self) -> Option<&dyn rspack_core::ModuleDependency> {
-    None
-  }
-
-  fn as_module_dependency_mut(&mut self) -> Option<&mut dyn rspack_core::ModuleDependency> {
-    None
-  }
-}
+impl AsModuleDependency for PureExpressionDependency {}
 
 impl DependencyTemplate for PureExpressionDependency {
   fn apply(&self, source: &mut TemplateReplaceSource, ctx: &mut TemplateContext) {
@@ -95,3 +88,5 @@ impl DependencyTemplate for PureExpressionDependency {
     source.insert(self.end, "))", None);
   }
 }
+
+impl AsContextDependency for PureExpressionDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -1,7 +1,8 @@
 use rspack_core::{
-  get_dependency_used_by_exports_condition, module_id, Dependency, DependencyCategory,
-  DependencyCondition, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedByExports,
+  get_dependency_used_by_exports_condition, module_id, AsContextDependency, Dependency,
+  DependencyCategory, DependencyCondition, DependencyId, DependencyTemplate, DependencyType,
+  ErrorSpan, ModuleDependency, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  UsedByExports,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -97,3 +98,5 @@ impl DependencyTemplate for URLDependency {
     );
   }
 }
+
+impl AsContextDependency for URLDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  Dependency, DependencyCategory, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
-  ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeGlobals, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource,
+  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
+  DependencyType, ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -126,3 +126,5 @@ impl DependencyTemplate for WorkerDependency {
     );
   }
 }
+
+impl AsContextDependency for WorkerDependency {}

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -182,6 +182,8 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
 
         let referenced_exports = if let Some(md) = dep.as_module_dependency() {
           md.get_referenced_exports(&self.compilation.module_graph, runtime.as_ref())
+        } else if dep.as_context_dependency().is_some() {
+          vec![ExtendedReferencedExport::Array(vec![])]
         } else {
           continue;
         };

--- a/crates/rspack_plugin_wasm/src/dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  AsDependencyTemplate, Dependency, DependencyCategory, DependencyId, DependencyType, ErrorSpan,
-  ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeSpec,
+  AsContextDependency, AsDependencyTemplate, Dependency, DependencyCategory, DependencyId,
+  DependencyType, ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeSpec,
 };
 use swc_core::ecma::atoms::JsWord;
 
@@ -79,3 +79,5 @@ impl ModuleDependency for WasmImportDependency {
 }
 
 impl AsDependencyTemplate for WasmImportDependency {}
+
+impl AsContextDependency for WasmImportDependency {}

--- a/crates/rspack_regex/src/lib.rs
+++ b/crates/rspack_regex/src/lib.rs
@@ -35,10 +35,6 @@ impl RspackRegex {
     self.algo.sticky()
   }
 
-  pub fn raw(&self) -> &str {
-    &self.raw
-  }
-
   pub fn with_flags(expr: &str, flags: &str) -> Result<Self, Error> {
     let mut chars = flags.chars().collect::<Vec<char>>();
     chars.sort();
@@ -68,4 +64,8 @@ impl TryFrom<SwcRegex> for RspackRegex {
   fn try_from(value: SwcRegex) -> Result<Self, Self::Error> {
     RspackRegex::with_flags(value.exp.as_ref(), value.flags.as_ref())
   }
+}
+
+pub fn regexp_as_str(reg: &RspackRegex) -> &str {
+  &reg.raw
 }

--- a/packages/rspack/tests/StatsTestCases.test.ts
+++ b/packages/rspack/tests/StatsTestCases.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import fs from "fs";
 import util from "util";
-import { rspack, RspackOptions, cleverMerge } from "../src";
+import { rspack, RspackOptions } from "../src";
 import serializer from "jest-serializer-path";
 
 expect.addSnapshotSerializer(serializer);

--- a/packages/rspack/tests/WatchTestCases.template.ts
+++ b/packages/rspack/tests/WatchTestCases.template.ts
@@ -10,7 +10,7 @@ import deprecationTracking from "./helpers/deprecationTracking";
 import FakeDocument from "./helpers/FakeDocument";
 import { rspack, RspackOptions } from "../src";
 
-function copyDiff(src, dest, initial) {
+function copyDiff(src: string, dest: string, initial: boolean) {
 	if (!fs.existsSync(dest)) fs.mkdirSync(dest);
 	const files = fs.readdirSync(src);
 	files.forEach(filename => {


### PR DESCRIPTION
Fixes #4594 

This PR introduces ﻿a trait called `ContextDependency`, which mocks the ﻿`ContextDependency` in webpack. This can assist in more closely aligning certain elements with webpack.

WARNING: This PR introduces many changes, and I'm **not** confident that it won't result in breaking changes.