### PR TITLE
fix: should store dependencies even if module factorization is failed

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -671,27 +671,31 @@ impl Compilation {
           match item {
             Ok(TaskResult::Factorize(box task_result)) => {
               let FactorizeTaskResult {
-                is_entry,
                 original_module_identifier,
                 factory_result,
-                diagnostics,
                 dependencies,
+                is_entry,
                 current_profile,
                 exports_info_related,
+                file_dependencies,
+                context_dependencies,
+                missing_dependencies,
+                diagnostics,
               } = task_result;
-
               if !diagnostics.is_empty() {
                 make_failed_dependencies.insert((dependencies[0], original_module_identifier));
               }
 
-              // TODO: should use `dep.optional` to test whether these diagnostics should be warnings or errors.
-              // https://github.com/webpack/webpack/blob/6be4065ade1e252c1d8dcba4af0f43e32af1bdc1/lib/Compilation.js#L1796
               self.push_batch_diagnostic(
                 diagnostics
                   .into_iter()
                   .map(|d| d.with_module_identifier(original_module_identifier))
                   .collect(),
               );
+
+              self.file_dependencies.extend(file_dependencies);
+              self.context_dependencies.extend(context_dependencies);
+              self.missing_dependencies.extend(missing_dependencies);
 
               if let Some(factory_result) = factory_result {
                 if let Some(counter) = &mut factorize_cache_counter {
@@ -701,16 +705,6 @@ impl Compilation {
                     counter.miss();
                   }
                 }
-
-                self
-                  .file_dependencies
-                  .extend(factory_result.file_dependencies);
-                self
-                  .context_dependencies
-                  .extend(factory_result.context_dependencies);
-                self
-                  .missing_dependencies
-                  .extend(factory_result.missing_dependencies);
 
                 if let Some(module) = factory_result.module {
                   let module_identifier = module.identifier();

--- a/crates/rspack_core/src/compiler/queue.rs
+++ b/crates/rspack_core/src/compiler/queue.rs
@@ -79,18 +79,18 @@ impl FactorizeTaskResult {
     self
   }
 
-  pub fn with_file_dependencies(mut self, files: impl IntoIterator<Item = PathBuf>) -> Self {
-    self.file_dependencies.extend(files);
+  fn with_file_dependencies(mut self, files: impl IntoIterator<Item = PathBuf>) -> Self {
+    self.file_dependencies = files.into_iter().collect();
     self
   }
 
-  pub fn with_context_dependencies(mut self, contexts: impl IntoIterator<Item = PathBuf>) -> Self {
-    self.context_dependencies.extend(contexts);
+  fn with_context_dependencies(mut self, contexts: impl IntoIterator<Item = PathBuf>) -> Self {
+    self.context_dependencies = contexts.into_iter().collect();
     self
   }
 
-  pub fn with_missing_dependencies(mut self, missing: impl IntoIterator<Item = PathBuf>) -> Self {
-    self.missing_dependencies.extend(missing);
+  fn with_missing_dependencies(mut self, missing: impl IntoIterator<Item = PathBuf>) -> Self {
+    self.missing_dependencies = missing.into_iter().collect();
     self
   }
 }

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -68,7 +68,7 @@ impl ContextModuleFactory {
     let factory_meta = Default::default();
     let mut file_dependencies = Default::default();
     let mut missing_dependencies = Default::default();
-    let context_dependencies = Default::default();
+    // let context_dependencies = Default::default();
     let specifier = dependency.request();
     let resolve_args = ResolveArgs {
       context: data.context.clone(),
@@ -123,11 +123,12 @@ impl ContextModuleFactory {
       }
     };
 
+    data.add_file_dependencies(file_dependencies);
+    data.add_missing_dependencies(missing_dependencies);
+    // data.add_context_dependencies(context_dependencies);
+
     Ok(ModuleFactoryResult {
       module: Some(module),
-      file_dependencies,
-      missing_dependencies,
-      context_dependencies,
       factory_meta,
       from_cache,
     })

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -12,15 +12,44 @@ pub struct ModuleFactoryCreateData {
   pub dependency: BoxDependency,
   pub issuer: Option<Box<str>>,
   pub issuer_identifier: Option<ModuleIdentifier>,
+
+  pub file_dependencies: HashSet<PathBuf>,
+  pub context_dependencies: HashSet<PathBuf>,
+  pub missing_dependencies: HashSet<PathBuf>,
   pub diagnostics: Vec<Diagnostic>,
+}
+
+impl ModuleFactoryCreateData {
+  pub fn add_file_dependency(&mut self, file: PathBuf) {
+    if file.is_absolute() {
+      self.file_dependencies.insert(file);
+    }
+  }
+
+  pub fn add_file_dependencies(&mut self, files: impl IntoIterator<Item = PathBuf>) {
+    self.file_dependencies.extend(files);
+  }
+
+  pub fn add_context_dependency(&mut self, context: PathBuf) {
+    self.context_dependencies.insert(context);
+  }
+
+  pub fn add_context_dependencies(&mut self, contexts: impl IntoIterator<Item = PathBuf>) {
+    self.context_dependencies.extend(contexts);
+  }
+
+  pub fn add_missing_dependency(&mut self, missing: PathBuf) {
+    self.missing_dependencies.insert(missing);
+  }
+
+  pub fn add_missing_dependencies(&mut self, missing: impl IntoIterator<Item = PathBuf>) {
+    self.missing_dependencies.extend(missing);
+  }
 }
 
 #[derive(Debug, Default)]
 pub struct ModuleFactoryResult {
   pub module: Option<BoxModule>,
-  pub file_dependencies: HashSet<PathBuf>,
-  pub context_dependencies: HashSet<PathBuf>,
-  pub missing_dependencies: HashSet<PathBuf>,
   pub factory_meta: FactoryMeta,
   pub from_cache: bool,
 }
@@ -29,9 +58,6 @@ impl ModuleFactoryResult {
   pub fn new_with_module(module: BoxModule) -> Self {
     Self {
       module: Some(module),
-      file_dependencies: Default::default(),
-      context_dependencies: Default::default(),
-      missing_dependencies: Default::default(),
       factory_meta: Default::default(),
       from_cache: false,
     }
@@ -39,38 +65,6 @@ impl ModuleFactoryResult {
 
   pub fn module(mut self, module: Option<BoxModule>) -> Self {
     self.module = module;
-    self
-  }
-
-  pub fn file_dependency(mut self, file: PathBuf) -> Self {
-    if file.is_absolute() {
-      self.file_dependencies.insert(file);
-    }
-    self
-  }
-
-  pub fn file_dependencies(mut self, files: impl IntoIterator<Item = PathBuf>) -> Self {
-    self.file_dependencies.extend(files);
-    self
-  }
-
-  pub fn context_dependency(mut self, context: PathBuf) -> Self {
-    self.context_dependencies.insert(context);
-    self
-  }
-
-  pub fn context_dependencies(mut self, contexts: impl IntoIterator<Item = PathBuf>) -> Self {
-    self.context_dependencies.extend(contexts);
-    self
-  }
-
-  pub fn missing_dependency(mut self, missing: PathBuf) -> Self {
-    self.missing_dependencies.insert(missing);
-    self
-  }
-
-  pub fn missing_dependencies(mut self, missing: impl IntoIterator<Item = PathBuf>) -> Self {
-    self.missing_dependencies.extend(missing);
     self
   }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -108,9 +108,9 @@ impl NormalModuleFactory {
       .after_resolve(&mut NormalModuleAfterResolveArgs {
         request: dependency.request(),
         context: data.context.as_ref(),
-        file_dependencies: &factory_result.file_dependencies,
-        context_dependencies: &factory_result.context_dependencies,
-        missing_dependencies: &factory_result.missing_dependencies,
+        file_dependencies: &data.file_dependencies,
+        context_dependencies: &data.context_dependencies,
+        missing_dependencies: &data.missing_dependencies,
         factory_meta: &factory_result.factory_meta,
         diagnostics: &mut data.diagnostics,
       })
@@ -644,11 +644,12 @@ impl NormalModuleFactory {
       .normal_module_factory_module(module, &mut create_data)
       .await?;
 
+    data.add_file_dependencies(file_dependencies);
+    data.add_file_dependency(file_dependency);
+    data.add_missing_dependencies(missing_dependencies);
+
     Ok(Some(
       ModuleFactoryResult::new_with_module(module)
-        .file_dependency(file_dependency)
-        .file_dependencies(file_dependencies)
-        .missing_dependencies(missing_dependencies)
         .factory_meta(factory_meta)
         .from_cache(from_cache),
     ))

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -2,6 +2,6 @@ import { answer } from "./answer";
 function render() {
 	document.getElementById(
 		"root"
-	).innerHTML = `the answer to the universe is ${answer}`;
+	).innerHTML = `the answer to the universe is ${answer} ${foo}`;
 }
 render();

--- a/examples/basic/src/index.js
+++ b/examples/basic/src/index.js
@@ -2,6 +2,6 @@ import { answer } from "./answer";
 function render() {
 	document.getElementById(
 		"root"
-	).innerHTML = `the answer to the universe is ${answer} ${foo}`;
+	).innerHTML = `the answer to the universe is ${answer}`;
 }
 render();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Aligns the behavior with webpack. So that rspack can watch missing dependencies, etc.
When `options.bail` is enabled, then rspack does nothing.


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Test blocked by https://github.com/web-infra-dev/rspack/pull/5152

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
