### PR TITLE
chore: deprecate @rspack/plugin-node-polyfill

### DIFF
--- a/packages/rspack-plugin-node-polyfill/README.md
+++ b/packages/rspack-plugin-node-polyfill/README.md
@@ -3,6 +3,8 @@
   <img alt="Rspack Banner" src="https://lf3-static.bytednsdoc.com/obj/eden-cn/rjhwzy/ljhwZthlaukjlkulzlp/rspack-banner-1610.png">
 </picture>
 
+# ⚠️ DEPRECATED: use node-polyfill-webpack-plugin@3.0 instead
+
 # @rspack/plugin-node-polyfill
 
 Node polyfill plugin for rspack.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
we're compatible with node-polyfill-webpack-plugin@3.0 now
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
