### PR TITLE
perf: compilation.hooks.optimizeChunkModules auto disable

### DIFF
--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -650,7 +650,7 @@ class Compiler {
 			stillValidModule: this.compilation.hooks.stillValidModule,
 			buildModule: this.compilation.hooks.buildModule,
 			thisCompilation: undefined,
-			optimizeChunkModules: undefined,
+			optimizeChunkModules: this.compilation.hooks.optimizeChunkModules,
 			contextModuleBeforeResolve: undefined,
 			normalModuleFactoryResolveForScheme: undefined,
 			executeModule: undefined


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

make compilation.hooks.optimizeChunkModules auto disable, this bug is introduced by
https://github.com/web-infra-dev/rspack/commit/46016b6f331c6a34e2f4a7e5cf0fd555e0dde5bd#diff-5eba14dafadd5b7ee447411919692ad06f841b6b93770e131cc6b364771f68b5

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
