### PR TITLE
fix: external modules in esm

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -207,7 +207,7 @@ module.exports = new Promise(function(resolve, reject) {{
             .boxed(),
           );
           format!(
-            "__WEBPACK_EXTERNAL_createRequire(import.meta.url)('{}')",
+            "module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)('{}')",
             request.primary()
           )
         } else {

--- a/packages/rspack/tests/configCases/library/esm-external/index.js
+++ b/packages/rspack/tests/configCases/library/esm-external/index.js
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import url from "node:url";
+
+export default function () {
+	console.info("hello world");
+}
+
+export const add = (a, b) => {
+	return a + b;
+};
+
+it("should run", function () {});
+
+it("should export module library", function () {
+	const source = fs.readFileSync(url.fileURLToPath(import.meta.url), "utf-8");
+	expect(source).toContain(`hello world`);
+});

--- a/packages/rspack/tests/configCases/library/esm-external/index.js
+++ b/packages/rspack/tests/configCases/library/esm-external/index.js
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import url from "node:url";
+import path from "node:path";
 
 export default function () {
 	console.info("hello world");
@@ -12,6 +13,11 @@ export const add = (a, b) => {
 it("should run", function () {});
 
 it("should export module library", function () {
-	const source = fs.readFileSync(url.fileURLToPath(import.meta.url), "utf-8");
-	expect(source).toContain(`hello world`);
+	const __filename = url.fileURLToPath(import.meta.url);
+	const source = fs.readFileSync(
+		path.join(path.dirname(__filename), "dist/main.js"),
+		"utf-8"
+	);
+	const createRequire = "__WEBPACK_EXTERNAL_createRequire";
+	expect(source).toContain(`${createRequire}(import.meta.url)('node:fs')})`);
 });

--- a/packages/rspack/tests/configCases/library/esm-external/webpack.config.js
+++ b/packages/rspack/tests/configCases/library/esm-external/webpack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("../../../../dist").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		libraryTarget: "module",
+		iife: false,
+		chunkFormat: "module",
+		filename: "main.js"
+	},
+	experiments: {
+		outputModule: true,
+		rspackFuture: {
+			newTreeshaking: false
+		}
+	},
+	target: "node"
+};


### PR DESCRIPTION
## Summary

External modules should also be exports in esm

## Test Plan

Add `packages/rspack/tests/configCases/library/esm-external`

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
