### PR TITLE
fix(webpack-test): fix the 1 second slow test

### DIFF
--- a/webpack-test/configCases/asset-modules/base-uri/index.js
+++ b/webpack-test/configCases/asset-modules/base-uri/index.js
@@ -1,5 +1,5 @@
 it("should handle different querystrings for assets correctly", () => {
 	__webpack_base_uri__ = "https://example.com";
-	const file = new URL("../_images/file.png", import.meta.url);
+	const file = new URL("../_images/empty.png", import.meta.url);
 	expect(file.href).toMatch(/^https:\/\/example.com\/path\/[0-9a-f]+.png$/);
 });


### PR DESCRIPTION
This test reads a huge png, which constantly takes 1 second.

Our webpack-test now runs in an instant :-)