### PR TITLE
chore: compat get default export

### DIFF
--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/new_treeshaking.snap
@@ -41,7 +41,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/* ./foo */"./foo.js");
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_foo__WEBPACK_IMPORTED_MODULE_0__);
 
-_foo__WEBPACK_IMPORTED_MODULE_0___default();
+_foo__WEBPACK_IMPORTED_MODULE_0___default()();
 }),
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/output.snap
@@ -41,7 +41,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/* ./foo */"./foo.js");
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_foo__WEBPACK_IMPORTED_MODULE_0__);
 
-_foo__WEBPACK_IMPORTED_MODULE_0___default();
+_foo__WEBPACK_IMPORTED_MODULE_0___default()();
 }),
 
 },function(__webpack_require__) {

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/new_treeshaking.snap
@@ -158,7 +158,7 @@ __webpack_require__.r(__webpack_exports__);
 
 it("should generate valid code", ()=>{
     expect((0, _a__WEBPACK_IMPORTED_MODULE_0__["default"])()).toBe("x");
-    expect(new (0, _d__WEBPACK_IMPORTED_MODULE_3__["default"])().method()).toBe("x");
+    expect(new _d__WEBPACK_IMPORTED_MODULE_3__["default"]().method()).toBe("x");
 });
 it("a should be used", ()=>{
     expect(_dep_a__WEBPACK_IMPORTED_MODULE_6__["default"]).toBe(true);

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/output.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/output.snap
@@ -158,7 +158,7 @@ __webpack_require__.r(__webpack_exports__);
 
 it("should generate valid code", ()=>{
     expect((0, _a__WEBPACK_IMPORTED_MODULE_0__["default"])()).toBe("x");
-    expect(new (0, _d__WEBPACK_IMPORTED_MODULE_3__["default"])().method()).toBe("x");
+    expect(new _d__WEBPACK_IMPORTED_MODULE_3__["default"]().method()).toBe("x");
 });
 it("a should be used", ()=>{
     expect(_dep_a__WEBPACK_IMPORTED_MODULE_6__["default"]).toBe(true);

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -32,7 +32,7 @@ pub fn export_from_import(
     {
       match exports_type {
         ExportsType::Dynamic => {
-          return format!("{import_var}_default{}", property_access(export_name, 1));
+          return format!("{import_var}_default(){}", property_access(export_name, 1));
         }
         ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
           export_name = export_name[1..].to_vec();

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -32,7 +32,14 @@ pub fn export_from_import(
     {
       match exports_type {
         ExportsType::Dynamic => {
-          return format!("{import_var}_default(){}", property_access(export_name, 1));
+          if is_call {
+            return format!("{import_var}_default(){}", property_access(export_name, 1));
+          } else {
+            return format!(
+              "({import_var}_default(){})",
+              property_access(export_name, 1)
+            );
+          }
         }
         ExportsType::DefaultOnly | ExportsType::DefaultWithNamed => {
           export_name = export_name[1..].to_vec();

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/compat_get_default_export.js
@@ -1,9 +1,11 @@
 // getDefaultExport function for compatibility with non-harmony modules
-__webpack_require__.n = function(module) {
-	// var getter = module && module.__esModule ?
-    //     function() { return module['default']; } :
-    //     function() { return module; }
-	// __webpack_require__.d(getter, { a: getter });
-	// return getter;
-	return module && module.__esModule ? module['default'] : module;
+__webpack_require__.n = function (module) {
+	var getter = module && module.__esModule ?
+		function () { return module['default']; } :
+		function () { return module; };
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
 };
+
+
+

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -5008,7 +5008,7 @@ exports[`StatsTestCases should print correct stats for resolve-overflow 1`] = `
         "hotModuleReplacement": false,
       },
       "name": "bundle.js",
-      "size": 725,
+      "size": 784,
       "type": "asset",
     },
   ],
@@ -5112,10 +5112,10 @@ console.log(a);
       "assets": [
         {
           "name": "bundle.js",
-          "size": 725,
+          "size": 784,
         },
       ],
-      "assetsSize": 725,
+      "assetsSize": 784,
       "chunks": [
         "main",
       ],
@@ -5139,7 +5139,7 @@ console.log(a);
   ],
   "errorsCount": 1,
   "filteredModules": undefined,
-  "hash": "316ac2fb3476f8bb6f1d",
+  "hash": "88fc59502999f71143b5",
   "logging": {},
   "modules": [
     {
@@ -5293,10 +5293,10 @@ console.log(a);
       "assets": [
         {
           "name": "bundle.js",
-          "size": 725,
+          "size": 784,
         },
       ],
-      "assetsSize": 725,
+      "assetsSize": 784,
       "chunks": [
         "main",
       ],
@@ -5312,8 +5312,8 @@ console.log(a);
 
 exports[`StatsTestCases should print correct stats for resolve-overflow 2`] = `
 "PublicPath: auto
-asset bundle.js 725 bytes {main} [emitted] (name: main)
-Entrypoint main 725 bytes = bundle.js
+asset bundle.js 784 bytes {main} [emitted] (name: main)
+Entrypoint main 784 bytes = bundle.js
 chunk {main} bundle.js (main) [entry]
   ./index.js [10] {main}
     entry ./index
@@ -5340,7 +5340,7 @@ error[internal]: Resolve error
 
 
 
-Rspack compiled with 1 error (316ac2fb3476f8bb6f1d)"
+Rspack compiled with 1 error (88fc59502999f71143b5)"
 `;
 
 exports[`StatsTestCases should print correct stats for resolve-unexpected-exports-in-pkg 1`] = `
@@ -5359,7 +5359,7 @@ exports[`StatsTestCases should print correct stats for resolve-unexpected-export
         "hotModuleReplacement": false,
       },
       "name": "bundle.js",
-      "size": 741,
+      "size": 802,
       "type": "asset",
     },
   ],
@@ -5463,10 +5463,10 @@ console.log(a);
       "assets": [
         {
           "name": "bundle.js",
-          "size": 741,
+          "size": 802,
         },
       ],
-      "assetsSize": 741,
+      "assetsSize": 802,
       "chunks": [
         "main",
       ],
@@ -5484,7 +5484,7 @@ console.log(a);
   ],
   "errorsCount": 1,
   "filteredModules": undefined,
-  "hash": "1126dba73be58b520899",
+  "hash": "70fb47b3fcabdfbd56a5",
   "logging": {},
   "modules": [
     {
@@ -5638,10 +5638,10 @@ console.log(a);
       "assets": [
         {
           "name": "bundle.js",
-          "size": 741,
+          "size": 802,
         },
       ],
-      "assetsSize": 741,
+      "assetsSize": 802,
       "chunks": [
         "main",
       ],
@@ -5657,8 +5657,8 @@ console.log(a);
 
 exports[`StatsTestCases should print correct stats for resolve-unexpected-exports-in-pkg 2`] = `
 "PublicPath: (none)
-asset bundle.js 741 bytes {main} [emitted] (name: main)
-Entrypoint main 741 bytes = bundle.js
+asset bundle.js 802 bytes {main} [emitted] (name: main)
+Entrypoint main 802 bytes = bundle.js
 chunk {main} bundle.js (main) [entry]
   ./index.js [10] {main}
     entry ./index
@@ -5679,7 +5679,7 @@ error[internal]: Export should be relative path and start with "./", but got ../
 
 
 
-Rspack compiled with 1 error (1126dba73be58b520899)"
+Rspack compiled with 1 error (70fb47b3fcabdfbd56a5)"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-modules 1`] = `
@@ -5975,7 +5975,7 @@ exports[`StatsTestCases should print correct stats for simple-module-source 1`] 
         "hotModuleReplacement": false,
       },
       "name": "bundle.js",
-      "size": 631,
+      "size": 690,
       "type": "asset",
     },
   ],
@@ -6106,10 +6106,10 @@ import rawModule from './raw.png';
       "assets": [
         {
           "name": "bundle.js",
-          "size": 631,
+          "size": 690,
         },
       ],
-      "assetsSize": 631,
+      "assetsSize": 690,
       "chunks": [
         "main",
       ],
@@ -6119,7 +6119,7 @@ import rawModule from './raw.png';
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "29752efc1d9212dd2d67",
+  "hash": "272d9a92b8ecd819a332",
   "logging": {},
   "modules": [
     {
@@ -6300,10 +6300,10 @@ import rawModule from './raw.png';
       "assets": [
         {
           "name": "bundle.js",
-          "size": 631,
+          "size": 690,
         },
       ],
-      "assetsSize": 631,
+      "assetsSize": 690,
       "chunks": [
         "main",
       ],
@@ -6319,13 +6319,13 @@ import rawModule from './raw.png';
 
 exports[`StatsTestCases should print correct stats for simple-module-source 2`] = `
 "PublicPath: (none)
-asset bundle.js 631 bytes [emitted] (name: main)
-Entrypoint main 631 bytes = bundle.js
+asset bundle.js 690 bytes [emitted] (name: main)
+Entrypoint main 690 bytes = bundle.js
 runtime modules 4 modules
 ./raw.png
 ./index.js
 ./stringModule.js
-Rspack compiled successfully (29752efc1d9212dd2d67)"
+Rspack compiled successfully (272d9a92b8ecd819a332)"
 `;
 
 exports[`StatsTestCases should print correct stats for stats-hooks 1`] = `

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -5484,7 +5484,7 @@ console.log(a);
   ],
   "errorsCount": 1,
   "filteredModules": undefined,
-  "hash": "70fb47b3fcabdfbd56a5",
+  "hash": "432c6329523a2019be22",
   "logging": {},
   "modules": [
     {
@@ -5679,7 +5679,7 @@ error[internal]: Export should be relative path and start with "./", but got ../
 
 
 
-Rspack compiled with 1 error (70fb47b3fcabdfbd56a5)"
+Rspack compiled with 1 error (432c6329523a2019be22)"
 `;
 
 exports[`StatsTestCases should print correct stats for runtime-modules 1`] = `

--- a/packages/rspack/tests/cases/parsing/issue-4643/d.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/d.js
@@ -1,13 +1,11 @@
 function c() {
 	this.val = "c";
-	this.b = "b";
 }
 
 c.prototype.value = function () {
 	return "c";
 };
-c.prototype.a = function () {
-	return "a";
-};
 
-module.exports = c;
+module.exports = {
+	c: c
+};

--- a/packages/rspack/tests/cases/parsing/issue-4643/e.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/e.js
@@ -2,7 +2,6 @@ module.exports = function () {
 	function c() {
 		this.val = "c";
 	}
-
 	c.prototype.value = function () {
 		return "c";
 	};

--- a/packages/rspack/tests/cases/parsing/issue-4643/e.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/e.js
@@ -1,0 +1,10 @@
+module.exports = function () {
+	function c() {
+		this.val = "c";
+	}
+
+	c.prototype.value = function () {
+		return "c";
+	};
+	return c;
+};

--- a/packages/rspack/tests/cases/parsing/issue-4643/index.js
+++ b/packages/rspack/tests/cases/parsing/issue-4643/index.js
@@ -1,6 +1,8 @@
 import a from "./a";
 import b from "./b";
 import c from "./c";
+import d from "./d";
+import e from "./e";
 
 it("should handle default exports when used as value", function () {
 	expect(a).toBe("a");
@@ -17,4 +19,20 @@ it("should handle default exports when used as class", function () {
 
 it("should handle default exports when used as class method callee", function () {
 	expect(new c().value()).toBe("c");
+	expect(new c().a()).toBe("a");
+});
+
+it("should handle default exports when used as class property", function () {
+	expect(new c().val).toBe("c");
+	expect(new c().b).toBe("b");
+});
+
+it("should handle default exports when used as class from object property", function () {
+	expect(new d.c().val).toBe("c");
+	expect(new d.c().value()).toBe("c");
+});
+
+it("should handle default exports when used as class from function", function () {
+	expect(new (e())().val).toBe("c");
+	expect(new (e())().value()).toBe("c");
 });

--- a/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/src/a.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/src/a.js
@@ -1,0 +1,2 @@
+import t from "./b";
+console.log(t);

--- a/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/src/b.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/src/b.js
@@ -1,0 +1,1 @@
+console.log("b");

--- a/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/src/index.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/src/index.js
@@ -1,0 +1,2 @@
+import "./a";
+console.log("hello, world");

--- a/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-compat-get-default-export/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/compat_get_default_export"]
+};


### PR DESCRIPTION
## Summary

Re-implement of #4639 and #4607
Depend on the modified logic of is_call in branch #4729

## Test Plan

- Add some edge cases

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
