### PR TITLE
feat: align webpack - allow `false` for `optimization.splitChunks` on options validation

### DIFF
--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -721,7 +721,7 @@ function getRawOptimization(
 }
 
 export function toRawSplitChunksOptions(
-	sc?: OptimizationSplitChunksOptions
+	sc?: false | OptimizationSplitChunksOptions
 ): RawOptions["optimization"]["splitChunks"] | undefined {
 	if (!sc) {
 		return;

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -979,7 +979,7 @@ const optimization = z.strictObject({
 	minimize: z.boolean().optional(),
 	minimizer: z.literal("...").or(plugin).array().optional(),
 	mergeDuplicateChunks: z.boolean().optional(),
-	splitChunks: optimizationSplitChunksOptions.optional(),
+	splitChunks: z.literal(false).or(optimizationSplitChunksOptions).optional(),
 	runtimeChunk: optimizationRuntimeChunk.optional(),
 	removeAvailableModules: z.boolean().optional(),
 	removeEmptyChunks: z.boolean().optional(),

--- a/packages/rspack/tests/configCases/split-chunks-common/default/index.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/default/index.js
@@ -1,0 +1,7 @@
+import("react-dom/server");
+
+it("split modules in node_modules as vendors", async () => {
+	await expect(require("fs/promises").readdir(__dirname)).resolves.toEqual(
+		expect.arrayContaining([expect.stringMatching(/vendors~/)])
+	);
+});

--- a/packages/rspack/tests/configCases/split-chunks-common/default/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/default/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["./main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks-common/default/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/default/webpack.config.js
@@ -1,0 +1,13 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "production",
+
+	entry: {
+		main: "./index"
+	},
+	target: "node",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {}
+};

--- a/packages/rspack/tests/configCases/split-chunks-common/disable/index.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/disable/index.js
@@ -1,0 +1,7 @@
+import("react-dom/server");
+
+it("should not split chunks when optimization.splitChunks is false", async () => {
+	await expect(require("fs/promises").readdir(__dirname)).resolves.toEqual(
+		expect.not.arrayContaining([expect.stringMatching(/~/)])
+	);
+});

--- a/packages/rspack/tests/configCases/split-chunks-common/disable/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/disable/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["./main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks-common/disable/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/disable/webpack.config.js
@@ -1,0 +1,13 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index"
+	},
+	target: "node",
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: false
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->


rspack disables SplitChunksPlugin when `optimization.splitChunks` is `false` which is of same behavior as webpack excepting rspack's options validation prints an error for it.

it is not documented on webpack's doc but allowed by webpack.

schema: https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/schemas/WebpackOptions.json#L2560


## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

- `optimization.splitChunks = undefined`: configCases/split-chunks-common/default
-  `optimization.splitChunks = false`: configCases/split-chunks-common/disable

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [x] Yes, the corresponding rspack-website PR is web-infra-dev/rspack-website#548
