### PR TITLE
fix: sort errors and warnings in stats based on offsets

### DIFF
--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -282,7 +282,7 @@ impl Stats<'_> {
     let mut diagnostic_displayer = DiagnosticDisplayer::new(self.compilation.options.stats.colors);
     self
       .compilation
-      .get_errors()
+      .get_errors_sorted()
       .map(|d| {
         let module_identifier = d.module_identifier();
         let (module_name, module_id) = module_identifier
@@ -314,7 +314,7 @@ impl Stats<'_> {
     let mut diagnostic_displayer = DiagnosticDisplayer::new(self.compilation.options.stats.colors);
     self
       .compilation
-      .get_warnings()
+      .get_warnings_sorted()
       .map(|d| {
         let module_identifier = d.module_identifier();
         let (module_name, module_id) = module_identifier


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

diagnostics tests should be stable.

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
