### PR TITLE
fix(runtime): globals on require in runtime plugin

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -49,10 +49,10 @@ static GLOBALS_ON_REQUIRE: Lazy<Vec<RuntimeGlobals>> = Lazy::new(|| {
     RuntimeGlobals::ASYNC_MODULE,
     // RuntimeGlobals::WASM_INSTANCES,
     RuntimeGlobals::INSTANTIATE_WASM,
-    // RuntimeGlobals::SHARE_SCOPE_MAP,
-    // RuntimeGlobals::INITIALIZE_SHARING,
+    RuntimeGlobals::SHARE_SCOPE_MAP,
+    RuntimeGlobals::INITIALIZE_SHARING,
     RuntimeGlobals::LOAD_SCRIPT,
-    // RuntimeGlobals::SYSTEM_CONTEXT,
+    RuntimeGlobals::SYSTEM_CONTEXT,
     RuntimeGlobals::ON_CHUNKS_LOADED,
   ]
 });


### PR DESCRIPTION
## Summary

Add `RuntimeGlobals::Require` when use property on it

## Test Plan



## Require Documentation?


- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
