### PR TITLE
fix(resolver): make sure package.json path is inside the resolved path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1727,9 +1727,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "oxc_resolver"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05eb41b7e97d361603484307a9fc526318320dd290739779b3af0f261195b417"
+checksum = "1d10d078b6ba0b8cfa0eb634ef749698aa82ef4a86c7ba1446453644ccf13fd2"
 dependencies = [
  "dashmap",
  "dunce",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -23,7 +23,7 @@ itertools = { workspace = true }
 mime_guess = { workspace = true }
 nodejs-resolver = { version = "0.1.0" }
 once_cell = { workspace = true }
-oxc_resolver = { version = "0.5.3" }
+oxc_resolver = { version = "0.5.4" }
 paste = { workspace = true }
 petgraph = { version = "0.6.3", features = ["serde-1"] }
 rayon = { workspace = true }


### PR DESCRIPTION
## Summary

Previously Package.json path returned the non-symlinked path, which breaks code splitting where it tries to resolve package_json.sideEffects.

https://github.com/oxc-project/oxc/pull/1481/files

## Test Plan

* I ran the code where it went wrong and made sure the path returned the symlinked one.
* I also added a runtime check inside oxc_resolver to make sure all paths are correct.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
