### PR TITLE
fix: full require in try catch should be optional

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -16,6 +16,7 @@ pub struct CommonJsFullRequireDependency {
   range: DependencyLocation,
   span: Option<ErrorSpan>,
   is_call: bool,
+  optional: bool,
 }
 
 impl CommonJsFullRequireDependency {
@@ -25,6 +26,7 @@ impl CommonJsFullRequireDependency {
     range: DependencyLocation,
     span: Option<ErrorSpan>,
     is_call: bool,
+    optional: bool,
   ) -> Self {
     Self {
       id: DependencyId::new(),
@@ -33,6 +35,7 @@ impl CommonJsFullRequireDependency {
       range,
       span,
       is_call,
+      optional,
     }
   }
 }
@@ -70,6 +73,10 @@ impl ModuleDependency for CommonJsFullRequireDependency {
 
   fn set_request(&mut self, request: String) {
     self.request = request;
+  }
+
+  fn get_optional(&self) -> bool {
+    self.optional
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_import_dependency_scanner.rs
@@ -153,6 +153,7 @@ impl<'a> CommonJsImportDependencyScanner<'a> {
         loc,
         Some(mem_expr.span.into()),
         is_call,
+        self.in_try,
       ))
     } else {
       None

--- a/packages/rspack/tests/cases/cjs-tree-shaking/full-require/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/full-require/index.js
@@ -32,3 +32,9 @@ it("should import by full require with require().l.m()().n", () => {
 	const res = require("./exports.js").l.m()().n;
 	expect(res).toBe("abc");
 });
+
+it("should not throw error when require in try catch", () => {
+	try {
+		let res = require("fail").a;
+	} catch (e) {}
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/full-require/warnings.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/full-require/warnings.js
@@ -1,0 +1,1 @@
+module.exports = [[/Can't resolve 'fail'/]];


### PR DESCRIPTION
## Summary


Related to comment in #5197, full rqeuire in try catch should be optional

## Test Plan

added

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
