### PR TITLE
feat: deprecate resolve.browserField and enable resolve.{preferAbsolute,restrictions,roots,aliasFields}

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1098,10 +1098,10 @@ export interface RawRemoteOptions {
 
 export interface RawResolveOptions {
   preferRelative?: boolean
+  preferAbsolute?: boolean
   extensions?: Array<string>
   mainFiles?: Array<string>
   mainFields?: Array<string>
-  browserField?: boolean
   conditionNames?: Array<string>
   alias?: Record<string, Array<string | false>>
   fallback?: Record<string, Array<string | false>>
@@ -1112,6 +1112,9 @@ export interface RawResolveOptions {
   fullySpecified?: boolean
   exportsFields?: Array<string>
   extensionAlias?: Record<string, Array<string>>
+  aliasFields?: Array<string>
+  restrictions?: Array<string>
+  roots?: Array<string>
 }
 
 export interface RawResolveTsconfigOptions {

--- a/crates/rspack_binding_options/src/options/raw_resolve.rs
+++ b/crates/rspack_binding_options/src/options/raw_resolve.rs
@@ -24,10 +24,10 @@ pub struct RawResolveTsconfigOptions {
 #[napi(object)]
 pub struct RawResolveOptions {
   pub prefer_relative: Option<bool>,
+  pub prefer_absolute: Option<bool>,
   pub extensions: Option<Vec<String>>,
   pub main_files: Option<Vec<String>>,
   pub main_fields: Option<Vec<String>>,
-  pub browser_field: Option<bool>,
   pub condition_names: Option<Vec<String>>,
   #[serde(serialize_with = "ordered_map")]
   #[napi(ts_type = "Record<string, Array<string | false>>")]
@@ -44,6 +44,9 @@ pub struct RawResolveOptions {
   #[serde(serialize_with = "ordered_map")]
   #[napi(ts_type = "Record<string, Array<string>>")]
   pub extension_alias: Option<HashMap<String, Vec<String>>>,
+  pub alias_fields: Option<Vec<String>>,
+  pub restrictions: Option<Vec<String>>,
+  pub roots: Option<Vec<String>>,
 }
 
 fn normalize_alias(alias: Option<RawAliasOption>) -> rspack_error::Result<Option<Alias>> {
@@ -80,8 +83,8 @@ impl TryFrom<RawResolveOptions> for Resolve {
 
   fn try_from(value: RawResolveOptions) -> Result<Self, Self::Error> {
     let prefer_relative = value.prefer_relative;
+    let prefer_absolute = value.prefer_absolute;
     let extensions = value.extensions;
-    let browser_field = value.browser_field;
     let main_files = value.main_files;
     let main_fields = value.main_fields;
     let condition_names = value.condition_names;
@@ -106,11 +109,16 @@ impl TryFrom<RawResolveOptions> for Resolve {
       .exports_fields
       .map(|v| v.into_iter().map(|s| vec![s]).collect());
     let extension_alias = value.extension_alias.map(|v| v.into_iter().collect());
+    let alias_fields = value
+      .alias_fields
+      .map(|v| v.into_iter().map(|s| vec![s]).collect());
+    let restrictions = value.restrictions;
+    let roots = value.roots;
     Ok(Resolve {
       modules,
       prefer_relative,
+      prefer_absolute,
       extensions,
-      browser_field,
       main_fields,
       main_files,
       condition_names,
@@ -122,6 +130,9 @@ impl TryFrom<RawResolveOptions> for Resolve {
       fully_specified,
       exports_field,
       extension_alias,
+      alias_fields,
+      restrictions,
+      roots,
     })
   }
 }

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -2,8 +2,9 @@ use hashlink::LinkedHashMap;
 
 use super::value_type::{GetValueType, ValueType};
 use super::{
-  Alias, BrowserField, ConditionNames, ExportsField, ExtensionAlias, Extensions, Fallback,
-  FullySpecified, MainFields, MainFiles, Modules, PreferRelative, Symlink, TsconfigOptions,
+  Alias, AliasFields, ConditionNames, ExportsField, ExtensionAlias, Extensions, Fallback,
+  FullySpecified, MainFields, MainFiles, Modules, PreferAbsolute, PreferRelative, Restrictions,
+  Roots, Symlink, TsconfigOptions,
 };
 use super::{ByDependency, DependencyCategoryStr, Resolve};
 
@@ -21,16 +22,19 @@ fn is_empty(resolve: &Resolve) -> bool {
   is_none!(extensions)
     && is_none!(alias)
     && is_none!(prefer_relative)
+    && is_none!(prefer_absolute)
     && is_none!(symlinks)
     && is_none!(main_files)
     && is_none!(main_fields)
-    && is_none!(browser_field)
     && is_none!(condition_names)
     && is_none!(modules)
     && is_none!(fallback)
     && is_none!(fully_specified)
     && is_none!(exports_field)
     && is_none!(extension_alias)
+    && is_none!(alias_fields)
+    && is_none!(restrictions)
+    && is_none!(roots)
     && is_none!(tsconfig)
     && is_none!(by_dependency)
 }
@@ -46,10 +50,10 @@ struct ResolveWithEntry {
   extensions: Entry<Extensions>,
   alias: Entry<Alias>,
   prefer_relative: Entry<PreferRelative>,
+  prefer_absolute: Entry<PreferAbsolute>,
   symlinks: Entry<Symlink>,
   main_files: Entry<MainFiles>,
   main_fields: Entry<MainFields>,
-  browser_field: Entry<BrowserField>,
   condition_names: Entry<ConditionNames>,
   modules: Entry<Modules>,
   fallback: Entry<Fallback>,
@@ -57,6 +61,9 @@ struct ResolveWithEntry {
   fully_specified: Entry<FullySpecified>,
   exports_field: Entry<ExportsField>,
   extension_alias: Entry<ExtensionAlias>,
+  alias_fields: Entry<AliasFields>,
+  restrictions: Entry<Restrictions>,
+  roots: Entry<Roots>,
 }
 
 fn parse_resolve(resolve: Resolve) -> ResolveWithEntry {
@@ -72,10 +79,10 @@ fn parse_resolve(resolve: Resolve) -> ResolveWithEntry {
     extensions: entry!(extensions),
     alias: entry!(alias),
     prefer_relative: entry!(prefer_relative),
+    prefer_absolute: entry!(prefer_absolute),
     symlinks: entry!(symlinks),
     main_files: entry!(main_files),
     main_fields: entry!(main_fields),
-    browser_field: entry!(browser_field),
     condition_names: entry!(condition_names),
     modules: entry!(modules),
     fallback: entry!(fallback),
@@ -83,6 +90,9 @@ fn parse_resolve(resolve: Resolve) -> ResolveWithEntry {
     fully_specified: entry!(fully_specified),
     exports_field: entry!(exports_field),
     extension_alias: entry!(extension_alias),
+    alias_fields: entry!(alias_fields),
+    restrictions: entry!(restrictions),
+    roots: entry!(roots),
   };
   let Some(by_dependency) = resolve.by_dependency else {
     return res;
@@ -114,16 +124,19 @@ fn parse_resolve(resolve: Resolve) -> ResolveWithEntry {
   update_by_value!(extensions);
   update_by_value!(alias);
   update_by_value!(prefer_relative);
+  update_by_value!(prefer_absolute);
   update_by_value!(symlinks);
   update_by_value!(main_files);
   update_by_value!(main_fields);
-  update_by_value!(browser_field);
   update_by_value!(condition_names);
   update_by_value!(modules);
   update_by_value!(fallback);
   update_by_value!(fully_specified);
   update_by_value!(exports_field);
   update_by_value!(extension_alias);
+  update_by_value!(alias_fields);
+  update_by_value!(restrictions);
+  update_by_value!(roots);
   update_by_value!(tsconfig);
 
   res
@@ -248,6 +261,12 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
       |_| true,
       |_, b| b
     ),
+    prefer_absolute: merge!(
+      prefer_absolute,
+      second.prefer_absolute.base.get_value_type(),
+      |_| true,
+      |_, b| b
+    ),
     symlinks: merge!(
       symlinks,
       second.symlinks.base.get_value_type(),
@@ -265,12 +284,6 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
       second.main_fields.base.get_value_type(),
       need_merge_base,
       |a, b| normalize_string_array(a, b)
-    ),
-    browser_field: merge!(
-      browser_field,
-      second.browser_field.base.get_value_type(),
-      |_| true,
-      |_, b| b
     ),
     condition_names: merge!(
       condition_names,
@@ -297,6 +310,9 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
     extension_alias: merge!(extension_alias, ValueType::Other, |_| false, |a, b| {
       extend_extension_alias(a, b)
     }),
+    alias_fields: merge!(alias_fields, ValueType::Other, |_| false, |_, b| b),
+    restrictions: merge!(restrictions, ValueType::Other, |_| false, |_, b| b),
+    roots: merge!(roots, ValueType::Other, |_| false, |_, b| b),
   };
 
   let mut by_dependency: LinkedHashMap<DependencyCategoryStr, Resolve> = LinkedHashMap::new();
@@ -316,10 +332,10 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
   setup_by_values!(extensions);
   setup_by_values!(alias);
   setup_by_values!(prefer_relative);
+  setup_by_values!(prefer_absolute);
   setup_by_values!(symlinks);
   setup_by_values!(main_files);
   setup_by_values!(main_fields);
-  setup_by_values!(browser_field);
   setup_by_values!(condition_names);
   setup_by_values!(tsconfig);
   setup_by_values!(modules);
@@ -327,6 +343,9 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
   setup_by_values!(fully_specified);
   setup_by_values!(exports_field);
   setup_by_values!(extension_alias);
+  setup_by_values!(alias_fields);
+  setup_by_values!(restrictions);
+  setup_by_values!(roots);
 
   macro_rules! to_resolve {
     ($ident: ident) => {
@@ -343,10 +362,10 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
   to_resolve!(extensions);
   to_resolve!(alias);
   to_resolve!(prefer_relative);
+  to_resolve!(prefer_absolute);
   to_resolve!(symlinks);
   to_resolve!(main_files);
   to_resolve!(main_fields);
-  to_resolve!(browser_field);
   to_resolve!(condition_names);
   to_resolve!(tsconfig);
   to_resolve!(modules);
@@ -354,6 +373,9 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
   to_resolve!(fully_specified);
   to_resolve!(exports_field);
   to_resolve!(extension_alias);
+  to_resolve!(alias_fields);
+  to_resolve!(restrictions);
+  to_resolve!(roots);
 
   let by_dependency = if by_dependency.iter().all(|(_, by_value)| is_empty(by_value)) {
     None
@@ -366,10 +388,10 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
     extensions: result_entry.extensions.base,
     alias: result_entry.alias.base,
     prefer_relative: result_entry.prefer_relative.base,
+    prefer_absolute: result_entry.prefer_absolute.base,
     symlinks: result_entry.symlinks.base,
     main_files: result_entry.main_files.base,
     main_fields: result_entry.main_fields.base,
-    browser_field: result_entry.browser_field.base,
     condition_names: result_entry.condition_names.base,
     tsconfig: result_entry.tsconfig.base,
     modules: result_entry.modules.base,
@@ -377,6 +399,9 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
     fully_specified: result_entry.fully_specified.base,
     exports_field: result_entry.exports_field.base,
     extension_alias: result_entry.extension_alias.base,
+    alias_fields: result_entry.alias_fields.base,
+    restrictions: result_entry.restrictions.base,
+    roots: result_entry.roots.base,
   }
 }
 
@@ -546,7 +571,6 @@ mod test {
       symlinks: Some(false),
       main_files: string_list(&["d", "e", "f"]),
       main_fields: string_list(&["g", "h", "i"]),
-      browser_field: Some(true),
       condition_names: string_list(&["j", "k"]),
       ..Default::default()
     };
@@ -554,7 +578,6 @@ mod test {
       extensions: string_list(&["a1", "b1"]),
       alias: Some(vec![("c2".to_string(), vec![AliasMap::Ignore])]),
       prefer_relative: Some(true),
-      browser_field: Some(true),
       main_files: string_list(&["d1", "e", "..."]),
       main_fields: string_list(&["...", "h", "..."]),
       condition_names: string_list(&["f", "..."]),

--- a/crates/rspack_core/src/options/resolve/mod.rs
+++ b/crates/rspack_core/src/options/resolve/mod.rs
@@ -12,16 +12,19 @@ pub type Alias = oxc_resolver::Alias;
 
 pub(super) type Extensions = Vec<String>;
 pub(super) type PreferRelative = bool;
+pub(super) type PreferAbsolute = bool;
 pub(super) type Symlink = bool;
 pub(super) type MainFiles = Vec<String>;
 pub(super) type MainFields = Vec<String>;
-pub(super) type BrowserField = bool;
+pub(super) type AliasFields = Vec<Vec<String>>;
 pub(super) type ConditionNames = Vec<String>;
 pub(super) type Fallback = Alias;
 pub(super) type FullySpecified = bool;
 pub(super) type ExportsField = Vec<Vec<String>>;
 pub(super) type ExtensionAlias = Vec<(String, Vec<String>)>;
 pub(super) type Modules = Vec<String>;
+pub(super) type Roots = Vec<String>;
+pub(super) type Restrictions = Vec<String>;
 
 #[derive(Debug, Clone, Default, Hash, PartialEq, Eq)]
 pub struct Resolve {
@@ -33,6 +36,8 @@ pub struct Resolve {
   /// Prefer to resolve request as relative request and
   /// fallback to resolving as modules.
   pub prefer_relative: Option<PreferRelative>,
+  /// Prefer absolute paths to `resolve.roots` when resolving.
+  pub prefer_absolute: Option<PreferAbsolute>,
   /// Whether to resolve the real path when the result
   /// is a symlink.
   pub symlinks: Option<Symlink>,
@@ -40,9 +45,6 @@ pub struct Resolve {
   pub main_files: Option<MainFiles>,
   /// Main fields in Description.
   pub main_fields: Option<MainFields>,
-  /// Whether read and parse `"browser"` filed
-  /// in package.json.
-  pub browser_field: Option<BrowserField>,
   /// Condition names for exports filed. Note that its
   /// type is a `HashSet`, because the priority is
   /// related to the order in which the export field
@@ -66,6 +68,13 @@ pub struct Resolve {
   /// A list map ext to another.
   /// Default is `[]`
   pub extension_alias: Option<ExtensionAlias>,
+  /// Specify a field, such as browser, to be parsed according to [this specification](https://github.com/defunctzombie/package-browser-field-spec).
+  pub alias_fields: Option<AliasFields>,
+  /// A list of directories where requests of server-relative URLs (starting with '/') are resolved
+  pub roots: Option<Roots>,
+  /// A list of resolve restrictions to restrict the paths that a request can be resolved on.
+  pub restrictions: Option<Roots>,
+  /// Configure resolve options by the type of module request.
   pub by_dependency: Option<ByDependency>,
 }
 

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -209,6 +209,7 @@ fn to_oxc_resolver_options(
     })
     .collect();
   let prefer_relative = options.prefer_relative.unwrap_or(false);
+  let prefer_absolute = options.prefer_absolute.unwrap_or(false);
   let symlinks = options.symlinks.unwrap_or(true);
   let main_files = options
     .main_files
@@ -216,14 +217,6 @@ fn to_oxc_resolver_options(
   let main_fields = options
     .main_fields
     .unwrap_or_else(|| vec![String::from("module"), String::from("main")]);
-  let alias_fields = (if options.browser_field.unwrap_or(true) {
-    vec!["browser".to_string()]
-  } else {
-    vec![]
-  })
-  .into_iter()
-  .map(|x| vec![x])
-  .collect();
   let condition_names = options
     .condition_names
     .unwrap_or_else(|| vec!["module".to_string(), "import".to_string()]);
@@ -250,6 +243,21 @@ fn to_oxc_resolver_options(
     .exports_field
     .unwrap_or_else(|| vec![vec!["exports".to_string()]]);
   let extension_alias = options.extension_alias.unwrap_or_default();
+  let alias_fields = options
+    .alias_fields
+    .unwrap_or_else(|| vec![vec![String::from("browser")]]);
+  let restrictions = options
+    .restrictions
+    .unwrap_or_default()
+    .into_iter()
+    .map(|s| oxc_resolver::Restriction::Path(PathBuf::from(s)))
+    .collect();
+  let roots = options
+    .roots
+    .unwrap_or_default()
+    .into_iter()
+    .map(PathBuf::from)
+    .collect();
   oxc_resolver::ResolveOptions {
     fallback,
     modules,
@@ -257,6 +265,7 @@ fn to_oxc_resolver_options(
     enforce_extension,
     alias,
     prefer_relative,
+    prefer_absolute,
     symlinks,
     alias_fields,
     description_files,
@@ -268,10 +277,8 @@ fn to_oxc_resolver_options(
     fully_specified,
     exports_fields,
     extension_alias,
-    // not supported by rspack yet
-    prefer_absolute: false,
-    restrictions: vec![],
-    roots: vec![],
+    restrictions,
+    roots,
     builtin_modules: false,
   }
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -796,15 +796,16 @@ const getResolveDefaults = ({
 	const tp = targetProperties;
 	const browserField =
 		tp && tp.web && (!tp.node || (tp.electron && tp.electronRenderer));
+	const aliasFields = browserField ? ["browser"] : [];
 
 	const cjsDeps = () => ({
-		browserField,
+		aliasFields,
 		mainFields: browserField ? ["browser", "module", "..."] : ["module", "..."],
 		conditionNames: ["require", "module", "..."],
 		extensions: [...jsExtensions]
 	});
 	const esmDeps = () => ({
-		browserField,
+		aliasFields,
 		mainFields: browserField ? ["browser", "module", "..."] : ["module", "..."],
 		conditionNames: ["import", "module", "..."],
 		extensions: [...jsExtensions]
@@ -815,7 +816,7 @@ const getResolveDefaults = ({
 		conditionNames: conditions,
 		mainFiles: ["index"],
 		extensions: [],
-		browserField,
+		aliasFields,
 		mainFields: ["main"].filter(Boolean),
 		exportsFields: ["exports"],
 		byDependency: {

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -360,7 +360,17 @@ const baseResolveOptions = z.strictObject({
 	 * This is `aliasField: ["browser"]` in webpack, because no one
 	 * uses aliasField other than "browser". ---@bvanjoi
 	 */
-	browserField: z.boolean().optional(),
+	browserField: z
+		.boolean()
+		.optional()
+		.refine(val => {
+			if (val !== undefined) {
+				deprecatedWarn(
+					`'resolve.browserField' has been deprecated, and will be removed in 0.6.0. Please use 'resolve.aliasField' instead.`
+				);
+			}
+			return true;
+		}),
 	conditionNames: z.array(z.string()).optional(),
 	extensions: z.array(z.string()).optional(),
 	fallback: resolveAlias.optional(),
@@ -368,12 +378,16 @@ const baseResolveOptions = z.strictObject({
 	mainFiles: z.array(z.string()).optional(),
 	modules: z.array(z.string()).optional(),
 	preferRelative: z.boolean().optional(),
+	preferAbsolute: z.boolean().optional(),
 	symlinks: z.boolean().optional(),
 	tsConfigPath: z.string().optional(),
 	tsConfig: resolveTsconfig.optional(),
 	fullySpecified: z.boolean().optional(),
 	exportsFields: z.array(z.string()).optional(),
-	extensionAlias: z.record(z.string().or(z.array(z.string()))).optional()
+	extensionAlias: z.record(z.string().or(z.array(z.string()))).optional(),
+	aliasFields: z.array(z.string()).optional(),
+	restrictions: z.array(z.string()).optional(),
+	roots: z.array(z.string()).optional()
 });
 
 export type ResolveOptions = z.infer<typeof baseResolveOptions> & {

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -661,31 +661,43 @@ describe("snapshots", () => {
 		-     "workerWasmLoading": "fetch",
 		+     "workerWasmLoading": "async-node",
 		@@ ... @@
-		-     "browserField": true,
-		+     "browserField": false,
+		-     "aliasFields": Array [
+		-       "browser",
+		-     ],
+		+     "aliasFields": Array [],
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
@@ -763,31 +775,43 @@ describe("snapshots", () => {
 		-     "workerWasmLoading": "fetch",
 		+     "workerWasmLoading": "async-node",
 		@@ ... @@
-		-     "browserField": true,
-		+     "browserField": false,
+		-     "aliasFields": Array [
+		-       "browser",
+		-     ],
+		+     "aliasFields": Array [],
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
@@ -848,31 +872,43 @@ describe("snapshots", () => {
 		-     "workerWasmLoading": "fetch",
 		+     "workerWasmLoading": "async-node",
 		@@ ... @@
-		-     "browserField": true,
-		+     "browserField": false,
+		-     "aliasFields": Array [
+		-       "browser",
+		-     ],
+		+     "aliasFields": Array [],
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@
-		-         "browserField": true,
-		+         "browserField": false,
+		-         "aliasFields": Array [
+		-           "browser",
+		-         ],
+		+         "aliasFields": Array [],
 		@@ ... @@
 		-           "browser",
 		@@ ... @@

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -281,10 +281,14 @@ exports[`snapshots should have the correct base config 1`] = `
   "plugins": [],
   "profile": false,
   "resolve": {
-    "browserField": true,
+    "aliasFields": [
+      "browser",
+    ],
     "byDependency": {
       "commonjs": {
-        "browserField": true,
+        "aliasFields": [
+          "browser",
+        ],
         "conditionNames": [
           "require",
           "module",
@@ -302,7 +306,9 @@ exports[`snapshots should have the correct base config 1`] = `
         ],
       },
       "esm": {
-        "browserField": true,
+        "aliasFields": [
+          "browser",
+        ],
         "conditionNames": [
           "import",
           "module",
@@ -320,7 +326,9 @@ exports[`snapshots should have the correct base config 1`] = `
         ],
       },
       "unknown": {
-        "browserField": true,
+        "aliasFields": [
+          "browser",
+        ],
         "conditionNames": [
           "require",
           "module",
@@ -341,7 +349,9 @@ exports[`snapshots should have the correct base config 1`] = `
         "preferRelative": true,
       },
       "wasm": {
-        "browserField": true,
+        "aliasFields": [
+          "browser",
+        ],
         "conditionNames": [
           "import",
           "module",
@@ -359,7 +369,9 @@ exports[`snapshots should have the correct base config 1`] = `
         ],
       },
       "worker": {
-        "browserField": true,
+        "aliasFields": [
+          "browser",
+        ],
         "conditionNames": [
           "import",
           "module",

--- a/webpack-test/TestCases.template.js
+++ b/webpack-test/TestCases.template.js
@@ -164,7 +164,6 @@ const describeCases = config => {
 										"main"
 									],
 									aliasFields: ["browser"],
-									browserField: true,
 									extensions: [".webpack.js", ".web.js", ".js", ".json"]
 								},
 								resolveLoader: {


### PR DESCRIPTION

## Summary

This PR deprecates resolve.browserField in favor of resolver.aliasFields.

In addition, resolve.{preferAbsolute,restrictions,roots,aliasFields} are all enabled and passed to `oxc_resolver`

## Test Plan

* CI passes

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [x] Yes, the corresponding rspack-website PR is \_\_
