### PR TITLE
chore: remove heavy debug node `util.inspect` call

### DIFF
--- a/packages/rspack/src/rspack.ts
+++ b/packages/rspack/src/rspack.ts
@@ -60,12 +60,6 @@ function createCompiler(userOptions: RspackOptions): Compiler {
 		infrastructureLogging: options.infrastructureLogging
 	}).apply(compiler);
 
-	const logger = compiler.getInfrastructureLogger("config");
-	logger.debug(
-		"RawOptions:",
-		util.inspect(userOptions, { colors: true, depth: null })
-	);
-
 	if (Array.isArray(options.plugins)) {
 		for (const plugin of options.plugins) {
 			if (typeof plugin === "function") {
@@ -76,10 +70,7 @@ function createCompiler(userOptions: RspackOptions): Compiler {
 		}
 	}
 	applyRspackOptionsDefaults(compiler.options);
-	logger.debug(
-		"NormalizedOptions:",
-		util.inspect(compiler.options, { colors: true, depth: null })
-	);
+
 	compiler.hooks.environment.call();
 	compiler.hooks.afterEnvironment.call();
 	new RspackOptionsApply().process(compiler.options, compiler);
@@ -148,10 +139,8 @@ function rspack(
 	} else {
 		const { compiler, watch } = create();
 		if (watch) {
-			util.deprecate(
-				() => { },
-				"A 'callback' argument needs to be provided to the 'rspack(options, callback)' function when the 'watch' option is set. There is no way to handle the 'watch' option without a callback."
-			)();
+			util.deprecate(() => {},
+			"A 'callback' argument needs to be provided to the 'rspack(options, callback)' function when the 'watch' option is set. There is no way to handle the 'watch' option without a callback.")();
 		}
 		return compiler;
 	}


### PR DESCRIPTION
closes #4996

Saves 80ms.

Do people use this debug? I don't think it's documented anywhere.