### PR TITLE
feat(compilation): support queue.wait_for

### DIFF
--- a/crates/rspack_core/src/utils/queue.rs
+++ b/crates/rspack_core/src/utils/queue.rs
@@ -1,32 +1,111 @@
+use std::any::Any;
 use std::collections::VecDeque;
+use std::hash::Hash;
 
-#[derive(Default)]
-pub struct WorkerQueue<T> {
-  inner: VecDeque<T>,
+use rustc_hash::FxHashMap;
+use tokio::sync::mpsc::UnboundedSender;
+
+pub trait Task<Key> {
+  fn get_key(&self) -> Key;
 }
 
-impl<T> WorkerQueue<T> {
+impl<T> Task<()> for T
+where
+  T: Any,
+{
+  fn get_key(&self) {}
+}
+
+struct QueueEntry<Key> {
+  finish: bool,
+  callbacks: Vec<UnboundedSender<Key>>,
+}
+
+impl<Key> std::fmt::Debug for QueueEntry<Key> {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("QueueEntry")
+      .field("finish", &self.finish)
+      .finish()
+  }
+}
+
+impl<Key> QueueEntry<Key> {
+  fn new() -> Self {
+    Self {
+      finish: false,
+      callbacks: Default::default(),
+    }
+  }
+}
+
+#[derive(Default, Debug)]
+pub struct WorkerQueue<T: Task<Key>, Key: std::fmt::Debug + Eq + Hash = ()> {
+  inner: VecDeque<T>,
+  entries: FxHashMap<Key, QueueEntry<Key>>,
+}
+
+#[allow(clippy::unwrap_in_result)]
+impl<T: Task<Key>, Key: Hash + Clone + Eq + std::fmt::Debug> WorkerQueue<T, Key> {
   pub fn new() -> Self {
     Self {
       inner: VecDeque::new(),
+      entries: Default::default(),
     }
   }
 
   pub fn add_task(&mut self, task: T) -> usize {
+    self.entries.insert(task.get_key(), QueueEntry::new());
+    self.inner.push_back(task);
+    self.inner.len()
+  }
+
+  pub fn add_task_with_callback(&mut self, task: T, callback: UnboundedSender<Key>) -> usize {
+    let entry = QueueEntry {
+      callbacks: vec![callback],
+      finish: false,
+    };
+
+    self.entries.insert(task.get_key(), entry);
     self.inner.push_back(task);
     self.inner.len()
   }
 
   pub fn add_tasks(&mut self, tasks: impl IntoIterator<Item = T>) -> usize {
-    self.inner.extend(tasks);
+    tasks.into_iter().for_each(|task| {
+      self.add_task(task);
+    });
     self.inner.len()
   }
 
   pub fn get_task(&mut self) -> Option<T> {
-    self.inner.pop_front()
+    if let Some(inner) = self.inner.pop_front() {
+      let key = inner.get_key();
+      if let Some(entry) = self.entries.get_mut(&key) {
+        entry.finish = true;
+        while let Some(callback) = entry.callbacks.pop() {
+          callback
+            .send(key.clone())
+            .expect("Failed to notify task result");
+        }
+      }
+
+      Some(inner)
+    } else {
+      None
+    }
   }
 
   pub fn is_empty(&self) -> bool {
     self.inner.is_empty()
+  }
+
+  pub fn wait_for(&mut self, key: Key, callback: UnboundedSender<Key>) {
+    if let Some(entry) = self.entries.get_mut(&key) {
+      if entry.finish {
+        callback.send(key).expect("Failed to notify task result");
+      } else {
+        entry.callbacks.push(callback);
+      }
+    }
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

compilation.executeModule needs to know when a module and all its children get built. Use queue.waitFor those modules, then do real execution

Note the difference compared to webpack, queue.waitFor from webpack can wait for module object directly, and get the task result of it. However our execution of task is transparent to WorkerQueue, so we can only waitFor module Identifier, and get the module identifier as result. However I think it's enough to implement executeModule. Webpack's queue.waitFor is just used to executeModule too.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
