### PR TITLE
refactor: move build_info and build_meta to module

### DIFF
--- a/crates/rspack_core/src/cache/occasion/build_module.rs
+++ b/crates/rspack_core/src/cache/occasion/build_module.rs
@@ -8,8 +8,8 @@ use rspack_identifier::Identifier;
 use crate::{
   cache::snapshot::{Snapshot, SnapshotManager},
   cache::storage,
-  BoxModule, BuildExtraDataType, BuildResult, DependencyTemplate, ModuleDependency,
-  NormalModuleSource,
+  BoxModule, BuildExtraDataType, BuildInfo, BuildMeta, BuildResult, DependencyTemplate, Module,
+  ModuleDependency, NormalModuleSource,
 };
 
 #[derive(Debug, Clone)]
@@ -17,6 +17,8 @@ pub struct NormalModuleStorageData {
   source: NormalModuleSource,
   code_generation_dependencies: Option<Vec<Box<dyn ModuleDependency>>>,
   presentational_dependencies: Option<Vec<Box<dyn DependencyTemplate>>>,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 type NormalModuleStorageExtraData = HashMap<BuildExtraDataType, AlignedVec>;
@@ -89,6 +91,11 @@ impl BuildModuleOccasion {
               *module.source_mut() = module_data.source;
               *module.code_generation_dependencies_mut() = module_data.code_generation_dependencies;
               *module.presentational_dependencies_mut() = module_data.presentational_dependencies;
+              if let (Some(build_info), Some(build_meta)) =
+                (module_data.build_info, module_data.build_meta)
+              {
+                module.set_module_build_info_and_meta(build_info, build_meta);
+              }
             }
             if let Some(extra_data) = extra_data {
               module.parser_and_generator_mut().resume(&extra_data);
@@ -168,6 +175,8 @@ impl BuildModuleOccasion {
               source: module.source().clone(),
               code_generation_dependencies: module.code_generation_dependencies().clone(),
               presentational_dependencies: module.presentational_dependencies().clone(),
+              build_info: module.build_info().cloned(),
+              build_meta: module.build_meta().cloned(),
             }),
             Some(extra_data),
           ),

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -7,8 +7,7 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   find_graph_roots, merge_runtime, BoxModule, Chunk, ChunkByUkey, ChunkGroup, ChunkGroupByUkey,
-  ChunkGroupUkey, ChunkUkey, Module, ModuleGraph, ModuleGraphModule, ModuleIdentifier,
-  RuntimeGlobals, SourceType,
+  ChunkGroupUkey, ChunkUkey, Module, ModuleGraph, ModuleIdentifier, RuntimeGlobals, SourceType,
 };
 use crate::{ChunkGraph, Compilation};
 
@@ -201,18 +200,13 @@ impl ChunkGraph {
     chunk: &ChunkUkey,
     source_type: SourceType,
     module_graph: &'module ModuleGraph,
-  ) -> Vec<&'module ModuleGraphModule> {
+  ) -> Vec<&'module BoxModule> {
     let chunk_graph_chunk = self.get_chunk_graph_chunk(chunk);
     let modules = chunk_graph_chunk
       .modules
       .iter()
-      .filter_map(|uri| module_graph.module_graph_module_by_identifier(uri))
-      .filter(|mgm| {
-        module_graph
-          .module_by_identifier(&mgm.module_identifier)
-          .map(|module| module.source_types().contains(&source_type))
-          .unwrap_or_default()
-      })
+      .filter_map(|uri| module_graph.module_by_identifier(uri))
+      .filter(|module| module.source_types().contains(&source_type))
       .collect::<Vec<_>>();
     modules
   }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -190,8 +190,8 @@ impl ChunkGraph {
         .get_exports_info(&module.identifier())
         .export_info_hash(&mut hasher, module_graph);
 
-      if let Some(mgm) = module_graph.module_graph_module_by_identifier(&module.identifier()) {
-        let export_type = mgm.get_exports_type(strict);
+      if let Some(module) = module_graph.module_by_identifier(&module.identifier()) {
+        let export_type = module.get_exports_type(strict);
         export_type.dyn_hash(&mut hasher);
       }
 
@@ -206,7 +206,7 @@ impl ChunkGraph {
     process_module_graph_module(module, module_graph, false).dyn_hash(&mut hasher);
 
     let strict: bool = module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .unwrap_or_else(|| {
         panic!(
           "Module({}) should be added before using",

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -922,11 +922,9 @@ impl Compilation {
                 original_module_identifier: module.identifier(),
                 resolve_options: module.get_resolve_options(),
               });
-              self.module_graph.set_module_build_info_and_meta(
-                &module.identifier(),
-                build_result.build_info,
-                build_result.build_meta,
-              );
+
+              module
+                .set_module_build_info_and_meta(build_result.build_info, build_result.build_meta);
               self.module_graph.add_module(module);
             }
             Ok(TaskResult::ProcessDependencies(task_result)) => {
@@ -1259,8 +1257,8 @@ impl Compilation {
 
   #[instrument(name = "compilation::create_module_assets", skip_all)]
   async fn create_module_assets(&mut self, _plugin_driver: SharedPluginDriver) {
-    for (module_identifier, mgm) in self.module_graph.module_graph_modules() {
-      if let Some(ref build_info) = mgm.build_info {
+    for (module_identifier, module) in self.module_graph.modules() {
+      if let Some(build_info) = module.build_info() {
         for asset in build_info.asset_filenames.iter() {
           for chunk in self
             .chunk_graph

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -19,12 +19,13 @@ use rustc_hash::FxHashMap as HashMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  contextify, get_exports_type_with_strict, stringify_map, to_path, AsyncDependenciesBlock,
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  ChunkGraph, ChunkGroupOptions, CodeGenerationResult, Compilation, ContextElementDependency,
-  DependenciesBlock, DependencyCategory, DependencyId, ExportsType, FakeNamespaceObjectMode,
-  GroupOptions, LibIdentOptions, Module, ModuleType, Resolve, ResolveInnerOptions,
-  ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals, RuntimeSpec, SourceType,
+  contextify, get_exports_type_with_strict, impl_build_info_meta, stringify_map, to_path,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, ChunkGraph, ChunkGroupOptions, CodeGenerationResult, Compilation,
+  ContextElementDependency, DependenciesBlock, DependencyCategory, DependencyId, ExportsType,
+  FakeNamespaceObjectMode, GroupOptions, LibIdentOptions, Module, ModuleType, Resolve,
+  ResolveInnerOptions, ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals,
+  RuntimeSpec, SourceType,
 };
 
 #[derive(Debug, Clone)]
@@ -190,6 +191,8 @@ pub struct ContextModule {
   identifier: Identifier,
   options: ContextModuleOptions,
   resolve_factory: Arc<ResolverFactory>,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl PartialEq for ContextModule {
@@ -208,6 +211,8 @@ impl ContextModule {
       identifier: create_identifier(&options),
       options,
       resolve_factory,
+      build_info: None,
+      build_meta: None,
     }
   }
 
@@ -558,6 +563,8 @@ impl DependenciesBlock for ContextModule {
 
 #[async_trait::async_trait]
 impl Module for ContextModule {
+  impl_build_info_meta!();
+
   fn module_type(&self) -> &ModuleType {
     &ModuleType::Js
   }

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -141,11 +141,11 @@ pub fn get_exports_type(
     .module_identifier_by_dependency_id(id)
     .expect("should have module");
   let strict = module_graph
-    .module_graph_module_by_identifier(parent_module)
+    .module_by_identifier(parent_module)
     .expect("should have mgm")
     .get_strict_harmony_module();
   module_graph
-    .module_graph_module_by_identifier(module)
+    .module_by_identifier(module)
     .expect("should have mgm")
     .get_exports_type(strict)
 }
@@ -159,7 +159,7 @@ pub fn get_exports_type_with_strict(
     .module_identifier_by_dependency_id(id)
     .expect("should have module");
   module_graph
-    .module_graph_module_by_identifier(module)
+    .module_by_identifier(module)
     .expect("should have mgm")
     .get_exports_type(strict)
 }

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -9,13 +9,13 @@ use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::{
-  extract_url_and_global, property_access,
+  extract_url_and_global, impl_build_info_meta, property_access,
   rspack_sources::{BoxSource, RawSource, Source, SourceExt},
-  to_identifier, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMetaExportsType,
-  BuildResult, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl, CodeGenerationResult,
-  Compilation, Context, DependenciesBlock, DependencyId, ExternalType, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleType, NormalInitFragment,
-  RuntimeGlobals, RuntimeSpec, SourceType,
+  to_identifier, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta,
+  BuildMetaExportsType, BuildResult, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl,
+  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, ExternalType,
+  InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleType,
+  NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -88,6 +88,8 @@ pub struct ExternalModule {
   external_type: ExternalType,
   /// Request intended by user (without loaders from config)
   user_request: String,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl ExternalModule {
@@ -99,6 +101,8 @@ impl ExternalModule {
       request,
       external_type,
       user_request,
+      build_info: None,
+      build_meta: None,
     }
   }
 
@@ -303,6 +307,8 @@ impl DependenciesBlock for ExternalModule {
 
 #[async_trait::async_trait]
 impl Module for ExternalModule {
+  impl_build_info_meta!();
+
   fn module_type(&self) -> &ModuleType {
     &ModuleType::Js
   }

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -615,17 +615,16 @@ impl ModuleGraph {
     build_info: BuildInfo,
     build_meta: BuildMeta,
   ) {
-    if let Some(mgm) = self.module_graph_module_by_identifier_mut(module_identifier) {
-      mgm.build_info = Some(build_info);
-      mgm.build_meta = Some(build_meta);
+    if let Some(module) = self.module_by_identifier_mut(module_identifier) {
+      module.set_module_build_info_and_meta(build_info, build_meta);
     }
   }
 
   #[inline]
   pub fn get_module_hash(&self, module_identifier: &ModuleIdentifier) -> Option<&RspackHashDigest> {
     self
-      .module_graph_module_by_identifier(module_identifier)
-      .and_then(|mgm| mgm.build_info.as_ref().and_then(|i| i.hash.as_ref()))
+      .module_by_identifier(module_identifier)
+      .and_then(|mgm| mgm.build_info().as_ref().and_then(|i| i.hash.as_ref()))
   }
 
   pub fn has_dependencies(
@@ -634,8 +633,8 @@ impl ModuleGraph {
     files: &HashSet<PathBuf>,
   ) -> bool {
     if let Some(build_info) = self
-      .module_graph_module_by_identifier(module_identifier)
-      .and_then(|mgm| mgm.build_info.as_ref())
+      .module_by_identifier(module_identifier)
+      .and_then(|module| module.build_info())
     {
       for item in files {
         if build_info.file_dependencies.contains(item)
@@ -776,10 +775,10 @@ mod test {
   use rspack_sources::Source;
 
   use crate::{
-    AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildResult,
-    CodeGenerationResult, Compilation, Context, DependenciesBlock, Dependency, DependencyId,
-    ExportInfo, ExportsInfo, Module, ModuleDependency, ModuleGraph, ModuleGraphModule,
-    ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, UsageState,
+    AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta,
+    BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock, Dependency,
+    DependencyId, ExportInfo, ExportsInfo, Module, ModuleDependency, ModuleGraph,
+    ModuleGraphModule, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, UsageState,
   };
 
   // Define a detailed node type for `ModuleGraphModule`s
@@ -845,6 +844,22 @@ mod test {
           _compilation: &Compilation,
           _runtime: Option<&RuntimeSpec>,
         ) -> Result<CodeGenerationResult> {
+          unreachable!()
+        }
+
+        fn build_meta(&self) -> Option<&BuildMeta> {
+          unreachable!()
+        }
+
+        fn build_info(&self) -> Option<&BuildInfo> {
+          unreachable!()
+        }
+
+        fn set_module_build_info_and_meta(
+          &mut self,
+          _build_info: BuildInfo,
+          _build_meta: BuildMeta,
+        ) {
           unreachable!()
         }
       }

--- a/crates/rspack_core/src/module_graph_module.rs
+++ b/crates/rspack_core/src/module_graph_module.rs
@@ -3,8 +3,7 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::ExportsInfoId;
 use crate::{
-  module_graph::ConnectionId, BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType,
-  ChunkGraph, DependencyId, ExportsArgument, ExportsType, FactoryMeta, ModuleArgument, ModuleGraph,
+  module_graph::ConnectionId, ChunkGraph, DependencyId, FactoryMeta, ModuleGraph,
   ModuleGraphConnection, ModuleIdentifier, ModuleIssuer, ModuleProfile, ModuleSyntax, ModuleType,
 };
 
@@ -26,8 +25,6 @@ pub struct ModuleGraphModule {
   pub post_order_index: Option<u32>,
   pub module_syntax: ModuleSyntax,
   pub factory_meta: Option<FactoryMeta>,
-  pub build_info: Option<BuildInfo>,
-  pub build_meta: Option<BuildMeta>,
   pub exports: ExportsInfoId,
   pub profile: Option<Box<ModuleProfile>>,
   pub is_async: bool,
@@ -51,8 +48,6 @@ impl ModuleGraphModule {
       post_order_index: None,
       module_syntax: ModuleSyntax::empty(),
       factory_meta: None,
-      build_info: None,
-      build_meta: None,
       exports: exports_info_id,
       profile: None,
       is_async: false,
@@ -133,79 +128,5 @@ impl ModuleGraphModule {
 
   pub fn get_issuer(&self) -> &ModuleIssuer {
     &self.issuer
-  }
-
-  pub fn get_exports_argument(&self) -> ExportsArgument {
-    self
-      .build_meta
-      .as_ref()
-      .map(|m| m.exports_argument)
-      .unwrap_or_default()
-  }
-
-  pub fn get_module_argument(&self) -> ModuleArgument {
-    self
-      .build_meta
-      .as_ref()
-      .map(|m| m.module_argument)
-      .unwrap_or_default()
-  }
-
-  pub fn get_exports_type(&self, strict: bool) -> ExportsType {
-    if let Some((export_type, default_object)) = self
-      .build_meta
-      .as_ref()
-      .map(|m| (&m.exports_type, &m.default_object))
-    {
-      match export_type {
-        BuildMetaExportsType::Flagged => {
-          if strict {
-            ExportsType::DefaultWithNamed
-          } else {
-            ExportsType::Namespace
-          }
-        }
-        BuildMetaExportsType::Namespace => ExportsType::Namespace,
-        BuildMetaExportsType::Default => match default_object {
-          BuildMetaDefaultObject::Redirect => ExportsType::DefaultWithNamed,
-          BuildMetaDefaultObject::RedirectWarn => {
-            if strict {
-              ExportsType::DefaultOnly
-            } else {
-              ExportsType::DefaultWithNamed
-            }
-          }
-          BuildMetaDefaultObject::False => ExportsType::DefaultOnly,
-        },
-        BuildMetaExportsType::Dynamic => {
-          if strict {
-            ExportsType::DefaultWithNamed
-          } else {
-            // TODO check target
-            ExportsType::Dynamic
-          }
-        }
-        // algin to undefined
-        BuildMetaExportsType::Unset => {
-          if strict {
-            ExportsType::DefaultWithNamed
-          } else {
-            ExportsType::Dynamic
-          }
-        }
-      }
-    } else if strict {
-      ExportsType::DefaultWithNamed
-    } else {
-      ExportsType::Dynamic
-    }
-  }
-
-  pub fn get_strict_harmony_module(&self) -> bool {
-    self
-      .build_meta
-      .as_ref()
-      .map(|m| m.strict_harmony_module)
-      .unwrap_or(false)
   }
 }

--- a/crates/rspack_core/src/plugin/args.rs
+++ b/crates/rspack_core/src/plugin/args.rs
@@ -9,9 +9,9 @@ use rspack_sources::BoxSource;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  Chunk, ChunkInitFragments, ChunkUkey, Compilation, Context, ContextModuleFactory,
-  DependencyCategory, DependencyType, ErrorSpan, FactoryMeta, ModuleDependency, ModuleGraphModule,
-  ModuleIdentifier, NormalModuleFactory, Resolve, RuntimeGlobals, SharedPluginDriver, Stats,
+  BoxModule, Chunk, ChunkInitFragments, ChunkUkey, Compilation, Context, ContextModuleFactory,
+  DependencyCategory, DependencyType, ErrorSpan, FactoryMeta, ModuleDependency, ModuleIdentifier,
+  NormalModuleFactory, Resolve, RuntimeGlobals, SharedPluginDriver, Stats,
 };
 
 #[derive(Debug)]
@@ -191,7 +191,7 @@ pub struct RenderModuleContentArgs<'a> {
   pub module_source: BoxSource,
   pub chunk_init_fragments: ChunkInitFragments,
   pub compilation: &'a Compilation,
-  pub module_graph_module: &'a ModuleGraphModule,
+  pub module: &'a BoxModule,
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -7,9 +7,9 @@ use rspack_identifier::Identifiable;
 use rspack_sources::{BoxSource, RawSource, Source, SourceExt};
 
 use crate::{
-  dependencies_block::AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildResult,
-  CodeGenerationResult, Context, DependenciesBlock, DependencyId, Module, ModuleIdentifier,
-  ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  dependencies_block::AsyncDependenciesBlockIdentifier, impl_build_info_meta, BuildContext,
+  BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Context, DependenciesBlock,
+  DependencyId, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
@@ -20,6 +20,8 @@ pub struct RawModule {
   identifier: ModuleIdentifier,
   readable_identifier: String,
   runtime_requirements: RuntimeGlobals,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 static RAW_MODULE_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -39,6 +41,8 @@ impl RawModule {
       identifier,
       readable_identifier,
       runtime_requirements,
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -69,6 +73,8 @@ impl DependenciesBlock for RawModule {
 
 #[async_trait::async_trait]
 impl Module for RawModule {
+  impl_build_info_meta!();
+
   fn module_type(&self) -> &ModuleType {
     &ModuleType::Js
   }

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -101,6 +101,21 @@ macro_rules! impl_runtime_module {
         None
       }
 
+      fn build_info(&self) -> Option<&$crate::BuildInfo> {
+        None
+      }
+
+      fn build_meta(&self) -> Option<&$crate::BuildMeta> {
+        None
+      }
+
+      fn set_module_build_info_and_meta(
+        &mut self,
+        build_info: $crate::BuildInfo,
+        build_meta: $crate::BuildMeta,
+      ) {
+      }
+
       fn code_generation(
         &self,
         compilation: &$crate::Compilation,

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -8,9 +8,9 @@ use rspack_identifier::{Identifiable, Identifier};
 use rspack_sources::Source;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildResult, ChunkUkey,
-  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
-  Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
+  impl_build_info_meta, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta,
+  BuildResult, ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock,
+  DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
@@ -19,6 +19,8 @@ pub struct SelfModule {
   readable_identifier: String,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl SelfModule {
@@ -29,6 +31,8 @@ impl SelfModule {
       readable_identifier: identifier,
       blocks: Default::default(),
       dependencies: Default::default(),
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -59,6 +63,8 @@ impl DependenciesBlock for SelfModule {
 
 #[async_trait]
 impl Module for SelfModule {
+  impl_build_info_meta!();
+
   fn size(&self, _source_type: &SourceType) -> f64 {
     self.identifier.len() as f64
   }

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -456,8 +456,8 @@ impl Stats<'_> {
     chunks.sort_unstable();
 
     let assets = module_assets.then(|| {
-      let mut assets: Vec<_> = mgm
-        .build_info
+      let mut assets: Vec<_> = module
+        .build_info()
         .as_ref()
         .map(|info| info.asset_filenames.iter().map(|i| i.to_string()).collect())
         .unwrap_or_default();

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -85,13 +85,13 @@ impl DependencyTemplate for CommonJsExportRequireDependency {
       ..
     } = code_generatable_context;
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
-    let exports_argument = mgm.get_exports_argument();
-    let module_argument = mgm.get_module_argument();
+    let exports_argument = module.get_exports_argument();
+    let module_argument = module.get_module_argument();
 
     let base = if self.base.is_exports() {
       runtime_requirements.insert(RuntimeGlobals::EXPORTS);

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -118,9 +118,9 @@ impl DependencyTemplate for CommonJsExportsDependency {
       ..
     } = code_generatable_context;
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
     let used = compilation
@@ -133,8 +133,8 @@ impl DependencyTemplate for CommonJsExportsDependency {
         UsedName::Vec(self.names.clone()),
       );
 
-    let exports_argument = mgm.get_exports_argument();
-    let module_argument = mgm.get_module_argument();
+    let exports_argument = module.get_exports_argument();
+    let module_argument = module.get_module_argument();
 
     let base = if self.base.is_exports() {
       runtime_requirements.insert(RuntimeGlobals::EXPORTS);

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -86,9 +86,9 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
       ..
     } = code_generatable_context;
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
     let used = if self.names.is_empty() {
@@ -106,8 +106,8 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
       UsedName::Vec(self.names.clone())
     };
 
-    let exports_argument = mgm.get_exports_argument();
-    let module_argument = mgm.get_module_argument();
+    let exports_argument = module.get_exports_argument();
+    let module_argument = module.get_module_argument();
 
     let base = if self.base.is_exports() {
       runtime_requirements.insert(RuntimeGlobals::EXPORTS);

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -33,11 +33,11 @@ impl DependencyTemplate for ModuleDecoratorDependency {
     runtime_requirements.insert(RuntimeGlobals::MODULE);
     runtime_requirements.insert(self.decorator);
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm");
-    let module_argument = mgm.get_module_argument();
+    let module_argument = module.get_module_argument();
 
     let module_id = compilation
       .chunk_graph

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
@@ -21,9 +21,9 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
       module,
       ..
     } = code_generatable_context;
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm");
     // TODO __esModule is used
     runtime_requirements.insert(RuntimeGlobals::MAKE_NAMESPACE_OBJECT);
@@ -32,7 +32,7 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
       format!(
         "{}({});\n",
         RuntimeGlobals::MAKE_NAMESPACE_OBJECT,
-        mgm.get_exports_argument()
+        module.get_exports_argument()
       ),
       InitFragmentStage::StageHarmonyExports,
       0,
@@ -52,14 +52,14 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
           RuntimeGlobals::ASYNC_MODULE,
           compilation
             .module_graph
-            .module_graph_module_by_identifier(&module.identifier())
+            .module_by_identifier(&module.identifier())
             .expect("should have mgm")
             .get_module_argument()
         ),
         InitFragmentStage::StageAsyncBoundary,
         0,
         InitFragmentKey::unique(),
-        Some(format!("\n__webpack_async_result__();\n}} catch(e) {{ __webpack_async_result__(e); }} }}{});", if matches!(mgm.build_meta.as_ref().map(|meta| meta.has_top_level_await), Some(true)) { ", 1" } else { "" })),
+        Some(format!("\n__webpack_async_result__();\n}} catch(e) {{ __webpack_async_result__(e); }} }}{});", if matches!(module.build_meta().as_ref().map(|meta| meta.has_top_level_await), Some(true)) { ", 1" } else { "" })),
       )));
     }
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -65,10 +65,9 @@ impl HarmonyExportImportedSpecifierDependency {
   pub fn active_exports<'a>(&self, module_graph: &'a ModuleGraph) -> &'a HashSet<JsWord> {
     let build_info = module_graph
       .parent_module_by_dependency_id(&self.id)
-      .and_then(|ident| module_graph.module_graph_module_by_identifier(&ident))
+      .and_then(|ident| module_graph.module_by_identifier(&ident))
       .expect("should have mgm")
-      .build_info
-      .as_ref()
+      .build_info()
       .expect("should have build info");
     &build_info.harmony_named_exports
   }
@@ -76,10 +75,9 @@ impl HarmonyExportImportedSpecifierDependency {
   pub fn all_star_exports<'a>(&self, module_graph: &'a ModuleGraph) -> &'a Vec<DependencyId> {
     let build_info = module_graph
       .parent_module_by_dependency_id(&self.id)
-      .and_then(|ident| module_graph.module_graph_module_by_identifier(&ident))
+      .and_then(|ident| module_graph.module_by_identifier(&ident))
       .expect("should have mgm")
-      .build_info
-      .as_ref()
+      .build_info()
       .expect("should have build info");
     &build_info.all_star_exports
   }
@@ -675,11 +673,11 @@ impl HarmonyExportImportedSpecifierDependency {
         runtime_requirements.insert(RuntimeGlobals::EXPORTS);
         runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
 
-        let mgm = compilation
+        let module = compilation
           .module_graph
-          .module_graph_module_by_identifier(&module.identifier())
+          .module_by_identifier(&module.identifier())
           .expect("should have module graph module");
-        let exports_name = mgm.get_exports_argument();
+        let exports_name = module.get_exports_argument();
         let is_async = compilation
           .module_graph
           .is_async(&module.identifier())
@@ -729,11 +727,11 @@ impl HarmonyExportImportedSpecifierDependency {
       key.into(),
       format!("/* {} */ {}", comment, return_value).into(),
     ));
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
-    HarmonyExportInitFragment::new(mgm.get_exports_argument(), export_map)
+    HarmonyExportInitFragment::new(module.get_exports_argument(), export_map)
   }
 
   fn get_reexport_fake_namespace_object_fragments(
@@ -750,9 +748,9 @@ impl HarmonyExportImportedSpecifierDependency {
       ..
     } = ctxt;
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
     runtime_requirements.insert(RuntimeGlobals::EXPORTS);
     runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
@@ -777,7 +775,7 @@ impl HarmonyExportImportedSpecifierDependency {
         None,
       )
       .boxed(),
-      HarmonyExportInitFragment::new(mgm.get_exports_argument(), export_map).boxed(),
+      HarmonyExportInitFragment::new(module.get_exports_argument(), export_map).boxed(),
     ];
     ctxt.init_fragments.extend_from_slice(&frags);
   }
@@ -810,11 +808,11 @@ impl HarmonyExportImportedSpecifierDependency {
       ..
     } = ctxt;
     let return_value = Self::get_return_value(name.to_string(), value_key);
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm");
-    let exports_name = mgm.get_exports_argument();
+    let exports_name = module.get_exports_argument();
     runtime_requirements.insert(RuntimeGlobals::EXPORTS);
     runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
     runtime_requirements.insert(RuntimeGlobals::HAS_OWN_PROPERTY);
@@ -849,9 +847,9 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
     let module = &code_generatable_context.module;
     let runtime = code_generatable_context.runtime;
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
 
     let import_var = get_import_var(&compilation.module_graph, self.id);
@@ -958,7 +956,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
       code_generatable_context
         .init_fragments
         .push(Box::new(HarmonyExportInitFragment::new(
-          mgm.get_exports_argument(),
+          module.get_exports_argument(),
           exports,
         )));
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -78,9 +78,9 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
       ..
     } = code_generatable_context;
 
-    let mgm = compilation
+    let module = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
 
     let used_name = if compilation.options.is_new_tree_shaking() {
@@ -113,7 +113,7 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
     };
     if let Some(used_name) = used_name {
       init_fragments.push(Box::new(HarmonyExportInitFragment::new(
-        mgm.get_exports_argument(),
+        module.get_exports_argument(),
         vec![(used_name, self.value.clone())],
       )));
     }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -220,7 +220,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
     runtime_requirements.insert(RuntimeGlobals::REQUIRE);
     let exports_argument = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm")
       .get_exports_argument();
     init_fragments.push(Box::new(NormalInitFragment::new(

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -30,7 +30,7 @@ impl DependencyTemplate for ModuleArgumentDependency {
 
     let module_argument = compilation
       .module_graph
-      .module_graph_module_by_identifier(&module.identifier())
+      .module_by_identifier(&module.identifier())
       .expect("should have mgm")
       .get_module_argument();
 

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -12,7 +12,7 @@ impl Plugin for APIPlugin {
     _ctx: PluginContext,
     mut args: RenderModuleContentArgs<'a>,
   ) -> PluginRenderModuleContentOutput<'a> {
-    if let Some(build_info) = &args.module_graph_module.build_info
+    if let Some(build_info) = &args.module.build_info()
       && build_info.need_create_require
     {
       args.chunk_init_fragments.push(

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -36,7 +36,12 @@ impl<'a> FlagDependencyExportsProxy<'a> {
       std::mem::take(&mut self.mg.module_identifier_to_module_graph_module);
     for mgm in module_graph_modules.values() {
       let exports_id = mgm.exports;
-      let is_module_without_exports = if let Some(ref build_meta) = mgm.build_meta {
+
+      let module = self
+        .mg
+        .module_by_identifier(&mgm.module_identifier)
+        .expect("should have module");
+      let is_module_without_exports = if let Some(build_meta) = module.build_meta() {
         build_meta.exports_type == BuildMetaExportsType::Unset
       } else {
         true
@@ -52,8 +57,8 @@ impl<'a> FlagDependencyExportsProxy<'a> {
         }
       }
 
-      if !mgm
-        .build_info
+      if !module
+        .build_info()
         .as_ref()
         .map(|item| item.hash.is_some())
         .unwrap_or_default()

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -328,10 +328,15 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       .module_graph
       .module_graph_module_by_identifier(&module_id)
       .expect("should have mgm");
+    let module = self
+      .compilation
+      .module_graph
+      .module_by_identifier(&module_id)
+      .expect("should have module");
     let mgm_exports_info_id = mgm.exports;
     if !used_exports.is_empty() {
-      let need_insert = match mgm.build_meta {
-        Some(ref build_meta) => matches!(build_meta.exports_type, BuildMetaExportsType::Unset),
+      let need_insert = match module.build_meta() {
+        Some(build_meta) => matches!(build_meta.exports_type, BuildMetaExportsType::Unset),
         None => true,
       };
       if need_insert {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -207,7 +207,7 @@ impl Plugin for JsPlugin {
       &compilation.module_graph,
     );
     // SAFETY: module identifier is unique
-    ordered_modules.sort_unstable_by_key(|m| m.module_identifier.as_str());
+    ordered_modules.sort_unstable_by_key(|m| m.identifier().as_str());
 
     ordered_modules
       .iter()
@@ -215,8 +215,8 @@ impl Plugin for JsPlugin {
         (
           compilation
             .code_generation_results
-            .get_hash(&mgm.module_identifier, Some(&chunk.runtime)),
-          compilation.chunk_graph.get_module_id(mgm.module_identifier),
+            .get_hash(&mgm.identifier(), Some(&chunk.runtime)),
+          compilation.chunk_graph.get_module_id(mgm.identifier()),
         )
       })
       .for_each(|(current, id)| {

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -21,16 +21,16 @@ impl Plugin for InferAsyncModulesPlugin {
 
     let mut modules: Vec<Identifier> = compilation
       .module_graph
-      .module_graph_modules()
+      .modules()
       .values()
       .filter(|m| {
-        if let Some(meta) = &m.build_meta {
+        if let Some(meta) = &m.build_meta() {
           meta.has_top_level_await
         } else {
           false
         }
       })
-      .map(|m| m.module_identifier)
+      .map(|m| m.identifier())
       .collect();
 
     modules.retain(|m| queue.insert(*m));

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -56,15 +56,18 @@ impl Plugin for MangleExportsPlugin {
       .cloned()
       .collect::<Vec<_>>();
     for identifier in module_id_list {
-      let Some(module) = mg.module_graph_module_by_identifier(&identifier) else {
+      let (Some(mgm), Some(module)) = (
+        mg.module_graph_module_by_identifier(&identifier),
+        mg.module_by_identifier(&identifier),
+      ) else {
         continue;
       };
       let is_namespace = module
-        .build_meta
+        .build_meta()
         .as_ref()
         .map(|meta| matches!(meta.exports_type, BuildMetaExportsType::Namespace))
         .unwrap_or_default();
-      let exports_info_id = module.exports;
+      let exports_info_id = mgm.exports;
       mangle_exports_info(mg, self.deterministic, exports_info_id, is_namespace);
     }
     Ok(None)

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -138,12 +138,12 @@ impl ParserAndGenerator for JsonParserAndGenerator {
         generate_context
           .runtime_requirements
           .insert(RuntimeGlobals::MODULE);
-        let mgm = compilation
+        let module = compilation
           .module_graph
-          .module_graph_module_by_identifier(&module.identifier())
+          .module_by_identifier(&module.identifier())
           .expect("should have module identifier");
-        let json_data = mgm
-          .build_info
+        let json_data = module
+          .build_info()
           .as_ref()
           .and_then(|info| info.json_data.as_ref())
           .expect("should have json data");

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, hash::Hash};
 
 use async_trait::async_trait;
 use rspack_core::{
-  block_promise, module_raw, returning_function,
+  block_promise, impl_build_info_meta, module_raw, returning_function,
   rspack_sources::{RawSource, Source, SourceExt},
   throw_missing_module_error_block, AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier,
   BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult,
@@ -28,6 +28,8 @@ pub struct ContainerEntryModule {
   lib_ident: String,
   exposes: Vec<(String, ExposeOptions)>,
   share_scope: String,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl ContainerEntryModule {
@@ -44,6 +46,8 @@ impl ContainerEntryModule {
       lib_ident,
       exposes,
       share_scope,
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -74,6 +78,8 @@ impl DependenciesBlock for ContainerEntryModule {
 
 #[async_trait]
 impl Module for ContainerEntryModule {
+  impl_build_info_meta!();
+
   fn size(&self, _source_type: &SourceType) -> f64 {
     42.0
   }

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -3,10 +3,11 @@ use std::hash::Hash;
 
 use async_trait::async_trait;
 use rspack_core::{
+  impl_build_info_meta,
   rspack_sources::{RawSource, Source, SourceExt},
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildResult, ChunkUkey,
-  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
-  Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
+  ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
+  LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::RspackHash;
@@ -23,6 +24,8 @@ pub struct FallbackModule {
   readable_identifier: String,
   lib_ident: String,
   requests: Vec<String>,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl FallbackModule {
@@ -42,6 +45,8 @@ impl FallbackModule {
       readable_identifier: identifier,
       lib_ident,
       requests,
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -72,6 +77,8 @@ impl DependenciesBlock for FallbackModule {
 
 #[async_trait]
 impl Module for FallbackModule {
+  impl_build_info_meta!();
+
   fn size(&self, _source_type: &SourceType) -> f64 {
     self.requests.len() as f64 * 5.0 + 42.0
   }

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -3,8 +3,9 @@ use std::hash::Hash;
 
 use async_trait::async_trait;
 use rspack_core::{
+  impl_build_info_meta,
   rspack_sources::{RawSource, Source, SourceExt},
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildResult,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
   Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
 };
@@ -32,6 +33,8 @@ pub struct RemoteModule {
   pub internal_request: String,
   pub share_scope: String,
   pub remote_key: String,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl RemoteModule {
@@ -60,6 +63,8 @@ impl RemoteModule {
       internal_request,
       share_scope,
       remote_key,
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -90,6 +95,8 @@ impl DependenciesBlock for RemoteModule {
 
 #[async_trait]
 impl Module for RemoteModule {
+  impl_build_info_meta!();
+
   fn size(&self, _source_type: &SourceType) -> f64 {
     6.0
   }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -2,10 +2,11 @@ use std::{borrow::Cow, hash::Hash};
 
 use async_trait::async_trait;
 use rspack_core::{
-  async_module_factory, rspack_sources::Source, sync_module_factory, AsyncDependenciesBlock,
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildResult,
-  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
-  Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  async_module_factory, impl_build_info_meta, rspack_sources::Source, sync_module_factory,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
+  DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
+  SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::RspackHash;
@@ -26,6 +27,8 @@ pub struct ConsumeSharedModule {
   readable_identifier: String,
   context: Context,
   options: ConsumeOptions,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl ConsumeSharedModule {
@@ -68,6 +71,8 @@ impl ConsumeSharedModule {
       readable_identifier: identifier,
       context,
       options,
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -98,6 +103,8 @@ impl DependenciesBlock for ConsumeSharedModule {
 
 #[async_trait]
 impl Module for ConsumeSharedModule {
+  impl_build_info_meta!();
+
   fn size(&self, _source_type: &SourceType) -> f64 {
     42.0
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -2,10 +2,11 @@ use std::{borrow::Cow, hash::Hash};
 
 use async_trait::async_trait;
 use rspack_core::{
-  async_module_factory, rspack_sources::Source, sync_module_factory, AsyncDependenciesBlock,
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildResult,
-  CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
-  Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  async_module_factory, impl_build_info_meta, rspack_sources::Source, sync_module_factory,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
+  DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
+  SourceType,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Result};
 use rspack_hash::RspackHash;
@@ -31,6 +32,8 @@ pub struct ProvideSharedModule {
   version: ProvideVersion,
   request: String,
   eager: bool,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl ProvideSharedModule {
@@ -56,6 +59,8 @@ impl ProvideSharedModule {
       version,
       request,
       eager,
+      build_info: None,
+      build_meta: None,
     }
   }
 }
@@ -86,6 +91,8 @@ impl DependenciesBlock for ProvideSharedModule {
 
 #[async_trait]
 impl Module for ProvideSharedModule {
+  impl_build_info_meta!();
+
   fn size(&self, _source_type: &SourceType) -> f64 {
     42.0
   }

--- a/crates/rspack_plugin_runtime/src/lazy_compilation.rs
+++ b/crates/rspack_plugin_runtime/src/lazy_compilation.rs
@@ -3,9 +3,10 @@ use std::hash::Hash;
 
 use async_trait::async_trait;
 use rspack_core::{
+  impl_build_info_meta,
   rspack_sources::{RawSource, Source, SourceExt},
-  AsyncDependenciesBlockIdentifier, Compilation, DependenciesBlock, DependencyId, Module,
-  ModuleType, NormalModuleCreateData, Plugin, PluginContext,
+  AsyncDependenciesBlockIdentifier, BuildInfo, BuildMeta, Compilation, DependenciesBlock,
+  DependencyId, Module, ModuleType, NormalModuleCreateData, Plugin, PluginContext,
   PluginNormalModuleFactoryCreateModuleHookOutput, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use rspack_core::{CodeGenerationResult, Context, ModuleIdentifier};
@@ -17,6 +18,8 @@ pub struct LazyCompilationProxyModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   pub module_identifier: ModuleIdentifier,
+  build_info: Option<BuildInfo>,
+  build_meta: Option<BuildMeta>,
 }
 
 impl DependenciesBlock for LazyCompilationProxyModule {
@@ -38,6 +41,8 @@ impl DependenciesBlock for LazyCompilationProxyModule {
 }
 
 impl Module for LazyCompilationProxyModule {
+  impl_build_info_meta!();
+
   fn module_type(&self) -> &ModuleType {
     &ModuleType::Js
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

move all build_info and build_meta to module trait instead of module graph module

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
