### PR TITLE
refactor(rspack_core): remove nodejs_resolver and `experiments.rspackFuture.newResolver`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,12 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
-name = "daachorse"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b7ef7a4be509357f4804d0a22e830daddb48f19fd604e4ad32ddce04a94c36"
-
-[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,26 +1615,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "nodejs-resolver"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517c9a4e74fdd7a26d38b1dca0cfff40af33ee3b1d5f379f7c9d711ba5a5d10d"
-dependencies = [
- "daachorse",
- "dashmap",
- "dunce",
- "indexmap 2.1.0",
- "jsonc-parser 0.22.1",
- "once_cell",
- "path-absolutize",
- "rustc-hash",
- "serde",
- "serde_json",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,9 +1731,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "oxc_resolver"
-version = "0.6.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ac76a705bf7db9d1e43904ed4704039de8fa654b0f613cc729c09bb67fd89f6"
+checksum = "8c9cab435ba03dc1974c54e8721313a4d4945af7afaa3882c8eee66e31711da7"
 dependencies = [
  "dashmap",
  "dunce",
@@ -1827,15 +1801,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
 
 [[package]]
-name = "path-absolutize"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43eb3595c63a214e1b37b44f44b0a84900ef7ae0b4c5efce59e123d246d7a0de"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
 name = "path-clean"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,15 +1811,6 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "path-dedot"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d55e486337acb9973cdea3ec5638c1b3bcb22e573b2b7b41969e0c744d5a15e"
-dependencies = [
- "once_cell",
-]
 
 [[package]]
 name = "pathdiff"
@@ -2588,7 +2544,6 @@ dependencies = [
  "itertools",
  "json",
  "mime_guess",
- "nodejs-resolver",
  "once_cell",
  "oxc_resolver",
  "paste",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1142,7 +1142,6 @@ export interface RawResolveTsconfigOptions {
 }
 
 export interface RawRspackFuture {
-  newResolver: boolean
   newTreeshaking: boolean
   disableTransformByDefault: boolean
 }

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -14,7 +14,6 @@ pub struct RawIncrementalRebuild {
 #[serde(rename_all = "camelCase")]
 #[napi(object)]
 pub struct RawRspackFuture {
-  pub new_resolver: bool,
   pub new_treeshaking: bool,
   pub disable_transform_by_default: bool,
 }
@@ -32,7 +31,6 @@ pub struct RawExperiments {
 impl From<RawRspackFuture> for RspackFuture {
   fn from(value: RawRspackFuture) -> Self {
     Self {
-      new_resolver: value.new_resolver,
       new_treeshaking: value.new_treeshaking,
       disable_transform_by_default: value.disable_transform_by_default,
     }

--- a/crates/rspack_binding_options/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_options/src/options/raw_resolve.rs
@@ -56,12 +56,12 @@ fn normalize_alias(alias: Option<RawAliasOption>) -> rspack_error::Result<Option
             .into_iter()
             .map(|value| {
               if let Some(s) = value.as_str() {
-                Ok(AliasMap::Target(s.to_string()))
+                Ok(AliasMap::Path(s.to_string()))
               } else if let Some(b) = value.as_bool() {
                 if b {
                   Err(internal_error!("Alias should not be true in {key}"))
                 } else {
-                  Ok(AliasMap::Ignored)
+                  Ok(AliasMap::Ignore)
                 }
               } else {
                 Err(internal_error!("Alias should be false or string in {key}"))

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -22,9 +22,8 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 json = { workspace = true }
 mime_guess = { workspace = true }
-nodejs-resolver = { version = "0.1.1" }
 once_cell = { workspace = true }
-oxc_resolver = { version = "0.6.2" }
+oxc_resolver = { version = "1.0.1" }
 paste = { workspace = true }
 petgraph = { version = "0.6.3", features = ["serde-1"] }
 rayon = { workspace = true }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -58,12 +58,8 @@ where
         debug_info.with_context(options.context.to_string());
       }
     }
-    let new_resolver = options.experiments.rspack_future.new_resolver;
-    let resolver_factory = Arc::new(ResolverFactory::new(new_resolver, options.resolve.clone()));
-    let loader_resolver_factory = Arc::new(ResolverFactory::new(
-      new_resolver,
-      options.resolve_loader.clone(),
-    ));
+    let resolver_factory = Arc::new(ResolverFactory::new(options.resolve.clone()));
+    let loader_resolver_factory = Arc::new(ResolverFactory::new(options.resolve_loader.clone()));
     let (plugin_driver, options) = PluginDriver::new(options, plugins, resolver_factory.clone());
     let cache = Arc::new(Cache::new(options.clone()));
     let is_new_treeshaking = options.is_new_tree_shaking();

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -23,7 +23,6 @@ impl IncrementalRebuildMakeState {
 
 #[derive(Debug, Default)]
 pub struct RspackFuture {
-  pub new_resolver: bool,
   pub new_treeshaking: bool,
   pub disable_transform_by_default: bool,
 }

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -542,7 +542,7 @@ mod test {
   fn test_merge_resolver_options_0() {
     let base = Resolve {
       extensions: string_list(&["a", "b"]),
-      alias: Some(vec![("c".to_string(), vec![AliasMap::Ignored])]),
+      alias: Some(vec![("c".to_string(), vec![AliasMap::Ignore])]),
       symlinks: Some(false),
       main_files: string_list(&["d", "e", "f"]),
       main_fields: string_list(&["g", "h", "i"]),
@@ -552,7 +552,7 @@ mod test {
     };
     let another = Resolve {
       extensions: string_list(&["a1", "b1"]),
-      alias: Some(vec![("c2".to_string(), vec![AliasMap::Ignored])]),
+      alias: Some(vec![("c2".to_string(), vec![AliasMap::Ignore])]),
       prefer_relative: Some(true),
       browser_field: Some(true),
       main_files: string_list(&["d1", "e", "..."]),
@@ -575,8 +575,8 @@ mod test {
     assert_eq!(
       options.alias.expect("should be Ok"),
       vec![
-        ("c2".to_string(), vec![AliasMap::Ignored]),
-        ("c".to_string(), vec![AliasMap::Ignored])
+        ("c2".to_string(), vec![AliasMap::Ignore]),
+        ("c".to_string(), vec![AliasMap::Ignore])
       ]
     );
     assert_eq!(options.condition_names.expect("should be Ok").len(), 3);
@@ -632,7 +632,7 @@ mod test {
     let second = Resolve {
       extensions: string_list(&["2"]),
       modules: string_list(&["2", "...", "3"]),
-      alias: Some(vec![("2".to_string(), vec![AliasMap::Ignored])]),
+      alias: Some(vec![("2".to_string(), vec![AliasMap::Ignore])]),
       ..Default::default()
     };
     pretty_assertions::assert_eq!(
@@ -640,7 +640,7 @@ mod test {
       Resolve {
         extensions: string_list(&["2"]),
         modules: string_list(&["2", "1", "3"]),
-        alias: Some(vec![("2".to_string(), vec![AliasMap::Ignored])]),
+        alias: Some(vec![("2".to_string(), vec![AliasMap::Ignore])]),
         ..Default::default()
       }
     )

--- a/crates/rspack_core/src/options/resolve/mod.rs
+++ b/crates/rspack_core/src/options/resolve/mod.rs
@@ -7,9 +7,9 @@ use hashlink::LinkedHashMap;
 
 use crate::DependencyCategory;
 
-pub type AliasMap = nodejs_resolver::AliasMap;
+pub type AliasMap = oxc_resolver::AliasValue;
+pub type Alias = oxc_resolver::Alias;
 
-pub type Alias = Vec<(String, Vec<AliasMap>)>;
 pub(super) type Extensions = Vec<String>;
 pub(super) type PreferRelative = bool;
 pub(super) type Symlink = bool;

--- a/crates/rspack_core/src/resolver/factory.rs
+++ b/crates/rspack_core/src/resolver/factory.rs
@@ -25,7 +25,7 @@ pub struct ResolverFactory {
 
 impl Default for ResolverFactory {
   fn default() -> Self {
-    Self::new(false, Resolve::default())
+    Self::new(Resolve::default())
   }
 }
 
@@ -34,10 +34,10 @@ impl ResolverFactory {
     self.resolver.clear_cache();
   }
 
-  pub fn new(new_resolver: bool, options: Resolve) -> Self {
+  pub fn new(options: Resolve) -> Self {
     Self {
       base_options: options.clone(),
-      resolver: Resolver::new(new_resolver, options),
+      resolver: Resolver::new(options),
       resolvers: Default::default(),
     }
   }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -10,29 +10,22 @@ use rspack_error::{
 use rspack_loader_runner::DescriptionData;
 
 use super::{ResolveResult, Resource};
-use crate::{DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType};
+use crate::{AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType};
 
-/// Proxy to [nodejs_resolver::Error] or [oxc_resolver::ResolveError]
+/// Proxy to [oxc_resolver::ResolveError]
 #[derive(Debug)]
 pub enum ResolveInnerError {
-  NodejsResolver(nodejs_resolver::Error),
   OxcResolver(oxc_resolver::ResolveError),
 }
 
-/// Proxy to [nodejs_resolver::Options] or [oxc_resolver::ResolveOptions]
+/// Proxy to [oxc_resolver::ResolveOptions]
 pub enum ResolveInnerOptions<'a> {
-  NodejsResolver(&'a nodejs_resolver::Options),
   OxcResolver(&'a oxc_resolver::ResolveOptions),
 }
 
 impl<'a> fmt::Debug for ResolveInnerOptions<'a> {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
-      Self::NodejsResolver(options) => {
-        let mut options = (*options).clone();
-        options.external_cache = None;
-        write!(f, "{:?}", options)
-      }
       Self::OxcResolver(options) => {
         write!(f, "{:?}", options)
       }
@@ -43,10 +36,6 @@ impl<'a> fmt::Debug for ResolveInnerOptions<'a> {
 impl<'a> ResolveInnerOptions<'a> {
   pub fn is_enforce_extension_enabled(&self) -> bool {
     match self {
-      Self::NodejsResolver(options) => matches!(
-        options.enforce_extension,
-        nodejs_resolver::EnforceExtension::Enabled
-      ),
       Self::OxcResolver(options) => matches!(
         options.enforce_extension,
         oxc_resolver::EnforceExtension::Enabled
@@ -56,50 +45,34 @@ impl<'a> ResolveInnerOptions<'a> {
 
   pub fn extensions(&self) -> impl Iterator<Item = &String> {
     match self {
-      Self::NodejsResolver(options) => options.extensions.iter(),
       Self::OxcResolver(options) => options.extensions.iter(),
     }
   }
 
   pub fn main_files(&self) -> impl Iterator<Item = &String> {
     match self {
-      Self::NodejsResolver(options) => options.main_files.iter(),
       Self::OxcResolver(options) => options.main_files.iter(),
     }
   }
 
   pub fn modules(&self) -> impl Iterator<Item = &String> {
     match self {
-      Self::NodejsResolver(options) => options.modules.iter(),
       Self::OxcResolver(options) => options.modules.iter(),
     }
   }
 }
 
-/// Proxy to [nodejs_resolver::Resolver] or [oxc_resolver::Resolver]
+/// Proxy to [oxc_resolver::Resolver]
 ///
 /// Internal caches are shared.
 #[derive(Debug)]
 pub enum Resolver {
-  NodejsResolver(nodejs_resolver::Resolver, Arc<nodejs_resolver::Cache>),
   OxcResolver(oxc_resolver::Resolver),
 }
 
 impl Resolver {
-  pub fn new(new_resolver: bool, options: Resolve) -> Self {
-    if new_resolver {
-      Self::new_oxc_resolver(options)
-    } else {
-      Self::new_nodejs_resolver(options)
-    }
-  }
-
-  fn new_nodejs_resolver(options: Resolve) -> Self {
-    let cache = Arc::new(nodejs_resolver::Cache::default());
-    let options =
-      to_nodejs_resolver_options(cache.clone(), options, false, DependencyCategory::Unknown);
-    let resolver = nodejs_resolver::Resolver::new(options);
-    Self::NodejsResolver(resolver, cache)
+  pub fn new(options: Resolve) -> Self {
+    Self::new_oxc_resolver(options)
   }
 
   fn new_oxc_resolver(options: Resolve) -> Self {
@@ -111,7 +84,6 @@ impl Resolver {
   /// Clear cache for all resolver instances
   pub fn clear_cache(&self) {
     match self {
-      Self::NodejsResolver(_, cache) => cache.entries.clear(),
       Self::OxcResolver(resolver) => resolver.clear_cache(),
     }
   }
@@ -123,16 +95,6 @@ impl Resolver {
     options_with_dependency_type: &ResolveOptionsWithDependencyType,
   ) -> Self {
     match self {
-      Self::NodejsResolver(_, cache) => {
-        let options = to_nodejs_resolver_options(
-          cache.clone(),
-          options,
-          options_with_dependency_type.resolve_to_context,
-          options_with_dependency_type.dependency_category,
-        );
-        let resolver = nodejs_resolver::Resolver::new(options);
-        Self::NodejsResolver(resolver, cache.clone())
-      }
       Self::OxcResolver(resolver) => {
         let options = to_oxc_resolver_options(
           options,
@@ -155,7 +117,6 @@ impl Resolver {
   /// Return the options from the resolver
   pub fn options(&self) -> ResolveInnerOptions<'_> {
     match self {
-      Self::NodejsResolver(resolver, _) => ResolveInnerOptions::NodejsResolver(&resolver.options),
       Self::OxcResolver(resolver) => ResolveInnerOptions::OxcResolver(resolver.options()),
     }
   }
@@ -163,20 +124,6 @@ impl Resolver {
   /// Resolve a specifier to a given path.
   pub fn resolve(&self, path: &Path, request: &str) -> Result<ResolveResult, ResolveInnerError> {
     match self {
-      Self::NodejsResolver(resolver, _) => resolver
-        .resolve(path, request)
-        .map(|result| match result {
-          nodejs_resolver::ResolveResult::Resource(r) => ResolveResult::Resource(Resource {
-            path: r.path,
-            query: r.query,
-            fragment: r.fragment,
-            description_data: r.description.map(|d| {
-              DescriptionData::new(d.dir().as_ref().to_path_buf(), Arc::clone(d.data().raw()))
-            }),
-          }),
-          nodejs_resolver::ResolveResult::Ignored => ResolveResult::Ignored,
-        })
-        .map_err(ResolveInnerError::NodejsResolver),
       Self::OxcResolver(resolver) => match resolver.resolve(path, request) {
         Ok(r) => Ok(ResolveResult::Resource(Resource {
           path: r.path().to_path_buf(),
@@ -184,7 +131,7 @@ impl Resolver {
           fragment: r.fragment().map(ToString::to_string),
           description_data: r
             .package_json()
-            .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(&d.raw_json))),
+            .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(d.raw_json()))),
         })),
         Err(oxc_resolver::ResolveError::Ignored(_)) => Ok(ResolveResult::Ignored),
         Err(error) => Err(ResolveInnerError::OxcResolver(error)),
@@ -196,72 +143,8 @@ impl Resolver {
 impl ResolveInnerError {
   pub fn into_resolve_error(self, args: &ResolveArgs<'_>) -> Error {
     match self {
-      Self::NodejsResolver(error) => map_nodejs_resolver_error(error, args),
       Self::OxcResolver(error) => map_oxc_resolver_error(error, args),
     }
-  }
-}
-
-fn to_nodejs_resolver_options(
-  cache: Arc<nodejs_resolver::Cache>,
-  options: Resolve,
-  resolve_to_context: bool,
-  dependency_type: DependencyCategory,
-) -> nodejs_resolver::Options {
-  let options = options.merge_by_dependency(dependency_type);
-  let tsconfig = options.tsconfig.map(|c| c.config_file);
-  let enforce_extension = nodejs_resolver::EnforceExtension::Auto;
-  let external_cache = Some(cache);
-  let description_file = String::from("package.json");
-  let extensions = options.extensions.unwrap_or_else(|| {
-    vec![".tsx", ".ts", ".jsx", ".js", ".mjs", ".json"]
-      .into_iter()
-      .map(|s| s.to_string())
-      .collect()
-  });
-  let alias = options.alias.unwrap_or_default();
-  let prefer_relative = options.prefer_relative.unwrap_or(false);
-  let symlinks = options.symlinks.unwrap_or(true);
-  let main_files = options
-    .main_files
-    .unwrap_or_else(|| vec![String::from("index")]);
-  let main_fields = options
-    .main_fields
-    .unwrap_or_else(|| vec![String::from("module"), String::from("main")]);
-  let browser_field = options.browser_field.unwrap_or(true);
-  let condition_names = std::collections::HashSet::from_iter(
-    options
-      .condition_names
-      .unwrap_or_else(|| vec!["module".to_string(), "import".to_string()]),
-  );
-  let modules = options
-    .modules
-    .unwrap_or_else(|| vec!["node_modules".to_string()]);
-  let fallback = options.fallback.unwrap_or_default();
-  let fully_specified = options.fully_specified.unwrap_or_default();
-  let exports_field = options
-    .exports_field
-    .unwrap_or_else(|| vec![vec!["exports".to_string()]]);
-  let extension_alias = options.extension_alias.unwrap_or_default();
-  nodejs_resolver::Options {
-    fallback,
-    modules,
-    extensions,
-    enforce_extension,
-    alias,
-    prefer_relative,
-    external_cache,
-    symlinks,
-    description_file,
-    main_files,
-    main_fields,
-    browser_field,
-    condition_names,
-    tsconfig,
-    resolve_to_context,
-    fully_specified,
-    exports_field,
-    extension_alias,
   }
 }
 
@@ -288,8 +171,8 @@ fn to_oxc_resolver_options(
       let value = value
         .into_iter()
         .map(|x| match x {
-          nodejs_resolver::AliasMap::Target(target) => oxc_resolver::AliasValue::Path(target),
-          nodejs_resolver::AliasMap::Ignored => oxc_resolver::AliasValue::Ignore,
+          AliasMap::Path(target) => oxc_resolver::AliasValue::Path(target),
+          AliasMap::Ignore => oxc_resolver::AliasValue::Ignore,
         })
         .collect();
       (key, value)
@@ -325,8 +208,8 @@ fn to_oxc_resolver_options(
       let value = value
         .into_iter()
         .map(|x| match x {
-          nodejs_resolver::AliasMap::Target(target) => oxc_resolver::AliasValue::Path(target),
-          nodejs_resolver::AliasMap::Ignored => oxc_resolver::AliasValue::Ignore,
+          AliasMap::Path(target) => oxc_resolver::AliasValue::Path(target),
+          AliasMap::Ignore => oxc_resolver::AliasValue::Ignore,
         })
         .collect();
       (key, value)
@@ -363,28 +246,9 @@ fn to_oxc_resolver_options(
   }
 }
 
-fn map_nodejs_resolver_error(error: nodejs_resolver::Error, args: &ResolveArgs<'_>) -> Error {
-  match error {
-    nodejs_resolver::Error::Io(error) => DiagnosticError::from(error.boxed()).into(),
-    nodejs_resolver::Error::UnexpectedJson((json_path, error)) => {
-      internal_error!("{error:?} in {json_path:?}")
-    }
-    nodejs_resolver::Error::UnexpectedValue(error) => {
-      internal_error!(error)
-    }
-    nodejs_resolver::Error::CantFindTsConfig(path) => {
-      internal_error!("{} is not a tsconfig", path.display())
-    }
-    _ => {
-      let is_recursion = matches!(error, nodejs_resolver::Error::Overflow);
-      map_resolver_error(is_recursion, args)
-    }
-  }
-}
-
 fn map_oxc_resolver_error(error: oxc_resolver::ResolveError, args: &ResolveArgs<'_>) -> Error {
   match error {
-    oxc_resolver::ResolveError::InvalidPackageTarget(specifier) => {
+    oxc_resolver::ResolveError::InvalidPackageTarget(specifier, _, _) => {
       let message = format!(
         "Export should be relative path and start with \"./\", but got {}",
         specifier
@@ -416,10 +280,10 @@ fn map_oxc_resolver_error(error: oxc_resolver::ResolveError, args: &ResolveArgs<
         path.display()
       )
     }
-    oxc_resolver::ResolveError::InvalidModuleSpecifier(error) => {
+    oxc_resolver::ResolveError::InvalidModuleSpecifier(error, _) => {
       internal_error!("Invalid module specifier: {}", error)
     }
-    oxc_resolver::ResolveError::PackagePathNotExported(error) => {
+    oxc_resolver::ResolveError::PackagePathNotExported(error, _) => {
       internal_error!("Package subpath '{}' is not defined by \"exports\"", error)
     }
     oxc_resolver::ResolveError::InvalidPackageConfig(path) => {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -769,11 +769,9 @@ function getRawExperiments(
 function getRawRspackFutureOptions(
 	future: RspackFutureOptions
 ): RawRspackFuture {
-	assert(!isNil(future.newResolver));
 	assert(!isNil(future.newTreeshaking));
 	assert(!isNil(future.disableTransformByDefault));
 	return {
-		newResolver: future.newResolver,
 		newTreeshaking: future.newTreeshaking,
 		disableTransformByDefault: future.disableTransformByDefault
 	};

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -184,7 +184,6 @@ const applyExperimentsDefaults = (
 
 	D(experiments, "rspackFuture", {});
 	if (typeof experiments.rspackFuture === "object") {
-		D(experiments.rspackFuture, "newResolver", true);
 		D(experiments.rspackFuture, "newTreeshaking", false);
 		D(experiments.rspackFuture, "disableTransformByDefault", true);
 		D(experiments.rspackFuture, "disableApplyEntryLazily", false);

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1039,22 +1039,6 @@ export type IncrementalRebuildOptions = z.infer<
 >;
 
 const rspackFutureOptions = z.strictObject({
-	newResolver: z
-		.boolean()
-		.optional()
-		.refine(val => {
-			if (val === false) {
-				deprecatedWarn(
-					`'experiments.rspackFuture.newResolver = ${JSON.stringify(
-						val
-					)}' has been deprecated, and will be drop support in 0.5.0, please switch 'experiments.rspackFuture.newResolver = true' to use new resolver, See the discussion ${termlink(
-						"here",
-						"https://github.com/web-infra-dev/rspack/issues/4825"
-					)}`
-				);
-			}
-			return true;
-		}),
 	newTreeshaking: z.boolean().optional(),
 	disableTransformByDefault: z.boolean().optional(),
 	disableApplyEntryLazily: z.boolean().optional()

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -28,7 +28,6 @@ exports[`snapshots should have the correct base config 1`] = `
     "rspackFuture": {
       "disableApplyEntryLazily": false,
       "disableTransformByDefault": true,
-      "newResolver": true,
       "newTreeshaking": false,
     },
     "topLevelAwait": true,

--- a/packages/rspack/tests/configCases/resolve/tsconfig-project-references-auto/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve/tsconfig-project-references-auto/webpack.config.js
@@ -9,10 +9,5 @@ module.exports = {
 			configFile: path.resolve(__dirname, "./tsconfig.json"),
 			references: "auto"
 		}
-	},
-	experiments: {
-		rspackFuture: {
-			newResolver: true
-		}
 	}
 };

--- a/packages/rspack/tests/configCases/resolve/tsconfig-project-references-manual/webpack.config.js
+++ b/packages/rspack/tests/configCases/resolve/tsconfig-project-references-manual/webpack.config.js
@@ -13,10 +13,5 @@ module.exports = {
 				path.resolve(__dirname, "./project_c/tsconfig.json")
 			]
 		}
-	},
-	experiments: {
-		rspackFuture: {
-			newResolver: true
-		}
 	}
 };


### PR DESCRIPTION
> [!NOTE] 
> The target branch is 0.5.0

## Summary

Remove  nodejs_resolver and `experiments.rspackFuture.newResolver` for v0.5.0

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [x] Yes, the corresponding rspack-website PR is https://github.com/web-infra-dev/rspack-website/pull/574
