### PR TITLE
revert: removes all deprecate warning in CI by github CI

### DIFF
--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -1,5 +1,4 @@
 import terminalLink from "terminal-link";
-import isCI from "is-ci";
 
 import type { JsAssetInfo, JsStatsError } from "@rspack/binding";
 
@@ -118,8 +117,7 @@ const getDeprecationStatus = () => {
 	const defaultEnableDeprecatedWarning = true;
 	if (
 		process.env.RSPACK_DEP_WARNINGS === "false" ||
-		process.env.RSPACK_DEP_WARNINGS === "0" ||
-		isCI
+		process.env.RSPACK_DEP_WARNINGS === "0"
 	) {
 		return false;
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Partially reverts: https://github.com/web-infra-dev/rspack/pull/5127

Keep `@types/is-ci` in `@rspack/core`

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
