### PR TITLE
refactor: 🤖 avoid clone exports info

### DIFF
--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -731,7 +731,7 @@ impl ExportInfoId {
     if self_export_info.target.is_empty() {
       return None;
     }
-    if already_visited.contains(&self) {
+    if already_visited.contains(self) {
       return Some(ResolvedExportInfoTargetWithCircular::Circular);
     }
     already_visited.insert(*self);
@@ -1323,13 +1323,9 @@ impl ExportInfo {
         if already_visited.contains(&export_info_id) {
           return Some(ResolvedExportInfoTargetWithCircular::Circular);
         }
-        let mut export_info = mg.get_export_info_by_id(&export_info_id).clone();
-        // dbg!(&export_info);
+        let export_info = mg.get_export_info_by_id(&export_info_id).clone();
 
-        let export_info_id = export_info.id;
-        let new_target = export_info
-          .id
-          ._get_target(mg, resolve_filter.clone(), already_visited);
+        let new_target = export_info_id._get_target(mg, resolve_filter.clone(), already_visited);
 
         match new_target {
           Some(ResolvedExportInfoTargetWithCircular::Circular) => {

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1323,8 +1323,6 @@ impl ExportInfo {
         if already_visited.contains(&export_info_id) {
           return Some(ResolvedExportInfoTargetWithCircular::Circular);
         }
-        let export_info = mg.get_export_info_by_id(&export_info_id).clone();
-
         let new_target = export_info_id._get_target(mg, resolve_filter.clone(), already_visited);
 
         match new_target {

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1419,14 +1419,6 @@ impl ExportInfo {
     false
   }
 
-  // pub fn create_nested_exports_info(&mut self, mg: &mut ModuleGraph) -> ExportsInfoId {
-  //   if self.exports_info_owned {
-  //     return self
-  //       .exports_info
-  //       .expect("should have exports_info when exports_info is true");
-  //   }
-  // }
-
   pub fn has_used_name(&self) -> bool {
     self.used_name.is_some()
   }

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -50,6 +50,10 @@ impl ExportsInfoId {
     mg.get_exports_info_by_id(self)
   }
 
+  pub fn get_exports_info_mut<'a>(&self, mg: &'a mut ModuleGraph) -> &'a mut ExportsInfo {
+    mg.get_exports_info_mut_by_id(self)
+  }
+
   /// # Panic
   /// it will panic if you provide a export info that does not exists in the module graph  
   pub fn set_has_provide_info(&self, mg: &mut ModuleGraph) {
@@ -651,6 +655,42 @@ impl ExportInfoId {
     self.get_export_info(mg).get_used(runtime)
   }
 
+  pub fn create_nested_exports_info(&self, mg: &mut ModuleGraph) -> ExportsInfoId {
+    let export_info = self.get_export_info(mg);
+
+    if export_info.exports_info_owned {
+      return export_info
+        .exports_info
+        .expect("should have exports_info when exports_info is true");
+    }
+    let export_info_mut = self.get_export_info_mut(mg);
+    export_info_mut.exports_info_owned = true;
+    let other_exports_info = ExportInfo::new(None, UsageState::Unknown, None);
+    let side_effects_only_info = ExportInfo::new(
+      Some("*side effects only*".into()),
+      UsageState::Unknown,
+      None,
+    );
+    let new_exports_info = ExportsInfo::new(other_exports_info.id, side_effects_only_info.id);
+    let new_exports_info_id = new_exports_info.id;
+
+    let old_exports_info = export_info_mut.exports_info;
+    export_info_mut.exports_info_owned = true;
+    export_info_mut.exports_info = Some(new_exports_info_id);
+
+    mg.exports_info_map
+      .insert(new_exports_info_id, new_exports_info);
+    mg.export_info_map
+      .insert(other_exports_info.id, other_exports_info);
+    mg.export_info_map
+      .insert(side_effects_only_info.id, side_effects_only_info);
+
+    new_exports_info_id.set_has_provide_info(mg);
+    if let Some(exports_info) = old_exports_info {
+      exports_info.set_redirect_name_to(mg, Some(new_exports_info_id));
+    }
+    new_exports_info_id
+  }
   fn set_has_use_info(&self, mg: &mut ModuleGraph) {
     let export_info = mg.get_export_info_mut_by_id(self);
     if !export_info.has_use_in_runtime_info {
@@ -671,12 +711,74 @@ impl ExportInfoId {
     mg: &mut ModuleGraph,
     resolve_filter: Option<ResolveFilterFnTy>,
   ) -> Option<ResolvedExportInfoTarget> {
-    let mut export_info = mg.get_export_info_mut_by_id(self).clone();
+    let filter = resolve_filter.unwrap_or(Arc::new(|_, _| true));
 
-    let target = export_info.get_target(mg, resolve_filter);
-    // avoid use ref and mut ref at the same time
-    _ = std::mem::replace(mg.get_export_info_mut_by_id(self), export_info);
-    target
+    let mut already_visited = HashSet::default();
+    match self._get_target(mg, filter, &mut already_visited) {
+      Some(ResolvedExportInfoTargetWithCircular::Circular) => None,
+      Some(ResolvedExportInfoTargetWithCircular::Target(target)) => Some(target),
+      None => None,
+    }
+  }
+
+  pub fn _get_target(
+    &self,
+    mg: &mut ModuleGraph,
+    resolve_filter: ResolveFilterFnTy,
+    already_visited: &mut HashSet<ExportInfoId>,
+  ) -> Option<ResolvedExportInfoTargetWithCircular> {
+    let self_export_info = self.get_export_info(mg);
+    if self_export_info.target.is_empty() {
+      return None;
+    }
+    if already_visited.contains(&self) {
+      return Some(ResolvedExportInfoTargetWithCircular::Circular);
+    }
+    already_visited.insert(*self);
+
+    let self_export_info_mut = self.get_export_info_mut(mg);
+    let values = self_export_info_mut
+      .get_max_target()
+      .values()
+      .map(|item| UnResolvedExportInfoTarget {
+        connection: item.connection,
+        export: item.exports.clone(),
+      })
+      .collect::<Vec<_>>();
+    let target = ExportInfo::resolve_target(
+      values.first().cloned(),
+      already_visited,
+      resolve_filter.clone(),
+      mg,
+    );
+
+    match target {
+      Some(ResolvedExportInfoTargetWithCircular::Circular) => {
+        Some(ResolvedExportInfoTargetWithCircular::Circular)
+      }
+      None => None,
+      Some(ResolvedExportInfoTargetWithCircular::Target(target)) => {
+        for val in values.into_iter().skip(1) {
+          let resolved_target =
+            ExportInfo::resolve_target(Some(val), already_visited, resolve_filter.clone(), mg);
+          match resolved_target {
+            Some(ResolvedExportInfoTargetWithCircular::Circular) => {
+              return Some(ResolvedExportInfoTargetWithCircular::Circular);
+            }
+            Some(ResolvedExportInfoTargetWithCircular::Target(tt)) => {
+              if target.module != tt.module {
+                return None;
+              }
+              if target.export != tt.export {
+                return None;
+              }
+            }
+            None => return None,
+          }
+        }
+        Some(ResolvedExportInfoTargetWithCircular::Target(target))
+      }
+    }
   }
 
   fn set_used_without_info(&self, mg: &mut ModuleGraph, runtime: Option<&RuntimeSpec>) -> bool {
@@ -746,14 +848,14 @@ impl ExportInfoId {
     resolve_filter: ResolveFilterFnTy,
     update_original_connection: UpdateOriginalFunctionTy,
   ) -> Option<ResolvedExportInfoTarget> {
-    let mut export_info = mg.get_export_info_mut_by_id(self).clone();
-    let target = export_info._get_target(mg, resolve_filter, &mut HashSet::default());
+    let target = self._get_target(mg, resolve_filter, &mut HashSet::default());
     let target = match target {
       Some(ResolvedExportInfoTargetWithCircular::Circular) => return None,
       Some(ResolvedExportInfoTargetWithCircular::Target(target)) => target,
       None => return None,
     };
-    let original_target = export_info
+    let export_info_mut = self.get_export_info_mut(mg);
+    let original_target = export_info_mut
       .get_max_target()
       .values()
       .next()
@@ -763,18 +865,21 @@ impl ExportInfoId {
     {
       return None;
     }
-    export_info.target.clear();
-    export_info.target_is_set = true;
-    export_info.target.insert(
+    export_info_mut.target.clear();
+    export_info_mut.target_is_set = true;
+    let updated_connection = update_original_connection(&target, mg);
+
+    // shadowning `export_info_mut` to reduce `&mut ModuleGraph` borrow life time, since
+    // `update_original_connection` also needs `&mut ModuleGraph`
+    let export_info_mut = self.get_export_info_mut(mg);
+    export_info_mut.target.insert(
       None,
       ExportInfoTargetValue {
-        connection: update_original_connection(&target, mg),
+        connection: updated_connection,
         exports: target.export.clone(),
         priority: 0,
       },
     );
-    // avoid use ref and mut ref at the same time
-    _ = std::mem::replace(mg.get_export_info_mut_by_id(self), export_info);
     Some(target)
   }
 
@@ -1177,21 +1282,6 @@ impl ExportInfo {
     &self.max_target
   }
 
-  pub fn get_target(
-    &mut self,
-    mg: &mut ModuleGraph,
-    resolve_filter: Option<ResolveFilterFnTy>,
-  ) -> Option<ResolvedExportInfoTarget> {
-    let filter = resolve_filter.unwrap_or(Arc::new(|_, _| true));
-
-    let mut already_visited = HashSet::default();
-    match self._get_target(mg, filter, &mut already_visited) {
-      Some(ResolvedExportInfoTargetWithCircular::Circular) => None,
-      Some(ResolvedExportInfoTargetWithCircular::Target(target)) => Some(target),
-      None => None,
-    }
-  }
-
   #[allow(clippy::unwrap_in_result)]
   fn resolve_target(
     input_target: Option<UnResolvedExportInfoTarget>,
@@ -1237,8 +1327,9 @@ impl ExportInfo {
         // dbg!(&export_info);
 
         let export_info_id = export_info.id;
-        let new_target = export_info._get_target(mg, resolve_filter.clone(), already_visited);
-        _ = std::mem::replace(mg.get_export_info_mut_by_id(&export_info_id), export_info);
+        let new_target = export_info
+          .id
+          ._get_target(mg, resolve_filter.clone(), already_visited);
 
         match new_target {
           Some(ResolvedExportInfoTargetWithCircular::Circular) => {
@@ -1272,64 +1363,6 @@ impl ExportInfo {
       }
     } else {
       None
-    }
-  }
-
-  pub fn _get_target(
-    &mut self,
-    mg: &mut ModuleGraph,
-    resolve_filter: ResolveFilterFnTy,
-    already_visited: &mut HashSet<ExportInfoId>,
-  ) -> Option<ResolvedExportInfoTargetWithCircular> {
-    if self.target.is_empty() {
-      return None;
-    }
-    if already_visited.contains(&self.id) {
-      return Some(ResolvedExportInfoTargetWithCircular::Circular);
-    }
-    already_visited.insert(self.id);
-
-    let values = self
-      .get_max_target()
-      .values()
-      .map(|item| UnResolvedExportInfoTarget {
-        connection: item.connection,
-        export: item.exports.clone(),
-      })
-      .collect::<Vec<_>>();
-    let target = Self::resolve_target(
-      values.first().cloned(),
-      already_visited,
-      resolve_filter.clone(),
-      mg,
-    );
-
-    match target {
-      Some(ResolvedExportInfoTargetWithCircular::Circular) => {
-        Some(ResolvedExportInfoTargetWithCircular::Circular)
-      }
-      None => None,
-      Some(ResolvedExportInfoTargetWithCircular::Target(target)) => {
-        for val in values.into_iter().skip(1) {
-          let resolved_target =
-            Self::resolve_target(Some(val), already_visited, resolve_filter.clone(), mg);
-          match resolved_target {
-            Some(ResolvedExportInfoTargetWithCircular::Circular) => {
-              return Some(ResolvedExportInfoTargetWithCircular::Circular);
-            }
-            Some(ResolvedExportInfoTargetWithCircular::Target(tt)) => {
-              if target.module != tt.module {
-                return None;
-              }
-              if target.export != tt.export {
-                return None;
-              }
-            }
-            None => return None,
-          }
-        }
-        Some(ResolvedExportInfoTargetWithCircular::Target(target))
-      }
     }
   }
 
@@ -1390,37 +1423,13 @@ impl ExportInfo {
     false
   }
 
-  pub fn create_nested_exports_info(&mut self, mg: &mut ModuleGraph) -> ExportsInfoId {
-    if self.exports_info_owned {
-      return self
-        .exports_info
-        .expect("should have exports_info when exports_info is true");
-    }
-    self.exports_info_owned = true;
-    let other_exports_info = ExportInfo::new(None, UsageState::Unknown, None);
-    let side_effects_only_info = ExportInfo::new(
-      Some("*side effects only*".into()),
-      UsageState::Unknown,
-      None,
-    );
-    let new_exports_info = ExportsInfo::new(other_exports_info.id, side_effects_only_info.id);
-    let new_exports_info_id = new_exports_info.id;
-    mg.exports_info_map
-      .insert(new_exports_info_id, new_exports_info);
-    mg.export_info_map
-      .insert(other_exports_info.id, other_exports_info);
-    mg.export_info_map
-      .insert(side_effects_only_info.id, side_effects_only_info);
-
-    let old_exports_info = self.exports_info;
-    new_exports_info_id.set_has_provide_info(mg);
-    self.exports_info_owned = true;
-    self.exports_info = Some(new_exports_info_id);
-    if let Some(exports_info) = old_exports_info {
-      exports_info.set_redirect_name_to(mg, Some(new_exports_info_id));
-    }
-    new_exports_info_id
-  }
+  // pub fn create_nested_exports_info(&mut self, mg: &mut ModuleGraph) -> ExportsInfoId {
+  //   if self.exports_info_owned {
+  //     return self
+  //       .exports_info
+  //       .expect("should have exports_info when exports_info is true");
+  //   }
+  // }
 
   pub fn has_used_name(&self) -> bool {
     self.used_name.is_some()

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -241,14 +241,8 @@ impl<'a> FlagDependencyExportsProxy<'a> {
         };
       let export_info_id = exports_info.get_export_info(&name, self.mg);
 
-      let mut export_info = self
-        .mg
-        .export_info_map
-        .get_mut(&export_info_id)
-        .expect("should have export info")
-        .clone();
-      // dbg!(&export_info);
-      if let Some(ref mut provided) = export_info.provided
+      let mut export_info_mut = export_info_id.get_export_info_mut(self.mg);
+      if let Some(ref mut provided) = export_info_mut.provided
         && matches!(
           provided,
           ExportInfoProvided::False | ExportInfoProvided::Null
@@ -258,18 +252,18 @@ impl<'a> FlagDependencyExportsProxy<'a> {
         self.changed = true;
       }
 
-      if Some(false) != export_info.can_mangle_provide && can_mangle == Some(false) {
-        export_info.can_mangle_provide = Some(false);
+      if Some(false) != export_info_mut.can_mangle_provide && can_mangle == Some(false) {
+        export_info_mut.can_mangle_provide = Some(false);
         self.changed = true;
       }
 
-      if terminal_binding && !export_info.terminal_binding {
-        export_info.terminal_binding = true;
+      if terminal_binding && !export_info_mut.terminal_binding {
+        export_info_mut.terminal_binding = true;
         self.changed = true;
       }
 
       if let Some(exports) = exports {
-        let nested_exports_info = export_info.create_nested_exports_info(self.mg);
+        let nested_exports_info = export_info_id.create_nested_exports_info(self.mg);
         self.merge_exports(
           nested_exports_info,
           exports,
@@ -278,9 +272,12 @@ impl<'a> FlagDependencyExportsProxy<'a> {
         );
       }
 
+      // shadowing the previous `export_info_mut` to reduce the mut borrow life time,
+      // cause `create_nested_exports_info` needs `&mut ModuleGraph`
+      let export_info_mut = export_info_id.get_export_info_mut(self.mg);
       if let Some(from) = from {
         let changed = if hidden {
-          export_info.unset_target(&dep_id)
+          export_info_mut.unset_target(&dep_id)
         } else {
           let fallback = rspack_core::Nullable::Value(vec![name.clone()]);
           let export_name = if let Some(from) = from_export {
@@ -288,20 +285,13 @@ impl<'a> FlagDependencyExportsProxy<'a> {
           } else {
             Some(&fallback)
           };
-          export_info.set_target(Some(dep_id), Some(from), export_name, priority)
+          export_info_mut.set_target(Some(dep_id), Some(from), export_name, priority)
         };
         self.changed |= changed;
       }
 
       // Recalculate target exportsInfo
-      let target = export_info.get_target(self.mg, None);
-      // dbg!(&target);
-      let export_info_old = self
-        .mg
-        .export_info_map
-        .get_mut(&export_info_id)
-        .expect("should have export info");
-      _ = std::mem::replace(export_info_old, export_info);
+      let target = export_info_id.get_target(self.mg, None);
 
       let mut target_exports_info: Option<ExportsInfoId> = None;
       if let Some(target) = target {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -241,7 +241,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
         };
       let export_info_id = exports_info.get_export_info(&name, self.mg);
 
-      let mut export_info_mut = export_info_id.get_export_info_mut(self.mg);
+      let export_info_mut = export_info_id.get_export_info_mut(self.mg);
       if let Some(ref mut provided) = export_info_mut.provided
         && matches!(
           provided,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. Using exports/export id to workaround rustc borrow rules instead clone them.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
