### PR TITLE
fix(webpack-test): fix the slow 5 seconds test

### DIFF
--- a/webpack-test/cases/parsing/issue-11353/async_generator_function.js
+++ b/webpack-test/cases/parsing/issue-11353/async_generator_function.js
@@ -3,7 +3,7 @@
 export default async function* asyncIdMaker(start = 1, end = 5){
 	for (let i = start; i <= end; i++) {
 
-		await new Promise(resolve => setTimeout(resolve, 1000));
+		await new Promise(resolve => setTimeout(resolve, 1));
 
 		yield i;
 	}


### PR DESCRIPTION
Found the slowest test by reading the logs :-)

![image](https://github.com/web-infra-dev/rspack/assets/1430279/1436a23b-9c3d-43e4-b052-b1e281a7f236)

```
 PASS  ./TestCasesNormal.basictest.js (12.318 s, 240 MB heap size)
 ```
 
 -> 

```
 PASS  ./TestCasesNormal.basictest.js (7.36 s, 287 MB heap size)
```

Sped up the test run by ... surprising 5 seconds!