### PR TITLE
chore(runtime-diff): module chunk loading runtime module

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
@@ -97,7 +97,10 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         source.add(RawSource::from(
           include_str!("runtime/css_loading_with_loading.js")
             .replace("$CHUNK_LOADING_GLOBAL_EXPR$", &chunk_loading_global_expr)
-            .replace("CSS_MATCHER", &render_condition_map(&condition_map)),
+            .replace(
+              "CSS_MATCHER",
+              &render_condition_map(&condition_map, "chunkId").to_string(),
+            ),
         ));
       }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -114,7 +114,10 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
       // If chunkId not corresponding chunkName will skip load it.
       source.add(RawSource::from(
         include_str!("runtime/import_scripts_chunk_loading.js")
-          .replace("JS_MATCHER", &render_condition_map(&condition_map))
+          .replace(
+            "JS_MATCHER",
+            &render_condition_map(&condition_map, "chunkId").to_string(),
+          )
           .replace("$URL$", &url)
           .replace("$CHUNK_LOADING_GLOBAL_EXPR$", &chunk_loading_global_expr),
       ));

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -74,8 +74,10 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
           .get_chunk_condition_map(&chunk.ukey, compilation, chunk_has_js);
       // If chunkId not corresponding chunkName will skip load it.
       source.add(RawSource::from(
-        include_str!("runtime/jsonp_chunk_loading.js")
-          .replace("JS_MATCHER", &render_condition_map(&condition_map)),
+        include_str!("runtime/jsonp_chunk_loading.js").replace(
+          "JS_MATCHER",
+          &render_condition_map(&condition_map, "chunkId").to_string(),
+        ),
       ));
     }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -150,16 +150,20 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
 
     if with_external_install_chunk {
       source.add(RawSource::from(format!(
-        "{} = installChunk;\n",
+        r#"
+        {} = installChunk;
+        "#,
         RuntimeGlobals::EXTERNAL_INSTALL_CHUNK
       )));
     }
 
     if with_on_chunk_load {
       source.add(RawSource::from(format!(
-        r#"{}.j = function(chunkId) {{
+        r#"
+        {}.j = function(chunkId) {{
             return installedChunks[chunkId] === 0;
-        }}"#,
+        }}
+        "#,
         RuntimeGlobals::ON_CHUNKS_LOADED
       )));
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -5,7 +5,11 @@ use rspack_core::{
 };
 use rspack_identifier::Identifier;
 
-use super::utils::{chunk_has_js, get_output_dir};
+use super::{
+  render_condition_map,
+  utils::{chunk_has_js, get_output_dir},
+  BooleanMatcher,
+};
 use crate::runtime_module::utils::{get_initial_chunk_ids, stringify_chunks};
 
 #[derive(Debug, Default, Eq)]
@@ -54,48 +58,57 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
       .chunk_by_ukey
       .get(&self.chunk.expect("The chunk should be attached."))
       .expect("Chunk is not found, make sure you had attach chunkUkey successfully.");
-    let with_hmr = self
-      .runtime_requirements
-      .contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS);
+
+    let with_base_uri = self.runtime_requirements.contains(RuntimeGlobals::BASE_URI);
     let with_external_install_chunk = self
       .runtime_requirements
       .contains(RuntimeGlobals::EXTERNAL_INSTALL_CHUNK);
-    let mut source = ConcatSource::default();
-    let root_output_dir = get_output_dir(chunk, compilation, true);
-    if self.runtime_requirements.contains(RuntimeGlobals::BASE_URI) {
-      source.add(self.generate_base_uri(chunk, compilation, &root_output_dir));
-    }
-
-    // object to store loaded and loading chunks
-    // undefined = chunk not loaded, null = chunk preloaded/prefetched
-    // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
-    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
-    if with_hmr {
-      let state_expression = format!("{}_module", RuntimeGlobals::HMR_RUNTIME_STATE_PREFIX);
-      source.add(RawSource::from(format!(
-        "var installedChunks = {} = {} || {};\n",
-        state_expression,
-        state_expression,
-        &stringify_chunks(&initial_chunks, 1)
-      )));
-    } else {
-      source.add(RawSource::from(format!(
-        "var installedChunks = {};\n",
-        &stringify_chunks(&initial_chunks, 0)
-      )));
-    }
-
     let with_loading = self
       .runtime_requirements
       .contains(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
     let with_on_chunk_load = self
       .runtime_requirements
       .contains(RuntimeGlobals::ON_CHUNKS_LOADED);
+    let with_hmr = self
+      .runtime_requirements
+      .contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS);
+
+    let condition_map =
+      compilation
+        .chunk_graph
+        .get_chunk_condition_map(&chunk.ukey, compilation, chunk_has_js);
+    let has_js_matcher = render_condition_map(&condition_map, "chunkId");
+    let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);
+
+    let root_output_dir = get_output_dir(chunk, compilation, true);
+
+    let mut source = ConcatSource::default();
+
+    if with_base_uri {
+      source.add(self.generate_base_uri(chunk, compilation, &root_output_dir));
+    }
+
+    source.add(RawSource::from(format!(
+      r#"
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
+      var installedChunks = {}{};
+      "#,
+      match with_hmr {
+        true => {
+          let state_expression = format!("{}_module", RuntimeGlobals::HMR_RUNTIME_STATE_PREFIX);
+          format!("{} = {} || ", state_expression, state_expression)
+        }
+        false => "".to_string(),
+      },
+      &stringify_chunks(&initial_chunks, 0)
+    )));
 
     if with_loading || with_external_install_chunk {
       source.add(RawSource::from(
         include_str!("runtime/module_chunk_loading.js").replace(
-          "$withOnChunkLoad$",
+          "$WITH_ON_CHUNK_LOAD$",
           match with_on_chunk_load {
             true => "__webpack_require__.O();",
             false => "",
@@ -105,20 +118,41 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
     }
 
     if with_loading {
-      source.add(RawSource::from(
+      let body = if matches!(has_js_matcher, BooleanMatcher::Condition(false)) {
+        "installedChunks[chunkId] = 0;".to_string()
+      } else {
         include_str!("runtime/module_chunk_loading_with_loading.js")
-          // TODO
-          .replace("JS_MATCHER", "chunkId")
+          .replace("$JS_MATCHER$", has_js_matcher.to_string().as_str())
           .replace(
-            "$importFunctionName$",
+            "$IMPORT_FUNCTION_NAME$",
             &compilation.options.output.import_function_name,
           )
-          .replace("$OUTPUT_DIR$", &root_output_dir),
-      ));
+          .replace("$OUTPUT_DIR$", &root_output_dir)
+          .replace(
+            "$MATCH_FALLBACK$",
+            if matches!(has_js_matcher, BooleanMatcher::Condition(true)) {
+              ""
+            } else {
+              "else installedChunks[chunkId] = 0;\n"
+            },
+          )
+      };
+
+      source.add(RawSource::from(format!(
+        r#"
+        {}.j = function (chunkId, promises) {{
+          {body}
+        }}
+        "#,
+        RuntimeGlobals::ENSURE_CHUNK_HANDLERS
+      )));
     }
 
     if with_external_install_chunk {
-      source.add(RawSource::from("__webpack_require__.C = installChunk;\n"));
+      source.add(RawSource::from(format!(
+        "{} = installChunk;\n",
+        RuntimeGlobals::EXTERNAL_INSTALL_CHUNK
+      )));
     }
 
     if with_on_chunk_load {

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -116,7 +116,10 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
           .get_chunk_condition_map(&chunk.ukey, compilation, chunk_has_js);
       source.add(RawSource::from(
         include_str!("runtime/readfile_chunk_loading_with_loading.js")
-          .replace("JS_MATCHER", &render_condition_map(&condition_map))
+          .replace(
+            "JS_MATCHER",
+            &render_condition_map(&condition_map, "chunkId").to_string(),
+          )
           .replace("$OUTPUT_DIR$", &root_output_dir),
       ));
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -117,7 +117,10 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
           .get_chunk_condition_map(&chunk.ukey, compilation, chunk_has_js);
       source.add(RawSource::from(
         include_str!("runtime/require_chunk_loading_with_loading.js")
-          .replace("JS_MATCHER", &render_condition_map(&condition_map))
+          .replace(
+            "JS_MATCHER",
+            &render_condition_map(&condition_map, "chunkId").to_string(),
+          )
           .replace("$OUTPUT_DIR$", &root_output_dir),
       ));
     }

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading.js
@@ -1,20 +1,22 @@
-var installChunk = function(data) {
-    var ids = data.ids, modules = data.modules, runtime = data.runtime;
+var installChunk = function (data) {
+    var ids = data.ids;
+    var modules = data.modules;
+    var runtime = data.runtime;
     // add "modules" to the modules object,
     // then flag all "ids" as loaded and fire callback
     var moduleId, chunkId, i = 0;
-    for(moduleId in modules) {
+    for (moduleId in modules) {
         if (__webpack_require__.o(modules, moduleId)) {
             __webpack_require__.m[moduleId] = modules[moduleId];
         }
     }
-    if(runtime) runtime(__webpack_require__);
-    for(;i < ids.length; i++) {
+    if (runtime) runtime(__webpack_require__);
+    for (; i < ids.length; i++) {
         chunkId = ids[i];
-        if(__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
+        if (__webpack_require__.o(installedChunks, chunkId) && installedChunks[chunkId]) {
             installedChunks[chunkId][0]();
         }
         installedChunks[ids[i]] = 0;
     }
-    $withOnChunkLoad$;
+    $WITH_ON_CHUNK_LOAD$
 };

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_loading.js
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/module_chunk_loading_with_loading.js
@@ -1,23 +1,21 @@
-__webpack_require__.f.j = function(chunkId, promises) {
-    // import() chunk loading for javascript
-    var installedChunkData = __webpack_require__.o(installedChunks, chunkId) ? installedChunks[chunkId] : undefined;
-    if(installedChunkData !== 0) { // 0 means "already installed".'
-        // a Promise means "currently loading".
-        if(installedChunkData) {
-            promises.push(installedChunkData[1]);
-        } else {
-            if (JS_MATCHER) {
-                // setup Promise in chunk cache
-                var promise = $importFunctionName$('$OUTPUT_DIR$' + __webpack_require__.u(chunkId)).then(installChunk, function(e){
-                    if(installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;
-                        throw e;
-                });
-                var promise = Promise.race([promise, new Promise(function(resolve){
-                    installedChunkData = installedChunks[chunkId] = [resolve];
-                })]);
-                promises.push(installedChunkData[1] = promise); 
-            }
-            else installedChunks[chunkId] = 0;
+// import() chunk loading for javascript
+var installedChunkData = __webpack_require__.o(installedChunks, chunkId) ? installedChunks[chunkId] : undefined;
+if (installedChunkData !== 0) { // 0 means "already installed".'
+    // a Promise means "currently loading".
+    if (installedChunkData) {
+        promises.push(installedChunkData[1]);
+    } else {
+        if ($JS_MATCHER$) {
+            // setup Promise in chunk cache
+            var promise = $IMPORT_FUNCTION_NAME$("$OUTPUT_DIR$" + __webpack_require__.u(chunkId)).then(installChunk, function (e) {
+                if (installedChunks[chunkId] !== 0) installedChunks[chunkId] = undefined;
+                throw e;
+            });
+            var promise = Promise.race([promise, new Promise(function (resolve) {
+                installedChunkData = installedChunks[chunkId] = [resolve];
+            })]);
+            promises.push(installedChunkData[1] = promise);
         }
+        $MATCH_FALLBACK$
     }
-};   
+}

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -1,19 +1,55 @@
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
+use once_cell::sync::Lazy;
+use regex::Regex;
 use rspack_core::{
   get_js_chunk_filename_template, stringify_map, Chunk, ChunkKind, ChunkLoading, ChunkUkey,
   Compilation, PathData, SourceType,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-pub fn render_condition_map(map: &HashMap<String, bool>) -> String {
+pub enum BooleanMatcher {
+  Condition(bool),
+  Matcher(String),
+}
+
+impl std::fmt::Display for BooleanMatcher {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Self::Condition(c) => write!(f, "{}", c),
+      Self::Matcher(m) => write!(f, "{}", m),
+    }
+  }
+}
+
+static QUOTE_META_REG: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"[-\[\]\\/{}()*+?.^$|]").expect("regexp init failed"));
+
+fn quote_meta(str: &str) -> String {
+  QUOTE_META_REG.replace_all(str, "\\$&").to_string()
+}
+
+fn render_condition_items_to_regex(items: Vec<&String>) -> String {
+  // TODO: align regex optimization with webpack
+  let conditional = items.iter().map(|i| quote_meta(i)).collect_vec();
+  if conditional.len() == 1 {
+    conditional
+      .first()
+      .expect("Should have one conditional")
+      .to_string()
+  } else {
+    format!(r#"({})"#, conditional.join("|"))
+  }
+}
+
+pub fn render_condition_map(map: &HashMap<String, bool>, value: &str) -> BooleanMatcher {
   let mut positive_items = map
     .iter()
     .filter(|(_, v)| **v)
     .map(|(k, _)| k)
     .collect::<Vec<_>>();
   if positive_items.is_empty() {
-    return false.to_string();
+    return BooleanMatcher::Condition(false);
   }
   let negative_items = map
     .iter()
@@ -21,18 +57,44 @@ pub fn render_condition_map(map: &HashMap<String, bool>) -> String {
     .map(|(k, _)| k)
     .collect::<Vec<_>>();
   if negative_items.is_empty() {
-    return true.to_string();
+    return BooleanMatcher::Condition(true);
   }
 
   positive_items.sort_unstable();
-  format!(
-    "[{}].indexOf(chunkId) > - 1",
-    positive_items
-      .iter()
-      .map(|s| format!("'{s}'"))
-      .collect::<Vec<_>>()
-      .join(",")
-  )
+
+  if positive_items.len() == 1 {
+    if let Some(first_item) = positive_items.first() {
+      return BooleanMatcher::Matcher(format!(
+        "{} == {}",
+        serde_json::to_string(first_item).expect("Invalid json to_string"),
+        value
+      ));
+    }
+  }
+
+  if negative_items.len() == 1 {
+    if let Some(first_item) = negative_items.first() {
+      return BooleanMatcher::Matcher(format!(
+        "{} != {}",
+        serde_json::to_string(first_item).expect("Invalid json to_string"),
+        value
+      ));
+    }
+  }
+
+  if positive_items.len() <= negative_items.len() {
+    BooleanMatcher::Matcher(format!(
+      r#"/^{}$/.test({})"#,
+      render_condition_items_to_regex(positive_items),
+      value
+    ))
+  } else {
+    BooleanMatcher::Matcher(format!(
+      r#"!/^{}$/.test({})"#,
+      render_condition_items_to_regex(negative_items),
+      value
+    ))
+  }
 }
 
 pub fn get_initial_chunk_ids(

--- a/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/rspack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/rspack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	entry: {
+		main: "./src/a.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkLoading: "import",
+		chunkFormat: "module",
+		enabledChunkLoadingTypes: ["import"]
+	},
+	optimization: {
+		runtimeChunk: {
+			name: "bundle"
+		}
+	},
+	target: "node"
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/src/a.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/src/a.js
@@ -1,0 +1,3 @@
+import("./b.js");
+console.log(111);
+export default 111;

--- a/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/src/b.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/src/b.js
@@ -1,0 +1,2 @@
+console.log(222);
+export default 222;

--- a/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/test.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/test.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	modules: false,
+	runtimeModules: ["webpack/runtime/module_chunk_loading"]
+};

--- a/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/webpack.config.js
+++ b/packages/rspack/tests/runtimeDiffCases/runtime-module-chunk-loading/webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+	entry: {
+		main: "./src/a.js"
+	},
+	output: {
+		filename: "[name].js",
+		chunkLoading: "import",
+		chunkFormat: "module",
+		enabledChunkLoadingTypes: ["import"]
+	},
+	optimization: {
+		runtimeChunk: {
+			name: "bundle"
+		}
+	},
+	target: "node"
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align module chunk loading runtime module with webpack. 

> Do not align whole logic of function `itemsToRegexp`

## Test Plan

- Reuse `packages/rspack/tests/configCases/output-module/simple` to test BooleanMatcher::Condition(true) 
- Reuse `packages/rspack/tests/configCases/output-module/single-runtime` to test BooleanMatcher::Matcher(String) 

Should add more test cases for module federation, because it will add more chunks to entrypoint chunk group.

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?



- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
