### PR TITLE
fix: cjs module reexport unused error

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -132,7 +132,7 @@ impl DependencyTemplate for CommonJsExportRequireDependency {
             0
           )
         ),
-        None => "/* unused reexport */ ".to_string(),
+        None => "/* unused reexport */ var __webpack_unused_export__".to_string(),
       };
       source.replace(self.range.0, self.range.1, expr.as_str(), None)
     } else if self.base.is_define_property() {

--- a/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/a.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/b.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/b.js
@@ -1,0 +1,1 @@
+module.exports = "b";

--- a/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/index.js
@@ -1,0 +1,3 @@
+import "./reexport";
+
+it("should run", () => {});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/reexport.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/reexport.js
@@ -1,0 +1,3 @@
+require("./a");
+
+module.exports = require("./b");

--- a/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/webpack.config.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/issue-5282/webpack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	mode: "production",
+	optimization: {
+		minimize: false,
+		moduleIds: "named"
+	},
+	experiments: {
+		rspackFuture: {
+			newTreeshaking: true
+		}
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #5282

## Test Plan

- Add `packages/rspack/tests/cases/cjs-tree-shaking/issue-5282`

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
