### PR TITLE
fix: libraryType=module when tree shaking is disabled

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -837,7 +837,15 @@ impl Compilation {
                 }
               }
 
-              if self.options.builtins.tree_shaking.enable() {
+              if self.options.builtins.tree_shaking.enable()
+                || (self.options.optimization.provided_exports
+                  && self
+                    .options
+                    .output
+                    .library
+                    .as_ref()
+                    .is_some_and(|l| l.library_type.eq("module")))
+              {
                 self
                   .optimize_analyze_result_map
                   .insert(module.identifier(), build_result.analyze_result);

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -209,7 +209,14 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     };
     diagnostics.append(&mut warning_diagnostics);
 
-    let analyze_result = if compiler_options.builtins.tree_shaking.enable() {
+    let analyze_result = if compiler_options.builtins.tree_shaking.enable()
+      || (compiler_options.optimization.provided_exports
+        && compiler_options
+          .output
+          .library
+          .as_ref()
+          .is_some_and(|l| l.library_type.eq("module")))
+    {
       let mut all_dependencies = dependencies.clone();
       for mut block in blocks.clone() {
         all_dependencies.extend(block.take_dependencies());

--- a/packages/rspack/tests/configCases/library/esm-external/index.js
+++ b/packages/rspack/tests/configCases/library/esm-external/index.js
@@ -10,7 +10,7 @@ export const add = (a, b) => {
 	return a + b;
 };
 
-it("should run", function () {});
+it("should run", function () { });
 
 it("should export module library", function () {
 	const __filename = url.fileURLToPath(import.meta.url);

--- a/packages/rspack/tests/configCases/library/issue-5138/index.js
+++ b/packages/rspack/tests/configCases/library/issue-5138/index.js
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import url from "node:url";
+import path from "node:path";
+
+export default function () {
+	console.info("hello world");
+}
+
+export const add = (a, b) => {
+	return a + b;
+};
+
+it("should run", function () {});
+
+it("should export module library", function () {
+	const __filename = url.fileURLToPath(import.meta.url);
+	const source = fs.readFileSync(
+		path.join(path.dirname(__filename), "dist/main.js"),
+		"utf-8"
+	);
+	const exportedAdd = "__webpack_exports__add as add";
+	const exportedDefault = "__webpack_exports__default as default";
+	expect(source).toContain(`export { ${exportedAdd}, ${exportedDefault} }`);
+});

--- a/packages/rspack/tests/configCases/library/issue-5138/webpack.config.js
+++ b/packages/rspack/tests/configCases/library/issue-5138/webpack.config.js
@@ -1,0 +1,19 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	output: {
+		libraryTarget: "module",
+		iife: false,
+		chunkFormat: "module",
+		filename: "main.js"
+	},
+	optimization: {
+		providedExports: true
+	},
+	experiments: {
+		outputModule: true,
+		rspackFuture: {
+			newTreeshaking: false
+		}
+	},
+	target: "node"
+};


### PR DESCRIPTION
## Summary

resolve: #5138

- When libraryType=module, ModuleLibraryPlugin needs exportsInfo to generate startup code
- The `providedExports` will always be true even when tree shaking is disabled
- Old tree shaking will not recognize `providedExports`, so this pr fixes it
- But `JsModule::analyze` may cause performance regression, so exportsInfo will be analyzed only when `providedExports=true` and `libraryType=module` 

## Test Plan

- Add `packages/rspack/tests/configCases/library/issue-5138`

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
