### PR TITLE
ci: fix flaky e2e tests

### DIFF
--- a/packages/playground/cases/context/delete-file/index.test.ts
+++ b/packages/playground/cases/context/delete-file/index.test.ts
@@ -18,11 +18,7 @@ test("delete file should work", async ({
 	expect(bodyResponse).toContain("this is mod2");
 	// mock file delete action
 	fileAction.deleteFile("src/mod1.js");
-	await rspack.waitingForHmr(async () => {
-		// ensure page status changed
-		const statusText = await page.textContent("#root");
-		return statusText === "__HMR_UPDATED__";
-	});
+	await expect(page.locator("#root")).toHaveText("__HMR_UPDATED__");
 	// asset new script content
 	const responseAfterDelete = await request.get(
 		`http://localhost:${rspack.devServer.options.port}/main.js`

--- a/packages/playground/cases/css/chunk-loading-order/index.test.ts
+++ b/packages/playground/cases/css/chunk-loading-order/index.test.ts
@@ -1,8 +1,6 @@
 import { test, expect } from "@/fixtures";
 
-test("should be red", async ({ page, rspack }) => {
-	await rspack.waitUntil(async function () {
-		return (await page.textContent("#status")) === "ok";
-	});
+test("should be red", async ({ page }) => {
+	await expect(page.locator("#status")).toHaveText("ok");
 	await expect(page.locator("body")).toHaveCSS("color", "rgb(255, 0, 0)");
 });

--- a/packages/playground/cases/css/css-filename/index.test.ts
+++ b/packages/playground/cases/css/css-filename/index.test.ts
@@ -9,12 +9,5 @@ test("should update css with filename", async ({
 	fileAction.updateFile("src/index.css", content =>
 		content.replace("rgb(255, 0, 0)", "rgb(0, 0, 255)")
 	);
-	await rspack.waitingForHmr(async function () {
-		try {
-			await expect(page.locator("body")).toHaveCSS("color", "rgb(0, 0, 255)");
-			return true;
-		} catch (e) {
-			return false;
-		}
-	});
+	await expect(page.locator("body")).toHaveCSS("color", "rgb(0, 0, 255)");
 });

--- a/packages/playground/cases/css/render-to-body/index.test.ts
+++ b/packages/playground/cases/css/render-to-body/index.test.ts
@@ -5,12 +5,5 @@ test("should update body css", async ({ page, fileAction, rspack }) => {
 	fileAction.updateFile("src/index.css", content =>
 		content.replace("block", "flex")
 	);
-	await rspack.waitingForHmr(async function () {
-		try {
-			await expect(page.locator("body")).toHaveCSS("display", "flex");
-			return true;
-		} catch (e) {
-			return false;
-		}
-	});
+	await expect(page.locator("body")).toHaveCSS("display", "flex");
 });

--- a/packages/playground/cases/hooks/asset-emitted/index.test.ts
+++ b/packages/playground/cases/hooks/asset-emitted/index.test.ts
@@ -19,10 +19,7 @@ test("asset emitted hook should only emit modified assets", async ({
 	fileAction.updateFile("src/index.js", content => {
 		return content.replace("__ROOT_TEXT__", "__OTHER_TEXT__");
 	});
-	await rspack.waitingForHmr(async () => {
-		const text = await page.textContent("#root");
-		return text === "__OTHER_TEXT____FOO_VALUE__";
-	});
+	await expect(page.locator("#root")).toHaveText("__OTHER_TEXT____FOO_VALUE__");
 	expect(assets).toEqual(["main.js"]);
 
 	// reset assets
@@ -32,10 +29,7 @@ test("asset emitted hook should only emit modified assets", async ({
 	fileAction.updateFile("src/foo.js", content => {
 		return content.replace("__FOO_VALUE__", "__VALUE__");
 	});
-	await rspack.waitingForHmr(async () => {
-		const text = await page.textContent("#root");
-		return text === "__OTHER_TEXT____VALUE__";
-	});
+	await expect(page.locator("#root")).toHaveText("__OTHER_TEXT____VALUE__");
 	// main.js contains runtime module, so it should also emit
 	expect(assets.sort()).toEqual(["main.js", "src_foo_js.js"]);
 
@@ -68,10 +62,7 @@ test("asset emitted should not emit removed assets", async ({
 	fileAction.updateFile("src/index.js", () => {
 		return 'document.getElementById("root").innerText = "__ROOT_TEXT__"';
 	});
-	await rspack.waitingForHmr(async () => {
-		const text = await page.textContent("#root");
-		return text === "__ROOT_TEXT__";
-	});
+	await expect(page.locator("#root")).toHaveText("__ROOT_TEXT__");
 	expect(assets).toEqual(["main.js"]);
 
 	// check dist dir

--- a/packages/playground/cases/html/issue-4366/index.test.ts
+++ b/packages/playground/cases/html/issue-4366/index.test.ts
@@ -1,17 +1,12 @@
 import { test, expect } from "@/fixtures";
 
-test("html should refresh after reload", async ({
-	page,
-	fileAction,
-	rspack
-}) => {
-	await expect(page.title()).resolves.toBe("123");
+test("html should refresh after reload", async ({ page, fileAction }) => {
+	await expect(page).toHaveTitle("123");
 	fileAction.updateFile("./src/index.html", content =>
 		content.replace("123", "456")
 	);
-	await rspack.waitUntil(async () => {
+	await expect(async () => {
 		await page.reload();
-		const t2 = await page.title();
-		return t2 === "456";
-	});
+		expect(await page.title()).toBe("456");
+	}).toPass();
 });

--- a/packages/playground/cases/react/basic-disableTransformByDefault/index.test.ts
+++ b/packages/playground/cases/react/basic-disableTransformByDefault/index.test.ts
@@ -5,55 +5,46 @@ test("render should work", async ({ page }) => {
 	expect(await page.textContent("#lazy-component")).toBe("Lazy Component");
 });
 
-test("hmr should work", async ({ page, fileAction, rspack }) => {
-	expect(await page.textContent("button")).toBe("10");
+test("hmr should work", async ({ page, fileAction }) => {
+	await expect(page.locator("button")).toHaveText("10");
 	await page.click("button");
-	expect(await page.textContent("button")).toBe("11");
-	expect(await page.textContent(".placeholder")).toBe("__PLACE_HOLDER__");
+	await expect(page.locator("button")).toHaveText("11");
+	await expect(page.locator(".placeholder")).toHaveText("__PLACE_HOLDER__");
 	fileAction.updateFile("src/App.jsx", content =>
 		content.replace("__PLACE_HOLDER__", "__EDITED__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".placeholder")) === "__EDITED__";
-	});
-	expect(await page.textContent("button")).toBe("11");
+	await expect(page.locator(".placeholder")).toHaveText("__EDITED__");
+	await expect(page.locator("button")).toHaveText("11");
 });
 
-test("context+component should work", async ({ page, fileAction, rspack }) => {
-	expect(await page.textContent("#context")).toBe("context-value");
+test("context+component should work", async ({ page, fileAction }) => {
+	await expect(page.locator("#context")).toHaveText("context-value");
 	await page.click("#context");
-	expect(await page.textContent("#context")).toBe("context-value-click");
+	await expect(page.locator("#context")).toHaveText("context-value-click");
 	fileAction.updateFile("src/CountProvider.jsx", content =>
 		content.replace("context-value", "context-value-update")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent("#context")) === "context-value-update";
-	});
+	await expect(page.locator("#context")).toHaveText("context-value-update");
 });
 
 test("ReactRefreshFinder should work", async ({ page }) => {
-	expect(await page.textContent("#nest-function")).toBe("nest-function");
+	await expect(page.locator("#nest-function")).toHaveText("nest-function");
 });
 
 test("update same export name from different module should work", async ({
 	page,
-	fileAction,
-	rspack
+	fileAction
 }) => {
-	expect(await page.textContent(".same-export-name1")).toBe("__NAME_1__");
-	expect(await page.textContent(".same-export-name2")).toBe("__NAME_2__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__NAME_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__NAME_2__");
 	fileAction.updateFile("src/SameExportName1.jsx", content =>
 		content.replace("__NAME_1__", "__name_1__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".same-export-name1")) === "__name_1__";
-	});
-	expect(await page.textContent(".same-export-name2")).toBe("__NAME_2__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__name_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__NAME_2__");
 	fileAction.updateFile("src/SameExportName2.jsx", content =>
 		content.replace("__NAME_2__", "__name_2__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".same-export-name2")) === "__name_2__";
-	});
-	expect(await page.textContent(".same-export-name1")).toBe("__name_1__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__name_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__name_2__");
 });

--- a/packages/playground/cases/react/basic/index.test.ts
+++ b/packages/playground/cases/react/basic/index.test.ts
@@ -5,55 +5,46 @@ test("render should work", async ({ page }) => {
 	expect(await page.textContent("#lazy-component")).toBe("Lazy Component");
 });
 
-test("hmr should work", async ({ page, fileAction, rspack }) => {
-	expect(await page.textContent("button")).toBe("10");
+test("hmr should work", async ({ page, fileAction }) => {
+	await expect(page.locator("button")).toHaveText("10");
 	await page.click("button");
-	expect(await page.textContent("button")).toBe("11");
-	expect(await page.textContent(".placeholder")).toBe("__PLACE_HOLDER__");
+	await expect(page.locator("button")).toHaveText("11");
+	await expect(page.locator(".placeholder")).toHaveText("__PLACE_HOLDER__");
 	fileAction.updateFile("src/App.jsx", content =>
 		content.replace("__PLACE_HOLDER__", "__EDITED__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".placeholder")) === "__EDITED__";
-	});
-	expect(await page.textContent("button")).toBe("11");
+	await expect(page.locator(".placeholder")).toHaveText("__EDITED__");
+	await expect(page.locator("button")).toHaveText("11");
 });
 
-test("context+component should work", async ({ page, fileAction, rspack }) => {
-	expect(await page.textContent("#context")).toBe("context-value");
+test("context+component should work", async ({ page, fileAction }) => {
+	await expect(page.locator("#context")).toHaveText("context-value");
 	await page.click("#context");
-	expect(await page.textContent("#context")).toBe("context-value-click");
+	await expect(page.locator("#context")).toHaveText("context-value-click");
 	fileAction.updateFile("src/CountProvider.jsx", content =>
 		content.replace("context-value", "context-value-update")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent("#context")) === "context-value-update";
-	});
+	await expect(page.locator("#context")).toHaveText("context-value-update");
 });
 
 test("ReactRefreshFinder should work", async ({ page }) => {
-	expect(await page.textContent("#nest-function")).toBe("nest-function");
+	await expect(page.locator("#nest-function")).toHaveText("nest-function");
 });
 
 test("update same export name from different module should work", async ({
 	page,
-	fileAction,
-	rspack
+	fileAction
 }) => {
-	expect(await page.textContent(".same-export-name1")).toBe("__NAME_1__");
-	expect(await page.textContent(".same-export-name2")).toBe("__NAME_2__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__NAME_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__NAME_2__");
 	fileAction.updateFile("src/SameExportName1.jsx", content =>
 		content.replace("__NAME_1__", "__name_1__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".same-export-name1")) === "__name_1__";
-	});
-	expect(await page.textContent(".same-export-name2")).toBe("__NAME_2__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__name_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__NAME_2__");
 	fileAction.updateFile("src/SameExportName2.jsx", content =>
 		content.replace("__NAME_2__", "__name_2__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".same-export-name2")) === "__name_2__";
-	});
-	expect(await page.textContent(".same-export-name1")).toBe("__name_1__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__name_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__name_2__");
 });

--- a/packages/playground/cases/react/class-component-disableTransformByDefault/index.test.ts
+++ b/packages/playground/cases/react/class-component-disableTransformByDefault/index.test.ts
@@ -1,24 +1,18 @@
 import { test, expect } from "@/fixtures";
 
 test("render should work", async ({ page }) => {
-	expect(await page.textContent(".header")).toBe("Hello World");
+	await expect(page.locator(".header")).toHaveText("Hello World");
 });
 
-test("class component hmr should work", async ({
-	page,
-	fileAction,
-	rspack
-}) => {
-	expect(await page.textContent("button")).toBe("10");
+test("class component hmr should work", async ({ page, fileAction }) => {
+	await expect(page.locator("button")).toHaveText("10");
 	await page.click("button");
-	expect(await page.textContent("button")).toBe("11");
-	expect(await page.textContent(".placeholder")).toBe("__PLACE_HOLDER__");
+	await expect(page.locator("button")).toHaveText("11");
+	await expect(page.locator(".placeholder")).toHaveText("__PLACE_HOLDER__");
 	fileAction.updateFile("src/App.jsx", content =>
 		content.replace("__PLACE_HOLDER__", "__EDITED__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".placeholder")) === "__EDITED__";
-	});
+	await expect(page.locator(".placeholder")).toHaveText("__EDITED__");
 	// class component will not keep local status
-	expect(await page.textContent("button")).toBe("10");
+	await expect(page.locator("button")).toHaveText("10");
 });

--- a/packages/playground/cases/react/class-component/index.test.ts
+++ b/packages/playground/cases/react/class-component/index.test.ts
@@ -1,24 +1,18 @@
 import { test, expect } from "@/fixtures";
 
 test("render should work", async ({ page }) => {
-	expect(await page.textContent(".header")).toBe("Hello World");
+	await expect(page.locator(".header")).toHaveText("Hello World");
 });
 
-test("class component hmr should work", async ({
-	page,
-	fileAction,
-	rspack
-}) => {
-	expect(await page.textContent("button")).toBe("10");
+test("class component hmr should work", async ({ page, fileAction }) => {
+	await expect(page.locator("button")).toHaveText("10");
 	await page.click("button");
-	expect(await page.textContent("button")).toBe("11");
-	expect(await page.textContent(".placeholder")).toBe("__PLACE_HOLDER__");
+	await expect(page.locator("button")).toHaveText("11");
+	await expect(page.locator(".placeholder")).toHaveText("__PLACE_HOLDER__");
 	fileAction.updateFile("src/App.jsx", content =>
 		content.replace("__PLACE_HOLDER__", "__EDITED__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".placeholder")) === "__EDITED__";
-	});
+	await expect(page.locator(".placeholder")).toHaveText("__EDITED__");
 	// class component will not keep local status
-	expect(await page.textContent("button")).toBe("10");
+	await expect(page.locator("button")).toHaveText("10");
 });

--- a/packages/playground/cases/react/tailwindcss-disableTransformByDefault/index.test.ts
+++ b/packages/playground/cases/react/tailwindcss-disableTransformByDefault/index.test.ts
@@ -22,10 +22,7 @@ test("tailwindcss should work when modify js file", async ({
 	fileAction.updateFile("src/App.jsx", content => {
 		return content.replace("text-2xl", "text-3xl");
 	});
-	await rspack.waitingForHmr(async () => {
-		const classNames = await page.getAttribute("#app", "class");
-		return classNames?.includes("text-3xl") || false;
-	});
+	await expect(page.locator("#app")).toHaveClass(/text-3xl/);
 
 	appFontSize = await getAppFontSize();
 	expect(appFontSize).toBe("30px");

--- a/packages/playground/cases/react/tailwindcss/index.test.ts
+++ b/packages/playground/cases/react/tailwindcss/index.test.ts
@@ -22,10 +22,8 @@ test("tailwindcss should work when modify js file", async ({
 	fileAction.updateFile("src/App.jsx", content => {
 		return content.replace("text-2xl", "text-3xl");
 	});
-	await rspack.waitingForHmr(async () => {
-		const classNames = await page.getAttribute("#app", "class");
-		return classNames?.includes("text-3xl") || false;
-	});
+
+	await expect(page.locator("#app")).toHaveClass(/text-3xl/);
 
 	appFontSize = await getAppFontSize();
 	expect(appFontSize).toBe("30px");

--- a/packages/playground/cases/react/with-babel/index.test.ts
+++ b/packages/playground/cases/react/with-babel/index.test.ts
@@ -5,55 +5,46 @@ test("render should work", async ({ page }) => {
 	expect(await page.textContent("#lazy-component")).toBe("Lazy Component");
 });
 
-test("hmr should work", async ({ page, fileAction, rspack }) => {
-	expect(await page.textContent("button")).toBe("10");
+test("hmr should work", async ({ page, fileAction }) => {
+	await expect(page.locator("button")).toHaveText("10");
 	await page.click("button");
-	expect(await page.textContent("button")).toBe("11");
-	expect(await page.textContent(".placeholder")).toBe("__PLACE_HOLDER__");
+	await expect(page.locator("button")).toHaveText("11");
+	await expect(page.locator(".placeholder")).toHaveText("__PLACE_HOLDER__");
 	fileAction.updateFile("src/App.jsx", content =>
 		content.replace("__PLACE_HOLDER__", "__EDITED__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".placeholder")) === "__EDITED__";
-	});
-	expect(await page.textContent("button")).toBe("11");
+	await expect(page.locator(".placeholder")).toHaveText("__EDITED__");
+	await expect(page.locator("button")).toHaveText("11");
 });
 
-test("context+component should work", async ({ page, fileAction, rspack }) => {
-	expect(await page.textContent("#context")).toBe("context-value");
+test("context+component should work", async ({ page, fileAction }) => {
+	await expect(page.locator("#context")).toHaveText("context-value");
 	await page.click("#context");
-	expect(await page.textContent("#context")).toBe("context-value-click");
+	await expect(page.locator("#context")).toHaveText("context-value-click");
 	fileAction.updateFile("src/CountProvider.jsx", content =>
 		content.replace("context-value", "context-value-update")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent("#context")) === "context-value-update";
-	});
+	await expect(page.locator("#context")).toHaveText("context-value-update");
 });
 
 test("ReactRefreshFinder should work", async ({ page }) => {
-	expect(await page.textContent("#nest-function")).toBe("nest-function");
+	await expect(page.locator("#nest-function")).toHaveText("nest-function");
 });
 
 test("update same export name from different module should work", async ({
 	page,
-	fileAction,
-	rspack
+	fileAction
 }) => {
-	expect(await page.textContent(".same-export-name1")).toBe("__NAME_1__");
-	expect(await page.textContent(".same-export-name2")).toBe("__NAME_2__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__NAME_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__NAME_2__");
 	fileAction.updateFile("src/SameExportName1.jsx", content =>
 		content.replace("__NAME_1__", "__name_1__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".same-export-name1")) === "__name_1__";
-	});
-	expect(await page.textContent(".same-export-name2")).toBe("__NAME_2__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__name_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__NAME_2__");
 	fileAction.updateFile("src/SameExportName2.jsx", content =>
 		content.replace("__NAME_2__", "__name_2__")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent(".same-export-name2")) === "__name_2__";
-	});
-	expect(await page.textContent(".same-export-name1")).toBe("__name_1__");
+	await expect(page.locator(".same-export-name1")).toHaveText("__name_1__");
+	await expect(page.locator(".same-export-name2")).toHaveText("__name_2__");
 });

--- a/packages/playground/cases/vue3/index.test.ts
+++ b/packages/playground/cases/vue3/index.test.ts
@@ -4,27 +4,22 @@ test("should successfully render vue3", async ({ page }) => {
 	expect(await page.textContent("h1")).toBe("vue3");
 });
 
-test("vue3 hmr", async ({ page, fileAction, rspack }) => {
+test("vue3 hmr", async ({ page, fileAction }) => {
 	await page.click("button");
-	expect(await page.textContent("button")).toBe("1");
+	await expect(page.locator("button")).toHaveText("1");
 	fileAction.updateFile("src/App.vue", content =>
 		content.replace("vue3", "vue3 hi")
 	);
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent("h1")) === "vue3 hi";
-	});
+	await expect(page.locator("h1")).toHaveText("vue3 hi");
 	// hmr should keep status
-	expect(await page.textContent("button")).toBe("1");
+	await expect(page.locator("button")).toHaveText("1");
 });
 
 // See: https://vuejs.org/guide/typescript/composition-api.html#typing-component-props
 test("vue3 should work with component props typing", async ({
 	page,
-	rspack,
 	fileAction
 }) => {
 	fileAction.updateFile("src/enums.ts", content => content.replace("0", "2"));
-	await rspack.waitingForHmr(async function () {
-		return (await page.textContent("button")) === "2";
-	});
+	await expect(page.locator("button")).toHaveText("2");
 });

--- a/packages/playground/fixtures/rspack.ts
+++ b/packages/playground/fixtures/rspack.ts
@@ -4,7 +4,6 @@ import { Compiler, Configuration, rspack } from "@rspack/core";
 import { RspackDevServer } from "@rspack/dev-server";
 import WebpackDevServer from "webpack-dev-server";
 import type { PathInfoFixtures } from "./pathInfo";
-import { sleep } from "@/utils/sleep";
 
 class Rspack {
 	projectDir: string;
@@ -46,25 +45,6 @@ class Rspack {
 		return new Promise<void>(resolve => {
 			this.onDone.push(resolve);
 		});
-	}
-
-	// TODO add some plugin to watch hmr complete
-	waitingForHmr(poll: () => Promise<boolean>) {
-		return this.waitUntil(poll);
-	}
-
-	async waitUntil(poll: () => Promise<boolean>) {
-		const maxTries = 100;
-		for (let tries = 0; tries < maxTries; tries++) {
-			const isSuccess = await poll();
-			if (isSuccess) {
-				return;
-			}
-			if (tries === maxTries - 1) {
-				throw new Error("out of max retry time");
-			}
-			await sleep(200);
-		}
 	}
 }
 

--- a/packages/playground/playwright.config.ts
+++ b/packages/playground/playwright.config.ts
@@ -18,6 +18,12 @@ export default defineConfig<RspackOptions>({
 	// timeout 30s
 	timeout: 30 * 1000,
 
+	// expect
+	expect: {
+		// auto-assertion could be used with HMR.
+		timeout: 30 * 1000
+	},
+
 	// Opt out of parallel tests on CI.
 	workers: process.env.CI ? 1 : undefined,
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

NOBODY likes flaky tests ;-(

Use auto-retrying assertions and remove manual pollings.
Ref: https://playwright.dev/docs/api/class-locator#locator-get-attribute
Ref: https://playwright.dev/docs/api/class-locator#locator-text-content


If there's any further tests not working, then It should at least be timeouts instead of something like context destroyed.


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
