### PR TITLE
fix: 🐛 class memeber side effects

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -90,7 +90,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       mut additional_data,
       ..
     } = parse_context;
-
+    dbg!(&resource_data.resource_path);
+    println!("{}\n", source.source().to_string());
     let mut diagnostics: Vec<Diagnostic> = vec![];
     let syntax = syntax_by_module_type(
       &resource_data.resource_path,
@@ -154,6 +155,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         .remove::<CodegenOptions>()
         .unwrap_or_else(|| CodegenOptions::new(&compiler_options.devtool, Some(true))),
     )?;
+    println!("{}", output.code);
 
     ast = match crate::ast::parse(
       output.code.clone(),

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -90,8 +90,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       mut additional_data,
       ..
     } = parse_context;
-    dbg!(&resource_data.resource_path);
-    println!("{}\n", source.source().to_string());
     let mut diagnostics: Vec<Diagnostic> = vec![];
     let syntax = syntax_by_module_type(
       &resource_data.resource_path,
@@ -155,7 +153,6 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         .remove::<CodegenOptions>()
         .unwrap_or_else(|| CodegenOptions::new(&compiler_options.devtool, Some(true))),
     )?;
-    println!("{}", output.code);
 
     ast = match crate::ast::parse(
       output.code.clone(),

--- a/crates/rspack_plugin_javascript/src/plugin/inner_graph_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inner_graph_plugin.rs
@@ -515,7 +515,6 @@ impl<'a> InnerGraphPlugin<'a> {
     module_identifier: ModuleIdentifier,
     comments: Option<SwcComments>,
   ) -> Self {
-    dbg!("new");
     Self {
       dependencies,
       unresolved_ctxt,

--- a/crates/rspack_plugin_javascript/src/plugin/inner_graph_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inner_graph_plugin.rs
@@ -8,7 +8,7 @@ use swc_core::{
     ast::{
       ArrowExpr, CallExpr, Callee, Class, ClassDecl, ClassExpr, ClassMember, DefaultDecl,
       ExportDecl, ExportDefaultDecl, ExportDefaultExpr, Expr, FnDecl, FnExpr, Function, Ident, Key,
-      MemberExpr, NamedExport, OptChainExpr, Pat, Program, Prop, PropName, VarDeclarator,
+      MemberExpr, NamedExport, OptChainExpr, Pat, Program, Prop, VarDeclarator,
     },
     atoms::JsWord,
     visit::{noop_visit_type, Visit, VisitWith},

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -284,6 +284,54 @@ pub fn is_pure_expression<'a>(
   }
 }
 
+pub fn is_pure_class_member<'a>(
+  member: &'a ClassMember,
+  unresolved_ctxt: SyntaxContext,
+  comments: Option<&'a SwcComments>,
+) -> bool {
+  let is_key_pure = match member.class_key() {
+    Some(PropName::Ident(_ident)) => true,
+    Some(PropName::Str(_)) => true,
+    Some(PropName::Num(_)) => true,
+    Some(PropName::Computed(computed)) => {
+      is_pure_expression(&computed.expr, unresolved_ctxt, comments)
+    }
+    Some(PropName::BigInt(_)) => true,
+    None => true,
+  };
+  if !is_key_pure {
+    return false;
+  }
+  let is_static = member.is_static();
+  let is_value_pure = match member {
+    ClassMember::Constructor(cons) => true,
+    ClassMember::Method(_) => true,
+    ClassMember::PrivateMethod(_) => true,
+    ClassMember::ClassProp(prop) => {
+      if let Some(ref value) = prop.value {
+        is_pure_expression(&value, unresolved_ctxt, comments)
+      } else {
+        true
+      }
+    }
+    ClassMember::PrivateProp(ref prop) => {
+      if let Some(ref value) = prop.value {
+        is_pure_expression(&value, unresolved_ctxt, comments)
+      } else {
+        true
+      }
+    }
+    ClassMember::TsIndexSignature(_) => unreachable!(),
+    ClassMember::Empty(_) => true,
+    ClassMember::StaticBlock(_) => false,
+    ClassMember::AutoAccessor(_) => false,
+  };
+  if is_static && !is_value_pure {
+    return false;
+  }
+  true
+}
+
 pub fn is_pure_decl(
   stmt: &Decl,
   unresolved_ctxt: SyntaxContext,

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -304,19 +304,19 @@ pub fn is_pure_class_member<'a>(
   }
   let is_static = member.is_static();
   let is_value_pure = match member {
-    ClassMember::Constructor(cons) => true,
+    ClassMember::Constructor(_) => true,
     ClassMember::Method(_) => true,
     ClassMember::PrivateMethod(_) => true,
     ClassMember::ClassProp(prop) => {
       if let Some(ref value) = prop.value {
-        is_pure_expression(&value, unresolved_ctxt, comments)
+        is_pure_expression(value, unresolved_ctxt, comments)
       } else {
         true
       }
     }
     ClassMember::PrivateProp(ref prop) => {
       if let Some(ref value) = prop.value {
-        is_pure_expression(&value, unresolved_ctxt, comments)
+        is_pure_expression(value, unresolved_ctxt, comments)
       } else {
         true
       }

--- a/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/a.js
+++ b/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/a.js
@@ -1,0 +1,1 @@
+export const a = 3;

--- a/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/index.js
+++ b/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/index.js
@@ -1,0 +1,4 @@
+import { res } from "./lib";
+it("should compile with static block", function () {
+	expect(res).toBe(1000);
+});

--- a/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/lib.js
+++ b/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/lib.js
@@ -1,0 +1,8 @@
+import { a } from "./a.js";
+export class T {
+	static {
+		this.a = a;
+	}
+}
+
+export const res = 1000;

--- a/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/webpack.config.js
+++ b/packages/rspack/tests/configCases/tree-shaking/inner-graph-static-block/webpack.config.js
@@ -1,0 +1,14 @@
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	mode: "production",
+	context: __dirname,
+	experiments: {
+		rspackFuture: {
+			newTreeshaking: true
+		}
+	},
+	optimization: {
+		moduleIds: "named",
+		minimize: false
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. fix inner graph to detect class member effects, should not add PureExpressionDep on `staticBlock`
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
1. added a unit test under packages/rspack
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
