### PR TITLE
feat: implement `ChunkGraph.getChunkModulesIterable` and `ChunkGraph.getChunkEntryModulesIterable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,6 +2501,7 @@ dependencies = [
  "rspack_plugin_worker",
  "rspack_regex",
  "rspack_swc_visitors",
+ "rspack_util",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -100,7 +100,9 @@ export function __chunk_group_inner_get_chunk_group(ukey: number, compilation: J
 
 export function __chunk_inner_can_be_initial(jsChunkUkey: number, compilation: JsCompilation): boolean
 
-export function __chunk_inner_get_chunk_modules(jsChunkUkey: number, compilation: JsCompilation, sortById: boolean): Array<JsModule>
+export function __chunk_inner_get_chunk_entry_modules(jsChunkUkey: number, compilation: JsCompilation): Array<JsModule>
+
+export function __chunk_inner_get_chunk_modules(jsChunkUkey: number, compilation: JsCompilation): Array<JsModule>
 
 export function __chunk_inner_has_runtime(jsChunkUkey: number, compilation: JsCompilation): boolean
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -100,6 +100,8 @@ export function __chunk_group_inner_get_chunk_group(ukey: number, compilation: J
 
 export function __chunk_inner_can_be_initial(jsChunkUkey: number, compilation: JsCompilation): boolean
 
+export function __chunk_inner_get_chunk_modules(jsChunkUkey: number, compilation: JsCompilation, sortById: boolean): Array<JsModule>
+
 export function __chunk_inner_has_runtime(jsChunkUkey: number, compilation: JsCompilation): boolean
 
 export function __chunk_inner_is_only_initial(jsChunkUkey: number, compilation: JsCompilation): boolean

--- a/crates/rspack_binding_values/Cargo.toml
+++ b/crates/rspack_binding_values/Cargo.toml
@@ -43,6 +43,7 @@ rspack_plugin_wasm                      = { path = "../rspack_plugin_wasm" }
 rspack_plugin_worker                    = { path = "../rspack_plugin_worker" }
 rspack_regex                            = { path = "../rspack_regex" }
 rspack_swc_visitors                     = { path = "../rspack_swc_visitors" }
+rspack_util                             = { path = "../rspack_util" }
 
 anyhow            = { workspace = true, features = ["backtrace"] }
 async-trait       = { workspace = true }

--- a/packages/rspack/src/Chunk.ts
+++ b/packages/rspack/src/Chunk.ts
@@ -72,24 +72,6 @@ export class Chunk {
 		);
 	}
 
-	getModules() {
-		return __chunk_inner_get_chunk_modules(
-			this.#inner.__inner_ukey,
-			this.#inner_compilation,
-			false
-		);
-	}
-
-	get modulesIterable() {
-		return new Set(
-			__chunk_inner_get_chunk_modules(
-				this.#inner.__inner_ukey,
-				this.#inner_compilation,
-				true
-			)
-		);
-	}
-
 	get groupsIterable(): Set<ChunkGroup> {
 		const chunk_groups = this.#inner.__inner_groups.map(ukey => {
 			const cg = __chunk_group_inner_get_chunk_group(
@@ -100,5 +82,9 @@ export class Chunk {
 		});
 		chunk_groups.sort(compareChunkGroupsByIndex);
 		return new Set(chunk_groups);
+	}
+
+	__internal_inner_ukey() {
+		return this.#inner.__inner_ukey;
 	}
 }

--- a/packages/rspack/src/Chunk.ts
+++ b/packages/rspack/src/Chunk.ts
@@ -1,6 +1,7 @@
 import {
 	__chunk_group_inner_get_chunk_group,
 	__chunk_inner_can_be_initial,
+	__chunk_inner_get_chunk_modules,
 	__chunk_inner_has_runtime,
 	__chunk_inner_is_only_initial,
 	type JsChunk,
@@ -68,6 +69,24 @@ export class Chunk {
 		return __chunk_inner_has_runtime(
 			this.#inner.__inner_ukey,
 			this.#inner_compilation
+		);
+	}
+
+	getModules() {
+		return __chunk_inner_get_chunk_modules(
+			this.#inner.__inner_ukey,
+			this.#inner_compilation,
+			false
+		);
+	}
+
+	get modulesIterable() {
+		return new Set(
+			__chunk_inner_get_chunk_modules(
+				this.#inner.__inner_ukey,
+				this.#inner_compilation,
+				true
+			)
 		);
 	}
 

--- a/packages/rspack/src/ChunkGraph.ts
+++ b/packages/rspack/src/ChunkGraph.ts
@@ -1,0 +1,25 @@
+import {
+	__chunk_inner_get_chunk_entry_modules,
+	__chunk_inner_get_chunk_modules
+} from "@rspack/binding";
+import { Chunk } from "./Chunk";
+import { Compilation } from "./Compilation";
+import { Module } from "./Module";
+
+export class ChunkGraph {
+	constructor(private compilation: Compilation) {}
+
+	getChunkModulesIterable(chunk: Chunk) {
+		return __chunk_inner_get_chunk_modules(
+			chunk.__internal_inner_ukey(),
+			this.compilation.__internal_getInner()
+		).map(m => Module.__from_binding(m));
+	}
+
+	getChunkEntryModulesIterable(chunk: Chunk) {
+		return __chunk_inner_get_chunk_entry_modules(
+			chunk.__internal_inner_ukey(),
+			this.compilation.__internal_getInner()
+		).map(m => Module.__from_binding(m));
+	}
+}

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -56,6 +56,7 @@ import { NormalizedJsModule, normalizeJsModule } from "./util/normalization";
 import MergeCaller from "./util/MergeCaller";
 import { Chunk } from "./Chunk";
 import { CodeGenerationResult, Module } from "./Module";
+import { ChunkGraph } from "./ChunkGraph";
 
 export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
 export type Assets = Record<string, Source>;
@@ -138,6 +139,7 @@ export class Compilation {
 	normalModuleFactory?: NormalModuleFactory;
 	children: Compilation[] = [];
 	contextModuleFactory?: ContextModuleFactory;
+	chunkGraph: ChunkGraph;
 	fileSystemInfo = {
 		createSnapshot() {
 			// fake implement to support html-webpack-plugin
@@ -188,6 +190,7 @@ export class Compilation {
 		this.options = compiler.options;
 		this.outputOptions = compiler.options.output;
 		this.logging = new Map();
+		this.chunkGraph = new ChunkGraph(this);
 		this.#inner = inner;
 		// Cache the current NormalModuleHooks
 	}

--- a/packages/rspack/tests/configCases/plugins/chunk-modules/async.js
+++ b/packages/rspack/tests/configCases/plugins/chunk-modules/async.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/rspack/tests/configCases/plugins/chunk-modules/index.js
+++ b/packages/rspack/tests/configCases/plugins/chunk-modules/index.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+it("chunk-modules", async () => {
+	const m = await import(/* webpackChunkName: "async" */ "./async");
+	expect(m.default).toBe(1);
+	const data = JSON.parse(
+		await fs.promises.readFile(path.join(__dirname, "data.json"), "utf-8")
+	);
+	expect(data.main.modules).toContain("/index.js");
+	expect(data.main.entryModules).toContain("/index.js");
+	expect(data.async.modules).toContain("/async.js");
+	expect(data.async.entryModules.length).toBe(0);
+});

--- a/packages/rspack/tests/configCases/plugins/chunk-modules/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/chunk-modules/webpack.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+	plugins: [
+		function plugin(compiler) {
+			compiler.hooks.compilation.tap("plugin", compilation => {
+				compilation.hooks.processAssets.tap("plugin", () => {
+					const chunkModules = {};
+					for (let chunk of compilation.chunks) {
+						const modules = compilation.chunkGraph
+							.getChunkModulesIterable(chunk)
+							.map(m => m.identifier().slice(compiler.context.length));
+						const entryModules = compilation.chunkGraph
+							.getChunkEntryModulesIterable(chunk)
+							.map(m => m.identifier().slice(compiler.context.length));
+						chunkModules[chunk.id] = { modules, entryModules };
+					}
+					compilation.emitAsset(
+						"data.json",
+						new compiler.webpack.sources.RawSource(
+							JSON.stringify(chunkModules, null, 2)
+						)
+					);
+				});
+			});
+		}
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

#4809 is caused by rspack being lack of ChunkGraph-related apis.

this pr simply implements one of such apis - `chunks.modulesIterable` - that is used by `LicenseWebpackPlugin`.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

1. Run `webpack --config rspack.config.js` (without configuration that causes errors) on `examples/plugin-compat/`  and `examples/plugin-compat/dist/3rdpartylicenses.txt` should be produced.
2. Run `rspack build` on `examples/plugin-compat/` (with same configuration as case 1) and a same `3rdpartylicenses.txt` should be produced.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
