### PR TITLE
fix: `succeedModule` should not panic

### DIFF
--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -5,6 +5,7 @@ use rspack_core::Module;
 use super::{JsCompatSource, ToJsCompatSource};
 use crate::JsCodegenerationResults;
 
+#[derive(Default)]
 #[napi(object)]
 pub struct JsModule {
   pub context: Option<String>,
@@ -71,7 +72,14 @@ impl ToJsModule for dyn Module + '_ {
           name_for_condition: name_for_condition(),
         })
       })
-      .map_err(|_| napi::Error::from_reason("Failed to convert module to JsModule"))
+      .or_else(|_| {
+        Ok(JsModule {
+          context: context(),
+          module_identifier: module_identifier(),
+          name_for_condition: name_for_condition(),
+          ..Default::default()
+        })
+      })
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

THIS PR is used only to make `succeedModule` and other module related hooks not being panicked at runtime. We haven't decided whether to keep this hook for performance reason.

closes https://github.com/web-infra-dev/rspack/issues/5054

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

Not for now.

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [X] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
