### PR TITLE
fix: try to fix execution context destroy

### DIFF
--- a/packages/playground/cases/chunk/issue-4936/index.test.ts
+++ b/packages/playground/cases/chunk/issue-4936/index.test.ts
@@ -1,9 +1,7 @@
-import { test } from "@/fixtures";
+import { expect, test } from "@/fixtures";
 
-test("should load success", async ({ page, fileAction, rspack }) => {
-	await rspack.waitUntil(async function () {
-		return (await page.title()) === "123";
-	});
+test("should load success", async ({ page, fileAction }) => {
+	await expect(page).toHaveTitle("123");
 
 	// use webpackChunkName
 	fileAction.updateFile(
@@ -13,7 +11,6 @@ import(/* webpackChunkName: "bar" */'./app').then((m) => {
 	m.title('456')
 });`
 	);
-	await rspack.waitUntil(async function () {
-		return (await page.title()) === "456";
-	});
+
+	await expect(page).toHaveTitle("456");
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Try to use [auto-retrying assertions](https://playwright.dev/docs/test-assertions#auto-retrying-assertions) to fix 'execution context was destroyed' error.

<img width="612" alt="image" src="https://github.com/web-infra-dev/rspack/assets/10465670/192d7dcb-972c-420b-942c-f040ead20312">

Related: https://github.com/web-infra-dev/rspack/actions/runs/7256799974/job/19770052584
Related: https://github.com/web-infra-dev/rspack/actions/runs/7237418804/job/19717072921


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
