### PR TITLE
fix: use fixed version for rspack in template

### DIFF
--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -11,8 +11,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@rspack/cli": "latest",
-    "@rspack/core": "latest",
+    "@rspack/cli": "0.3.14",
+    "@rspack/core": "0.3.14",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.1",
     "typescript": "^5.0.4"

--- a/packages/create-rspack/template-react/package.json
+++ b/packages/create-rspack/template-react/package.json
@@ -11,8 +11,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@rspack/cli": "latest",
-    "@rspack/core": "latest",
+    "@rspack/cli": "0.3.14",
+    "@rspack/core": "0.3.14",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.8"
   }

--- a/packages/create-rspack/template-vue/package.json
+++ b/packages/create-rspack/template-vue/package.json
@@ -12,8 +12,8 @@
     "vue": "3.2.45"
   },
   "devDependencies": {
-    "@rspack/cli": "latest",
-    "@rspack/core": "latest",
+    "@rspack/cli": "0.3.14",
+    "@rspack/core": "0.3.14",
     "vue-loader": "^17.2.2"
   },
   "keywords": [],


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use fixed version instead of latest in template of `create-rspack`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
