### PR TITLE
feat(cli): support built-in rspack envs

### DIFF
--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import type { RspackCLI } from "../rspack-cli";
 import { RspackCommand } from "../types";
-import { commonOptions } from "../utils/options";
+import { commonOptions, setBuiltinEnvArg } from "../utils/options";
 import { MultiStats, Stats } from "@rspack/core";
 
 export class BuildCommand implements RspackCommand {
@@ -21,6 +21,15 @@ export class BuildCommand implements RspackCommand {
 					}
 				}),
 			async options => {
+				if (options.watch) {
+					// @ts-expect-error
+					setBuiltinEnvArg(options.env, "WATCH", true);
+				} else {
+					// @ts-expect-error
+					setBuiltinEnvArg(options.env, "BUNDLE", true);
+					// @ts-expect-error
+					setBuiltinEnvArg(options.env, "BUILD", true);
+				}
 				const logger = cli.getLogger();
 				let createJsonStringifyStream: typeof import("@discoveryjs/json-ext").stringifyStream;
 				if (options.json) {

--- a/packages/rspack-cli/src/commands/build.ts
+++ b/packages/rspack-cli/src/commands/build.ts
@@ -1,7 +1,11 @@
 import * as fs from "fs";
 import type { RspackCLI } from "../rspack-cli";
 import { RspackCommand } from "../types";
-import { commonOptions, setBuiltinEnvArg } from "../utils/options";
+import {
+	commonOptions,
+	ensureEnvObject,
+	setBuiltinEnvArg
+} from "../utils/options";
 import { MultiStats, Stats } from "@rspack/core";
 
 export class BuildCommand implements RspackCommand {
@@ -21,14 +25,12 @@ export class BuildCommand implements RspackCommand {
 					}
 				}),
 			async options => {
+				const env = ensureEnvObject(options);
 				if (options.watch) {
-					// @ts-expect-error
-					setBuiltinEnvArg(options.env, "WATCH", true);
+					setBuiltinEnvArg(env, "WATCH", true);
 				} else {
-					// @ts-expect-error
-					setBuiltinEnvArg(options.env, "BUNDLE", true);
-					// @ts-expect-error
-					setBuiltinEnvArg(options.env, "BUILD", true);
+					setBuiltinEnvArg(env, "BUNDLE", true);
+					setBuiltinEnvArg(env, "BUILD", true);
 				}
 				const logger = cli.getLogger();
 				let createJsonStringifyStream: typeof import("@discoveryjs/json-ext").stringifyStream;

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -1,7 +1,11 @@
 import type { RspackCLI } from "../rspack-cli";
 import { RspackDevServer } from "@rspack/dev-server";
 import { RspackCommand } from "../types";
-import { commonOptions, setBuiltinEnvArg } from "../utils/options";
+import {
+	commonOptions,
+	ensureEnvObject,
+	setBuiltinEnvArg
+} from "../utils/options";
 import { Compiler, DevServer } from "@rspack/core";
 
 export class ServeCommand implements RspackCommand {
@@ -11,8 +15,7 @@ export class ServeCommand implements RspackCommand {
 			"run the rspack dev server.",
 			commonOptions,
 			async options => {
-				// @ts-expect-error
-				setBuiltinEnvArg(options.env, "SERVE", true);
+				setBuiltinEnvArg(ensureEnvObject(options), "SERVE", true);
 				const rspackOptions = {
 					...options,
 					argv: {

--- a/packages/rspack-cli/src/commands/serve.ts
+++ b/packages/rspack-cli/src/commands/serve.ts
@@ -1,7 +1,7 @@
 import type { RspackCLI } from "../rspack-cli";
 import { RspackDevServer } from "@rspack/dev-server";
 import { RspackCommand } from "../types";
-import { commonOptions } from "../utils/options";
+import { commonOptions, setBuiltinEnvArg } from "../utils/options";
 import { Compiler, DevServer } from "@rspack/core";
 
 export class ServeCommand implements RspackCommand {
@@ -11,6 +11,8 @@ export class ServeCommand implements RspackCommand {
 			"run the rspack dev server.",
 			commonOptions,
 			async options => {
+				// @ts-expect-error
+				setBuiltinEnvArg(options.env, "SERVE", true);
 				const rspackOptions = {
 					...options,
 					argv: {

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -162,7 +162,7 @@ export function ensureEnvObject<T extends Record<string, unknown>>(
 	options: yargs.Arguments
 ): T {
 	if (Array.isArray(options.env)) {
-		// for cases that cli haven't haven `normalizeEnv` middleware applied
+		// in case that cli haven't got `normalizeEnv` middleware applied
 		normalizeEnv(options);
 	}
 	options.env = options.env || {};

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -129,3 +129,27 @@ export function normalizeEnv(argv: yargs.Arguments) {
 	const envObj = ((argv.env as string[]) ?? []).reduce(parseValue, {});
 	argv.env = envObj;
 }
+
+/**
+ * set builtin env from cli - like `WEBPACK_BUNDLE=true`. also for `RSPACK_` prefixed.
+ * @param env the `argv.env` object
+ * @param envNameSuffix the added env will be `WEBPACK_${envNameSuffix}` and `RSPACK_${envNameSuffix}`
+ * @param value
+ */
+export function setBuiltinEnvArg(
+	env: Record<string, any>,
+	envNameSuffix: string,
+	value: any
+) {
+	const envNames = [
+		// TODO: breaking change, we could bring it in 0.5
+		// `WEBPACK_${envNameSuffix}`,
+		`RSPACK_${envNameSuffix}`
+	];
+	for (const envName of envNames) {
+		if (envName in env) {
+			continue;
+		}
+		env[envName] = value;
+	}
+}

--- a/packages/rspack-cli/src/utils/options.ts
+++ b/packages/rspack-cli/src/utils/options.ts
@@ -142,7 +142,7 @@ export function setBuiltinEnvArg(
 	value: any
 ) {
 	const envNames = [
-		// TODO: breaking change, we could bring it in 0.5
+		// TODO: breaking change
 		// `WEBPACK_${envNameSuffix}`,
 		`RSPACK_${envNameSuffix}`
 	];
@@ -152,4 +152,19 @@ export function setBuiltinEnvArg(
 		}
 		env[envName] = value;
 	}
+}
+
+/**
+ * infer `argv.env` as an object for it was transformed from array to object after `normalizeEnv` middleware
+ * @returns the reference of `argv.env` object
+ */
+export function ensureEnvObject<T extends Record<string, unknown>>(
+	options: yargs.Arguments
+): T {
+	if (Array.isArray(options.env)) {
+		// for cases that cli haven't haven `normalizeEnv` middleware applied
+		normalizeEnv(options);
+	}
+	options.env = options.env || {};
+	return options.env as T;
 }

--- a/packages/rspack-cli/tests/build/basic/basic.test.ts
+++ b/packages/rspack-cli/tests/build/basic/basic.test.ts
@@ -1,4 +1,4 @@
-import { readFile, run } from "../../utils/test-utils";
+import { readFile, run, runWatch } from "../../utils/test-utils";
 import { resolve } from "path";
 
 describe("build command", () => {
@@ -26,6 +26,26 @@ describe("build command", () => {
 		expect(exitCode).toBe(0);
 		expect(stderr).toBeFalsy();
 		expect(stdout).toBeTruthy();
+	});
+	it("should pass env.RSPACK_BUILD and env.RSPACK_BUNDLE for function configuration on build mode", async () => {
+		const { stdout } = await run(__dirname, ["--config", "./entry.env.js"]);
+		expect(stdout).toContain("RSPACK_BUILD=true");
+		expect(stdout).toContain("RSPACK_BUNDLE=true");
+		expect(stdout).not.toContain("RSPACK_WATCH=true");
+	});
+
+	it("should pass env.RSPACK_WATCH for function configuration on watch mode", async () => {
+		const { stdout } = await runWatch(
+			__dirname,
+			["--watch", "--config", "./entry.env.js"],
+			{
+				// `Rspack compiled successfully` or `Rspack compiled with 1 error`
+				killString: /rspack compiled/i
+			}
+		);
+		expect(stdout).not.toContain("RSPACK_BUILD=true");
+		expect(stdout).not.toContain("RSPACK_BUNDLE=true");
+		expect(stdout).toContain("RSPACK_WATCH=true");
 	});
 	it("should work with configuration return promise", async () => {
 		const { exitCode, stderr, stdout } = await run(__dirname, [

--- a/packages/rspack-cli/tests/build/basic/entry.env.js
+++ b/packages/rspack-cli/tests/build/basic/entry.env.js
@@ -1,0 +1,11 @@
+module.exports = function (env) {
+	console.log(
+		["RSPACK_BUNDLE", "RSPACK_BUILD", "RSPACK_WATCH"]
+			.map(key => `${key}=${env[key]}`)
+			.join("\n")
+	);
+	return {
+		mode: "development",
+		entry: "./src/entry.js"
+	};
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

### 1. tell the end devs they are using rspack

for sharing configuration file between rspack and webpack.

for instance:

```js
// rspack.config.js
module.exports = function(env) {
  /** align with webpack's WEBPACK_BUNDLE @{link https://github.com/webpack/webpack-cli/blob/eea6adf7d34dfbfd3b5b784ece4a4664834f5a6a/packages/webpack-cli/src/webpack-cli.ts#L2500-L2503} */
  const isRspack = env.RSPACK_BUNDLE;
  const config = {};
  if (isRspack) {
    config.experiments.rspackFuture = {
      newTreeShaking: true
    };
  }
  return config;
}
```

i'm also going to add `WEBPACK_` prefixed builtin env in 0.5.0.

### ~2. tell the plugin devs they are using rspack~

the plugin dev can separately introduce different logics for rspack and webpack.

for instance:

```js
const plugin = {
  apply(compiler) {
    const { isRspack } = compiler;
    if (isRspack) {
      // do something special
    }
  }
}
```

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
