### PR TITLE
fix: parse left and right when eval failed for logic expr

### DIFF
--- a/crates/rspack_plugin_javascript/src/utils/const/logic_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/const/logic_expr.rs
@@ -8,10 +8,8 @@ use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependen
 // FIXME: a temp hack to avoid bwchecker.
 bitflags::bitflags! {
   pub struct Continue: u8 {
-    const NO = 1 << 0;
-    const LEFT = 1 << 1;
-    const RIGHT = 1 << 2;
-    const LEFT_AND_RIGHT = 1 << 3;
+    const LEFT = 1 << 0;
+    const RIGHT = 1 << 1;
   }
 }
 
@@ -23,7 +21,7 @@ pub fn expression_logic_operator(
     let param = scanner.evaluate_expression(&expr.left);
     let boolean = param.as_bool();
     let Some(bool) = boolean else {
-      return (None, Continue::NO);
+      return (None, Continue::all());
     };
     let mut deps = vec![];
     let mut c = Continue::empty();
@@ -57,7 +55,7 @@ pub fn expression_logic_operator(
     }
     (Some(deps), c)
   } else {
-    (None, Continue::LEFT_AND_RIGHT)
+    (None, Continue::all())
   }
   // else if expr.op == BinaryOp::NullishCoalescing {
   //   // TODO: support `??`

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -267,13 +267,11 @@ impl Visit for CommonJsImportDependencyScanner<'_> {
     self.replace_require_resolve(&bin_expr.right, value);
 
     let (deps, c) = expression_logic_operator(self, bin_expr);
-    if c == Continue::NO {
-    } else if c == Continue::LEFT {
+    if c.contains(Continue::LEFT) {
       bin_expr.left.visit_children_with(self);
-    } else if c == Continue::RIGHT {
+    }
+    if c.contains(Continue::RIGHT) {
       bin_expr.right.visit_children_with(self);
-    } else if c == Continue::LEFT_AND_RIGHT {
-      bin_expr.visit_children_with(self);
     }
     let Some(deps) = deps else {
       return;

--- a/packages/rspack/tests/cases/parsing/issue-4816/index.js
+++ b/packages/rspack/tests/cases/parsing/issue-4816/index.js
@@ -27,4 +27,5 @@ it("should build success for logic op", () => {
 	expect(typeof require !== "function" && require("fail")).toBe(false);
 	expect(true && require("./a")).toBe("a");
 	expect(typeof require === "function" && require("./a")).toBe("a");
+	expect(!require("./a") && !require("./b")).toBe(false);
 });


### PR DESCRIPTION
Fixes #4997 

 Parsing of left and right expressions should continue even if the evaluation of the logical expression fails.