### PR TITLE
feat(rspack_core): improve resolver error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,7 +141,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -152,7 +152,7 @@ checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -175,7 +175,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -607,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eed5fff0d93c7559121e9c72bf9c242295869396255071ff2cb1617147b608c5"
 dependencies = [
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -819,7 +819,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -884,7 +884,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -1185,7 +1185,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -1487,7 +1487,7 @@ checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -1725,9 +1725,9 @@ checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "oxc_resolver"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9cab435ba03dc1974c54e8721313a4d4945af7afaa3882c8eee66e31711da7"
+checksum = "6e472bf2c768ffcdfa226cd3763133aedc6df5dc57555fe611b3cfcc6515cd4d"
 dependencies = [
  "dashmap",
  "dunce",
@@ -1848,7 +1848,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -1914,7 +1914,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -1952,7 +1952,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -2003,7 +2003,7 @@ checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -2078,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
  "unicode-ident",
 ]
@@ -2116,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -3421,9 +3421,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
 dependencies = [
  "serde_derive",
 ]
@@ -3440,13 +3440,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -3462,9 +3462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "6fbd975230bada99c8bb618e0c365c2eefa219158d5c6c29610fd09ff1833257"
 dependencies = [
  "indexmap 2.1.0",
  "itoa",
@@ -3623,7 +3623,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -3674,7 +3674,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -3923,7 +3923,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4000,7 +4000,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4155,7 +4155,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4504,7 +4504,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4611,7 +4611,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4810,7 +4810,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4888,7 +4888,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -4967,7 +4967,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5008,7 +5008,7 @@ checksum = "ff9719b6085dd2824fd61938a881937be14b08f95e2d27c64c825a9f65e052ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5032,7 +5032,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5048,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.32"
+version = "2.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5096,7 +5096,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5121,22 +5121,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5227,7 +5227,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5249,7 +5249,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]
 
 [[package]]
@@ -5491,7 +5491,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
  "wasm-bindgen-shared",
 ]
 
@@ -5513,7 +5513,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5778,5 +5778,5 @@ checksum = "c2f140bda219a26ccc0cdb03dba58af72590c53b22642577d88a927bc5c87d6b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.32",
+ "syn 2.0.46",
 ]

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -23,7 +23,7 @@ itertools = { workspace = true }
 json = { workspace = true }
 mime_guess = { workspace = true }
 once_cell = { workspace = true }
-oxc_resolver = { version = "1.0.1" }
+oxc_resolver = { version = "1.1.0" }
 paste = { workspace = true }
 petgraph = { version = "0.6.3", features = ["serde-1"] }
 rayon = { workspace = true }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -248,64 +248,10 @@ fn to_oxc_resolver_options(
 
 fn map_oxc_resolver_error(error: oxc_resolver::ResolveError, args: &ResolveArgs<'_>) -> Error {
   match error {
-    oxc_resolver::ResolveError::InvalidPackageTarget(specifier, _, _) => {
-      let message = format!(
-        "Export should be relative path and start with \"./\", but got {}",
-        specifier
-      );
-      internal_error!(message)
-    }
     oxc_resolver::ResolveError::IOError(error) => DiagnosticError::from(error.boxed()).into(),
-    oxc_resolver::ResolveError::Builtin(error) => {
-      internal_error!("Builtin module: {}", error)
-    }
-    oxc_resolver::ResolveError::Ignored(path) => {
-      internal_error!("Path is ignored: {}", path.display())
-    }
-    oxc_resolver::ResolveError::TsconfigNotFound(path) => {
-      internal_error!("{} is not a tsconfig", path.display())
-    }
-    oxc_resolver::ResolveError::ExtensionAlias => {
-      internal_error!("All of the aliased extension are not found")
-    }
-    oxc_resolver::ResolveError::Specifier(_) => {
-      internal_error!("The provided patn specifier cannot be parsed")
-    }
-    oxc_resolver::ResolveError::JSON(json) => {
-      internal_error!("{:?}", json)
-    }
-    oxc_resolver::ResolveError::Restriction(path) => {
-      internal_error!(
-        "Restriction by `ResolveOptions::restrictions`: {}",
-        path.display()
-      )
-    }
-    oxc_resolver::ResolveError::InvalidModuleSpecifier(error, _) => {
-      internal_error!("Invalid module specifier: {}", error)
-    }
-    oxc_resolver::ResolveError::PackagePathNotExported(error, _) => {
-      internal_error!("Package subpath '{}' is not defined by \"exports\"", error)
-    }
-    oxc_resolver::ResolveError::InvalidPackageConfig(path) => {
-      internal_error!("Invalid package config in: {}", path.display())
-    }
-    oxc_resolver::ResolveError::InvalidPackageConfigDefault(path) => {
-      internal_error!("Default condition should be last one: {}", path.display())
-    }
-    oxc_resolver::ResolveError::InvalidPackageConfigDirectory(path) => {
-      internal_error!(
-        "Expecting folder to folder mapping. \"{}\" should end with \"/\"",
-        path.display()
-      )
-    }
-    oxc_resolver::ResolveError::PackageImportNotDefined(error) => {
-      internal_error!("Package import not defined: {}", error)
-    }
-    oxc_resolver::ResolveError::Unimplemented(error) => {
-      internal_error!("{} is unimplemented", error)
-    }
     oxc_resolver::ResolveError::Recursion => map_resolver_error(true, args),
     oxc_resolver::ResolveError::NotFound(_) => map_resolver_error(false, args),
+    _ => internal_error!("{}", error),
   }
 }
 

--- a/packages/rspack/tests/StatsTestCases.test.ts
+++ b/packages/rspack/tests/StatsTestCases.test.ts
@@ -90,9 +90,18 @@ describe("StatsTestCases", () => {
 				return s.replace(project_dir_reg, "<PROJECT_ROOT>").replace(/\\/g, "/");
 			}
 
+			// Remove the "|" padding from miette. Different terminal widths returns
+			// different padding, which breaks local and CI checks.
+			function serializeMietteDiagnostic(s: string): string {
+				if (!s) return "";
+				return s.replace(/\n[ ]+│ /, "");
+			}
+
 			statsJson.errors?.forEach(error => {
-				error.message = serializePath(error.message);
-				error.formatted = serializePath(error.formatted);
+				error.message = serializeMietteDiagnostic(serializePath(error.message));
+				error.formatted = serializeMietteDiagnostic(
+					serializePath(error.formatted)
+				);
 				if (error.moduleIdentifier) {
 					error.moduleIdentifier = serializePath(error.moduleIdentifier);
 				}
@@ -106,8 +115,12 @@ describe("StatsTestCases", () => {
 			});
 			statsJson.children?.forEach(child => {
 				child.errors?.forEach(error => {
-					error.message = serializePath(error.message);
-					error.formatted = serializePath(error.formatted);
+					error.message = serializeMietteDiagnostic(
+						serializePath(error.message)
+					);
+					error.formatted = serializeMietteDiagnostic(
+						serializePath(error.formatted)
+					);
 					if (error.moduleIdentifier) {
 						error.moduleIdentifier = serializePath(error.moduleIdentifier);
 					}
@@ -122,7 +135,7 @@ describe("StatsTestCases", () => {
 			});
 			expect(statsJson).toMatchSnapshot();
 			let statsString = stats.toString(statsOptions);
-			statsString = serializePath(statsString);
+			statsString = serializeMietteDiagnostic(serializePath(statsString));
 			expect(statsString).toMatchSnapshot();
 		});
 	});

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -4951,8 +4951,7 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
 {
   "errors": [
     {
-      "formatted": "  × 
-  │   x Expected '{', got 'error'
+      "formatted": "  ×   x Expected '{', got 'error'
   │    ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
   │  1 | export error;
   │    :        ^^^^^
@@ -4960,8 +4959,7 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
   │ 
   ╰─▶ Syntax Error
 ",
-      "message": "  × 
-  │   x Expected '{', got 'error'
+      "message": "  ×   x Expected '{', got 'error'
   │    ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
   │  1 | export error;
   │    :        ^^^^^
@@ -4982,8 +4980,7 @@ exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-l
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error-builtin-swc-loader 2`] = `
-"ERROR in ./index.ts   × 
-  │   x Expected '{', got 'error'
+"ERROR in ./index.ts   ×   x Expected '{', got 'error'
   │    ,-[<PROJECT_ROOT>/tests/statsCases/parse-error-builtin-swc-loader/index.ts:1:1]
   │  1 | export error;
   │    :        ^^^^^
@@ -5358,11 +5355,9 @@ console.log(a);
   },
   "errors": [
     {
-      "formatted": "  × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-
-  │ a/package.json
+      "formatted": "  × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-a/package.json
 ",
-      "message": "  × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-
-  │ a/package.json
+      "message": "  × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-a/package.json
 ",
       "moduleId": "10",
       "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/index.js",
@@ -5457,8 +5452,7 @@ chunk {909} bundle.js (main) [entry]
 webpack/runtime/make_namespace_object {909}
   
 
-ERROR in ./index.js   × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-
-  │ a/package.json
+ERROR in ./index.js   × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-a/package.json
 
 Rspack compiled with 1 error (d522bd63336c0fb69e32)"
 `;

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -5358,9 +5358,11 @@ console.log(a);
   },
   "errors": [
     {
-      "formatted": "  × Export should be relative path and start with "./", but got ../../index.js
+      "formatted": "  × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-
+  │ a/package.json
 ",
-      "message": "  × Export should be relative path and start with "./", but got ../../index.js
+      "message": "  × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-
+  │ a/package.json
 ",
       "moduleId": "10",
       "moduleIdentifier": "<PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/index.js",
@@ -5455,7 +5457,8 @@ chunk {909} bundle.js (main) [entry]
 webpack/runtime/make_namespace_object {909}
   
 
-ERROR in ./index.js   × Export should be relative path and start with "./", but got ../../index.js
+ERROR in ./index.js   × Invalid "exports" target "../../index.js" defined for '.' in the package config <PROJECT_ROOT>/tests/statsCases/resolve-unexpected-exports-in-pkg/node_modules/pkg-
+  │ a/package.json
 
 Rspack compiled with 1 error (d522bd63336c0fb69e32)"
 `;


### PR DESCRIPTION
> [!NOTE] 
> The target branch is 0.5.0

## Summary

Previously some ESM error messages did not report enough context (e.g. package.json location), causing confusion to the user.

The specific error messages are in https://github.com/oxc-project/oxc_resolver/blob/main/src/error.rs


## Test Plan

* Snapshots are updated, showing better error messages - they have package.json information
* CI passes

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
