### PR TITLE
fix: only register `SplitChunkPlugin` once

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -143,6 +143,8 @@ export const enum BuiltinPluginName {
   WebWorkerTemplatePlugin = 'WebWorkerTemplatePlugin',
   MergeDuplicateChunksPlugin = 'MergeDuplicateChunksPlugin',
   ContainerPlugin = 'ContainerPlugin',
+  SplitChunksPlugin = 'SplitChunksPlugin',
+  OldSplitChunksPlugin = 'OldSplitChunksPlugin',
   HttpExternalsRspackPlugin = 'HttpExternalsRspackPlugin',
   CopyRspackPlugin = 'CopyRspackPlugin',
   HtmlRspackPlugin = 'HtmlRspackPlugin',

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -46,7 +46,7 @@ pub use self::{
 };
 use crate::{
   RawEntryPluginOptions, RawExternalItemWrapper, RawExternalsPluginOptions,
-  RawHttpExternalsRspackPluginOptions, RawOptionsApply,
+  RawHttpExternalsRspackPluginOptions, RawOptionsApply, RawSplitChunksOptions,
 };
 
 #[napi(string_enum)]
@@ -72,6 +72,8 @@ pub enum BuiltinPluginName {
   WebWorkerTemplatePlugin,
   MergeDuplicateChunksPlugin,
   ContainerPlugin,
+  SplitChunksPlugin,
+  OldSplitChunksPlugin,
 
   // rspack specific plugins
   HttpExternalsRspackPlugin,
@@ -183,6 +185,16 @@ impl RawOptionsApply for BuiltinPlugin {
           ContainerPlugin::new(downcast_into::<RawContainerPluginOptions>(self.options)?.into())
             .boxed(),
         );
+      }
+      BuiltinPluginName::SplitChunksPlugin => {
+        use rspack_plugin_split_chunks_new::SplitChunksPlugin;
+        let options = downcast_into::<RawSplitChunksOptions>(self.options)?.into();
+        plugins.push(SplitChunksPlugin::new(options).boxed());
+      }
+      BuiltinPluginName::OldSplitChunksPlugin => {
+        use rspack_plugin_split_chunks::SplitChunksPlugin;
+        let options = downcast_into::<RawSplitChunksOptions>(self.options)?.into();
+        plugins.push(SplitChunksPlugin::new(options).boxed());
       }
 
       // rspack specific plugins

--- a/crates/rspack_binding_options/src/options/raw_optimization.rs
+++ b/crates/rspack_binding_options/src/options/raw_optimization.rs
@@ -6,7 +6,6 @@ use rspack_ids::{
   DeterministicChunkIdsPlugin, DeterministicModuleIdsPlugin, NamedChunkIdsPlugin,
   NamedModuleIdsPlugin,
 };
-use rspack_plugin_split_chunks::SplitChunksPlugin;
 use serde::Deserialize;
 
 use crate::{RawOptionsApply, RawSplitChunksOptions};
@@ -36,17 +35,6 @@ impl RawOptionsApply for RawOptimizationOptions {
     self,
     plugins: &mut Vec<Box<dyn rspack_core::Plugin>>,
   ) -> Result<Self::Options, rspack_error::Error> {
-    if let Some(options) = self.split_chunks {
-      let split_chunks_plugin = IS_ENABLE_NEW_SPLIT_CHUNKS.with(|is_enable_new_split_chunks| {
-        if *is_enable_new_split_chunks {
-          rspack_plugin_split_chunks_new::SplitChunksPlugin::new(options.into()).boxed()
-        } else {
-          SplitChunksPlugin::new(options.into()).boxed()
-        }
-      });
-
-      plugins.push(split_chunks_plugin);
-    }
     let chunk_ids_plugin = match self.chunk_ids.as_ref() {
       "named" => NamedChunkIdsPlugin::new(None, None).boxed(),
       "deterministic" => DeterministicChunkIdsPlugin::default().boxed(),

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -12,18 +12,10 @@ use rspack_core::{
 static UNSPECIFIED_EXTERNAL_TYPE_REGEXP: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^[a-z0-9-]+ ").expect("Invalid regex"));
 
+#[derive(Debug)]
 pub struct ExternalsPlugin {
   externals: Vec<ExternalItem>,
   r#type: ExternalType,
-}
-
-impl Debug for ExternalsPlugin {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("ExternalPlugin")
-      .field("externals", &"Function")
-      .field("r#type", &self.r#type)
-      .finish()
-  }
 }
 
 impl ExternalsPlugin {

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -363,7 +363,6 @@ impl JsPlugin {
     let source = args
       .compilation
       .plugin_driver
-      .clone()
       .render_chunk(RenderChunkArgs {
         compilation: args.compilation,
         chunk_ukey: &args.chunk_ukey,

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -122,6 +122,7 @@ class Compiler {
 	options: RspackOptionsNormalized;
 	#disabledHooks: string[];
 	parentCompilation?: Compilation;
+
 	constructor(context: string, options: RspackOptionsNormalized) {
 		this.outputFileSystem = fs;
 		this.options = options;
@@ -194,6 +195,7 @@ class Compiler {
 			this.options.output.hashFunction
 		);
 	}
+
 	/**
 	 * Lazy initialize instance so it could access the changed options
 	 */

--- a/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
@@ -1,0 +1,22 @@
+import assert from "assert";
+import { toRawSplitChunksOptions } from "../config/adapter";
+import { type OptimizationSplitChunksOptions } from "../config/zod";
+import { BuiltinPluginName, create } from "./base";
+
+export const SplitChunksPlugin = create(
+	BuiltinPluginName.SplitChunksPlugin,
+	(options: OptimizationSplitChunksOptions) => {
+		let raw = toRawSplitChunksOptions(options);
+		assert(typeof raw !== "undefined");
+		return raw;
+	}
+);
+
+export const OldSplitChunksPlugin = create(
+	BuiltinPluginName.SplitChunksPlugin,
+	(options: OptimizationSplitChunksOptions) => {
+		let raw = toRawSplitChunksOptions(options);
+		assert(typeof raw !== "undefined");
+		return raw;
+	}
+);

--- a/packages/rspack/src/builtin-plugin/base.ts
+++ b/packages/rspack/src/builtin-plugin/base.ts
@@ -26,7 +26,9 @@ export enum BuiltinPluginName {
 	LimitChunkCountPlugin = "LimitChunkCountPlugin",
 	WebWorkerTemplatePlugin = "WebWorkerTemplatePlugin",
 	MergeDuplicateChunksPlugin = "MergeDuplicateChunksPlugin",
-	ContainerPlugin = "ContainerPlugin"
+	ContainerPlugin = "ContainerPlugin",
+	SplitChunksPlugin = "SplitChunksPlugin",
+	OldSplitChunksPlugin = "OldSplitChunksPlugin"
 }
 
 export abstract class RspackBuiltinPlugin implements RspackPluginInstance {

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -19,6 +19,7 @@ export * from "./HotModuleReplacementPlugin";
 export * from "./WebWorkerTemplatePlugin";
 export * from "./LimitChunkCountPlugin";
 export * from "./MergeDuplicateChunksPlugin";
+export * from "./SplitChunksPlugin";
 
 export * from "./HtmlRspackPlugin";
 export * from "./CopyRspackPlugin";

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -716,7 +716,7 @@ function getRawOptimization(
 	};
 }
 
-function toRawSplitChunksOptions(
+export function toRawSplitChunksOptions(
 	sc?: OptimizationSplitChunksOptions
 ): RawOptions["optimization"]["splitChunks"] | undefined {
 	if (!sc) {

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -34,7 +34,9 @@ import {
 	ModuleChunkFormatPlugin,
 	NodeTargetPlugin,
 	DefinePlugin,
-	MergeDuplicateChunksPlugin
+	MergeDuplicateChunksPlugin,
+	SplitChunksPlugin,
+	OldSplitChunksPlugin
 } from "./builtin-plugin";
 
 export function optionsApply_compat(
@@ -189,6 +191,18 @@ export class RspackOptionsApply {
 		if (options.builtins.devFriendlySplitChunks) {
 			options.optimization.splitChunks = undefined;
 		}
+
+		if (
+			options.optimization.splitChunks &&
+			options.experiments.newSplitChunks === false
+		) {
+			new OldSplitChunksPlugin(options.optimization.splitChunks).apply(
+				compiler
+			);
+		} else if (options.optimization.splitChunks) {
+			new SplitChunksPlugin(options.optimization.splitChunks).apply(compiler);
+		}
+
 		if (options.optimization.nodeEnv) {
 			new DefinePlugin({
 				"process.env.NODE_ENV": JSON.stringify(options.optimization.nodeEnv)

--- a/packages/rspack/tests/configCases/chunk-loading/issue-4754/child-entry.js
+++ b/packages/rspack/tests/configCases/chunk-loading/issue-4754/child-entry.js
@@ -1,0 +1,3 @@
+it("should never run this file because child compiler only compile not emit", () => {
+	expect(1).toBe(2);
+});

--- a/packages/rspack/tests/configCases/chunk-loading/issue-4754/index.js
+++ b/packages/rspack/tests/configCases/chunk-loading/issue-4754/index.js
@@ -1,0 +1,3 @@
+it("should build success", () => {
+	expect(1).toBe(1);
+});

--- a/packages/rspack/tests/configCases/chunk-loading/issue-4754/webpack.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/issue-4754/webpack.config.js
@@ -1,0 +1,28 @@
+const path = require("path");
+
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.make.tap("make", compilation => {
+					const childEntry = path.resolve(__dirname, "./child-entry.js");
+					const childCompiler = compilation.createChildCompiler("name", {}, [
+						new compiler.webpack.EntryPlugin(compiler.context, childEntry)
+					]);
+					childCompiler.compile(() => {});
+				});
+			}
+		}
+	],
+	optimization: {
+		splitChunks: {
+			cacheGroups: {
+				singleVendor: {
+					chunks: "all",
+					enforce: true,
+					name: "vendor"
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
Fixes #4754

#4754 panics because it erroneously generates chunks by registering ﻿`SplitChunksPlugin` twice, while in reality, webpack only registers it once (specifically in the root compiler). As a result, it executes an additional `﻿render_chunk` operation, leading to a panic.

In this PR, I have relocated the registration of `﻿SplitChunksPlugin` to `﻿createCompiler` to ensure that it only registers once.
