### PR TITLE
chore: add debug info under panic with debug build

### DIFF
--- a/crates/node_binding/src/panic.rs
+++ b/crates/node_binding/src/panic.rs
@@ -55,7 +55,9 @@ pub fn install_panic_handler() {
     #[cfg(debug_assertions)]
     {
       use rspack_core::debug_info::DEBUG_INFO;
-      eprintln!("{}", DEBUG_INFO.lock().unwrap());
+      if let Ok(info) = DEBUG_INFO.lock() {
+        eprintln!("{}", info);
+      }
     }
     panic_handler(panic);
   }))

--- a/crates/node_binding/src/panic.rs
+++ b/crates/node_binding/src/panic.rs
@@ -1,7 +1,7 @@
 use color_backtrace::{default_output_stream, BacktracePrinter};
 
 pub fn install_panic_handler() {
-  BacktracePrinter::default()
+  let panic_handler = BacktracePrinter::default()
     .message("Panic occurred at runtime. Please file an issue on GitHub with the backtrace below: https://github.com/web-infra-dev/rspack/issues")
     .add_frame_filter(Box::new(|frames| {
       static NAME_PREFIXES: &[&str] = &[
@@ -48,5 +48,15 @@ pub fn install_panic_handler() {
     .verbosity(color_backtrace::Verbosity::Medium)
     .lib_verbosity(color_backtrace::Verbosity::Medium)
     .print_addresses(false)
-    .install(default_output_stream());
+    // .install(default_output_stream());
+    .into_panic_handler(default_output_stream());
+
+  std::panic::set_hook(Box::new(move |panic| {
+    #[cfg(debug_assertions)]
+    {
+      use rspack_core::debug_info::DEBUG_INFO;
+      eprintln!("{}", DEBUG_INFO.lock().unwrap());
+    }
+    panic_handler(panic);
+  }))
 }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -20,7 +20,6 @@ use swc_core::ecma::atoms::JsWord;
 use tracing::instrument;
 
 use crate::cache::Cache;
-use crate::debug_info::DEBUG_INFO;
 use crate::tree_shaking::symbol::{IndirectType, StarSymbolKind, DEFAULT_JS_WORD};
 use crate::tree_shaking::visitor::SymbolRef;
 use crate::{
@@ -55,7 +54,7 @@ where
   pub fn new(options: CompilerOptions, plugins: Vec<BoxPlugin>, output_filesystem: T) -> Self {
     #[cfg(debug_assertions)]
     {
-      DEBUG_INFO
+      crate::debug_info::DEBUG_INFO
         .lock()
         .unwrap()
         .with_context(options.context.to_string());

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -54,10 +54,9 @@ where
   pub fn new(options: CompilerOptions, plugins: Vec<BoxPlugin>, output_filesystem: T) -> Self {
     #[cfg(debug_assertions)]
     {
-      crate::debug_info::DEBUG_INFO
-        .lock()
-        .unwrap()
-        .with_context(options.context.to_string());
+      if let Ok(mut debug_info) = crate::debug_info::DEBUG_INFO.lock() {
+        debug_info.with_context(options.context.to_string());
+      }
     }
     let new_resolver = options.experiments.rspack_future.new_resolver;
     let resolver_factory = Arc::new(ResolverFactory::new(new_resolver, options.resolve.clone()));

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -20,6 +20,7 @@ use swc_core::ecma::atoms::JsWord;
 use tracing::instrument;
 
 use crate::cache::Cache;
+use crate::debug_info::DEBUG_INFO;
 use crate::tree_shaking::symbol::{IndirectType, StarSymbolKind, DEFAULT_JS_WORD};
 use crate::tree_shaking::visitor::SymbolRef;
 use crate::{
@@ -52,6 +53,13 @@ where
 {
   #[instrument(skip_all)]
   pub fn new(options: CompilerOptions, plugins: Vec<BoxPlugin>, output_filesystem: T) -> Self {
+    #[cfg(debug_assertions)]
+    {
+      DEBUG_INFO
+        .lock()
+        .unwrap()
+        .with_context(options.context.to_string());
+    }
     let new_resolver = options.experiments.rspack_future.new_resolver;
     let resolver_factory = Arc::new(ResolverFactory::new(new_resolver, options.resolve.clone()));
     let loader_resolver_factory = Arc::new(ResolverFactory::new(

--- a/crates/rspack_core/src/debug_info.rs
+++ b/crates/rspack_core/src/debug_info.rs
@@ -26,7 +26,7 @@ macro_rules! write_debug_info {
       let e = format!("\u{001b}[1m\u{001b}[33m{tt}\u{001b}[0m: {e}");
       writeln!($f, "{}", e)?;
     } else {
-      let e = format!("{tt}: <empty>");
+      let e = format!("\u{001b}[1m\u{001b}[33m{tt}\u{001b}[0m: <empty>");
       writeln!($f, "{}", e)?;
     }
   };

--- a/crates/rspack_core/src/debug_info.rs
+++ b/crates/rspack_core/src/debug_info.rs
@@ -1,0 +1,44 @@
+use std::fmt::Display;
+use std::sync::Mutex;
+
+/// Debug info used when programs panics
+/// Only works with #[cfg(debug_assertions)]
+pub struct DebugInfo {
+  /// The base directory. See [options.context](https://webpack.js.org/configuration/entry-context/#context)
+  pub(crate) context: Option<String>,
+}
+
+impl DebugInfo {
+  const fn new() -> Self {
+    Self { context: None }
+  }
+
+  pub(crate) fn with_context(&mut self, context: String) -> &mut Self {
+    self.context = Some(context);
+    self
+  }
+}
+
+macro_rules! write_debug_info {
+  ($f:ident,$tt:tt,$expr:expr) => {
+    let tt = $tt.to_string();
+    if let Some(e) = &$expr {
+      let e = format!("\u{001b}[1m\u{001b}[33m{tt}\u{001b}[0m: {e}");
+      writeln!($f, "{}", e)?;
+    } else {
+      let e = format!("{tt}: <empty>");
+      writeln!($f, "{}", e)?;
+    }
+  };
+}
+
+impl Display for DebugInfo {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(f, "DebugInfo:\n")?;
+    write_debug_info!(f, "context", &self.context);
+
+    Ok(())
+  }
+}
+
+pub static DEBUG_INFO: Mutex<DebugInfo> = Mutex::new(DebugInfo::new());

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -89,6 +89,9 @@ pub mod tree_shaking;
 pub use rspack_loader_runner::{get_scheme, ResourceData, Scheme, BUILTIN_LOADER_PREFIX};
 pub use rspack_sources;
 
+#[cfg(debug_assertions)]
+pub mod debug_info;
+
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SourceType {
   JavaScript,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Print debug info with additional information when program panics.

<img width="1080" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/2620f0ec-d0a1-45a2-b743-e9a5de04419e">


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
