### PR TITLE
fix: remove module/exports evaluation 

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
@@ -22,37 +22,8 @@ use crate::{
     CommonJsExportRequireDependency, CommonJsExportsDependency, CommonJsSelfReferenceDependency,
     ExportsBase, ModuleDecoratorDependency,
   },
-  parser_plugin::JavascriptParserPlugin,
-  utils::eval::{self, BasicEvaluatedExpression},
   ClassExt,
 };
-
-pub fn get_typeof_evaluate_of_export(sym: &str) -> Option<&str> {
-  match sym {
-    "module" => Some("object"),
-    "exports" => Some("object"),
-    _ => None,
-  }
-}
-
-pub struct CommonJsExportParserPlugin;
-
-impl JavascriptParserPlugin for CommonJsExportParserPlugin {
-  fn evaluate_typeof(
-    &self,
-    expression: &swc_core::ecma::ast::Ident,
-    start: u32,
-    end: u32,
-    unresolved_mark: swc_core::common::SyntaxContext,
-  ) -> Option<BasicEvaluatedExpression> {
-    if expression.span.ctxt == unresolved_mark {
-      get_typeof_evaluate_of_export(expression.sym.as_ref() as &str)
-        .map(|res| eval::evaluate_to_string(res.to_string(), start, end))
-    } else {
-      None
-    }
-  }
-}
 
 pub struct CommonJsExportDependencyScanner<'a> {
   dependencies: &'a mut Vec<BoxDependency>,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -9,7 +9,6 @@ use swc_core::ecma::ast::{Lit, TryStmt, UnaryExpr, UnaryOp};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
 use super::api_scanner::ApiParserPlugin;
-use super::common_js_export_scanner::CommonJsExportParserPlugin;
 use super::context_helper::scanner_context_module;
 use super::expr_matcher::{is_module_require, is_require};
 use super::{expr_matcher, is_unresolved_member_object_ident, is_unresolved_require};
@@ -89,7 +88,6 @@ impl<'a> CommonJsImportDependencyScanner<'a> {
       Box::new(CommonJsImportsParserPlugin),
       Box::new(RequireContextDependencyParserPlugin),
       Box::new(ApiParserPlugin),
-      Box::new(CommonJsExportParserPlugin),
     ];
     let plugin_drive = JavaScriptParserPluginDrive::new(plugins);
     Self {

--- a/packages/rspack/tests/cases/parsing/typeof-api/index.js
+++ b/packages/rspack/tests/cases/parsing/typeof-api/index.js
@@ -1,15 +1,12 @@
 it("should evaluate api typeof", function () {
 	expect(require("./typeof")).toEqual({
 		require: "function",
-		module: "object",
 		__webpack_is_included__: "function"
 	});
 });
 
 it("should not parse filtered stuff", function () {
 	if (typeof require !== "function") require("fail");
-	if (typeof module !== "object") require("fail");
-	if (typeof exports !== "object") require("fail");
 	if (typeof __webpack_hash__ !== "string") require("fail");
 	if (typeof __webpack_public_path__ !== "string") require("fail");
 	if (typeof __webpack_modules__ !== "object") require("fail");

--- a/packages/rspack/tests/cases/parsing/typeof-api/typeof.js
+++ b/packages/rspack/tests/cases/parsing/typeof-api/typeof.js
@@ -1,3 +1,2 @@
 module.exports.require = typeof require;
-module.exports.module = typeof module;
 module.exports.__webpack_is_included__ = typeof __webpack_is_included__;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Source Code: 
```js
// lodash-es/isBuffer.js
import root from './_root.js';
import stubFalse from './stubFalse.js';

/** Detect free variable `exports`. */
var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;

// ...
```

Webpack register module&exports evaluateTypeOf only when module type is JAVASCRIPT_MODULE_TYPE_AUTO or JAVASCRIPT_MODULE_TYPE_DYNAMIC. So typeof module and typeof exports will not be evalutated in ESM.

```js
// exports is undefined in esm, so the following code will not execute
var freeExports = typeof exports == 'object' && exports && !exports.nodeType && exports;
```

But currently rspack CommonJsImportScanner will evaluate in all types of javascript modules.
```js
var freeExports = true && exports && !exports.nodeType && exports;
```

According to this, should remove module&exports evaluation and add them back in the future when scanner can be full align with webpack.

## Test Plan

- Fixed

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
