### PR TITLE
feat: bump tracing to support `NO_COLOR`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5362,11 +5362,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -5374,9 +5373,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5396,9 +5395,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5406,20 +5405,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ similar            = { version = "2.2.1" }
 sugar_path         = { version = "0.0.12" }
 testing_macros     = { version = "0.2.11" }
 tokio              = { version = "1.29.1" }
-tracing            = { version = "0.1.37" }
-tracing-subscriber = { version = "0.3.17" }
+tracing            = { version = "0.1.40" }
+tracing-subscriber = { version = "0.3.18" }
 url                = { version = "2.4.0" }
 urlencoding        = { version = "2.1.2" }
 ustr               = { version = "0.9.0" }


### PR DESCRIPTION
Fixes #5149 

edit: `tracing` had support `NO_COLOR` in https://github.com/tokio-rs/tracing/commit/81ab9d6faedaf5a1e4b9d69567949052a401e723, we can use it directly.

~~This PR introduces the `﻿RSPACK_LOG_COLOR` environment variable, which can have one of three values: `﻿always`, `﻿never`, or `﻿auto`:~~
~~- `﻿always`: Always displays colors, both in the terminal and when writing to files.~~
~~- `﻿never`: Never displays colors.~~
~~- `auto (default)`: Displays colors in the terminal but not when writing to files.~~


~~Here's a comparison before and after applying the `﻿RSPACK_PROFILE=TRACE=layer=logger npx rspack build > log.log` command:~~

<img width="1605" alt="image" src="https://github.com/web-infra-dev/rspack/assets/30187863/20dfd2c7-d7c0-4f61-8e07-63ed6fa3e8eb">
