### PR TITLE
fix(treeshaking): calculate add_connection_states right

### DIFF
--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -145,10 +145,10 @@ pub fn add_connection_states(a: ConnectionState, b: ConnectionState) -> Connecti
     return ConnectionState::Bool(true);
   }
   if matches!(a, ConnectionState::Bool(false)) {
-    return ConnectionState::Bool(false);
+    return b;
   }
   if matches!(b, ConnectionState::Bool(false)) {
-    return ConnectionState::Bool(false);
+    return a;
   }
   if matches!(a, ConnectionState::TransitiveOnly) {
     return b;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

When one connection state is false should return the other, align [webpack](https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/ModuleGraphConnection.js#L29-L36)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
