### PR TITLE
fix: address expect-error in react-refresh and script

### DIFF
--- a/packages/rspack-plugin-react-refresh/src/index.ts
+++ b/packages/rspack-plugin-react-refresh/src/index.ts
@@ -42,11 +42,9 @@ class ReactRefreshRspackPlugin {
 		}).apply(compiler);
 
 		compiler.options.module.rules.unshift({
-			// @ts-expect-error
-			include: this.options.include,
-			// @ts-expect-error
+			include: this.options.include!,
 			exclude: {
-				or: [this.options.exclude, [...runtimePaths]].filter(Boolean)
+				or: [this.options.exclude!, [...runtimePaths]].filter(Boolean)
 			},
 			use: "builtin:react-refresh-loader"
 		});

--- a/packages/rspack-plugin-react-refresh/src/options.ts
+++ b/packages/rspack-plugin-react-refresh/src/options.ts
@@ -9,6 +9,7 @@ const d = <K extends keyof PluginOptions>(
 	property: K,
 	defaultValue?: PluginOptions[K]
 ) => {
+	// TODO: should we also add default for null?
 	if (
 		typeof object[property] === "undefined" &&
 		typeof defaultValue !== "undefined"

--- a/scripts/meta/check_is_workspace_root.js
+++ b/scripts/meta/check_is_workspace_root.js
@@ -17,7 +17,7 @@ try {
 	const err = new Error(
 		`Make sure you are in workspace root to run this script`
 	);
-	// @ts-expect-error
+	// @ts-expect-error error.cause is introduced in ES2022, ignore here
 	err.cause = oldErr;
 	throw err;
 }


### PR DESCRIPTION
## Summary

part of #4640

Some errors are truly expected to work around typescript complaints.
I added comments for these comments.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
