### PR TITLE
feat(compilation): introduce queue handles representing task_queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3175,8 +3175,10 @@ name = "rspack_util"
 version = "0.1.0"
 dependencies = [
  "concat-string",
+ "dashmap",
  "once_cell",
  "regex",
+ "rustc-hash",
  "sugar_path",
  "swc_core",
 ]

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -1,9 +1,11 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use derivative::Derivative;
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result};
 use rspack_sources::BoxSource;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 use crate::{
   cache::Cache, BoxDependency, BuildContext, BuildResult, Compilation, CompilerContext,
@@ -26,6 +28,8 @@ pub trait WorkerTask {
   async fn run(self) -> Result<TaskResult>;
 }
 
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct FactorizeTask {
   pub module_factory: Arc<dyn ModuleFactory>,
   pub original_module_identifier: Option<ModuleIdentifier>,
@@ -43,6 +47,7 @@ pub struct FactorizeTask {
   pub plugin_driver: SharedPluginDriver,
   pub cache: Arc<Cache>,
   pub current_profile: Option<Box<ModuleProfile>>,
+  #[derivative(Debug = "ignore")]
   pub callback: Option<ModuleCreationCallback>,
 }
 
@@ -54,7 +59,10 @@ pub struct ExportsInfoRelated {
   pub side_effects_info: ExportInfo,
 }
 
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct FactorizeTaskResult {
+  pub dependency: DependencyId,
   pub original_module_identifier: Option<ModuleIdentifier>,
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
@@ -67,28 +75,8 @@ pub struct FactorizeTaskResult {
   pub context_dependencies: HashSet<PathBuf>,
   pub missing_dependencies: HashSet<PathBuf>,
   pub diagnostics: Vec<Diagnostic>,
+  #[derivative(Debug = "ignore")]
   pub callback: Option<ModuleCreationCallback>,
-}
-
-impl std::fmt::Debug for FactorizeTaskResult {
-  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("FactorizeTaskResult")
-      .field(
-        "original_module_identifier",
-        &self.original_module_identifier,
-      )
-      .field("factory_result", &self.factory_result)
-      .field("dependencies", &self.dependencies)
-      .field("diagnostics", &self.diagnostics)
-      .field("is_entry", &self.is_entry)
-      .field("current_profile", &self.current_profile)
-      .field("exports_info_related", &self.exports_info_related)
-      .field("file_dependencies", &self.file_dependencies)
-      .field("context_dependencies", &self.context_dependencies)
-      .field("missing_dependencies", &self.missing_dependencies)
-      .field("diagnostics", &self.diagnostics)
-      .finish()
-  }
 }
 
 impl FactorizeTaskResult {
@@ -125,6 +113,7 @@ impl WorkerTask for FactorizeTask {
       current_profile.mark_factory_start();
     }
     let dependency = self.dependency;
+    let dep_id = *dependency.id();
 
     let context = if let Some(context) = dependency.get_context() {
       context
@@ -143,6 +132,7 @@ impl WorkerTask for FactorizeTask {
     );
     let exports_info = ExportsInfo::new(other_exports_info.id, side_effects_only_info.id);
     let factorize_task_result = FactorizeTaskResult {
+      dependency: dep_id,
       original_module_identifier: self.original_module_identifier,
       factory_result: None,
       dependencies: self.dependencies,
@@ -221,6 +211,8 @@ impl WorkerTask for FactorizeTask {
 
 pub type FactorizeQueue = WorkerQueue<FactorizeTask>;
 
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct AddTask {
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub module: Box<dyn Module>,
@@ -228,6 +220,7 @@ pub struct AddTask {
   pub dependencies: Vec<DependencyId>,
   pub is_entry: bool,
   pub current_profile: Option<Box<ModuleProfile>>,
+  #[derivative(Debug = "ignore")]
   pub callback: Option<ModuleCreationCallback>,
 }
 
@@ -336,6 +329,7 @@ fn set_resolved_module(
 
 pub type AddQueue = WorkerQueue<AddTask>;
 
+#[derive(Debug)]
 pub struct BuildTask {
   pub module: Box<dyn Module>,
   pub resolver_factory: Arc<ResolverFactory>,
@@ -432,6 +426,7 @@ impl WorkerTask for BuildTask {
 
 pub type BuildQueue = WorkerQueue<BuildTask>;
 
+#[derive(Debug)]
 pub struct ProcessDependenciesTask {
   pub original_module_identifier: ModuleIdentifier,
   pub dependencies: Vec<DependencyId>,
@@ -498,3 +493,162 @@ impl CleanTask {
 pub type CleanQueue = WorkerQueue<CleanTask>;
 
 pub type ModuleCreationCallback = Box<dyn FnOnce(&BoxModule) + Send>;
+
+pub type QueueHandleCallback = Box<dyn FnOnce(WaitTaskResult, &mut Compilation) + Send + Sync>;
+
+#[derive(Debug)]
+pub enum QueueTask {
+  Factorize(Box<FactorizeTask>),
+  Add(Box<AddTask>),
+  Build(Box<BuildTask>),
+  ProcessDependencies(Box<ProcessDependenciesTask>),
+  Subscription(Box<Subscription>),
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum WaitTask {
+  Factorize(DependencyId),
+  Add(ModuleIdentifier),
+  Build(ModuleIdentifier),
+  ProcessDependencies(ModuleIdentifier),
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WaitTaskKey {
+  Dependency(DependencyId),
+  Identifier(ModuleIdentifier),
+}
+
+impl From<ModuleIdentifier> for WaitTaskKey {
+  fn from(value: ModuleIdentifier) -> Self {
+    Self::Identifier(value)
+  }
+}
+
+impl From<DependencyId> for WaitTaskKey {
+  fn from(value: DependencyId) -> Self {
+    Self::Dependency(value)
+  }
+}
+
+pub type WaitTaskResult = ModuleIdentifier;
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct Subscription {
+  task: WaitTask,
+  #[derivative(Debug = "ignore")]
+  callback: QueueHandleCallback,
+}
+
+/// QueueHandler can let you have access to `make` phase.
+/// You can also subscribe task, by calling wait_for to
+/// wait for certain task
+#[derive(Clone, Debug)]
+pub struct QueueHandler {
+  sender: UnboundedSender<QueueTask>,
+}
+
+impl QueueHandler {
+  pub fn add_task(&self, task: QueueTask) -> Result<()> {
+    self.sender.send(task).expect("Unexpected dropped receiver");
+    Ok(())
+  }
+
+  pub fn wait_for(&self, wait_task: WaitTask, callback: QueueHandleCallback) {
+    self
+      .sender
+      .send(QueueTask::Subscription(Box::new(Subscription {
+        task: wait_task,
+        callback,
+      })))
+      .expect("failed to wait task");
+  }
+}
+
+pub struct QueueHandlerProcessor {
+  receiver: UnboundedReceiver<QueueTask>,
+  callbacks: [HashMap<WaitTaskKey, Vec<QueueHandleCallback>>; 4],
+  finished: [HashMap<WaitTaskKey, WaitTaskResult>; 4],
+}
+
+impl QueueHandlerProcessor {
+  fn get_bucket_and_key(task: WaitTask) -> (usize, WaitTaskKey) {
+    let (bucket, key) = match task {
+      WaitTask::Factorize(dep_id) => (0, dep_id.into()),
+      WaitTask::Add(m) => (1, m.into()),
+      WaitTask::Build(m) => (2, m.into()),
+      WaitTask::ProcessDependencies(m) => (3, m.into()),
+    };
+
+    (bucket, key)
+  }
+
+  pub fn try_process(
+    &mut self,
+    compilation: &mut Compilation,
+    factorize_queue: &mut FactorizeQueue,
+    add_queue: &mut AddQueue,
+    build_queue: &mut BuildQueue,
+    process_dependencies_queue: &mut ProcessDependenciesQueue,
+  ) {
+    while let Ok(task) = self.receiver.try_recv() {
+      match task {
+        QueueTask::Factorize(task) => {
+          factorize_queue.add_task(*task);
+        }
+        QueueTask::Add(task) => {
+          add_queue.add_task(*task);
+        }
+        QueueTask::Build(task) => {
+          build_queue.add_task(*task);
+        }
+        QueueTask::ProcessDependencies(task) => {
+          process_dependencies_queue.add_task(*task);
+        }
+        QueueTask::Subscription(subscription) => {
+          let Subscription { task, callback } = *subscription;
+          let (bucket, key) = Self::get_bucket_and_key(task);
+
+          if let Some(module) = self.finished[bucket].get(&key) {
+            // already finished
+            callback(*module, compilation);
+          } else {
+            self.callbacks[bucket]
+              .entry(key)
+              .or_default()
+              .push(callback);
+          }
+        }
+      }
+    }
+  }
+
+  pub fn complete_task(
+    &mut self,
+    task: WaitTask,
+    task_result: WaitTaskResult,
+    compilation: &mut Compilation,
+  ) {
+    let (bucket, key) = Self::get_bucket_and_key(task);
+    self.finished[bucket].insert(key, task_result);
+    if let Some(callbacks) = self.callbacks[bucket].get_mut(&key) {
+      while let Some(cb) = callbacks.pop() {
+        cb(task_result, compilation);
+      }
+    }
+  }
+}
+
+pub fn create_queue_handle() -> (QueueHandler, QueueHandlerProcessor) {
+  let (tx, rx) = unbounded_channel();
+
+  (
+    QueueHandler { sender: tx },
+    QueueHandlerProcessor {
+      receiver: rx,
+      callbacks: Default::default(),
+      finished: Default::default(),
+    },
+  )
+}

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -45,6 +45,10 @@ impl<T: std::fmt::Debug> TWithDiagnosticArray<T> {
   pub fn split_into_parts(self) -> (T, Vec<Diagnostic>) {
     (self.inner, self.diagnostic)
   }
+
+  pub fn get(&self) -> &T {
+    &self.inner
+  }
 }
 
 impl<T: Clone + std::fmt::Debug> Clone for TWithDiagnosticArray<T> {

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -9,8 +9,10 @@ version    = "0.1.0"
 
 [dependencies]
 concat-string = { workspace = true }
+dashmap       = { workspace = true }
 once_cell     = { workspace = true }
 regex         = { workspace = true }
+rustc-hash    = { workspace = true }
 sugar_path    = { workspace = true }
 
 swc_core = { workspace = true, features = ["ecma_ast"] }

--- a/crates/rspack_util/src/fx_dashmap.rs
+++ b/crates/rspack_util/src/fx_dashmap.rs
@@ -1,0 +1,7 @@
+use std::hash::BuildHasherDefault;
+
+use dashmap::{DashMap, DashSet};
+use rustc_hash::FxHasher;
+
+pub type FxDashMap<K, V> = DashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FxDashSet<V> = DashSet<V, BuildHasherDefault<FxHasher>>;

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -3,6 +3,7 @@
 use std::future::Future;
 pub mod comparators;
 pub mod ext;
+pub mod fx_dashmap;
 pub mod identifier;
 pub mod number_hash;
 pub mod swc;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

### Introduce QueueHandle

In Webpack, any plugin can add task to factorizeQueue, buildQueue and other workerQueue, we can use QueueHandle to do the same. A queue handle can be sent through threads, without mutable reference, to let other plugins be capable to push new task into the queue.

### Refactor succeed_module

Add more dependency id as arg for succeed_module hook input.

### Add FxDashMap and FxDashSet

For more performant dashmap

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
