### PR TITLE
fix(resolver): resolve query and fragments with unicode filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,9 +1700,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "oxc_resolver"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d10d078b6ba0b8cfa0eb634ef749698aa82ef4a86c7ba1446453644ccf13fd2"
+checksum = "86104f0a8e964f993b513a8d31241d9f9e953bda770f0232ca34df2e618ed19b"
 dependencies = [
  "dashmap",
  "dunce",
@@ -3455,9 +3455,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
@@ -3474,9 +3474,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -23,7 +23,7 @@ itertools = { workspace = true }
 mime_guess = { workspace = true }
 nodejs-resolver = { version = "0.1.1" }
 once_cell = { workspace = true }
-oxc_resolver = { version = "0.5.4" }
+oxc_resolver = { version = "0.5.5" }
 paste = { workspace = true }
 petgraph = { version = "0.6.3", features = ["serde-1"] }
 rayon = { workspace = true }

--- a/packages/rspack/tests/cases/resolve/query/index.js
+++ b/packages/rspack/tests/cases/resolve/query/index.js
@@ -11,4 +11,13 @@ it("should make different modules for query", function () {
 	expect(a === b).toBe(false);
 	expect(a === c).toBe(false);
 	expect(b === c).toBe(false);
+
+	var d = require("./测试");
+	var e = require("./测试?1");
+	var f = require("./测试.js");
+	var g = require("./测试.js?1");
+	expect(d).toBe("测试");
+	expect(e).toBe("测试");
+	expect(f).toBe("测试");
+	expect(g).toBe("测试");
 });

--- a/packages/rspack/tests/cases/resolve/query/测试.js
+++ b/packages/rspack/tests/cases/resolve/query/测试.js
@@ -1,0 +1,1 @@
+module.exports = "测试";


### PR DESCRIPTION
closes #4630

## Summary


Source: https://github.com/oxc-project/oxc/pull/1591


<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

I have:
* added integration test in rspack tests
* added integration test on the oxc side
* verified this manually on https://github.com/h-a-n-a/issue_1130_rspack_new_resolver


## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
