### PR TITLE
fix: append builtin minify plugin for child compiler

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -135,6 +135,7 @@ export interface BeforeResolveData {
 export interface BuiltinPlugin {
   name: BuiltinPluginName
   options: unknown
+  canInherentFromParent?: boolean
 }
 
 export const enum BuiltinPluginName {

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -96,6 +96,7 @@ pub enum BuiltinPluginName {
 pub struct BuiltinPlugin {
   pub name: BuiltinPluginName,
   pub options: JsUnknown,
+  pub can_inherent_from_parent: Option<bool>,
 }
 
 impl RawOptionsApply for BuiltinPlugin {

--- a/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
@@ -9,14 +9,16 @@ export const SplitChunksPlugin = create(
 		let raw = toRawSplitChunksOptions(options);
 		assert(typeof raw !== "undefined");
 		return raw;
-	}
+	},
+	"thisCompilation"
 );
 
 export const OldSplitChunksPlugin = create(
-	BuiltinPluginName.SplitChunksPlugin,
+	BuiltinPluginName.OldSplitChunksPlugin,
 	(options: OptimizationSplitChunksOptions) => {
 		let raw = toRawSplitChunksOptions(options);
 		assert(typeof raw !== "undefined");
 		return raw;
-	}
+	},
+	"thisCompilation"
 );

--- a/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
@@ -330,5 +330,6 @@ export const SwcJsMinimizerRspackPlugin = create(
 			include: options?.include,
 			exclude: options?.exclude
 		};
-	}
+	},
+	"compilation"
 );

--- a/packages/rspack/tests/configCases/plugins/issue-4982/child.js
+++ b/packages/rspack/tests/configCases/plugins/issue-4982/child.js
@@ -1,0 +1,3 @@
+const a = 1;
+const b = `hello/${a}`;
+console.log(b);

--- a/packages/rspack/tests/configCases/plugins/issue-4982/index.js
+++ b/packages/rspack/tests/configCases/plugins/issue-4982/index.js
@@ -1,0 +1,3 @@
+it("should build success", () => {
+	expect(1).toBe(1);
+});

--- a/packages/rspack/tests/configCases/plugins/issue-4982/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/issue-4982/webpack.config.js
@@ -1,0 +1,39 @@
+const rspack = require("@rspack/core");
+const path = require("path");
+const assert = require("assert");
+
+module.exports = {
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.make.tap("child", compilation => {
+					const childCompiler = compilation.createChildCompiler(
+						"child",
+						{
+							filename: compiler.options.output.filename
+						},
+						[
+							new compiler.webpack.EntryPlugin(
+								compiler.context,
+								path.resolve(__dirname, "./child.js"),
+								{ name: "child" }
+							)
+						]
+					);
+					childCompiler.compile((_err, result) => {
+						const assets = result
+							.getAssets()
+							.filter(asset => asset.name === "child.js");
+						assert(assets.length === 1);
+						const asset = assets[0];
+						assert(asset.source.source().toString().includes("hello/1"));
+					});
+				});
+			}
+		}
+	],
+	optimization: {
+		minimize: true,
+		minimizer: [new rspack.SwcJsMinimizerRspackPlugin()]
+	}
+};


### PR DESCRIPTION
Fixes #4982 

webpack can utilize `this.hooks[name].taps.slice()` to enable the `childCompiler` to inherit these plugins from webpack. However, we can't do the same.

Therefore, we're adding this plugin to ensure these plugins function properly.