### PR TITLE
fix: replace undefined with void in hooks

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -105,21 +105,21 @@ export class Compilation {
 		childCompiler: tapable.SyncHook<[Compiler, string, number]>;
 		log: tapable.SyncBailHook<[string, LogEntry], true>;
 		additionalAssets: any;
-		optimizeModules: tapable.SyncBailHook<Iterable<JsModule>, undefined>;
-		afterOptimizeModules: tapable.SyncHook<Iterable<JsModule>, undefined>;
+		optimizeModules: tapable.SyncBailHook<Iterable<JsModule>, void>;
+		afterOptimizeModules: tapable.SyncHook<Iterable<JsModule>, void>;
 		optimizeTree: tapable.AsyncSeriesBailHook<
 			[Iterable<Chunk>, Iterable<JsModule>],
-			undefined
+			void
 		>;
 		optimizeChunkModules: tapable.AsyncSeriesBailHook<
 			[Iterable<Chunk>, Iterable<JsModule>],
-			undefined
+			void
 		>;
-		finishModules: tapable.AsyncSeriesHook<[Iterable<JsModule>], undefined>;
-		chunkAsset: tapable.SyncHook<[JsChunk, string], undefined>;
+		finishModules: tapable.AsyncSeriesHook<[Iterable<JsModule>], void>;
+		chunkAsset: tapable.SyncHook<[JsChunk, string], void>;
 		processWarnings: tapable.SyncWaterfallHook<[Error[]]>;
-		succeedModule: tapable.SyncHook<[JsModule], undefined>;
-		stillValidModule: tapable.SyncHook<[JsModule], undefined>;
+		succeedModule: tapable.SyncHook<[JsModule], void>;
+		stillValidModule: tapable.SyncHook<[JsModule], void>;
 		statsFactory: tapable.SyncHook<[StatsFactory, StatsOptions], void>;
 		statsPrinter: tapable.SyncHook<[StatsPrinter, StatsOptions], void>;
 		buildModule: tapable.SyncHook<[NormalizedJsModule]>;


### PR DESCRIPTION
## Summary

`undefined` requires an explicit `return` statement.

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
