### PR TITLE
chore: run webpack tests in parallel

### DIFF
--- a/webpack-test/jest.config.js
+++ b/webpack-test/jest.config.js
@@ -50,8 +50,5 @@ module.exports =  {
       "<rootDir>/schemas",
       "<rootDir>/node_modules"
     ],
-    "testEnvironment": "./patch-node-env.js",
-    "coverageReporters": [
-      "json"
-    ]
-  }
+    "testEnvironment": "./patch-node-env.js"
+}

--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.d.ts",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest  --logHeapUsage --runInBand --bail --forceExit",
-    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --forceExit --json | node scripts/test-metric.js",
-    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --runInBand --bail --json --forceExit"
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest  --logHeapUsage --bail --forceExit",
+    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --bail --forceExit --json | node scripts/test-metric.js",
+    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --bail --json --forceExit"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

Assumptions don't hold overtime.

We added `--runInBand` to webpack-test's jest when it was flaky, it isn't anymore.

Removing `--runInBand` reduces execution time from 15s to 12s on my i7.

I also removed `coverageReporters` because we are not using any test coverages.

After running on CI:

```
PASS ./TestCasesNormal.basictest.js (32.799 s, 297 MB heap size)
PASS ./ConfigTestCases.basictest.js (5.595 s, 433 MB heap size)
```
->
```
PASS ./TestCasesNormal.basictest.js (16.218 s, 234 MB heap size)
PASS ./ConfigTestCases.basictest.js (5.581 s, 207 MB heap size)
```

## Test Plan

CI passes.