### PR TITLE
chore: add link to rspack-contrib/rspack-examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,13 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 ## Links
 
-| Name                                                                                    | Description                                                                 |
-| --------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [Rspack website](https://rspack.dev)                                                    | Official documentation for Rspack                                           |
-| [Rspack website repo](https://github.com/web-infra-dev/rspack-website)                  | Repository of official documentation                                        |
-| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                       | Rusty [webpack-sources](https://www.npmjs.com/package/webpack-sources) port |
-| [rspack-migration-showcase](https://github.com/web-infra-dev/rspack-migration-showcase) | Migration showcases for Rspack                                              |
+| Name                                                                                    | Description                                                                   |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [Rspack website](https://rspack.dev)                                                    | Official documentation for Rspack                                             |
+| [Rspack website repo](https://github.com/web-infra-dev/rspack-website)                  | Repository of official documentation                                          |
+| [Rspack examples repo](https://github.com/rspack-contrib/rspack-examples)               | Rspack configuration examples                                                 |
+| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                       | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
+| [rspack-migration-showcase](https://github.com/web-infra-dev/rspack-migration-showcase) | Migration showcases for Rspack                                                |
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,7 @@
 | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
 | [Rspack 文档](https://rspack.dev)                                                       | Rspack 官方文档                                                              |
 | [Rspack 文档仓库](https://github.com/web-infra-dev/rspack-website)                      | Rspack 官方文档的代码仓库                                                    |
+| [Rspack examples repo](https://github.com/rspack-contrib/rspack-examples)               | Rspack 配置示例                                                              |
 | [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                       | Rust 版本的 [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
 | [rspack-migration-showcase](https://github.com/web-infra-dev/rspack-migration-showcase) | 迁移到 Rspack 的示例项目                                                     |
 


### PR DESCRIPTION
## Summary

Part of https://github.com/web-infra-dev/rspack/issues/5295

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
