### PR TITLE
refactor: change return type of `render_manifest` to `TWithDiagnosticArray`

### DIFF
--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, path::Path};
 
 use dashmap::DashMap;
-use rspack_error::Result;
+use rspack_error::{IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_hash::RspackHashDigest;
 use rspack_loader_runner::{Content, ResourceData};
 use rspack_sources::BoxSource;
@@ -32,7 +32,7 @@ pub type PluginNormalModuleFactoryBeforeResolveOutput = Result<Option<bool>>;
 pub type PluginNormalModuleFactoryAfterResolveOutput = Result<Option<bool>>;
 pub type PluginContentHashHookOutput = Result<Option<(SourceType, RspackHashDigest)>>;
 pub type PluginChunkHashHookOutput = Result<()>;
-pub type PluginRenderManifestHookOutput = Result<Vec<RenderManifestEntry>>;
+pub type PluginRenderManifestHookOutput = Result<TWithDiagnosticArray<Vec<RenderManifestEntry>>>;
 pub type PluginRenderChunkHookOutput = Result<Option<BoxSource>>;
 pub type PluginProcessAssetsOutput = Result<()>;
 pub type PluginOptimizeChunksOutput = Result<()>;
@@ -179,7 +179,7 @@ pub trait Plugin: Debug + Send + Sync {
     _ctx: PluginContext,
     _args: RenderManifestArgs<'_>,
   ) -> PluginRenderManifestHookOutput {
-    Ok(vec![])
+    Ok(vec![].with_empty_diagnostic())
   }
 
   // JavascriptModulesPlugin hook

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -562,6 +562,6 @@ impl Plugin for AssetPlugin {
       .flatten()
       .collect::<Vec<RenderManifestEntry>>();
 
-    Ok(assets)
+    Ok(assets.with_empty_diagnostic())
   }
 }

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -14,7 +14,7 @@ use rspack_core::{
   Compilation, CompilationArgs, CompilationParams, CompilerOptions, DependencyType,
   LibIdentOptions, PluginCompilationHookOutput, PublicPath,
 };
-use rspack_error::Result;
+use rspack_error::{IntoTWithDiagnosticArray, Result};
 use rspack_hash::RspackHash;
 
 use crate::parser_and_generator::CssParserAndGenerator;
@@ -205,7 +205,7 @@ impl Plugin for CssPlugin {
     let compilation = args.compilation;
     let chunk = args.chunk_ukey.as_ref(&compilation.chunk_by_ukey);
     if matches!(chunk.kind, ChunkKind::HotUpdate) {
-      return Ok(vec![]);
+      return Ok(vec![].with_empty_diagnostic());
     }
 
     let ordered_css_modules = Self::get_ordered_chunk_css_modules(
@@ -217,7 +217,7 @@ impl Plugin for CssPlugin {
 
     // Prevent generating css files for chunks which don't contain css modules.
     if ordered_css_modules.is_empty() {
-      return Ok(Default::default());
+      return Ok(vec![].with_empty_diagnostic());
     }
 
     let source = Self::render_chunk_to_source(compilation, chunk, &ordered_css_modules)?;
@@ -255,12 +255,15 @@ impl Plugin for CssPlugin {
     } else {
       source.boxed()
     };
-    Ok(vec![RenderManifestEntry::new(
-      source.boxed(),
-      output_path,
-      asset_info,
-      false,
-      false,
-    )])
+    Ok(
+      vec![RenderManifestEntry::new(
+        source.boxed(),
+        output_path,
+        asset_info,
+        false,
+        false,
+      )]
+      .with_empty_diagnostic(),
+    )
   }
 }

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -250,7 +250,7 @@ impl Plugin for HotModuleReplacementPlugin {
             .connect_chunk_and_runtime_module(ukey, runtime_module);
         }
 
-        let render_manifest = compilation
+        let render_manifest_result = compilation
           .plugin_driver
           .render_manifest(RenderManifestArgs {
             compilation,
@@ -258,6 +258,9 @@ impl Plugin for HotModuleReplacementPlugin {
           })
           .await
           .expect("render_manifest failed in rebuild");
+
+        let (render_manifest, diagnostics) = render_manifest_result.split_into_parts();
+        compilation.push_batch_diagnostic(diagnostics);
 
         for entry in render_manifest {
           let filename = if entry.has_filename() {

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -11,7 +11,7 @@ use rspack_core::{
   PluginCompilationHookOutput, PluginContext, PluginRenderManifestHookOutput, RenderManifestEntry,
   RuntimeGlobals, SelfModuleFactory, SourceType,
 };
-use rspack_error::Result;
+use rspack_error::{IntoTWithDiagnosticArray, Result};
 use rspack_hash::RspackHash;
 
 use crate::parser_and_generator::JavaScriptParserAndGenerator;
@@ -261,7 +261,7 @@ impl Plugin for JsPlugin {
         &compilation.chunk_graph,
         &compilation.module_graph,
       ) {
-        return Ok(vec![]);
+        return Ok(vec![].with_empty_diagnostic());
       }
       self.render_chunk_impl(&args).await?
     };
@@ -284,13 +284,16 @@ impl Plugin for JsPlugin {
         .runtime(&chunk.runtime),
     );
     asset_info.set_javascript_module(compilation.options.output.module);
-    Ok(vec![RenderManifestEntry::new(
-      source,
-      output_path,
-      asset_info,
-      false,
-      false,
-    )])
+    Ok(
+      vec![RenderManifestEntry::new(
+        source,
+        output_path,
+        asset_info,
+        false,
+        false,
+      )]
+      .with_empty_diagnostic(),
+    )
   }
 
   fn additional_tree_runtime_requirements(

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   ParserAndGenerator, Plugin, PluginCompilationHookOutput, PluginContext,
   PluginRenderManifestHookOutput, RenderManifestArgs, RenderManifestEntry, SourceType,
 };
-use rspack_error::Result;
+use rspack_error::{IntoTWithDiagnosticArray, Result};
 
 use crate::{AsyncWasmParserAndGenerator, ModuleIdToFileName};
 
@@ -110,6 +110,6 @@ impl Plugin for AsyncWasmPlugin {
       .flatten()
       .collect::<Vec<RenderManifestEntry>>();
 
-    Ok(files)
+    Ok(files.with_empty_diagnostic())
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Change ret type of render_manifest to TWithDiagnostics, so that plugin can emit diagnostics in render_manifest hook


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
