### PR TITLE
fix: failed to import string json

### DIFF
--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 use json::{
   number::Number,
   object::Object,
+  stringify,
   Error::{
     ExceededDepthLimit, FailedUtf8Parsing, UnexpectedCharacter, UnexpectedEndOfJson, WrongType,
   },
@@ -169,7 +170,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           _ => json_data.clone(),
         };
         let is_js_object = final_json.is_object() || final_json.is_array();
-        let final_json_string = final_json.to_string();
+        let final_json_string = stringify(final_json);
         let json_str = utils::escape_json(&final_json_string);
         let json_expr = if is_js_object && json_str.len() > 20 {
           Cow::Owned(format!(

--- a/crates/rspack_plugin_json/tests/fixtures/simple/index.js
+++ b/crates/rspack_plugin_json/tests/fixtures/simple/index.js
@@ -1,3 +1,3 @@
 import json from './json.json'
-
-console.log(json)
+import str from './string.json'
+console.log(json,str)

--- a/crates/rspack_plugin_json/tests/fixtures/simple/snapshot/output.snap
+++ b/crates/rspack_plugin_json/tests/fixtures/simple/snapshot/output.snap
@@ -7,12 +7,17 @@ source: crates/rspack_testing/src/run_fixture.rs
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */var _json_json__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./json.json */"./json.json");
+/* harmony import */var _string_json__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./string.json */"./string.json");
 
-console.log(_json_json__WEBPACK_IMPORTED_MODULE_0__);
+
+console.log(_json_json__WEBPACK_IMPORTED_MODULE_0__, _string_json__WEBPACK_IMPORTED_MODULE_1__);
 }),
 "./json.json": (function (module) {
 "use strict";
 module.exports = JSON.parse('{"hello":"world is better \'","b":"\\\\"}')}),
+"./string.json": (function (module) {
+"use strict";
+module.exports = "hello world"}),
 
 },function(__webpack_require__) {
 var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }

--- a/crates/rspack_plugin_json/tests/fixtures/simple/string.json
+++ b/crates/rspack_plugin_json/tests/fixtures/simple/string.json
@@ -1,0 +1,1 @@
+"hello world"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
related to https://github.com/toeverything/blocksuite-ecosystem-ci/pull/27#discussion_r1440548551
This is a failing case when import json file contains a string
* string.json
```json
"hello world"
```

`stringify`  ref: https://github.com/maciejhirsz/json-rust/blob/master/tests/stringify.rs
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
pass this test
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
