### PR TITLE
fix(harmony-deps-scanner): should only be `dep.call=true` in call_expr or tagged template's tag

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -23,7 +23,7 @@ pub struct HarmonyImportSpecifierDependency {
   start: u32,
   end: u32,
   ids: Vec<JsWord>,
-  call: bool,
+  pub(crate) call: bool,
   direct_import: bool,
   specifier: Specifier,
   used_by_exports: Option<UsedByExports>,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -632,6 +632,7 @@ mod test {
       nested(foo).call(true);
       nested(foo)``
       (`${foo}`)``
+      (new foo()).bar();
     "#
       .into(),
       swc_core::ecma::parser::Syntax::Es(Default::default()),
@@ -647,7 +648,7 @@ mod test {
       .filter_map(|dep| dep.downcast_ref::<HarmonyImportSpecifierDependency>())
       .collect::<Vec<_>>();
 
-    assert_eq!(specifiers.len(), 7);
+    assert_eq!(specifiers.len(), 8);
     assert!(specifiers.iter().all(|d| !d.call));
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -542,11 +542,11 @@ impl Visit for HarmonyImportRefDependencyScanner<'_> {
   }
 
   fn visit_tagged_tpl(&mut self, n: &TaggedTpl) {
-    n.tpl.visit_with(self);
-
     self.enter_callee = true;
     n.tag.visit_with(self);
     self.enter_callee = false;
+
+    n.tpl.visit_with(self);
   }
 
   fn visit_import_decl(&mut self, _decl: &ImportDecl) {}
@@ -629,7 +629,9 @@ mod test {
       new foo().bar;
       new foo.bar();
       `${foo}`;
-      chain(foo).call(true);
+      nested(foo).call(true);
+      nested(foo)``
+      (`${foo}`)``
     "#
       .into(),
       swc_core::ecma::parser::Syntax::Es(Default::default()),
@@ -645,7 +647,7 @@ mod test {
       .filter_map(|dep| dep.downcast_ref::<HarmonyImportSpecifierDependency>())
       .collect::<Vec<_>>();
 
-    assert_eq!(specifiers.len(), 5);
+    assert_eq!(specifiers.len(), 7);
     assert!(specifiers.iter().all(|d| !d.call));
   }
 }


### PR DESCRIPTION
## Summary

There is a field in harmonyImportSpecifier called `call`, it should be true if the imported specifier in call_expr or tagged templates'tag.

for example:

```javascript
import { foo } from 'bar'

foo() // call=true
foo`` // call=true
new foo() // call=false (undefined in webpack
`${foo}` // call=false (undefined in webpack
```

Before:
The new expression or tagged template expression both are not correct cases for `call` to be `true`, we only checked callee before

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
