### PR TITLE
refactor: error and diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1432,12 +1441,33 @@ checksum = "1c90329e44f9208b55f45711f9558cec15d7ef8295cc65ecd6d4188ae8edc58c"
 dependencies = [
  "atty",
  "backtrace",
- "miette-derive",
+ "miette-derive 4.7.1",
  "once_cell",
  "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
+ "supports-color 1.3.1",
+ "supports-hyperlinks 1.2.0",
+ "supports-unicode 1.0.2",
+ "terminal_size",
+ "textwrap 0.15.2",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive 5.10.0",
+ "once_cell",
+ "owo-colors",
+ "supports-color 2.1.0",
+ "supports-hyperlinks 2.1.0",
+ "supports-unicode 2.0.0",
  "terminal_size",
  "textwrap 0.15.2",
  "thiserror",
@@ -1453,6 +1483,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2593,6 +2634,7 @@ dependencies = [
  "anyhow",
  "futures",
  "insta",
+ "miette 5.10.0",
  "rspack-codespan-reporting",
  "rspack_binding_options",
  "rspack_core",
@@ -2605,6 +2647,7 @@ dependencies = [
  "sugar_path",
  "swc_core",
  "termcolor",
+ "thiserror",
  "tokio",
 ]
 
@@ -3806,6 +3849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
 name = "supports-hyperlinks"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3815,12 +3868,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
 name = "supports-unicode"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8b945e45b417b125a8ec51f1b7df2f8df7920367700d1f98aedd21e5735f8b2"
 dependencies = [
  "atty",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
+dependencies = [
+ "is-terminal",
 ]
 
 [[package]]
@@ -4868,7 +4939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29add35412af288be50e1012bbb825a66871bb2b4d960d1c456917ec3ccea32"
 dependencies = [
  "anyhow",
- "miette",
+ "miette 4.7.1",
  "once_cell",
  "parking_lot 0.12.1",
  "swc_common",

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -1067,10 +1067,10 @@ impl<'a> CodeSizeOptimizer<'a> {
                   })
                   .collect::<Vec<_>>();
                 error_message += &join_string_component(module_identifier_list);
-                errors.push(Error::InternalError(InternalError {
+                errors.push(Error::InternalError(InternalError::new(
                   error_message,
-                  severity: Severity::Warn,
-                }));
+                  Severity::Warn,
+                )));
                 ret[0].1.clone()
               }
             };
@@ -1101,10 +1101,10 @@ impl<'a> CodeSizeOptimizer<'a> {
                 .normal_module_source_path_by_identifier(&star_symbol.src());
               if let Some(module_path) = module_path {
                 let error_message = format!("Can't get analyze result of {module_path}");
-                errors.push(Error::InternalError(InternalError {
+                errors.push(Error::InternalError(InternalError::new(
                   error_message,
-                  severity: Severity::Warn,
-                }));
+                  Severity::Warn,
+                )));
               }
             }
             return;

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -11,12 +11,14 @@ version    = "0.1.0"
 anyhow             = { workspace = true, features = ["backtrace"] }
 codespan-reporting = { version = "=0.11.2", package = "rspack-codespan-reporting" }
 futures            = { workspace = true }
+miette             = { version = "5", features = ["fancy"] }
 rspack_sources     = { workspace = true }
 rspack_util        = { path = "../rspack_util" }
 serde_json         = { workspace = true }
 sugar_path         = { workspace = true }
 swc_core           = { workspace = true, features = ["common"] }
 termcolor          = "1.2"
+thiserror          = "1"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/rspack_error/src/diagnostic.rs
+++ b/crates/rspack_error/src/diagnostic.rs
@@ -9,6 +9,15 @@ pub enum Severity {
   Warn,
 }
 
+impl From<Severity> for miette::Severity {
+  fn from(value: Severity) -> Self {
+    match value {
+      Severity::Error => miette::Severity::Error,
+      Severity::Warn => miette::Severity::Warning,
+    }
+  }
+}
+
 impl fmt::Display for Severity {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     write!(
@@ -87,11 +96,11 @@ impl From<Error> for Vec<Diagnostic> {
     let severity = err.severity();
     let diagnostic = match err {
       Error::InternalError(err) => Diagnostic {
-        message: err.error_message,
+        message: err.error_message().to_string(),
         source_info: None,
         start: 0,
         end: 0,
-        severity: err.severity,
+        severity: err.severity(),
         ..Default::default()
       },
       Error::Napi {

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -11,6 +11,9 @@ pub mod emitter;
 
 mod macros;
 
+pub use miette;
+pub use thiserror;
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// A helper struct for change logic from
@@ -81,6 +84,7 @@ impl<T: Sized + std::fmt::Debug> IntoTWithDiagnosticArray for T {
 pub mod __private {
   pub use core::result::Result::Err;
 
+  pub use crate::diagnostic::Severity;
   pub use crate::error::{Error, InternalError};
   pub use crate::internal_error;
 }

--- a/crates/rspack_error/src/macros.rs
+++ b/crates/rspack_error/src/macros.rs
@@ -1,12 +1,9 @@
 #[macro_export]
 macro_rules! internal_error {
   (@base $expr:expr) => {
-    $crate::__private::Error::InternalError({
-      $crate::__private::InternalError {
-        error_message: $expr,
-        ..Default::default()
-      }
-    })
+    $crate::__private::Error::InternalError(
+      $crate::__private::InternalError::new($expr, $crate::__private::Severity::Error)
+    )
   };
   ($str:literal $(,)?) => {{
     let err = format!($str);

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -473,16 +473,16 @@ impl Loader<LoaderRunnerContext> for SassLoader {
     let sass_options = self.get_sass_options(loader_context, content.try_into_string()?, logger);
     let result = Sass::new(&self.options.__exe_path)
       .map_err(|e| {
-        rspack_error::Error::InternalError(InternalError {
-          severity: Severity::Error,
-          error_message: format!(
+        rspack_error::Error::InternalError(InternalError::new(
+          format!(
             "{}: The dart-sass-embedded path is {}, your OS is {}, your Arch is {}",
             e.message(),
             &self.options.__exe_path.display(),
             get_os(),
             get_arch(),
           ),
-        })
+          Severity::Error,
+        ))
       })?
       .render(sass_options)
       .map_err(sass_exception_to_error)?;

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -66,10 +66,10 @@ impl Plugin for EnsureChunkConditionsPlugin {
                 }
               }
               if chunk_group.is_initial() {
-                return Err(Error::InternalError(rspack_error::InternalError {
-                  error_message: format!("Cannot fulfil chunk condition of {}", module_id),
-                  severity: Default::default(),
-                }));
+                return Err(Error::InternalError(rspack_error::InternalError::new(
+                  format!("Cannot fulfil chunk condition of {}", module_id),
+                  Default::default(),
+                )));
               }
               let parent_chunks = chunk_group.parents_iterable();
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This chain of PRs are intended to solve problems related to errors/diagnostics as follows.

`InternalErrors` are abusively used across rspack crates. However these errors
should provide more useful **context**. See: https://github.com/web-infra-dev/rspack/issues/4613, https://github.com/web-infra-dev/rspack/issues/4321.
`Diagnostics` in rspack is represented by another custom type
to be fed to `codespan-reporting` in reporting. This indicates that errors
should be converted in the first place in order to be consumed by `Stats`.

In the following PRs, the essential idea to solve the problems are as follows:

1. `miette` and `thiserror`: This pair of libraries can either make fancy diagnostics and create easy to read errors. `GraphicalReportHandler` of `miette` can be helpful to directly print error diagnostics.
2. `codespan-reporting` is removed as rspack will never rely on custom diagnostics anymore
3. Custom error code to maximize the compatibility with Webpack's error types
4. Improved webpack error overlay

Some miscellaneous are included in the graphite stack. Take a look over the PR tree down below.

**This** PR did some small initialization works.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [x] Yes, the corresponding rspack-website PR is \_\_
