### PR TITLE
test: jest serializer path should be working with non-ascii code

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -778,7 +778,7 @@ impl NormalModuleFactory {
 }
 
 /// Using `u32` instead of `usize` to reduce memory usage,
-/// `u32` is 4 bytes on 64bit machine, comare to `usize` which is 8 bytes.
+/// `u32` is 4 bytes on 64bit machine, comparing to `usize` which is 8 bytes.
 /// Rspan aka `Rspack span`, just avoiding conflict with span in other crate
 /// ## Warning
 /// RSpan is zero based, `Span` of `swc` is 1 based. see https://swc-css.netlify.app/?code=eJzLzC3ILypRSFRIK8rPVVAvSS0u0csqVgcAZaoIKg

--- a/packages/rspack/jest.config.js
+++ b/packages/rspack/jest.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 /** @type {import('ts-jest/dist/types').JestConfigWithTsJest} */
 const config = {
 	testEnvironment: "../../scripts/test/patch-node-env.cjs",
@@ -18,6 +20,10 @@ const config = {
 		"ts-jest": {
 			tsconfig: "<rootDir>/tests/tsconfig.json"
 		}
+	},
+	moduleNameMapper: {
+		// Fixed jest-serialize-path not working when non-ascii code contains.
+		slash: path.join(__dirname, "../../scripts/test/slash.cjs")
 	}
 };
 

--- a/scripts/test/slash.cjs
+++ b/scripts/test/slash.cjs
@@ -1,0 +1,15 @@
+/**
+ * The following code is copied from
+ * https://github.com/sindresorhus/slash/blob/98b618f5a3bfcb5dd374b204868818845b87bb2f/index.js
+ *
+ * MIT Licensed
+ * Author Sindre Sorhus @sindresorhus
+ */
+module.exports = function slash(path) {
+	const isExtendedLengthPath = path.startsWith("\\\\?\\");
+
+	if (isExtendedLengthPath) {
+		return path;
+	}
+	return path.replace(/\\/g, "/");
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The old package `slash`  introduced in `jest-serializer-path` which is a long not maintained project is later fixed this issue.

This PR fixed `jest-serializer-path` not working when non-ascii code contains by syncing the implementation from the newest version.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
