### PR TITLE
fix: do not generate dependency after removing

### DIFF
--- a/crates/rspack_plugin_javascript/src/utils/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/utils/const/if_stmt.rs
@@ -176,7 +176,7 @@ pub fn statement_if(
       )
     };
 
-    scanner.removed.push(DependencyLocation::new(
+    scanner.ignored.push(DependencyLocation::new(
       branch_to_remove.span().real_lo(),
       branch_to_remove.span().real_hi(),
     ));

--- a/crates/rspack_plugin_javascript/src/utils/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/utils/const/if_stmt.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use rspack_core::{ConstDependency, SpanExt};
+use rspack_core::{ConstDependency, DependencyLocation, SpanExt};
 use rustc_hash::FxHashSet;
 use swc_core::common::Spanned;
 use swc_core::ecma::ast::{BlockStmt, DoWhileStmt, ForHead, ForInStmt, ForOfStmt, Ident, IfStmt};
@@ -175,6 +175,11 @@ pub fn statement_if(
         declarations.iter().map(|decl| decl.sym.as_str()).join(", ")
       )
     };
+
+    scanner.removed.push(DependencyLocation::new(
+      branch_to_remove.span().real_lo(),
+      branch_to_remove.span().real_hi(),
+    ));
     scanner
       .presentational_dependencies
       .push(Box::new(ConstDependency::new(

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
@@ -5,7 +5,7 @@ use super::BasicEvaluatedExpression;
 use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 
 pub fn eval_array_expression(
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
   expr: &ArrayLit,
 ) -> Option<BasicEvaluatedExpression> {
   let mut items = vec![];

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -66,7 +66,7 @@ fn handle_template_string_compare(
 fn handle_strict_equality_comparison(
   eql: bool,
   expr: &BinExpr,
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
 ) -> Option<BasicEvaluatedExpression> {
   assert!(expr.op == BinaryOp::EqEqEq || expr.op == BinaryOp::NotEqEq);
   let left = scanner.evaluate_expression(&expr.left);
@@ -93,7 +93,7 @@ fn handle_strict_equality_comparison(
 fn handle_abstract_equality_comparison(
   eql: bool,
   expr: &BinExpr,
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
 ) -> Option<BasicEvaluatedExpression> {
   let left = scanner.evaluate_expression(&expr.left);
   let right = scanner.evaluate_expression(&expr.right);
@@ -118,7 +118,7 @@ fn handle_abstract_equality_comparison(
 }
 
 pub fn eval_binary_expression(
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
   expr: &BinExpr,
 ) -> Option<BasicEvaluatedExpression> {
   match expr.op {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_cond_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_cond_expr.rs
@@ -4,7 +4,7 @@ use super::BasicEvaluatedExpression;
 use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 
 pub fn eval_cond_expression(
-  scanner: &CommonJsImportDependencyScanner,
+  scanner: &mut CommonJsImportDependencyScanner,
   cond: &CondExpr,
 ) -> Option<BasicEvaluatedExpression> {
   let condition = scanner.evaluate_expression(&cond.test);

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -6,7 +6,7 @@ use crate::utils::eval;
 use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 
 pub fn eval_new_expression(
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
   expr: &NewExpr,
 ) -> Option<BasicEvaluatedExpression> {
   let Some(ident) = expr.callee.as_ident() else {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_tpl_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_tpl_expr.rs
@@ -12,7 +12,7 @@ pub enum TemplateStringKind {
 }
 
 fn get_simplified_template_result(
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
   node: &Tpl,
 ) -> (Vec<BasicEvaluatedExpression>, Vec<BasicEvaluatedExpression>) {
   let mut quasis: Vec<BasicEvaluatedExpression> = vec![];
@@ -55,7 +55,7 @@ fn get_simplified_template_result(
 }
 
 pub fn eval_tpl_expression(
-  scanner: &CommonJsImportDependencyScanner<'_>,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
   tpl: &Tpl,
 ) -> Option<BasicEvaluatedExpression> {
   let (quasis, mut parts) = get_simplified_template_result(scanner, tpl);

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -6,7 +6,7 @@ use crate::parser_plugin::JavascriptParserPlugin;
 use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 
 fn eval_typeof(
-  scanner: &CommonJsImportDependencyScanner,
+  scanner: &mut CommonJsImportDependencyScanner,
   expr: &UnaryExpr,
 ) -> Option<BasicEvaluatedExpression> {
   assert!(expr.op == UnaryOp::TypeOf);
@@ -27,7 +27,7 @@ fn eval_typeof(
 }
 
 pub fn eval_unary_expression(
-  scanner: &CommonJsImportDependencyScanner,
+  scanner: &mut CommonJsImportDependencyScanner,
   expr: &UnaryExpr,
 ) -> Option<BasicEvaluatedExpression> {
   match expr.op {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -16,7 +16,7 @@ use swc_core::{
 use super::expr_matcher;
 use crate::{
   dependency::{ModuleArgumentDependency, WebpackIsIncludedDependency},
-  get_removed, no_visit_removed,
+  no_visit_removed,
 };
 
 pub const WEBPACK_HASH: &str = "__webpack_hash__";
@@ -47,8 +47,6 @@ pub struct ApiScanner<'a> {
 }
 
 impl<'a> ApiScanner<'a> {
-  get_removed!();
-
   pub fn new(
     unresolved_ctxt: SyntaxContext,
     resource_data: &'a ResourceData,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  BuildInfo, ConstDependency, Dependency, DependencyTemplate, ResourceData, RuntimeGlobals,
-  RuntimeRequirementsDependency, SpanExt,
+  BuildInfo, ConstDependency, Dependency, DependencyLocation, DependencyTemplate, ResourceData,
+  RuntimeGlobals, RuntimeRequirementsDependency, SpanExt,
 };
 use swc_core::{
   common::{Spanned, SyntaxContext},
@@ -14,7 +14,10 @@ use swc_core::{
 };
 
 use super::expr_matcher;
-use crate::dependency::{ModuleArgumentDependency, WebpackIsIncludedDependency};
+use crate::{
+  dependency::{ModuleArgumentDependency, WebpackIsIncludedDependency},
+  get_removed, no_visit_removed,
+};
 
 pub const WEBPACK_HASH: &str = "__webpack_hash__";
 pub const WEBPACK_PUBLIC_PATH: &str = "__webpack_public_path__";
@@ -40,9 +43,12 @@ pub struct ApiScanner<'a> {
   pub resource_data: &'a ResourceData,
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   pub dependencies: &'a mut Vec<Box<dyn Dependency>>,
+  pub removed: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> ApiScanner<'a> {
+  get_removed!();
+
   pub fn new(
     unresolved_ctxt: SyntaxContext,
     resource_data: &'a ResourceData,
@@ -50,6 +56,7 @@ impl<'a> ApiScanner<'a> {
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     module: bool,
     build_info: &'a mut BuildInfo,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       unresolved_ctxt,
@@ -59,12 +66,14 @@ impl<'a> ApiScanner<'a> {
       resource_data,
       presentational_dependencies,
       dependencies,
+      removed,
     }
   }
 }
 
 impl Visit for ApiScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_var_declarator(&mut self, var_declarator: &VarDeclarator) {
     match &var_declarator.name {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -16,7 +16,7 @@ use swc_core::{
 use super::expr_matcher;
 use crate::{
   dependency::{ModuleArgumentDependency, WebpackIsIncludedDependency},
-  no_visit_removed,
+  no_visit_ignored_stmt,
 };
 
 pub const WEBPACK_HASH: &str = "__webpack_hash__";
@@ -43,7 +43,7 @@ pub struct ApiScanner<'a> {
   pub resource_data: &'a ResourceData,
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   pub dependencies: &'a mut Vec<Box<dyn Dependency>>,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> ApiScanner<'a> {
@@ -54,7 +54,7 @@ impl<'a> ApiScanner<'a> {
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     module: bool,
     build_info: &'a mut BuildInfo,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       unresolved_ctxt,
@@ -64,14 +64,14 @@ impl<'a> ApiScanner<'a> {
       resource_data,
       presentational_dependencies,
       dependencies,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for ApiScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_var_declarator(&mut self, var_declarator: &VarDeclarator) {
     match &var_declarator.name {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
@@ -37,7 +37,7 @@ pub struct CommonJsExportDependencyScanner<'a> {
   stmt_level: u32,
   last_stmt_is_expr_stmt: bool,
   is_top_level: bool,
-  removed: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> CommonJsExportDependencyScanner<'a> {
@@ -48,7 +48,7 @@ impl<'a> CommonJsExportDependencyScanner<'a> {
     build_meta: &'a mut BuildMeta,
     module_type: ModuleType,
     parser_exports_state: &'a mut Option<bool>,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
@@ -62,7 +62,7 @@ impl<'a> CommonJsExportDependencyScanner<'a> {
       stmt_level: 0,
       last_stmt_is_expr_stmt: false,
       is_top_level: true,
-      removed,
+      ignored,
     }
   }
 }
@@ -79,7 +79,7 @@ impl Visit for CommonJsExportDependencyScanner<'_> {
   fn visit_stmt(&mut self, stmt: &Stmt) {
     let span = stmt.span();
     if self
-      .removed
+      .ignored
       .iter()
       .any(|r| r.start() <= span.real_lo() && span.real_hi() <= r.end())
     {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -150,7 +150,7 @@ impl<'a> CommonJsImportDependencyScanner<'a> {
       return None;
     };
 
-    let in_try = self.in_try.clone();
+    let in_try = self.in_try;
 
     let process_require_item = |p: &BasicEvaluatedExpression| {
       p.is_string().then(|| {
@@ -229,7 +229,7 @@ impl<'a> Visit for CommonJsImportDependencyScanner<'a> {
       return;
     };
 
-    let deps = self.require_handler(&call_expr);
+    let deps = self.require_handler(call_expr);
 
     if let Some((commonjs_require_deps, require_helper_deps)) = deps {
       for dep in commonjs_require_deps {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use rspack_core::{context_reg_exp, ContextOptions, DependencyCategory};
+use rspack_core::{context_reg_exp, ContextOptions, DependencyCategory, DependencyLocation};
 use rspack_core::{BoxDependency, ConstDependency, ContextMode, ContextNameSpaceObject};
 use rspack_core::{DependencyTemplate, SpanExt};
 use swc_core::common::{Spanned, SyntaxContext};
@@ -45,6 +45,7 @@ pub struct CommonJsImportDependencyScanner<'a> {
   pub(crate) in_if: bool,
   pub(crate) is_strict: bool,
   pub(crate) plugin_drive: Rc<JavaScriptParserPluginDrive>,
+  pub(crate) removed: &'a mut Vec<DependencyLocation>,
 }
 
 #[derive(Debug)]
@@ -79,6 +80,7 @@ impl<'a> CommonJsImportDependencyScanner<'a> {
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     let plugins: Vec<BoxJavascriptParserPlugin> = vec![
       Box::new(CommonJsImportsParserPlugin),
@@ -93,6 +95,7 @@ impl<'a> CommonJsImportDependencyScanner<'a> {
       in_if: false,
       is_strict: false,
       plugin_drive: Rc::new(plugin_drive),
+      removed,
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -6,33 +6,33 @@ use swc_core::ecma::ast::{Expr, Ident};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use super::expr_matcher;
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 
 pub struct CommonJsScanner<'a> {
   unresolved_ctxt: SyntaxContext,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   has_module_ident: bool,
-  removed: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> CommonJsScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
       unresolved_ctxt,
       has_module_ident: false,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for CommonJsScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_ident(&mut self, ident: &Ident) {
     if self.has_module_ident {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -6,7 +6,7 @@ use swc_core::ecma::ast::{Expr, Ident};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use super::expr_matcher;
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 pub struct CommonJsScanner<'a> {
   unresolved_ctxt: SyntaxContext,
@@ -16,8 +16,6 @@ pub struct CommonJsScanner<'a> {
 }
 
 impl<'a> CommonJsScanner<'a> {
-  get_removed!();
-
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -1,31 +1,40 @@
-use rspack_core::{DependencyTemplate, RuntimeGlobals, RuntimeRequirementsDependency};
+use rspack_core::{
+  DependencyLocation, DependencyTemplate, RuntimeGlobals, RuntimeRequirementsDependency,
+};
 use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{Expr, Ident};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use super::expr_matcher;
+use crate::{get_removed, no_visit_removed};
 
 pub struct CommonJsScanner<'a> {
   unresolved_ctxt: SyntaxContext,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   has_module_ident: bool,
+  removed: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> CommonJsScanner<'a> {
+  get_removed!();
+
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
       unresolved_ctxt,
       has_module_ident: false,
+      removed,
     }
   }
 }
 
 impl Visit for CommonJsScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_ident(&mut self, ident: &Ident) {
     if self.has_module_ident {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/compatibility_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/compatibility_scanner.rs
@@ -1,32 +1,40 @@
-use rspack_core::{ConstDependency, DependencyTemplate, SpanExt};
+use rspack_core::{ConstDependency, DependencyLocation, DependencyTemplate, SpanExt};
 use rustc_hash::FxHashMap;
 use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{FnDecl, Ident, Program};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
+
+use crate::{get_removed, no_visit_removed};
 
 pub struct CompatibilityScanner<'a> {
   unresolved_ctxt: SyntaxContext,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   count: u8, // flag __webpack_require__ count
   name_map: FxHashMap<SyntaxContext, u8>,
+  removed: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> CompatibilityScanner<'a> {
+  get_removed!();
+
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
       unresolved_ctxt,
       count: 0,
       name_map: Default::default(),
+      removed,
     }
   }
 }
 
 impl Visit for CompatibilityScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_program(&mut self, program: &Program) {
     program.visit_children_with(self);
@@ -35,6 +43,7 @@ impl Visit for CompatibilityScanner<'_> {
       unresolved_ctxt: self.unresolved_ctxt,
       name_map: &self.name_map,
       presentational_dependencies: self.presentational_dependencies,
+      removed: self.removed,
     });
   }
 
@@ -53,10 +62,16 @@ pub struct ReplaceNestWebpackRequireVisitor<'a> {
   unresolved_ctxt: SyntaxContext,
   name_map: &'a FxHashMap<SyntaxContext, u8>,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
+  removed: &'a mut Vec<DependencyLocation>,
+}
+
+impl ReplaceNestWebpackRequireVisitor<'_> {
+  get_removed!();
 }
 
 impl Visit for ReplaceNestWebpackRequireVisitor<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_ident(&mut self, ident: &Ident) {
     if &ident.sym == "__webpack_require__" && ident.span.ctxt != self.unresolved_ctxt {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/compatibility_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/compatibility_scanner.rs
@@ -4,7 +4,7 @@ use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{FnDecl, Ident, Program};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 pub struct CompatibilityScanner<'a> {
   unresolved_ctxt: SyntaxContext,
@@ -15,8 +15,6 @@ pub struct CompatibilityScanner<'a> {
 }
 
 impl<'a> CompatibilityScanner<'a> {
-  get_removed!();
-
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
@@ -63,10 +61,6 @@ pub struct ReplaceNestWebpackRequireVisitor<'a> {
   name_map: &'a FxHashMap<SyntaxContext, u8>,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   removed: &'a mut Vec<DependencyLocation>,
-}
-
-impl ReplaceNestWebpackRequireVisitor<'_> {
-  get_removed!();
 }
 
 impl Visit for ReplaceNestWebpackRequireVisitor<'_> {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
@@ -9,12 +9,12 @@ use swc_core::{
   },
 };
 
-use crate::{dependency::ExportInfoApiDependency, no_visit_removed};
+use crate::{dependency::ExportInfoApiDependency, no_visit_ignored_stmt};
 
 pub struct ExportInfoApiScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   unresolved_ctxt: SyntaxContext,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 //__webpack_exports_info__.a.used
@@ -22,19 +22,19 @@ impl<'a> ExportInfoApiScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
       unresolved_ctxt,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for ExportInfoApiScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_member_expr(&mut self, member_expr: &MemberExpr) {
     let expression_info = extract_member_expression_chain(member_expr);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
@@ -9,7 +9,7 @@ use swc_core::{
   },
 };
 
-use crate::{dependency::ExportInfoApiDependency, get_removed, no_visit_removed};
+use crate::{dependency::ExportInfoApiDependency, no_visit_removed};
 
 pub struct ExportInfoApiScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
@@ -19,8 +19,6 @@ pub struct ExportInfoApiScanner<'a> {
 
 //__webpack_exports_info__.a.used
 impl<'a> ExportInfoApiScanner<'a> {
-  get_removed!();
-
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
@@ -1,4 +1,6 @@
-use rspack_core::{extract_member_expression_chain, ConstDependency, DependencyTemplate, SpanExt};
+use rspack_core::{
+  extract_member_expression_chain, ConstDependency, DependencyLocation, DependencyTemplate, SpanExt,
+};
 use swc_core::{
   common::SyntaxContext,
   ecma::{
@@ -7,28 +9,34 @@ use swc_core::{
   },
 };
 
-use crate::dependency::ExportInfoApiDependency;
+use crate::{dependency::ExportInfoApiDependency, get_removed, no_visit_removed};
 
 pub struct ExportInfoApiScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   unresolved_ctxt: SyntaxContext,
+  pub removed: &'a mut Vec<DependencyLocation>,
 }
 
 //__webpack_exports_info__.a.used
 impl<'a> ExportInfoApiScanner<'a> {
+  get_removed!();
+
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
       unresolved_ctxt,
+      removed,
     }
   }
 }
 
 impl Visit for ExportInfoApiScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_member_expr(&mut self, member_expr: &MemberExpr) {
     let expression_info = extract_member_expression_chain(member_expr);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
-  BuildInfo, BuildMeta, BuildMetaExportsType, DependencyTemplate, ExportsArgument, ModuleArgument,
-  ModuleIdentifier, ModuleType,
+  BuildInfo, BuildMeta, BuildMetaExportsType, DependencyLocation, DependencyTemplate,
+  ExportsArgument, ModuleArgument, ModuleIdentifier, ModuleType,
 };
 use rspack_error::miette::{diagnostic, Diagnostic};
 use rspack_error::DiagnosticExt;
@@ -8,6 +8,7 @@ use swc_core::ecma::ast::{ArrowExpr, AwaitExpr, Constructor, Function, ModuleIte
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::dependency::HarmonyCompatibilityDependency;
+use crate::{get_removed, no_visit_removed};
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/HarmonyDetectionParserPlugin.js
 pub struct HarmonyDetectionScanner<'a> {
@@ -18,9 +19,12 @@ pub struct HarmonyDetectionScanner<'a> {
   top_level_await: bool,
   code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
+  removed: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> HarmonyDetectionScanner<'a> {
+  get_removed!();
+
   pub fn new(
     module_identifier: &'a ModuleIdentifier,
     build_info: &'a mut BuildInfo,
@@ -29,6 +33,7 @@ impl<'a> HarmonyDetectionScanner<'a> {
     top_level_await: bool,
     code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       module_identifier,
@@ -38,12 +43,14 @@ impl<'a> HarmonyDetectionScanner<'a> {
       top_level_await,
       code_generable_dependencies,
       errors,
+      removed,
     }
   }
 }
 
 impl Visit for HarmonyDetectionScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_program(&mut self, program: &'_ Program) {
     let strict_harmony_module = matches!(self.module_type, ModuleType::JsEsm | ModuleType::JsxEsm);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -8,7 +8,7 @@ use swc_core::ecma::ast::{ArrowExpr, AwaitExpr, Constructor, Function, ModuleIte
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::dependency::HarmonyCompatibilityDependency;
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/HarmonyDetectionParserPlugin.js
 pub struct HarmonyDetectionScanner<'a> {
@@ -19,7 +19,7 @@ pub struct HarmonyDetectionScanner<'a> {
   top_level_await: bool,
   code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  removed: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> HarmonyDetectionScanner<'a> {
@@ -32,7 +32,7 @@ impl<'a> HarmonyDetectionScanner<'a> {
     top_level_await: bool,
     code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       module_identifier,
@@ -42,14 +42,14 @@ impl<'a> HarmonyDetectionScanner<'a> {
       top_level_await,
       code_generable_dependencies,
       errors,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for HarmonyDetectionScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_program(&mut self, program: &'_ Program) {
     let strict_harmony_module = matches!(self.module_type, ModuleType::JsEsm | ModuleType::JsxEsm);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -25,6 +25,7 @@ pub struct HarmonyDetectionScanner<'a> {
 impl<'a> HarmonyDetectionScanner<'a> {
   get_removed!();
 
+  #[allow(clippy::too_many_arguments)]
   pub fn new(
     module_identifier: &'a ModuleIdentifier,
     build_info: &'a mut BuildInfo,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -8,7 +8,7 @@ use swc_core::ecma::ast::{ArrowExpr, AwaitExpr, Constructor, Function, ModuleIte
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::dependency::HarmonyCompatibilityDependency;
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/HarmonyDetectionParserPlugin.js
 pub struct HarmonyDetectionScanner<'a> {
@@ -23,8 +23,6 @@ pub struct HarmonyDetectionScanner<'a> {
 }
 
 impl<'a> HarmonyDetectionScanner<'a> {
-  get_removed!();
-
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     module_identifier: &'a ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_export_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_export_dependency_scanner.rs
@@ -23,7 +23,7 @@ use crate::{
     HarmonyExportImportedSpecifierDependency, HarmonyExportSpecifierDependency, Specifier,
     DEFAULT_EXPORT,
   },
-  get_removed, no_visit_removed,
+  no_visit_removed,
 };
 
 pub struct HarmonyExportDependencyScanner<'a, 'b> {
@@ -37,8 +37,6 @@ pub struct HarmonyExportDependencyScanner<'a, 'b> {
 }
 
 impl<'a, 'b> HarmonyExportDependencyScanner<'a, 'b> {
-  get_removed!();
-
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_export_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_export_dependency_scanner.rs
@@ -23,7 +23,7 @@ use crate::{
     HarmonyExportImportedSpecifierDependency, HarmonyExportSpecifierDependency, Specifier,
     DEFAULT_EXPORT,
   },
-  no_visit_removed,
+  no_visit_ignored_stmt,
 };
 
 pub struct HarmonyExportDependencyScanner<'a, 'b> {
@@ -33,7 +33,7 @@ pub struct HarmonyExportDependencyScanner<'a, 'b> {
   pub build_info: &'a mut BuildInfo,
   pub rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
   pub comments: Option<&'b SwcComments>,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a, 'b> HarmonyExportDependencyScanner<'a, 'b> {
@@ -44,7 +44,7 @@ impl<'a, 'b> HarmonyExportDependencyScanner<'a, 'b> {
     build_info: &'a mut BuildInfo,
     rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
     comments: Option<&'b SwcComments>,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
@@ -53,14 +53,14 @@ impl<'a, 'b> HarmonyExportDependencyScanner<'a, 'b> {
       build_info,
       rewrite_usage_span,
       comments,
-      removed,
+      ignored,
     }
   }
 }
 
 impl<'a, 'b> Visit for HarmonyExportDependencyScanner<'a, 'b> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_program(&mut self, program: &'_ Program) {
     program.visit_children_with(self);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -18,7 +18,7 @@ use crate::dependency::{
   HarmonyExportImportedSpecifierDependency, HarmonyImportSideEffectDependency,
   HarmonyImportSpecifierDependency, Specifier,
 };
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 #[derive(Debug)]
 pub struct ImporterReferenceInfo {
@@ -79,8 +79,6 @@ pub struct HarmonyImportDependencyScanner<'a> {
 }
 
 impl<'a> HarmonyImportDependencyScanner<'a> {
-  get_removed!();
-
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -1,4 +1,5 @@
 use indexmap::IndexMap;
+use rspack_core::DependencyLocation;
 use rspack_core::{
   extract_member_expression_chain, tree_shaking::symbol::DEFAULT_JS_WORD, BoxDependency,
   BoxDependencyTemplate, BuildInfo, ConstDependency, DependencyType, SpanExt,
@@ -17,6 +18,7 @@ use crate::dependency::{
   HarmonyExportImportedSpecifierDependency, HarmonyImportSideEffectDependency,
   HarmonyImportSpecifierDependency, Specifier,
 };
+use crate::{get_removed, no_visit_removed};
 
 #[derive(Debug)]
 pub struct ImporterReferenceInfo {
@@ -72,16 +74,20 @@ pub struct HarmonyImportDependencyScanner<'a> {
   pub imports: Imports,
   pub build_info: &'a mut BuildInfo,
   pub rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
-  last_harmony_import_order: i32,
+  pub last_harmony_import_order: i32,
+  pub removed: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> HarmonyImportDependencyScanner<'a> {
+  get_removed!();
+
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,
     import_map: &'a mut ImportMap,
     build_info: &'a mut BuildInfo,
     rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
@@ -91,12 +97,14 @@ impl<'a> HarmonyImportDependencyScanner<'a> {
       build_info,
       rewrite_usage_span,
       last_harmony_import_order: 0,
+      removed,
     }
   }
 }
 
 impl Visit for HarmonyImportDependencyScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_program(&mut self, program: &Program) {
     // collect import map info
@@ -607,12 +615,14 @@ mod test {
     let mut deps = vec![];
     let mut presentation_deps = vec![];
     let mut rewrite_usage_span = Default::default();
+    let mut removed = vec![];
     let mut scanner = HarmonyImportDependencyScanner::new(
       &mut deps,
       &mut presentation_deps,
       &mut import_map,
       &mut build_info,
       &mut rewrite_usage_span,
+      &mut removed,
     );
 
     program.visit_with(&mut scanner);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -18,7 +18,7 @@ use crate::dependency::{
   HarmonyExportImportedSpecifierDependency, HarmonyImportSideEffectDependency,
   HarmonyImportSpecifierDependency, Specifier,
 };
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 
 #[derive(Debug)]
 pub struct ImporterReferenceInfo {
@@ -75,7 +75,7 @@ pub struct HarmonyImportDependencyScanner<'a> {
   pub build_info: &'a mut BuildInfo,
   pub rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
   pub last_harmony_import_order: i32,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> HarmonyImportDependencyScanner<'a> {
@@ -85,7 +85,7 @@ impl<'a> HarmonyImportDependencyScanner<'a> {
     import_map: &'a mut ImportMap,
     build_info: &'a mut BuildInfo,
     rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
@@ -95,14 +95,14 @@ impl<'a> HarmonyImportDependencyScanner<'a> {
       build_info,
       rewrite_usage_span,
       last_harmony_import_order: 0,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for HarmonyImportDependencyScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_program(&mut self, program: &Program) {
     // collect import map info
@@ -613,14 +613,14 @@ mod test {
     let mut deps = vec![];
     let mut presentation_deps = vec![];
     let mut rewrite_usage_span = Default::default();
-    let mut removed = vec![];
+    let mut ignored = vec![];
     let mut scanner = HarmonyImportDependencyScanner::new(
       &mut deps,
       &mut presentation_deps,
       &mut import_map,
       &mut build_info,
       &mut rewrite_usage_span,
-      &mut removed,
+      &mut ignored,
     );
 
     program.visit_with(&mut scanner);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
@@ -7,15 +7,11 @@ use swc_core::ecma::{
   visit::{noop_visit_type, Visit, VisitWith},
 };
 
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 pub struct HarmonyTopLevelThis<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   pub removed: &'a mut Vec<DependencyLocation>,
-}
-
-impl HarmonyTopLevelThis<'_> {
-  get_removed!();
 }
 
 impl Visit for HarmonyTopLevelThis<'_> {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
@@ -7,16 +7,16 @@ use swc_core::ecma::{
   visit::{noop_visit_type, Visit, VisitWith},
 };
 
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 
 pub struct HarmonyTopLevelThis<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl Visit for HarmonyTopLevelThis<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_function(&mut self, _: &Function) {}
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
@@ -1,4 +1,4 @@
-use rspack_core::{ConstDependency, DependencyTemplate, SpanExt};
+use rspack_core::{ConstDependency, DependencyLocation, DependencyTemplate, SpanExt};
 use swc_core::ecma::{
   ast::{
     ClassMember, ClassMethod, ClassProp, Expr, Function, GetterProp, MethodProp, Prop, PropName,
@@ -7,12 +7,20 @@ use swc_core::ecma::{
   visit::{noop_visit_type, Visit, VisitWith},
 };
 
+use crate::{get_removed, no_visit_removed};
+
 pub struct HarmonyTopLevelThis<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
+  pub removed: &'a mut Vec<DependencyLocation>,
+}
+
+impl HarmonyTopLevelThis<'_> {
+  get_removed!();
 }
 
 impl Visit for HarmonyTopLevelThis<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_function(&mut self, _: &Function) {}
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
@@ -16,7 +16,7 @@ use crate::{
     HarmonyAcceptDependency, ImportMetaHotAcceptDependency, ImportMetaHotDeclineDependency,
     ModuleArgumentDependency, ModuleHotAcceptDependency, ModuleHotDeclineDependency,
   },
-  get_removed, no_visit_removed,
+  no_visit_removed,
   visitors::{is_import_meta_hot_accept_call, is_import_meta_hot_decline_call},
 };
 
@@ -30,8 +30,6 @@ pub struct HotModuleReplacementScanner<'a> {
 type CreateDependency = fn(u32, u32, JsWord, Option<ErrorSpan>) -> BoxDependency;
 
 impl<'a> HotModuleReplacementScanner<'a> {
-  get_removed!();
-
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
@@ -16,7 +16,7 @@ use crate::{
     HarmonyAcceptDependency, ImportMetaHotAcceptDependency, ImportMetaHotDeclineDependency,
     ModuleArgumentDependency, ModuleHotAcceptDependency, ModuleHotDeclineDependency,
   },
-  no_visit_removed,
+  no_visit_ignored_stmt,
   visitors::{is_import_meta_hot_accept_call, is_import_meta_hot_decline_call},
 };
 
@@ -24,7 +24,7 @@ pub struct HotModuleReplacementScanner<'a> {
   pub dependencies: &'a mut Vec<BoxDependency>,
   pub presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,
   pub build_meta: &'a BuildMeta,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 type CreateDependency = fn(u32, u32, JsWord, Option<ErrorSpan>) -> BoxDependency;
@@ -34,13 +34,13 @@ impl<'a> HotModuleReplacementScanner<'a> {
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,
     build_meta: &'a BuildMeta,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
       presentational_dependencies,
       build_meta,
-      removed,
+      ignored,
     }
   }
 
@@ -109,7 +109,7 @@ impl<'a> HotModuleReplacementScanner<'a> {
 
 impl<'a> Visit for HotModuleReplacementScanner<'a> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_expr(&mut self, expr: &Expr) {
     if expr_matcher::is_module_hot(expr) || expr_matcher::is_import_meta_webpack_hot(expr) {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
@@ -11,7 +11,7 @@ use url::Url;
 use super::{
   expr_matcher, is_member_expr_starts_with, is_member_expr_starts_with_import_meta_webpack_hot,
 };
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/ImportMetaPlugin.js
 // TODO:
@@ -28,8 +28,6 @@ pub struct ImportMetaScanner<'a> {
 }
 
 impl<'a> ImportMetaScanner<'a> {
-  get_removed!();
-
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     resource_data: &'a ResourceData,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
@@ -11,7 +11,7 @@ use url::Url;
 use super::{
   expr_matcher, is_member_expr_starts_with, is_member_expr_starts_with_import_meta_webpack_hot,
 };
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 
 // Port from https://github.com/webpack/webpack/blob/main/lib/dependencies/ImportMetaPlugin.js
 // TODO:
@@ -24,7 +24,7 @@ pub struct ImportMetaScanner<'a> {
   pub compiler_options: &'a CompilerOptions,
   pub resource_data: &'a ResourceData,
   pub warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> ImportMetaScanner<'a> {
@@ -33,21 +33,21 @@ impl<'a> ImportMetaScanner<'a> {
     resource_data: &'a ResourceData,
     compiler_options: &'a CompilerOptions,
     warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
       resource_data,
       compiler_options,
       warning_diagnostics,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for ImportMetaScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_unary_expr(&mut self, unary_expr: &UnaryExpr) {
     if let UnaryExpr {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -20,8 +20,8 @@ use super::context_helper::scanner_context_module;
 use super::{is_import_meta_context_call, parse_order_string};
 use crate::dependency::{ImportContextDependency, ImportDependency};
 use crate::dependency::{ImportEagerDependency, ImportMetaContextDependency};
+use crate::no_visit_removed;
 use crate::utils::{get_bool_by_obj_prop, get_literal_str_by_obj_prop, get_regex_by_obj_prop};
-use crate::{get_removed, no_visit_removed};
 
 pub struct ImportScanner<'a> {
   module_identifier: ModuleIdentifier,
@@ -141,8 +141,6 @@ static WEBPACK_MAGIC_COMMENT_REGEXP: Lazy<regex::Regex> = Lazy::new(|| {
 });
 
 impl<'a> ImportScanner<'a> {
-  get_removed!();
-
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     module_identifier: ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -20,7 +20,7 @@ use super::context_helper::scanner_context_module;
 use super::{is_import_meta_context_call, parse_order_string};
 use crate::dependency::{ImportContextDependency, ImportDependency};
 use crate::dependency::{ImportEagerDependency, ImportMetaContextDependency};
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 use crate::utils::{get_bool_by_obj_prop, get_literal_str_by_obj_prop, get_regex_by_obj_prop};
 
 pub struct ImportScanner<'a> {
@@ -31,7 +31,7 @@ pub struct ImportScanner<'a> {
   pub build_meta: &'a BuildMeta,
   pub options: Option<&'a JavascriptParserOptions>,
   pub warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 fn create_import_meta_context_dependency(node: &CallExpr) -> Option<ImportMetaContextDependency> {
@@ -150,7 +150,7 @@ impl<'a> ImportScanner<'a> {
     build_meta: &'a BuildMeta,
     options: Option<&'a JavascriptParserOptions>,
     warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       module_identifier,
@@ -160,7 +160,7 @@ impl<'a> ImportScanner<'a> {
       build_meta,
       options,
       warning_diagnostics,
-      removed,
+      ignored,
     }
   }
 
@@ -235,7 +235,7 @@ impl<'a> ImportScanner<'a> {
 
 impl Visit for ImportScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_call_expr(&mut self, node: &CallExpr) {
     if !node.args.is_empty()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
@@ -7,7 +7,7 @@ use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::Ident;
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 
 const DIR_NAME: &str = "__dirname";
 const FILE_NAME: &str = "__filename";
@@ -19,7 +19,7 @@ pub struct NodeStuffScanner<'a> {
   pub compiler_options: &'a CompilerOptions,
   pub node_option: &'a NodeOption,
   pub resource_data: &'a ResourceData,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 impl<'a> NodeStuffScanner<'a> {
@@ -29,7 +29,7 @@ impl<'a> NodeStuffScanner<'a> {
     compiler_options: &'a CompilerOptions,
     node_option: &'a NodeOption,
     resource_data: &'a ResourceData,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
@@ -37,14 +37,14 @@ impl<'a> NodeStuffScanner<'a> {
       compiler_options,
       node_option,
       resource_data,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for NodeStuffScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_ident(&mut self, ident: &Ident) {
     if ident.span.ctxt == self.unresolved_ctxt {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
@@ -7,7 +7,7 @@ use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::Ident;
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
-use crate::{get_removed, no_visit_removed};
+use crate::no_visit_removed;
 
 const DIR_NAME: &str = "__dirname";
 const FILE_NAME: &str = "__filename";
@@ -23,8 +23,6 @@ pub struct NodeStuffScanner<'a> {
 }
 
 impl<'a> NodeStuffScanner<'a> {
-  get_removed!();
-
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
@@ -4,7 +4,7 @@ use swc_core::ecma::{
   visit::{noop_visit_type, Visit, VisitWith},
 };
 
-use crate::{dependency::URLDependency, get_removed, no_visit_removed};
+use crate::{dependency::URLDependency, no_visit_removed};
 
 pub struct UrlScanner<'a> {
   pub dependencies: &'a mut Vec<BoxDependency>,
@@ -15,8 +15,6 @@ pub struct UrlScanner<'a> {
 
 // new URL("./foo.png", import.meta.url);
 impl<'a> UrlScanner<'a> {
-  get_removed!();
-
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     worker_syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
@@ -1,34 +1,40 @@
-use rspack_core::{BoxDependency, SpanExt};
+use rspack_core::{BoxDependency, DependencyLocation, SpanExt};
 use swc_core::ecma::{
   ast::NewExpr,
   visit::{noop_visit_type, Visit, VisitWith},
 };
 
-use crate::dependency::URLDependency;
+use crate::{dependency::URLDependency, get_removed, no_visit_removed};
 
 pub struct UrlScanner<'a> {
   pub dependencies: &'a mut Vec<BoxDependency>,
   worker_syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
   relative: bool,
+  removed: &'a mut Vec<DependencyLocation>,
 }
 
 // new URL("./foo.png", import.meta.url);
 impl<'a> UrlScanner<'a> {
+  get_removed!();
+
   pub fn new(
     dependencies: &'a mut Vec<BoxDependency>,
     worker_syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
     relative: bool,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
       worker_syntax_list,
       relative,
+      removed,
     }
   }
 }
 
 impl Visit for UrlScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr) {
     // TODO: https://github.com/web-infra-dev/rspack/discussions/3619

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/url_scanner.rs
@@ -4,13 +4,13 @@ use swc_core::ecma::{
   visit::{noop_visit_type, Visit, VisitWith},
 };
 
-use crate::{dependency::URLDependency, no_visit_removed};
+use crate::{dependency::URLDependency, no_visit_ignored_stmt};
 
 pub struct UrlScanner<'a> {
   pub dependencies: &'a mut Vec<BoxDependency>,
   worker_syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
   relative: bool,
-  removed: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut Vec<DependencyLocation>,
 }
 
 // new URL("./foo.png", import.meta.url);
@@ -19,20 +19,20 @@ impl<'a> UrlScanner<'a> {
     dependencies: &'a mut Vec<BoxDependency>,
     worker_syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
     relative: bool,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
       worker_syntax_list,
       relative,
-      removed,
+      ignored,
     }
   }
 }
 
 impl Visit for UrlScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr) {
     // TODO: https://github.com/web-infra-dev/rspack/discussions/3619

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -294,7 +294,7 @@ pub fn is_unresolved_require(expr: &Expr, unresolved_ctxt: SyntaxContext) -> boo
 }
 
 #[macro_export]
-macro_rules! no_visit_removed {
+macro_rules! no_visit_ignored_stmt {
   () => {
     fn visit_stmt(&mut self, stmt: &swc_core::ecma::ast::Stmt) {
       use rspack_core::SpanExt;
@@ -302,7 +302,7 @@ macro_rules! no_visit_removed {
       use swc_core::ecma::visit::VisitWith;
       let span = stmt.span();
       if self
-        .removed
+        .ignored
         .iter()
         .any(|r| r.start() <= span.real_lo() && span.real_hi() <= r.end())
       {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -294,15 +294,6 @@ pub fn is_unresolved_require(expr: &Expr, unresolved_ctxt: SyntaxContext) -> boo
 }
 
 #[macro_export]
-macro_rules! get_removed {
-  () => {
-    fn get_removed(&self) -> &Vec<DependencyLocation> {
-      self.removed
-    }
-  };
-}
-
-#[macro_export]
 macro_rules! no_visit_removed {
   () => {
     fn visit_stmt(&mut self, stmt: &swc_core::ecma::ast::Stmt) {
@@ -311,7 +302,7 @@ macro_rules! no_visit_removed {
       use swc_core::ecma::visit::VisitWith;
       let span = stmt.span();
       if self
-        .get_removed()
+        .removed
         .iter()
         .any(|r| r.start() <= span.real_lo() && span.real_hi() <= r.end())
       {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -292,3 +292,32 @@ pub fn is_unresolved_require(expr: &Expr, unresolved_ctxt: SyntaxContext) -> boo
   assert!(ident.sym.eq("require"));
   ident.span.ctxt == unresolved_ctxt
 }
+
+#[macro_export]
+macro_rules! get_removed {
+  () => {
+    fn get_removed(&self) -> &Vec<DependencyLocation> {
+      self.removed
+    }
+  };
+}
+
+#[macro_export]
+macro_rules! no_visit_removed {
+  () => {
+    fn visit_stmt(&mut self, stmt: &swc_core::ecma::ast::Stmt) {
+      use rspack_core::SpanExt;
+      use swc_core::common::Spanned;
+      use swc_core::ecma::visit::VisitWith;
+      let span = stmt.span();
+      if self
+        .get_removed()
+        .iter()
+        .any(|r| r.start() <= span.real_lo() && span.real_hi() <= r.end())
+      {
+        return;
+      }
+      stmt.visit_children_with(self);
+    }
+  };
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -11,7 +11,7 @@ use swc_core::ecma::ast::{Expr, ExprOrSpread, NewExpr};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::dependency::WorkerDependency;
-use crate::no_visit_removed;
+use crate::no_visit_ignored_stmt;
 use crate::utils::get_literal_str_by_obj_prop;
 
 // TODO: should created by WorkerPlugin
@@ -23,7 +23,7 @@ pub struct WorkerScanner<'a> {
   module_identifier: &'a ModuleIdentifier,
   output_options: &'a OutputOptions,
   syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
-  pub removed: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut Vec<DependencyLocation>,
 }
 
 // new Worker(new URL("./foo.worker.js", import.meta.url));
@@ -32,7 +32,7 @@ impl<'a> WorkerScanner<'a> {
     module_identifier: &'a ModuleIdentifier,
     output_options: &'a OutputOptions,
     syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
-    removed: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies: Vec::new(),
@@ -42,7 +42,7 @@ impl<'a> WorkerScanner<'a> {
       module_identifier,
       output_options,
       syntax_list,
-      removed,
+      ignored,
     }
   }
 
@@ -144,7 +144,7 @@ impl<'a> WorkerScanner<'a> {
 
 impl Visit for WorkerScanner<'_> {
   noop_visit_type!();
-  no_visit_removed!();
+  no_visit_ignored_stmt!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr) {
     if let Some((parsed_path, parsed_options)) = self.parse_new_worker(new_expr) {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -12,6 +12,7 @@ use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::dependency::WorkerDependency;
 use crate::utils::get_literal_str_by_obj_prop;
+use crate::{get_removed, no_visit_removed};
 
 // TODO: should created by WorkerPlugin
 pub struct WorkerScanner<'a> {
@@ -22,14 +23,18 @@ pub struct WorkerScanner<'a> {
   module_identifier: &'a ModuleIdentifier,
   output_options: &'a OutputOptions,
   syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
+  pub removed: &'a mut Vec<DependencyLocation>,
 }
 
 // new Worker(new URL("./foo.worker.js", import.meta.url));
 impl<'a> WorkerScanner<'a> {
+  get_removed!();
+
   pub fn new(
     module_identifier: &'a ModuleIdentifier,
     output_options: &'a OutputOptions,
     syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
+    removed: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies: Vec::new(),
@@ -39,6 +44,7 @@ impl<'a> WorkerScanner<'a> {
       module_identifier,
       output_options,
       syntax_list,
+      removed,
     }
   }
 
@@ -140,6 +146,7 @@ impl<'a> WorkerScanner<'a> {
 
 impl Visit for WorkerScanner<'_> {
   noop_visit_type!();
+  no_visit_removed!();
 
   fn visit_new_expr(&mut self, new_expr: &NewExpr) {
     if let Some((parsed_path, parsed_options)) = self.parse_new_worker(new_expr) {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -11,8 +11,8 @@ use swc_core::ecma::ast::{Expr, ExprOrSpread, NewExpr};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::dependency::WorkerDependency;
+use crate::no_visit_removed;
 use crate::utils::get_literal_str_by_obj_prop;
-use crate::{get_removed, no_visit_removed};
 
 // TODO: should created by WorkerPlugin
 pub struct WorkerScanner<'a> {
@@ -28,8 +28,6 @@ pub struct WorkerScanner<'a> {
 
 // new Worker(new URL("./foo.worker.js", import.meta.url));
 impl<'a> WorkerScanner<'a> {
-  get_removed!();
-
   pub fn new(
     module_identifier: &'a ModuleIdentifier,
     output_options: &'a OutputOptions,

--- a/packages/rspack/tests/cases/parsing/remove-dependency/index.js
+++ b/packages/rspack/tests/cases/parsing/remove-dependency/index.js
@@ -1,0 +1,69 @@
+it("should not generate dependency after removing by evaluation for api", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		__webpack_hash__;
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for nested webpack require", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		__webpack_require__.d = 1;
+		function __webpack_require__() {}
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for nested webpack exports info", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		__webpack_exports_info__;
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for module id", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		module.id;
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for exports", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		exports.aaa;
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for __filename", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		__filename;
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for new URL", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		new URL("file://abc");
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for import meta", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		import.meta;
+		require("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for import()", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		import("failed");
+	}
+});
+
+it("should not generate dependency after removing by evaluation for new Worker()", function () {
+	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+		new Worker("aaa");
+		require("failed");
+	}
+});

--- a/packages/rspack/tests/cases/parsing/remove-dependency/index.js
+++ b/packages/rspack/tests/cases/parsing/remove-dependency/index.js
@@ -1,12 +1,12 @@
 it("should not generate dependency after removing by evaluation for api", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		__webpack_hash__;
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for nested webpack require", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		__webpack_require__.d = 1;
 		function __webpack_require__() {}
 		require("failed");
@@ -14,55 +14,55 @@ it("should not generate dependency after removing by evaluation for nested webpa
 });
 
 it("should not generate dependency after removing by evaluation for nested webpack exports info", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		__webpack_exports_info__;
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for module id", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		module.id;
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for exports", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		exports.aaa;
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for __filename", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		__filename;
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for new URL", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		new URL("file://abc");
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for import meta", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		import.meta;
 		require("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for import()", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		import("failed");
 	}
 });
 
 it("should not generate dependency after removing by evaluation for new Worker()", function () {
-	if (typeof __webpack_chunkname__ !== "string" /* always false */) {
+	if (typeof require !== "function" /* always false */) {
 		new Worker("aaa");
 		require("failed");
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix code generation error when code removed by compile time evaluation

```js
// source
if (typeof require !== 'function' /* always false */) {
  __webpack_hash__
}

// before
if (false /* always false */ ) __webpack_require__.h(){}

// after
if (false /* always false */ ) {}
```

Due to the lack of parser hooks, scanners will not be stopped even when the statements had been removed. So dependencies will be generated and trigger DependencyTemplate.apply as well. The code will be insert and cause runtime error.



## Test Plan

- Add `packages/rspack/tests/cases/parsing/remove-dependency`

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
