### PR TITLE
fix: use correct DefinePlugin in plugin-react-refresh

### DIFF
--- a/packages/rspack-plugin-react-refresh/src/index.ts
+++ b/packages/rspack-plugin-react-refresh/src/index.ts
@@ -1,6 +1,5 @@
 import path from "path";
 import type { Compiler } from "@rspack/core";
-import { DefinePlugin } from "@rspack/core";
 import { normalizeOptions, type PluginOptions } from "./options";
 
 export type { PluginOptions };
@@ -68,7 +67,7 @@ class ReactRefreshRspackPlugin {
 				)
 			)
 		};
-		new DefinePlugin(definedModules).apply(compiler);
+		new compiler.webpack.DefinePlugin(definedModules).apply(compiler);
 
 		const refreshPath = path.dirname(require.resolve("react-refresh"));
 		compiler.options.resolve.alias = {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
