### PR TITLE
fix(@rspack/core): minify should be disabled when minimizer is an empty array

### DIFF
--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -272,6 +272,10 @@ export function deprecated_resolveBuiltins(
 					"https://www.rspack.dev/config/plugins.html#SwcCssMinimizerRspackPlugin"
 				)}`
 			);
+		if (options.optimization.minimize) {
+			new SwcJsMinimizerRspackPlugin(builtins.minifyOptions).apply(compiler);
+			new SwcCssMinimizerRspackPlugin().apply(compiler);
+		}
 	}
 	if (builtins.devFriendlySplitChunks) {
 		isRoot &&
@@ -280,15 +284,6 @@ export function deprecated_resolveBuiltins(
 					builtins.devFriendlySplitChunks
 				)}' has been deprecated, please switch to 'builtins.devFriendlySplitChunks = false' to use webpack's behavior.`
 			);
-	}
-	const shouldApplyBuiltinMinify =
-		options.optimization.minimize &&
-		// only when `...` has not been replaced by factory plugin instance
-		options.optimization.minimizer!.some(item => item === "...");
-
-	if (shouldApplyBuiltinMinify) {
-		new SwcJsMinimizerRspackPlugin(builtins.minifyOptions).apply(compiler);
-		new SwcCssMinimizerRspackPlugin().apply(compiler);
 	}
 
 	let noEmitAssets = false;

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -281,10 +281,12 @@ export function deprecated_resolveBuiltins(
 				)}' has been deprecated, please switch to 'builtins.devFriendlySplitChunks = false' to use webpack's behavior.`
 			);
 	}
-	const disableMinify =
-		!options.optimization.minimize ||
-		options.optimization.minimizer!.some(item => item !== "...");
-	if (!disableMinify) {
+	const shouldApplyBuiltinMinify =
+		options.optimization.minimize &&
+		// only when `...` has not been replaced by factory plugin instance
+		options.optimization.minimizer!.some(item => item === "...");
+
+	if (shouldApplyBuiltinMinify) {
 		new SwcJsMinimizerRspackPlugin(builtins.minifyOptions).apply(compiler);
 		new SwcCssMinimizerRspackPlugin().apply(compiler);
 	}

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -43,10 +43,6 @@ import {
 import Template from "../Template";
 import { assertNotNill } from "../util/assertNotNil";
 import { ASSET_MODULE_TYPE } from "../ModuleTypeConstants";
-import {
-	SwcCssMinimizerRspackPlugin,
-	SwcJsMinimizerRspackPlugin
-} from "../builtin-plugin";
 
 export const applyRspackOptionsDefaults = (
 	options: RspackOptionsNormalized

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -43,6 +43,8 @@ import {
 import Template from "../Template";
 import { assertNotNill } from "../util/assertNotNil";
 import { ASSET_MODULE_TYPE } from "../ModuleTypeConstants";
+import { SwcJsMinimizerRspackPlugin } from "../builtin-plugin/SwcJsMinimizerPlugin";
+import { SwcCssMinimizerRspackPlugin } from "../builtin-plugin/SwcCssMinimizerPlugin";
 
 export const applyRspackOptionsDefaults = (
 	options: RspackOptionsNormalized
@@ -754,23 +756,12 @@ const applyOptimizationDefaults = (
 	D(optimization, "realContentHash", production);
 	D(optimization, "minimize", production);
 	A(optimization, "minimizer", () => [
-		// TODO: enable this when drop support for builtins options
-		// new SwcJsMinimizerPlugin(),
-		// new SwcCssMinimizerPlugin()
 		{
 			apply(compiler) {
-				const {
-					SwcJsMinimizerRspackPlugin
-				} = require("../builtin-plugin/SwcJsMinimizerPlugin");
-				const {
-					SwcCssMinimizerRspackPlugin
-				} = require("../builtin-plugin/SwcCssMinimizerPlugin");
-
-				new SwcJsMinimizerRspackPlugin(
-					/** @deprecated when drop support for `builtins.minifyOptions` */
-					compiler.options.builtins.minifyOptions
-				).apply(compiler);
-				new SwcCssMinimizerRspackPlugin().apply(compiler);
+				if (!compiler.options.builtins.minifyOptions) {
+					new SwcJsMinimizerRspackPlugin().apply(compiler);
+					new SwcCssMinimizerRspackPlugin().apply(compiler);
+				}
 			}
 		}
 	]);

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -43,6 +43,10 @@ import {
 import Template from "../Template";
 import { assertNotNill } from "../util/assertNotNil";
 import { ASSET_MODULE_TYPE } from "../ModuleTypeConstants";
+import {
+	SwcCssMinimizerRspackPlugin,
+	SwcJsMinimizerRspackPlugin
+} from "../builtin-plugin";
 
 export const applyRspackOptionsDefaults = (
 	options: RspackOptionsNormalized
@@ -757,6 +761,22 @@ const applyOptimizationDefaults = (
 		// TODO: enable this when drop support for builtins options
 		// new SwcJsMinimizerPlugin(),
 		// new SwcCssMinimizerPlugin()
+		{
+			apply(compiler) {
+				const {
+					SwcJsMinimizerRspackPlugin
+				} = require("../builtin-plugin/SwcJsMinimizerPlugin");
+				const {
+					SwcCssMinimizerRspackPlugin
+				} = require("../builtin-plugin/SwcCssMinimizerPlugin");
+
+				new SwcJsMinimizerRspackPlugin(
+					/** @deprecated when drop support for `builtins.minifyOptions` */
+					compiler.options.builtins.minifyOptions
+				).apply(compiler);
+				new SwcCssMinimizerRspackPlugin().apply(compiler);
+			}
+		}
 	]);
 	F(optimization, "nodeEnv", () => {
 		if (production) return "production";

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -182,7 +182,11 @@ exports[`snapshots should have the correct base config 1`] = `
     "mangleExports": false,
     "mergeDuplicateChunks": true,
     "minimize": false,
-    "minimizer": [],
+    "minimizer": [
+      {
+        "apply": [Function],
+      },
+    ],
     "moduleIds": "named",
     "nodeEnv": false,
     "providedExports": true,

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -544,7 +544,7 @@ exports[`StatsTestCases should print correct stats for filename 1`] = `
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "6f17aa7aca3c999821d9",
+  "hash": "46f54e617829bfd491ce",
   "logging": {},
   "modules": [
     {
@@ -787,7 +787,7 @@ webpack/runtime/make_namespace_object {main}
 webpack/runtime/require_chunk_loading {main}
 webpack/runtime/define_property_getters {main}
 webpack/runtime/get_chunk_filename/javascript {main}
-Rspack compiled successfully (6f17aa7aca3c999821d9)"
+Rspack compiled successfully (46f54e617829bfd491ce)"
 `;
 
 exports[`StatsTestCases should print correct stats for hot+production 1`] = `
@@ -2128,7 +2128,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "e89c872d1e75813bdb9e",
+      "hash": "2a56f68ffba86871ad13",
       "logging": {},
       "modules": [
         {
@@ -2814,7 +2814,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "1d6dfae243e6f20761c0",
+      "hash": "f0283a871516efd975ed",
       "logging": {},
       "modules": [
         {
@@ -3534,7 +3534,7 @@ import(/* webpackChunkName: "c" */ "./c");
       "errors": [],
       "errorsCount": 0,
       "filteredModules": undefined,
-      "hash": "d1db619b64f02a6c8201",
+      "hash": "d0461c301e764a97aa87",
       "logging": {},
       "modules": [
         {
@@ -3905,7 +3905,7 @@ import(/* webpackChunkName: "c" */ "./c");
   ],
   "errors": [],
   "errorsCount": 0,
-  "hash": "c6559f6e73dc156f845fe89c872d1e75813bdb9e1d6dfae243e6f20761c0d1db619b64f02a6c8201",
+  "hash": "c6559f6e73dc156f845f2a56f68ffba86871ad13f0283a871516efd975edd0461c301e764a97aa87",
   "warnings": [],
   "warningsCount": 0,
 }
@@ -3982,7 +3982,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/javascript {main}
-  2 chunks compiled successfully (e89c872d1e75813bdb9e)
+  2 chunks compiled successfully (2a56f68ffba86871ad13)
 
 3 chunks:
   PublicPath: (none)
@@ -4022,7 +4022,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/javascript {main}
-  3 chunks compiled successfully (1d6dfae243e6f20761c0)
+  3 chunks compiled successfully (f0283a871516efd975ed)
 
 4 chunks:
   PublicPath: (none)
@@ -4064,7 +4064,7 @@ exports[`StatsTestCases should print correct stats for limit-chunk-count-plugin 
   webpack/runtime/define_property_getters {main}
   webpack/runtime/create_fake_namespace_object {main}
   webpack/runtime/get_chunk_filename/javascript {main}
-  4 chunks compiled successfully (d1db619b64f02a6c8201)"
+  4 chunks compiled successfully (d0461c301e764a97aa87)"
 `;
 
 exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin-warn 1`] = `

--- a/packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array/index.css
+++ b/packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array/index.css
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array/index.js
+++ b/packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array/index.js
@@ -1,0 +1,18 @@
+require("./index.css");
+
+const fs = require("fs");
+const path = require("path");
+
+function test() {
+	return 123;
+}
+
+it("format", () => {
+	const content = fs.readFileSync(__filename, "utf-8");
+	expect(content).toMatch("\n");
+});
+
+it("css", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "main.css"), "utf-8");
+	expect(content).toMatch("\n");
+});

--- a/packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array/webpack.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	optimization: {
+		minimize: true,
+		minimizer: []
+	}
+};


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fixes #4899

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

- [x] new test case added: `packages/rspack/tests/configCases/plugins/minify-disabled-on-empty-array`
- [x] all test cases with name match `/minify/` should pass

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
