### PR TITLE
fix(plugin-runtime): `stringify_chunk` should escape special chars in chunk names as js\'s JSON.stringify do

### DIFF
--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -351,21 +351,3 @@ fn test_get_undo_path() {
     "../../"
   );
 }
-
-#[test]
-fn test_stringify_chunks() {
-  #[rustfmt::skip]
-  let pass = [
-    (Vec::from(["foo"]), r#"{"foo": 0,}"#),
-    (Vec::from(["aaa", "bbb"]), r#"{"aaa": 0,"bbb": 0,}"#),
-    (Vec::from(["foo", "bar"]), r#"{"bar": 0,"foo": 0,}"#),
-    (Vec::from([r#"fo"o"#]), r#"{"fo\"o": 0,}"#),
-    (Vec::from(["foo\tbar"]), r#"{"foo\tbar": 0,}"#),
-    (Vec::from([r#"html-0-c:\users\default\index.html"#]), r#"{"html-0-c:\\users\\default\\index.html": 0,}"#),
-  ];
-
-  for (chunks, res) in pass {
-    let cks = chunks.iter().map(|x| x.to_string()).collect::<HashSet<_>>();
-    assert_eq!(stringify_chunks(&cks, 0), res.to_string());
-  }
-}

--- a/packages/rspack/tests/configCases/chunk-loading/chunk-name/a.js
+++ b/packages/rspack/tests/configCases/chunk-loading/chunk-name/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/packages/rspack/tests/configCases/chunk-loading/chunk-name/index.js
+++ b/packages/rspack/tests/configCases/chunk-loading/chunk-name/index.js
@@ -1,0 +1,3 @@
+it('output js should execute when chunk name has `"` or `\\`', async () => {
+	await expect(import(`./a`)).resolves.toMatchObject({ a: 1 });
+});

--- a/packages/rspack/tests/configCases/chunk-loading/chunk-name/test.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/chunk-name/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["index.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/chunk-loading/chunk-name/webpack.config.js
+++ b/packages/rspack/tests/configCases/chunk-loading/chunk-name/webpack.config.js
@@ -1,0 +1,10 @@
+const { EntryPlugin } = require("@rspack/core");
+const path = require("path");
+module.exports = {
+	plugins: [
+		new EntryPlugin(__dirname, path.resolve(__dirname, "./index.js"), {
+			name: "HtmlWebpackPlugin_0-C:\\userCode\\x-project\\node_modules\\html-webpack-plugin\\lib\\loader.js!C:\\userCode\\x-project\\index.html",
+			filename: "index.js"
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fix artifact problem on case:

https://github.com/web-infra-dev/rspack/blob/a5e489842cdd0f4599757f8ae868a9a6154cfad0/packages/rspack/tests/configCases/chunk-loading/chunk-name/webpack.config.js

![image](https://github.com/web-infra-dev/rspack/assets/18117084/7fc480c1-ad5f-4341-951b-2086a5be0f6c)

```markdown
* Feature Related: Chunk Loading
* Case: There's `\\u`, `\\x` or `"` in chunk name
```

The artifact would contain code like `var installedChunks = {"aa\uaaa\xaaa"aaa": 0,};` that is invalid.

### Real world case:

```markdown
* OS: Windows
* Setup: html-webpack-plugin@5.6.0
* Edge situation:  There's any path component starting with `u` or `x`
```

Error sample:

```
start   Compiling...
error   Compile error: 
Failed to compile, check the errors for troubleshooting.
SyntaxError
  × [html-rspack-plugin]: Invalid Unicode escape sequence
  │ C:\userCode\23-2-2\vue-app6\node_modules\@rsbuild\core\static\template.html:74
  │ var installedChunks = {"HtmlWebpackPlugin_0-C:\userCode\23-2-2\vue-app6\node_modules\html-webpack-plugin\lib\loader.js!C:\userCode\23-2-2\vue-
  │ app6\node_modules\@rsbuild\core\static\template.html": 0,};
  │                                               ^^^^^^
```

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

Unit tests and configTest case added

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
