### PR TITLE
fix:  should return number.to_string instead of char::from

### DIFF
--- a/crates/rspack/tests/fixtures.rs
+++ b/crates/rspack/tests/fixtures.rs
@@ -64,6 +64,15 @@ fn tree_shaking(fixture_path: PathBuf) {
         if options.optimization.side_effects.is_enable() {
           plugins.push(Box::<SideEffectsFlagPlugin>::default());
         }
+        if options.optimization.mangle_exports.is_enable() {
+          plugins.push(
+            MangleExportsPlugin::new(!matches!(
+              options.optimization.mangle_exports,
+              MangleExportsOption::Size
+            ))
+            .boxed(),
+          );
+        }
         plugins.push(Box::<FlagDependencyExportsPlugin>::default());
         plugins.push(Box::<FlagDependencyUsagePlugin>::default());
       },

--- a/crates/rspack_plugin_javascript/src/utils/mangle_exports.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mangle_exports.rs
@@ -60,9 +60,7 @@ pub fn number_to_identifier_continuation(mut n: u32) -> String {
 
   // numbers
   if n < 10 {
-    return char::from_u32(n)
-      .expect("should convert successfully")
-      .to_string();
+    return n.to_string();
   }
 
   if n == 10 {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
