### PR TITLE
fix: not enable rspack-plugin-react-refresh when mode set to 'product…

### DIFF
--- a/packages/rspack-dev-server/tests/normalizeOptions.test.ts
+++ b/packages/rspack-dev-server/tests/normalizeOptions.test.ts
@@ -30,7 +30,7 @@ describe("normalize options snapshot", () => {
 		).toMatchSnapshot();
 	});
 
-	it("shouldn't have reactRefreshEntry.js by default when rspackFuture.disableReactRefreshByDefault is enabled", async () => {
+	it("shouldn't have reactRefreshEntry.js by default when in production mode", async () => {
 		const reactRefreshEntry =
 			"<prefix>/rspack-plugin-react-refresh/client/reactRefreshEntry.js";
 		const entries1 = await getAdditionEntries(
@@ -44,10 +44,18 @@ describe("normalize options snapshot", () => {
 			{},
 			{
 				entry: ["something"],
-				plugins: [new ReactRefreshPlugin()]
+				plugins: [new ReactRefreshPlugin({ forceEnable: true })]
 			}
 		);
 		expect(entries2["undefined"]).toContain(reactRefreshEntry);
+		const entries3 = await getAdditionEntries(
+			{},
+			{
+				entry: ["something"],
+				plugins: [new ReactRefreshPlugin()]
+			}
+		);
+		expect(entries2["undefined"]).not.toContain(reactRefreshEntry);
 	});
 
 	it("should apply HMR plugin by default", async () => {

--- a/packages/rspack-dev-server/tests/normalizeOptions.test.ts
+++ b/packages/rspack-dev-server/tests/normalizeOptions.test.ts
@@ -36,6 +36,7 @@ describe("normalize options snapshot", () => {
 		const entries1 = await getAdditionEntries(
 			{},
 			{
+				mode: "production",
 				entry: ["something"]
 			}
 		);
@@ -43,6 +44,7 @@ describe("normalize options snapshot", () => {
 		const entries2 = await getAdditionEntries(
 			{},
 			{
+				mode: "production",
 				entry: ["something"],
 				plugins: [new ReactRefreshPlugin({ forceEnable: true })]
 			}
@@ -51,11 +53,21 @@ describe("normalize options snapshot", () => {
 		const entries3 = await getAdditionEntries(
 			{},
 			{
+				mode: "development",
 				entry: ["something"],
 				plugins: [new ReactRefreshPlugin()]
 			}
 		);
-		expect(entries2["undefined"]).not.toContain(reactRefreshEntry);
+		expect(entries3["undefined"]).toContain(reactRefreshEntry);
+		const entries4 = await getAdditionEntries(
+			{},
+			{
+				mode: "production",
+				entry: ["something"],
+				plugins: [new ReactRefreshPlugin()]
+			}
+		);
+		expect(entries4["undefined"]).not.toContain(reactRefreshEntry);
 	});
 
 	it("should apply HMR plugin by default", async () => {

--- a/packages/rspack-plugin-react-refresh/src/index.ts
+++ b/packages/rspack-plugin-react-refresh/src/index.ts
@@ -34,6 +34,17 @@ class ReactRefreshRspackPlugin {
 	}
 
 	apply(compiler: Compiler) {
+		if (
+			// Webpack do not set process.env.NODE_ENV, so we need to check for mode.
+			// Ref: https://github.com/webpack/webpack/issues/7074
+			(compiler.options.mode !== "development" ||
+				// We also check for production process.env.NODE_ENV,
+				// in case it was set and mode is non-development (e.g. 'none')
+				(process.env.NODE_ENV && process.env.NODE_ENV === "production")) &&
+			!this.options.forceEnable
+		) {
+			return;
+		}
 		new compiler.webpack.EntryPlugin(compiler.context, reactRefreshEntryPath, {
 			name: undefined
 		}).apply(compiler);

--- a/packages/rspack-plugin-react-refresh/src/options.ts
+++ b/packages/rspack-plugin-react-refresh/src/options.ts
@@ -2,6 +2,7 @@ export type PluginOptions = {
 	include?: string | RegExp | (string | RegExp)[] | null;
 	exclude?: string | RegExp | (string | RegExp)[] | null;
 	library?: string;
+	forceEnable?: boolean;
 };
 
 const d = <K extends keyof PluginOptions>(
@@ -22,5 +23,6 @@ export function normalizeOptions(options: PluginOptions) {
 	d(options, "exclude", /node_modules/i);
 	d(options, "include", /\.([cm]js|[jt]sx?|flow)$/i);
 	d(options, "library");
+	d(options, "forceEnable", false);
 	return options;
 }


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request!
  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix https://github.com/web-infra-dev/rspack/issues/5258
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
No Need
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
