### PR TITLE
chore: skip show sccache stats

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -37,15 +37,13 @@ runs:
           set -e
           if [ -x "$(command -v sccache)" ]; then
             export RUSTC_WRAPPER=sccache
+            echo "enable sccache"
           fi
           ${{ inputs.pre }}
           rustup target add ${{ inputs.target }}
           corepack enable
           RUST_TARGET=${{ inputs.target }} pnpm build:binding:${{ inputs.profile }}
           ${{ inputs.post }}
-          if [ -x "$(command -v sccache)" ]; then
-            sccache --show-stats
-          fi
         '
 
         docker run \


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`sccache --show-stats` sometimes makes ci fail, but the build succeeds, this pr will skip this failed operation. more error info see:
https://github.com/web-infra-dev/rspack/actions/runs/6925892459/job/18837235457?pr=4041#step:7:461

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
