### PR TITLE
chore(webpack-test): make tests more future proof

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "A Fast Rust-based web bundler",
   "private": true,
+  "main": "./packages/rspack/dist/index.js",
   "scripts": {
     "x": "zx x.mjs",
     "dev": "pnpm --filter @rspack/cli run dev",

--- a/webpack-test/ConfigTestCases.template.js
+++ b/webpack-test/ConfigTestCases.template.js
@@ -59,7 +59,9 @@ const describeCases = config => {
 			stderr = captureStdio(process.stderr, true);
 		});
 		afterEach(() => {
-			stderr.restore();
+			if (stderr) {
+				stderr.restore();
+			}
 		});
 		jest.setTimeout(TIMEOUT);
 
@@ -88,10 +90,12 @@ const describeCases = config => {
 						const cacheDirectory = path.join(outBaseDir, ".cache", testSubPath);
 						let options, optionsArr, testConfig;
 						beforeAll(() => {
-							options = prepareOptions(
-								require(path.join(testDirectory, "webpack.config.js")),
-								{ testPath: outputDirectory }
-							);
+							expect(() => {
+								options = prepareOptions(
+									require(path.join(testDirectory, "webpack.config.js")),
+									{ testPath: outputDirectory }
+								);
+							}).not.toThrow();
 							optionsArr = [].concat(options);
 							optionsArr.forEach((options, idx) => {
 								if (!options.context) options.context = testDirectory;

--- a/webpack-test/configCases/async-library/0-create-library/test.filter.js
+++ b/webpack-test/configCases/async-library/0-create-library/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}

--- a/webpack-test/configCases/issues/issue-7563/test.filter.js
+++ b/webpack-test/configCases/issues/issue-7563/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}


### PR DESCRIPTION
## Summary

This PR tries to make webpack-test more future proof by catching more errors where appropriate.

`webpack-test` has the assumption where all configs are valid and everything will compile, but this is not the case with Rspack.

I also found 2 passing tests so I added to this PR.

## Test Plan

* CI passes.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
