### PR TITLE
fix: empty name and complex member expression in cjs dependency

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -53,9 +53,13 @@ impl ModuleDependency for CommonJsSelfReferenceDependency {
     _runtime: Option<&rspack_core::RuntimeSpec>,
   ) -> Vec<rspack_core::ExtendedReferencedExport> {
     if self.is_call {
-      vec![ExtendedReferencedExport::Array(
-        self.names[0..self.names.len() - 1].to_vec(),
-      )]
+      if self.names.is_empty() {
+        vec![ExtendedReferencedExport::Array(vec![])]
+      } else {
+        vec![ExtendedReferencedExport::Array(
+          self.names[0..self.names.len() - 1].to_vec(),
+        )]
+      }
     } else {
       vec![ExtendedReferencedExport::Array(self.names.clone())]
     }

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/assign-exports.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/assign-exports.js
@@ -1,0 +1,12 @@
+exports.abc = {};
+
+for (let i of [
+	{
+		name: "a"
+	},
+	{
+		name: "b"
+	}
+]) {
+	exports.abc[i.name] = i.name;
+}

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/assign-module-exports.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/assign-module-exports.js
@@ -1,0 +1,12 @@
+module.exports.abc = {};
+
+for (let i of [
+	{
+		name: "a"
+	},
+	{
+		name: "b"
+	}
+]) {
+	module.exports.abc[i.name] = i.name;
+}

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/assign-this.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/assign-this.js
@@ -1,0 +1,12 @@
+this.abc = {};
+
+for (let i of [
+	{
+		name: "a"
+	},
+	{
+		name: "b"
+	}
+]) {
+	this.abc[i.name] = i.name;
+}

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/index.js
@@ -1,0 +1,35 @@
+it("should read assign exports", () => {
+	var e = require("./assign-exports");
+	expect(e.abc.a).toBe("a");
+	expect(e.abc.b).toBe("b");
+});
+
+it("should read assign module.exports", () => {
+	var e = require("./assign-module-exports");
+	expect(e.abc.a).toBe("a");
+	expect(e.abc.b).toBe("b");
+});
+
+it("should read assign this", () => {
+	var e = require("./assign-this");
+	expect(e.abc.a).toBe("a");
+	expect(e.abc.b).toBe("b");
+});
+
+// it("should read self exports", () => {
+//   var e = require("./self-exports");
+//   expect(e.abc.a).toBe("a");
+//   expect(e.abc.b).toBe("b");
+// });
+
+// it("should read self module.exports", () => {
+//   var e = require("./self-module-exports");
+//   expect(e.abc.a).toBe("a");
+//   expect(e.abc.b).toBe("b");
+// });
+
+it("should read self this", () => {
+	var e = require("./self-this");
+	expect(e.abc.a).toBe("a");
+	expect(e.abc.b).toBe("b");
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/self-exports.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/self-exports.js
@@ -1,0 +1,18 @@
+exports.aaa = [
+	{
+		name: "a",
+		index: 0
+	},
+	{
+		name: "b",
+		index: 1
+	}
+];
+
+var aaa = {};
+
+for (let k of exports.aaa) {
+	aaa[k.name] = exports.aaa[k.index].name;
+}
+
+exports.abc = aaa;

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/self-module-exports.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/self-module-exports.js
@@ -1,0 +1,18 @@
+module.exports.aaa = [
+	{
+		name: "a",
+		index: 0
+	},
+	{
+		name: "b",
+		index: 1
+	}
+];
+
+var aaa = {};
+
+for (let k of module.exports.aaa) {
+	aaa[k.name] = module.exports.aaa[k.index].name;
+}
+
+module.exports.abc = aaa;

--- a/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/self-this.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/complex-member/self-this.js
@@ -1,0 +1,18 @@
+this.aaa = [
+	{
+		name: "a",
+		index: 0
+	},
+	{
+		name: "b",
+		index: 1
+	}
+];
+
+var aaa = {};
+
+for (let k of this.aaa) {
+	aaa[k.name] = this.aaa[k.index].name;
+}
+
+this.abc = aaa;


### PR DESCRIPTION
## Summary


- Compatible with empty names of CommonJsSelfReferenceDependency
- Fix commonjs export scanner to compatible complex member expression

## Test Plan

- Add `packages/rspack/tests/cases/cjs-tree-shaking/complex-member`

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
