### PR TITLE
fix: compare blocks and its group_options

### DIFF
--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -303,7 +303,7 @@ impl ChunkGroupKind {
 
 pub type EntryRuntime = String;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EntryOptions {
   pub name: Option<String>,
   pub runtime: Option<EntryRuntime>,
@@ -315,7 +315,7 @@ pub struct EntryOptions {
   pub library: Option<LibraryOptions>,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ChunkGroupOptions {
   pub name: Option<String>,
 }
@@ -327,7 +327,7 @@ impl ChunkGroupOptions {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum GroupOptions {
   Entrypoint(Box<EntryOptions>),
   ChunkGroup(ChunkGroupOptions),

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -14,7 +14,6 @@ impl<T> Compiler<T>
 where
   T: AsyncWritableFileSystem + Send + Sync,
 {
-  // TODO: remove this function when we had `record` in compiler.
   pub async fn rebuild(
     &mut self,
     changed_files: std::collections::HashSet<String>,

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -385,6 +385,22 @@ impl ModuleGraph {
       })
   }
 
+  pub(crate) fn get_module_dependencies_modules_and_blocks(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> (Vec<&ModuleIdentifier>, &[AsyncDependenciesBlockIdentifier]) {
+    let Some(m) = self.module_by_identifier(module_identifier) else {
+      unreachable!("cannot find the module correspanding to {module_identifier}");
+    };
+    let modules = m
+      .get_dependencies()
+      .iter()
+      .filter_map(|id| self.module_identifier_by_dependency_id(id))
+      .collect();
+    let blocks = m.get_blocks();
+    (modules, blocks)
+  }
+
   pub fn dependency_by_connection_id(
     &self,
     connection_id: &ConnectionId,

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -66,7 +66,7 @@ pub struct TrustedTypes {
   pub policy_name: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ChunkLoading {
   Enable(ChunkLoadingType),
   Disable,
@@ -81,7 +81,7 @@ impl From<&str> for ChunkLoading {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ChunkLoadingType {
   Jsonp,
   ImportScripts,
@@ -252,7 +252,7 @@ impl<'a> PathData<'a> {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Filename {
   template: String,
 }
@@ -418,7 +418,7 @@ fn hash_len(hash: &str, caps: &Captures) -> usize {
     .min(hash_len)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PublicPath {
   // TODO: should be RawPublicPath(Filename)
   String(String),
@@ -515,7 +515,7 @@ pub fn get_js_chunk_filename_template<'filename>(
   }
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LibraryOptions {
   pub name: Option<LibraryName>,
   pub export: Option<LibraryExport>,
@@ -530,7 +530,7 @@ pub type LibraryType = String;
 
 pub type LibraryExport = Vec<String>;
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LibraryAuxiliaryComment {
   pub root: Option<String>,
   pub commonjs: Option<String>,
@@ -538,19 +538,19 @@ pub struct LibraryAuxiliaryComment {
   pub amd: Option<String>,
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LibraryName {
   NonUmdObject(LibraryNonUmdObject),
   UmdObject(LibraryCustomUmdObject),
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LibraryNonUmdObject {
   Array(Vec<String>),
   String(String),
 }
 
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LibraryCustomUmdObject {
   pub amd: Option<String>,
   pub commonjs: Option<String>,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -104,6 +104,11 @@ fn create_import_meta_context_dependency(node: &CallExpr) -> Option<ImportMetaCo
   ))
 }
 
+static WEBPACK_CHUNK_NAME_CAPTURE_RE: Lazy<regex::Regex> = Lazy::new(|| {
+  regex::Regex::new(r#"webpackChunkName\s*:\s*("(?P<_1>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)"|'(?P<_2>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)'|`(?P<_3>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)`)"#)
+    .expect("invalid regex")
+});
+
 impl<'a> ImportScanner<'a> {
   pub fn new(
     module_identifier: ModuleIdentifier,
@@ -124,10 +129,6 @@ impl<'a> ImportScanner<'a> {
   }
 
   fn try_extract_webpack_chunk_name(&self, first_arg_span_of_import_call: &Span) -> Option<String> {
-    static WEBPACK_CHUNK_NAME_CAPTURE_RE: Lazy<regex::Regex> = Lazy::new(|| {
-      regex::Regex::new(r#"webpackChunkName\s*:\s*("(?P<_1>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)"|'(?P<_2>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)'|`(?P<_3>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)`)"#)
-        .expect("invalid regex")
-    });
     self
       .comments
       .with_leading(first_arg_span_of_import_call.lo, |comments| {

--- a/packages/playground/cases/chunk/issue-4936/index.test.ts
+++ b/packages/playground/cases/chunk/issue-4936/index.test.ts
@@ -1,0 +1,19 @@
+import { test } from "@/fixtures";
+
+test("should load success", async ({ page, fileAction, rspack }) => {
+	await rspack.waitUntil(async function () {
+		return (await page.title()) === "123";
+	});
+
+	// use webpackChunkName
+	fileAction.updateFile(
+		"./src/index.js",
+		() => `
+import(/* webpackChunkName: "bar" */'./app').then((m) => {
+	m.title('456')
+});`
+	);
+	await rspack.waitUntil(async function () {
+		return (await page.title()) === "456";
+	});
+});

--- a/packages/playground/cases/chunk/issue-4936/rspack.config.js
+++ b/packages/playground/cases/chunk/issue-4936/rspack.config.js
@@ -1,0 +1,10 @@
+const rspack = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	entry: "./src/index.js",
+	stats: "none",
+	mode: "development",
+	plugins: [new rspack.HtmlRspackPlugin()]
+};

--- a/packages/playground/cases/chunk/issue-4936/src/app.js
+++ b/packages/playground/cases/chunk/issue-4936/src/app.js
@@ -1,0 +1,3 @@
+export function title(t) {
+	document.title = t;
+}

--- a/packages/playground/cases/chunk/issue-4936/src/index.js
+++ b/packages/playground/cases/chunk/issue-4936/src/index.js
@@ -1,0 +1,3 @@
+import("./app").then(m => {
+	m.title("123");
+});

--- a/packages/playground/cases/html/issue-4366/index.test.ts
+++ b/packages/playground/cases/html/issue-4366/index.test.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "@/fixtures";
-import { sleep } from "@/utils/sleep";
 
 test("html should refresh after reload", async ({
 	page,


### PR DESCRIPTION
Fixes #4936 

In this PR, I have added ﻿`group_options` because merely comparing the module identifier is not sufficient for caching.