### PR TITLE
chore: deprecate @rspack/plugin-html

### DIFF
--- a/packages/rspack-plugin-html/README.md
+++ b/packages/rspack-plugin-html/README.md
@@ -3,6 +3,8 @@
   <img alt="Rspack Banner" src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610.png">
 </picture>
 
+# ⚠️ DEPRECATED: use html-webpack-plugin instead
+
 # @rspack/plugin-html
 
 HTML plugin for rspack, Modified from [jantimon/html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
since we're compatible with html-webpack-plugin, deprecate @rspack/plugin-html，
but I'm not sure whether html-webpack-plugin will break rspack in the future.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
No Need
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
