### PR TITLE
feat: JsAsset remove version field

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -202,11 +202,6 @@ export interface JsAssetInfo {
    * related object to other assets, keyed by type of relation (only points from parent to child)
    */
   related: JsAssetInfoRelated
-  /**
-   * the asset version, emit can be skipped when both filename and version are the same
-   * An empty string means no version, it will always emit
-   */
-  version: string
 }
 
 export interface JsAssetInfoRelated {

--- a/crates/rspack_binding_values/src/asset.rs
+++ b/crates/rspack_binding_values/src/asset.rs
@@ -40,9 +40,6 @@ pub struct JsAssetInfo {
   // pub javascript_module:
   /// related object to other assets, keyed by type of relation (only points from parent to child)
   pub related: JsAssetInfoRelated,
-  /// the asset version, emit can be skipped when both filename and version are the same
-  /// An empty string means no version, it will always emit
-  pub version: String,
 }
 
 impl From<JsAssetInfo> for rspack_core::AssetInfo {
@@ -55,7 +52,7 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
       chunk_hash: i.chunk_hash.into_iter().collect(),
       related: i.related.into(),
       content_hash: i.content_hash.into_iter().collect(),
-      version: i.version,
+      version: String::from(""),
       source_filename: i.source_filename,
     }
   }
@@ -86,7 +83,6 @@ impl From<rspack_core::AssetInfo> for JsAssetInfo {
       related: info.related.into(),
       chunk_hash: info.chunk_hash.into_iter().collect(),
       content_hash: info.content_hash.into_iter().collect(),
-      version: info.version,
       source_filename: info.source_filename,
     }
   }

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -108,7 +108,6 @@ export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
 		related: {},
 		chunkHash: [],
 		contentHash: [],
-		version: "",
 		...info
 	};
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The `version` field in JsAsset is used to control whether emit the asset, but it is not aligned with webpack

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
