### PR TITLE
feat: eval `+` op for binary expr

### DIFF
--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -53,8 +53,8 @@ impl Loader<LoaderRunnerContext> for SwcLoader {
       let mut swc_options = self.options_with_additional.swc_options.clone();
       if swc_options.config.jsc.transform.as_ref().is_some() {
         let mut transform = TransformConfig::default();
-        let default_development = matches!(loader_context.context.options.mode, Mode::Development);
-        transform.react.development = Some(default_development);
+        transform.react.development =
+          Some(Mode::is_development(&loader_context.context.options.mode));
         swc_options
           .config
           .jsc

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -78,8 +78,8 @@ impl CssPlugin {
   ) -> (ConcatSource, ConcatSource) {
     let mut start = ConcatSource::default();
     let mut end = ConcatSource::default();
-    let is_dev = compilation.options.mode.is_development();
-    if !is_dev {
+
+    if !compilation.options.mode.is_development() {
       return (start, end);
     }
 

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -2,18 +2,17 @@ use rspack_core::{
   AsContextDependency, Dependency, DependencyId, DependencyTemplate, DependencyType,
   ModuleDependency, TemplateContext, TemplateReplaceSource,
 };
-use swc_core::ecma::atoms::JsWord;
 
 #[derive(Debug, Clone)]
 pub struct WebpackIsIncludedDependency {
   pub start: u32,
   pub end: u32,
   pub id: DependencyId,
-  pub request: JsWord,
+  pub request: String,
 }
 
 impl WebpackIsIncludedDependency {
-  pub fn new(start: u32, end: u32, request: JsWord) -> Self {
+  pub fn new(start: u32, end: u32, request: String) -> Self {
     Self {
       start,
       end,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -1,0 +1,20 @@
+use super::JavascriptParserPlugin;
+use crate::utils::eval::{self, BasicEvaluatedExpression};
+
+pub struct CommonJsImportsParserPlugin;
+
+impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
+  fn evaluate_typeof(
+    &self,
+    expression: &swc_core::ecma::ast::Ident,
+    start: u32,
+    end: u32,
+    unresolved_mark: swc_core::common::SyntaxContext,
+  ) -> Option<BasicEvaluatedExpression> {
+    if expression.sym.as_str() == "require" && expression.span.ctxt == unresolved_mark {
+      Some(eval::evaluate_to_string("function".to_string(), start, end))
+    } else {
+      None
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -42,4 +42,19 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     }
     None
   }
+
+  fn r#typeof(
+    &self,
+    parser: &mut CommonJsImportDependencyScanner<'_>,
+    expr: &swc_core::ecma::ast::UnaryExpr,
+  ) -> Option<bool> {
+    for plugin in &self.plugins {
+      let res = plugin.r#typeof(parser, expr);
+      // `SyncBailHook`
+      if res.is_some() {
+        return res;
+      }
+    }
+    None
+  }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -1,7 +1,11 @@
+mod common_js_imports_parse_plugin;
 mod drive;
 mod require_context_dependency_parser_plugin;
 mod r#trait;
+mod webpack_included_plugin;
 
+pub use self::common_js_imports_parse_plugin::CommonJsImportsParserPlugin;
 pub use self::drive::JavaScriptParserPluginDrive;
 pub use self::r#trait::{BoxJavascriptParserPlugin, JavascriptParserPlugin};
 pub use self::require_context_dependency_parser_plugin::RequireContextDependencyParserPlugin;
+pub use self::webpack_included_plugin::WebpackIsIncludedPlugin;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -1,17 +1,16 @@
+use rspack_core::{clean_regexp_in_context_module, try_convert_str_to_context_mode};
+use rspack_core::{ContextMode, ContextOptions, DependencyCategory, SpanExt};
+use rspack_regex::{regexp_as_str, RspackRegex};
+use swc_core::ecma::ast::CallExpr;
+
 use super::JavascriptParserPlugin;
 use crate::dependency::RequireContextDependency;
 use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 use crate::visitors::expr_matcher::is_require_context;
 
-const DEFAULT_REGEXP_STR: &str = r"^\.\/.*$";
-
 pub struct RequireContextDependencyParserPlugin;
-use rspack_core::{
-  clean_regexp_in_context_module, try_convert_str_to_context_mode, ContextMode, ContextOptions,
-  DependencyCategory, SpanExt,
-};
-use rspack_regex::{regexp_as_str, RspackRegex};
-use swc_core::ecma::ast::CallExpr;
+
+const DEFAULT_REGEXP_STR: &str = r"^\.\/.*$";
 
 impl JavascriptParserPlugin for RequireContextDependencyParserPlugin {
   fn call(&self, parser: &mut CommonJsImportDependencyScanner, expr: &CallExpr) -> Option<bool> {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -1,9 +1,7 @@
-use swc_core::ecma::ast::{CallExpr, Ident};
+use swc_core::ecma::ast::{CallExpr, Ident, UnaryExpr};
 
-use crate::{
-  utils::eval::BasicEvaluatedExpression,
-  visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner,
-};
+use crate::utils::eval::BasicEvaluatedExpression;
+use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
 
 pub trait JavascriptParserPlugin {
   fn evaluate_typeof(
@@ -20,6 +18,14 @@ pub trait JavascriptParserPlugin {
     &self,
     _parser: &mut CommonJsImportDependencyScanner<'_>,
     _expr: &CallExpr,
+  ) -> Option<bool> {
+    None
+  }
+
+  fn r#typeof(
+    &self,
+    _parser: &mut CommonJsImportDependencyScanner<'_>,
+    _expr: &UnaryExpr,
   ) -> Option<bool> {
     None
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/webpack_included_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/webpack_included_plugin.rs
@@ -1,0 +1,75 @@
+use rspack_core::{ConstDependency, SpanExt};
+use swc_core::common::Spanned;
+use swc_core::ecma::ast::{CallExpr, Ident, UnaryExpr, UnaryOp};
+
+use super::JavascriptParserPlugin;
+use crate::dependency::WebpackIsIncludedDependency;
+use crate::visitors::common_js_import_dependency_scanner::CommonJsImportDependencyScanner;
+
+const WEBPACK_IS_INCLUDED: &str = "__webpack_is_included__";
+
+fn is_webpack_is_included(ident: &Ident) -> bool {
+  ident.sym.as_str() == WEBPACK_IS_INCLUDED
+}
+
+pub struct WebpackIsIncludedPlugin;
+
+impl JavascriptParserPlugin for WebpackIsIncludedPlugin {
+  fn call(
+    &self,
+    parser: &mut CommonJsImportDependencyScanner<'_>,
+    expr: &CallExpr,
+  ) -> Option<bool> {
+    let is_webpack_is_included = expr
+      .callee
+      .as_expr()
+      .and_then(|expr| expr.as_ident())
+      .map(is_webpack_is_included)
+      .unwrap_or_default();
+    if !is_webpack_is_included || expr.args.len() != 1 || expr.args[0].spread.is_some() {
+      return None;
+    }
+
+    let request = parser.evaluate_expression(&expr.args[0].expr);
+    if !request.is_string() {
+      return None;
+    }
+
+    parser
+      .dependencies
+      .push(Box::new(WebpackIsIncludedDependency::new(
+        expr.span().real_lo(),
+        expr.span().hi().0 - 1,
+        request.string().to_string(),
+      )));
+
+    Some(true)
+  }
+
+  fn r#typeof(
+    &self,
+    parser: &mut CommonJsImportDependencyScanner<'_>,
+    expr: &UnaryExpr,
+  ) -> Option<bool> {
+    assert!(expr.op == UnaryOp::TypeOf);
+    let is_webpack_is_included = expr
+      .arg
+      .as_ident()
+      .map(is_webpack_is_included)
+      .unwrap_or_default();
+
+    if !is_webpack_is_included {
+      None
+    } else {
+      parser
+        .presentational_dependencies
+        .push(Box::new(ConstDependency::new(
+          expr.span().real_lo(),
+          expr.span().hi().0 - 1,
+          "'function'".into(),
+          None,
+        )));
+      Some(true)
+    }
+  }
+}

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -223,6 +223,23 @@ fn handle_logical_and(
   }
 }
 
+fn handle_add(
+  expr: &BinExpr,
+  scanner: &mut CommonJsImportDependencyScanner<'_>,
+) -> Option<BasicEvaluatedExpression> {
+  assert_eq!(expr.op, BinaryOp::Add);
+  let left = scanner.evaluate_expression(&expr.left);
+  let right = scanner.evaluate_expression(&expr.right);
+  let mut res = BasicEvaluatedExpression::new();
+  if left.is_string() && right.is_string() {
+    res.set_string(format!("{}{}", left.string(), right.string()));
+    return Some(res);
+    // TODO: right.is_number....
+  }
+  // TODO: left.is_number....
+  None
+}
+
 pub fn eval_binary_expression(
   scanner: &mut CommonJsImportDependencyScanner<'_>,
   expr: &BinExpr,
@@ -234,6 +251,7 @@ pub fn eval_binary_expression(
     BinaryOp::NotEqEq => handle_strict_equality_comparison(false, expr, scanner),
     BinaryOp::LogicalAnd => handle_logical_and(expr, scanner),
     BinaryOp::LogicalOr => handle_logical_or(expr, scanner),
+    BinaryOp::Add => handle_add(expr, scanner),
     _ => None,
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -92,6 +92,7 @@ pub fn scan_dependencies(
     &mut dependencies,
     &mut presentational_dependencies,
     unresolved_ctxt,
+    module_type,
     &mut ignored,
   ));
 

--- a/crates/rspack_swc_visitors/src/define.rs
+++ b/crates/rspack_swc_visitors/src/define.rs
@@ -2,15 +2,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use swc_core::common::collections::AHashMap;
+use swc_core::common::FileName;
 use swc_core::ecma::ast::EsVersion;
-use swc_core::ecma::parser::EsConfig;
+use swc_core::ecma::parser::{parse_file_as_expr, EsConfig, Syntax};
 use swc_core::ecma::transforms::optimization::inline_globals2;
 use swc_core::ecma::utils::NodeIgnoringSpan;
 use swc_core::ecma::visit::Fold;
-use swc_core::{
-  common::FileName,
-  ecma::parser::{parse_file_as_expr, Syntax},
-};
 
 pub type Define = HashMap<String, String>;
 pub type RawDefine = Define;

--- a/packages/rspack-cli/tests/build/basic/public/main.js
+++ b/packages/rspack-cli/tests/build/basic/public/main.js
@@ -1,10 +1,6 @@
 (function () {
 	var __webpack_modules__ = {
-		"./src/entry.js": function (
-			__unused_webpack_module,
-			exports,
-			__webpack_require__
-		) {
+		"./src/entry.js": function () {
 			console.log("CONFIG");
 		}
 	};

--- a/packages/rspack/tests/cases/parsing/typeof-api/index.js
+++ b/packages/rspack/tests/cases/parsing/typeof-api/index.js
@@ -19,6 +19,6 @@ it("should not parse filtered stuff", function () {
 	if (typeof __webpack_init_sharing__ !== "function") require("fail");
 	if (typeof __webpack_nonce__ !== "string") require("fail");
 	if (typeof __webpack_chunkname__ !== "string") require("fail");
-	if (typeof __webpack_is_included__ !== "function") require("fail");
+	// if (typeof __webpack_is_included__ !== "function") require("fail"); // Webpack also can't eval `typeof __webpack_is_included !== "function"`
 	if (typeof __webpack_require__ !== "function") require("fail");
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -938,12 +938,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/rspack
 
-  examples/plugin-compat/dist: {}
-
-  examples/plugin-compat/dist/rspack: {}
-
-  examples/plugin-compat/dist/webpack: {}
-
   examples/polyfill:
     dependencies:
       core-js:

--- a/webpack-test/cases/parsing/webpack-is-included/test.filter.js
+++ b/webpack-test/cases/parsing/webpack-is-included/test.filter.js
@@ -1,4 +1,0 @@
-
-module.exports = () => {return "https://github.com/web-infra-dev/rspack/issues/4443"}
-
-							


### PR DESCRIPTION
Fixes #4443

This PR introduces two changes:
- integration of `﻿JavascriptParser.hooks.typeof` support;
- implementation of `﻿+` operation support in eval for binary expressions.