### PR TITLE
feat: unsupport require property

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -1,8 +1,7 @@
 use rspack_core::{
-  ConstDependency, DependencyLocation, DependencyTemplate, RuntimeGlobals,
-  RuntimeRequirementsDependency, SpanExt,
+  DependencyLocation, DependencyTemplate, RuntimeGlobals, RuntimeRequirementsDependency,
 };
-use swc_core::common::{Spanned, SyntaxContext};
+use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{Expr, Ident};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 
@@ -62,24 +61,6 @@ impl Visit for CommonJsScanner<'_> {
         .presentational_dependencies
         .push(Box::new(RuntimeRequirementsDependency::new(
           RuntimeGlobals::MODULE_LOADED,
-        )));
-    }
-    if expr_matcher::is_require_main(expr) {
-      let mut runtime_requirements = RuntimeGlobals::default();
-      runtime_requirements.insert(RuntimeGlobals::MODULE_CACHE);
-      runtime_requirements.insert(RuntimeGlobals::ENTRY_MODULE_ID);
-      self
-        .presentational_dependencies
-        .push(Box::new(ConstDependency::new(
-          expr.span().real_lo(),
-          expr.span().real_hi(),
-          format!(
-            "{}[{}]",
-            RuntimeGlobals::MODULE_CACHE,
-            RuntimeGlobals::ENTRY_MODULE_ID
-          )
-          .into(),
-          Some(runtime_requirements),
         )));
     }
     expr.visit_children_with(self);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -102,6 +102,7 @@ pub fn scan_dependencies(
     &mut presentational_dependencies,
     compiler_options.output.module,
     build_info,
+    &mut warning_diagnostics,
     &mut ignored,
   ));
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -1,7 +1,8 @@
 use itertools::Itertools;
 use rspack_core::{
-  extract_member_expression_chain, DependencyLocation, ExpressionInfoKind, SpanExt,
+  extract_member_expression_chain, ConstDependency, DependencyLocation, ExpressionInfoKind, SpanExt,
 };
+use rspack_error::miette::{MietteDiagnostic, Severity};
 use rustc_hash::FxHashSet as HashSet;
 use swc_core::{
   common::{Spanned, SyntaxContext},
@@ -104,6 +105,14 @@ pub(crate) mod expr_matcher {
     is_import_meta_url: "import.meta.url",
     is_import_meta: "import.meta",
     is_object_define_property: "Object.defineProperty",
+    // unsupported require property
+    is_require_extensions: "require.extensions",
+    is_require_ensure: "require.ensure",
+    is_require_config: "require.config",
+    is_require_version: "require.vesrion",
+    is_require_amd: "require.amd",
+    is_require_include: "require.include",
+    is_require_onerror: "require.onError",
   });
 }
 
@@ -420,4 +429,22 @@ fn test_is_require_call_start() {
   test!("module.require.a().b", false);
   test!("module.require.a.b", false);
   test!("a.module.require.b", false);
+}
+
+pub fn expression_not_supported(
+  name: &str,
+  expr: &Expr,
+) -> (Box<MietteDiagnostic>, Box<ConstDependency>) {
+  (
+    Box::new(
+      MietteDiagnostic::new(format!("{name} is not supported by Rspack."))
+        .with_severity(Severity::Warning),
+    ),
+    Box::new(ConstDependency::new(
+      expr.span().real_lo(),
+      expr.span().real_hi(),
+      "(void 0)".into(),
+      None,
+    )),
+  )
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -105,7 +105,7 @@ pub(crate) mod expr_matcher {
     is_import_meta_url: "import.meta.url",
     is_import_meta: "import.meta",
     is_object_define_property: "Object.defineProperty",
-    // unsupported require property
+    // unsupported
     is_require_extensions: "require.extensions",
     is_require_ensure: "require.ensure",
     is_require_config: "require.config",
@@ -113,6 +113,8 @@ pub(crate) mod expr_matcher {
     is_require_amd: "require.amd",
     is_require_include: "require.include",
     is_require_onerror: "require.onError",
+    is_require_main_require: "require.main.require",
+    is_module_parent_require: "module.parent.require",
   });
 }
 

--- a/packages/rspack/tests/cases/parsing/unsupport-require-property/index.js
+++ b/packages/rspack/tests/cases/parsing/unsupport-require-property/index.js
@@ -6,6 +6,8 @@ it("should transform unsupported require api to undefined", function () {
 	expect(require.amd).toBeUndefined();
 	expect(require.include).toBeUndefined();
 	expect(require.onError).toBeUndefined();
+	expect(require.main.require).toBeUndefined();
+	expect(module.parent.require).toBeUndefined();
 
 	expect(require.include("a")).toBeUndefined();
 	expect(
@@ -14,4 +16,6 @@ it("should transform unsupported require api to undefined", function () {
 		})
 	).toBeUndefined();
 	expect(require.onError(function () {})).toBeUndefined();
+	expect(require.main.require("a")).toBeUndefined();
+	expect(module.parent.require("a")).toBeUndefined();
 });

--- a/packages/rspack/tests/cases/parsing/unsupport-require-property/index.js
+++ b/packages/rspack/tests/cases/parsing/unsupport-require-property/index.js
@@ -1,0 +1,17 @@
+it("should transform unsupported require api to undefined", function () {
+	expect(require.extensions).toBeUndefined();
+	expect(require.ensure).toBeUndefined();
+	expect(require.config).toBeUndefined();
+	expect(require.vesrion).toBeUndefined();
+	expect(require.amd).toBeUndefined();
+	expect(require.include).toBeUndefined();
+	expect(require.onError).toBeUndefined();
+
+	expect(require.include("a")).toBeUndefined();
+	expect(
+		require.ensure(["a", "b"], function (require) {
+			/* ... */
+		})
+	).toBeUndefined();
+	expect(require.onError(function () {})).toBeUndefined();
+});

--- a/packages/rspack/tests/cases/parsing/unsupport-require-property/warnings.js
+++ b/packages/rspack/tests/cases/parsing/unsupport-require-property/warnings.js
@@ -1,0 +1,12 @@
+module.exports = [
+	[/require.extensions is not supported by Rspack/],
+	[/require.ensure is not supported by Rspack/],
+	[/require.config is not supported by Rspack/],
+	[/require.vesrion is not supported by Rspack/],
+	[/require.amd is not supported by Rspack/],
+	[/require.include is not supported by Rspack/],
+	[/require.onError is not supported by Rspack/],
+	[/require.include\(\) is not supported by Rspack/],
+	[/require.ensure\(\) is not supported by Rspack/],
+	[/require.onError\(\) is not supported by Rspack/]
+];

--- a/packages/rspack/tests/cases/parsing/unsupport-require-property/warnings.js
+++ b/packages/rspack/tests/cases/parsing/unsupport-require-property/warnings.js
@@ -6,7 +6,11 @@ module.exports = [
 	[/require.amd is not supported by Rspack/],
 	[/require.include is not supported by Rspack/],
 	[/require.onError is not supported by Rspack/],
+	[/require.main.require is not supported by Rspack/],
+	[/module.parent.require is not supported by Rspack/],
 	[/require.include\(\) is not supported by Rspack/],
 	[/require.ensure\(\) is not supported by Rspack/],
-	[/require.onError\(\) is not supported by Rspack/]
+	[/require.onError\(\) is not supported by Rspack/],
+	[/require.main.require\(\) is not supported by Rspack/],
+	[/module.parent.require\(\) is not supported by Rspack/]
 ];


### PR DESCRIPTION
## Summary

resolve #5040, resolve #5235

Transform unsupport require.xxx or require.xxx() to undefined and throw warnings

## Test Plan

- Add `packages/rspack/tests/cases/parsing/unsupport-require-property`

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
