### PR TITLE
fix: should not remove unsupport require declaration when local variable

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashSet as HashSet;
 use swc_core::{
   common::{Spanned, SyntaxContext},
   ecma::{
-    ast::{CallExpr, Expr, ExprOrSpread, MemberExpr, ObjectPat, ObjectPatProp, PropName},
+    ast::{CallExpr, Expr, ExprOrSpread, Ident, MemberExpr, ObjectPat, ObjectPatProp, PropName},
     atoms::{Atom, JsWord},
   },
 };
@@ -449,4 +449,14 @@ pub fn expression_not_supported(
       None,
     )),
   )
+}
+
+pub fn extract_member_root(mut expr: &Expr) -> Option<Ident> {
+  loop {
+    match expr {
+      Expr::Ident(id) => return Some(id.to_owned()),
+      Expr::Member(MemberExpr { obj, .. }) => expr = obj.as_ref(),
+      _ => return None,
+    }
+  }
 }

--- a/packages/rspack/tests/cases/parsing/unsupport-require-property/index.js
+++ b/packages/rspack/tests/cases/parsing/unsupport-require-property/index.js
@@ -18,4 +18,34 @@ it("should transform unsupported require api to undefined", function () {
 	expect(require.onError(function () {})).toBeUndefined();
 	expect(require.main.require("a")).toBeUndefined();
 	expect(module.parent.require("a")).toBeUndefined();
+
+	function requireInBlock() {
+		var require = {
+			extensions: {},
+			ensure: {},
+			config: {},
+			vesrion: {},
+			amd: {},
+			include: {},
+			onError: {},
+			main: {
+				require: {}
+			}
+		};
+		var module = {
+			parent: {
+				require: {}
+			}
+		};
+		expect(require.extensions).toBeTruthy();
+		expect(require.ensure).toBeTruthy();
+		expect(require.config).toBeTruthy();
+		expect(require.vesrion).toBeTruthy();
+		expect(require.amd).toBeTruthy();
+		expect(require.include).toBeTruthy();
+		expect(require.onError).toBeTruthy();
+		expect(require.main.require).toBeTruthy();
+		expect(module.parent.require).toBeTruthy();
+	}
+	requireInBlock();
 });


### PR DESCRIPTION

## Summary

 should not remove unsupport require declaration when local variable

## Test Plan

- Added

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
