### PR TITLE
ci: speed up CI by turning off sourcemap for arco-pro

### DIFF
--- a/examples/arco-pro/rspack.config.js
+++ b/examples/arco-pro/rspack.config.js
@@ -10,6 +10,7 @@ const config = {
 	context: __dirname,
 	entry: "./src/index.tsx",
 	target: ["web", "es5"],
+	devtool: false,
 	devServer: {
 		port: 5555,
 		webSocketServer: "sockjs",


### PR DESCRIPTION
## Summary

It currently takes 200s for arco-pro to build in CI.

On my local machine, turning off sourcemap results in 20s -> 13s and 1.1G max rss -> 700MB.

## Test Plan

* CI passes and arco-pro build time decreases.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
