### PR TITLE
fix: unnecessary import runtime code from css_loading_with_loading.js

### DIFF
--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -201,6 +201,9 @@ pub fn render_runtime_modules(
     .collect::<Vec<_>>();
   runtime_modules.sort_unstable_by_key(|(_, m)| m.stage());
   runtime_modules.iter().for_each(|((_, source), module)| {
+    if source.size() == 0 {
+      return;
+    }
     if is_diff_mode() {
       sources.add(RawSource::from(format!(
         "/* start::{} */\n",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Avoid importing runtime code from `css_loading_with_loading.js` when no CSS files are imported.

The relevant code lines in the webpack can be found here: https://github.com/webpack/webpack/blob/main/lib/css/CssLoadingRuntimeModule.js#L87

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
