### PR TITLE
refactor: remove `get` and `get_mut` in `Database`

### DIFF
--- a/crates/rspack_binding_values/src/chunk.rs
+++ b/crates/rspack_binding_values/src/chunk.rs
@@ -90,10 +90,7 @@ impl JsChunk {
 
 fn chunk(ukey: u32, compilation: &Compilation) -> &Chunk {
   let ukey = ChunkUkey::from(ukey as usize);
-  compilation
-    .chunk_by_ukey
-    .get(&ukey)
-    .expect("Chunk must exist")
+  compilation.chunk_by_ukey.expect_get(&ukey)
 }
 
 #[napi(js_name = "__chunk_inner_is_only_initial")]

--- a/crates/rspack_binding_values/src/chunk_group.rs
+++ b/crates/rspack_binding_values/src/chunk_group.rs
@@ -21,13 +21,7 @@ impl JsChunkGroup {
       chunks: cg
         .chunks
         .iter()
-        .map(|k| {
-          JsChunk::from(
-            compilation.chunk_by_ukey.get(k).unwrap_or_else(|| {
-              panic!("Could not find Chunk({k:?}) belong to ChunkGroup: {cg:?}",)
-            }),
-          )
-        })
+        .map(|k| JsChunk::from(compilation.chunk_by_ukey.expect_get(k)))
         .collect(),
       index: cg.index,
       inner_parents: cg
@@ -42,10 +36,7 @@ impl JsChunkGroup {
 
 fn chunk_group(ukey: u32, compilation: &Compilation) -> &ChunkGroup {
   let ukey = ChunkGroupUkey::from(ukey as usize);
-  compilation
-    .chunk_group_by_ukey
-    .get(&ukey)
-    .expect("chunk group should exists")
+  compilation.chunk_group_by_ukey.expect_get(&ukey)
 }
 
 #[napi(js_name = "__chunk_group_inner_get_chunk_group")]

--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -6,6 +6,7 @@ use napi::NapiRaw;
 use napi_derive::napi;
 use rspack_binding_macros::call_js_function_with_napi_objects;
 use rspack_binding_macros::convert_raw_napi_value_to_napi_value;
+use rspack_core::get_chunk_from_ukey;
 use rspack_core::rspack_sources::BoxSource;
 use rspack_core::AssetInfo;
 use rspack_core::ModuleIdentifier;
@@ -165,7 +166,7 @@ impl JsCompilation {
       .inner
       .named_chunks
       .get(&name)
-      .and_then(|c| self.inner.chunk_by_ukey.get(c).map(JsChunk::from))
+      .and_then(|c| get_chunk_from_ukey(c, &self.inner.chunk_by_ukey).map(JsChunk::from))
   }
 
   #[napi]

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -146,11 +146,7 @@ impl<'me> CodeSplitter<'me> {
       let entrypoint = {
         let ukey = entrypoint.ukey;
         compilation.chunk_group_by_ukey.add(entrypoint);
-
-        compilation
-          .chunk_group_by_ukey
-          .get(&ukey)
-          .ok_or_else(|| internal_error!("no chunk group found"))?
+        compilation.chunk_group_by_ukey.expect_get(&ukey)
       };
 
       for module_identifier in module_identifiers {
@@ -213,10 +209,7 @@ impl<'me> CodeSplitter<'me> {
           .get(name)
           .ok_or_else(|| internal_error!("no entrypoints found"))?;
 
-        let entry_point = compilation
-          .chunk_group_by_ukey
-          .get_mut(ukey)
-          .ok_or_else(|| internal_error!("no chunk group found"))?;
+        let entry_point = compilation.chunk_group_by_ukey.expect_get_mut(ukey);
 
         let chunk = match compilation.named_chunks.get(runtime) {
           Some(ukey) => {
@@ -232,10 +225,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
               entry_point.set_runtime_chunk(entry_chunk);
               continue;
             }
-            compilation
-              .chunk_by_ukey
-              .get_mut(ukey)
-              .ok_or_else(|| internal_error!("no chunk found"))?
+            compilation.chunk_by_ukey.expect_get_mut(ukey)
           }
           None => {
             let chunk_ukey = Compilation::add_named_chunk(
@@ -275,8 +265,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       let chunk_group = self
         .compilation
         .chunk_group_by_ukey
-        .get_mut(&chunk_group)
-        .ok_or_else(|| internal_error!("no chunk group found"))?;
+        .expect_get_mut(&chunk_group);
 
       self.next_chunk_group_index += 1;
       chunk_group.index = Some(self.next_chunk_group_index);
@@ -398,8 +387,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let chunk_group = self
       .compilation
       .chunk_group_by_ukey
-      .get_mut(&item.chunk_group)
-      .expect("chunk group not found");
+      .expect_get_mut(&item.chunk_group);
 
     if chunk_group
       .module_pre_order_indices
@@ -441,8 +429,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let chunk_group = self
       .compilation
       .chunk_group_by_ukey
-      .get_mut(&item.chunk_group)
-      .expect("chunk group not found");
+      .expect_get_mut(&item.chunk_group);
 
     if chunk_group
       .module_post_order_indices

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -8,7 +8,10 @@ use rspack_database::{DatabaseItem, Ukey};
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet, FxHasher};
 
-use crate::{compare_chunk_group, sort_group_by_index, ChunkGraph, ChunkGroup, ChunkGroupOrderKey};
+use crate::{
+  compare_chunk_group, get_chunk_group_from_ukey, sort_group_by_index, ChunkGraph, ChunkGroup,
+  ChunkGroupOrderKey,
+};
 use crate::{ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, SourceType};
 use crate::{Compilation, EntryOptions, Filename, ModuleGraph, RuntimeSpec};
 
@@ -88,7 +91,7 @@ impl Chunk {
     chunk_group_by_ukey: &'a ChunkGroupByUkey,
   ) -> Option<&'a EntryOptions> {
     for group_ukey in &self.groups {
-      if let Some(group) = chunk_group_by_ukey.get(group_ukey)
+      if let Some(group) = get_chunk_group_from_ukey(group_ukey, chunk_group_by_ukey)
         && let Some(entry_options) = group.kind.get_entry_options()
       {
         return Some(entry_options);
@@ -105,9 +108,7 @@ impl Chunk {
     self
       .get_sorted_groups_iter(chunk_group_by_ukey)
       .for_each(|group| {
-        let group = chunk_group_by_ukey
-          .get_mut(group)
-          .expect("Group should exist");
+        let group = chunk_group_by_ukey.expect_get_mut(group);
         group.insert_chunk(new_chunk.ukey, self.ukey);
         new_chunk.add_group(group.ukey);
       });
@@ -119,7 +120,7 @@ impl Chunk {
     self
       .groups
       .iter()
-      .filter_map(|ukey| chunk_group_by_ukey.get(ukey))
+      .filter_map(|ukey| get_chunk_group_from_ukey(ukey, chunk_group_by_ukey))
       .any(|group| group.is_initial())
   }
 
@@ -127,7 +128,7 @@ impl Chunk {
     self
       .groups
       .iter()
-      .filter_map(|ukey| chunk_group_by_ukey.get(ukey))
+      .filter_map(|ukey| get_chunk_group_from_ukey(ukey, chunk_group_by_ukey))
       .all(|group| group.is_initial())
   }
 
@@ -148,9 +149,7 @@ impl Chunk {
       chunk_group_by_ukey: &ChunkGroupByUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
-      let group = chunk_group_by_ukey
-        .get(chunk_group_ukey)
-        .expect("Group should exist");
+      let group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
 
       for chunk_ukey in group.chunks.iter() {
         chunks.insert(*chunk_ukey);
@@ -195,9 +194,7 @@ impl Chunk {
       chunk_group_by_ukey: &ChunkGroupByUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
-      let group = chunk_group_by_ukey
-        .get(chunk_group_ukey)
-        .expect("Group should exist");
+      let group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
 
       if group.is_initial() {
         for chunk_ukey in group.chunks.iter() {
@@ -243,9 +240,7 @@ impl Chunk {
       chunk_group_by_ukey: &ChunkGroupByUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
-      let group = chunk_group_by_ukey
-        .get(chunk_group_ukey)
-        .expect("Group should exist");
+      let group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
 
       for chunk_ukey in group.async_entrypoints_iterable() {
         async_entrypoints.insert(*chunk_ukey);
@@ -280,7 +275,7 @@ impl Chunk {
     self
       .groups
       .iter()
-      .filter_map(|ukey| chunk_group_by_ukey.get(ukey))
+      .filter_map(|ukey| get_chunk_group_from_ukey(ukey, chunk_group_by_ukey))
       .any(|group| group.kind.is_entrypoint() && group.get_runtime_chunk() == self.ukey)
   }
 
@@ -318,13 +313,13 @@ impl Chunk {
       initial_queue: &mut IndexSet<ChunkGroupUkey, BuildHasherDefault<FxHasher>>,
       chunk_group_ukey: &ChunkGroupUkey,
     ) {
-      if let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) {
+      if let Some(chunk_group) = get_chunk_group_from_ukey(chunk_group_ukey, chunk_group_by_ukey) {
         for child_ukey in chunk_group
           .children
           .iter()
           .sorted_by(|a, b| sort_group_by_index(a, b, chunk_group_by_ukey))
         {
-          if let Some(chunk_group) = chunk_group_by_ukey.get(child_ukey) {
+          if let Some(chunk_group) = get_chunk_group_from_ukey(child_ukey, chunk_group_by_ukey) {
             if chunk_group.is_initial() && !initial_queue.contains(&chunk_group.ukey) {
               initial_queue.insert(chunk_group.ukey);
               add_to_queue(chunk_group_by_ukey, queue, initial_queue, &chunk_group.ukey);
@@ -352,7 +347,7 @@ impl Chunk {
       chunk_group_ukey: &ChunkGroupUkey,
       visit_chunk_groups: &mut HashSet<ChunkGroupUkey>,
     ) {
-      if let Some(chunk_group) = chunk_group_by_ukey.get(chunk_group_ukey) {
+      if let Some(chunk_group) = get_chunk_group_from_ukey(chunk_group_ukey, chunk_group_by_ukey) {
         for chunk_ukey in chunk_group.chunks.iter() {
           if !initial_chunks.contains(chunk_ukey) {
             chunks.insert(*chunk_ukey);
@@ -414,9 +409,7 @@ impl Chunk {
 
   pub fn disconnect_from_groups(&mut self, chunk_group_by_ukey: &mut ChunkGroupByUkey) {
     for group_ukey in self.groups.iter() {
-      let group = chunk_group_by_ukey
-        .get_mut(group_ukey)
-        .expect("Group should exist");
+      let group = chunk_group_by_ukey.expect_get_mut(group_ukey);
       group.remove_chunk(&self.ukey);
     }
     self.groups.clear();
@@ -442,7 +435,9 @@ impl Chunk {
       .get_chunk_entry_modules_with_chunk_group_iterable(&self.ukey)
     {
       compilation.chunk_graph.get_module_id(*module).hash(hasher);
-      if let Some(chunk_group) = compilation.chunk_group_by_ukey.get(chunk_group) {
+      if let Some(chunk_group) =
+        get_chunk_group_from_ukey(chunk_group, &compilation.chunk_group_by_ukey)
+      {
         chunk_group.id(compilation).hash(hasher);
       }
     }
@@ -461,9 +456,7 @@ impl Chunk {
     let mut list = vec![];
     let chunk_group_by_ukey = &compilation.chunk_group_by_ukey;
     for group_ukey in self.get_sorted_groups_iter(chunk_group_by_ukey) {
-      let group = chunk_group_by_ukey
-        .get(group_ukey)
-        .expect("chunk group do not exists");
+      let group = chunk_group_by_ukey.expect_get(group_ukey);
       if let Some(last_chunk) = group.chunks.last() {
         if is_self_last_chunk && !last_chunk.eq(&self.ukey) {
           continue;
@@ -475,9 +468,7 @@ impl Chunk {
         .iter()
         .sorted_by(|a, b| sort_group_by_index(a, b, chunk_group_by_ukey))
       {
-        let child_group = chunk_group_by_ukey
-          .get(child_group_ukey)
-          .expect("child group do not exists");
+        let child_group = chunk_group_by_ukey.expect_get(child_group_ukey);
         let order = child_group
           .kind
           .get_normal_options()
@@ -509,10 +500,7 @@ impl Chunk {
       BuildHasherDefault<FxHasher>,
     > = IndexMap::default();
     for (_, group_ukey, child_group_ukey) in list.iter() {
-      let child_group = chunk_group_by_ukey
-        .get(child_group_ukey)
-        .expect("chunk group do not exists");
-
+      let child_group = chunk_group_by_ukey.expect_get(child_group_ukey);
       result
         .entry(group_ukey.to_owned())
         .or_default()
@@ -523,9 +511,7 @@ impl Chunk {
       result
         .iter()
         .map(|(group_ukey, chunks)| {
-          let group = chunk_group_by_ukey
-            .get(group_ukey)
-            .expect("chunk group do not exists");
+          let group = chunk_group_by_ukey.expect_get(group_ukey);
           (
             group.chunks.clone(),
             chunks.iter().map(|x| x.to_owned()).collect_vec(),
@@ -551,10 +537,7 @@ impl Chunk {
       >,
       compilation: &Compilation,
     ) {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(chunk_ukey)
-        .expect("chunk do not exists");
+      let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
       let order_children = chunk.get_children_of_type_in_order(order, compilation, true);
       if let (Some(chunk_id), Some(order_children)) = (chunk.id.to_owned(), order_children) {
         let child_chunk_ids = order_children
@@ -563,8 +546,7 @@ impl Chunk {
             child_chunks.iter().filter_map(|chunk_ukey| {
               compilation
                 .chunk_by_ukey
-                .get(chunk_ukey)
-                .expect("chunk do not exists")
+                .expect_get(chunk_ukey)
                 .id
                 .to_owned()
             })
@@ -582,9 +564,7 @@ impl Chunk {
       for chunk_ukey in self
         .get_sorted_groups_iter(&compilation.chunk_group_by_ukey)
         .filter_map(|chunk_group_ukey| {
-          compilation
-            .chunk_group_by_ukey
-            .get(chunk_group_ukey)
+          get_chunk_group_from_ukey(chunk_group_ukey, &compilation.chunk_group_by_ukey)
             .map(|g| g.chunks.to_owned())
         })
         .flatten()

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -301,18 +301,12 @@ impl ChunkGraph {
   ) -> HashMap<String, bool> {
     let mut map = HashMap::default();
 
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(chunk_ukey)
-      .expect("Chunk should exist");
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
     for c in chunk
       .get_all_referenced_chunks(&compilation.chunk_group_by_ukey)
       .iter()
     {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(c)
-        .expect("Chunk should exist");
+      let chunk = compilation.chunk_by_ukey.expect_get(c);
       map.insert(chunk.expect_id().to_string(), filter(c, compilation));
     }
 
@@ -384,9 +378,7 @@ impl ChunkGraph {
   ) -> bool {
     let cgc = self.get_chunk_graph_chunk(chunk_ukey);
     for (_, chunk_group_ukey) in cgc.entry_modules.iter() {
-      let chunk_group = chunk_group_by_ukey
-        .get(chunk_group_ukey)
-        .expect("should have chunk group");
+      let chunk_group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
       for c in chunk_group.chunks.iter() {
         if c != chunk_ukey {
           return true;
@@ -402,21 +394,17 @@ impl ChunkGraph {
     chunk_by_ukey: &ChunkByUkey,
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> impl Iterator<Item = ChunkUkey> {
-    let chunk = chunk_by_ukey.get(chunk_ukey).expect("should have chunk");
+    let chunk = chunk_by_ukey.expect_get(chunk_ukey);
     let mut set = IndexSet::new();
     for chunk_group_ukey in chunk.get_sorted_groups_iter(chunk_group_by_ukey) {
-      let chunk_group = chunk_group_by_ukey
-        .get(chunk_group_ukey)
-        .expect("should have chunk group");
+      let chunk_group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
       if chunk_group.kind.is_entrypoint() {
         let entry_point_chunk = chunk_group.get_entry_point_chunk();
         let cgc = self.get_chunk_graph_chunk(&entry_point_chunk);
         for (_, chunk_group_ukey) in cgc.entry_modules.iter() {
-          let chunk_group = chunk_group_by_ukey
-            .get(chunk_group_ukey)
-            .expect("should have chunk group");
+          let chunk_group = chunk_group_by_ukey.expect_get(chunk_group_ukey);
           for c in chunk_group.chunks.iter() {
-            let chunk = chunk_by_ukey.get(c).expect("should have chunk");
+            let chunk = chunk_by_ukey.expect_get(c);
             if c != chunk_ukey && c != &entry_point_chunk && !chunk.has_runtime(chunk_group_by_ukey)
             {
               set.insert(*c);
@@ -447,8 +435,8 @@ impl ChunkGraph {
     chunk_by_ukey: &ChunkByUkey,
     chunk_group_by_ukey: &ChunkGroupByUkey,
   ) -> bool {
-    let chunk_a = chunk_by_ukey.get(chunk_a_ukey).expect("should have chunk");
-    let chunk_b = chunk_by_ukey.get(chunk_b_ukey).expect("should have chunk");
+    let chunk_a = chunk_by_ukey.expect_get(chunk_a_ukey);
+    let chunk_b = chunk_by_ukey.expect_get(chunk_b_ukey);
     if chunk_a.prevent_integration || chunk_b.prevent_integration {
       return false;
     }
@@ -510,7 +498,7 @@ impl ChunkGraph {
     let modules_size = get_modules_size(&modules);
     let chunk_overhead = options.chunk_overhead.unwrap_or(10000f64);
     let entry_chunk_multiplicator = options.entry_chunk_multiplicator.unwrap_or(10f64);
-    let chunk = chunk_by_ukey.get(chunk_ukey).expect("chunk not found");
+    let chunk = chunk_by_ukey.expect_get(chunk_ukey);
     chunk_overhead
       + modules_size
         * (if chunk.can_be_initial(chunk_group_by_ukey) {
@@ -546,8 +534,8 @@ impl ChunkGraph {
     let chunk_overhead = options.chunk_overhead.unwrap_or(10000f64);
     let entry_chunk_multiplicator = options.entry_chunk_multiplicator.unwrap_or(10f64);
 
-    let chunk_a = chunk_by_ukey.get(chunk_a_ukey).expect("chunk not found");
-    let chunk_b = chunk_by_ukey.get(chunk_b_ukey).expect("chunk not found");
+    let chunk_a = chunk_by_ukey.expect_get(chunk_a_ukey);
+    let chunk_b = chunk_by_ukey.expect_get(chunk_b_ukey);
 
     chunk_overhead
       + modules_size

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -8,9 +8,9 @@ use rspack_util::ext::DynHash;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, ChunkByUkey, ChunkGroup, ChunkGroupByUkey,
-  ChunkGroupUkey, ChunkUkey, ExportsHash, ModuleIdentifier, RuntimeGlobals, RuntimeSpec,
-  RuntimeSpecMap, RuntimeSpecSet,
+  get_chunk_group_from_ukey, AsyncDependenciesBlockIdentifier, BoxModule, ChunkByUkey, ChunkGroup,
+  ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, ExportsHash, ModuleIdentifier, RuntimeGlobals,
+  RuntimeSpec, RuntimeSpecMap, RuntimeSpecSet,
 };
 use crate::{ChunkGraph, ModuleGraph};
 
@@ -130,7 +130,7 @@ impl ChunkGraph {
     let cgm = self.get_chunk_graph_module(module_identifier);
     let mut runtimes = RuntimeSpecSet::default();
     for chunk_ukey in cgm.chunks.iter() {
-      let chunk = chunk_by_ukey.get(chunk_ukey).expect("Chunk should exist");
+      let chunk = chunk_by_ukey.expect_get(chunk_ukey);
       runtimes.set(chunk.runtime.clone());
     }
     runtimes
@@ -154,7 +154,7 @@ impl ChunkGraph {
     self
       .block_to_chunk_group_ukey
       .get(block)
-      .and_then(|ukey| chunk_group_by_ukey.get(ukey))
+      .and_then(|ukey| get_chunk_group_from_ukey(ukey, chunk_group_by_ukey))
   }
 
   pub fn connect_block_and_chunk_group(

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -8,7 +8,9 @@ use rspack_identifier::IdentifierMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::MakeParam;
-use crate::{fast_set, ChunkKind, Compilation, Compiler, ModuleGraph, RuntimeSpec};
+use crate::{
+  fast_set, get_chunk_from_ukey, ChunkKind, Compilation, Compiler, ModuleGraph, RuntimeSpec,
+};
 
 impl<T> Compiler<T>
 where
@@ -28,10 +30,7 @@ where
 
     let mut all_old_runtime: RuntimeSpec = Default::default();
     for entry_ukey in old.compilation.get_chunk_graph_entries() {
-      if let Some(runtime) = old
-        .compilation
-        .chunk_by_ukey
-        .get(&entry_ukey)
+      if let Some(runtime) = get_chunk_from_ukey(&entry_ukey, &old.compilation.chunk_by_ukey)
         .map(|entry_chunk| entry_chunk.runtime.clone())
       {
         all_old_runtime.extend(runtime);

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -316,3 +316,36 @@ impl From<&str> for ModuleType {
 pub type ChunkByUkey = Database<Chunk>;
 pub type ChunkGroupByUkey = Database<ChunkGroup>;
 pub(crate) type SharedPluginDriver = Arc<PluginDriver>;
+
+pub fn get_chunk_group_from_ukey<'a>(
+  ukey: &ChunkGroupUkey,
+  chunk_group_by_ukey: &'a ChunkGroupByUkey,
+) -> Option<&'a ChunkGroup> {
+  if chunk_group_by_ukey.contains(ukey) {
+    Some(chunk_group_by_ukey.expect_get(ukey))
+  } else {
+    None
+  }
+}
+
+pub fn get_chunk_from_ukey<'a>(
+  ukey: &ChunkUkey,
+  chunk_by_ukey: &'a ChunkByUkey,
+) -> Option<&'a Chunk> {
+  if chunk_by_ukey.contains(ukey) {
+    Some(chunk_by_ukey.expect_get(ukey))
+  } else {
+    None
+  }
+}
+
+pub fn get_mut_chunk_from_ukey<'a>(
+  ukey: &ChunkUkey,
+  chunk_by_ukey: &'a mut ChunkByUkey,
+) -> Option<&'a mut Chunk> {
+  if chunk_by_ukey.contains(ukey) {
+    Some(chunk_by_ukey.expect_get_mut(ukey))
+  } else {
+    None
+  }
+}

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -35,11 +35,7 @@ pub struct ContentHashArgs<'c> {
 
 impl<'me> ContentHashArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(&self.chunk_ukey)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(&self.chunk_ukey)
   }
 }
 
@@ -52,11 +48,7 @@ pub struct ChunkHashArgs<'c> {
 
 impl<'me> ChunkHashArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(&self.chunk_ukey)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(&self.chunk_ukey)
   }
 }
 
@@ -68,11 +60,7 @@ pub struct RenderManifestArgs<'me> {
 
 impl<'me> RenderManifestArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(&self.chunk_ukey)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(&self.chunk_ukey)
   }
 }
 
@@ -173,11 +161,7 @@ pub struct AdditionalModuleRequirementsArgs<'a> {
 
 impl<'me> AdditionalChunkRuntimeRequirementsArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(self.chunk)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(self.chunk)
   }
 }
 
@@ -196,11 +180,7 @@ pub struct ChunkAssetArgs<'a> {
 
 impl<'me> RenderChunkArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(self.chunk_ukey)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(self.chunk_ukey)
   }
 }
 
@@ -223,11 +203,7 @@ pub struct RenderStartupArgs<'a> {
 
 impl<'me> RenderStartupArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(self.chunk)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(self.chunk)
   }
 }
 
@@ -240,11 +216,7 @@ pub struct RenderArgs<'a> {
 
 impl<'me> RenderArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(self.chunk)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(self.chunk)
   }
 }
 
@@ -256,11 +228,7 @@ pub struct JsChunkHashArgs<'a> {
 
 impl<'me> JsChunkHashArgs<'me> {
   pub fn chunk(&self) -> &Chunk {
-    self
-      .compilation
-      .chunk_by_ukey
-      .get(self.chunk_ukey)
-      .expect("chunk should exist in chunk_by_ukey")
+    self.compilation.chunk_by_ukey.expect_get(self.chunk_ukey)
   }
 }
 

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -105,14 +105,8 @@ pub fn sort_group_by_index(
   ukey_b: &ChunkGroupUkey,
   chunk_group_by_ukey: &ChunkGroupByUkey,
 ) -> Ordering {
-  let index_a = chunk_group_by_ukey
-    .get(ukey_a)
-    .expect("Group should exists")
-    .index;
-  let index_b = chunk_group_by_ukey
-    .get(ukey_b)
-    .expect("Group should exists")
-    .index;
+  let index_a = chunk_group_by_ukey.expect_get(ukey_a).index;
+  let index_b = chunk_group_by_ukey.expect_get(ukey_b).index;
   match index_a {
     None => match index_b {
       None => Ordering::Equal,
@@ -130,16 +124,8 @@ pub fn compare_chunk_group(
   ukey_b: &ChunkGroupUkey,
   compilation: &Compilation,
 ) -> Ordering {
-  let chunks_a = &compilation
-    .chunk_group_by_ukey
-    .get(ukey_a)
-    .expect("Group should exists")
-    .chunks;
-  let chunks_b = &compilation
-    .chunk_group_by_ukey
-    .get(ukey_b)
-    .expect("Group should exists")
-    .chunks;
+  let chunks_a = &compilation.chunk_group_by_ukey.expect_get(ukey_a).chunks;
+  let chunks_b = &compilation.chunk_group_by_ukey.expect_get(ukey_b).chunks;
   match chunks_a.len().cmp(&chunks_b.len()) {
     Ordering::Less => Ordering::Greater,
     Ordering::Greater => Ordering::Less,

--- a/crates/rspack_database/src/database.rs
+++ b/crates/rspack_database/src/database.rs
@@ -35,14 +35,6 @@ impl<Item: Any> Database<Item> {
     self.inner.contains_key(id)
   }
 
-  pub fn get(&self, id: &Ukey<Item>) -> Option<&Item> {
-    self.inner.get(id)
-  }
-
-  pub fn get_mut(&mut self, id: &Ukey<Item>) -> Option<&mut Item> {
-    self.inner.get_mut(id)
-  }
-
   pub fn remove(&mut self, id: &Ukey<Item>) -> Option<Item> {
     self.inner.remove(id)
   }
@@ -55,14 +47,14 @@ impl<Item: Any> Database<Item> {
     self
       .inner
       .get(id)
-      .unwrap_or_else(|| panic!("Not found {id:?}"))
+      .unwrap_or_else(|| panic!("Chunk({id:?}) not found in ChunkGroup: {self:?}"))
   }
 
   pub fn expect_get_mut(&mut self, id: &Ukey<Item>) -> &mut Item {
     self
       .inner
       .get_mut(id)
-      .unwrap_or_else(|| panic!("Not found {id:?}"))
+      .unwrap_or_else(|| panic!("Chunk({id:?}) not found in ChunkGroup"))
   }
 
   pub fn values(&self) -> impl Iterator<Item = &Item> {

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -65,10 +65,7 @@ impl Plugin for DeterministicChunkIdsPlugin {
     );
 
     chunk_key_to_id.into_iter().for_each(|(chunk_ukey, id)| {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get_mut(&chunk_ukey)
-        .expect("Chunk should exists");
+      let chunk = compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
       chunk.id = Some(id.to_string());
       chunk.ids = vec![id.to_string()];
     });

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -463,10 +463,7 @@ pub fn assign_ascending_chunk_ids(chunks: &[ChunkUkey], compilation: &mut Compil
   let mut next_id = 0;
   if !used_ids.is_empty() {
     for chunk in chunks {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get_mut(chunk)
-        .expect("Chunk not found");
+      let chunk = compilation.chunk_by_ukey.expect_get_mut(chunk);
       if chunk.id.is_none() {
         while used_ids.contains(&next_id.to_string()) {
           next_id += 1;
@@ -478,10 +475,7 @@ pub fn assign_ascending_chunk_ids(chunks: &[ChunkUkey], compilation: &mut Compil
     }
   } else {
     for chunk in chunks {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get_mut(chunk)
-        .expect("Chunk not found");
+      let chunk = compilation.chunk_by_ukey.expect_get_mut(chunk);
       if chunk.id.is_none() {
         chunk.id = Some(next_id.to_string());
         chunk.ids = vec![next_id.to_string()];

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -67,10 +67,7 @@ impl Plugin for NamedChunkIdsPlugin {
       .collect::<Vec<_>>();
 
     chunk_id_to_name.into_iter().for_each(|(chunk_ukey, name)| {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get_mut(&chunk_ukey)
-        .expect("Chunk should exist");
+      let chunk = compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
       chunk.id = Some(name.clone());
       chunk.ids = vec![name];
     });

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -165,10 +165,7 @@ impl Plugin for CssPlugin {
     args: &rspack_core::ContentHashArgs<'_>,
   ) -> rspack_core::PluginContentHashHookOutput {
     let compilation = &args.compilation;
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(&args.chunk_ukey)
-      .expect("should have chunk");
+    let chunk = compilation.chunk_by_ukey.expect_get(&args.chunk_ukey);
     let ordered_modules = Self::get_ordered_chunk_css_modules(
       chunk,
       &compilation.chunk_graph,

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
-use rspack_core::{Logger, OptimizeChunksArgs, Plugin, PluginContext, PluginOptimizeChunksOutput};
+use rspack_core::{
+  get_chunk_from_ukey, get_chunk_group_from_ukey, Logger, OptimizeChunksArgs, Plugin,
+  PluginContext, PluginOptimizeChunksOutput,
+};
 
 #[derive(Debug)]
 pub struct EnsureChunkConditionsPlugin;
@@ -47,7 +50,7 @@ impl Plugin for EnsureChunkConditionsPlugin {
     for (module_id, chunk_keys) in &source_module_chunks {
       let mut target_chunks = HashSet::new();
       for chunk_key in chunk_keys {
-        if let Some(chunk) = compilation.chunk_by_ukey.get(chunk_key) {
+        if let Some(chunk) = get_chunk_from_ukey(chunk_key, &compilation.chunk_by_ukey) {
           let mut chunk_group_keys = chunk.groups.iter().collect::<Vec<_>>();
           let mut visited_chunk_group_keys = HashSet::new();
           'out: while let Some(chunk_group_key) = chunk_group_keys.pop() {
@@ -55,7 +58,9 @@ impl Plugin for EnsureChunkConditionsPlugin {
               continue;
             }
             visited_chunk_group_keys.insert(chunk_group_key);
-            if let Some(chunk_group) = compilation.chunk_group_by_ukey.get(chunk_group_key) {
+            if let Some(chunk_group) =
+              get_chunk_group_from_ukey(chunk_group_key, &compilation.chunk_group_by_ukey)
+            {
               for chunk in &chunk_group.chunks {
                 if let Some(module) = compilation.module_graph.module_by_identifier(module_id) {
                   if matches!(module.chunk_condition(chunk, compilation), Some(true)) {

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -263,10 +263,7 @@ impl Plugin for HotModuleReplacementPlugin {
           let filename = if entry.has_filename() {
             entry.filename().to_string()
           } else {
-            let chunk = compilation
-              .chunk_by_ukey
-              .get(&ukey)
-              .expect("should have update chunk");
+            let chunk = compilation.chunk_by_ukey.expect_get(&ukey);
             compilation.get_path(
               &compilation.options.output.hot_update_chunk_filename,
               PathData::default().chunk(chunk).hash_optional(

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyId, DependencyTemplate,
-  DependencyType, ErrorSpan, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
-  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
+  get_chunk_from_ukey, AsContextDependency, Dependency, DependencyCategory, DependencyId,
+  DependencyTemplate, DependencyType, ErrorSpan, ExtendedReferencedExport, ModuleDependency,
+  ModuleGraph, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -97,7 +97,7 @@ impl DependencyTemplate for WorkerDependency {
           .get_block_chunk_group(block, &compilation.chunk_group_by_ukey)
       })
       .map(|entrypoint| entrypoint.get_entry_point_chunk())
-      .and_then(|ukey| compilation.chunk_by_ukey.get(&ukey))
+      .and_then(|ukey| get_chunk_from_ukey(&ukey, &compilation.chunk_by_ukey))
       .and_then(|chunk| chunk.id.as_deref())
       .and_then(|chunk_id| serde_json::to_string(chunk_id).ok())
       .expect("failed to get json stringified chunk id");

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -136,10 +136,7 @@ impl JsPlugin {
     let runtime_requirements = compilation
       .chunk_graph
       .get_chunk_runtime_requirements(chunk_ukey);
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(chunk_ukey)
-      .expect("chunk should exist in chunk_by_ukey");
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
     let module_factories = runtime_requirements.contains(RuntimeGlobals::MODULE_FACTORIES);
     // let require_function = runtime_requirements.contains(RuntimeGlobals::REQUIRE);
     let intercept_module_execution =
@@ -190,20 +187,17 @@ impl JsPlugin {
           .chunk_graph
           .get_chunk_entry_modules_with_chunk_group_iterable(chunk_ukey);
         for (i, (module, entry)) in entries.iter().enumerate() {
-          let chunk_group = compilation
-            .chunk_group_by_ukey
-            .get(entry)
-            .expect("should have chunk group");
+          let chunk_group = compilation.chunk_group_by_ukey.expect_get(entry);
           let chunk_ids = chunk_group
             .chunks
             .iter()
             .filter(|c| *c != chunk_ukey)
             .map(|chunk_ukey| {
-              let chunk = compilation
+              compilation
                 .chunk_by_ukey
-                .get(chunk_ukey)
-                .expect("Chunk not found");
-              chunk.expect_id().to_string()
+                .expect_get(chunk_ukey)
+                .expect_id()
+                .to_string()
             })
             .collect::<Vec<_>>();
           let module_id = compilation

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -19,10 +19,7 @@ pub fn render_chunk_modules(
     SourceType::JavaScript,
     module_graph,
   );
-  let chunk = compilation
-    .chunk_by_ukey
-    .get(chunk_ukey)
-    .expect("chunk not found");
+  let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
 
   let plugin_driver = &compilation.plugin_driver;
 

--- a/crates/rspack_plugin_library/src/utils.rs
+++ b/crates/rspack_plugin_library/src/utils.rs
@@ -57,10 +57,7 @@ pub fn get_options_for_chunk<'a>(
   {
     return None;
   }
-  let chunk = compilation
-    .chunk_by_ukey
-    .get(chunk_ukey)
-    .expect("chunk not found");
+  let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
   chunk
     .get_entry_options(&compilation.chunk_group_by_ukey)
     .and_then(|options| options.library.as_ref())

--- a/crates/rspack_plugin_limit_chunk_count/src/chunk_combination.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/chunk_combination.rs
@@ -55,8 +55,8 @@ impl ChunkCombinationBucket {
     }
   }
 
-  pub fn get_mut(&mut self, ukey: &ChunkCombinationUkey) -> Option<&mut ChunkCombination> {
-    self.combinations_by_ukey.get_mut(ukey)
+  pub fn get_mut(&mut self, ukey: &ChunkCombinationUkey) -> &mut ChunkCombination {
+    self.combinations_by_ukey.expect_get_mut(ukey)
   }
 
   pub fn add(&mut self, combination: ChunkCombination) {
@@ -67,14 +67,8 @@ impl ChunkCombinationBucket {
 
   fn sort_combinations(&mut self) {
     self.sorted_combinations.sort_by(|a_ukey, b_ukey| {
-      let a = self
-        .combinations_by_ukey
-        .get(a_ukey)
-        .expect("chunk combination not found");
-      let b = self
-        .combinations_by_ukey
-        .get(b_ukey)
-        .expect("chunk combination not found");
+      let a = self.combinations_by_ukey.expect_get(a_ukey);
+      let b = self.combinations_by_ukey.expect_get(b_ukey);
       // Layer 1: ordered by largest size benefit
       if a.size_diff < b.size_diff {
         Ordering::Less
@@ -357,28 +351,28 @@ mod test {
     combinations.delete(&combination_6);
     combinations.delete(&combination_10);
 
-    let c = combinations.get_mut(&combination_2).unwrap();
+    let c = combinations.get_mut(&combination_2);
     c.a = chunk_1;
     c.integrated_size = 10074_f64;
     c.a_size = 10044_f64;
     c.size_diff = 10000_f64;
     combinations.update();
 
-    let c = combinations.get_mut(&combination_4).unwrap();
+    let c = combinations.get_mut(&combination_4);
     c.a = chunk_1;
     c.integrated_size = 10074_f64;
     c.a_size = 10044_f64;
     c.size_diff = 10000_f64;
     combinations.update();
 
-    let c = combinations.get_mut(&combination_7).unwrap();
+    let c = combinations.get_mut(&combination_7);
     c.a = chunk_1;
     c.integrated_size = 10066_f64;
     c.a_size = 10044_f64;
     c.size_diff = 10000_f64;
     combinations.update();
 
-    let c = combinations.get_mut(&combination_8).unwrap();
+    let c = combinations.get_mut(&combination_8);
     c.a = chunk_1;
     c.integrated_size = 11450_f64;
     c.a_size = 10044_f64;

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -32,14 +32,7 @@ impl Plugin for MergeDuplicateChunksPlugin {
       .copied()
       .collect::<Vec<_>>();
 
-    chunk_ukeys.sort_by_key(|ukey| {
-      compilation
-        .chunk_by_ukey
-        .get(ukey)
-        .expect("should has ukey")
-        .name
-        .as_ref()
-    });
+    chunk_ukeys.sort_by_key(|ukey| compilation.chunk_by_ukey.expect_get(ukey).name.as_ref());
 
     for chunk_ukey in chunk_ukeys {
       if !compilation.chunk_by_ukey.contains(&chunk_ukey) {
@@ -85,14 +78,8 @@ impl Plugin for MergeDuplicateChunksPlugin {
         && !possible_duplicates.is_empty()
       {
         'outer: for other_chunk_ukey in possible_duplicates {
-          let chunk = compilation
-            .chunk_by_ukey
-            .get(&chunk_ukey)
-            .expect("should have chunk");
-          let other_chunk = compilation
-            .chunk_by_ukey
-            .get(&other_chunk_ukey)
-            .expect("should have chunk");
+          let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
+          let other_chunk = compilation.chunk_by_ukey.expect_get(&other_chunk_ukey);
           if other_chunk.has_runtime(&compilation.chunk_group_by_ukey)
             != chunk.has_runtime(&compilation.chunk_group_by_ukey)
           {

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -29,10 +29,7 @@ impl Plugin for ArrayPushCallbackChunkFormatPlugin {
     let compilation = &mut args.compilation;
     let chunk_ukey = args.chunk;
     let runtime_requirements = &mut args.runtime_requirements;
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(chunk_ukey)
-      .ok_or_else(|| internal_error!("chunk not found"))?;
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
 
     if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
       return Ok(());

--- a/crates/rspack_plugin_runtime/src/chunk_prefetch_preload.rs
+++ b/crates/rspack_plugin_runtime/src/chunk_prefetch_preload.rs
@@ -32,10 +32,7 @@ impl Plugin for ChunkPrefetchPreloadPlugin {
       .get_number_of_entry_modules(chunk_ukey)
       > 0
     {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(chunk_ukey)
-        .expect("chunk do not exists");
+      let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
       if let Some(startup_child_chunks) =
         chunk.get_children_of_type_in_order(&ChunkGroupOrderKey::Prefetch, compilation, false)
       {
@@ -59,10 +56,7 @@ impl Plugin for ChunkPrefetchPreloadPlugin {
     let compilation = &mut args.compilation;
     let runtime_requirements = &mut args.runtime_requirements;
     let chunk_ukey = args.chunk;
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(chunk_ukey)
-      .expect("chunk do not exists");
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
     let chunk_map = chunk.get_child_ids_by_orders_map(false, compilation);
 
     if let Some(prefetch_map) = chunk_map.get(&ChunkGroupOrderKey::Prefetch) {

--- a/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/common_js_chunk_format.rs
@@ -7,7 +7,6 @@ use rspack_core::{
   PluginAdditionalChunkRuntimeRequirementsOutput, PluginContext, PluginJsChunkHashHookOutput,
   PluginRenderChunkHookOutput, RenderChunkArgs, RenderStartupArgs, RuntimeGlobals,
 };
-use rspack_error::internal_error;
 use rspack_plugin_javascript::runtime::{render_chunk_runtime_modules, render_iife};
 
 use crate::{
@@ -32,10 +31,7 @@ impl Plugin for CommonJsChunkFormatPlugin {
     let compilation = &mut args.compilation;
     let chunk_ukey = args.chunk;
     let runtime_requirements = &mut args.runtime_requirements;
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(chunk_ukey)
-      .ok_or_else(|| internal_error!("chunk not found"))?;
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
 
     if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
       return Ok(());

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -32,10 +32,7 @@ impl Plugin for ModuleChunkFormatPlugin {
     let compilation = &mut args.compilation;
     let chunk_ukey = args.chunk;
     let runtime_requirements = &mut args.runtime_requirements;
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(chunk_ukey)
-      .unwrap_or_else(|| panic!("chunk not found"));
+    let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
 
     if chunk.has_runtime(&compilation.chunk_group_by_ukey) {
       return Ok(());
@@ -139,9 +136,8 @@ impl Plugin for ModuleChunkFormatPlugin {
           .expect("should have module id");
         let runtime_chunk = compilation
           .chunk_group_by_ukey
-          .get(entry)
-          .map(|e| e.get_runtime_chunk())
-          .expect("should have runtime chunk");
+          .expect_get(entry)
+          .get_runtime_chunk();
         let chunks = get_all_chunks(
           entry,
           &runtime_chunk,
@@ -155,10 +151,7 @@ impl Plugin for ModuleChunkFormatPlugin {
           }
           loaded_chunks.insert(*chunk_ukey);
           let index = loaded_chunks.len();
-          let chunk = compilation
-            .chunk_by_ukey
-            .get(chunk_ukey)
-            .expect("chunk should exist in chunk_by_ukey");
+          let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
           let other_chunk_output_name = get_chunk_output_name(chunk, compilation);
           startup_source.push(format!(
             "import * as __webpack_chunk_${index}__ from '{}';",

--- a/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/auto_public_path.rs
@@ -38,10 +38,7 @@ impl RuntimeModule for AutoPublicPathRuntimeModule {
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk = self.chunk.expect("The chunk should be attached");
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(&chunk)
-      .expect("Chunk is not found, make sure you had attach chunkUkey successfully.");
+    let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
     let filename = get_js_chunk_filename_template(
       chunk,
       &compilation.options.output,

--- a/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/base_uri.rs
@@ -1,5 +1,5 @@
 use rspack_core::{
-  impl_runtime_module,
+  get_chunk_from_ukey, impl_runtime_module,
   rspack_sources::{BoxSource, RawSource, SourceExt},
   ChunkUkey, Compilation, RuntimeGlobals, RuntimeModule,
 };
@@ -23,7 +23,7 @@ impl RuntimeModule for BaseUriRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let base_uri = self
       .chunk
-      .and_then(|ukey| compilation.chunk_by_ukey.get(&ukey))
+      .and_then(|ukey| get_chunk_from_ukey(&ukey, &compilation.chunk_by_ukey))
       .and_then(|chunk| chunk.get_entry_options(&compilation.chunk_group_by_ukey))
       .and_then(|options| options.base_uri.as_ref())
       .and_then(|base_uri| serde_json::to_string(base_uri).ok())

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_name.rs
@@ -31,11 +31,7 @@ impl RuntimeModule for ChunkNameRuntimeModule {
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     if let Some(chunk_ukey) = self.chunk {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(&chunk_ukey)
-        .expect("Chunk not found");
-
+      let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       RawSource::from(format!(
         "{} = {};",
         RuntimeGlobals::CHUNK_NAME,

--- a/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/chunk_prefetch_startup.rs
@@ -43,12 +43,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
             .iter()
             .filter_map(|c| {
               if c.to_owned().eq(&chunk_ukey) {
-                compilation
-                  .chunk_by_ukey
-                  .get(c)
-                  .expect("group chunk not exists")
-                  .id
-                  .to_owned()
+                compilation.chunk_by_ukey.expect_get(c).id.to_owned()
               } else {
                 None
               }
@@ -57,14 +52,7 @@ impl RuntimeModule for ChunkPrefetchStartupRuntimeModule {
 
           let child_chunk_ids = child_chunks
             .iter()
-            .filter_map(|c| {
-              compilation
-                .chunk_by_ukey
-                .get(c)
-                .expect("child chunk not exists")
-                .id
-                .to_owned()
-            })
+            .filter_map(|c| compilation.chunk_by_ukey.expect_get(c).id.to_owned())
             .collect_vec();
 
           let body = match child_chunks.len() {

--- a/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/css_loading.rs
@@ -34,10 +34,7 @@ impl RuntimeModule for CssLoadingRuntimeModule {
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     if let Some(chunk_ukey) = self.chunk {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(&chunk_ukey)
-        .expect("Chunk not found");
+      let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk_ukey);
 
       let with_hmr = runtime_requirements.contains(RuntimeGlobals::HMR_DOWNLOAD_UPDATE_HANDLERS);
@@ -58,14 +55,15 @@ impl RuntimeModule for CssLoadingRuntimeModule {
       let mut initial_chunk_ids_with_css = HashSet::default();
       let mut initial_chunk_ids_without_css = HashSet::default();
       for chunk_ukey in initial_chunks.iter() {
-        let chunk = compilation
+        let id = compilation
           .chunk_by_ukey
-          .get(chunk_ukey)
-          .expect("Chunk not found");
+          .expect_get(chunk_ukey)
+          .expect_id()
+          .to_string();
         if chunk_has_css(chunk_ukey, compilation) {
-          initial_chunk_ids_with_css.insert(chunk.expect_id().to_string());
+          initial_chunk_ids_with_css.insert(id);
         } else {
-          initial_chunk_ids_without_css.insert(chunk.expect_id().to_string());
+          initial_chunk_ids_without_css.insert(id);
         }
       }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_filename.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt};
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use rspack_core::{
-  get_filename_without_hash_length, impl_runtime_module,
+  get_chunk_from_ukey, get_filename_without_hash_length, impl_runtime_module,
   rspack_sources::{BoxSource, RawSource, SourceExt},
   Chunk, ChunkUkey, Compilation, Filename, PathData, RuntimeGlobals, RuntimeModule, SourceType,
 };
@@ -80,7 +80,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunks = self
       .chunk
-      .and_then(|chunk_ukey| compilation.chunk_by_ukey.get(&chunk_ukey))
+      .and_then(|chunk_ukey| get_chunk_from_ukey(&chunk_ukey, &compilation.chunk_by_ukey))
       .map(|chunk| {
         let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey);
         if (self.all_chunks)(runtime_requirements) {
@@ -120,7 +120,7 @@ impl RuntimeModule for GetChunkFilenameRuntimeModule {
     if let Some(chunks) = chunks {
       chunks
         .iter()
-        .filter_map(|chunk_ukey| compilation.chunk_by_ukey.get(chunk_ukey))
+        .filter_map(|chunk_ukey| get_chunk_from_ukey(chunk_ukey, &compilation.chunk_by_ukey))
         .for_each(|chunk| {
           let filename_template = (self.filename_for_chunk)(chunk, compilation);
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_chunk_update_filename.rs
@@ -27,10 +27,7 @@ impl RuntimeModule for GetChunkUpdateFilenameRuntimeModule {
   }
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     if let Some(chunk_ukey) = self.chunk {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(&chunk_ukey)
-        .expect("Chunk not found");
+      let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let filename = compilation.get_path(
         &compilation.options.output.hot_update_chunk_filename,
         PathData::default()

--- a/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/get_main_filename.rs
@@ -31,10 +31,7 @@ impl RuntimeModule for GetMainFilenameRuntimeModule {
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     if let Some(chunk_ukey) = self.chunk {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(&chunk_ukey)
-        .expect("Chunk not found");
+      let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
       let filename = compilation.get_path(
         &self.filename.clone().into(),
         PathData::default()

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -59,8 +59,7 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk = compilation
       .chunk_by_ukey
-      .get(&self.chunk.expect("The chunk should be attached."))
-      .expect("Chunk is not found, make sure you had attach chunkUkey successfully.");
+      .expect_get(&self.chunk.expect("The chunk should be attached."));
 
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey);
     let initial_chunks = get_initial_chunk_ids(self.chunk, compilation, chunk_has_js);

--- a/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/jsonp_chunk_loading.rs
@@ -48,8 +48,7 @@ impl RuntimeModule for JsonpChunkLoadingRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk = compilation
       .chunk_by_ukey
-      .get(&self.chunk.expect("The chunk should be attached"))
-      .expect("should have chunk");
+      .expect_get(&self.chunk.expect("The chunk should be attached"));
 
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey);
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_chunk_with_block.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_chunk_with_block.rs
@@ -29,11 +29,7 @@ impl RuntimeModule for LoadChunkWithBlockRuntimeModule {
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk_ukey = self.chunk.expect("should have chunk");
-    let runtime = &compilation
-      .chunk_by_ukey
-      .get(&chunk_ukey)
-      .expect("should have chunk")
-      .runtime;
+    let runtime = &compilation.chunk_by_ukey.expect_get(&chunk_ukey).runtime;
 
     let blocks = compilation
       .module_graph
@@ -52,10 +48,7 @@ impl RuntimeModule for LoadChunkWithBlockRuntimeModule {
           .chunks
           .iter()
           .filter_map(|chunk_ukey| {
-            let chunk = compilation
-              .chunk_by_ukey
-              .get(chunk_ukey)
-              .expect("chunk should exist");
+            let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
             if chunk.runtime.is_superset(runtime) {
               Some(chunk.expect_id().to_string())
             } else {

--- a/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/module_chunk_loading.rs
@@ -59,8 +59,7 @@ impl RuntimeModule for ModuleChunkLoadingRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk = compilation
       .chunk_by_ukey
-      .get(&self.chunk.expect("The chunk should be attached."))
-      .expect("Chunk is not found, make sure you had attach chunkUkey successfully.");
+      .expect_get(&self.chunk.expect("The chunk should be attached."));
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey);
 
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);

--- a/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/readfile_chunk_loading.rs
@@ -65,8 +65,7 @@ impl RuntimeModule for ReadFileChunkLoadingRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk = compilation
       .chunk_by_ukey
-      .get(&self.chunk.expect("The chunk should be attached."))
-      .expect("Chunk is not found, make sure you had attach chunkUkey successfully.");
+      .expect_get(&self.chunk.expect("The chunk should be attached."));
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey);
 
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);

--- a/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/require_js_chunk_loading.rs
@@ -66,8 +66,7 @@ impl RuntimeModule for RequireChunkLoadingRuntimeModule {
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     let chunk = compilation
       .chunk_by_ukey
-      .get(&self.chunk.expect("The chunk should be attached."))
-      .expect("Chunk is not found, make sure you had attach chunkUkey successfully.");
+      .expect_get(&self.chunk.expect("The chunk should be attached."));
     let runtime_requirements = get_chunk_runtime_requirements(compilation, &chunk.ukey);
 
     let with_base_uri = runtime_requirements.contains(RuntimeGlobals::BASE_URI);

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime_id.rs
@@ -32,10 +32,7 @@ impl RuntimeModule for RuntimeIdRuntimeModule {
 
   fn generate(&self, compilation: &Compilation) -> BoxSource {
     if let Some(chunk_ukey) = self.chunk {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(&chunk_ukey)
-        .expect("Chunk not found");
+      let chunk = compilation.chunk_by_ukey.expect_get(&chunk_ukey);
 
       let runtime = &chunk.runtime;
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/startup_chunk_dependencies.rs
@@ -40,11 +40,11 @@ impl RuntimeModule for StartupChunkDependenciesRuntimeModule {
           &compilation.chunk_group_by_ukey,
         )
         .map(|chunk_ukey| {
-          let chunk = compilation
+          compilation
             .chunk_by_ukey
-            .get(&chunk_ukey)
-            .expect("Chunk not found");
-          chunk.expect_id().to_string()
+            .expect_get(&chunk_ukey)
+            .expect_id()
+            .to_string()
         })
         .collect::<Vec<_>>();
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -3,8 +3,8 @@ use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::{Captures, Regex};
 use rspack_core::{
-  get_js_chunk_filename_template, stringify_map, Chunk, ChunkKind, ChunkLoading, ChunkUkey,
-  Compilation, PathData, SourceType,
+  get_chunk_from_ukey, get_js_chunk_filename_template, stringify_map, Chunk, ChunkKind,
+  ChunkLoading, ChunkUkey, Compilation, PathData, SourceType,
 };
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -105,17 +105,14 @@ pub fn get_initial_chunk_ids(
   filter_fn: impl Fn(&ChunkUkey, &Compilation) -> bool,
 ) -> HashSet<String> {
   match chunk {
-    Some(chunk_ukey) => match compilation.chunk_by_ukey.get(&chunk_ukey) {
+    Some(chunk_ukey) => match get_chunk_from_ukey(&chunk_ukey, &compilation.chunk_by_ukey) {
       Some(chunk) => {
         let mut js_chunks = chunk
           .get_all_initial_chunks(&compilation.chunk_group_by_ukey)
           .iter()
           .filter(|key| !(chunk_ukey.eq(key) || filter_fn(key, compilation)))
           .map(|chunk_ukey| {
-            let chunk = compilation
-              .chunk_by_ukey
-              .get(chunk_ukey)
-              .expect("Chunk not found");
+            let chunk = compilation.chunk_by_ukey.expect_get(chunk_ukey);
             chunk.expect_id().to_string()
           })
           .collect::<HashSet<_>>();
@@ -231,9 +228,7 @@ pub fn is_enabled_for_chunk(
   expected: &ChunkLoading,
   compilation: &Compilation,
 ) -> bool {
-  let chunk_loading = compilation
-    .chunk_by_ukey
-    .get(chunk_ukey)
+  let chunk_loading = get_chunk_from_ukey(chunk_ukey, &compilation.chunk_by_ukey)
     .and_then(|chunk| chunk.get_entry_options(&compilation.chunk_group_by_ukey))
     .and_then(|options| options.chunk_loading.as_ref())
     .unwrap_or(&compilation.options.output.chunk_loading);

--- a/crates/rspack_plugin_runtime/src/runtime_plugin.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_plugin.rs
@@ -237,16 +237,13 @@ impl Plugin for RuntimePlugin {
       &TREE_DEPENDENCIES,
     );
 
-    let public_path = {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(chunk)
-        .expect("should have chunk");
-      chunk
-        .get_entry_options(&compilation.chunk_group_by_ukey)
-        .and_then(|options| options.public_path.clone())
-        .unwrap_or(compilation.options.output.public_path.clone())
-    };
+    let public_path = compilation
+      .chunk_by_ukey
+      .expect_get(chunk)
+      .get_entry_options(&compilation.chunk_group_by_ukey)
+      .and_then(|options| options.public_path.clone())
+      .unwrap_or_else(|| compilation.options.output.public_path.clone());
+
     // TODO check output.scriptType
     if matches!(public_path, PublicPath::Auto)
       && runtime_requirements.contains(RuntimeGlobals::PUBLIC_PATH)
@@ -279,10 +276,7 @@ impl Plugin for RuntimePlugin {
     }
 
     if runtime_requirements.contains(RuntimeGlobals::ENSURE_CHUNK) {
-      let c = compilation
-        .chunk_by_ukey
-        .get(chunk)
-        .expect("should have chunk");
+      let c = compilation.chunk_by_ukey.expect_get(chunk);
       let has_async_chunks = c.has_async_chunks(&compilation.chunk_group_by_ukey);
       if has_async_chunks {
         runtime_requirements_mut.insert(RuntimeGlobals::ENSURE_CHUNK_HANDLERS);
@@ -295,10 +289,7 @@ impl Plugin for RuntimePlugin {
     }
 
     let library_type = {
-      let chunk = compilation
-        .chunk_by_ukey
-        .get(chunk)
-        .expect("should have chunk");
+      let chunk = compilation.chunk_by_ukey.expect_get(chunk);
       chunk
         .get_entry_options(&compilation.chunk_group_by_ukey)
         .and_then(|options| options.library.as_ref())

--- a/crates/rspack_plugin_split_chunks/src/utils.rs
+++ b/crates/rspack_plugin_split_chunks/src/utils.rs
@@ -135,9 +135,7 @@ pub(crate) fn check_min_size_reduction(
 pub(crate) fn get_requests(chunk: &Chunk, chunk_group_by_ukey: &ChunkGroupByUkey) -> u32 {
   let mut requests = 0;
   for group in &chunk.groups {
-    let group = chunk_group_by_ukey
-      .get(group)
-      .expect("ChunkGroup not found");
+    let group = chunk_group_by_ukey.expect_get(group);
     requests = u32::max(requests, group.chunks.len() as u32)
   }
   requests

--- a/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks_new/src/plugin/module_group.rs
@@ -199,9 +199,7 @@ impl SplitChunksPlugin {
             chunk_combination
               .iter()
               .map(|c| {
-                chunk_db
-                  .get(c)
-                  .expect("This should never happen, please file an issue")
+                chunk_db.expect_get(c)
               })
               // Filter by `splitChunks.cacheGroups.{cacheGroup}.chunks`
               .filter(|c| (cache_group.chunk_filter)(c, chunk_group_db))

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -45,10 +45,7 @@ impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
       None => "\" + wasmModuleHash + \"".to_string(),
     };
 
-    let chunk = compilation
-      .chunk_by_ukey
-      .get(&self.chunk)
-      .expect("chunk not found");
+    let chunk = compilation.chunk_by_ukey.expect_get(&self.chunk);
     let path = compilation.get_path(
       &fake_filename,
       PathData::default()


### PR DESCRIPTION
Removed ﻿`Database::get` and ﻿`Database::get_mut` since they were not commonly used.

Introduced ﻿`get_chunk_from_ukey` and ﻿`get_chunk_group_from_ukey` for more specific functionalities.