### PR TITLE
chore: pnpm set cache dir by version

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         # set cache-dir to .cache
-        pnpm config set store-dir ~/.cache/pnpm
+        pnpm config set store-dir ~/.cache/pnpm/$(pnpm -v)
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Restore pnpm cache


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

We upgrade pnpm version from v7 to v8, but share the node_modules cache will case [some bugs](https://github.com/web-infra-dev/rspack/actions/runs/6926876033/job/18847080010?pr=4041) in self hosted runner. This PR will use the diff cache directory via pnpm version


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
