### PR TITLE
perf: reduce aggregateTimeout to speed up HMR

### DIFF
--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -58,6 +58,12 @@ class Watching {
 		this.handler = handler;
 		this.suspended = false;
 
+		// The default aggregateTimeout of WatchPack is 200ms,
+		// using smaller values can improve hmr performance
+		if (typeof this.watchOptions.aggregateTimeout !== "number") {
+			this.watchOptions.aggregateTimeout = 5;
+		}
+
 		process.nextTick(() => {
 			if (this.#initial) this.#invalidate();
 		});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The default aggregateTimeout of WatchPack is `200ms`, using smaller values can improve hmr performance.

- webpack defaults to 20ms: https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/Watching.js#L53-L55
- next.js defaults to 5ms: https://github.com/vercel/next.js/blob/0a4f26f1ef26ae07131bea07e5a2058807193c65/packages/next/taskfile-watch.js#L40

Ref:

- https://github.com/webpack/watchpack/tree/dc690bbaea140820f1d9c7c2ec4dff8902798ff9#api

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
