### PR TITLE
chore: canary release add windows and enable windows ci on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,13 +43,16 @@ jobs:
       runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
       test-diff: true
 
-  # test-windows:
-  #   name: Test Windows
-  #   uses: ./.github/workflows/reusable-build.yml
-  #   with:
-  #     target: x86_64-pc-windows-msvc
-  #     profile: "debug"
-  #     test-diff: true
+  test-windows:
+    name: Test Windows
+    needs: [get-runner-labels]
+    if: github.ref_name == 'main'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      target: x86_64-pc-windows-msvc
+      profile: "debug"
+      runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
+      test-diff: true
 
   test-mac:
     name: Test Mac

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -25,6 +25,8 @@ jobs:
             runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
           - target: x86_64-unknown-linux-gnu # For Cloud IDE
             runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
+          - target: x86_64-pc-windows-msvc
+            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: refs/pull/${{ github.event.issue.number }}/head


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

canary release add windows platform and enable windows ci on main branch

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
