### PR TITLE
refactor: use `BasicEvaluatedExpression`

### DIFF
--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -48,10 +48,12 @@ impl DependencyLocation {
     Self { start, end }
   }
 
+  #[inline]
   pub fn start(&self) -> u32 {
     self.start
   }
 
+  #[inline]
   pub fn end(&self) -> u32 {
     self.end
   }

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -336,11 +336,11 @@ pub fn module_raw(
   }
 }
 
-pub fn miss_module(request: &str) -> String {
+fn miss_module(request: &str) -> String {
   format!("Object({}())", throw_missing_module_error_function(request))
 }
 
-pub fn throw_missing_module_error_function(request: &str) -> String {
+fn throw_missing_module_error_function(request: &str) -> String {
   format!(
     "function webpackMissingModule() {{ {} }}",
     throw_missing_module_error_block(request)
@@ -353,9 +353,8 @@ pub fn throw_missing_module_error_block(request: &str) -> String {
   )
 }
 
-pub fn weak_error(request: &str) -> String {
-  let msg = format!("Module is not available (weak dependency), request is {request}.");
-  format!("var e = new Error('{msg}'); e.code = 'MODULE_NOT_FOUND'; throw e;")
+fn weak_error(request: &str) -> String {
+  format!("var e = new Error('Module is not available (weak dependency), request is {request}'); e.code = 'MODULE_NOT_FOUND'; throw e;")
 }
 
 pub fn returning_function(return_value: &str, args: &str) -> String {

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -9,12 +9,13 @@ version    = "0.1.0"
 rspack_testing = { path = "../rspack_testing" }
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow          = { workspace = true }
 async-recursion = { workspace = true }
-async-trait = { workspace = true }
-either = "1"
-indexmap = { workspace = true }
+async-trait     = { workspace = true }
+either          = "1"
+indexmap        = { workspace = true }
 linked_hash_set = { workspace = true }
+# num-bigint = { version = "0.4.4" }
 once_cell = { workspace = true }
 preset_env_base = { workspace = true }
 rayon = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/mod.rs
@@ -1,10 +1,13 @@
 mod common_js_exports_dependency;
 mod common_js_require_dependency;
 // mod common_js
+mod module_decorator_dependency;
+mod require_header_dependency;
+mod require_resolve_dependency;
+
 pub use common_js_exports_dependency::CommonJsExportsDependency;
 pub use common_js_exports_dependency::ExportsBase;
 pub use common_js_require_dependency::CommonJsRequireDependency;
-mod require_resolve_dependency;
-pub use require_resolve_dependency::RequireResolveDependency;
-mod module_decorator_dependency;
 pub use module_decorator_dependency::ModuleDecoratorDependency;
+pub use require_header_dependency::RequireHeaderDependency;
+pub use require_resolve_dependency::RequireResolveDependency;

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -1,0 +1,52 @@
+use rspack_core::{AsContextDependency, AsModuleDependency, Dependency};
+use rspack_core::{DependencyId, DependencyLocation};
+use rspack_core::{DependencyTemplate, RuntimeGlobals, TemplateContext};
+
+#[derive(Debug, Clone)]
+pub struct RequireHeaderDependency {
+  id: DependencyId,
+  loc: DependencyLocation,
+}
+
+impl RequireHeaderDependency {
+  pub fn new(start: u32, end: u32) -> Self {
+    let loc = DependencyLocation::new(start, end);
+    Self {
+      id: DependencyId::new(),
+      loc,
+    }
+  }
+}
+
+impl Dependency for RequireHeaderDependency {
+  fn dependency_debug_name(&self) -> &'static str {
+    "RequireHeaderDependency"
+  }
+
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+}
+
+impl AsModuleDependency for RequireHeaderDependency {}
+impl AsContextDependency for RequireHeaderDependency {}
+
+impl DependencyTemplate for RequireHeaderDependency {
+  fn apply(
+    &self,
+    source: &mut rspack_core::TemplateReplaceSource,
+    code_generatable_context: &mut rspack_core::TemplateContext,
+  ) {
+    let TemplateContext {
+      runtime_requirements,
+      ..
+    } = code_generatable_context;
+    runtime_requirements.insert(RuntimeGlobals::REQUIRE);
+    source.replace(
+      self.loc.start(),
+      self.loc.end() - 1,
+      RuntimeGlobals::REQUIRE.name(),
+      None,
+    );
+  }
+}

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -4,16 +4,16 @@
 #![feature(box_patterns)]
 #![recursion_limit = "256"]
 
-pub(crate) mod dependency;
-mod plugin;
-pub use plugin::*;
 pub mod ast;
-pub(crate) mod parser_and_generator;
+pub mod dependency;
+pub mod parser_and_generator;
+mod plugin;
 pub mod runtime;
 pub mod utils;
 pub mod visitors;
 
 pub use crate::plugin::infer_async_modules_plugin::InferAsyncModulesPlugin;
+pub use crate::plugin::*;
 
 #[derive(Debug)]
 pub struct TransformOutput {

--- a/crates/rspack_plugin_javascript/src/utils/basic_evaluated_expression.rs
+++ b/crates/rspack_plugin_javascript/src/utils/basic_evaluated_expression.rs
@@ -1,0 +1,297 @@
+use std::borrow::Cow;
+
+use rspack_core::{DependencyLocation, SpanExt};
+use swc_core::common::Spanned;
+use swc_core::ecma::ast;
+
+#[derive(Debug, Clone)]
+enum TemplateStringKind {
+  Cooked,
+  // Raw,
+}
+
+#[derive(Debug, Clone)]
+enum Ty {
+  Unknown,
+  // TypeUndefined,
+  // TypeNull,
+  String,
+  // TypeNumber,
+  #[allow(dead_code)] // FIXME: remove this later
+  Boolean,
+  // TypeRegExp,
+  Conditional,
+  // TypeArray,
+  // TypeConstArray,
+  // TypeIdentifier,
+  // TypeWrapped,
+  TemplateString,
+}
+
+type Lit = ast::Lit;
+type Expr = ast::Expr;
+type Boolean = bool;
+// type Number = f64;
+// type Bigint = num_bigint::BigInt;
+// type Regexp = rspack_regex::RspackRegex;
+type String<'a> = Cow<'a, str>;
+
+#[derive(Debug)]
+pub struct BasicEvaluatedExpression<'a> {
+  ty: Ty,
+  range: Option<DependencyLocation>,
+  falsy: bool,
+  truthy: bool,
+  side_effects: bool,
+  nullish: Option<bool>,
+  bool: Option<Boolean>,
+  // number: Option<Number>,
+  string: Option<String<'a>>,
+  // bigint: Option<Bigint>,
+  quasis: Option<Vec<BasicEvaluatedExpression<'a>>>,
+  parts: Option<Vec<BasicEvaluatedExpression<'a>>>,
+  template_string_kind: Option<TemplateStringKind>,
+
+  options: Option<Vec<BasicEvaluatedExpression<'a>>>,
+}
+
+impl<'a> BasicEvaluatedExpression<'a> {
+  fn new() -> Self {
+    Self {
+      ty: Ty::Unknown,
+      range: None,
+      falsy: false,
+      truthy: false,
+      side_effects: true,
+      nullish: None,
+      bool: None,
+      // number: None,
+      // bigint: None,
+      quasis: None,
+      parts: None,
+      template_string_kind: None,
+      options: None,
+      string: None,
+    }
+  }
+
+  pub fn is_unknown(&self) -> bool {
+    matches!(self.ty, Ty::Unknown)
+  }
+
+  pub fn is_conditional(&self) -> bool {
+    matches!(self.ty, Ty::Conditional)
+  }
+
+  pub fn is_string(&self) -> bool {
+    matches!(self.ty, Ty::String)
+  }
+
+  pub fn is_bool(&self) -> bool {
+    matches!(self.ty, Ty::Boolean)
+  }
+
+  pub fn as_string(&self) -> Option<std::string::String> {
+    if self.is_bool() {
+      Some(self.bool().to_string())
+    } else if self.is_string() {
+      Some(self.string().to_string())
+    } else {
+      None
+    }
+  }
+
+  pub fn as_bool(&self) -> Option<Boolean> {
+    if self.truthy {
+      Some(true)
+    } else if self.falsy || self.nullish == Some(true) {
+      Some(false)
+    } else {
+      self.bool
+    }
+  }
+
+  pub fn could_have_side_effects(&self) -> bool {
+    self.side_effects
+  }
+
+  fn set_side_effects(&mut self, side_effects: bool) {
+    self.side_effects = side_effects
+  }
+
+  pub fn options(&self) -> &Vec<BasicEvaluatedExpression<'a>> {
+    self.options.as_ref().expect("options should not empty")
+  }
+
+  fn set_options(&mut self, options: Option<Vec<BasicEvaluatedExpression<'a>>>) {
+    self.ty = Ty::Conditional;
+    self.options = options;
+    self.side_effects = true;
+  }
+
+  fn add_options(&mut self, options: Vec<BasicEvaluatedExpression<'a>>) {
+    if let Some(old) = &mut self.options {
+      old.extend(options);
+    } else {
+      self.ty = Ty::Conditional;
+      self.options = Some(options);
+      self.side_effects = true;
+    }
+  }
+
+  pub fn range(&self) -> (u32, u32) {
+    let range = self.range.expect("range should not empty");
+    (range.start(), range.end())
+  }
+
+  /// Please refrain from declaring `set_range`` as public,
+  /// as it should remain encapsulated for verification during evaluations.
+  fn set_range(&mut self, start: u32, end: u32) {
+    self.range = Some(DependencyLocation::new(start, end))
+  }
+
+  fn set_template_string(
+    &mut self,
+    quasis: Vec<BasicEvaluatedExpression<'a>>,
+    parts: Vec<BasicEvaluatedExpression<'a>>,
+    kind: TemplateStringKind,
+  ) {
+    self.ty = Ty::TemplateString;
+    self.quasis = Some(quasis);
+    self.side_effects = parts.iter().any(|p| p.side_effects);
+    self.parts = Some(parts);
+    self.template_string_kind = Some(kind);
+  }
+
+  fn set_string(&mut self, string: String<'a>) {
+    self.ty = Ty::String;
+    self.string = Some(string);
+    self.side_effects = false;
+  }
+
+  pub fn string(&self) -> &String {
+    self.string.as_ref().expect("make sure string exists")
+  }
+
+  pub fn bool(&self) -> Boolean {
+    self.bool.expect("make sure bool exists")
+  }
+}
+
+fn get_simplified_template_result(
+  node: &ast::Tpl,
+) -> (Vec<BasicEvaluatedExpression>, Vec<BasicEvaluatedExpression>) {
+  let mut quasis: Vec<BasicEvaluatedExpression> = vec![];
+  let mut parts: Vec<BasicEvaluatedExpression> = vec![];
+  for i in 0..node.quasis.len() {
+    let quasi_expr = &node.quasis[i];
+    // FIXME: `quasi_exp.cooked` -> `quasi_exp[kind]`
+    // and the kind is a argument
+    let quasi = quasi_expr
+      .cooked
+      .as_ref()
+      .expect("quasic should be not empty");
+    if i > 0 {
+      let len = parts.len();
+      let prev_expr = &mut parts[len - 1];
+      let expr = evaluate_expression(&node.exprs[i - 1]);
+      if !expr.could_have_side_effects()
+        && let Some(str) = expr.as_string()
+      {
+        prev_expr.set_string(Cow::Owned(format!(
+          "{}{}{}",
+          prev_expr.string(),
+          str,
+          quasi
+        )));
+        prev_expr.set_range(prev_expr.range().0, prev_expr.range().1);
+        // prev_expr.set_expression(None);
+        continue;
+      }
+      parts.push(expr);
+    }
+
+    let part = || {
+      let mut part = BasicEvaluatedExpression::new();
+      part.set_string(Cow::Borrowed(quasi.as_str()));
+      part.set_range(quasi_expr.span().real_lo(), quasi_expr.span_hi().0);
+      part
+    };
+    // part.set_expression(Some(quasi_expr));
+    quasis.push(part());
+    parts.push(part())
+  }
+
+  (quasis, parts)
+}
+
+// same as `JavascriptParser._initializeEvaluating` in webpack
+fn evaluating(expr: &Expr) -> Option<BasicEvaluatedExpression<'_>> {
+  match expr {
+    Expr::Tpl(tpl) => {
+      let (quasis, mut parts) = get_simplified_template_result(tpl);
+      if parts.len() == 1 {
+        let mut part = parts.remove(0);
+        part.set_range(tpl.span().real_lo(), tpl.span().hi().0);
+        Some(part)
+      } else {
+        let mut res = BasicEvaluatedExpression::new();
+        res.set_range(tpl.span().real_lo(), tpl.span().hi().0);
+        res.set_template_string(quasis, parts, TemplateStringKind::Cooked);
+        Some(res)
+      }
+    }
+    Expr::Lit(Lit::Str(str)) => {
+      let mut res = BasicEvaluatedExpression::new();
+      res.set_range(str.span().real_lo(), str.span_hi().0);
+      res.set_string(Cow::Borrowed(str.value.as_str()));
+      Some(res)
+    }
+    Expr::Cond(cond) => {
+      let condition = evaluate_expression(&cond.test);
+      let condition_value = condition.as_bool();
+      let mut res;
+      if let Some(bool) = condition_value {
+        if bool {
+          res = evaluate_expression(&cond.cons)
+        } else {
+          res = evaluate_expression(&cond.alt)
+        };
+        if condition.is_conditional() {
+          res.set_side_effects(true)
+        }
+      } else {
+        let cons = evaluate_expression(&cond.cons);
+        let alt = evaluate_expression(&cond.alt);
+        res = BasicEvaluatedExpression::new();
+        if cons.is_conditional() {
+          res.set_options(cons.options)
+        } else {
+          res.set_options(Some(vec![cons]))
+        }
+        if alt.is_conditional() {
+          if let Some(options) = alt.options {
+            res.add_options(options)
+          }
+        } else {
+          res.add_options(vec![alt])
+        }
+      }
+      res.set_range(cond.span.lo.0, cond.span.hi.0);
+      Some(res)
+    }
+    _ => None,
+  }
+}
+
+// same as `JavascriptParser.evaluateExpression` in webpack
+pub fn evaluate_expression(expr: &Expr) -> BasicEvaluatedExpression<'_> {
+  match evaluating(expr) {
+    Some(evaluated) => evaluated,
+    None => {
+      let mut evaluated = BasicEvaluatedExpression::new();
+      evaluated.set_range(expr.span_lo().0, expr.span_hi().0);
+      evaluated
+    }
+  }
+}

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -79,7 +79,7 @@ describe("Stats", () => {
 
 
 
-		Rspack compiled with 1 error (9bed7a0c293db88bb175)"
+		Rspack compiled with 1 error (b5e049b7786f599663d7)"
 	`);
 	});
 

--- a/packages/rspack/tests/__snapshots__/Stats.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Stats.test.ts.snap
@@ -421,7 +421,7 @@ exports.c = require("./c?c=3");
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "7da8f62e8c5a2bdc7ca4",
+  "hash": "376d5471ba0e66400f21",
   "logging": {},
   "modules": [
     {

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1516,7 +1516,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "4da06cdbffcc858493d3",
+      "hash": "c6559f6e73dc156f845f",
       "logging": {},
       "modules": [
         {
@@ -2132,7 +2132,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "b7c4a03979d24b362924",
+      "hash": "86986b7c6dbbb1f6ba21",
       "logging": {},
       "modules": [
         {
@@ -2818,7 +2818,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "64096f05f9e44ebb2bba",
+      "hash": "0627cca023f3570cd858",
       "logging": {},
       "modules": [
         {
@@ -3538,7 +3538,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "2a2f992ca23e8aee62a6",
+      "hash": "33c0b9a14121f0416de0",
       "logging": {},
       "modules": [
         {
@@ -3909,7 +3909,7 @@ import(/* webpackChunkName: "c" */ "./c");
   ],
   "errors": [],
   "errorsCount": 0,
-  "hash": "4da06cdbffcc858493d3b7c4a03979d24b36292464096f05f9e44ebb2bba2a2f992ca23e8aee62a6",
+  "hash": "c6559f6e73dc156f845f86986b7c6dbbb1f6ba210627cca023f3570cd85833c0b9a14121f0416de0",
   "warnings": [],
   "warningsCount": 0,
 }
@@ -3948,7 +3948,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/make_namespace_object {main}
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
-  1 chunks compiled successfully (4da06cdbffcc858493d3)
+  1 chunks compiled successfully (c6559f6e73dc156f845f)
 
 2 chunks:
   PublicPath: (none)
@@ -3986,7 +3986,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/__webpack_require__.u {main}
-  2 chunks compiled successfully (b7c4a03979d24b362924)
+  2 chunks compiled successfully (86986b7c6dbbb1f6ba21)
 
 3 chunks:
   PublicPath: (none)
@@ -4026,7 +4026,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/__webpack_require__.u {main}
-  3 chunks compiled successfully (64096f05f9e44ebb2bba)
+  3 chunks compiled successfully (0627cca023f3570cd858)
 
 4 chunks:
   PublicPath: (none)
@@ -4068,7 +4068,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/__webpack_require__.u {main}
-  4 chunks compiled successfully (2a2f992ca23e8aee62a6)"
+  4 chunks compiled successfully (33c0b9a14121f0416de0)"
 `;
 
 exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin-warn 1`] = `

--- a/packages/rspack/tests/cases/parsing/issue-4816/a.js
+++ b/packages/rspack/tests/cases/parsing/issue-4816/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/cases/parsing/issue-4816/b.js
+++ b/packages/rspack/tests/cases/parsing/issue-4816/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/packages/rspack/tests/cases/parsing/issue-4816/index.js
+++ b/packages/rspack/tests/cases/parsing/issue-4816/index.js
@@ -1,0 +1,5 @@
+it("condition expr should works in require", () => {
+	const ok = () => {};
+	const res = require(ok() ? "./a" : `./b`);
+	expect(res).toBe("b");
+});


### PR DESCRIPTION
Fixes #4816
Related to #4424

This PR introduces ﻿`BasicEvaluatedExpression` which is utilized to process expressions during js parsing.