### PR TITLE
fix: module decorator when harmony mixed

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
@@ -173,23 +173,24 @@ impl Visit for CommonJsExportDependencyScanner<'_> {
             )));
         }
 
-        assign_expr.right.visit_children_with(self);
-        return;
-      }
-      if self.is_exports_or_module_exports_or_this_expr(expr) {
-        self.enable();
+        if self.is_exports_or_module_exports_or_this_expr(expr) {
+          self.enable();
 
-        if is_require_call_expr(&assign_expr.right, self.unresolved_ctxt) {
-          // exports = require('xx');
-          // module.exports = require('xx');
-          // this = require('xx');
-          // It's possible to reexport __esModule, so we must convert to a dynamic module
-          self.set_dynamic();
-        } else {
-          // exports = {};
-          // module.exports = {};
-          // this = {};
-          self.bailout();
+          if is_require_call_expr(&assign_expr.right, self.unresolved_ctxt) {
+            // exports = require('xx');
+            // module.exports = require('xx');
+            // this = require('xx');
+            // It's possible to reexport __esModule, so we must convert to a dynamic module
+            self.set_dynamic();
+          } else {
+            // exports = {};
+            // module.exports = {};
+            // this = {};
+            self.bailout();
+            if expr_matcher::is_module_exports(expr) {
+              assign_expr.left.visit_children_with(self);
+            }
+          }
         }
         assign_expr.right.visit_children_with(self);
         return;

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/bbb.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/bbb.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs.js
@@ -1,0 +1,5 @@
+module.exports = 1;
+
+it("should not decorate commonjs module", function () {
+	expect(__webpack_module__.children).toBeFalsy();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs1.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs1.js
@@ -1,0 +1,6 @@
+it("should decorate commonjs module with node module decorator when define property", function () {
+	expect(__webpack_module__.children).toBeTruthy();
+	expect(function () {
+		Object.defineProperty(module, "exports", { value: 1 });
+	}).not.toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs2.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs2.js
@@ -1,0 +1,7 @@
+it("should decorate commonjs module with node module decorator when assign to module", function () {
+	expect(__webpack_module__.children).toBeTruthy();
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).not.toThrowError();
+	module = 1;
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs3.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs3.js
@@ -1,0 +1,8 @@
+typeof module.xxx;
+
+it("should decorate commonjs module with node module decorator when access to module", function () {
+	expect(__webpack_module__.children).toBeTruthy();
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).not.toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs4.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs4.js
@@ -1,0 +1,8 @@
+module.xxx = 1;
+
+it("should decorate commonjs module with node module decorator when assign to module.xxx", function () {
+	expect(__webpack_module__.children).toBeTruthy();
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).not.toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs5.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/cjs5.js
@@ -1,0 +1,8 @@
+module.__esModule = 1;
+
+it("should decorate commonjs module with node module decorator when assign to module.__esModule", function () {
+	expect(__webpack_module__.children).toBeTruthy();
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).not.toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm1.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm1.js
@@ -1,0 +1,7 @@
+import "./bbb";
+
+it("should decorate esm and commonjs mix with harmony module decorator when assign to module.exports", function () {
+	expect(function () {
+		module.exports = 1;
+	}).toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm2.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm2.js
@@ -1,0 +1,9 @@
+import "./bbb";
+
+module = 1;
+
+it("should decorate esm and commonjs mix with harmony module decorator when assign to module", function () {
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm3.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm3.js
@@ -1,0 +1,9 @@
+import "./bbb";
+
+module.__esModule = 1;
+
+it("should decorate esm and commonjs mix with harmony module decorator when assign to module._esModule", function () {
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm4.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm4.js
@@ -1,0 +1,9 @@
+import "./bbb";
+
+typeof module;
+
+it("should decorate esm and commonjs mix with harmony module decorator when access module", function () {
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm5.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm5.js
@@ -1,0 +1,7 @@
+import "./bbb";
+
+it("should decorate esm and commonjs mix with harmony module decorator when Object.defineProperty(module, 'exports', xxx);", function () {
+	expect(function () {
+		Object.defineProperty(module, "exports", 1);
+	}).toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm6.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/esm6.js
@@ -1,0 +1,9 @@
+import "./bbb";
+
+module.xxx = 1;
+
+it("should decorate esm and commonjs mix with harmony module decorator when assign to module.xxx", function () {
+	expect(function () {
+		__webpack_module__.exports = 1;
+	}).toThrowError();
+});

--- a/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/index.js
+++ b/packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator/index.js
@@ -1,0 +1,10 @@
+require("./cjs");
+require("./cjs1");
+require("./cjs2");
+require("./cjs3");
+require("./cjs4");
+require("./esm1");
+require("./esm2");
+require("./esm3");
+require("./esm4");
+require("./esm5");


### PR DESCRIPTION
## Summary

Fix commonjs exports scanner to generate ModuleDecoratorDependency correctly

## Test Plan

Adding `packages/rspack/tests/cases/parsing/harmony-commonjs-mix-decorator` to check:
- HarmonyModuleDecorator should be append correctly
- NodeModuleDecorator should be append correctly

1. Use `module.children` to check module has been decorated
2. If harmony mixed, assigning to `module.exports` will throw an error

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
