### PR TITLE
test: remove manual path normalizations in snapshots

### DIFF
--- a/packages/rspack/tests/Stats.test.ts
+++ b/packages/rspack/tests/Stats.test.ts
@@ -56,9 +56,8 @@ describe("Stats", () => {
 			context: __dirname,
 			entry: "./fixtures/abc"
 		});
-		expect(
-			stats?.toString({ timings: false, version: false }).replace(/\\/g, "/")
-		).toMatchInlineSnapshot(`
+		expect(stats?.toString({ timings: false, version: false }))
+			.toMatchInlineSnapshot(`
 		"PublicPath: auto
 		asset main.js 758 bytes [emitted] (name: main)
 		Entrypoint main 758 bytes = main.js
@@ -135,7 +134,6 @@ describe("Stats", () => {
 		expect(
 			stats
 				?.toString({ all: false, logging: "verbose" })
-				.replace(/\\/g, "/")
 				.replace(/\d+ ms/g, "X ms")
 		).toMatchInlineSnapshot(`
 		"LOG from rspack.Compilation
@@ -208,10 +206,7 @@ describe("Stats", () => {
 			profile: true
 		});
 		expect(
-			stats
-				?.toString({ all: false, modules: true })
-				.replace(/\\/g, "/")
-				.replace(/\d+ ms/g, "X ms")
+			stats?.toString({ all: false, modules: true }).replace(/\d+ ms/g, "X ms")
 		).toMatchInlineSnapshot(`
 		"./fixtures/a.js
 		  X ms (resolving: X ms, integration: X ms, building: X ms)
@@ -351,7 +346,7 @@ describe("Stats", () => {
 			ids: true
 		};
 		expect(stats?.toJson(options)).toMatchSnapshot();
-		expect(stats?.toString(options).replace(/\\/g, "/")).toMatchInlineSnapshot(`
+		expect(stats?.toString(options)).toMatchInlineSnapshot(`
 		"asset main.js 211 bytes {main} [emitted] (name: main)
 		chunk {main} main.js (main) [entry]
 		./fixtures/a.js [585] {main}"

--- a/packages/rspack/tests/StatsTestCases.test.ts
+++ b/packages/rspack/tests/StatsTestCases.test.ts
@@ -7,11 +7,6 @@ import { isValidTestCaseDir } from "./utils";
 
 expect.addSnapshotSerializer(serializer);
 
-const project_dir_reg = new RegExp(
-	path.join(__dirname, "..").replace(/\\/g, "\\\\"),
-	"g"
-);
-
 const base = path.resolve(__dirname, "statsCases");
 const tests = fs.readdirSync(base).filter(testName => {
 	return (
@@ -85,44 +80,8 @@ describe("StatsTestCases", () => {
 				expect(statsJson.errors.length === 0);
 			}
 
-			function serializePath(s?: string): string {
-				if (!s) return "";
-				return s.replace(project_dir_reg, "<PROJECT_ROOT>").replace(/\\/g, "/");
-			}
-
-			statsJson.errors?.forEach(error => {
-				error.message = serializePath(error.message);
-				error.formatted = serializePath(error.formatted);
-				if (error.moduleIdentifier) {
-					error.moduleIdentifier = serializePath(error.moduleIdentifier);
-				}
-			});
-			statsJson.warnings?.forEach(error => {
-				error.message = serializePath(error.message);
-				error.formatted = serializePath(error.formatted);
-				if (error.moduleIdentifier) {
-					error.moduleIdentifier = serializePath(error.moduleIdentifier);
-				}
-			});
-			statsJson.children?.forEach(child => {
-				child.errors?.forEach(error => {
-					error.message = serializePath(error.message);
-					error.formatted = serializePath(error.formatted);
-					if (error.moduleIdentifier) {
-						error.moduleIdentifier = serializePath(error.moduleIdentifier);
-					}
-				});
-				child.warnings?.forEach(error => {
-					error.message = serializePath(error.message);
-					error.formatted = serializePath(error.formatted);
-					if (error.moduleIdentifier) {
-						error.moduleIdentifier = serializePath(error.moduleIdentifier);
-					}
-				});
-			});
 			expect(statsJson).toMatchSnapshot();
 			let statsString = stats.toString(statsOptions);
-			statsString = serializePath(statsString);
 			expect(statsString).toMatchSnapshot();
 		});
 	});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Since https://github.com/web-infra-dev/rspack/pull/5190 fixed the serializer, then we can remove these not necessary manual replacements.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
