### PR TITLE
feat: diagnostics in overlay

### DIFF
--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -184,7 +184,7 @@ impl JsCompilation {
       Some(module) => match module.as_normal_module_mut() {
         Some(module) => {
           let compat_source = CompatSource::from(source).boxed();
-          *module.source_mut() = NormalModuleSource::new_built(compat_source, &[]);
+          *module.source_mut() = NormalModuleSource::new_built(compat_source, vec![]);
           true
         }
         None => false,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -696,6 +696,8 @@ impl Compilation {
 
               module_graph_module.set_issuer_if_unset(original_module_identifier);
               module_graph_module.factory_meta = Some(factory_result.factory_meta);
+              // TODO: should use `dep.optional` to test whether these diagnostics should be warnings or errors.
+              // https://github.com/webpack/webpack/blob/6be4065ade1e252c1d8dcba4af0f43e32af1bdc1/lib/Compilation.js#L1796
               self.push_batch_diagnostic(diagnostics);
 
               self

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -302,11 +302,9 @@ impl Stats<'_> {
       .compilation
       .get_errors()
       .map(|d| StatsError {
-        message: format!(
-          "{message}\n{labels}",
-          message = d.message(),
-          labels = d.labels_string().unwrap_or_default()
-        ),
+        message: diagnostic_displayer
+          .emit_diagnostic(d)
+          .expect("should print diagnostics"),
         formatted: diagnostic_displayer
           .emit_diagnostic(d)
           .expect("should print diagnostics"),
@@ -320,11 +318,9 @@ impl Stats<'_> {
       .compilation
       .get_warnings()
       .map(|d| StatsWarning {
-        message: format!(
-          "{message}\n{labels}",
-          message = d.message(),
-          labels = d.labels_string().unwrap_or_default()
-        ),
+        message: diagnostic_displayer
+          .emit_diagnostic(d)
+          .expect("should print diagnostics"),
         formatted: diagnostic_displayer
           .emit_diagnostic(d)
           .expect("should print diagnostics"),

--- a/crates/rspack_error/src/diagnostic.rs
+++ b/crates/rspack_error/src/diagnostic.rs
@@ -1,6 +1,6 @@
 use std::{fmt, ops::Deref, sync::Arc};
 
-use miette::MietteDiagnostic;
+use miette::{GraphicalReportHandler, GraphicalTheme, IntoDiagnostic, MietteDiagnostic};
 
 use crate::Error;
 
@@ -63,20 +63,19 @@ impl Deref for Diagnostic {
 }
 
 impl Diagnostic {
-  pub fn message(&self) -> String {
-    self.0.to_string()
+  pub fn render_report(&self, colored: bool) -> crate::Result<String> {
+    let h = GraphicalReportHandler::new().with_theme(if colored {
+      GraphicalTheme::unicode()
+    } else {
+      GraphicalTheme::unicode_nocolor()
+    });
+    let mut buf = String::new();
+    h.render_report(&mut buf, self.as_ref()).into_diagnostic()?;
+    Ok(buf)
   }
 
-  pub fn labels_string(&self) -> Option<String> {
-    self
-      .0
-      .labels()
-      .map(|l| {
-        l.into_iter()
-          .filter_map(|l| l.label().map(ToString::to_string))
-          .collect::<Vec<_>>()
-      })
-      .map(|s| s.join("\n"))
+  pub fn message(&self) -> String {
+    self.0.to_string()
   }
 
   pub fn severity(&self) -> Severity {

--- a/crates/rspack_error/src/emitter.rs
+++ b/crates/rspack_error/src/emitter.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Context;
-use miette::{GraphicalReportHandler, GraphicalTheme, IntoDiagnostic};
+use miette::IntoDiagnostic;
 use termcolor::{Buffer, ColorSpec, StandardStreamLock, WriteColor};
 use termcolor::{ColorChoice, StandardStream};
 
@@ -157,14 +157,7 @@ fn emit_diagnostic<T: Write + WriteColor>(
   diagnostic: &Diagnostic,
   writer: &mut T,
 ) -> crate::Result<()> {
-  let h = GraphicalReportHandler::new().with_theme(if writer.supports_color() {
-    GraphicalTheme::unicode()
-  } else {
-    GraphicalTheme::unicode_nocolor()
-  });
-  let mut buf = String::new();
-  h.render_report(&mut buf, diagnostic.as_ref())
-    .into_diagnostic()?;
+  let buf = diagnostic.render_report(writer.supports_color())?;
   writer.write_all(buf.as_bytes()).into_diagnostic()?;
   // reset to original color after emitting a diagnostic, this avoids interference stdio of other procedure.
   writer.reset().into_diagnostic()?;

--- a/packages/rspack/tests/Compiler.test.ts
+++ b/packages/rspack/tests/Compiler.test.ts
@@ -1272,7 +1272,7 @@ describe("Compiler", () => {
 			compiler.build(err => {
 				const stats = new Stats(compiler.compilation);
 				expect(stats.toJson().errors[0].message).toMatchInlineSnapshot(`
-			"Conflict: Multiple assets emit different content to the same filename main.js
+			"  × Conflict: Multiple assets emit different content to the same filename main.js
 			"
 		`);
 				done();

--- a/packages/rspack/tests/Errors.test.ts
+++ b/packages/rspack/tests/Errors.test.ts
@@ -143,7 +143,7 @@ it("should emit warnings for resolve failure in esm", async () => {
 		  "errors": Array [
 		    Object {
 		      "formatted": "  × Error[internal]: Resolve error\\n   ╭─[tests/fixtures/errors/resolve-fail-esm/index.js:1:1]\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
-		      "message": "Error[internal]: Resolve error\\nFailed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js",
+		      "message": "  × Error[internal]: Resolve error\\n   ╭─[tests/fixtures/errors/resolve-fail-esm/index.js:1:1]\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
 		    },
 		  ],
 		  "warnings": Array [],

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -60,8 +60,8 @@ describe("Stats", () => {
 			stats?.toString({ timings: false, version: false }).replace(/\\/g, "/")
 		).toMatchInlineSnapshot(`
 		"PublicPath: auto
-		asset main.js 464 bytes [emitted] (name: main)
-		Entrypoint main 464 bytes = main.js
+		asset main.js 634 bytes [emitted] (name: main)
+		Entrypoint main 634 bytes = main.js
 		./fixtures/a.js
 		./fixtures/b.js
 		./fixtures/c.js
@@ -76,7 +76,7 @@ describe("Stats", () => {
 		   ╰────
 
 
-		Rspack compiled with 1 error (d102369880762d1e05db)"
+		Rspack compiled with 1 error (ae9cd940d0424968e31c)"
 	`);
 	});
 

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1085,8 +1085,13 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
    ·            ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 ",
-      "message": "Error[javascript]: JavaScript parsing error
-\`let\` cannot be used as an identifier in strict mode",
+      "message": "  × Error[javascript]: JavaScript parsing error
+   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+ 1 │ let let = let;
+   ·           ─┬─
+   ·            ╰── \`let\` cannot be used as an identifier in strict mode
+   ╰────
+",
     },
     {
       "formatted": "  × Error[javascript]: JavaScript parsing error
@@ -1096,8 +1101,13 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
    ·      ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 ",
-      "message": "Error[javascript]: JavaScript parsing error
-\`let\` cannot be used as an identifier in strict mode",
+      "message": "  × Error[javascript]: JavaScript parsing error
+   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+ 1 │ let let = let;
+   ·     ─┬─
+   ·      ╰── \`let\` cannot be used as an identifier in strict mode
+   ╰────
+",
     },
   ],
   "errorsCount": 2,
@@ -4092,7 +4102,9 @@ exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin
 
   ⚠ Experimental plugins are not currently supported.
 ",
-      "message": "Experimental plugins are not currently supported.
+      "message": "builtin:swc-loader
+
+  ⚠ Experimental plugins are not currently supported.
 ",
     },
   ],
@@ -4168,8 +4180,14 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
  2 │ (function() {
    ╰────
 ",
-      "message": "Error[javascript]: JavaScript parsing error
-Expected a semicolon",
+      "message": "  × Error[javascript]: JavaScript parsing error
+   ╭─[bundle.js:1:1]
+ 1 │ const a {}
+   ·         ┬
+   ·         ╰── Expected a semicolon
+ 2 │ (function() {
+   ╰────
+",
     },
   ],
   "errorsCount": 1,
@@ -4256,8 +4274,13 @@ exports[`StatsTestCases should print correct stats for normal-errors 1`] = `
    ·          ╰── Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
    ╰────
 ",
-      "message": "Error[internal]: Resolve error
-Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js",
+      "message": "  × Error[internal]: Resolve error
+   ╭─[tests/statsCases/normal-errors/index.js:1:1]
+ 1 │ import "not-exist";
+   · ─────────┬─────────
+   ·          ╰── Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
+   ╰────
+",
     },
   ],
   "errorsCount": 1,
@@ -4858,8 +4881,15 @@ exports[`StatsTestCases should print correct stats for parse-error 1`] = `
  7 │ error
    ╰────
 ",
-      "message": "Error[javascript]: JavaScript parsing error
-Expected ';', '}' or <eof>",
+      "message": "  × Error[javascript]: JavaScript parsing error
+   ╭─[tests/statsCases/parse-error/b.js:5:1]
+ 5 │ a
+ 6 │ parser )
+   ·        ┬
+   ·        ╰── Expected ';', '}' or <eof>
+ 7 │ error
+   ╰────
+",
     },
   ],
   "errorsCount": 1,
@@ -4896,13 +4926,14 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
   │ 
   ╰─▶ Syntax Error
 ",
-      "message": "
-  x Expected '{', got 'error'
-   ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
- 1 | export error;
-   :        ^^^^^
-   \`----
-
+      "message": "  × 
+  │   x Expected '{', got 'error'
+  │    ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
+  │  1 | export error;
+  │    :        ^^^^^
+  │    \`----
+  │ 
+  ╰─▶ Syntax Error
 ",
     },
   ],
@@ -5126,8 +5157,14 @@ console.log(a);
  2 │ console.log(a);
    ╰────
 ",
-      "message": "Error[internal]: Resolve error
-Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias",
+      "message": "  × Error[internal]: Resolve error
+   ╭─[tests/statsCases/resolve-overflow/index.js:1:1]
+ 1 │ import { a } from "cycle-alias/a";
+   · ─────────────────┬────────────────
+   ·                  ╰── Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias
+ 2 │ console.log(a);
+   ╰────
+",
     },
   ],
   "errorsCount": 1,
@@ -5471,7 +5508,7 @@ console.log(a);
     {
       "formatted": "  × Export should be relative path and start with "./", but got ../../index.js
 ",
-      "message": "Export should be relative path and start with "./", but got ../../index.js
+      "message": "  × Export should be relative path and start with "./", but got ../../index.js
 ",
     },
   ],
@@ -6547,8 +6584,15 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
  4 │     
    ╰────
 ",
-      "message": "Warning[internal]: Resolve error
-Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js",
+      "message": "  ⚠ Warning[internal]: Resolve error
+   ╭─[tests/statsCases/try-require--module/index.js:1:1]
+ 1 │     try {
+ 2 │ ╭─▶     require('./missing-module')
+ 3 │ ├─▶ } catch (e) {
+   · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js
+ 4 │     
+   ╰────
+",
     },
   ],
   "warningsCount": 1,
@@ -6585,8 +6629,15 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
  4 │     
    ╰────
 ",
-      "message": "Warning[internal]: Resolve error
-Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js",
+      "message": "  ⚠ Warning[internal]: Resolve error
+   ╭─[tests/statsCases/try-require-resolve-module/index.js:1:1]
+ 1 │     try {
+ 2 │ ╭─▶     require.resolve('./missing-module')
+ 3 │ ├─▶ } catch (e) {
+   · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js
+ 4 │     
+   ╰────
+",
     },
   ],
   "warningsCount": 1,
@@ -6623,8 +6674,15 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
  4 │     
    ╰────
 ",
-      "message": "Warning[internal]: Resolve error
-Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js",
+      "message": "  ⚠ Warning[internal]: Resolve error
+   ╭─[tests/statsCases/try-require-resolve-weak-module/index.js:1:1]
+ 1 │     try {
+ 2 │ ╭─▶     require.resolveWeak('./missing-module')
+ 3 │ ├─▶ } catch (e) {
+   · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js
+ 4 │     
+   ╰────
+",
     },
   ],
   "warningsCount": 1,

--- a/webpack-test/configCases/plugins/environment-plugin/errors-sort.js
+++ b/webpack-test/configCases/plugins/environment-plugin/errors-sort.js
@@ -13,6 +13,9 @@ module.exports = function (arr) {
 			return -1
 		}
 
-		return a.message.localeCompare(b.message);
+		// Sort errors with label, as `error.message` may contain different span locations,
+		// thus resulting the final message not stable.
+		let RE = /Failed to resolve (\w+)/;
+		return a.message.match(RE)[1].localeCompare(b.message.match(RE)[1])
 	});
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Rspack and webpack both have different errors for module.
This PR replaced the error for `message` of `StatsError` with `miette::Diagnostic` to make error more likely as Webpack's.

The example below show the difference between Webpack and Rspack's `ModuleParseError`. Currently, Rspack does not implement fine-grained error. This will be improved one by one.


Rspack:
<img width="617" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/d56a505f-27eb-4718-a4b0-8500603d7584">
Webpack:
<img width="614" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/cd1e46eb-367e-4bef-ac1c-a36958d6909b">


## Test Plan

See snapshot changes.

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
