### PR TITLE
feat: support eval abstract equal

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -1,5 +1,5 @@
 use super::{BoxJavascriptParserPlugin, JavascriptParserPlugin};
-use crate::utils::BasicEvaluatedExpression;
+use crate::utils::eval::BasicEvaluatedExpression;
 
 pub struct JavaScriptParserPluginDrive {
   plugins: Vec<BoxJavascriptParserPlugin>,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -1,4 +1,4 @@
-use crate::utils::BasicEvaluatedExpression;
+use crate::utils::eval::BasicEvaluatedExpression;
 
 pub trait JavascriptParserPlugin {
   fn evaluate_typeof(

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
@@ -1,0 +1,26 @@
+use rspack_core::SpanExt;
+use swc_core::ecma::ast::ArrayLit;
+
+use super::BasicEvaluatedExpression;
+use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
+
+pub fn eval_array_expression<'a>(
+  scanner: &'a CommonJsImportDependencyScanner<'a>,
+  expr: &'a ArrayLit,
+) -> Option<BasicEvaluatedExpression> {
+  let mut items = vec![];
+
+  for elem in &expr.elems {
+    if let Some(elem) = elem
+      && elem.spread.is_none()
+    {
+      items.push(scanner.evaluate_expression(&elem.expr));
+    } else {
+      return None;
+    }
+  }
+
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+  res.set_items(items);
+  Some(res)
+}

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -1,7 +1,7 @@
 use rspack_core::SpanExt;
 use swc_core::ecma::ast::{BinExpr, BinaryOp};
 
-use crate::utils::BasicEvaluatedExpression;
+use crate::utils::eval::BasicEvaluatedExpression;
 use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 
 /// `eql` is `true` for `===` and `false` for `!==`
@@ -25,12 +25,39 @@ fn handle_strict_equality_comparison<'a>(
     None
   }
 }
+/// `eql` is `true` for `==` and `false` for `!=`
+fn handle_abstract_equality_comparison<'a>(
+  eql: bool,
+  expr: &'a BinExpr,
+  scanner: &'a CommonJsImportDependencyScanner<'a>,
+) -> Option<BasicEvaluatedExpression> {
+  let left = scanner.evaluate_expression(&expr.left);
+  let right = scanner.evaluate_expression(&expr.right);
+  let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi().0);
+
+  let left_const = left.is_compile_time_value();
+  let right_const = right.is_compile_time_value();
+
+  if left_const && right_const {
+    res.set_bool(eql == left.compare_compile_time_value(&right));
+    res.set_side_effects(left.could_have_side_effects() || right.could_have_side_effects());
+    Some(res)
+  } else if left.is_array() && right.is_array() {
+    res.set_bool(!eql);
+    res.set_side_effects(left.could_have_side_effects() || right.could_have_side_effects());
+    Some(res)
+  } else {
+    None
+  }
+}
 
 pub fn eval_binary_expression<'a>(
   scanner: &'a CommonJsImportDependencyScanner<'a>,
   expr: &'a BinExpr,
 ) -> Option<BasicEvaluatedExpression> {
   match expr.op {
+    BinaryOp::EqEq => handle_abstract_equality_comparison(true, expr, scanner),
+    BinaryOp::NotEq => handle_abstract_equality_comparison(false, expr, scanner),
     BinaryOp::EqEqEq => handle_strict_equality_comparison(true, expr, scanner),
     BinaryOp::NotEqEq => handle_strict_equality_comparison(false, expr, scanner),
     _ => None,

--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -1,5 +1,5 @@
 mod r#const;
-mod eval;
+pub mod eval;
 mod get_prop_from_obj;
 pub mod mangle_exports;
 
@@ -12,10 +12,6 @@ use swc_core::common::{SourceFile, Span, Spanned};
 use swc_core::ecma::parser::Syntax;
 use swc_core::ecma::parser::{EsConfig, TsConfig};
 
-pub(crate) use self::eval::{
-  eval_binary_expression, eval_cond_expression, eval_lit_expr, eval_tpl_expression,
-  eval_unary_expression, evaluate_to_string, BasicEvaluatedExpression,
-};
 pub use self::get_prop_from_obj::*;
 pub use self::r#const::*;
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -13,11 +13,8 @@ use crate::dependency::{CommonJsRequireDependency, RequireResolveDependency};
 use crate::parser_plugin::{
   BoxJavascriptParserPlugin, JavaScriptParserPluginDrive, JavascriptParserPlugin,
 };
-use crate::utils::{
-  eval_binary_expression, eval_cond_expression, eval_lit_expr, eval_tpl_expression,
-  eval_unary_expression, evaluate_to_string, expression_logic_operator, BasicEvaluatedExpression,
-  Continue,
-};
+use crate::utils::eval::{self, BasicEvaluatedExpression};
+use crate::utils::{expression_logic_operator, Continue};
 
 struct CommonJsImportsParserPlugin;
 
@@ -30,7 +27,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     unresolved_mark: swc_core::common::SyntaxContext,
   ) -> Option<BasicEvaluatedExpression> {
     if expression.sym.as_str() == "require" && expression.span.ctxt == unresolved_mark {
-      Some(evaluate_to_string("function".to_string(), start, end))
+      Some(eval::evaluate_to_string("function".to_string(), start, end))
     } else {
       None
     }
@@ -294,11 +291,12 @@ impl CommonJsImportDependencyScanner<'_> {
   // FIXME: should mv it to plugin
   fn evaluating(&self, expr: &Expr) -> Option<BasicEvaluatedExpression> {
     match expr {
-      Expr::Tpl(tpl) => eval_tpl_expression(self, tpl),
-      Expr::Lit(lit) => eval_lit_expr(lit),
-      Expr::Cond(cond) => eval_cond_expression(self, cond),
-      Expr::Unary(unary) => eval_unary_expression(self, unary),
-      Expr::Bin(binary) => eval_binary_expression(self, binary),
+      Expr::Tpl(tpl) => eval::eval_tpl_expression(self, tpl),
+      Expr::Lit(lit) => eval::eval_lit_expr(lit),
+      Expr::Cond(cond) => eval::eval_cond_expression(self, cond),
+      Expr::Unary(unary) => eval::eval_unary_expression(self, unary),
+      Expr::Bin(binary) => eval::eval_binary_expression(self, binary),
+      Expr::Array(array) => eval::eval_array_expression(self, array),
       _ => None,
     }
   }

--- a/packages/rspack/tests/cases/parsing/issue-4816/index.js
+++ b/packages/rspack/tests/cases/parsing/issue-4816/index.js
@@ -27,5 +27,18 @@ it("should build success for logic op", () => {
 	expect(typeof require !== "function" && require("fail")).toBe(false);
 	expect(true && require("./a")).toBe("a");
 	expect(typeof require === "function" && require("./a")).toBe("a");
+
 	expect(!require("./a") && !require("./b")).toBe(false);
+
+	expect("hello" && (() => "value5")()).toBe("value5");
+	expect("" || (() => "value6")()).toBe("value6");
+	expect(
+		(function () {
+			return "value7" === typeof "value7" && "value7";
+		})()
+	).toBe(false);
+	expect([] != [] || require("fail")).toBe(true);
+	expect(null === 1 && require("fail")).toBe(false);
+	// NEXT:
+	// expect([] === [] && require("fail")).toBe(false);
 });


### PR DESCRIPTION
Related to #4424 

Now, we can use `[] != [] || require("fail")`