### PR TITLE
feat: progress plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,8 +2956,6 @@ dependencies = [
  "linked-hash-map",
  "rspack_core",
  "rspack_error",
- "rustc-hash",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2955,6 +2955,7 @@ dependencies = [
  "indicatif",
  "rspack_core",
  "rspack_error",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,6 +2956,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rustc-hash",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "indicatif",
+ "linked-hash-map",
  "rspack_core",
  "rspack_error",
  "rustc-hash",

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -12,3 +12,4 @@ async-trait  = { workspace = true }
 indicatif    = "0.17.5"
 rspack_core  = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
+rustc-hash   = { workspace = true }

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -13,3 +13,4 @@ indicatif    = "0.17.5"
 rspack_core  = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 rustc-hash   = { workspace = true }
+tokio        = { workspace = true }

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -8,9 +8,10 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait  = { workspace = true }
-indicatif    = "0.17.5"
-rspack_core  = { path = "../rspack_core" }
-rspack_error = { path = "../rspack_error" }
-rustc-hash   = { workspace = true }
-tokio        = { workspace = true }
+async-trait     = { workspace = true }
+indicatif       = "0.17.5"
+linked-hash-map = "0.5.6"
+rspack_core     = { path = "../rspack_core" }
+rspack_error    = { path = "../rspack_error" }
+rustc-hash      = { workspace = true }
+tokio           = { workspace = true }

--- a/crates/rspack_plugin_progress/Cargo.toml
+++ b/crates/rspack_plugin_progress/Cargo.toml
@@ -13,5 +13,3 @@ indicatif       = "0.17.5"
 linked-hash-map = "0.5.6"
 rspack_core     = { path = "../rspack_core" }
 rspack_error    = { path = "../rspack_error" }
-rustc-hash      = { workspace = true }
-tokio           = { workspace = true }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -1,16 +1,18 @@
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::RwLock;
 use std::time::Duration;
 use std::{cmp, sync::atomic::AtomicU32, time::Instant};
 
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspack_core::{
-  Compilation, DoneArgs, MakeParam, Module, ModuleIdentifier, OptimizeChunksArgs, Plugin,
-  PluginBuildEndHookOutput, PluginContext, PluginMakeHookOutput, PluginOptimizeChunksOutput,
-  PluginProcessAssetsOutput, ProcessAssetsArgs,
+  BoxModule, Compilation, CompilationArgs, CompilationParams, DoneArgs, MakeParam, Module,
+  ModuleIdentifier, NormalModuleCreateData, OptimizeChunksArgs, Plugin, PluginBuildEndHookOutput,
+  PluginCompilationHookOutput, PluginContext, PluginMakeHookOutput,
+  PluginNormalModuleFactoryModuleHookOutput, PluginOptimizeChunksOutput, PluginProcessAssetsOutput,
+  PluginThisCompilationHookOutput, ProcessAssetsArgs, ThisCompilationArgs,
 };
 use rspack_error::Result;
 use rustc_hash::FxHashMap as HashMap;
-use tokio::sync::RwLock;
 
 #[derive(Debug, Clone, Default)]
 pub struct ProgressPluginOptions {
@@ -72,31 +74,35 @@ impl ProgressPlugin {
       queue: vec![],
     }
   }
-  pub async fn update_throttled(&self) {
-    if *self.last_update_time.read().await + Duration::from_millis(50) < Instant::now() {
-      self.update(None).await;
+  pub fn update_throttled(&self) {
+    if *self.last_update_time.read().expect("TODO:") + Duration::from_millis(50) < Instant::now() {
+      self.update(None);
     }
     // *self.last_update_time.write().expect("TODO:") = Instant::now();
   }
-  async fn update(&self, time: Option<Duration>) {
+  fn update(&self, time: Option<Duration>) {
     let modules_done = self.modules_done.load(SeqCst);
     let dependencies_done = self.dependencies_done.load(SeqCst);
     let percent_by_module = (modules_done as f32)
       / (cmp::max(
-        self.last_modules_count.read().await.unwrap_or(1),
+        self.last_modules_count.read().expect("TODO:").unwrap_or(1),
         self.modules_count.load(SeqCst),
       ) as f32);
 
     let percent_by_dependencies = (self.dependencies_done.load(SeqCst) as f32)
       / (cmp::max(
-        self.last_dependencies_count.read().await.unwrap_or(1),
+        self
+          .last_dependencies_count
+          .read()
+          .expect("TODO:")
+          .unwrap_or(1),
         self.dependencies_count.load(SeqCst),
       ) as f32);
 
     let percent = (percent_by_module + percent_by_dependencies) / 2.0;
 
     let mut items = vec![];
-    let mut stat_items = vec![];
+    let mut stat_items: Vec<String> = vec![];
     {
       // TODO: dependencies_done modules_done report
       // stat_items.push(format!(
@@ -109,21 +115,19 @@ impl ProgressPlugin {
       //   modules_done,
       //   self.modules_count.load(SeqCst)
       // ));
-      stat_items.push(format!("{} active", self.active_modules.read().await.len()));
-      items.push(stat_items.join(" "));
-      let last_active_module = self.last_active_module.read().await;
+      // stat_items.push(format!("{} active", self.active_modules.read().expect("TODO:").len()));
+      // items.push(stat_items.join(" "));
+      let last_active_module = self.last_active_module.read().expect("TODO:");
 
       if let Some(last_active_module) = last_active_module.clone() {
         items.push(last_active_module.to_string());
       }
     }
 
-    self
-      .handler(0.1 + percent * 0.55, String::from("building"), items, time)
-      .await;
+    self.handler(0.1 + percent * 0.55, String::from("building"), items, time);
     // self.queue.push() * self.last_update_time.write().await = Instant::now();
   }
-  pub async fn handler(
+  pub fn handler(
     &self,
     percent: f32,
     msg: String,
@@ -131,12 +135,12 @@ impl ProgressPlugin {
     time: Option<Duration>,
   ) {
     if self.options.profile {
-      self.default_handler(percent, msg, state_items, time).await;
+      self.default_handler(percent, msg, state_items, time);
     } else {
       self.progress_bar_handler(percent, msg, state_items);
     }
   }
-  async fn default_handler(
+  fn default_handler(
     &self,
     percentage: f32,
     msg: String,
@@ -146,7 +150,7 @@ impl ProgressPlugin {
     let full_state = [vec![msg.clone()], items.clone()].concat();
     let now = Instant::now();
     {
-      let mut last_state_info = self.last_state_info.write().await;
+      let mut last_state_info = self.last_state_info.write().expect("TODO:");
       // println!("{:?} {:?}", full_state, last_state_info);
       let len = full_state.len().max(last_state_info.len());
       let original_last_state_info_len = last_state_info.len();
@@ -207,18 +211,14 @@ impl ProgressPlugin {
     self.progress_bar.set_position((percent * 100.0) as u64);
   }
 
-  async fn sealing_hooks_report(&self, name: &str) {
-    self
-      .default_handler(
-        0.7
-          + 0.25
-            * (self.sealing_hooks_report_index.load(SeqCst) / self.number_of_sealing_hooks) as f32,
-        "sealing".to_string(),
-        vec![name.to_string()],
-        None,
-      )
-      .await;
-    self.sealing_hooks_report_index.fetch_add(1, SeqCst);
+  fn sealing_hooks_report(&self, name: &str, index: i32) {
+    let number_of_sealing_hooks = 38;
+    self.handler(
+      0.7 + 0.25 * (index / number_of_sealing_hooks) as f32,
+      "sealing".to_string(),
+      vec![name.to_string()],
+      None,
+    );
   }
 }
 #[async_trait::async_trait]
@@ -237,9 +237,47 @@ impl Plugin for ProgressPlugin {
       self.progress_bar.reset();
       self.progress_bar.set_prefix(self.options.prefix.clone());
     }
-    self.handler(0.01, String::from("make"), vec![], None).await;
+    self.handler(0.01, String::from("make"), vec![], None);
     self.modules_count.store(0, SeqCst);
     self.modules_done.store(0, SeqCst);
+    Ok(())
+  }
+
+  async fn before_compile(&self, _params: &CompilationParams) -> Result<()> {
+    self.handler(
+      0.06,
+      "setup".to_string(),
+      vec!["before compile".to_string()],
+      None,
+    );
+    Ok(())
+  }
+
+  async fn this_compilation(
+    &self,
+    _args: ThisCompilationArgs<'_>,
+    _params: &CompilationParams,
+  ) -> PluginThisCompilationHookOutput {
+    self.handler(
+      0.08,
+      "setup".to_string(),
+      vec!["compilation".to_string()],
+      None,
+    );
+    Ok(())
+  }
+
+  async fn compilation(
+    &self,
+    _args: CompilationArgs<'_>,
+    _params: &CompilationParams,
+  ) -> PluginCompilationHookOutput {
+    self.handler(
+      0.09,
+      "setup".to_string(),
+      vec!["compilation".to_string()],
+      None,
+    );
     Ok(())
   }
 
@@ -270,13 +308,10 @@ impl Plugin for ProgressPlugin {
   // }
 
   async fn build_module(&self, module: &mut dyn Module) -> Result<()> {
-    if let Some(module) = module.as_normal_module() {
-      self.last_active_module.write().await.replace(module.id());
-    }
     self
       .active_modules
       .write()
-      .await
+      .expect("TODO:")
       .insert(module.identifier(), Instant::now());
     self.modules_count.fetch_add(1, SeqCst);
     // self.update().await;
@@ -301,47 +336,85 @@ impl Plugin for ProgressPlugin {
     self
       .last_active_module
       .write()
-      .await
+      .expect("TODO:")
       .replace(module.identifier());
 
     let time = self
       .active_modules
       .read()
-      .await
+      .expect("TODO:")
       .get(&module.identifier())
       .map(|time| Instant::now() - *time);
-    self.update(time).await;
+    self.update(time);
     // } else if self.modules_done.load(SeqCst) < 50 || self.modules_done.load(SeqCst) % 100 == 0 {
     //   self.update_throttled();
     // }
-    let mut last_active_module = Default::default();
-    let active_modules = self.active_modules.read().await;
-    active_modules.iter().for_each(|(module, _)| {
-      last_active_module = module.clone();
-    });
-    self
-      .last_active_module
-      .write()
-      .await
-      .replace(last_active_module);
+    let mut active_modules = self.active_modules.write().expect("TODO:");
+    active_modules.remove(&module.identifier());
+    Ok(())
+  }
+
+  async fn finish_make(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.handler(
+      0.69,
+      "building".to_string(),
+      vec!["finish make".to_string()],
+      None,
+    );
     Ok(())
   }
 
   async fn finish_modules(&self, _modules: &mut Compilation) -> Result<()> {
-    self.sealing_hooks_report("finish modules").await;
+    self.sealing_hooks_report("finish modules", 0);
     Ok(())
   }
 
-  // TODO: entries count
+  fn seal(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.sealing_hooks_report("plugins", 1);
+    Ok(())
+  }
+
+  async fn optimize_dependencies(&self, _compilation: &mut Compilation) -> Result<Option<()>> {
+    self.sealing_hooks_report("dependencies", 2);
+    Ok(None)
+  }
+
+  async fn optimize_modules(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.sealing_hooks_report("module optimization", 7);
+    Ok(())
+  }
+
+  async fn after_optimize_modules(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.sealing_hooks_report("after module optimization", 8);
+    Ok(())
+  }
 
   async fn optimize_chunks(
     &self,
     _ctx: PluginContext,
     _args: OptimizeChunksArgs<'_>,
   ) -> PluginOptimizeChunksOutput {
-    self
-      .handler(0.8, String::from("optimizing chunks"), vec![], None)
-      .await;
+    self.sealing_hooks_report("chunk optimization", 9);
+    Ok(())
+  }
+
+  async fn optimize_tree(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.sealing_hooks_report("module and chunk tree optimization", 11);
+    Ok(())
+  }
+
+  async fn optimize_chunk_modules(&self, _args: OptimizeChunksArgs<'_>) -> Result<()> {
+    self.sealing_hooks_report("chunk modules optimization", 13);
+    Ok(())
+  }
+
+  fn module_ids(&self, _modules: &mut Compilation) -> Result<()> {
+    self.sealing_hooks_report("module ids", 16);
+    Ok(())
+  }
+
+  fn chunk_ids(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.sealing_hooks_report("chunk ids", 21);
     Ok(())
   }
 
@@ -350,10 +423,31 @@ impl Plugin for ProgressPlugin {
     _ctx: PluginContext,
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
-    self
-      .handler(0.9, String::from("processing assets"), vec![], None)
-      .await;
+    self.sealing_hooks_report("asset processing", 35);
+    Ok(())
+  }
 
+  async fn after_process_assets(
+    &self,
+    _ctx: PluginContext,
+    _args: ProcessAssetsArgs<'_>,
+  ) -> PluginProcessAssetsOutput {
+    self.sealing_hooks_report("after asset optimization", 36);
+    Ok(())
+  }
+
+  async fn emit(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.handler(0.98, "emitting".to_string(), vec!["emit".to_string()], None);
+    Ok(())
+  }
+
+  async fn after_emit(&self, _compilation: &mut Compilation) -> Result<()> {
+    self.handler(
+      0.98,
+      "emitting".to_string(),
+      vec!["after emit".to_string()],
+      None,
+    );
     Ok(())
   }
 
@@ -362,12 +456,14 @@ impl Plugin for ProgressPlugin {
     _ctx: PluginContext,
     _args: DoneArgs<'s, 'c>,
   ) -> PluginBuildEndHookOutput {
-    self.handler(1.0, String::from("done"), vec![], None).await;
+    self.handler(1.0, String::from("done"), vec![], None);
+    self.handler(1.0, String::from(""), vec![], None);
     if !self.options.profile {
       self.progress_bar.finish();
     }
-    *self.last_modules_count.write().await = Some(self.modules_count.load(SeqCst));
-    *self.last_dependencies_count.write().await = Some(self.dependencies_count.load(SeqCst));
+    *self.last_modules_count.write().expect("TODO:") = Some(self.modules_count.load(SeqCst));
+    *self.last_dependencies_count.write().expect("TODO:") =
+      Some(self.dependencies_count.load(SeqCst));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -402,7 +402,6 @@ impl Plugin for ProgressPlugin {
     _args: DoneArgs<'s, 'c>,
   ) -> PluginBuildEndHookOutput {
     self.handler(1.0, String::from("done"), vec![], None);
-    self.handler(1.0, String::from(""), vec![], None);
     if !self.options.profile {
       self.progress_bar.finish();
     }

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -4,13 +4,12 @@ use std::{cmp, sync::atomic::AtomicU32, time::Instant};
 
 use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspack_core::{
-  BoxModule, Compilation, DoneArgs, FactorizeArgs, MakeParam, Module, NormalModuleCreateData,
-  OptimizeChunksArgs, Plugin, PluginBuildEndHookOutput, PluginContext, PluginFactorizeHookOutput,
-  PluginMakeHookOutput, PluginNormalModuleFactoryModuleHookOutput, PluginOptimizeChunksOutput,
+  Compilation, DoneArgs, MakeParam, Module, ModuleIdentifier, OptimizeChunksArgs, Plugin,
+  PluginBuildEndHookOutput, PluginContext, PluginMakeHookOutput, PluginOptimizeChunksOutput,
   PluginProcessAssetsOutput, ProcessAssetsArgs,
 };
 use rspack_error::Result;
-use rustc_hash::FxHashSet as HashSet;
+use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Clone, Default)]
@@ -28,14 +27,15 @@ pub struct ProgressPlugin {
   pub dependencies_done: AtomicU32,
   pub modules_count: AtomicU32,
   pub modules_done: AtomicU32,
-  pub active_modules: RwLock<HashSet<String>>,
+  pub active_modules: RwLock<HashMap<ModuleIdentifier, Instant>>,
   pub last_modules_count: RwLock<Option<u32>>,
   pub last_dependencies_count: RwLock<Option<u32>>,
-  pub last_active_module: RwLock<Option<String>>,
+  pub last_active_module: RwLock<Option<ModuleIdentifier>>,
   pub last_state_info: RwLock<Vec<ProgressPluginStateInfo>>,
   pub last_update_time: RwLock<Instant>,
   pub sealing_hooks_report_index: AtomicU32,
   pub number_of_sealing_hooks: u32,
+  pub queue: Vec<String>,
 }
 #[derive(Debug)]
 pub struct ProgressPluginStateInfo {
@@ -61,7 +61,7 @@ impl ProgressPlugin {
       dependencies_count: AtomicU32::new(0),
       dependencies_done: AtomicU32::new(0),
       modules_done: AtomicU32::new(0),
-      active_modules: RwLock::new(HashSet::default()),
+      active_modules: RwLock::new(HashMap::default()),
       last_modules_count: RwLock::new(None),
       last_dependencies_count: RwLock::new(None),
       last_active_module: RwLock::new(None),
@@ -69,15 +69,16 @@ impl ProgressPlugin {
       last_update_time: RwLock::new(Instant::now()),
       sealing_hooks_report_index: AtomicU32::new(0),
       number_of_sealing_hooks: 20,
+      queue: vec![],
     }
   }
   pub async fn update_throttled(&self) {
     if *self.last_update_time.read().await + Duration::from_millis(50) < Instant::now() {
-      self.update();
+      self.update(None).await;
     }
     // *self.last_update_time.write().expect("TODO:") = Instant::now();
   }
-  async fn update(&self) {
+  async fn update(&self, time: Option<Duration>) {
     let modules_done = self.modules_done.load(SeqCst);
     let dependencies_done = self.dependencies_done.load(SeqCst);
     let percent_by_module = (modules_done as f32)
@@ -97,6 +98,7 @@ impl ProgressPlugin {
     let mut items = vec![];
     let mut stat_items = vec![];
     {
+      // TODO: dependencies_done modules_done report
       // stat_items.push(format!(
       //   "{}/{} dependencies",
       //   dependencies_done,
@@ -112,28 +114,40 @@ impl ProgressPlugin {
       let last_active_module = self.last_active_module.read().await;
 
       if let Some(last_active_module) = last_active_module.clone() {
-        items.push(last_active_module);
+        items.push(last_active_module.to_string());
       }
     }
 
     self
-      .handler(0.1 + percent * 0.55, String::from("building"), items)
+      .handler(0.1 + percent * 0.55, String::from("building"), items, time)
       .await;
-    *self.last_update_time.write().await = Instant::now();
+    // self.queue.push() * self.last_update_time.write().await = Instant::now();
   }
-  pub async fn handler(&self, percent: f32, msg: String, state_items: Vec<String>) {
+  pub async fn handler(
+    &self,
+    percent: f32,
+    msg: String,
+    state_items: Vec<String>,
+    time: Option<Duration>,
+  ) {
     if self.options.profile {
-      self.default_handler(percent, msg, state_items).await;
+      self.default_handler(percent, msg, state_items, time).await;
     } else {
       self.progress_bar_handler(percent, msg, state_items);
     }
   }
-  async fn default_handler(&self, percentage: f32, msg: String, items: Vec<String>) {
+  async fn default_handler(
+    &self,
+    percentage: f32,
+    msg: String,
+    items: Vec<String>,
+    time: Option<Duration>,
+  ) {
     let full_state = [vec![msg.clone()], items.clone()].concat();
     let now = Instant::now();
     {
       let mut last_state_info = self.last_state_info.write().await;
-      println!("{:?} {:?}", full_state, last_state_info);
+      // println!("{:?} {:?}", full_state, last_state_info);
       let len = full_state.len().max(last_state_info.len());
       let original_last_state_info_len = last_state_info.len();
       for i in (0..len).rev() {
@@ -146,8 +160,11 @@ impl ProgressPlugin {
             },
           )
         } else if i + 1 > full_state.len() || !last_state_info[i].value.eq(&full_state[i]) {
-          let diff = (now - last_state_info[i].time).as_millis();
-
+          let diff = match time {
+            Some(time) => time,
+            _ => now - last_state_info[i].time,
+          }
+          .as_millis();
           let report_state = if i > 0 {
             last_state_info[i - 1].value.clone() + " > " + last_state_info[i].value.clone().as_str()
           } else {
@@ -198,6 +215,7 @@ impl ProgressPlugin {
             * (self.sealing_hooks_report_index.load(SeqCst) / self.number_of_sealing_hooks) as f32,
         "sealing".to_string(),
         vec![name.to_string()],
+        None,
       )
       .await;
     self.sealing_hooks_report_index.fetch_add(1, SeqCst);
@@ -219,61 +237,54 @@ impl Plugin for ProgressPlugin {
       self.progress_bar.reset();
       self.progress_bar.set_prefix(self.options.prefix.clone());
     }
-    self.handler(0.01, String::from("make"), vec![]).await;
+    self.handler(0.01, String::from("make"), vec![], None).await;
     self.modules_count.store(0, SeqCst);
     self.modules_done.store(0, SeqCst);
     Ok(())
   }
 
-  async fn factorize(
-    &self,
-    _ctx: PluginContext,
-    _args: FactorizeArgs<'_>,
-  ) -> PluginFactorizeHookOutput {
-    self.dependencies_count.fetch_add(1, SeqCst);
-    if self.dependencies_count.load(SeqCst) < 50 || self.dependencies_count.load(SeqCst) % 100 == 0
-    {
-      self.update_throttled().await
-    };
-    Ok(None)
-  }
+  // async fn factorize(
+  //   &self,
+  //   _ctx: PluginContext,
+  //   _args: FactorizeArgs<'_>,
+  // ) -> PluginFactorizeHookOutput {
+  //   self.dependencies_count.fetch_add(1, SeqCst);
+  //   if self.dependencies_count.load(SeqCst) < 50 || self.dependencies_count.load(SeqCst) % 100 == 0
+  //   {
+  //     self.update_throttled().await
+  //   };
+  //   Ok(None)
+  // }
 
-  async fn normal_module_factory_module(
-    &self,
-    _ctx: PluginContext,
-    module: BoxModule,
-    _args: &NormalModuleCreateData,
-  ) -> PluginNormalModuleFactoryModuleHookOutput {
-    self.dependencies_done.fetch_add(1, SeqCst);
-    if self.dependencies_done.load(SeqCst) < 50 || self.dependencies_done.load(SeqCst) % 100 == 0 {
-      self.update_throttled().await
-    };
-    Ok(module)
-  }
+  // async fn normal_module_factory_module(
+  //   &self,
+  //   _ctx: PluginContext,
+  //   module: BoxModule,
+  //   _args: &NormalModuleCreateData,
+  // ) -> PluginNormalModuleFactoryModuleHookOutput {
+  //   self.dependencies_done.fetch_add(1, SeqCst);
+  //   if self.dependencies_done.load(SeqCst) < 50 || self.dependencies_done.load(SeqCst) % 100 == 0 {
+  //     self.update_throttled().await
+  //   };
+  //   Ok(module)
+  // }
 
   async fn build_module(&self, module: &mut dyn Module) -> Result<()> {
     if let Some(module) = module.as_normal_module() {
-      self
-        .last_active_module
-        .write()
-        .await
-        .replace(module.id().to_string());
+      self.last_active_module.write().await.replace(module.id());
     }
     self
       .active_modules
       .write()
       .await
-      .insert(module.identifier().to_string());
+      .insert(module.identifier(), Instant::now());
     self.modules_count.fetch_add(1, SeqCst);
-    self.update().await;
+    // self.update().await;
     Ok(())
   }
 
   async fn succeed_module(&self, module: &dyn Module) -> Result<()> {
-    // println!("succeed module {}", module.identifier());
-    let id = module.identifier().to_string();
     self.modules_done.fetch_add(1, SeqCst);
-    let active_modules = self.active_modules.read().await;
     // let mut last_active_module = self.last_active_module.write().expect("TODO:");
     // let mut last_active_module = String::new();
     // active_modules.iter().for_each(|module| {
@@ -287,14 +298,26 @@ impl Plugin for ProgressPlugin {
     //   .as_ref()
     //   .is_some_and(|module| module.eq(&id))
     // {
-    self.last_active_module.write().await.replace(id.clone());
-    // self.update().await;
+    self
+      .last_active_module
+      .write()
+      .await
+      .replace(module.identifier());
+
+    let time = self
+      .active_modules
+      .read()
+      .await
+      .get(&module.identifier())
+      .map(|time| Instant::now() - *time);
+    self.update(time).await;
     // } else if self.modules_done.load(SeqCst) < 50 || self.modules_done.load(SeqCst) % 100 == 0 {
     //   self.update_throttled();
     // }
-    let mut last_active_module = String::new();
-    active_modules.iter().for_each(|module| {
-      last_active_module = module.to_string();
+    let mut last_active_module = Default::default();
+    let active_modules = self.active_modules.read().await;
+    active_modules.iter().for_each(|(module, _)| {
+      last_active_module = module.clone();
     });
     self
       .last_active_module
@@ -317,7 +340,7 @@ impl Plugin for ProgressPlugin {
     _args: OptimizeChunksArgs<'_>,
   ) -> PluginOptimizeChunksOutput {
     self
-      .handler(0.8, String::from("optimizing chunks"), vec![])
+      .handler(0.8, String::from("optimizing chunks"), vec![], None)
       .await;
     Ok(())
   }
@@ -328,7 +351,7 @@ impl Plugin for ProgressPlugin {
     _args: ProcessAssetsArgs<'_>,
   ) -> PluginProcessAssetsOutput {
     self
-      .handler(0.9, String::from("processing assets"), vec![])
+      .handler(0.9, String::from("processing assets"), vec![], None)
       .await;
 
     Ok(())
@@ -339,7 +362,7 @@ impl Plugin for ProgressPlugin {
     _ctx: PluginContext,
     _args: DoneArgs<'s, 'c>,
   ) -> PluginBuildEndHookOutput {
-    self.handler(1.0, String::from("done"), vec![]).await;
+    self.handler(1.0, String::from("done"), vec![], None).await;
     if !self.options.profile {
       self.progress_bar.finish();
     }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
#4973 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
Last time in #3803, we only supported the activeModule report and progress_handler compatibility. However, it had some issues, such as the default_handler not correctly reflecting the build duration. Due to several missing sealing hooks, the process duration wasn't accurate either.

Comparing to webpack, rspack will build modules with mulitple threads, between `build_module` and `succeed_module` , maybe other module will be build in other thread. Now we have `default_handler` and `progress_handler`, and in the future there may be some custom handler from user.
We don't want the progress bar shows "building module2" after module2 build succeed, so we should correct the progress bar message, when module2 `succeed_module`. In code side, I use `linked_hash_map` which can keep the insertion order to record the active modules, so after module2 build succeed, we can get the last active module accroding to the insertion order(I'm not sure whether there has performance problem)
<img width="1233" alt="image" src="https://github.com/web-infra-dev/rspack/assets/87003751/2f1b2d24-a6d7-4bb1-8f80-e2feb692853c">
In profile mode, this mode will print module build message in terminal, we should guarantee module's build time instead of module's build order
<img width="1152" alt="image" src="https://github.com/web-infra-dev/rspack/assets/87003751/4a58e250-6355-4f8a-9c05-776c6695b653">

<img width="1665" alt="image" src="https://github.com/web-infra-dev/rspack/assets/87003751/8f3f4e7e-95ae-43af-b980-2d0eef3d357a">

## Test Plan


## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
