### PR TITLE
fix: remove available modules from ancestor

### DIFF
--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/foo.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'foo'

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/index.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/index.js
@@ -1,0 +1,3 @@
+import './foo.js'
+import('./parent-1.js')
+import('./parent-2.js')

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/parent-1.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/parent-1.js
@@ -1,0 +1,1 @@
+import('./shared')

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/parent-2.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/parent-2.js
@@ -1,0 +1,1 @@
+import('./shared')

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/shared.js
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/shared.js
@@ -1,0 +1,3 @@
+// should not contain foo as ancestor already has
+import './foo'
+console.log('shared')

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/snapshot/output.snap
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/snapshot/output.snap
@@ -1,0 +1,59 @@
+---
+source: crates/rspack_testing/src/run_fixture.rs
+assertion_line: 146
+---
+```js title=index.js
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["index"], {
+"./foo.js": (function (module, exports, __webpack_require__) {
+module.exports = 'foo';
+}),
+"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo.js */"./foo.js");
+/* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_foo_js__WEBPACK_IMPORTED_MODULE_0__);
+
+__webpack_require__.el("./index.js@19:42").then(__webpack_require__.t.bind(__webpack_require__, /*! ./parent-1.js */"./parent-1.js", 23));
+__webpack_require__.el("./index.js@44:67").then(__webpack_require__.t.bind(__webpack_require__, /*! ./parent-2.js */"./parent-2.js", 23));
+}),
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
+
+}
+]);
+```
+
+```js title=parent-1_js.js
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["parent-1_js"], {
+"./parent-1.js": (function (__unused_webpack_module, exports, __webpack_require__) {
+__webpack_require__.el("./parent-1.js@0:18").then(__webpack_require__.bind(__webpack_require__, /*! ./shared */"./shared.js"));
+}),
+
+}]);
+```
+
+```js title=parent-2_js.js
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["parent-2_js"], {
+"./parent-2.js": (function (__unused_webpack_module, exports, __webpack_require__) {
+__webpack_require__.el("./parent-2.js@0:18").then(__webpack_require__.bind(__webpack_require__, /*! ./shared */"./shared.js"));
+}),
+
+}]);
+```
+
+```js title=shared_js.js
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["shared_js"], {
+"./shared.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
+/* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_foo__WEBPACK_IMPORTED_MODULE_0__);
+// should not contain foo as ancestor already has
+
+console.log('shared');
+}),
+
+}]);
+```

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/test.config.json
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/test.config.json
@@ -1,0 +1,9 @@
+{
+	"entry": {
+		"index": {
+			"import": [
+				"./index.js"
+			]
+		}
+	}
+}

--- a/crates/rspack_core/src/build_chunk_graph/remove_parent_modules.rs
+++ b/crates/rspack_core/src/build_chunk_graph/remove_parent_modules.rs
@@ -1,12 +1,12 @@
 // This is not a port of https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/optimize/RemoveParentModulesPlugin.js
 // But they do the same thing.
 
-use std::sync::Arc;
+use std::{hash::BuildHasherDefault, sync::Arc};
 
-use dashmap::DashMap;
+use dashmap::{DashMap, DashSet};
 use rayon::prelude::ParallelBridge;
 use rayon::prelude::*;
-use rspack_identifier::IdentifierSet;
+use rspack_identifier::{IdentifierHasher, IdentifierSet};
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::code_splitter::CodeSplitter;
@@ -33,6 +33,7 @@ impl RemoveParentModulesContext {
 }
 
 impl<'me> CodeSplitter<'me> {
+  #[tracing::instrument(skip_all)]
   fn prepare_remove_parent_modules(&mut self) -> FxHashMap<ChunkUkey, DefinitelyLoadedModules> {
     #[derive(Debug, Clone)]
     struct AnalyzeContext<'a> {
@@ -89,18 +90,25 @@ impl<'me> CodeSplitter<'me> {
           return Some(loaded_modules.clone());
         }
 
-        let loaded_modules = loaded_modules_of_parents
-          .into_par_iter()
-          .fold(IdentifierSet::default, |mut acc, cur| {
-            // The word `Definitely` in `DefinitelyLoadedModules` infers that
-            // we need the intersection of all parent loaded modules.
-            acc.retain(|x| cur.contains(x));
-            acc
-          })
-          .flatten()
-          // With the module itself
-          .chain(ctx.chunk_modules(&ctx.target_ukey).par_iter().cloned())
-          .collect::<IdentifierSet>();
+        let loaded_modules: DashSet<
+          rspack_identifier::Identifier,
+          BuildHasherDefault<IdentifierHasher>,
+        > = DashSet::<ModuleIdentifier, BuildHasherDefault<IdentifierHasher>>::from_iter(
+          loaded_modules_of_parents
+            .first()
+            .map(|item| item.as_ref().clone())
+            .unwrap_or(IdentifierSet::default())
+            .into_iter(),
+        );
+        loaded_modules_of_parents.par_iter().for_each(|cur| {
+          // The word `Definitely` in `DefinitelyLoadedModules` infers that
+          // we need the intersection of all parent loaded modules.
+          loaded_modules.retain(|x| cur.contains(x));
+        });
+
+        let mut loaded_modules = IdentifierSet::from_iter(loaded_modules.into_iter());
+
+        loaded_modules.extend(ctx.chunk_modules(&ctx.target_ukey).iter().cloned());
 
         Some(Arc::new(loaded_modules))
       };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Giving chunk group relations as following:

```
A
|  \
B  C
|  /
D
```

Remove availableModules can remove modules from parents and ancestor, we have this logic before, but for some reason it didn't work properly, this is a fix for this

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
