### PR TITLE
fix: keep the query passed to loader

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -18,7 +18,8 @@ import type {
 	RawRspackFuture,
 	RawLibraryName,
 	RawLibraryOptions,
-	JsModule
+	JsModule,
+	RawModuleRuleUse
 } from "@rspack/binding";
 import assert from "assert";
 import { Compiler } from "../Compiler";
@@ -378,7 +379,7 @@ const getRawModuleRule = (
 			}
 		];
 	}
-	let funcUse;
+	let funcUse: undefined | ((rawContext: RawFuncUseCtx) => RawModuleRuleUse[]);
 	if (typeof rule.use === "function") {
 		funcUse = (rawContext: RawFuncUseCtx) => {
 			const context = {

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -318,9 +318,9 @@ function resolveStringifyLoaders(
 	const obj = parsePathQueryFragment(use.loader);
 	let ident: string | null = null;
 
-	if (use.options === null) obj.query = "";
-	else if (use.options === undefined) obj.query = "";
-	else if (typeof use.options === "string") obj.query = "?" + use.options;
+	if (use.options === null) {
+	} else if (use.options === undefined) {
+	} else if (typeof use.options === "string") obj.query = "?" + use.options;
 	else if (use.ident) obj.query = "??" + (ident = use.ident);
 	else if (typeof use.options === "object" && use.options.ident)
 		obj.query = "??" + (ident = use.options.ident);

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -110,8 +110,8 @@ function createLoaderObject(loader: any, compiler: Compiler): LoaderObject {
 				obj.type = value.type;
 				obj.options = value.options;
 				obj.ident = value.ident;
-				if (obj.options === null) obj.query = "";
-				else if (obj.options === undefined) obj.query = "";
+				if (obj.options === null) obj.query = value.query;
+				else if (obj.options === undefined) obj.query = value.query;
 				else if (typeof obj.options === "string") obj.query = "?" + obj.options;
 				else if (obj.ident) obj.query = "??" + obj.ident;
 				else if (typeof obj.options === "object" && obj.options.ident)
@@ -187,7 +187,9 @@ export async function runLoaders(
 			}
 			obj.options = compiler.ruleSet.references.get(ident);
 			if (obj.options === undefined) {
-				throw new Error("Invalid ident is provided by referenced loader");
+				throw new Error(
+					`Invalid ident("${ident}") is provided by referenced loader`
+				);
 			}
 			obj.ident = ident;
 		}

--- a/packages/rspack/tests/configCases/module/issue-4777/index.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/index.js
@@ -1,0 +1,18 @@
+it("should loader the correctly query", () => {
+	expect(require("./sub/a")).toBe("?query=a");
+	// FIXME: should return `query` and `fragment` in rust side
+	// expect(require('./sub/b')).toBe('?query=alias')
+	// FIXME: should return `query` and `fragment` in rust side
+	// expect(require('./sub/c')).toBe('?query=alias')
+	expect(require("./sub/d")).toBe("?query=d");
+	expect(require("./sub/e")).toBe("?query=options-e");
+	expect(require("./sub/f")).toStrictEqual({
+		query: "options-object-f"
+	});
+	expect(require("./sub/g")).toStrictEqual({
+		query: "options-object-g"
+	});
+	expect(require("./sub/h")).toStrictEqual({
+		query: "options-object-h"
+	});
+});

--- a/packages/rspack/tests/configCases/module/issue-4777/loader.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/loader.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+	return `module.exports=${JSON.stringify(this.query)}`;
+};

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/a.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/a.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/b.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/b.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/c.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/c.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/d.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/d.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/e.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/e.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/f.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/f.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/g.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/g.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/sub/h.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/sub/h.js
@@ -1,0 +1,1 @@
+module.exports = "";

--- a/packages/rspack/tests/configCases/module/issue-4777/webpack.config.js
+++ b/packages/rspack/tests/configCases/module/issue-4777/webpack.config.js
@@ -1,0 +1,70 @@
+module.exports = {
+	resolveLoader: {
+		alias: {
+			"my-loader": "./loader.js?query=alias"
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /a\.js$/,
+				use: {
+					loader: "./loader?query=a"
+				}
+			},
+			{
+				test: /b\.js$/,
+				use: {
+					loader: "my-loader"
+				}
+			},
+			{
+				test: /c\.js$/,
+				use: {
+					loader: "my-loader?query=c"
+				}
+			},
+			{
+				test: /d\.js$/,
+				use: {
+					loader: "./loader",
+					options: "query=d"
+				}
+			},
+			{
+				test: /e\.js$/,
+				use: {
+					loader: "./loader?query=e",
+					options: "query=options-e"
+				}
+			},
+			{
+				test: /f\.js$/,
+				use: {
+					loader: "./loader?query=f",
+					options: {
+						query: "options-object-f"
+					}
+				}
+			},
+			{
+				test: /g\.js$/,
+				use: {
+					loader: "my-loader",
+					options: {
+						query: "options-object-g"
+					}
+				}
+			},
+			{
+				test: /h\.js$/,
+				use: {
+					loader: "my-loader?query=h",
+					options: {
+						query: "options-object-h"
+					}
+				}
+			}
+		]
+	}
+};

--- a/webpack-test/configCases/loaders/issue-3320/test.filter.js
+++ b/webpack-test/configCases/loaders/issue-3320/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return true}


### PR DESCRIPTION
Fixes #4777 

In this PR, I have chosen to retain the original query instead of replacing it with an empty string.