### PR TITLE
fix: production environment refreshPlugin error

### DIFF
--- a/packages/create-rspack/template-react-ts/rspack.config.js
+++ b/packages/create-rspack/template-react-ts/rspack.config.js
@@ -57,6 +57,6 @@ module.exports = {
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		new refreshPlugin()
-	]
+		isDev ? new refreshPlugin() : null
+	].filter(Boolean),
 };

--- a/packages/create-rspack/template-react/rspack.config.js
+++ b/packages/create-rspack/template-react/rspack.config.js
@@ -57,6 +57,6 @@ module.exports = {
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		new refreshPlugin()
-	]
+		isDev ? new refreshPlugin() : null
+	].filter(Boolean)
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Under the current template, the production environment build will use the refreshPlugin, resulting in an error when directly opening the index.html.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
