### PR TITLE
test: prevent .DS_store been add to test cases on macos

### DIFF
--- a/packages/rspack/tests/ConfigCase.template.ts
+++ b/packages/rspack/tests/ConfigCase.template.ts
@@ -1,7 +1,11 @@
 "use strict";
 import { rspack } from "../src";
 import assert from "assert";
-import { ensureRspackConfigNotExist, ensureWebpackConfigExist } from "./utils";
+import {
+	ensureRspackConfigNotExist,
+	ensureWebpackConfigExist,
+	isValidTestCaseDir
+} from "./utils";
 
 const path = require("path");
 const fs = require("graceful-fs");
@@ -26,18 +30,21 @@ const define = function (...args) {
 };
 
 const casesPath = path.join(__dirname, "configCases");
-const categories = fs.readdirSync(casesPath).map(cat => {
-	return {
-		name: cat,
-		tests: fs
-			.readdirSync(path.join(casesPath, cat))
-			.filter(folder => !folder.startsWith("_") && !folder.startsWith("."))
-			.filter(folder =>
-				fs.lstatSync(path.join(casesPath, cat, folder)).isDirectory()
-			)
-			.sort()
-	};
-});
+const categories = fs
+	.readdirSync(casesPath)
+	.filter(isValidTestCaseDir)
+	.map(cat => {
+		return {
+			name: cat,
+			tests: fs
+				.readdirSync(path.join(casesPath, cat))
+				.filter(isValidTestCaseDir)
+				.filter(folder =>
+					fs.lstatSync(path.join(casesPath, cat, folder)).isDirectory()
+				)
+				.sort()
+		};
+	});
 
 const createLogger = appendTarget => {
 	return {

--- a/packages/rspack/tests/ConfigCase.template.ts
+++ b/packages/rspack/tests/ConfigCase.template.ts
@@ -31,7 +31,7 @@ const categories = fs.readdirSync(casesPath).map(cat => {
 		name: cat,
 		tests: fs
 			.readdirSync(path.join(casesPath, cat))
-			.filter(folder => !folder.startsWith("_"))
+			.filter(folder => !folder.startsWith("_") && !folder.startsWith("."))
 			.filter(folder =>
 				fs.lstatSync(path.join(casesPath, cat, folder)).isDirectory()
 			)

--- a/packages/rspack/tests/HotTestCases.template.ts
+++ b/packages/rspack/tests/HotTestCases.template.ts
@@ -10,6 +10,7 @@ import {
 	Stats,
 	HotModuleReplacementPlugin
 } from "@rspack/core";
+import { isValidTestCaseDir } from "./utils";
 
 export function describeCases(config: {
 	name: string;
@@ -22,11 +23,12 @@ export function describeCases(config: {
 	const categories = fs
 		.readdirSync(casesPath)
 		.filter(dir => fs.statSync(path.join(casesPath, dir)).isDirectory())
+		.filter(isValidTestCaseDir)
 		.map(cat => ({
 			name: cat,
 			tests: fs
 				.readdirSync(path.join(casesPath, cat))
-				.filter(folder => folder.indexOf("_") < 0)
+				.filter(isValidTestCaseDir)
 		}));
 	describe(config.name, () => {
 		categories.forEach(category => {

--- a/packages/rspack/tests/RuntimeDiff.diff.test.ts
+++ b/packages/rspack/tests/RuntimeDiff.diff.test.ts
@@ -8,6 +8,7 @@ import {
 	TModuleCompareResult
 } from "@rspack/test-tools";
 import rimraf from "rimraf";
+import { isValidTestCaseDir } from "./utils";
 
 const DEFAULT_CASE_CONFIG: IDiffProcessorOptions = {
 	webpackPath: require.resolve("webpack"),
@@ -182,9 +183,7 @@ function checkCompareResults(
 
 const caseDir: string = path.resolve(__dirname, "runtimeDiffCases");
 const tempDir: string = path.resolve(__dirname, "js");
-const cases: string[] = fs
-	.readdirSync(caseDir)
-	.filter(testName => !testName.startsWith("."));
+const cases: string[] = fs.readdirSync(caseDir).filter(isValidTestCaseDir);
 
 describe(`RuntimeDiffCases`, () => {
 	for (let name of cases) {

--- a/packages/rspack/tests/StatsTestCases.test.ts
+++ b/packages/rspack/tests/StatsTestCases.test.ts
@@ -3,6 +3,7 @@ import fs from "fs";
 import util from "util";
 import { rspack, RspackOptions } from "../src";
 import serializer from "jest-serializer-path";
+import { isValidTestCaseDir } from "./utils";
 
 expect.addSnapshotSerializer(serializer);
 
@@ -14,7 +15,7 @@ const project_dir_reg = new RegExp(
 const base = path.resolve(__dirname, "statsCases");
 const tests = fs.readdirSync(base).filter(testName => {
 	return (
-		!testName.startsWith(".") &&
+		isValidTestCaseDir(testName) &&
 		(fs.existsSync(path.resolve(base, testName, "index.js")) ||
 			fs.existsSync(path.resolve(base, testName, "webpack.config.js")))
 	);

--- a/packages/rspack/tests/WatchTestCases.template.ts
+++ b/packages/rspack/tests/WatchTestCases.template.ts
@@ -9,11 +9,12 @@ import prepareOptions from "./helpers/prepareOptions";
 import deprecationTracking from "./helpers/deprecationTracking";
 import FakeDocument from "./helpers/FakeDocument";
 import { rspack, RspackOptions } from "../src";
+import { isValidTestCaseDir } from "./utils";
 
 function copyDiff(src: string, dest: string, initial: boolean) {
 	if (!fs.existsSync(dest)) fs.mkdirSync(dest);
 	const files = fs.readdirSync(src);
-	files.forEach(filename => {
+	files.filter(isValidTestCaseDir).forEach(filename => {
 		const srcFile = path.join(src, filename);
 		const destFile = path.join(dest, filename);
 		const directory = fs.statSync(srcFile).isDirectory();

--- a/packages/rspack/tests/case.template.ts
+++ b/packages/rspack/tests/case.template.ts
@@ -5,19 +5,20 @@ import util from "util";
 import { rspack, RspackOptions } from "../src";
 import assert from "assert";
 import createLazyTestEnv from "./helpers/createLazyTestEnv";
+import { isValidTestCaseDir } from "./utils";
 
 // most of these could be removed when we support external builtins by default
 export function describeCases(config: { name: string; casePath: string }) {
 	const casesPath = path.resolve(__dirname, config.casePath);
 	let categoriesDir = fs.readdirSync(casesPath);
 	let categories = categoriesDir
-		.filter(x => x !== "dist" && !x.startsWith("."))
+		.filter(x => isValidTestCaseDir(x) && x !== "dist")
 		.map(cat => {
 			return {
 				name: cat,
 				tests: fs
 					.readdirSync(path.resolve(casesPath, cat))
-					.filter(folder => !folder.includes("_") && !folder.startsWith("."))
+					.filter(isValidTestCaseDir)
 			};
 		});
 	describe(config.name, () => {

--- a/packages/rspack/tests/utils.ts
+++ b/packages/rspack/tests/utils.ts
@@ -25,3 +25,7 @@ export function ensureRspackConfigNotExist(testCaseDir: string) {
 		throw Error(`rspack config file should not exist in ${testCaseDir}`);
 	}
 }
+
+export function isValidTestCaseDir(testCaseDir: string) {
+	return !testCaseDir.startsWith("_") && !testCaseDir.startsWith(".");
+}


### PR DESCRIPTION
## Summary

Add filter to directories of test cases which can not start with `.`

## Test Plan

Noop

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
