### PR TITLE
chore: optimize diff test case

### DIFF
--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -1,21 +1,13 @@
 const path = require("path");
 const rspack = require("@rspack/core");
-const ReactRefreshPlugin = require("@rspack/plugin-react-refresh");
 const { default: HtmlPlugin } = require("@rspack/plugin-html");
-
-const prod = process.env.NODE_ENV === "production";
 
 /** @type {import('@rspack/cli').Configuration} */
 const config = {
-	mode: 'development',
+	mode: 'production',
 	context: __dirname,
 	entry: "./src/index.tsx",
 	target: ["web", "es5"],
-	devServer: {
-		port: 5555,
-		webSocketServer: "sockjs",
-		historyApiFallback: true
-	},
 	module: {
 		rules: [
 			{
@@ -63,8 +55,8 @@ const config = {
 						transform: {
 							react: {
 								runtime: "automatic",
-								development: !prod,
-								refresh: !prod
+								development: false,
+								refresh: false
 							}
 						},
 						externalHelpers: true
@@ -113,8 +105,6 @@ const config = {
 			template: path.join(__dirname, "index.html"),
 			favicon: path.join(__dirname, "public", "favicon.ico")
 		}),
-		new ReactRefreshPlugin(),
-		new rspack.ProgressPlugin()
 	],
 	infrastructureLogging: {
 		debug: false

--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -79,7 +79,8 @@ const config = {
 			// expression, which causes stack overflow for swc parser in debug mode.
 			// Alias to the unminified version mitigates this problem.
 			// See also <https://github.com/search?q=repo%3Aswc-project%2Fswc+parser+stack+overflow&type=issues>
-			mockjs: require.resolve("./patches/mock.js")
+			mockjs: require.resolve("./patches/mock.js"),
+			"@swc/helpers": require.resolve('@swc/helpers'),
 		}
 	},
 	output: {
@@ -90,6 +91,7 @@ const config = {
 	optimization: {
 		minimize: false, // Disabling minification because it takes too long on CI
 		realContentHash: true,
+		usedExports: false,
 		splitChunks: {
 			cacheGroups: {
 				someVendor: {
@@ -110,6 +112,7 @@ const config = {
 		debug: false
 	},
 	experiments: {
+		css: true,
 		rspackFuture: {
 			disableTransformByDefault: true
 		}

--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -116,6 +116,14 @@ const config = {
 		rspackFuture: {
 			disableTransformByDefault: true
 		}
-	}
+	},
+	builtins: {
+		css: {
+			modules: {
+				exportsOnly: true,
+				localIdentName: "example-arco-design-pro---[path][name][ext]-[local]",
+			},
+		},
+	},
 };
 module.exports = config;

--- a/diffcases/arco-pro/webpack.config.js
+++ b/diffcases/arco-pro/webpack.config.js
@@ -1,21 +1,12 @@
 const path = require("path");
-const webpack = require("webpack");
-const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
-
-const prod = process.env.NODE_ENV === "production";
 
 /** @type {import('webpack').Configuration} */
 const config = {
-	mode: 'development',
+	mode: 'production',
 	context: __dirname,
 	entry: "./src/index.tsx",
 	target: ["web", "es5"],
-	devServer: {
-		port: 5555,
-		webSocketServer: "sockjs",
-		historyApiFallback: true
-	},
 	module: {
 		rules: [
 			{
@@ -68,8 +59,8 @@ const config = {
 						transform: {
 							react: {
 								runtime: "automatic",
-								development: !prod,
-								refresh: !prod
+								development: false,
+								refresh: false
 							}
 						},
 						externalHelpers: true
@@ -119,8 +110,6 @@ const config = {
 			template: path.join(__dirname, "index.html"),
 			favicon: path.join(__dirname, "public", "favicon.ico")
 		}),
-		new ReactRefreshPlugin(),
-		new webpack.ProgressPlugin()
 	],
 	infrastructureLogging: {
 		debug: false

--- a/diffcases/arco-pro/webpack.config.js
+++ b/diffcases/arco-pro/webpack.config.js
@@ -11,18 +11,13 @@ const config = {
 		rules: [
 			{
 				test: /\.less$/,
-				use: ["style-loader", "css-loader", "less-loader"],
-				exclude: /\.module\.less$/
+				use: "less-loader",
+				type: "css"
 			},
 			{
 				test: /\.module\.less$/,
-				use: ["style-loader", {
-					loader: "css-loader",
-					options: {
-						modules: true,
-						importLoaders: 1,
-					},
-				}, "less-loader"],
+				use: "less-loader",
+				type: "css/module"
 			},
 			{
 				test: /\.svg$/,
@@ -83,7 +78,7 @@ const config = {
 			// expression, which causes stack overflow for swc parser in debug mode.
 			// Alias to the unminified version mitigates this problem.
 			// See also <https://github.com/search?q=repo%3Aswc-project%2Fswc+parser+stack+overflow&type=issues>
-			mockjs: require.resolve("./patches/mock.js")
+			mockjs: require.resolve("./patches/mock.js"),
 		},
 		extensions: [".js", ".jsx", ".ts", ".tsx", ".css", ".less"]
 	},
@@ -95,6 +90,7 @@ const config = {
 	optimization: {
 		minimize: false, // Disabling minification because it takes too long on CI
 		realContentHash: true,
+		usedExports: false,
 		splitChunks: {
 			cacheGroups: {
 				someVendor: {
@@ -102,6 +98,11 @@ const config = {
 					minChunks: 2
 				}
 			}
+		}
+	},
+	experiments: {
+		css: {
+			exportsOnly: true
 		}
 	},
 	plugins: [

--- a/packages/rspack-test-tools/src/compare/compare.ts
+++ b/packages/rspack-test-tools/src/compare/compare.ts
@@ -96,10 +96,10 @@ export function compareModules(
 		const renamed = replaceRuntimeModuleName(name);
 		const sourceContent =
 			sourceModules.has(renamed) &&
-			formatCode(sourceModules.get(renamed)!, formatOptions);
+			formatCode(name, sourceModules.get(renamed)!, formatOptions);
 		const distContent =
 			distModules.has(renamed) &&
-			formatCode(distModules.get(renamed)!, formatOptions);
+			formatCode(name, distModules.get(renamed)!, formatOptions);
 
 		compareResults.push({
 			...compareContent(sourceContent, distContent),

--- a/packages/rspack-test-tools/src/compare/compare.ts
+++ b/packages/rspack-test-tools/src/compare/compare.ts
@@ -122,9 +122,9 @@ export function compareContent(
 					source: sourceContent,
 					dist: distContent,
 					lines: {
-						source: lines,
+						source: 0,
 						common: lines,
-						dist: lines
+						dist: 0
 					}
 				};
 			} else {

--- a/packages/rspack-test-tools/src/compare/format-code.ts
+++ b/packages/rspack-test-tools/src/compare/format-code.ts
@@ -119,8 +119,8 @@ export function formatCode(
 	});
 	let result = generate(ast, {
 		comments: false,
-		compact: false,
-		concise: false
+		compact: true,
+		concise: true
 	}).code;
 
 	if (options.ignoreModuleArguments) {

--- a/packages/rspack-test-tools/src/compare/format-code.ts
+++ b/packages/rspack-test-tools/src/compare/format-code.ts
@@ -9,7 +9,12 @@ export interface IFormatCodeOptions {
 	ignorePropertyQuotationMark: boolean;
 	ignoreModuleId: boolean;
 	ignoreModuleArguments: boolean;
+	ignoreBlockOnlyStatement: boolean;
+	ignoreSwcHelpersPath: boolean;
 }
+
+const SWC_HELPER_PATH_REG =
+	/^_swc_helpers_[a-zA-Z\d_-]+__WEBPACK_IMPORTED_MODULE_xxx__$/;
 
 export function formatCode(raw: string, options: IFormatCodeOptions) {
 	const ast = parse(raw, {
@@ -30,6 +35,34 @@ export function formatCode(raw: string, options: IFormatCodeOptions) {
 					/__WEBPACK_IMPORTED_MODULE_\d+__/g,
 					"__WEBPACK_IMPORTED_MODULE_xxx__"
 				);
+			}
+			if (options.ignoreSwcHelpersPath) {
+				if (SWC_HELPER_PATH_REG.test(path.node.name)) {
+					path.node.name = `$$SWC_HELPERS$$`;
+				}
+			}
+		},
+		IfStatement(path) {
+			if (options.ignoreBlockOnlyStatement) {
+				const consequent = path.get("consequent");
+				if (
+					consequent.isBlockStatement() &&
+					consequent.node.body.length === 1
+				) {
+					consequent.replaceWith(consequent.node.body[0]);
+				}
+				const alternate = path.get("alternate");
+				if (alternate.isBlockStatement() && alternate.node.body.length === 1) {
+					alternate.replaceWith(alternate.node.body[0]);
+				}
+			}
+		},
+		For(path) {
+			if (options.ignoreBlockOnlyStatement) {
+				const body = path.get("body");
+				if (body.isBlockStatement() && body.node.body.length === 1) {
+					body.replaceWith(body.node.body[0]);
+				}
 			}
 		}
 	});

--- a/packages/rspack-test-tools/src/compare/format-code.ts
+++ b/packages/rspack-test-tools/src/compare/format-code.ts
@@ -12,12 +12,19 @@ export interface IFormatCodeOptions {
 	ignoreBlockOnlyStatement: boolean;
 	ignoreSwcHelpersPath: boolean;
 	ignoreObjectPropertySequence: boolean;
+	ignoreCssFilePath: boolean;
 }
 
 const SWC_HELPER_PATH_REG =
 	/^_swc_helpers_[a-zA-Z\d_-]+__WEBPACK_IMPORTED_MODULE_xxx__$/;
+const CSS_FILE_EXT_REG = /(le|sa|c|sc)ss$/;
+const INVALID_PATH_REG = /[<>:"/\\|?*.]/g;
 
-export function formatCode(raw: string, options: IFormatCodeOptions) {
+export function formatCode(
+	name: string,
+	raw: string,
+	options: IFormatCodeOptions
+) {
 	const ast = parse(raw, {
 		sourceType: "unambiguous"
 	});
@@ -27,6 +34,15 @@ export function formatCode(raw: string, options: IFormatCodeOptions) {
 				const keyPath = path.get("key");
 				if (keyPath.isIdentifier()) {
 					keyPath.replaceWith(T.stringLiteral(keyPath.node.name));
+				}
+			}
+			if (options.ignoreCssFilePath && CSS_FILE_EXT_REG.test(name)) {
+				const valuePath = path.get("value");
+				if (valuePath.isStringLiteral()) {
+					valuePath.node.value = valuePath.node.value.replace(
+						INVALID_PATH_REG,
+						"-"
+					);
 				}
 			}
 		},

--- a/packages/rspack-test-tools/src/compare/format-code.ts
+++ b/packages/rspack-test-tools/src/compare/format-code.ts
@@ -66,11 +66,19 @@ export function formatCode(
 					consequent.isBlockStatement() &&
 					consequent.node.body.length === 1
 				) {
-					consequent.replaceWith(consequent.node.body[0]);
+					consequent.node.body[0].leadingComments =
+						consequent.node.leadingComments;
+					consequent.replaceWith(
+						T.cloneNode(consequent.node.body[0], true, false)
+					);
 				}
 				const alternate = path.get("alternate");
 				if (alternate.isBlockStatement() && alternate.node.body.length === 1) {
-					alternate.replaceWith(alternate.node.body[0]);
+					alternate.node.body[0].leadingComments =
+						alternate.node.leadingComments;
+					alternate.replaceWith(
+						T.cloneNode(alternate.node.body[0], true, false)
+					);
 				}
 			}
 		},
@@ -78,7 +86,8 @@ export function formatCode(
 			if (options.ignoreBlockOnlyStatement) {
 				const body = path.get("body");
 				if (body.isBlockStatement() && body.node.body.length === 1) {
-					body.replaceWith(body.node.body[0]);
+					body.node.body[0].leadingComments = body.node.leadingComments;
+					body.replaceWith(T.cloneNode(body.node.body[0], true, false));
 				}
 			}
 		},
@@ -119,8 +128,11 @@ export function formatCode(
 	});
 	let result = generate(ast, {
 		comments: false,
-		compact: true,
-		concise: true
+		compact: false,
+		concise: false,
+		jsescOption: {
+			quotes: "double"
+		}
 	}).code;
 
 	if (options.ignoreModuleArguments) {

--- a/packages/rspack-test-tools/src/compare/replace-module-argument.ts
+++ b/packages/rspack-test-tools/src/compare/replace-module-argument.ts
@@ -1,3 +1,5 @@
 export function replaceModuleArgument(raw: string) {
-	return raw.trim().replace(/^\(function\([\w_,]+\){/, "(function () {");
+	return raw
+		.trim()
+		.replace(/^\(function\s?\([\w_,\s]+\)\s?{/, "(function () {");
 }

--- a/packages/rspack-test-tools/src/compare/replace-module-argument.ts
+++ b/packages/rspack-test-tools/src/compare/replace-module-argument.ts
@@ -1,3 +1,3 @@
 export function replaceModuleArgument(raw: string) {
-	return raw.trim().replace(/^\(function \([\w_,\s]+\) {/, "(function () {");
+	return raw.trim().replace(/^\(function\([\w_,]+\){/, "(function () {");
 }

--- a/packages/rspack-test-tools/src/processor/diff.ts
+++ b/packages/rspack-test-tools/src/processor/diff.ts
@@ -203,6 +203,7 @@ export class DiffProcessor implements ITestProcessor {
 			ignoreBlockOnlyStatement: this.options.ignoreBlockOnlyStatement,
 			ignoreSwcHelpersPath: this.options.ignoreSwcHelpersPath,
 			ignoreObjectPropertySequence: this.options.ignoreObjectPropertySequence,
+			ignoreCssFilePath: this.options.ignoreCssFilePath,
 			replacements: this.options.replacements || {}
 		};
 		for (let hash of this.hashes) {

--- a/packages/rspack-test-tools/src/processor/diff.ts
+++ b/packages/rspack-test-tools/src/processor/diff.ts
@@ -202,6 +202,7 @@ export class DiffProcessor implements ITestProcessor {
 			ignorePropertyQuotationMark: this.options.ignorePropertyQuotationMark,
 			ignoreBlockOnlyStatement: this.options.ignoreBlockOnlyStatement,
 			ignoreSwcHelpersPath: this.options.ignoreSwcHelpersPath,
+			ignoreObjectPropertySequence: this.options.ignoreObjectPropertySequence,
 			replacements: this.options.replacements || {}
 		};
 		for (let hash of this.hashes) {

--- a/packages/rspack-test-tools/src/processor/diff.ts
+++ b/packages/rspack-test-tools/src/processor/diff.ts
@@ -163,6 +163,9 @@ export class DiffProcessor implements ITestProcessor {
 						},
 						path: dist
 					},
+					optimization: {
+						concatenateModules: false
+					},
 					plugins: [createModulePlaceholderPlugin(this.options.webpackPath)]
 				},
 				{

--- a/packages/rspack-test-tools/src/processor/diff.ts
+++ b/packages/rspack-test-tools/src/processor/diff.ts
@@ -200,6 +200,8 @@ export class DiffProcessor implements ITestProcessor {
 			ignoreModuleArguments: this.options.ignoreModuleArguments,
 			ignoreModuleId: this.options.ignoreModuleId,
 			ignorePropertyQuotationMark: this.options.ignorePropertyQuotationMark,
+			ignoreBlockOnlyStatement: this.options.ignoreBlockOnlyStatement,
+			ignoreSwcHelpersPath: this.options.ignoreSwcHelpersPath,
 			replacements: this.options.replacements || {}
 		};
 		for (let hash of this.hashes) {

--- a/packages/rspack-test-tools/src/processor/diff.ts
+++ b/packages/rspack-test-tools/src/processor/diff.ts
@@ -164,6 +164,7 @@ export class DiffProcessor implements ITestProcessor {
 						path: dist
 					},
 					optimization: {
+						mangleExports: false,
 						concatenateModules: false
 					},
 					plugins: [createModulePlaceholderPlugin(this.options.webpackPath)]
@@ -179,6 +180,9 @@ export class DiffProcessor implements ITestProcessor {
 				{
 					output: {
 						path: dist
+					},
+					optimization: {
+						mangleExports: false
 					},
 					experiments: {
 						rspackFuture: {

--- a/packages/rspack-test-tools/src/reporter/diff-html.ts
+++ b/packages/rspack-test-tools/src/reporter/diff-html.ts
@@ -58,16 +58,21 @@ export class DiffHtmlReporter implements ITestReporter<TModuleCompareResult[]> {
 						root: id,
 						data: items
 					};
-					const content = template.replace(
-						DIFF_STATS_PLACEHOLDER,
-						JSON.stringify(data)
-					);
 					const casename = path.basename(id);
 					const extname = path.extname(viewerFile);
 					const filename = path.basename(viewerFile, extname);
+					const content = template.replace(
+						`<script id="${DIFF_STATS_PLACEHOLDER}"></script>`,
+						`<script src="${filename}_${casename}.js"></script>`
+					);
 					fs.writeFileSync(
 						path.join(this.options.dist, `${filename}_${casename}${extname}`),
 						content,
+						"utf-8"
+					);
+					fs.writeFileSync(
+						path.join(this.options.dist, `${filename}_${casename}.js`),
+						`window.$$diff_detail$$ = ${JSON.stringify(data)}`,
 						"utf-8"
 					);
 				}

--- a/packages/rspack-test-tools/src/webpack/module-placeholder-plugin.ts
+++ b/packages/rspack-test-tools/src/webpack/module-placeholder-plugin.ts
@@ -32,9 +32,8 @@ function createRenderRuntimeModulesFn(Template) {
 				runtimeSource = codeGenResult.sources.get("runtime");
 			}
 			if (runtimeSource) {
-				source.add(
-					Template.toNormalComment(`start::${module.identifier()}`) + "\n"
-				);
+				let identifier = module.identifier();
+				source.add(Template.toNormalComment(`start::${identifier}`) + "\n");
 				if (!module.shouldIsolate()) {
 					source.add(runtimeSource);
 					source.add("\n\n");
@@ -47,9 +46,7 @@ function createRenderRuntimeModulesFn(Template) {
 					source.add(new PrefixSource("\t", runtimeSource));
 					source.add("\n}();\n\n");
 				}
-				source.add(
-					Template.toNormalComment(`end::${module.identifier()}`) + "\n"
-				);
+				source.add(Template.toNormalComment(`end::${identifier}`) + "\n");
 			}
 		}
 		return source;
@@ -114,7 +111,11 @@ export function createModulePlaceholderPlugin(webpackPath) {
 						let footer = cacheEntry.footer;
 						if (header === undefined) {
 							const req = module.readableIdentifier(requestShortener);
-							const reqStr = req.replace(/\*\//g, "*_/");
+							let reqStr = req.replace(/\*\//g, "*_/");
+							// handle css module identifier
+							if (reqStr.startsWith("css ")) {
+								reqStr = reqStr.replace(/^css[\s]+/, "").trim();
+							}
 							header = new RawSource(`\n/* start::${reqStr} */\n`);
 							footer = new RawSource(`\n/* end::${reqStr} */\n`);
 							cacheEntry.header = header;

--- a/packages/rspack-test-tools/viewer/pages/diff-report.tsx
+++ b/packages/rspack-test-tools/viewer/pages/diff-report.tsx
@@ -9,6 +9,10 @@ import { generateTreeData } from '../utils/generateTreeData';
 const Sider = Layout.Sider;
 const Content = Layout.Content;
 
+declare var window: {
+  $$diff_detail$$: TDiffStats
+};
+
 type TDiffItem = {
   name: string;
   source: string;
@@ -30,10 +34,9 @@ export const DiffReportPage: React.FC<{}> = () => {
   const [current, setCurrent] = useState<TDiffItem>();
 
   useEffect(() => {
-    const data = document.getElementById('DIFF_DETAIL')?.textContent?.trim();
-    if (!data || data === '$$diff_detail$$') return;
     try {
-      const stats: TDiffStats = JSON.parse(data);
+      const stats: TDiffStats = window.$$diff_detail$$;
+      if (!stats) return;
       setTreeData([{
         key: 'summary',
         title: 'Summary',

--- a/packages/rspack-test-tools/viewer/templates/diff.html
+++ b/packages/rspack-test-tools/viewer/templates/diff.html
@@ -4,11 +4,11 @@
 <head>
 	<meta charset="utf-8" />
 	<title>Rspack Diff Viewer</title>
-	<script id="DIFF_DETAIL" type="text/json">$$RSPACK_DIFF_STATS_PLACEHOLDER$$</script>
+	<script id="$$RSPACK_DIFF_STATS_PLACEHOLDER$$"></script>
 </head>
 
-
 <body>
+
 	<div id="root"></div>
 </body>
 

--- a/packages/rspack-test-tools/viewer/utils/generateTreeData.tsx
+++ b/packages/rspack-test-tools/viewer/utils/generateTreeData.tsx
@@ -1,5 +1,15 @@
 import { TreeDataType } from "@arco-design/web-react/es/Tree/interface";
 import { ECompareResultType } from "../../src/type";
+import { IconDriveFile } from "@arco-design/web-react/Icon"
+import React from "react";
+
+const DIFF_TYPE_COLOR = {
+	[ECompareResultType.Same]: "#00B42A",
+	[ECompareResultType.Missing]: "#86909C",
+	[ECompareResultType.OnlyDist]: "#CB272D",
+	[ECompareResultType.OnlySource]: "#CB272D",
+	[ECompareResultType.Different]: "#F77234",
+};
 
 export const generateTreeData = (
 	root: string,
@@ -26,7 +36,11 @@ export const generateTreeData = (
 				const fileMeta: TreeDataType = {
 					key: file.name,
 					title: splitPath[i],
-					data: file
+					data: file,
+					style: {
+						color: DIFF_TYPE_COLOR[file.type]
+					},
+					icon: <IconDriveFile />
 				};
 				if (parentDirectory) {
 					if (fileMap.has(fileMeta.key!)) {

--- a/packages/rspack-test-tools/viewer/utils/generateTreeData.tsx
+++ b/packages/rspack-test-tools/viewer/utils/generateTreeData.tsx
@@ -1,6 +1,5 @@
 import { TreeDataType } from "@arco-design/web-react/es/Tree/interface";
 import { ECompareResultType } from "../../src/type";
-import React from "react";
 
 const DIFF_TYPE_COLOR = {
 	[ECompareResultType.Same]: "#00B42A",

--- a/packages/rspack-test-tools/viewer/utils/generateTreeData.tsx
+++ b/packages/rspack-test-tools/viewer/utils/generateTreeData.tsx
@@ -1,6 +1,5 @@
 import { TreeDataType } from "@arco-design/web-react/es/Tree/interface";
 import { ECompareResultType } from "../../src/type";
-import { IconDriveFile } from "@arco-design/web-react/Icon"
 import React from "react";
 
 const DIFF_TYPE_COLOR = {
@@ -40,7 +39,6 @@ export const generateTreeData = (
 					style: {
 						color: DIFF_TYPE_COLOR[file.type]
 					},
-					icon: <IconDriveFile />
 				};
 				if (parentDirectory) {
 					if (fileMap.has(fileMeta.key!)) {

--- a/packages/rspack/tests/RuntimeDiff.diff.test.ts
+++ b/packages/rspack/tests/RuntimeDiff.diff.test.ts
@@ -124,6 +124,7 @@ function createDiffProcessor(config: IDiffProcessorOptions) {
 		ignorePropertyQuotationMark: config.ignorePropertyQuotationMark ?? true,
 		ignoreBlockOnlyStatement: config.ignoreBlockOnlyStatement ?? true,
 		ignoreSwcHelpersPath: config.ignoreSwcHelpersPath ?? true,
+		ignoreObjectPropertySequence: config.ignoreObjectPropertySequence ?? true,
 		onCompareModules: createCompareResultHandler("modules"),
 		onCompareRuntimeModules: createCompareResultHandler("runtimeModules")
 	});

--- a/packages/rspack/tests/RuntimeDiff.diff.test.ts
+++ b/packages/rspack/tests/RuntimeDiff.diff.test.ts
@@ -13,10 +13,7 @@ import { isValidTestCaseDir } from "./utils";
 const DEFAULT_CASE_CONFIG: IDiffProcessorOptions = {
 	webpackPath: require.resolve("webpack"),
 	rspackPath: require.resolve("@rspack/core"),
-	files: ["bundle.js"],
-	ignorePropertyQuotationMark: true,
-	ignoreModuleId: true,
-	ignoreModuleArguments: true
+	files: ["bundle.js"]
 };
 
 type TFileCompareResult = {
@@ -125,6 +122,7 @@ function createDiffProcessor(config: IDiffProcessorOptions) {
 		ignoreBlockOnlyStatement: config.ignoreBlockOnlyStatement ?? true,
 		ignoreSwcHelpersPath: config.ignoreSwcHelpersPath ?? true,
 		ignoreObjectPropertySequence: config.ignoreObjectPropertySequence ?? true,
+		ignoreCssFilePath: config.ignoreCssFilePath ?? true,
 		onCompareModules: createCompareResultHandler("modules"),
 		onCompareRuntimeModules: createCompareResultHandler("runtimeModules")
 	});

--- a/packages/rspack/tests/RuntimeDiff.diff.test.ts
+++ b/packages/rspack/tests/RuntimeDiff.diff.test.ts
@@ -122,6 +122,8 @@ function createDiffProcessor(config: IDiffProcessorOptions) {
 		ignoreModuleId: config.ignoreModuleId ?? true,
 		ignoreModuleArguments: config.ignoreModuleArguments ?? true,
 		ignorePropertyQuotationMark: config.ignorePropertyQuotationMark ?? true,
+		ignoreBlockOnlyStatement: config.ignoreBlockOnlyStatement ?? true,
+		ignoreSwcHelpersPath: config.ignoreSwcHelpersPath ?? true,
 		onCompareModules: createCompareResultHandler("modules"),
 		onCompareRuntimeModules: createCompareResultHandler("runtimeModules")
 	});

--- a/scripts/diff.cjs
+++ b/scripts/diff.cjs
@@ -37,6 +37,8 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
         ignoreModuleId: true,
         ignoreModuleArguments: true,
         ignorePropertyQuotationMark: true,
+        ignoreBlockOnlyStatement: true,
+        ignoreSwcHelpersPath: true,
         onCompareModules: function (file, results) {
           htmlReporter.increment(name, results);
           statsReporter.increment(name, results);
@@ -64,6 +66,7 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
     } catch (e) {
       htmlReporter.failure(name)
       statsReporter.failure(name);
+      console.error(e);
     }
   }
   await htmlReporter.output();

--- a/scripts/diff.cjs
+++ b/scripts/diff.cjs
@@ -40,6 +40,7 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
         ignoreBlockOnlyStatement: true,
         ignoreSwcHelpersPath: true,
         ignoreObjectPropertySequence: true,
+        ignoreCssFilePath: true,
         onCompareModules: function (file, results) {
           htmlReporter.increment(name, results);
           statsReporter.increment(name, results);

--- a/scripts/diff.cjs
+++ b/scripts/diff.cjs
@@ -46,6 +46,7 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
           statsReporter.increment(name, results);
         },
         onCompareRuntimeModules: function (file, results) {
+          console.log(results);
           htmlReporter.increment(name, results);
           statsReporter.increment(name, results);
         },

--- a/scripts/diff.cjs
+++ b/scripts/diff.cjs
@@ -39,6 +39,7 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
         ignorePropertyQuotationMark: true,
         ignoreBlockOnlyStatement: true,
         ignoreSwcHelpersPath: true,
+        ignoreObjectPropertySequence: true,
         onCompareModules: function (file, results) {
           htmlReporter.increment(name, results);
           statsReporter.increment(name, results);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary


1. Modify diff cases
  - Remove react refresh plugin
  - Use prod mode
  - Use experiments css 
2. Transform generated code of diff case to prevent unnecessary diff lines
  - Add `ignoreBlockOnlyStatement` to prevent differences caused by single-statement blocks
  - Add `ignoreSwcHelpersPath` to prevent differences caused by injecting @swc/helpers
  - Add `ignoreObjectPropertySequence` to prevent differences caused by sequence of object properties
  - Add `ignoreCssFilePath` to prevent differences caused by webpack css local idents

## Test Plan



## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
