### PR TITLE
chore: commonjs exports dependency

### DIFF
--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/new_treeshaking.snap
@@ -5,9 +5,9 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./zh_locale.js": (function (__unused_webpack_module, exports, __webpack_require__) {
 "use strict";
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, "__esModule", ({
     value: true
-});
+}));
 exports["default"] = void 0;
 /* eslint-disable no-template-curly-in-string */ var _default = {};
 exports["default"] = _default;

--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/output.snap
@@ -5,9 +5,9 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./zh_locale.js": (function (__unused_webpack_module, exports, __webpack_require__) {
 "use strict";
-Object.defineProperty(exports, "__esModule", {
+Object.defineProperty(exports, "__esModule", ({
     value: true
-});
+}));
 exports["default"] = void 0;
 /* eslint-disable no-template-curly-in-string */ var _default = {};
 exports["default"] = _default;

--- a/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/snapshot/new_treeshaking.snap
@@ -12,7 +12,7 @@ __webpack_require__.r(__webpack_exports__);
 /*#__PURE__*/ (_lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache || (_lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache = __webpack_require__.t(_lib__WEBPACK_IMPORTED_MODULE_0__, 2)));
 }),
 "./lib.js": (function (__unused_webpack_module, exports, __webpack_require__) {
-exports['a'] = 100000;
+exports.a = 100000;
 }),
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/snapshot/output.snap
@@ -12,7 +12,7 @@ __webpack_require__.r(__webpack_exports__);
 /*#__PURE__*/ (_lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache || (_lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache = __webpack_require__.t(_lib__WEBPACK_IMPORTED_MODULE_0__, 2)));
 }),
 "./lib.js": (function (__unused_webpack_module, exports, __webpack_require__) {
-exports['a'] = 100000;
+exports.a = 100000;
 }),
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/new_treeshaking.snap
@@ -27,7 +27,7 @@ __webpack_require__.el(/* ./bar */"./bar.js").then(__webpack_require__.bind(__we
     console.log(mod);
 });
  const a = "a";
-exports.test = 30;
+__webpack_exports__.test = 30;
 }),
 "./foo.js": (function (module, exports, __webpack_require__) {
 {

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/output.snap
@@ -27,7 +27,7 @@ __webpack_require__.el(/* ./bar */"./bar.js").then(__webpack_require__.bind(__we
     console.log(mod);
 });
  const a = "a";
-exports.test = 30;
+__webpack_exports__.test = 30;
 }),
 "./foo.js": (function (module, exports, __webpack_require__) {
 {

--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -24,6 +24,8 @@ pub enum DependencyType {
   DynamicImportEager,
   // cjs require
   CjsRequire,
+  // cjs exports
+  CjsExports,
   // new URL("./foo", import.meta.url)
   NewUrl,
   // new Worker()
@@ -75,6 +77,7 @@ impl DependencyType {
       DependencyType::EsmImportSpecifier => Cow::Borrowed("esm import specifier"),
       DependencyType::DynamicImport => Cow::Borrowed("dynamic import"),
       DependencyType::CjsRequire => Cow::Borrowed("cjs require"),
+      DependencyType::CjsExports => Cow::Borrowed("cjs exports"),
       DependencyType::NewUrl => Cow::Borrowed("new URL()"),
       DependencyType::NewWorker => Cow::Borrowed("new Worker()"),
       DependencyType::ImportMetaHotAccept => Cow::Borrowed("import.meta.webpackHot.accept"),

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -61,7 +61,7 @@ pub fn export_from_import(
           format!("var {import_var}_namespace_cache;\n",),
           InitFragmentStage::StageHarmonyExports,
           -1,
-          InitFragmentKey::uniqie(),
+          InitFragmentKey::unique(),
           None,
         )
         .boxed(),

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -348,7 +348,10 @@ impl ExportsInfoId {
         let info = self.get_read_only_export_info(&name, mg);
         info.get_used_name(&name, runtime).map(UsedName::Str)
       }
-      UsedName::Vec(_) => todo!(),
+      UsedName::Vec(_) => {
+        // TODO
+        Some(name.clone())
+      }
     }
   }
 
@@ -514,7 +517,7 @@ impl ExportsInfo {
   }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum UsedName {
   Str(JsWord),
   Vec(Vec<JsWord>),

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -19,8 +19,8 @@ pub struct InitFragmentContents {
   pub end: Option<String>,
 }
 
-pub struct InitFragmentKeyUniqie;
-pub type InitFragmentKeyUKey = rspack_database::Ukey<InitFragmentKeyUniqie>;
+pub struct InitFragmentKeyUnique;
+pub type InitFragmentKeyUKey = rspack_database::Ukey<InitFragmentKeyUnique>;
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum InitFragmentKey {
@@ -31,12 +31,12 @@ pub enum InitFragmentKey {
   AwaitDependencies,
   HarmonyCompatibility,
   ModuleDecorator(String /* module_id */),
-  Uniqie(InitFragmentKeyUKey),
+  Unique(InitFragmentKeyUKey),
 }
 
 impl InitFragmentKey {
-  pub fn uniqie() -> Self {
-    Self::Uniqie(rspack_database::Ukey::new())
+  pub fn unique() -> Self {
+    Self::Unique(rspack_database::Ukey::new())
   }
 }
 
@@ -79,7 +79,7 @@ impl InitFragmentKey {
       | InitFragmentKey::HarmonyExportStar(_)
       | InitFragmentKey::ExternalModule(_)
       | InitFragmentKey::ModuleDecorator(_) => first(fragments),
-      InitFragmentKey::HarmonyCompatibility | InitFragmentKey::Uniqie(_) => {
+      InitFragmentKey::HarmonyCompatibility | InitFragmentKey::Unique(_) => {
         debug_assert!(fragments.len() == 1, "fragment = {:?}", self);
         first(fragments)
       }

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -220,6 +220,8 @@ bitflags! {
      * the System.register context object
      */
     const SYSTEM_CONTEXT = 1 << 49;
+
+    const THIS_AS_EXPORTS = 1 << 50;
   }
 }
 
@@ -290,6 +292,7 @@ impl RuntimeGlobals {
       R::HARMONY_MODULE_DECORATOR => "__webpack_require__.hmd",
       R::NODE_MODULE_DECORATOR => "__webpack_require__.nmd",
       R::SYSTEM_CONTEXT => "__webpack_require__.y",
+      R::THIS_AS_EXPORTS => "top-level-this-exports",
       r => panic!(
         "Unexpected flag `{r:?}`. RuntimeGlobals should only be printed for one single flag."
       ),

--- a/crates/rspack_core/src/utils/visitor.rs
+++ b/crates/rspack_core/src/utils/visitor.rs
@@ -225,6 +225,10 @@ pub fn extract_member_expression_chain<'e, T: Into<MaybeExpr<'e>>>(
       Expr::Member(ref expr) => {
         walk_member_expr(expr, false, members, members_optionals, members_spans, kind)
       }
+      Expr::This(ref this_expr) => {
+        members.push_front((JsWord::from("this"), this_expr.span.ctxt));
+        members_spans.push_front(this_expr.span);
+      }
       Expr::Ident(ref ident) => {
         members.push_front((ident.sym.clone(), ident.span.ctxt));
         members_spans.push_front(ident.span);

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
@@ -1,4 +1,7 @@
+mod common_js_exports_dependency;
 mod common_js_require_dependency;
+pub use common_js_exports_dependency::CommonJsExportsDependency;
+pub use common_js_exports_dependency::ExportsBase;
 pub use common_js_require_dependency::CommonJsRequireDependency;
 mod require_resolve_dependency;
 pub use require_resolve_dependency::RequireResolveDependency;

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
@@ -58,7 +58,7 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
         ),
         InitFragmentStage::StageAsyncBoundary,
         0,
-        InitFragmentKey::uniqie(),
+        InitFragmentKey::unique(),
         Some(format!("\n__webpack_async_result__();\n}} catch(e) {{ __webpack_async_result__(e); }} }}{});", if matches!(mgm.build_meta.as_ref().map(|meta| meta.has_top_level_await), Some(true)) { ", 1" } else { "" })),
       )));
     }

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -86,9 +86,17 @@ impl JsPlugin {
             execOptions.factory.call(module.exports, module, module.exports, execOptions.require);
             "#,
       ),
-      false => RawSource::from(
-        "__webpack_modules__[moduleId](module, module.exports, __webpack_require__);\n",
-      ),
+      false => {
+        if runtime_requirements.contains(RuntimeGlobals::THIS_AS_EXPORTS) {
+          RawSource::from(
+            "__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);\n",
+          )
+        } else {
+          RawSource::from(
+            "__webpack_modules__[moduleId](module, module.exports, __webpack_require__);\n",
+          )
+        }
+      }
     };
 
     if strict_module_error_handling {

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -104,18 +104,35 @@ fn render_module(
   runtime_requirements: Option<&RuntimeGlobals>,
   module_id: &str,
 ) -> Result<BoxSource> {
-  // TODO unused exports_argument
-  let module_argument = {
+  let need_module = runtime_requirements.is_some_and(|r| r.contains(RuntimeGlobals::MODULE));
+  // TODO: determine arguments by runtime requirements after aligning commonjs dependencies with webpack
+  // let need_exports = runtime_requirements.is_some_and(|r| r.contains(RuntimeGlobals::EXPORTS));
+  // let need_require = runtime_requirements.is_some_and(|r| {
+  //   r.contains(RuntimeGlobals::REQUIRE) || r.contains(RuntimeGlobals::REQUIRE_SCOPE)
+  // });
+  let need_exports = true;
+  let need_require = true;
+
+  let mut args = Vec::new();
+  if need_module || need_exports || need_require {
     let module_argument = mgm.get_module_argument();
-    if let Some(runtime_requirements) = runtime_requirements
-      && runtime_requirements.contains(RuntimeGlobals::MODULE)
-    {
+    args.push(if need_module {
       module_argument.to_string()
     } else {
       format!("__unused_webpack_{module_argument}")
-    }
-  };
-  let exports_argument = mgm.get_exports_argument();
+    });
+  }
+  if need_exports || need_require {
+    let exports_argument = mgm.get_exports_argument();
+    args.push(if need_exports {
+      exports_argument.to_string()
+    } else {
+      format!("__unused_webpack_{exports_argument}")
+    });
+  }
+  if need_require {
+    args.push(RuntimeGlobals::REQUIRE.to_string());
+  }
   let mut sources = ConcatSource::new([
     RawSource::from(serde_json::to_string(module_id).map_err(|e| internal_error!(e.to_string()))?),
     RawSource::from(": "),
@@ -124,8 +141,8 @@ fn render_module(
     sources.add(RawSource::from(format!("\n/* start::{} */\n", module_id)));
   }
   sources.add(RawSource::from(format!(
-    "(function ({module_argument}, {exports_argument}, {}) {{\n",
-    RuntimeGlobals::REQUIRE
+    "(function ({}) {{\n",
+    args.join(", ")
   )));
   if let Some(build_info) = &mgm.build_info
     && build_info.strict

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -117,6 +117,7 @@ pub fn scan_dependencies(
     ));
     program.visit_with(&mut RequireContextScanner::new(&mut dependencies));
     program.visit_with(&mut CommonJsExportDependencyScanner::new(
+      &mut dependencies,
       &mut presentational_dependencies,
       unresolved_ctxt,
       build_meta,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -97,9 +97,6 @@ pub(crate) mod expr_matcher {
     is_import_meta_webpack_context: "import.meta.webpackContext",
     is_import_meta_url: "import.meta.url",
     is_import_meta: "import.meta",
-    is_exports_esmodule: "exports.__esModule",
-    is_this_esmodule: "this.__esModule",
-    is_module_exports_esmodule: "module.exports.__esModule",
     is_object_define_property: "Object.defineProperty",
   });
 }

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -79,7 +79,7 @@ describe("Stats", () => {
 
 
 
-		Rspack compiled with 1 error (720d278abb396fd4623f)"
+		Rspack compiled with 1 error (22193973344376247dbc)"
 	`);
 	});
 

--- a/packages/rspack/tests/__snapshots__/Stats.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Stats.test.ts.snap
@@ -421,7 +421,7 @@ exports.c = require("./c?c=3");
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "592ad362eb9d0efc897b",
+  "hash": "f141b204a28da3455a73",
   "logging": {},
   "modules": [
     {

--- a/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/arrow.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/arrow.js
@@ -1,0 +1,8 @@
+const F = () => {
+	this.test1 = true;
+	Object.defineProperty(this, "test2", {
+		value: true
+	});
+	return this;
+};
+exports.fff = F();

--- a/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/class.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/class.js
@@ -1,0 +1,9 @@
+class F {
+	constructor() {
+		this.test1 = true;
+		Object.defineProperty(this, "test2", {
+			value: true
+		});
+	}
+}
+exports.fff = new F();

--- a/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/function.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/function.js
@@ -1,0 +1,7 @@
+function F() {
+	this.test1 = true;
+	Object.defineProperty(this, "test2", {
+		value: true
+	});
+}
+exports.fff = new F();

--- a/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/non-root-this/index.js
@@ -1,0 +1,15 @@
+it("should not rewrite this nested in functions", () => {
+	const f = require("./function.js").fff;
+	expect(f.test1).toBe(true);
+	expect(f.test2).toBe(true);
+});
+it("should not rewrite this nested in class", () => {
+	const f = require("./class.js").fff;
+	expect(f.test1).toBe(true);
+	expect(f.test2).toBe(true);
+});
+it("should not rewrite this nested in arrow functions", () => {
+	const f = require("./arrow.js").fff;
+	expect(f.test1).toBe(true);
+	expect(f.test2).toBe(true);
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/exports.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/exports.js
@@ -1,0 +1,16 @@
+exports.aaa = function () {
+	return 1;
+};
+exports.aaa.bbb = function () {
+	return 2;
+};
+Object.defineProperty(exports, "ccc", {
+	value: function () {
+		return 3;
+	}
+});
+Object.defineProperty(exports.ccc, "ddd", {
+	value: function () {
+		return 4;
+	}
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/index.js
@@ -1,0 +1,21 @@
+it("should handle sub properties of module exports correctly", () => {
+	const mod = require("./module-exports.js");
+	expect(mod.aaa()).toBe(1);
+	expect(mod.aaa.bbb()).toBe(2);
+	expect(mod.ccc()).toBe(3);
+	expect(mod.ccc.ddd()).toBe(4);
+});
+it("should handle sub properties of this correctly", () => {
+	const mod = require("./this.js");
+	expect(mod.aaa()).toBe(1);
+	expect(mod.aaa.bbb()).toBe(2);
+	expect(mod.ccc()).toBe(3);
+	expect(mod.ccc.ddd()).toBe(4);
+});
+it("should handle sub properties of exports correctly", () => {
+	const mod = require("./exports.js");
+	expect(mod.aaa()).toBe(1);
+	expect(mod.aaa.bbb()).toBe(2);
+	expect(mod.ccc()).toBe(3);
+	expect(mod.ccc.ddd()).toBe(4);
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/module-exports.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/module-exports.js
@@ -1,0 +1,16 @@
+module.exports.aaa = function () {
+	return 1;
+};
+module.exports.aaa.bbb = function () {
+	return 2;
+};
+Object.defineProperty(module.exports, "ccc", {
+	value: function () {
+		return 3;
+	}
+});
+Object.defineProperty(module.exports.ccc, "ddd", {
+	value: function () {
+		return 4;
+	}
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/this.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/sub-properties/this.js
@@ -1,0 +1,16 @@
+this.aaa = function () {
+	return 1;
+};
+this.aaa.bbb = function () {
+	return 2;
+};
+Object.defineProperty(this, "ccc", {
+	value: function () {
+		return 3;
+	}
+});
+Object.defineProperty(this.ccc, "ddd", {
+	value: function () {
+		return 4;
+	}
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/top-level-this/block.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/top-level-this/block.js
@@ -1,0 +1,10 @@
+if (this.aaa !== 1) {
+	this.aaa = 1;
+}
+
+while (true) {
+	Object.defineProperty(this, "bbb", {
+		value: 2
+	});
+	break;
+}

--- a/packages/rspack/tests/cases/cjs-tree-shaking/top-level-this/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/top-level-this/index.js
@@ -1,0 +1,10 @@
+it("should handle top level this in the root scope", () => {
+	const mod = require("./root.js");
+	expect(mod.aaa).toBe(1);
+	expect(mod.bbb).toBe(2);
+});
+it("should handle top level this in block scope", () => {
+	const mod = require("./block.js");
+	expect(mod.aaa).toBe(1);
+	expect(mod.bbb).toBe(2);
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/top-level-this/root.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/top-level-this/root.js
@@ -1,0 +1,4 @@
+this.aaa = 1;
+Object.defineProperty(this, "bbb", {
+	value: 2
+});

--- a/webpack-test/cases/cjs-tree-shaking/bailouts/test.filter.js
+++ b/webpack-test/cases/cjs-tree-shaking/bailouts/test.filter.js
@@ -1,5 +1,4 @@
 const { FilteredStatus } = require("../../../lib/util/filterUtil")
 
-module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4313, https://github.com/web-infra-dev/rspack/issues/4324"]}
+module.exports = () => { return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4313"] }
 
-							

--- a/webpack-test/cases/cjs-tree-shaking/exports/test.filter.js
+++ b/webpack-test/cases/cjs-tree-shaking/exports/test.filter.js
@@ -1,5 +1,0 @@
-const { FilteredStatus } = require("../../../lib/util/filterUtil")
-
-module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4324"]}
-
-							

--- a/webpack-test/cases/cjs-tree-shaking/object-define-property-replace/test.filter.js
+++ b/webpack-test/cases/cjs-tree-shaking/object-define-property-replace/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4324"}
-
-							


### PR DESCRIPTION
## Summary

Re-implement PR: https://github.com/web-infra-dev/rspack/pull/4572
The PR had been reverted because wrong transformation of `this.x.y` in class.

resolve #4324 

## Test Plan

1. Adding `rspack/tests/cases/cjs-tree-shaking/non-root-this` to check this in functions/arrow functions/classes
2. Adding `rspack/tests/cases/cjs-tree-shaking/sub-properties` to check get members of this/exports/module.exports
3. Reuse `webpack-test/cases/cjs-tree-shaking/exports` and `webpack-test/cases/cjs-tree-shaking/object-define-property-replace` and remove their test.filter.js

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
