### PR TITLE
fix: remove static new_treeshaking switch

### DIFF
--- a/crates/rspack/tests/fixtures.rs
+++ b/crates/rspack/tests/fixtures.rs
@@ -1,10 +1,8 @@
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 
 use cargo_rst::git_diff;
 use rspack_core::{
   BoxPlugin, CompilerOptions, MangleExportsOption, PluginExt, TreeShaking, UsedExportsOption,
-  IS_NEW_TREESHAKING,
 };
 use rspack_plugin_javascript::{
   FlagDependencyExportsPlugin, FlagDependencyUsagePlugin, MangleExportsPlugin,
@@ -50,7 +48,6 @@ fn tree_shaking(fixture_path: PathBuf) {
   // First test is old version tree shaking snapshot test
   test_fixture(&fixture_path, Box::new(|_, _| {}), None);
   // second test is webpack based tree shaking
-  IS_NEW_TREESHAKING.store(true, Ordering::SeqCst);
   test_fixture(
     &fixture_path,
     Box::new(

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -8,7 +8,7 @@ use rspack_identifier::IdentifierMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::MakeParam;
-use crate::{fast_set, ChunkKind, Compilation, Compiler, RuntimeSpec};
+use crate::{fast_set, ChunkKind, Compilation, Compiler, ModuleGraph, RuntimeSpec};
 
 impl<T> Compiler<T>
 where
@@ -68,7 +68,7 @@ where
 
       let mut new_compilation = Compilation::new(
         self.options.clone(),
-        Default::default(),
+        ModuleGraph::default().with_treeshaking(self.options.is_new_tree_shaking()),
         self.plugin_driver.clone(),
         self.resolver_factory.clone(),
         self.loader_resolver_factory.clone(),

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(anonymous_lifetime_in_impl_trait)]
 #![feature(hash_raw_entry)]
 
-use std::sync::atomic::AtomicBool;
 use std::{fmt, sync::Arc};
 mod dependencies_block;
 pub use dependencies_block::{
@@ -310,5 +309,3 @@ impl TryFrom<&str> for ModuleType {
 pub type ChunkByUkey = Database<Chunk>;
 pub type ChunkGroupByUkey = Database<ChunkGroup>;
 pub(crate) type SharedPluginDriver = Arc<PluginDriver>;
-
-pub static IS_NEW_TREESHAKING: AtomicBool = AtomicBool::new(false);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove static new_treeshaking switch because when run tests, this can be affected by other test cases

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
