### PR TITLE
refactor: should not always rely on `Result`

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -13,7 +13,6 @@ use rspack_core::{ChunkAssetArgs, ModuleIdentifier, NormalModuleAfterResolveArgs
 use rspack_core::{NormalModuleBeforeResolveArgs, PluginNormalModuleFactoryAfterResolveOutput};
 use rspack_core::{PluginNormalModuleFactoryBeforeResolveOutput, ResourceData};
 use rspack_core::{PluginNormalModuleFactoryResolveForSchemeOutput, PluginShouldEmitHookOutput};
-use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use rspack_napi_shared::NapiResultExt;
 
@@ -96,7 +95,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call compilation: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call compilation: {err}"))
   }
 
   async fn this_compilation(
@@ -119,7 +118,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call this_compilation: {err}"))
   }
 
   async fn chunk_asset(&self, args: &ChunkAssetArgs) -> rspack_error::Result<()> {
@@ -135,7 +134,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       )
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to chunk asset: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to chunk asset: {err}"))
   }
 
   #[tracing::instrument(name = "js_hooks_adapter::make", skip_all)]
@@ -155,7 +154,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call make: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call make: {err}"))
   }
 
   async fn before_resolve(
@@ -171,7 +170,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call this_compilation: {err}"))
     {
       Ok((ret, resolve_data)) => {
         args.request = resolve_data.request;
@@ -195,7 +194,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call this_compilation: {err}"))
   }
   async fn context_module_before_resolve(
     &self,
@@ -207,7 +206,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(args.clone().into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call this_compilation: {err}"))
   }
   async fn normal_module_factory_resolve_for_scheme(
     &self,
@@ -222,7 +221,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(args.into(), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call this_compilation: {err}"))?;
+      .unwrap_or_else(|err| panic!("Failed to call this_compilation: {err}"));
     res.map(|res| {
       let JsResolveForSchemeResult {
         resource_data,
@@ -251,7 +250,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage additional: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage additional: {err}"))
   }
 
   async fn process_assets_stage_pre_process(
@@ -268,7 +267,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage pre-process: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage pre-process: {err}"))
   }
 
   async fn process_assets_stage_derived(
@@ -285,7 +284,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage derived: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage derived: {err}"))
   }
 
   async fn process_assets_stage_additions(
@@ -302,7 +301,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage additions: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage additions: {err}"))
   }
 
   async fn process_assets_stage_none(
@@ -319,7 +318,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets: {err}"))
   }
 
   async fn process_assets_stage_optimize(
@@ -336,7 +335,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage optimize: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage optimize: {err}"))
   }
 
   async fn process_assets_stage_optimize_count(
@@ -353,9 +352,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(
-        |err| internal_error!("Failed to call process assets stage optimize count: {err}",),
-      )?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage optimize count: {err}"))
   }
 
   async fn process_assets_stage_optimize_compatibility(
@@ -372,9 +369,9 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        internal_error!("Failed to call process assets stage optimize compatibility: {err}",)
-      })?
+      .unwrap_or_else(|err| {
+        panic!("Failed to call process assets stage optimize compatibility: {err}")
+      })
   }
 
   async fn process_assets_stage_optimize_size(
@@ -391,7 +388,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage optimize size: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage optimize size: {err}"))
   }
 
   async fn process_assets_stage_dev_tooling(
@@ -408,7 +405,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage dev tooling: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage dev tooling: {err}"))
   }
 
   async fn process_assets_stage_optimize_inline(
@@ -425,9 +422,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        internal_error!("Failed to call process assets stage optimize inline: {err}",)
-      })?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage optimize inline: {err}"))
   }
 
   async fn process_assets_stage_summarize(
@@ -445,7 +440,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage summarize: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage summarize: {err}"))
   }
 
   async fn process_assets_stage_optimize_hash(
@@ -462,7 +457,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage summarize: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage summarize: {err}"))
   }
 
   async fn process_assets_stage_optimize_transfer(
@@ -479,9 +474,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| {
-        internal_error!("Failed to call process assets stage optimize transfer: {err}",)
-      })?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage optimize transfer: {err}"))
   }
 
   async fn process_assets_stage_analyse(
@@ -498,7 +491,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage analyse: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage analyse: {err}"))
   }
 
   async fn process_assets_stage_report(
@@ -515,7 +508,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call process assets stage report: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call process assets stage report: {err}"))
   }
 
   async fn optimize_modules(
@@ -535,7 +528,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::Blocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call optimize modules: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call optimize modules: {err}"))
   }
 
   async fn optimize_tree(
@@ -550,7 +543,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call optimize tree: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call optimize tree: {err}"))
   }
 
   async fn optimize_chunk_modules(
@@ -572,7 +565,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to compilation: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to compilation: {err}"))
   }
 
   async fn before_compile(
@@ -588,7 +581,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call({}, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call before compile: {err}",))?
+      .unwrap_or_else(|err| panic!("Failed to call before compile: {err}"))
   }
 
   async fn after_compile(
@@ -610,7 +603,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call after compile: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call after compile: {err}"))
   }
 
   async fn finish_make(
@@ -632,7 +625,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call finish make: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call finish make: {err}"))
   }
 
   async fn build_module(&self, module: &mut dyn rspack_core::Module) -> rspack_error::Result<()> {
@@ -648,7 +641,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       )
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call build module: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call build module: {err}"))
   }
 
   async fn finish_modules(
@@ -670,7 +663,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to finish modules: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to finish modules: {err}"))
   }
 
   async fn emit(&self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
@@ -683,7 +676,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call emit: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call emit: {err}"))
   }
 
   async fn asset_emitted(&self, args: &rspack_core::AssetEmittedArgs) -> rspack_error::Result<()> {
@@ -697,7 +690,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(args, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call asset emitted: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call asset emitted: {err}"))
   }
 
   async fn should_emit(
@@ -719,7 +712,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(compilation, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await;
-    res.map_err(|err| internal_error!("Failed to call should emit: {err}"))?
+    res.unwrap_or_else(|err| panic!("Failed to call should emit: {err}"))
   }
 
   async fn after_emit(&self, _: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
@@ -732,7 +725,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call((), ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call after emit: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call after emit: {err}"))
   }
 
   async fn succeed_module(&self, args: &dyn rspack_core::Module) -> rspack_error::Result<()> {
@@ -747,7 +740,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       .call(js_module, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call succeed_module hook: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call succeed_module hook: {err}"))
   }
 
   async fn still_valid_module(&self, args: &dyn rspack_core::Module) -> rspack_error::Result<()> {
@@ -763,7 +756,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       )
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call still_valid_module hook: {err}"))?
+      .unwrap_or_else(|err| panic!("Failed to call still_valid_module hook: {err}"))
   }
 
   fn execute_module(
@@ -791,7 +784,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
       )
       .into_rspack_result()?
       .blocking_recv()
-      .map_err(|recv_err| rspack_error::internal_error!(recv_err.to_string()))?
+      .unwrap_or_else(|recv_err| panic!("{}", recv_err.to_string()))
   }
 }
 

--- a/crates/rspack_ast/src/lib.rs
+++ b/crates/rspack_ast/src/lib.rs
@@ -1,7 +1,5 @@
 mod ast;
 
-use rspack_error::{internal_error, Result};
-
 pub use crate::ast::css;
 use crate::ast::css::Ast as CssAst;
 pub use crate::ast::javascript;
@@ -17,20 +15,6 @@ pub enum RspackAst {
 }
 
 impl RspackAst {
-  pub fn try_into_javascript(self) -> Result<JsAst> {
-    match self {
-      RspackAst::JavaScript(program) => Ok(program),
-      RspackAst::Css(_) => Err(internal_error!("Failed to cast `CSS` AST to `JavaScript`")),
-    }
-  }
-
-  pub fn try_into_css(self) -> Result<CssAst> {
-    match self {
-      RspackAst::Css(stylesheet) => Ok(stylesheet),
-      RspackAst::JavaScript(_) => Err(internal_error!("Failed to cast `JavaScript` AST to `CSS`")),
-    }
-  }
-
   pub fn as_javascript(&self) -> Option<&JsAst> {
     match self {
       RspackAst::JavaScript(program) => Some(program),

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_banner.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_banner.rs
@@ -4,7 +4,7 @@ use derivative::Derivative;
 use napi::{Either, Env, JsFunction};
 use napi_derive::napi;
 use rspack_binding_values::JsChunk;
-use rspack_error::{internal_error, Result};
+use rspack_error::Result;
 use rspack_napi_shared::{
   get_napi_env,
   threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_banner.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_banner.rs
@@ -53,7 +53,7 @@ impl TryFrom<RawBannerContentWrapper> for BannerContent {
                 .call(ctx.into(), ThreadsafeFunctionCallMode::NonBlocking)
                 .into_rspack_result()?
                 .await
-                .map_err(|err| internal_error!("Failed to call rule.use function: {err}"))?
+                .unwrap_or_else(|err| panic!("Failed to call rule.use function: {err}"))
             })
           },
         )))

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -106,7 +106,7 @@ impl TryFrom<RawExternalItemWrapper> for ExternalItem {
               .call(ctx.into(), ThreadsafeFunctionCallMode::NonBlocking)
               .into_rspack_result()?
               .await
-              .map_err(|err| internal_error!("Failed to call external function: {err}"))?
+              .unwrap_or_else(|err| panic!("Failed to call external function: {err}"))
               .map(|r| r.into())
           })
         })))

--- a/crates/rspack_binding_options/src/options/raw_external.rs
+++ b/crates/rspack_binding_options/src/options/raw_external.rs
@@ -7,7 +7,6 @@ use napi::{Env, JsFunction};
 use napi_derive::napi;
 use rspack_core::ExternalItemFnCtx;
 use rspack_core::{ExternalItem, ExternalItemFnResult, ExternalItemValue};
-use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use rspack_napi_shared::{get_napi_env, JsRegExp, JsRegExpExt, NapiResultExt};
 

--- a/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
@@ -133,7 +133,7 @@ impl Loader<LoaderRunnerContext> for JsLoaderAdapter {
       .call(js_loader_context, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call loader: {err}"))??;
+      .unwrap_or_else(|err| panic!("Failed to call loader: {err}"))?;
 
     if let Some(loader_result) = loader_result {
       // This indicate that the JS loaders pitched(return something) successfully
@@ -163,7 +163,7 @@ impl Loader<LoaderRunnerContext> for JsLoaderAdapter {
       .call(js_loader_context, ThreadsafeFunctionCallMode::NonBlocking)
       .into_rspack_result()?
       .await
-      .map_err(|err| internal_error!("Failed to call loader: {err}"))??;
+      .unwrap_or_else(|err| panic!("Failed to call loader: {err}"))?;
 
     if let Some(loader_result) = loader_result {
       sync_loader_context(loader_result, loader_context)?;

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -239,9 +239,9 @@ impl TryFrom<RawRuleSetCondition> for rspack_core::RuleSetCondition {
               .call(data, ThreadsafeFunctionCallMode::NonBlocking)
               .into_rspack_result()?
               .await
-              .map_err(|err| {
-                internal_error!("Failed to call RuleSetCondition func_matcher: {err}")
-              })?
+              .unwrap_or_else(|err| {
+                panic!("Failed to call RuleSetCondition func_matcher: {err}")
+              })
           })
         }))
       }
@@ -609,7 +609,7 @@ impl RawOptionsApply for RawModuleRule {
                 .call(ctx.into(), ThreadsafeFunctionCallMode::NonBlocking)
                 .into_rspack_result()?
                 .await
-                .map_err(|err| internal_error!("Failed to call rule.use function: {err}"))?
+                .unwrap_or_else(|err| panic!("Failed to call rule.use function: {err}"))
                 .map(|uses| {
                   uses
                     .into_iter()

--- a/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
@@ -43,12 +43,7 @@ pub(super) fn normalize_raw_cache_group_test(raw: RawCacheGroupTest) -> CacheGro
           .into_rspack_result()
           .expect("into rspack result failed")
           .blocking_recv()
-          .unwrap_or_else(|err| {
-            panic!(
-              "{}",
-              internal_error!("Failed to call external function: {err}")
-            )
-          })
+          .unwrap_or_else(|err| panic!("Failed to call external function: {err}"))
           .expect("failed")
       }))
     }

--- a/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_cache_group_test.rs
@@ -4,7 +4,6 @@ use napi::bindgen_prelude::Either3;
 use napi::{Env, JsFunction};
 use napi_derive::napi;
 use rspack_binding_values::{JsModule, ToJsModule};
-use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use rspack_napi_shared::{get_napi_env, JsRegExp, JsRegExpExt, NapiResultExt};
 use rspack_plugin_split_chunks_new::{CacheGroupTest, CacheGroupTestFnCtx};

--- a/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_name.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_name.rs
@@ -48,12 +48,7 @@ pub(super) fn normalize_raw_chunk_name(raw: RawChunkOptionName) -> ChunkNameGett
           .into_rspack_result()
           .expect("into rspack result failed")
           .blocking_recv()
-          .unwrap_or_else(|err| {
-            panic!(
-              "{}",
-              internal_error!("Failed to call external function: {err}")
-            )
-          })
+          .unwrap_or_else(|err| panic!("Failed to call external function: {err}"))
           .expect("failed")
       }))
     }

--- a/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_name.rs
+++ b/crates/rspack_binding_options/src/options/raw_split_chunks/raw_split_chunk_name.rs
@@ -4,7 +4,6 @@ use napi::bindgen_prelude::Either3;
 use napi::{Env, JsFunction};
 use napi_derive::napi;
 use rspack_binding_values::{JsModule, ToJsModule};
-use rspack_error::internal_error;
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use rspack_napi_shared::{get_napi_env, NapiResultExt};
 use rspack_plugin_split_chunks_new::{ChunkNameGetter, ChunkNameGetterFnCtx};

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -11,7 +11,7 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use rspack_error::{
-  internal_error, miette::IntoDiagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
+  miette::IntoDiagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
 };
 use rspack_hash::RspackHash;
 use rspack_identifier::{Identifiable, Identifier};

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -359,18 +359,18 @@ impl ContextModule {
   }
 
   #[inline]
-  fn get_source_string(&self, compilation: &Compilation) -> Result<BoxSource> {
+  fn get_source_string(&self, compilation: &Compilation) -> BoxSource {
     match self.options.context_options.mode {
-      ContextMode::Lazy => Ok(self.get_lazy_source(compilation)),
+      ContextMode::Lazy => self.get_lazy_source(compilation),
       ContextMode::LazyOnce => {
         let block = self
           .get_blocks()
           .first()
-          .ok_or_else(|| internal_error!("LazyOnce ContextModule should have first block"))?;
+          .expect("LazyOnce ContextModule should have first block");
         let block = compilation
           .module_graph
           .block_by_id(block)
-          .ok_or_else(|| internal_error!("should have block"))?;
+          .expect("should have block");
         self.generate_source(block.get_dependencies(), compilation)
       }
       _ => self.generate_source(self.get_dependencies(), compilation),
@@ -429,11 +429,7 @@ impl ContextModule {
     source.boxed()
   }
 
-  fn generate_source(
-    &self,
-    dependencies: &[DependencyId],
-    compilation: &Compilation,
-  ) -> Result<BoxSource> {
+  fn generate_source(&self, dependencies: &[DependencyId], compilation: &Compilation) -> BoxSource {
     let map = self.get_user_request_map(dependencies, compilation);
     let fake_map = self.get_fake_map(dependencies, compilation);
     let mode = &self.options.context_options.mode;
@@ -521,7 +517,7 @@ impl ContextModule {
     source.add(RawSource::from(format!(
       "webpackContext.id = '{}';\n",
       serde_json::to_string(self.id(&compilation.chunk_graph))
-        .map_err(|e| internal_error!(e.to_string()))?
+        .unwrap_or_else(|e| panic!("{}", e.to_string()))
     )));
     source.add(RawSource::from(
       r#"
@@ -532,7 +528,7 @@ impl ContextModule {
       module.exports = webpackContext;
       "#,
     ));
-    Ok(source.boxed())
+    source.boxed()
   }
 }
 
@@ -639,7 +635,7 @@ impl Module for ContextModule {
       let block = compilation
         .module_graph
         .block_by_id(block)
-        .ok_or_else(|| internal_error!("should have block in ContextModule code_generation"))?;
+        .expect("should have block in ContextModule code_generation");
       all_deps.extend(block.get_dependencies());
     }
     let fake_map = self.get_fake_map(all_deps.iter(), compilation);
@@ -648,7 +644,7 @@ impl Module for ContextModule {
         .runtime_requirements
         .insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
     }
-    code_generation_result.add(SourceType::JavaScript, self.get_source_string(compilation)?);
+    code_generation_result.add(SourceType::JavaScript, self.get_source_string(compilation));
     code_generation_result.set_hash(
       &compilation.options.output.hash_function,
       &compilation.options.output.hash_digest,

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -3,7 +3,7 @@ use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 
 use dashmap::DashMap;
-use rspack_error::{internal_error, Result};
+use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
 use rspack_identifier::{Identifiable, IdentifierMap};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -230,11 +230,11 @@ impl ModuleGraph {
     {
       let mgm = self
         .module_graph_module_by_identifier_mut(&module_identifier)
-        .ok_or_else(|| {
-          internal_error!(
+        .unwrap_or_else(|| {
+          panic!(
             "Failed to set resolved module: Module linked to module identifier {module_identifier} cannot be found"
           )
-        })?;
+        });
 
       mgm.add_incoming_connection(connection_id);
     }

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -1,4 +1,4 @@
-use rspack_error::{internal_error, Result};
+use rspack_error::Result;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::ExportsInfoId;
@@ -83,13 +83,11 @@ impl ModuleGraphModule {
       .map(|connection_id| {
         module_graph
           .connection_by_connection_id(connection_id)
-          .ok_or_else(|| {
-            internal_error!(
-              "connection_id_to_connection does not have connection_id: {connection_id:?}"
-            )
+          .unwrap_or_else(|| {
+            panic!("connection_id_to_connection does not have connection_id: {connection_id:?}")
           })
       })
-      .collect::<Result<Vec<_>>>()?
+      .collect::<Vec<_>>()
       .into_iter();
 
     Ok(result)
@@ -105,13 +103,11 @@ impl ModuleGraphModule {
       .map(|connection_id| {
         module_graph
           .connection_by_connection_id(connection_id)
-          .ok_or_else(|| {
-            internal_error!(
-              "connection_id_to_connection does not have connection_id: {connection_id:?}"
-            )
+          .unwrap_or_else(|| {
+            panic!("connection_id_to_connection does not have connection_id: {connection_id:?}")
           })
       })
-      .collect::<Result<Vec<_>>>()?
+      .collect::<Vec<_>>()
       .into_iter();
 
     Ok(result)

--- a/crates/rspack_loader_react_refresh/src/lib.rs
+++ b/crates/rspack_loader_react_refresh/src/lib.rs
@@ -1,5 +1,5 @@
 use rspack_core::LoaderRunnerContext;
-use rspack_error::{internal_error, Result};
+use rspack_error::Result;
 use rspack_loader_runner::{Identifiable, Identifier, Loader, LoaderContext};
 
 pub struct ReactRefreshLoader {
@@ -27,9 +27,7 @@ impl ReactRefreshLoader {
 #[async_trait::async_trait]
 impl Loader<LoaderRunnerContext> for ReactRefreshLoader {
   async fn run(&self, loader_context: &mut LoaderContext<'_, LoaderRunnerContext>) -> Result<()> {
-    let Some(content) = std::mem::take(&mut loader_context.content) else {
-      return Err(internal_error!("Content should be available"));
-    };
+    let content = std::mem::take(&mut loader_context.content).expect("Content should be available");
     let mut source = content.try_into_string()?;
     source += r#"
 function $RefreshSig$() {

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -378,7 +378,7 @@ impl<C> TryFrom<LoaderContext<'_, C>> for TWithDiagnosticArray<LoaderResult> {
         let loader = loader_context.__loader_items[0].to_string();
         internal_error!("Final loader({loader}) didn't return a Buffer or String")
       } else {
-        internal_error!("Content is not available, it is a bug")
+        panic!("content should be available");
       }
     })?;
 

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -482,23 +482,20 @@ impl Loader<LoaderRunnerContext> for SassLoader {
       })?
       .render(sass_options)
       .map_err(sass_exception_to_error)?;
-    let source_map = result
-      .map
-      .map(|map| -> Result<SourceMap> {
-        let mut map = SourceMap::from_slice(&map).map_err(|e| internal_error!(e.to_string()))?;
-        for source in map.sources_mut() {
-          if source.starts_with("file:") {
-            *source = Url::parse(source)
-              .expect("TODO:")
-              .to_file_path()
-              .expect("TODO:")
-              .display()
-              .to_string();
-          }
+    let source_map = result.map.map(|map| {
+      let mut map = SourceMap::from_slice(&map).expect("should be able to generate source-map");
+      for source in map.sources_mut() {
+        if source.starts_with("file:") {
+          *source = Url::parse(source)
+            .expect("TODO:")
+            .to_file_path()
+            .expect("TODO:")
+            .display()
+            .to_string();
         }
-        Ok(map)
-      })
-      .transpose()?;
+      }
+      map
+    });
 
     loader_context.content = Some(result.css.into());
     loader_context.source_map = source_map;

--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -47,9 +47,7 @@ pub const SWC_LOADER_IDENTIFIER: &str = "builtin:swc-loader";
 impl Loader<LoaderRunnerContext> for SwcLoader {
   async fn run(&self, loader_context: &mut LoaderContext<'_, LoaderRunnerContext>) -> Result<()> {
     let resource_path = loader_context.resource_path.to_path_buf();
-    let Some(content) = std::mem::take(&mut loader_context.content) else {
-      return Err(internal_error!("Content should be available"));
-    };
+    let content = std::mem::take(&mut loader_context.content).expect("content should be available");
 
     let swc_options = {
       let mut swc_options = self.options_with_additional.swc_options.clone();

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -423,9 +423,10 @@ impl ParserAndGenerator for AssetParserAndGenerator {
           Ok(RawSource::from(source.buffer().to_vec()).boxed())
         }
       }
-      t => Err(internal_error!(format!(
-        "Unsupported source type {t:?} for plugin JavaScript"
-      ))),
+      _ => panic!(
+        "Unsupported source type: {:?}",
+        generate_context.requested_source_type
+      ),
     };
 
     result

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -536,7 +536,7 @@ impl Plugin for AssetPlugin {
       .map(|m| {
         let code_gen_result = compilation
           .code_generation_results
-          .get(&m.identifier(), Some(&chunk.runtime))?;
+          .get(&m.identifier(), Some(&chunk.runtime));
 
         let result = code_gen_result.get(&SourceType::Asset).map(|source| {
           let asset_filename = code_gen_result

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -15,7 +15,7 @@ use rspack_core::{
   ParseContext, ParseResult, ParserAndGenerator, SourceType, TemplateContext,
 };
 use rspack_core::{ModuleInitFragments, RuntimeGlobals};
-use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 use swc_core::{css::parser::parser::ParserConfig, ecma::atoms::JsWord};
@@ -201,7 +201,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
           value: source_code,
           name: module_user_request,
           source_map: SourceMap::from_slice(&source_map)
-            .map_err(|e| internal_error!(e.to_string()))?,
+            .expect("should be able to generate source-map"),
           // Safety: original source exists in code generation
           original_source: Some(source.source().to_string()),
           // Safety: original source exists in code generation
@@ -280,13 +280,13 @@ impl ParserAndGenerator for CssParserAndGenerator {
           .insert(RuntimeGlobals::MODULE);
         Ok(RawSource::from(locals).boxed())
       }
-      _ => Err(internal_error!(
+      _ => unreachable!(
         "Unsupported source type: {:?}",
         generate_context.requested_source_type
-      )),
-    }?;
+      ),
+    };
 
-    Ok(result)
+    result
   }
   fn store(&self, extra_data: &mut HashMap<BuildExtraDataType, AlignedVec>) {
     let data = self.exports.to_owned();

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -280,7 +280,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
           .insert(RuntimeGlobals::MODULE);
         Ok(RawSource::from(locals).boxed())
       }
-      _ => unreachable!(
+      _ => panic!(
         "Unsupported source type: {:?}",
         generate_context.requested_source_type
       ),

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -37,7 +37,7 @@ impl CssPlugin {
         let module_id = &module.identifier();
         let code_gen_result = compilation
           .code_generation_results
-          .get(module_id, Some(&chunk.runtime))?;
+          .get(module_id, Some(&chunk.runtime));
 
         Ok(
           code_gen_result

--- a/crates/rspack_plugin_css/src/swc_css_compiler.rs
+++ b/crates/rspack_plugin_css/src/swc_css_compiler.rs
@@ -94,7 +94,7 @@ impl SwcCssCompiler {
         value: code,
         name: filename,
         source_map: rspack_sources::SourceMap::from_slice(&source_map)
-          .map_err(|e| internal_error!(e.to_string()))?,
+          .expect("should be able to generate source-map"),
         original_source: Some(input_source),
         inner_source_map: input_source_map,
         remove_original_source: true,

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -17,7 +17,7 @@ use rspack_core::{
   ProcessAssetsArgs, RenderModuleContentArgs, SourceType,
 };
 use rspack_error::miette::IntoDiagnostic;
-use rspack_error::{internal_error, Error, Result};
+use rspack_error::{Error, Result};
 use rspack_util::swc::normalize_custom_filename;
 use rustc_hash::FxHashMap as HashMap;
 use serde_json::json;

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -137,7 +137,7 @@ impl Plugin for DevtoolPlugin {
             let mut map_buffer = Vec::new();
             map
               .to_writer(&mut map_buffer)
-              .map_err(|e| internal_error!(e.to_string()))?;
+              .unwrap_or_else(|e| panic!("{}", e.to_string()));
             Ok::<Vec<u8>, Error>(map_buffer)
           })
           .transpose()?;
@@ -284,7 +284,7 @@ pub fn wrap_eval_source_map(
   let mut map_buffer = Vec::new();
   map
     .to_writer(&mut map_buffer)
-    .map_err(|e| internal_error!(e.to_string()))?;
+    .unwrap_or_else(|e| panic!("{}", e.to_string()));
   let base64 = rspack_base64::encode_to_string(&map_buffer);
   let footer =
     format!("\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,{base64}");

--- a/crates/rspack_plugin_javascript/src/ast/stringify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/stringify.rs
@@ -126,7 +126,7 @@ pub fn print(
     source_map
       .build_source_map_with_config(&src_map_buf, None, source_map_config)
       .to_writer(&mut buf)
-      .map_err(|e| internal_error!(e.to_string()))?;
+      .unwrap_or_else(|e| panic!("{}", e.to_string()));
     // SAFETY: This buffer is already sanitized
     Some(unsafe { String::from_utf8_unchecked(buf) })
   } else {

--- a/crates/rspack_plugin_javascript/src/ast/stringify.rs
+++ b/crates/rspack_plugin_javascript/src/ast/stringify.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rspack_ast::javascript::Ast;
 use rspack_core::Devtool;
-use rspack_error::{internal_error, miette::IntoDiagnostic, Result};
+use rspack_error::{miette::IntoDiagnostic, Result};
 use swc_core::base::config::JsMinifyFormatOptions;
 use swc_core::{
   common::{

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -11,9 +11,7 @@ use rspack_core::{
   DependencyId, GenerateContext, Module, ParseContext, ParseResult, ParserAndGenerator, SourceType,
   TemplateContext, TemplateReplaceSource,
 };
-use rspack_error::{
-  internal_error, Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray,
-};
+use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use swc_core::common::SyntaxContext;
 
 use crate::ast::CodegenOptions;

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -256,7 +256,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       SourceMapSource::new(SourceMapSourceOptions {
         value: output.code,
         name: resource_data.resource_path.to_string_lossy().to_string(),
-        source_map: SourceMap::from_json(&map).unwrap_or_else(|e| panic!("{}", e.to_string())),
+        source_map: SourceMap::from_json(&map).expect("should be able to generate source-map"),
         inner_source_map: use_source_map.then_some(original_map).flatten(),
         remove_original_source: true,
         ..Default::default()

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -256,7 +256,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       SourceMapSource::new(SourceMapSourceOptions {
         value: output.code,
         name: resource_data.resource_path.to_string_lossy().to_string(),
-        source_map: SourceMap::from_json(&map).map_err(|e| internal_error!(e.to_string()))?,
+        source_map: SourceMap::from_json(&map).unwrap_or_else(|e| panic!("{}", e.to_string())),
         inner_source_map: use_source_map.then_some(original_map).flatten(),
         remove_original_source: true,
         ..Default::default()

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -329,10 +329,10 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
 
       render_init_fragments(source.boxed(), init_fragments, generate_context)
     } else {
-      Err(internal_error!(
-        "Unsupported source type {:?} for plugin JavaScript",
-        generate_context.requested_source_type,
-      ))
+      panic!(
+        "Unsupported source type: {:?}",
+        generate_context.requested_source_type
+      )
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -34,8 +34,7 @@ pub fn render_chunk_modules(
     .filter_map(|mgm| {
       let code_gen_result = compilation
         .code_generation_results
-        .get(&mgm.module_identifier, Some(&chunk.runtime))
-        .expect("should have code generation result");
+        .get(&mgm.module_identifier, Some(&chunk.runtime));
       if let Some(origin_source) = code_gen_result.get(&SourceType::JavaScript) {
         let render_module_result = plugin_driver
           .render_module_content(RenderModuleContentArgs {

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -129,10 +129,10 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .boxed(),
         )
       }
-      _ => Err(internal_error!(format!(
+      _ => unreachable!(
         "Unsupported source type {:?} for plugin Json",
         generate_context.requested_source_type,
-      ))),
+      ),
     }
   }
 }

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -129,9 +129,9 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .boxed(),
         )
       }
-      _ => unreachable!(
-        "Unsupported source type {:?} for plugin Json",
-        generate_context.requested_source_type,
+      _ => panic!(
+        "Unsupported source type: {:?}",
+        generate_context.requested_source_type
       ),
     }
   }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -49,11 +49,10 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
         .clone()
         .expect("should have moduleId at <ConsumeSharedRuntimeModule as RuntimeModule>::generate");
       ids.push(id.clone());
-      if let Ok(code_gen) = compilation
+      let code_gen = compilation
         .code_generation_results
-        .get(&module, Some(&chunk.runtime))
-        && let Some(data) = code_gen.data.get::<CodeGenerationDataConsumeShared>()
-      {
+        .get(&module, Some(&chunk.runtime));
+      if let Some(data) = code_gen.data.get::<CodeGenerationDataConsumeShared>() {
         module_id_to_consume_data_mapping.insert(id, format!(
           "{{ shareScope: {}, shareKey: {}, import: {}, requiredVersion: {}, strictVersion: {}, singleton: {}, eager: {}, fallback: {} }}",
           json_stringify(&data.share_scope),

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -53,7 +53,7 @@ impl RuntimeModule for ShareRuntimeModule {
       for m in modules {
         let code_gen = compilation
           .code_generation_results
-          .get(&m.identifier(), Some(&chunk.runtime)).expect("should have code_generation_result of share-init sourceType module at <ShareRuntimeModule as RuntimeModule>::generate");
+          .get(&m.identifier(), Some(&chunk.runtime));
         let Some(data) = code_gen.data.get::<CodeGenerationDataShareInit>() else {
           continue;
         };

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -7,7 +7,6 @@ use rspack_core::{
   PluginAdditionalChunkRuntimeRequirementsOutput, PluginContext, PluginJsChunkHashHookOutput,
   PluginRenderChunkHookOutput, RenderChunkArgs, RenderStartupArgs, RuntimeGlobals,
 };
-use rspack_error::internal_error;
 use rspack_plugin_javascript::runtime::render_chunk_runtime_modules;
 use rustc_hash::FxHashSet as HashSet;
 
@@ -91,9 +90,7 @@ impl Plugin for ModuleChunkFormatPlugin {
     let chunk = args.chunk();
     let base_chunk_output_name = get_chunk_output_name(chunk, compilation);
     if matches!(chunk.kind, ChunkKind::HotUpdate) {
-      return Err(internal_error!(
-        "HMR is not implemented for module chunk format yet"
-      ));
+      unreachable!("HMR is not implemented for module chunk format yet");
     }
 
     let mut sources = ConcatSource::default();

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -35,7 +35,7 @@ impl Plugin for ModuleChunkFormatPlugin {
     let chunk = compilation
       .chunk_by_ukey
       .get(chunk_ukey)
-      .ok_or_else(|| internal_error!("chunk not found"))?;
+      .unwrap_or_else(|| panic!("chunk not found"));
 
     if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
       return Ok(());

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -19,7 +19,7 @@ use rspack_core::{
   PluginProcessAssetsOutput, ProcessAssetsArgs,
 };
 use rspack_error::miette::IntoDiagnostic;
-use rspack_error::{internal_error, Diagnostic, Result};
+use rspack_error::{Diagnostic, Result};
 use rspack_regex::RspackRegex;
 use rspack_util::try_any_sync;
 use swc_config::config_types::BoolOrDataConfig;

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -223,7 +223,7 @@ impl Plugin for SwcJsMinimizerRspackPlugin {
             SourceMapSource::new(SourceMapSourceOptions {
               value: output.code,
               name: filename,
-              source_map: SourceMap::from_json(map).map_err(|e| internal_error!(e.to_string()))?,
+              source_map: SourceMap::from_json(map).expect("should be able to generate source-map"),
               original_source: None,
               inner_source_map: input_source_map,
               remove_original_source: true,

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -92,7 +92,7 @@ impl Plugin for AsyncWasmPlugin {
       .map(|m| {
         let code_gen_result = compilation
           .code_generation_results
-          .get(&m.identifier(), Some(&chunk.runtime))?;
+          .get(&m.identifier(), Some(&chunk.runtime));
 
         let result = code_gen_result.get(&SourceType::Wasm).map(|source| {
           let (output_path, asset_info) = self


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Adjust some of expectations with the philosophy of https://github.com/web-infra-dev/rspack/pull/4848:

1. NAPI should panic if failed to call
2. Assume every source-map emitted from SWC are valid source-maps.
3. Some minor changes

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

as-is.

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
