### PR TITLE
chore: send notification when main branch ci failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,3 +196,22 @@ jobs:
 
       - name: Run test
         run: cargo test --workspace -- --nocapture
+
+  failure_notification:
+    name: Failure Notification
+    needs: [test-linux, test-windows, test-mac, rust_check, rust_test]
+    if: ${{ failure() && !cancelled() && github.ref_name == 'main' && github.repository_owner == 'web-infra-dev' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - shell: bash
+        run: ./scripts/alert/lark.js
+        env:
+          TITLE: CI failed on main branch
+          DESCRIPTION: |
+            commitID: [${{github.sha}}](${{github.server_url}}/${{github.repository}}/commit/${{github.sha}})
+          URL: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}
+          LARK_WEBHOOK_URL: ${{secrets.LARK_WEBHOOK_URL}}

--- a/scripts/alert/lark.js
+++ b/scripts/alert/lark.js
@@ -1,0 +1,54 @@
+#!/bin/env node
+
+const TITLE = process.env.TITLE;
+const DESCRIPTION = process.env.DESCRIPTION;
+const URL = process.env.URL;
+const LARK_WEBHOOK_URL = process.env.LARK_WEBHOOK_URL;
+
+if (!TITLE || !DESCRIPTION) {
+	throw new Error("please input title and description");
+}
+
+const res = await fetch(LARK_WEBHOOK_URL, {
+	method: "POST",
+	headers: {
+		"Content-Type": "application/json"
+	},
+	body: JSON.stringify({
+		msg_type: "interactive",
+		card: {
+			header: {
+				template: "red",
+				title: {
+					content: TITLE,
+					tag: "plain_text"
+				}
+			},
+			elements: [
+				{
+					tag: "markdown",
+					content: DESCRIPTION
+				},
+				{
+					tag: "action",
+					actions: [
+						{
+							tag: "button",
+							text: {
+								content: "Details",
+								tag: "plain_text"
+							},
+							url: URL,
+							type: "danger"
+						}
+					]
+				}
+			]
+		}
+	})
+});
+
+if (!res.ok) {
+	const data = await res.text();
+	throw new Error("send alert failed with " + data);
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

send notification to `Lark` when main branch ci failed

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
