### PR TITLE
chore(runtime-diff): align module decorator runtime modules with webpack

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/harmony_module_decorator.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/harmony_module_decorator.js
@@ -1,11 +1,11 @@
-__webpack_require__.hmd = function(module) {
+__webpack_require__.hmd = function (module) {
     module = Object.create(module);
     if (!module.children) module.children = [];
     Object.defineProperty(module, 'exports', {
         enumerable: true,
-        set: function() {
+        set: function () {
             throw new Error('ES Modules may not assign module.exports or exports.*, Use ESM export syntax, instead: ' + module.id);
         }
     });
     return module;
-}
+};

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/node_module_decorator.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/node_module_decorator.js
@@ -1,5 +1,5 @@
-__webpack_require__.nmd = function(module) {
+__webpack_require__.nmd = function (module) {
     module.paths = [];
     if (!module.children) module.children = [];
     return module;
-}
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/src/aaa.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/src/aaa.js
@@ -1,0 +1,3 @@
+import bbb from "bbb";
+
+module.exports = bbb;

--- a/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/src/bbb.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/src/bbb.js
@@ -1,0 +1,1 @@
+export default 123;

--- a/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/src/index.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/src/index.js
@@ -1,0 +1,2 @@
+var aaa = require("./aaa");
+console.log(aaa);

--- a/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-harmony-module-decorator/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/harmony_module_decorator"]
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/src/aaa.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/src/aaa.js
@@ -1,0 +1,1 @@
+module.exports = require("./bbb");

--- a/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/src/bbb.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/src/bbb.js
@@ -1,0 +1,1 @@
+Object.defineProperty(module, "exports", 123123);

--- a/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/src/index.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/src/index.js
@@ -1,0 +1,2 @@
+var aaa = require("./aaa");
+console.log(aaa);

--- a/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-node-module-decorator/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/node_module_decorator"]
+};


### PR DESCRIPTION
## Summary

Depend on #4900 

Align module decorator runtime with webpack
- HarmonyModuleDecoratorRuntimeModule
- NodeModuleDecoratorRuntimeModule

## Test Plan

- Test cases in `packages/rspack/tests/runtimeDiffCases`

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
