### PR TITLE
ci: increase timeout for e2e test

### DIFF
--- a/packages/playground/playwright.config.ts
+++ b/packages/playground/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 import type { RspackOptions } from "./fixtures";
 
+// 3x timeout for each case for CI
+const TIMEOUT = process.env.CI ? 3 : 1;
+
 export default defineConfig<RspackOptions>({
 	// Look for test files in the "fixtures" directory, relative to this configuration file.
 	testDir: "./cases",
@@ -16,12 +19,12 @@ export default defineConfig<RspackOptions>({
 	retries: 0,
 
 	// timeout 30s
-	timeout: 30 * 1000,
+	timeout: 30 * 1000 * TIMEOUT,
 
 	// expect
 	expect: {
 		// auto-assertion could be used with HMR.
-		timeout: 30 * 1000
+		timeout: 30 * 1000 * TIMEOUT
 	},
 
 	// Opt out of parallel tests on CI.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

After https://github.com/web-infra-dev/rspack/pull/5215 is merged, the only factors that fails any test includes malfunctioned tests and test timeouts. 

According to the slow testing here: https://github.com/web-infra-dev/rspack/actions/runs/7406317445/job/20150717451#step:5:473the timeout limit for the CI is probably not enough. So I changed to 3x in CI.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
