### PR TITLE
fix: remove @types/webpack-dev-server

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -38,7 +38,6 @@ export class RspackDevServer extends WebpackDevServer {
 
 	constructor(options: DevServer, compiler: Compiler | MultiCompiler) {
 		super(
-			// @ts-expect-error
 			{
 				...options,
 				setupMiddlewares: (middlewares, devServer) => {
@@ -74,7 +73,6 @@ export class RspackDevServer extends WebpackDevServer {
 						}
 					}
 
-					// @ts-expect-error
 					options.setupMiddlewares?.call(this, middlewares, devServer);
 					return middlewares;
 				}

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -18,9 +18,7 @@
     "test": "cross-env NO_COLOR=1 RSPACK_DEP_WARNINGS=false node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage --testPathIgnorePatterns \".diff.test.ts\"",
     "test-diff": "cross-env RSPACK_DIFF=true NO_COLOR=1 RSPACK_DEP_WARNINGS=false node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage --testPathPattern \".diff.test.ts\""
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "engines": {
     "node": ">=16.0.0"
   },
@@ -39,7 +37,6 @@
     "@swc/jest": "^0.2.29",
     "@types/watchpack": "^2.4.0",
     "@types/webpack": "5.28.3",
-    "@types/webpack-dev-server": "^4.7.2",
     "@types/webpack-sources": "3.2.0",
     "@types/ws": "8.5.3",
     "babel-loader": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1457,9 +1457,6 @@ importers:
       '@types/webpack':
         specifier: 5.28.3
         version: 5.28.3(@swc/core@1.3.96)
-      '@types/webpack-dev-server':
-        specifier: ^4.7.2
-        version: 4.7.2(webpack@5.89.0)
       '@types/webpack-sources':
         specifier: 3.2.0
         version: 3.2.0
@@ -12415,20 +12412,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-      - webpack-cli
-    dev: true
-
-  /@types/webpack-dev-server@4.7.2(webpack@5.89.0):
-    resolution: {integrity: sha512-Y3p0Fmfvp0MHBDoCzo+xFJaWTw0/z37mWIo6P15j+OtmUDLvznJWdZNeD7Q004R+MpQlys12oXbXsrXRmxwg4Q==}
-    deprecated: This is a stub types definition. webpack-dev-server provides its own type definitions, so you do not need this installed.
-    dependencies:
-      webpack-dev-server: 4.13.2(webpack@5.89.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
       - webpack-cli
     dev: true
 
@@ -28125,20 +28108,6 @@ packages:
       webpack: 5.76.0
     dev: false
 
-  /webpack-dev-middleware@5.3.3(webpack@5.89.0):
-    resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
-    engines: {node: '>= 12.13.0'}
-    peerDependencies:
-      webpack: ^4.0.0 || ^5.0.0
-    dependencies:
-      colorette: 2.0.19
-      memfs: 3.4.12
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.0.1
-      webpack: 5.89.0(@swc/core@1.3.96)
-    dev: true
-
   /webpack-dev-middleware@6.0.2:
     resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
     engines: {node: '>= 14.15.0'}
@@ -28272,57 +28241,6 @@ packages:
       - supports-color
       - utf-8-validate
     dev: false
-
-  /webpack-dev-server@4.13.2(webpack@5.89.0):
-    resolution: {integrity: sha512-5i6TrGBRxG4vnfDpB6qSQGfnB6skGBXNL5/542w2uRGLimX6qeE5BQMLrzIC3JYV/xlGOv+s+hTleI9AZKUQNw==}
-    engines: {node: '>= 12.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack: ^4.37.0 || ^5.0.0
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
-      '@types/express': 4.17.14
-      '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.0
-      '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.3
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.0.14
-      chokidar: 3.5.3
-      colorette: 2.0.19
-      compression: 1.7.4
-      connect-history-api-fallback: 2.0.0
-      default-gateway: 6.0.3
-      express: 4.18.2
-      graceful-fs: 4.2.10
-      html-entities: 2.3.3
-      http-proxy-middleware: 2.0.6(@types/express@4.17.14)
-      ipaddr.js: 2.0.1
-      launch-editor: 2.6.0
-      open: 8.4.2
-      p-retry: 4.6.2
-      rimraf: 3.0.2
-      schema-utils: 4.0.1
-      selfsigned: 2.1.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack: 5.89.0(@swc/core@1.3.96)
-      webpack-dev-middleware: 5.3.3(webpack@5.89.0)
-      ws: 8.13.0
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-    dev: true
 
   /webpack-hot-middleware@2.25.3:
     resolution: {integrity: sha512-IK/0WAHs7MTu1tzLTjio73LjS3Ov+VvBKQmE8WPlJutgG5zT6Urgq/BbAdRrHTRpyzK0dvAvFh1Qg98akxgZpA==}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`@types/webpack-dev-server` will cause two versions of webpack-dev-server to be installed. This will make ci fail https://github.com/web-infra-dev/rspack/actions/runs/6954833718/job/18922501326?pr=4743

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
