### PR TITLE
feat: support String.raw for context module

### DIFF
--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -74,6 +74,9 @@ impl ContextNameSpaceObject {
 }
 
 pub fn context_reg_exp(expr: &str, flags: &str) -> Option<RspackRegex> {
+  if expr.is_empty() {
+    return None;
+  }
   let regexp = RspackRegex::with_flags(expr, flags).expect("reg failed");
   clean_regexp_in_context_module(regexp)
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_helper.rs
@@ -179,7 +179,7 @@ fn scan_context_module_tagged_tpl(tpl: &TaggedTpl) -> (String, String) {
     {
       scan_context_module_tpl(tpl.tpl.as_ref(), TemplateStringKind::Raw)
     }
-    _ => scan_context_module_tpl(tpl.tpl.as_ref(), TemplateStringKind::Cooked),
+    _ => (String::from("."), String::new()),
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_helper.rs
@@ -25,7 +25,7 @@ pub fn scanner_context_module(expr: &Expr) -> Option<(String, String)> {
     }
     Expr::Bin(bin) => scan_context_module_bin(bin),
     Expr::Call(call) => scan_context_module_concat_call(call),
-    Expr::TaggedTpl(t_tpl) => scan_context_module_tagged_tpl(t_tpl),
+    Expr::TaggedTpl(t_tpl) => Some(scan_context_module_tagged_tpl(t_tpl)),
     _ => None,
   }
 }
@@ -163,7 +163,7 @@ fn scan_context_module_concat_call(expr: &CallExpr) -> Option<(String, String)> 
 }
 
 // require(String.raw`./${a}.js`)
-fn scan_context_module_tagged_tpl(tpl: &TaggedTpl) -> Option<(String, String)> {
+fn scan_context_module_tagged_tpl(tpl: &TaggedTpl) -> (String, String) {
   match tpl.tag.as_member() {
     Some(tag)
       if tag
@@ -177,15 +177,9 @@ fn scan_context_module_tagged_tpl(tpl: &TaggedTpl) -> Option<(String, String)> {
           .map(|ident| ident.sym == *"raw")
           .unwrap_or(false) =>
     {
-      Some(scan_context_module_tpl(
-        tpl.tpl.as_ref(),
-        TemplateStringKind::Raw,
-      ))
+      scan_context_module_tpl(tpl.tpl.as_ref(), TemplateStringKind::Raw)
     }
-    _ => Some(scan_context_module_tpl(
-      tpl.tpl.as_ref(),
-      TemplateStringKind::Cooked,
-    )),
+    _ => scan_context_module_tpl(tpl.tpl.as_ref(), TemplateStringKind::Cooked),
   }
 }
 

--- a/packages/rspack/tests/cases/context/context-module-cjs-require-tagged-template/child/child/index.js
+++ b/packages/rspack/tests/cases/context/context-module-cjs-require-tagged-template/child/child/index.js
@@ -1,0 +1,1 @@
+export const value = "dynamic";

--- a/packages/rspack/tests/cases/context/context-module-cjs-require-tagged-template/child/index.js
+++ b/packages/rspack/tests/cases/context/context-module-cjs-require-tagged-template/child/index.js
@@ -1,0 +1,13 @@
+it("context module(sync) + cjs require + tagged template", function (done) {
+	let a = "child/index";
+	let module = require(String.raw`./${a}.js`);
+	expect(module.value).toBe("dynamic");
+
+	let tagFunc = function () {
+		return "fail";
+	};
+	expect(function () {
+		require(tagFunc`./${a}.js`);
+	}).toThrowError(/Cannot find module/);
+	done();
+});

--- a/packages/rspack/tests/cases/context/context-module-cjs-require-tagged-template/index.js
+++ b/packages/rspack/tests/cases/context/context-module-cjs-require-tagged-template/index.js
@@ -1,0 +1,1 @@
+require("./child/index.js");

--- a/packages/rspack/tests/cases/context/context-module-dynamic-import-tagged-template/child/index.js
+++ b/packages/rspack/tests/cases/context/context-module-dynamic-import-tagged-template/child/index.js
@@ -1,0 +1,1 @@
+export const value = "dynamic";

--- a/packages/rspack/tests/cases/context/context-module-dynamic-import-tagged-template/index.js
+++ b/packages/rspack/tests/cases/context/context-module-dynamic-import-tagged-template/index.js
@@ -1,0 +1,14 @@
+it("context module + dynamic import + tagged template", function (done) {
+	let a = "child/index";
+	import(String.raw`./${a}.js`).then(module => {
+		expect(module.value).toBe("dynamic");
+	});
+
+	let tagFunc = function () {
+		return "./child/index";
+	};
+	import(tagFunc`./${a}.js`).catch(err => {
+		expect(err.message).toMatch(/Cannot find module/);
+		done();
+	});
+});

--- a/webpack-test/cases/parsing/complex-require/test.filter.js
+++ b/webpack-test/cases/parsing/complex-require/test.filter.js
@@ -8,6 +8,6 @@ module.exports = function (config) {
 };
 
 */
-module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4420, https://github.com/web-infra-dev/rspack/issues/4304, https://github.com/web-infra-dev/rspack/issues/4313"]}
+module.exports = () => {return [FilteredStatus.PARTIAL_PASS, "https://github.com/web-infra-dev/rspack/issues/4304, https://github.com/web-infra-dev/rspack/issues/4313"]}
 
 							


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
resolve #4420 
Add `templateStringKind` param for `scan_context_module_tpl`, if there is no `String.raw` tag function, inner_reg will created by `templateElement.cooked`, otherwise `templateElement.raw` will be used
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
