### PR TITLE
feat: add module parse error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,6 +2646,7 @@ dependencies = [
  "rspack_binding_options",
  "rspack_core",
  "rspack_fs",
+ "rspack_identifier",
  "rspack_sources",
  "rspack_testing",
  "rspack_tracing",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -441,6 +441,9 @@ export interface JsStatsChunkGroupAsset {
 export interface JsStatsError {
   message: string
   formatted: string
+  moduleIdentifier?: string
+  moduleName?: string
+  moduleId?: string
 }
 
 export interface JsStatsGetAssets {
@@ -502,6 +505,9 @@ export interface JsStatsModuleReason {
 export interface JsStatsWarning {
   message: string
   formatted: string
+  moduleIdentifier?: string
+  moduleName?: string
+  moduleId?: string
 }
 
 export interface NodeFS {

--- a/crates/rspack_binding_values/src/stats.rs
+++ b/crates/rspack_binding_values/src/stats.rs
@@ -13,6 +13,9 @@ use super::{JsCompilation, ToJsCompatSource};
 pub struct JsStatsError {
   pub message: String,
   pub formatted: String,
+  pub module_identifier: Option<String>,
+  pub module_name: Option<String>,
+  pub module_id: Option<String>,
 }
 
 impl From<rspack_core::StatsError> for JsStatsError {
@@ -20,6 +23,9 @@ impl From<rspack_core::StatsError> for JsStatsError {
     Self {
       message: stats.message,
       formatted: stats.formatted,
+      module_identifier: stats.module_identifier,
+      module_name: stats.module_name,
+      module_id: stats.module_id,
     }
   }
 }
@@ -28,6 +34,9 @@ impl From<rspack_core::StatsError> for JsStatsError {
 pub struct JsStatsWarning {
   pub message: String,
   pub formatted: String,
+  pub module_identifier: Option<String>,
+  pub module_name: Option<String>,
+  pub module_id: Option<String>,
 }
 
 impl From<rspack_core::StatsWarning> for JsStatsWarning {
@@ -35,6 +44,9 @@ impl From<rspack_core::StatsWarning> for JsStatsWarning {
     Self {
       message: stats.message,
       formatted: stats.formatted,
+      module_identifier: stats.module_identifier,
+      module_name: stats.module_name,
+      module_id: stats.module_id,
     }
   }
 }

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -270,7 +270,14 @@ impl WorkerTask for BuildTask {
           .await
           .unwrap_or_else(|e| panic!("Run succeed_module hook failed: {}", e));
 
-        result.map(|t| (t.with_diagnostic(module.clone_diagnostics()), module))
+        result.map(|t| {
+          let diagnostics = module
+            .clone_diagnostics()
+            .into_iter()
+            .map(|d| d.with_module_identifier(Some(module.identifier())))
+            .collect();
+          (t.with_diagnostic(diagnostics), module)
+        })
       })
       .await
     {

--- a/crates/rspack_core/src/diagnostics.rs
+++ b/crates/rspack_core/src/diagnostics.rs
@@ -1,0 +1,94 @@
+use std::fmt::Display;
+
+use itertools::Itertools;
+use rspack_error::{
+  miette::{self, Diagnostic},
+  thiserror::{self, Error},
+};
+
+use crate::BoxLoader;
+
+///////////////////// Module /////////////////////
+
+/// Represent any errors or warnings during module parse
+/// This does NOT aligned with webpack as webpack does not have parse warning.
+/// However, rspack may create warning during parsing stage, taking CSS as an example.
+#[derive(Debug, Error)]
+#[error("{title}")]
+pub struct ModuleParseError {
+  message: String,
+  title: &'static str,
+  help: String,
+  #[source]
+  source: Box<dyn Diagnostic + Send + Sync>,
+}
+
+impl miette::Diagnostic for ModuleParseError {
+  // Passthrough the severity
+  fn severity(&self) -> Option<miette::Severity> {
+    self.source.severity()
+  }
+
+  fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    match self.severity().unwrap_or(miette::Severity::Error) {
+      miette::Severity::Advice => unreachable!("miette::Severity::Advice should not be used"),
+      miette::Severity::Warning => Some(Box::new("ModuleParseWarning")),
+      miette::Severity::Error => Some(Box::new("ModuleParseError")),
+    }
+  }
+
+  fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+    if self.help.is_empty() {
+      return None;
+    }
+    Some(Box::new(&self.help))
+  }
+
+  fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+    Some(&*self.source)
+  }
+}
+
+impl ModuleParseError {
+  pub fn new(source: Box<dyn Diagnostic + Send + Sync>, loaders: &[BoxLoader]) -> Self {
+    let message = source.to_string();
+    let mut help = String::new();
+    let mut title = "Module parse failed:";
+    if source.severity().unwrap_or(miette::Severity::Error) >= miette::Severity::Error {
+      if loaders.is_empty() {
+        help = format!("{help}\nYou may need an appropriate loader to handle this file type.");
+      } else if !loaders.is_empty() {
+        let s = loaders
+          .iter()
+          .map(|l| {
+            let l = l.identifier().to_string();
+            format!("\n * {l}")
+          })
+          .join("");
+        help = format!("{help}\nFile was processed with these loaders:{s}\nYou may need an additional loader to handle the result of these loaders.");
+      } else {
+        help = "\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://www.rspack.dev/guide/loader.html".to_string();
+      }
+    } else {
+      title = "Module parse warning:"
+    }
+    Self {
+      message,
+      title,
+      help,
+      source,
+    }
+  }
+}
+
+/// Mark boxed errors as [crate::diagnostics::ModuleParseError],
+/// then, map it to diagnostics
+pub fn map_box_diagnostics_to_module_parse_diagnostics(
+  errors: Vec<Box<dyn Diagnostic + Send + Sync + 'static>>,
+  loaders: &[BoxLoader],
+) -> Vec<rspack_error::Diagnostic> {
+  errors
+    .into_iter()
+    .map(|e| rspack_error::miette::Error::new(ModuleParseError::new(e, loaders)).into())
+    .collect()
+}

--- a/crates/rspack_core/src/diagnostics.rs
+++ b/crates/rspack_core/src/diagnostics.rs
@@ -57,7 +57,7 @@ impl ModuleParseError {
     if source.severity().unwrap_or(miette::Severity::Error) >= miette::Severity::Error {
       if loaders.is_empty() {
         help = format!("{help}\nYou may need an appropriate loader to handle this file type.");
-      } else if !loaders.is_empty() {
+      } else {
         let s = loaders
           .iter()
           .map(|l| {
@@ -66,8 +66,6 @@ impl ModuleParseError {
           })
           .join("");
         help = format!("{help}\nFile was processed with these loaders:{s}\nYou may need an additional loader to handle the result of these loaders.");
-      } else {
-        help = "\nYou may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://www.rspack.dev/guide/loader.html".to_string();
       }
     } else {
       title = "Module parse warning:"

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -7,6 +7,7 @@
 
 use std::{fmt, sync::Arc};
 mod dependencies_block;
+pub mod diagnostics;
 pub use dependencies_block::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, DependenciesBlock, DependencyLocation,
 };

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -391,6 +391,7 @@ impl Module for NormalModule {
         module_parser_options: self.parser_options.as_ref(),
         module_type: &self.module_type,
         module_user_request: &self.user_request,
+        loaders: &self.loaders,
         resource_data: &self.resource_data,
         compiler_options: build_context.compiler_options,
         additional_data: loader_result.additional_data,

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -1,24 +1,28 @@
 use std::{collections::HashMap, fmt::Debug};
 
+use derivative::Derivative;
 use rkyv::AlignedVec;
 use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_loader_runner::{AdditionalData, ResourceData};
 use rspack_sources::BoxSource;
 
 use crate::{
-  tree_shaking::visitor::OptimizeAnalyzeResult, AsyncDependenciesBlock, BoxDependency,
+  tree_shaking::visitor::OptimizeAnalyzeResult, AsyncDependenciesBlock, BoxDependency, BoxLoader,
   BuildExtraDataType, BuildInfo, BuildMeta, CodeGenerationData, Compilation, CompilerOptions,
   DependencyTemplate, GeneratorOptions, Module, ModuleDependency, ModuleIdentifier, ModuleType,
   ParserOptions, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct ParseContext<'a> {
   pub source: BoxSource,
   pub module_identifier: ModuleIdentifier,
   pub module_type: &'a ModuleType,
   pub module_user_request: &'a str,
   pub module_parser_options: Option<&'a ParserOptions>,
+  #[derivative(Debug = "ignore")]
+  pub loaders: &'a [BoxLoader],
   pub resource_data: &'a ResourceData,
   pub compiler_options: &'a CompilerOptions,
   pub additional_data: AdditionalData,

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -301,13 +301,29 @@ impl Stats<'_> {
     self
       .compilation
       .get_errors()
-      .map(|d| StatsError {
-        message: diagnostic_displayer
-          .emit_diagnostic(d)
-          .expect("should print diagnostics"),
-        formatted: diagnostic_displayer
-          .emit_diagnostic(d)
-          .expect("should print diagnostics"),
+      .map(|d| {
+        let module_identifier = d.module_identifier();
+        let (module_name, module_id) = module_identifier
+          .and_then(|identifier| {
+            let module = self
+              .compilation
+              .module_graph
+              .module_by_identifier(&identifier)?;
+            Some(get_stats_module_name_and_id(module, self.compilation))
+          })
+          .unzip();
+
+        StatsError {
+          message: diagnostic_displayer
+            .emit_diagnostic(d)
+            .expect("should print diagnostics"),
+          formatted: diagnostic_displayer
+            .emit_diagnostic(d)
+            .expect("should print diagnostics"),
+          module_identifier: module_identifier.map(|i| i.to_string()),
+          module_name,
+          module_id: module_id.flatten(),
+        }
       })
       .collect()
   }
@@ -317,13 +333,29 @@ impl Stats<'_> {
     self
       .compilation
       .get_warnings()
-      .map(|d| StatsWarning {
-        message: diagnostic_displayer
-          .emit_diagnostic(d)
-          .expect("should print diagnostics"),
-        formatted: diagnostic_displayer
-          .emit_diagnostic(d)
-          .expect("should print diagnostics"),
+      .map(|d| {
+        let module_identifier = d.module_identifier();
+        let (module_name, module_id) = module_identifier
+          .and_then(|identifier| {
+            let module = self
+              .compilation
+              .module_graph
+              .module_by_identifier(&identifier)?;
+            Some(get_stats_module_name_and_id(module, self.compilation))
+          })
+          .unzip();
+
+        StatsWarning {
+          message: diagnostic_displayer
+            .emit_diagnostic(d)
+            .expect("should print diagnostics"),
+          formatted: diagnostic_displayer
+            .emit_diagnostic(d)
+            .expect("should print diagnostics"),
+          module_identifier: module_identifier.map(|i| i.to_string()),
+          module_name,
+          module_id: module_id.flatten(),
+        }
       })
       .collect()
   }
@@ -613,12 +645,18 @@ fn get_stats_module_name_and_id(
 pub struct StatsError {
   pub message: String,
   pub formatted: String,
+  pub module_identifier: Option<String>,
+  pub module_name: Option<String>,
+  pub module_id: Option<String>,
 }
 
 #[derive(Debug)]
 pub struct StatsWarning {
   pub message: String,
   pub formatted: String,
+  pub module_identifier: Option<String>,
+  pub module_name: Option<String>,
+  pub module_id: Option<String>,
 }
 
 #[derive(Debug)]

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -8,16 +8,17 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow         = { workspace = true, features = ["backtrace"] }
-futures        = { workspace = true }
-miette         = { version = "5", features = ["fancy"] }
-rspack_sources = { workspace = true }
-rspack_util    = { path = "../rspack_util" }
-serde_json     = { workspace = true }
-sugar_path     = { workspace = true }
-swc_core       = { workspace = true, features = ["common"] }
-termcolor      = "1"
-thiserror      = "1"
+anyhow            = { workspace = true, features = ["backtrace"] }
+futures           = { workspace = true }
+miette            = { version = "5", features = ["fancy"] }
+rspack_identifier = { path = "../rspack_identifier" }
+rspack_sources    = { workspace = true }
+rspack_util       = { path = "../rspack_util" }
+serde_json        = { workspace = true }
+sugar_path        = { workspace = true }
+swc_core          = { workspace = true, features = ["common"] }
+termcolor         = "1"
+thiserror         = "1"
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -3,10 +3,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use miette::{
-  Diagnostic, IntoDiagnostic, LabeledSpan, MietteDiagnostic, NamedSource, SourceCode, SourceSpan,
-};
-use rspack_util::swc::normalize_custom_filename;
+use miette::{Diagnostic, IntoDiagnostic, LabeledSpan, MietteDiagnostic, SourceCode, SourceSpan};
 use sugar_path::SugarPath;
 use swc_core::common::SourceFile;
 use thiserror::Error;
@@ -55,7 +52,7 @@ pub struct TraceableError {
   kind: DiagnosticKind,
   message: String,
   severity: miette::Severity,
-  src: NamedSource,
+  src: String,
   label: SourceSpan,
 }
 
@@ -98,8 +95,6 @@ impl TraceableError {
     title: String,
     message: String,
   ) -> Self {
-    let file_path = normalize_custom_filename(&source_file.name.to_string()).to_string();
-    let file_path = relative_to_pwd(PathBuf::from(file_path));
     let file_src = source_file.src.to_string();
     let start = if start >= file_src.len() { 0 } else { start };
     let end = if end >= file_src.len() { 0 } else { end };
@@ -108,26 +103,24 @@ impl TraceableError {
       kind: Default::default(),
       message,
       severity: Default::default(),
-      src: NamedSource::new(file_path.as_os_str().to_string_lossy(), file_src),
+      src: file_src,
       label: SourceSpan::new(start.into(), end.saturating_sub(start).into()),
     }
   }
 
   pub fn from_file(
-    file_path: String,
     file_src: String,
     start: usize,
     end: usize,
     title: String,
     message: String,
   ) -> Self {
-    let file_path = relative_to_pwd(PathBuf::from(file_path));
     Self {
       title,
       kind: Default::default(),
       message,
       severity: Default::default(),
-      src: NamedSource::new(file_path.as_os_str().to_string_lossy(), file_src),
+      src: file_src,
       label: SourceSpan::new(start.into(), end.saturating_sub(start).into()),
     }
   }
@@ -142,14 +135,7 @@ impl TraceableError {
     let file_src = std::fs::read_to_string(path).into_diagnostic()?;
     let start = if start >= file_src.len() { 0 } else { start };
     let end = if end >= file_src.len() { 0 } else { end };
-    Ok(Self::from_file(
-      path.to_string_lossy().into_owned(),
-      file_src,
-      start,
-      end,
-      title,
-      message,
-    ))
+    Ok(Self::from_file(file_src, start, end, title, message))
   }
 }
 
@@ -222,16 +208,6 @@ macro_rules! impl_diagnostic_transparent {
 }
 
 impl_diagnostic_transparent!(InternalError);
-
-/// # Panic
-///
-/// Panics if `current_dir` is not accessible.
-/// See [std::env::current_dir] for details.
-fn relative_to_pwd(file: impl AsRef<Path>) -> PathBuf {
-  file
-    .as_ref()
-    .relative(std::env::current_dir().expect("`current_dir` should exist"))
-}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 pub enum DiagnosticKind {

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -1,10 +1,6 @@
-use std::{
-  fmt,
-  path::{Path, PathBuf},
-};
+use std::{fmt, path::Path};
 
 use miette::{Diagnostic, IntoDiagnostic, LabeledSpan, MietteDiagnostic, SourceCode, SourceSpan};
-use sugar_path::SugarPath;
 use swc_core::common::SourceFile;
 use thiserror::Error;
 

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -41,8 +41,8 @@ pub struct AnyhowError(#[from] anyhow::Error);
 /// For a [TraceableError], the path is required.
 /// Because if the source code is missing when you construct a [TraceableError], we could read it from file system later
 /// when convert it into [crate::Diagnostic], but the reverse will not working.
-#[derive(Debug, Error)]
-#[error("{severity:?}[{kind}]: {title}")]
+#[derive(Debug, Clone, Error)]
+#[error("{title}")]
 pub struct TraceableError {
   title: String,
   kind: DiagnosticKind,

--- a/crates/rspack_error/src/ext.rs
+++ b/crates/rspack_error/src/ext.rs
@@ -1,5 +1,7 @@
 use std::error::Error;
 
+use miette::Diagnostic;
+
 /// Useful to convert [std::error::Error] to [crate::DiagnosticError]
 pub trait ErrorExt {
   fn boxed(self) -> Box<dyn Error + Send + Sync>;
@@ -7,6 +9,16 @@ pub trait ErrorExt {
 
 impl<T: Error + Send + Sync + 'static> ErrorExt for T {
   fn boxed(self) -> Box<dyn Error + Send + Sync> {
+    Box::new(self)
+  }
+}
+
+pub trait DiagnosticExt {
+  fn boxed(self) -> Box<dyn Diagnostic + Send + Sync>;
+}
+
+impl<T: Diagnostic + Send + Sync + 'static> DiagnosticExt for T {
+  fn boxed(self) -> Box<dyn Diagnostic + Send + Sync> {
     Box::new(self)
   }
 }

--- a/crates/rspack_error/src/lib.rs
+++ b/crates/rspack_error/src/lib.rs
@@ -18,7 +18,7 @@ pub use thiserror;
 
 pub type Error = miette::Error;
 
-pub type Result<T> = std::result::Result<T, miette::Error>;
+pub type Result<T, E = miette::Error> = std::result::Result<T, E>;
 
 /// A helper struct for change logic from
 /// return something to something with diagnostics array

--- a/crates/rspack_error/tests/fixtures/char-based-offset-error-span/fixtures__char-based-offset-error-span.snap
+++ b/crates/rspack_error/tests/fixtures/char-based-offset-error-span/fixtures__char-based-offset-error-span.snap
@@ -2,8 +2,9 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: char-based-offset-error-span
 ---
-  × Error[scss]: Sass Error
-   ╭─[tests/fixtures/char-based-offset-error-span/index.scss:4:1]
+  × Sass Error
+   ╭─[3:1]
+ 3 │ // a̐éö̲
  4 │ .wrong {
  5 │   wrong: $wrong;
    ·          ───┬──

--- a/crates/rspack_error/tests/fixtures/html_syntax_error/fixtures__html_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/html_syntax_error/fixtures__html_syntax_error.snap
@@ -2,15 +2,15 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: html_syntax_error
 ---
-  × Error[html]: HTML parsing error
-   ╭─[tests/fixtures/html_syntax_error/index.html:1:1]
+  × HTML parsing error
+   ╭─[1:1]
  1 │ <head>
    · ───┬──
    ·    ╰── Start tag seen without seeing a doctype first, expected "<!DOCTYPE html>"
  2 │   </something>
    ╰────
-  × Error[html]: HTML parsing error
-   ╭─[tests/fixtures/html_syntax_error/index.html:1:1]
+  × HTML parsing error
+   ╭─[1:1]
  1 │ <head>
  2 │   </something>
    ·   ▲

--- a/crates/rspack_error/tests/fixtures/js_syntax_error/fixtures__js_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/js_syntax_error/fixtures__js_syntax_error.snap
@@ -2,19 +2,33 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: js_syntax_error
 ---
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/fixtures/js_syntax_error/index.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/fixtures/js_syntax_error/index.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 

--- a/crates/rspack_error/tests/fixtures/jsx_syntax_error/fixtures__jsx_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/jsx_syntax_error/fixtures__jsx_syntax_error.snap
@@ -2,16 +2,28 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: jsx_syntax_error
 ---
-  × Error[jsx]: JSX parsing error
-   ╭─[tests/fixtures/jsx_syntax_error/index.jsx:1:1]
- 1 │ let a = <test>/test>;
-   ·                    ▲
-   ·                    ╰── Unexpected token. Did you mean `{'>'}` or `&gt;`?
-   ╰────
-  × Error[jsx]: JSX parsing error
-   ╭─[tests/fixtures/jsx_syntax_error/index.jsx:1:1]
- 1 │ let a = <test>/test>;
-   · ▲
-   · ╰── Unexpected eof
-   ╰────
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JSX parsing error
+         ╭────
+       1 │ let a = <test>/test>;
+         ·                    ▲
+         ·                    ╰── Unexpected token. Did you mean `{'>'}` or `&gt;`?
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JSX parsing error
+         ╭────
+       1 │ let a = <test>/test>;
+         · ▲
+         · ╰── Unexpected eof
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 

--- a/crates/rspack_error/tests/fixtures/recoverable_syntax_error/fixtures__recoverable_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/recoverable_syntax_error/fixtures__recoverable_syntax_error.snap
@@ -2,16 +2,28 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: recoverable_syntax_error
 ---
-  × Error[tsx]: TSX parsing error
-   ╭─[tests/fixtures/recoverable_syntax_error/index.tsx:1:1]
- 1 │ let c = <test>() => {}</test>;
-   ·                        ┬
-   ·                        ╰── Expression expected
-   ╰────
-  × Error[tsx]: TSX parsing error
-   ╭─[tests/fixtures/recoverable_syntax_error/index.tsx:1:1]
- 1 │ let c = <test>() => {}</test>;
-   ·                       ┬
-   ·                       ╰── Expected a semicolon
-   ╰────
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × TSX parsing error
+         ╭────
+       1 │ let c = <test>() => {}</test>;
+         ·                        ┬
+         ·                        ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × TSX parsing error
+         ╭────
+       1 │ let c = <test>() => {}</test>;
+         ·                       ┬
+         ·                       ╰── Expected a semicolon
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 

--- a/crates/rspack_error/tests/fixtures/sass-warnings/fixtures__sass-warnings.snap
+++ b/crates/rspack_error/tests/fixtures/sass-warnings/fixtures__sass-warnings.snap
@@ -2,8 +2,8 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: sass-warnings
 ---
-  ⚠ Warning[scss]: Sass Warning
-   ╭─[tests/fixtures/sass-warnings/index.scss:1:1]
+  ⚠ Sass Warning
+   ╭─[1:1]
  1 │ .c {
  2 │   width: (12px/4px);
    ·           ────┬───

--- a/crates/rspack_error/tests/fixtures/ts_syntax_error/fixtures__ts_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/ts_syntax_error/fixtures__ts_syntax_error.snap
@@ -2,12 +2,19 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: ts_syntax_error
 ---
-  × Error[typescript]: Typescript parsing error
-   ╭─[tests/fixtures/ts_syntax_error/index.ts:4:1]
- 4 │     d = 10
- 5 │     g = CONST
-   ·     ┬
-   ·     ╰── Expected ',', got 'g'
- 6 │ }
-   ╰────
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × Typescript parsing error
+         ╭─[3:1]
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+       5 │     g = CONST
+         ·     ┬
+         ·     ╰── Expected ',', got 'g'
+       6 │ }
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 

--- a/crates/rspack_error/tests/fixtures/tsx_syntax_error/fixtures__tsx_syntax_error.snap
+++ b/crates/rspack_error/tests/fixtures/tsx_syntax_error/fixtures__tsx_syntax_error.snap
@@ -2,10 +2,16 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: tsx_syntax_error
 ---
-  × Error[tsx]: TSX parsing error
-   ╭─[tests/fixtures/tsx_syntax_error/index.tsx:1:1]
- 1 │ let c = <test>/test>;
-   ·          ──┬─
-   ·            ╰── Unexpected token `test`. Expected jsx identifier
-   ╰────
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × TSX parsing error
+         ╭────
+       1 │ let c = <test>/test>;
+         ·          ──┬─
+         ·            ╰── Unexpected token `test`. Expected jsx identifier
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 

--- a/crates/rspack_error/tests/out_of_order/multi_json_syntax_error/fixtures__multi_json_syntax_error.snap
+++ b/crates/rspack_error/tests/out_of_order/multi_json_syntax_error/fixtures__multi_json_syntax_error.snap
@@ -2,15 +2,16 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: multi_json_syntax_error
 ---
-  × Error[json]: Json parsing error
-   ╭─[tests/out_of_order/multi_json_syntax_error/a.json:2:1]
+  × Json parsing error
+   ╭─[1:1]
+ 1 │ {
  2 │   "a"
  3 │ }
    · ┬
    · ╰── Unexpected character }
    ╰────
-  × Error[json]: Json parsing error
-   ╭─[tests/out_of_order/multi_json_syntax_error/b.json:1:1]
+  × Json parsing error
+   ╭────
  1 │ "测试utf8\"
    ·           ▲
    ·           ╰── Unexpected end of JSON

--- a/crates/rspack_error/tests/out_of_order/multiple_file_syntax_error/fixtures__multiple_file_syntax_error.snap
+++ b/crates/rspack_error/tests/out_of_order/multiple_file_syntax_error/fixtures__multiple_file_syntax_error.snap
@@ -2,109 +2,207 @@
 source: crates/rspack_error/tests/fixtures.rs
 expression: multiple_file_syntax_error
 ---
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/a.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/a.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/b.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/b.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/c.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/c.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/d.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/d.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/e.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/e.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/f.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/f.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/g.js:1:1]
- 1 │ const CONST = 9000 % 2;
- 2 │ const  D {
-   ·          ┬
-   ·          ╰── Expected a semicolon
- 3 │     // Comma is required, but parser can recover because of the newline.
-   ╰────
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/out_of_order/multiple_file_syntax_error/g.js:5:1]
- 5 │     g = CONST
- 6 │ }
-   · ▲
-   · ╰── Expression expected
-   ╰────
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[1:1]
+       1 │ const CONST = 9000 % 2;
+       2 │ const  D {
+         ·          ┬
+         ·          ╰── Expected a semicolon
+       3 │     // Comma is required, but parser can recover because of the newline.
+       4 │     d = 10
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │     d = 10
+       5 │     g = CONST
+       6 │ }
+         · ▲
+         · ╰── Expression expected
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -557,7 +557,7 @@ fn make_traceable_error(title: &str, message: &str, span: &SourceSpan) -> Option
         .to_string_lossy()
         .to_string()
     })
-    .and_then(|path| std::fs::read_to_string(&path).ok().map(|source| source))
+    .and_then(|path| std::fs::read_to_string(path).ok())
     .map(|source| {
       let start = utf16::to_byte_idx(&source, span.start.offset);
       let end = utf16::to_byte_idx(&source, span.end.offset);

--- a/crates/rspack_loader_sass/src/lib.rs
+++ b/crates/rspack_loader_sass/src/lib.rs
@@ -557,21 +557,10 @@ fn make_traceable_error(title: &str, message: &str, span: &SourceSpan) -> Option
         .to_string_lossy()
         .to_string()
     })
-    .and_then(|path| {
-      std::fs::read_to_string(&path)
-        .ok()
-        .map(|source| (path, source))
-    })
-    .map(|(path, source)| {
+    .and_then(|path| std::fs::read_to_string(&path).ok().map(|source| source))
+    .map(|source| {
       let start = utf16::to_byte_idx(&source, span.start.offset);
       let end = utf16::to_byte_idx(&source, span.end.offset);
-      TraceableError::from_file(
-        path,
-        source,
-        start,
-        end,
-        title.to_string(),
-        message.to_string(),
-      )
+      TraceableError::from_file(source, start, end, title.to_string(), message.to_string())
     })
 }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -7,6 +7,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rkyv::{from_bytes, to_bytes, AlignedVec};
 use rspack_core::{
+  diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   rspack_sources::{
     BoxSource, MapOptions, RawSource, ReplaceSource, Source, SourceExt, SourceMap, SourceMapSource,
     SourceMapSourceOptions,
@@ -77,6 +78,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
       build_info,
       build_meta,
       code_generation_dependencies,
+      loaders,
       ..
     } = parse_context;
 
@@ -103,10 +105,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
     let mut diagnostic_vec = vec![];
 
     if is_enable_css_modules {
-      let TWithDiagnosticArray {
-        inner: mut stylesheet,
-        diagnostic,
-      } = swc_compiler.parse_file(
+      let mut stylesheet = swc_compiler.parse_file(
         &resource_path.to_string_lossy(),
         source_code,
         ParserConfig {
@@ -151,18 +150,13 @@ impl ParserAndGenerator for CssParserAndGenerator {
       )?;
       source_code = code;
       source_map = map;
-      diagnostic_vec.extend(diagnostic)
     }
 
-    let TWithDiagnosticArray {
-      inner: new_stylesheet_ast,
-      diagnostic: new_diagnostic,
-    } = SwcCssCompiler::default().parse_file(
+    let new_stylesheet_ast = SwcCssCompiler::default().parse_file(
       &parse_context.resource_data.resource_path.to_string_lossy(),
       source_code.clone(),
       Default::default(),
     )?;
-    diagnostic_vec.extend(new_diagnostic);
 
     let mut dependencies = analyze_dependencies(
       &new_stylesheet_ast,
@@ -224,7 +218,10 @@ impl ParserAndGenerator for CssParserAndGenerator {
         source: new_source,
         analyze_result: Default::default(),
       }
-      .with_diagnostic(diagnostic_vec),
+      .with_diagnostic(map_box_diagnostics_to_module_parse_diagnostics(
+        diagnostic_vec,
+        loaders,
+      )),
     )
   }
 

--- a/crates/rspack_plugin_css/src/swc_css_compiler.rs
+++ b/crates/rspack_plugin_css/src/swc_css_compiler.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rspack_core::rspack_sources::{self, SourceExt};
-use rspack_error::{internal_error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{internal_error, Result};
 use swc_core::common::{input::SourceFileInput, source_map::SourceMapGenConfig, FileName};
 use swc_core::common::{Globals, GLOBALS};
 use swc_core::css::codegen::{
@@ -18,12 +18,7 @@ pub struct SwcCssCompiler {
 }
 
 impl SwcCssCompiler {
-  pub fn parse_file(
-    &self,
-    path: &str,
-    source: String,
-    config: ParserConfig,
-  ) -> Result<TWithDiagnosticArray<Stylesheet>> {
+  pub fn parse_file(&self, path: &str, source: String, config: ParserConfig) -> Result<Stylesheet> {
     let fm = self
       .cm
       .new_source_file(FileName::Custom(path.to_string()), source);
@@ -31,9 +26,7 @@ impl SwcCssCompiler {
     let lexer = Lexer::new(SourceFileInput::from(&*fm), None, config);
     let mut parser = Parser::new(lexer, config);
     let stylesheet = parser.parse_all();
-    stylesheet
-      .map_err(|e| internal_error!("Css parsing failed {}", e.message()))
-      .map(|stylesheet| stylesheet.with_diagnostic(vec![]))
+    stylesheet.map_err(|e| internal_error!("Css parsing failed {}", e.message()))
   }
 
   pub fn codegen(
@@ -82,9 +75,8 @@ impl SwcCssCompiler {
     input_source_map: Option<rspack_sources::SourceMap>,
     gen_source_map: SwcCssSourceMapGenConfig,
   ) -> Result<rspack_sources::BoxSource> {
-    let parsed = self.parse_file(filename, input_source.clone(), Default::default())?;
+    let mut ast = self.parse_file(filename, input_source.clone(), Default::default())?;
     // ignore errors since css in webpack is tolerant, and diagnostics already reported in parse.
-    let (mut ast, _) = parsed.split_into_parts();
     GLOBALS.set(&Globals::default(), || {
       minifier::minify(&mut ast, minifier::options::MinifyOptions::default());
     });

--- a/crates/rspack_plugin_css/src/visitors/mod.rs
+++ b/crates/rspack_plugin_css/src/visitors/mod.rs
@@ -1,7 +1,8 @@
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rspack_core::{BoxDependency, ModuleDependency, SpanExt};
-use rspack_error::Diagnostic;
+use rspack_error::miette::{diagnostic, Diagnostic, Severity};
+use rspack_error::DiagnosticExt;
 use swc_core::common::Span;
 use swc_core::css::ast::{
   AtRule, AtRuleName, Function, ImportHref, ImportPrelude, Stylesheet, Token, TokenAndSpan, Url,
@@ -19,7 +20,7 @@ static IS_MODULE_REQUEST: Lazy<Regex> = Lazy::new(|| Regex::new(r"^~").expect("T
 pub fn analyze_dependencies(
   ss: &Stylesheet,
   code_generation_dependencies: &mut Vec<Box<dyn ModuleDependency>>,
-  diagnostics: &mut Vec<Diagnostic>,
+  diagnostics: &mut Vec<Box<dyn Diagnostic + Send + Sync>>,
 ) -> Vec<BoxDependency> {
   let mut v = Analyzer {
     deps: Vec::new(),
@@ -38,18 +39,24 @@ pub fn analyze_dependencies(
 struct Analyzer<'a> {
   deps: Vec<BoxDependency>,
   code_generation_dependencies: &'a mut Vec<Box<dyn ModuleDependency>>,
-  diagnostics: &'a mut Vec<Diagnostic>,
+  diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
   nearest_at_import_span: Option<Span>,
   url_function_span: Option<Span>,
   // in_support_contdition: bool,
 }
 
-fn replace_module_request_prefix(specifier: String, diagnostics: &mut Vec<Diagnostic>) -> String {
+fn replace_module_request_prefix(
+  specifier: String,
+  diagnostics: &mut Vec<Box<dyn Diagnostic + Send + Sync>>,
+) -> String {
   if IS_MODULE_REQUEST.is_match(&specifier) {
-    diagnostics.push(Diagnostic::warn(
-      "css: Deprecated '~'".to_string(),
-      "'@import' or 'url()' with a request starts with '~' is deprecated.".to_string(),
-    ));
+    diagnostics.push(
+      diagnostic!(
+        severity = Severity::Warning,
+        "css: Deprecated '~'\n'@import' or 'url()' with a request starts with '~' is deprecated.",
+      )
+      .boxed(),
+    );
     IS_MODULE_REQUEST.replace(&specifier, "").to_string()
   } else {
     specifier

--- a/crates/rspack_plugin_javascript/src/ast/parse.rs
+++ b/crates/rspack_plugin_javascript/src/ast/parse.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rspack_ast::javascript::Ast;
 use rspack_core::ModuleType;
-use rspack_error::BatchErrors;
+use rspack_error::TraceableError;
 use swc_core::common::comments::Comments;
 use swc_core::common::{FileName, SourceFile};
 use swc_core::ecma::ast::{self, EsVersion, Program};
@@ -68,7 +68,7 @@ pub fn parse(
   syntax: Syntax,
   filename: &str,
   module_type: &ModuleType,
-) -> Result<Ast, BatchErrors> {
+) -> Result<Ast, Vec<TraceableError>> {
   let source_code = if syntax.dts() {
     // dts build result must be empty
     "".to_string()
@@ -91,12 +91,12 @@ pub fn parse(
     Some(&comments),
   ) {
     Ok(program) => Ok(Ast::new(program, cm, Some(comments))),
-    Err(errs) => Err(BatchErrors(
+    Err(errs) => Err(
       errs
         .dedup_ecma_errors()
         .into_iter()
         .map(|err| ecma_parse_error_deduped_to_rspack_error(err, &fm, module_type))
         .collect::<Vec<_>>(),
-    )),
+    ),
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -1,4 +1,5 @@
 use rspack_ast::RspackAst;
+use rspack_core::diagnostics::map_box_diagnostics_to_module_parse_diagnostics;
 use rspack_core::rspack_sources::{
   BoxSource, MapOptions, OriginalSource, RawSource, ReplaceSource, Source, SourceExt, SourceMap,
   SourceMapSource, SourceMapSourceOptions,
@@ -11,7 +12,8 @@ use rspack_core::{
   DependencyId, GenerateContext, Module, ParseContext, ParseResult, ParserAndGenerator, SourceType,
   TemplateContext, TemplateReplaceSource,
 };
-use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::miette::Diagnostic;
+use rspack_error::{DiagnosticExt, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use swc_core::common::SyntaxContext;
 
 use crate::ast::CodegenOptions;
@@ -87,10 +89,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       build_info,
       build_meta,
       module_identifier,
+      loaders,
       mut additional_data,
       ..
     } = parse_context;
-    let mut diagnostics: Vec<Diagnostic> = vec![];
+    let mut diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>> = vec![];
     let syntax = syntax_by_module_type(
       &resource_data.resource_path,
       module_type,
@@ -102,7 +105,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     let original_map = source.map(&MapOptions::new(!compiler_options.devtool.cheap()));
     let source = source.source();
 
-    let gen_terminate_res = |diagnostics: Vec<Diagnostic>| {
+    let gen_terminate_res = |diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>>| {
       Ok(
         ParseResult {
           source: create_source(
@@ -115,7 +118,10 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
           presentational_dependencies: vec![],
           analyze_result: Default::default(),
         }
-        .with_diagnostic(diagnostics),
+        .with_diagnostic(map_box_diagnostics_to_module_parse_diagnostics(
+          diagnostics,
+          loaders,
+        )),
       )
     };
 
@@ -131,7 +137,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         ) {
           Ok(ast) => ast,
           Err(e) => {
-            diagnostics.append(&mut e.into());
+            diagnostics.append(&mut e.into_iter().map(|e| e.boxed()).collect());
             return gen_terminate_res(diagnostics);
           }
         }
@@ -162,7 +168,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     ) {
       Ok(ast) => ast,
       Err(e) => {
-        diagnostics.append(&mut e.into());
+        diagnostics.append(&mut e.into_iter().map(|e| e.boxed()).collect());
         return gen_terminate_res(diagnostics);
       }
     };
@@ -195,8 +201,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       )
     }) {
       Ok(result) => result,
-      Err(e) => {
-        diagnostics.append(&mut e.into());
+      Err(mut e) => {
+        diagnostics.append(&mut e);
         return gen_terminate_res(diagnostics);
       }
     };
@@ -283,7 +289,10 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         presentational_dependencies,
         analyze_result,
       }
-      .with_diagnostic(diagnostics),
+      .with_diagnostic(map_box_diagnostics_to_module_parse_diagnostics(
+        diagnostics,
+        loaders,
+      )),
     )
   }
 

--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -6,7 +6,7 @@ pub mod mangle_exports;
 use std::path::Path;
 
 use rspack_core::{ErrorSpan, ModuleType};
-use rspack_error::{DiagnosticKind, Error};
+use rspack_error::{DiagnosticKind, TraceableError};
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::common::{SourceFile, Span, Spanned};
 use swc_core::ecma::parser::Syntax;
@@ -130,7 +130,7 @@ pub fn ecma_parse_error_deduped_to_rspack_error(
   EcmaError(message, span): EcmaError,
   fm: &SourceFile,
   module_type: &ModuleType,
-) -> Error {
+) -> TraceableError {
   let (file_type, diagnostic_kind) = match module_type {
     ModuleType::Js | ModuleType::JsDynamic | ModuleType::JsEsm => {
       ("JavaScript", DiagnosticKind::JavaScript)
@@ -141,15 +141,14 @@ pub fn ecma_parse_error_deduped_to_rspack_error(
     _ => unreachable!(),
   };
   let span: ErrorSpan = span.into();
-  let traceable_error = rspack_error::TraceableError::from_source_file(
+  rspack_error::TraceableError::from_source_file(
     fm,
     span.start as usize,
     span.end as usize,
     format!("{file_type} parsing error"),
     message,
   )
-  .with_kind(diagnostic_kind);
-  traceable_error.into()
+  .with_kind(diagnostic_kind)
 }
 
 pub fn is_diff_mode() -> bool {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -2,7 +2,8 @@ use rspack_core::{
   BuildInfo, BuildMeta, BuildMetaExportsType, DependencyTemplate, ExportsArgument, ModuleArgument,
   ModuleIdentifier, ModuleType,
 };
-use rspack_error::internal_error;
+use rspack_error::miette::{diagnostic, Diagnostic};
+use rspack_error::DiagnosticExt;
 use swc_core::ecma::ast::{ArrowExpr, AwaitExpr, Constructor, Function, ModuleItem, Program};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
@@ -16,7 +17,7 @@ pub struct HarmonyDetectionScanner<'a> {
   module_type: &'a ModuleType,
   top_level_await: bool,
   code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  errors: &'a mut Vec<rspack_error::Error>,
+  errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
 }
 
 impl<'a> HarmonyDetectionScanner<'a> {
@@ -27,7 +28,7 @@ impl<'a> HarmonyDetectionScanner<'a> {
     module_type: &'a ModuleType,
     top_level_await: bool,
     code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-    errors: &'a mut Vec<rspack_error::Error>,
+    errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
   ) -> Self {
     Self {
       module_identifier,
@@ -61,14 +62,17 @@ impl Visit for HarmonyDetectionScanner<'_> {
 
     if has_top_level_await(program) {
       if !self.top_level_await {
-        self.errors.push(internal_error!("The top-level-await experiment is not enabled (set experiments.topLevelAwait: true to enabled it)"));
+        self.errors.push(diagnostic!("The top-level-await experiment is not enabled (set experiments.topLevelAwait: true to enabled it)").boxed());
       } else if is_harmony || strict_harmony_module {
         self.build_meta.has_top_level_await = true;
       } else {
-        self.errors.push(internal_error!(
-          "Top-level-await is only supported in EcmaScript Modules: {}",
-          self.module_identifier
-        ));
+        self.errors.push(
+          diagnostic!(
+            "Top-level-await is only supported in EcmaScript Modules: {}",
+            self.module_identifier
+          )
+          .boxed(),
+        );
       }
     }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -23,7 +23,7 @@ use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
   CompilerOptions, JavascriptParserUrl, ModuleIdentifier, ModuleType, ResourceData,
 };
-use rspack_error::{BatchErrors, Diagnostic};
+use rspack_error::miette::Diagnostic;
 use rustc_hash::FxHashMap as HashMap;
 use swc_core::common::Span;
 use swc_core::common::{comments::Comments, Mark, SyntaxContext};
@@ -53,7 +53,7 @@ pub struct ScanDependenciesResult {
   // TODO: rename this name
   pub rewrite_usage_span: HashMap<Span, ExtraSpanInfo>,
   pub import_map: ImportMap,
-  pub warning_diagnostics: Vec<Diagnostic>,
+  pub warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -75,8 +75,8 @@ pub fn scan_dependencies(
   build_info: &mut BuildInfo,
   build_meta: &mut BuildMeta,
   module_identifier: ModuleIdentifier,
-) -> Result<ScanDependenciesResult, BatchErrors> {
-  let mut warning_diagnostics: Vec<Diagnostic> = vec![];
+) -> Result<ScanDependenciesResult, Vec<Box<dyn Diagnostic + Send + Sync>>> {
+  let mut warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>> = vec![];
   let mut errors = vec![];
   let mut dependencies = vec![];
   let mut blocks = vec![];
@@ -242,6 +242,6 @@ pub fn scan_dependencies(
       warning_diagnostics,
     })
   } else {
-    Err(rspack_error::BatchErrors(errors))
+    Err(errors)
   }
 }

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -43,7 +43,6 @@ impl ParserAndGenerator for JsonParserAndGenerator {
   ) -> Result<TWithDiagnosticArray<rspack_core::ParseResult>> {
     let rspack_core::ParseContext {
       source: box_source,
-      resource_data,
       build_info,
       build_meta,
       ..
@@ -71,7 +70,6 @@ impl ParserAndGenerator for JsonParserAndGenerator {
             start_offset
           };
           TraceableError::from_file(
-            resource_data.resource_path.to_string_lossy().to_string(),
             source.into_owned(),
             // one character offset
             start_offset,
@@ -89,7 +87,6 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           // End offset of json file
           let offset = source.len() - 1;
           TraceableError::from_file(
-            resource_data.resource_path.to_string_lossy().to_string(),
             source.into_owned(),
             offset,
             offset,

--- a/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
@@ -182,7 +182,13 @@ pub fn minify(
               errs
                 .dedup_ecma_errors()
                 .into_iter()
-                .map(|err| ecma_parse_error_deduped_to_rspack_error(err, &fm, &ModuleType::Js))
+                .map(|err| {
+                  rspack_error::miette::Error::new(ecma_parse_error_deduped_to_rspack_error(
+                    err,
+                    &fm,
+                    &ModuleType::Js,
+                  ))
+                })
                 .collect::<Vec<_>>(),
             )
           })?;

--- a/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
@@ -596,20 +596,20 @@ const SIMPLE_PRINTERS: Record<
 	// "error.chunkInitial": (chunkInitial, { formatFlag }) =>
 	// 	chunkInitial ? formatFlag("initial") : undefined,
 	// "error.file": (file, { bold }) => bold(file),
-	// "error.moduleName": (moduleName, { bold }) => {
-	// 	return moduleName.includes("!")
-	// 		? `${bold(moduleName.replace(/^(\s|\S)*!/, ""))} (${moduleName})`
-	// 		: `${bold(moduleName)}`;
-	// },
+	"error.moduleName": (moduleName, { bold }) => {
+		return moduleName.includes("!")
+			? `${bold(moduleName.replace(/^(\s|\S)*!/, ""))} (${moduleName})`
+			: `${bold(moduleName)}`;
+	},
 	// "error.loc": (loc, { green }) => green(loc),
-	// "error.message": (message, { bold, formatError }) =>
-	// 	message.includes("\u001b[") ? message : bold(formatError(message)),
+	"error.message": (message, { bold, formatError }) =>
+		message.includes("\u001b[") ? message : bold(formatError(message)),
 	// "error.details": (details, { formatError }) => formatError(details),
 	// "error.stack": stack => stack,
 	// "error.moduleTrace": moduleTrace => undefined,
 	// "error.separator!": () => "\n",
 	// Error was already formatted on the native.
-	error: error => error.formatted,
+	// error: error => error,
 
 	"loggingEntry(error).loggingEntry.message": (message, { red }) =>
 		mapLines(message, x => `<e> ${red(x)}`),

--- a/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts
@@ -586,6 +586,28 @@ const SIMPLE_PRINTERS: Record<
 	"chunkOrigin.moduleName": (moduleName, { bold }) => bold(moduleName),
 	"chunkOrigin.loc": loc => loc,
 
+	// TODO: should align webpack error
+	// "error.compilerPath": (compilerPath, { bold }) =>
+	// 	compilerPath ? bold(`(${compilerPath})`) : undefined,
+	// "error.chunkId": (chunkId, { formatChunkId }) =>
+	// 	isValidId(chunkId) ? formatChunkId(chunkId) : undefined,
+	// "error.chunkEntry": (chunkEntry, { formatFlag }) =>
+	// 	chunkEntry ? formatFlag("entry") : undefined,
+	// "error.chunkInitial": (chunkInitial, { formatFlag }) =>
+	// 	chunkInitial ? formatFlag("initial") : undefined,
+	// "error.file": (file, { bold }) => bold(file),
+	// "error.moduleName": (moduleName, { bold }) => {
+	// 	return moduleName.includes("!")
+	// 		? `${bold(moduleName.replace(/^(\s|\S)*!/, ""))} (${moduleName})`
+	// 		: `${bold(moduleName)}`;
+	// },
+	// "error.loc": (loc, { green }) => green(loc),
+	// "error.message": (message, { bold, formatError }) =>
+	// 	message.includes("\u001b[") ? message : bold(formatError(message)),
+	// "error.details": (details, { formatError }) => formatError(details),
+	// "error.stack": stack => stack,
+	// "error.moduleTrace": moduleTrace => undefined,
+	// "error.separator!": () => "\n",
 	// Error was already formatted on the native.
 	error: error => error.formatted,
 

--- a/packages/rspack/tests/Errors.test.ts
+++ b/packages/rspack/tests/Errors.test.ts
@@ -146,8 +146,8 @@ it("should emit warnings for resolve failure in esm", async () => {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "formatted": "  × Error[internal]: Resolve error\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
-		      "message": "  × Error[internal]: Resolve error\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
+		      "formatted": "  × Resolve error\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
+		      "message": "  × Resolve error\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
 		    },
 		  ],
 		  "warnings": Array [],

--- a/packages/rspack/tests/Errors.test.ts
+++ b/packages/rspack/tests/Errors.test.ts
@@ -146,8 +146,8 @@ it("should emit warnings for resolve failure in esm", async () => {
 		Object {
 		  "errors": Array [
 		    Object {
-		      "formatted": "  × Error[internal]: Resolve error\\n   ╭─[tests/fixtures/errors/resolve-fail-esm/index.js:1:1]\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
-		      "message": "  × Error[internal]: Resolve error\\n   ╭─[tests/fixtures/errors/resolve-fail-esm/index.js:1:1]\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
+		      "formatted": "  × Error[internal]: Resolve error\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
+		      "message": "  × Error[internal]: Resolve error\\n   ╭────\\n 1 │ import { answer } from './answer'\\n   · ▲\\n   · ╰── Failed to resolve ./answer in javascript/esm|<cwd>/tests/fixtures/errors/resolve-fail-esm/index.js\\n   ╰────\\n",
 		    },
 		  ],
 		  "warnings": Array [],

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -60,23 +60,29 @@ describe("Stats", () => {
 			stats?.toString({ timings: false, version: false }).replace(/\\/g, "/")
 		).toMatchInlineSnapshot(`
 		"PublicPath: auto
-		asset main.js 623 bytes [emitted] (name: main)
-		Entrypoint main 623 bytes = main.js
+		asset main.js 794 bytes [emitted] (name: main)
+		Entrypoint main 794 bytes = main.js
 		./fixtures/a.js
 		./fixtures/b.js
 		./fixtures/c.js
 		./fixtures/abc.js
 
-		ERROR in ./fixtures/b.js   × Error[javascript]: JavaScript parsing error
-		   ╭─[4:1]
-		 4 │ 
-		 5 │ // Test CJS top-level return
-		 6 │ return;
-		   · ───┬───
-		   ·    ╰── Return statement is not allowed here
-		   ╰────
+		ERROR in ./fixtures/b.js ModuleParseError
 
-		Rspack compiled with 1 error (584d0056cef886864930)"
+		  × Module parse failed:
+		  ╰─▶   × JavaScript parsing error
+		         ╭─[4:1]
+		       4 │
+		       5 │ // Test CJS top-level return
+		       6 │ return;
+		         · ───┬───
+		         ·    ╰── Return statement is not allowed here
+		         ╰────
+		      
+		  help: 
+		        You may need an appropriate loader to handle this file type.
+
+		Rspack compiled with 1 error (79a430f2fdbcdc199916)"
 	`);
 	});
 

--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -60,23 +60,23 @@ describe("Stats", () => {
 			stats?.toString({ timings: false, version: false }).replace(/\\/g, "/")
 		).toMatchInlineSnapshot(`
 		"PublicPath: auto
-		asset main.js 634 bytes [emitted] (name: main)
-		Entrypoint main 634 bytes = main.js
+		asset main.js 623 bytes [emitted] (name: main)
+		Entrypoint main 623 bytes = main.js
 		./fixtures/a.js
 		./fixtures/b.js
 		./fixtures/c.js
 		./fixtures/abc.js
 
-		  × Error[javascript]: JavaScript parsing error
-		   ╭─[tests/fixtures/b.js:5:1]
+		ERROR in ./fixtures/b.js   × Error[javascript]: JavaScript parsing error
+		   ╭─[4:1]
+		 4 │ 
 		 5 │ // Test CJS top-level return
 		 6 │ return;
 		   · ───┬───
 		   ·    ╰── Return statement is not allowed here
 		   ╰────
 
-
-		Rspack compiled with 1 error (ae9cd940d0424968e31c)"
+		Rspack compiled with 1 error (584d0056cef886864930)"
 	`);
 	});
 

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1079,35 +1079,41 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
   "errors": [
     {
       "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+   ╭────
  1 │ let let = let;
    ·           ─┬─
    ·            ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 ",
       "message": "  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+   ╭────
  1 │ let let = let;
    ·           ─┬─
    ·            ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 ",
+      "moduleId": "21",
+      "moduleIdentifier": "javascript/esm|<PROJECT_ROOT>/tests/statsCases/identifier-let-strict-mode/index.js",
+      "moduleName": "./index.js",
     },
     {
       "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+   ╭────
  1 │ let let = let;
    ·     ─┬─
    ·      ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 ",
       "message": "  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+   ╭────
  1 │ let let = let;
    ·     ─┬─
    ·      ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 ",
+      "moduleId": "21",
+      "moduleIdentifier": "javascript/esm|<PROJECT_ROOT>/tests/statsCases/identifier-let-strict-mode/index.js",
+      "moduleName": "./index.js",
     },
   ],
   "errorsCount": 2,
@@ -1118,21 +1124,19 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
 `;
 
 exports[`StatsTestCases should print correct stats for identifier-let-strict-mode 2`] = `
-"  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+"ERROR in ./index.js   × Error[javascript]: JavaScript parsing error
+   ╭────
  1 │ let let = let;
    ·           ─┬─
    ·            ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
 
-
-  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/identifier-let-strict-mode/index.js:1:1]
+ERROR in ./index.js   × Error[javascript]: JavaScript parsing error
+   ╭────
  1 │ let let = let;
    ·     ─┬─
    ·      ╰── \`let\` cannot be used as an identifier in strict mode
    ╰────
-
 
 Rspack compiled with 2 errors"
 `;
@@ -4106,6 +4110,9 @@ exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin
 
   ⚠ Experimental plugins are not currently supported.
 ",
+      "moduleId": "498",
+      "moduleIdentifier": "builtin:swc-loader??ruleSet[1].rules[0].use[0]!<PROJECT_ROOT>/tests/statsCases/loader-builtin-swc-plugin-warn/index.js",
+      "moduleName": "./index.js",
     },
   ],
   "warningsCount": 1,
@@ -4113,10 +4120,9 @@ exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin
 `;
 
 exports[`StatsTestCases should print correct stats for loader-builtin-swc-plugin-warn 2`] = `
-"builtin:swc-loader
+"WARNING in ./index.js builtin:swc-loader
 
   ⚠ Experimental plugins are not currently supported.
-
 
 Rspack compiled with 1 warning"
 `;
@@ -4173,19 +4179,21 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
   "errors": [
     {
       "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭─[bundle.js:1:1]
+   ╭─[1:1]
  1 │ const a {}
    ·         ┬
    ·         ╰── Expected a semicolon
  2 │ (function() {
+ 3 │ var __webpack_modules__ = {
    ╰────
 ",
       "message": "  × Error[javascript]: JavaScript parsing error
-   ╭─[bundle.js:1:1]
+   ╭─[1:1]
  1 │ const a {}
    ·         ┬
    ·         ╰── Expected a semicolon
  2 │ (function() {
+ 3 │ var __webpack_modules__ = {
    ╰────
 ",
     },
@@ -4198,14 +4206,14 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
 `;
 
 exports[`StatsTestCases should print correct stats for minify-error-recovery 2`] = `
-"  × Error[javascript]: JavaScript parsing error
-   ╭─[bundle.js:1:1]
+"ERROR in × Error[javascript]: JavaScript parsing error
+   ╭─[1:1]
  1 │ const a {}
    ·         ┬
    ·         ╰── Expected a semicolon
  2 │ (function() {
+ 3 │ var __webpack_modules__ = {
    ╰────
-
 
 Rspack compiled with 1 error"
 `;
@@ -4268,14 +4276,14 @@ exports[`StatsTestCases should print correct stats for normal-errors 1`] = `
   "errors": [
     {
       "formatted": "  × Error[internal]: Resolve error
-   ╭─[tests/statsCases/normal-errors/index.js:1:1]
+   ╭────
  1 │ import "not-exist";
    · ─────────┬─────────
    ·          ╰── Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
    ╰────
 ",
       "message": "  × Error[internal]: Resolve error
-   ╭─[tests/statsCases/normal-errors/index.js:1:1]
+   ╭────
  1 │ import "not-exist";
    · ─────────┬─────────
    ·          ╰── Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
@@ -4291,13 +4299,12 @@ exports[`StatsTestCases should print correct stats for normal-errors 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for normal-errors 2`] = `
-"  × Error[internal]: Resolve error
-   ╭─[tests/statsCases/normal-errors/index.js:1:1]
+"ERROR in × Error[internal]: Resolve error
+   ╭────
  1 │ import "not-exist";
    · ─────────┬─────────
    ·          ╰── Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
    ╰────
-
 
 Rspack compiled with 1 error"
 `;
@@ -4873,23 +4880,30 @@ exports[`StatsTestCases should print correct stats for parse-error 1`] = `
   "errors": [
     {
       "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/parse-error/b.js:5:1]
+   ╭─[4:1]
+ 4 │ includes
  5 │ a
  6 │ parser )
    ·        ┬
    ·        ╰── Expected ';', '}' or <eof>
  7 │ error
+ 8 │ in
    ╰────
 ",
       "message": "  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/parse-error/b.js:5:1]
+   ╭─[4:1]
+ 4 │ includes
  5 │ a
  6 │ parser )
    ·        ┬
    ·        ╰── Expected ';', '}' or <eof>
  7 │ error
+ 8 │ in
    ╰────
 ",
+      "moduleId": "996",
+      "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/parse-error/b.js",
+      "moduleName": "./b.js",
     },
   ],
   "errorsCount": 1,
@@ -4900,15 +4914,16 @@ exports[`StatsTestCases should print correct stats for parse-error 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error 2`] = `
-"  × Error[javascript]: JavaScript parsing error
-   ╭─[tests/statsCases/parse-error/b.js:5:1]
+"ERROR in ./b.js   × Error[javascript]: JavaScript parsing error
+   ╭─[4:1]
+ 4 │ includes
  5 │ a
  6 │ parser )
    ·        ┬
    ·        ╰── Expected ';', '}' or <eof>
  7 │ error
+ 8 │ in
    ╰────
-
 
 Rspack compiled with 1 error"
 `;
@@ -4935,6 +4950,9 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
   │ 
   ╰─▶ Syntax Error
 ",
+      "moduleId": "620",
+      "moduleIdentifier": "builtin:swc-loader??ruleSet[1].rules[0].use[0]!<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts",
+      "moduleName": "./index.ts",
     },
   ],
   "errorsCount": 1,
@@ -4945,7 +4963,7 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-loader 2`] = `
-"  × 
+"ERROR in ./index.ts   × 
   │   x Expected '{', got 'error'
   │    ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
   │  1 | export error;
@@ -4953,7 +4971,6 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
   │    \`----
   │ 
   ╰─▶ Syntax Error
-
 
 Rspack compiled with 1 error"
 `;
@@ -5150,7 +5167,7 @@ console.log(a);
   "errors": [
     {
       "formatted": "  × Error[internal]: Resolve error
-   ╭─[tests/statsCases/resolve-overflow/index.js:1:1]
+   ╭─[1:1]
  1 │ import { a } from "cycle-alias/a";
    · ─────────────────┬────────────────
    ·                  ╰── Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias
@@ -5158,7 +5175,7 @@ console.log(a);
    ╰────
 ",
       "message": "  × Error[internal]: Resolve error
-   ╭─[tests/statsCases/resolve-overflow/index.js:1:1]
+   ╭─[1:1]
  1 │ import { a } from "cycle-alias/a";
    · ─────────────────┬────────────────
    ·                  ╰── Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias
@@ -5361,14 +5378,13 @@ webpack/runtime/compat_get_default_export {main}
   esm import specifier cycle-alias/a [10]
   
 
-  × Error[internal]: Resolve error
-   ╭─[tests/statsCases/resolve-overflow/index.js:1:1]
+ERROR in × Error[internal]: Resolve error
+   ╭─[1:1]
  1 │ import { a } from "cycle-alias/a";
    · ─────────────────┬────────────────
    ·                  ╰── Can't resolve "cycle-alias/a" in <PROJECT_ROOT>/tests/statsCases/resolve-overflow/index.js , maybe it had cycle alias
  2 │ console.log(a);
    ╰────
-
 
 Rspack compiled with 1 error (52b8b881d7951db09212)"
 `;
@@ -5706,8 +5722,7 @@ webpack/runtime/compat_get_default_export {main}
   esm import specifier pkg-a [10]
   
 
-  × Export should be relative path and start with "./", but got ../../index.js
-
+ERROR in × Export should be relative path and start with "./", but got ../../index.js
 
 Rspack compiled with 1 error (2b490d57b0f2f7155006)"
 `;
@@ -6576,21 +6591,23 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
   "warnings": [
     {
       "formatted": "  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require--module/index.js:1:1]
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js
  4 │     
+ 5 │     }
    ╰────
 ",
       "message": "  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require--module/index.js:1:1]
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js
  4 │     
+ 5 │     }
    ╰────
 ",
     },
@@ -6600,15 +6617,15 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
 `;
 
 exports[`StatsTestCases should print correct stats for try-require--module 2`] = `
-"  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require--module/index.js:1:1]
+"WARNING in ⚠ Warning[internal]: Resolve error
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require--module/index.js
  4 │     
+ 5 │     }
    ╰────
-
 
 Rspack compiled with 1 warning"
 `;
@@ -6621,21 +6638,23 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
   "warnings": [
     {
       "formatted": "  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require-resolve-module/index.js:1:1]
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolve('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js
  4 │     
+ 5 │     }
    ╰────
 ",
       "message": "  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require-resolve-module/index.js:1:1]
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolve('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js
  4 │     
+ 5 │     }
    ╰────
 ",
     },
@@ -6645,15 +6664,15 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
 `;
 
 exports[`StatsTestCases should print correct stats for try-require-resolve-module 2`] = `
-"  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require-resolve-module/index.js:1:1]
+"WARNING in ⚠ Warning[internal]: Resolve error
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolve('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-module/index.js
  4 │     
+ 5 │     }
    ╰────
-
 
 Rspack compiled with 1 warning"
 `;
@@ -6666,21 +6685,23 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
   "warnings": [
     {
       "formatted": "  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require-resolve-weak-module/index.js:1:1]
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolveWeak('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js
  4 │     
+ 5 │     }
    ╰────
 ",
       "message": "  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require-resolve-weak-module/index.js:1:1]
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolveWeak('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js
  4 │     
+ 5 │     }
    ╰────
 ",
     },
@@ -6690,15 +6711,15 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
 `;
 
 exports[`StatsTestCases should print correct stats for try-require-resolve-weak-module 2`] = `
-"  ⚠ Warning[internal]: Resolve error
-   ╭─[tests/statsCases/try-require-resolve-weak-module/index.js:1:1]
+"WARNING in ⚠ Warning[internal]: Resolve error
+   ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolveWeak('./missing-module')
  3 │ ├─▶ } catch (e) {
    · ╰──── Failed to resolve ./missing-module in <PROJECT_ROOT>/tests/statsCases/try-require-resolve-weak-module/index.js
  4 │     
+ 5 │     }
    ╰────
-
 
 Rspack compiled with 1 warning"
 `;

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -1078,38 +1078,62 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
 {
   "errors": [
     {
-      "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭────
- 1 │ let let = let;
-   ·           ─┬─
-   ·            ╰── \`let\` cannot be used as an identifier in strict mode
-   ╰────
+      "formatted": "ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭────
+       1 │ let let = let;
+         ·           ─┬─
+         ·            ╰── \`let\` cannot be used as an identifier in strict mode
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 ",
-      "message": "  × Error[javascript]: JavaScript parsing error
-   ╭────
- 1 │ let let = let;
-   ·           ─┬─
-   ·            ╰── \`let\` cannot be used as an identifier in strict mode
-   ╰────
+      "message": "ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭────
+       1 │ let let = let;
+         ·           ─┬─
+         ·            ╰── \`let\` cannot be used as an identifier in strict mode
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 ",
       "moduleId": "21",
       "moduleIdentifier": "javascript/esm|<PROJECT_ROOT>/tests/statsCases/identifier-let-strict-mode/index.js",
       "moduleName": "./index.js",
     },
     {
-      "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭────
- 1 │ let let = let;
-   ·     ─┬─
-   ·      ╰── \`let\` cannot be used as an identifier in strict mode
-   ╰────
+      "formatted": "ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭────
+       1 │ let let = let;
+         ·     ─┬─
+         ·      ╰── \`let\` cannot be used as an identifier in strict mode
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 ",
-      "message": "  × Error[javascript]: JavaScript parsing error
-   ╭────
- 1 │ let let = let;
-   ·     ─┬─
-   ·      ╰── \`let\` cannot be used as an identifier in strict mode
-   ╰────
+      "message": "ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭────
+       1 │ let let = let;
+         ·     ─┬─
+         ·      ╰── \`let\` cannot be used as an identifier in strict mode
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 ",
       "moduleId": "21",
       "moduleIdentifier": "javascript/esm|<PROJECT_ROOT>/tests/statsCases/identifier-let-strict-mode/index.js",
@@ -1124,19 +1148,31 @@ exports[`StatsTestCases should print correct stats for identifier-let-strict-mod
 `;
 
 exports[`StatsTestCases should print correct stats for identifier-let-strict-mode 2`] = `
-"ERROR in ./index.js   × Error[javascript]: JavaScript parsing error
-   ╭────
- 1 │ let let = let;
-   ·           ─┬─
-   ·            ╰── \`let\` cannot be used as an identifier in strict mode
-   ╰────
+"ERROR in ./index.js ModuleParseError
 
-ERROR in ./index.js   × Error[javascript]: JavaScript parsing error
-   ╭────
- 1 │ let let = let;
-   ·     ─┬─
-   ·      ╰── \`let\` cannot be used as an identifier in strict mode
-   ╰────
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭────
+       1 │ let let = let;
+         ·           ─┬─
+         ·            ╰── \`let\` cannot be used as an identifier in strict mode
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+ERROR in ./index.js ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭────
+       1 │ let let = let;
+         ·     ─┬─
+         ·      ╰── \`let\` cannot be used as an identifier in strict mode
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 
 Rspack compiled with 2 errors"
 `;
@@ -4178,7 +4214,7 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
 {
   "errors": [
     {
-      "formatted": "  × Error[javascript]: JavaScript parsing error
+      "formatted": "  × JavaScript parsing error
    ╭─[1:1]
  1 │ const a {}
    ·         ┬
@@ -4187,7 +4223,7 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
  3 │ var __webpack_modules__ = {
    ╰────
 ",
-      "message": "  × Error[javascript]: JavaScript parsing error
+      "message": "  × JavaScript parsing error
    ╭─[1:1]
  1 │ const a {}
    ·         ┬
@@ -4206,7 +4242,7 @@ exports[`StatsTestCases should print correct stats for minify-error-recovery 1`]
 `;
 
 exports[`StatsTestCases should print correct stats for minify-error-recovery 2`] = `
-"ERROR in × Error[javascript]: JavaScript parsing error
+"ERROR in × JavaScript parsing error
    ╭─[1:1]
  1 │ const a {}
    ·         ┬
@@ -4275,14 +4311,14 @@ exports[`StatsTestCases should print correct stats for normal-errors 1`] = `
 {
   "errors": [
     {
-      "formatted": "  × Error[internal]: Resolve error
+      "formatted": "  × Resolve error
    ╭────
  1 │ import "not-exist";
    · ─────────┬─────────
    ·          ╰── Failed to resolve not-exist in <PROJECT_ROOT>/tests/statsCases/normal-errors/index.js
    ╰────
 ",
-      "message": "  × Error[internal]: Resolve error
+      "message": "  × Resolve error
    ╭────
  1 │ import "not-exist";
    · ─────────┬─────────
@@ -4299,7 +4335,7 @@ exports[`StatsTestCases should print correct stats for normal-errors 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for normal-errors 2`] = `
-"ERROR in × Error[internal]: Resolve error
+"ERROR in × Resolve error
    ╭────
  1 │ import "not-exist";
    · ─────────┬─────────
@@ -4879,27 +4915,39 @@ exports[`StatsTestCases should print correct stats for parse-error 1`] = `
 {
   "errors": [
     {
-      "formatted": "  × Error[javascript]: JavaScript parsing error
-   ╭─[4:1]
- 4 │ includes
- 5 │ a
- 6 │ parser )
-   ·        ┬
-   ·        ╰── Expected ';', '}' or <eof>
- 7 │ error
- 8 │ in
-   ╰────
+      "formatted": "ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │ includes
+       5 │ a
+       6 │ parser )
+         ·        ┬
+         ·        ╰── Expected ';', '}' or <eof>
+       7 │ error
+       8 │ in
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 ",
-      "message": "  × Error[javascript]: JavaScript parsing error
-   ╭─[4:1]
- 4 │ includes
- 5 │ a
- 6 │ parser )
-   ·        ┬
-   ·        ╰── Expected ';', '}' or <eof>
- 7 │ error
- 8 │ in
-   ╰────
+      "message": "ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │ includes
+       5 │ a
+       6 │ parser )
+         ·        ┬
+         ·        ╰── Expected ';', '}' or <eof>
+       7 │ error
+       8 │ in
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 ",
       "moduleId": "996",
       "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/parse-error/b.js",
@@ -4914,16 +4962,22 @@ exports[`StatsTestCases should print correct stats for parse-error 1`] = `
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error 2`] = `
-"ERROR in ./b.js   × Error[javascript]: JavaScript parsing error
-   ╭─[4:1]
- 4 │ includes
- 5 │ a
- 6 │ parser )
-   ·        ┬
-   ·        ╰── Expected ';', '}' or <eof>
- 7 │ error
- 8 │ in
-   ╰────
+"ERROR in ./b.js ModuleParseError
+
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error
+         ╭─[4:1]
+       4 │ includes
+       5 │ a
+       6 │ parser )
+         ·        ┬
+         ·        ╰── Expected ';', '}' or <eof>
+       7 │ error
+       8 │ in
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
 
 Rspack compiled with 1 error"
 `;
@@ -5166,7 +5220,7 @@ console.log(a);
   },
   "errors": [
     {
-      "formatted": "  × Error[internal]: Resolve error
+      "formatted": "  × Resolve error
    ╭─[1:1]
  1 │ import { a } from "cycle-alias/a";
    · ─────────────────┬────────────────
@@ -5174,7 +5228,7 @@ console.log(a);
  2 │ console.log(a);
    ╰────
 ",
-      "message": "  × Error[internal]: Resolve error
+      "message": "  × Resolve error
    ╭─[1:1]
  1 │ import { a } from "cycle-alias/a";
    · ─────────────────┬────────────────
@@ -5378,7 +5432,7 @@ webpack/runtime/compat_get_default_export {main}
   esm import specifier cycle-alias/a [10]
   
 
-ERROR in × Error[internal]: Resolve error
+ERROR in × Resolve error
    ╭─[1:1]
  1 │ import { a } from "cycle-alias/a";
    · ─────────────────┬────────────────
@@ -6590,7 +6644,7 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
   "logging": {},
   "warnings": [
     {
-      "formatted": "  ⚠ Warning[internal]: Resolve error
+      "formatted": "  ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require('./missing-module')
@@ -6600,7 +6654,7 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
  5 │     }
    ╰────
 ",
-      "message": "  ⚠ Warning[internal]: Resolve error
+      "message": "  ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require('./missing-module')
@@ -6617,7 +6671,7 @@ exports[`StatsTestCases should print correct stats for try-require--module 1`] =
 `;
 
 exports[`StatsTestCases should print correct stats for try-require--module 2`] = `
-"WARNING in ⚠ Warning[internal]: Resolve error
+"WARNING in ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require('./missing-module')
@@ -6637,7 +6691,7 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
   "logging": {},
   "warnings": [
     {
-      "formatted": "  ⚠ Warning[internal]: Resolve error
+      "formatted": "  ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolve('./missing-module')
@@ -6647,7 +6701,7 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
  5 │     }
    ╰────
 ",
-      "message": "  ⚠ Warning[internal]: Resolve error
+      "message": "  ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolve('./missing-module')
@@ -6664,7 +6718,7 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-modul
 `;
 
 exports[`StatsTestCases should print correct stats for try-require-resolve-module 2`] = `
-"WARNING in ⚠ Warning[internal]: Resolve error
+"WARNING in ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolve('./missing-module')
@@ -6684,7 +6738,7 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
   "logging": {},
   "warnings": [
     {
-      "formatted": "  ⚠ Warning[internal]: Resolve error
+      "formatted": "  ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolveWeak('./missing-module')
@@ -6694,7 +6748,7 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
  5 │     }
    ╰────
 ",
-      "message": "  ⚠ Warning[internal]: Resolve error
+      "message": "  ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolveWeak('./missing-module')
@@ -6711,7 +6765,7 @@ exports[`StatsTestCases should print correct stats for try-require-resolve-weak-
 `;
 
 exports[`StatsTestCases should print correct stats for try-require-resolve-weak-module 2`] = `
-"WARNING in ⚠ Warning[internal]: Resolve error
+"WARNING in ⚠ Resolve error
    ╭─[1:1]
  1 │     try {
  2 │ ╭─▶     require.resolveWeak('./missing-module')


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This PR introduces detailed `StatsError` and `ModuleParseError`.
`StatsError['moduleName']` and `StatsError['moduleIdentifier']` are both useful in webpack-error-overlay.

`ModuleParseError` is different to Webpack's, as webpack does not contain `ModuleParseWarning`. Rspack combines these two types together.

Note: webpack does have `ModuleWarning`, but it's not the same. Please don't get confused.

### Parsing error:

<img width="1049" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/724566e8-3885-42d9-8c02-627e748be057">

### Parsing warning:
<img width="879" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/8a5a1e3e-e555-4ba7-a3a3-bbd03df8f671">
Note: this does not show up on overlay by default.


## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
