### PR TITLE
feat(runtime): support __webpack_chunkname__

### DIFF
--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -232,6 +232,8 @@ bitflags! {
     const SCRIPT_NONCE = 1 << 54;
 
     const RELATIVE_URL = 1 << 55;
+
+    const CHUNK_NAME = 1 << 56;
   }
 }
 
@@ -308,6 +310,7 @@ impl RuntimeGlobals {
       R::INITIALIZE_SHARING => "__webpack_require__.I",
       R::SCRIPT_NONCE => "__webpack_require__.nc",
       R::RELATIVE_URL => "__webpack_require__.U",
+      R::CHUNK_NAME => "__webpack_require__.cn",
       r => panic!(
         "Unexpected flag `{r:?}`. RuntimeGlobals should only be printed for one single flag."
       ),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -25,6 +25,7 @@ pub const SYSTEM_CONTEXT: &str = "__system_context__";
 pub const WEBPACK_SHARE_SCOPES: &str = "__webpack_share_scopes__";
 pub const WEBPACK_INIT_SHARING: &str = "__webpack_init_sharing__";
 pub const WEBPACK_NONCE: &str = "__webpack_nonce__";
+pub const WEBPACK_CHUNK_NAME: &str = "__webpack_chunkname__";
 
 pub struct ApiScanner<'a> {
   pub unresolved_ctxt: SyntaxContext,
@@ -214,6 +215,16 @@ impl Visit for ApiScanner<'_> {
             ident.span.real_hi(),
             RuntimeGlobals::SCRIPT_NONCE.name().into(),
             Some(RuntimeGlobals::SCRIPT_NONCE),
+          )));
+      }
+      WEBPACK_CHUNK_NAME => {
+        self
+          .presentational_dependencies
+          .push(Box::new(ConstDependency::new(
+            ident.span.real_lo(),
+            ident.span.real_hi(),
+            RuntimeGlobals::CHUNK_NAME.name().into(),
+            Some(RuntimeGlobals::CHUNK_NAME),
           )));
       }
       _ => {}

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
@@ -1,0 +1,51 @@
+use rspack_core::{
+  impl_runtime_module,
+  rspack_sources::{BoxSource, RawSource, SourceExt},
+  ChunkUkey, Compilation, RuntimeGlobals, RuntimeModule,
+};
+use rspack_identifier::Identifier;
+
+#[derive(Debug, Eq)]
+pub struct ChunkNameRuntimeModule {
+  id: Identifier,
+  chunk: Option<ChunkUkey>,
+}
+
+impl Default for ChunkNameRuntimeModule {
+  fn default() -> Self {
+    Self {
+      id: Identifier::from("webpack/runtime/chunk_name"),
+      chunk: None,
+    }
+  }
+}
+
+impl RuntimeModule for ChunkNameRuntimeModule {
+  fn attach(&mut self, chunk: ChunkUkey) {
+    self.chunk = Some(chunk);
+  }
+
+  fn name(&self) -> Identifier {
+    self.id
+  }
+
+  fn generate(&self, compilation: &Compilation) -> BoxSource {
+    if let Some(chunk_ukey) = self.chunk {
+      let chunk = compilation
+        .chunk_by_ukey
+        .get(&chunk_ukey)
+        .expect("Chunk not found");
+
+      RawSource::from(format!(
+        "{} = {};",
+        RuntimeGlobals::CHUNK_NAME,
+        serde_json::to_string(&chunk.name).expect("Invalid json string")
+      ))
+      .boxed()
+    } else {
+      unreachable!("should attach chunk for css_loading")
+    }
+  }
+}
+
+impl_runtime_module!(ChunkNameRuntimeModule);

--- a/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
@@ -1,6 +1,7 @@
 mod async_module;
 mod auto_public_path;
 mod base_uri;
+mod chunk_name;
 mod compat_get_default_export;
 mod create_fake_namespace_object;
 mod create_script_url;
@@ -37,6 +38,7 @@ mod utils;
 pub use async_module::AsyncRuntimeModule;
 pub use auto_public_path::AutoPublicPathRuntimeModule;
 pub use base_uri::BaseUriRuntimeModule;
+pub use chunk_name::ChunkNameRuntimeModule;
 pub use compat_get_default_export::CompatGetDefaultExportRuntimeModule;
 pub use create_fake_namespace_object::CreateFakeNamespaceObjectRuntimeModule;
 pub use create_script_url::CreateScriptUrlRuntimeModule;

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -11,20 +11,20 @@ use rspack_core::{
 
 use crate::runtime_module::{
   is_enabled_for_chunk, AsyncRuntimeModule, AutoPublicPathRuntimeModule, BaseUriRuntimeModule,
-  CompatGetDefaultExportRuntimeModule, CreateFakeNamespaceObjectRuntimeModule,
-  CreateScriptUrlRuntimeModule, DefinePropertyGettersRuntimeModule, EnsureChunkRuntimeModule,
-  GetChunkFilenameRuntimeModule, GetChunkUpdateFilenameRuntimeModule, GetFullHashRuntimeModule,
-  GetMainFilenameRuntimeModule, GetTrustedTypesPolicyRuntimeModule, GlobalRuntimeModule,
-  HarmonyModuleDecoratorRuntimeModule, HasOwnPropertyRuntimeModule,
-  LoadChunkWithBlockRuntimeModule, LoadScriptRuntimeModule, MakeNamespaceObjectRuntimeModule,
-  NodeModuleDecoratorRuntimeModule, NonceRuntimeModule, NormalRuntimeModule,
-  OnChunkLoadedRuntimeModule, PublicPathRuntimeModule, RelativeUrlRuntimeModule,
-  SystemContextRuntimeModule,
+  ChunkNameRuntimeModule, CompatGetDefaultExportRuntimeModule,
+  CreateFakeNamespaceObjectRuntimeModule, CreateScriptUrlRuntimeModule,
+  DefinePropertyGettersRuntimeModule, EnsureChunkRuntimeModule, GetChunkFilenameRuntimeModule,
+  GetChunkUpdateFilenameRuntimeModule, GetFullHashRuntimeModule, GetMainFilenameRuntimeModule,
+  GetTrustedTypesPolicyRuntimeModule, GlobalRuntimeModule, HarmonyModuleDecoratorRuntimeModule,
+  HasOwnPropertyRuntimeModule, LoadChunkWithBlockRuntimeModule, LoadScriptRuntimeModule,
+  MakeNamespaceObjectRuntimeModule, NodeModuleDecoratorRuntimeModule, NonceRuntimeModule,
+  NormalRuntimeModule, OnChunkLoadedRuntimeModule, PublicPathRuntimeModule,
+  RelativeUrlRuntimeModule, SystemContextRuntimeModule,
 };
 
 static GLOBALS_ON_REQUIRE: Lazy<Vec<RuntimeGlobals>> = Lazy::new(|| {
   vec![
-    // RuntimeGlobals::CHUNK_NAME,
+    RuntimeGlobals::CHUNK_NAME,
     // RuntimeGlobals::RUNTIME_ID,
     RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT,
     RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT,
@@ -384,6 +384,9 @@ impl Plugin for RuntimePlugin {
         }
         RuntimeGlobals::RELATIVE_URL => {
           compilation.add_runtime_module(chunk, RelativeUrlRuntimeModule::default().boxed());
+        }
+        RuntimeGlobals::CHUNK_NAME => {
+          compilation.add_runtime_module(chunk, ChunkNameRuntimeModule::default().boxed());
         }
         _ => {}
       }

--- a/webpack-test/configCases/parsing/extended-api/test.filter.js
+++ b/webpack-test/configCases/parsing/extended-api/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}


### PR DESCRIPTION
## Summary

Align `__webpack_chunkname__` and ChunkNameRuntimeModule with webpack

## Test Plan

- Reuse `webpack-test/configCases/parsing/extended-api` 

## Require Documentation?

- [] No
- [x] Yes, the corresponding rspack-website PR is \_\_
