### PR TITLE
fix: module graph incorrect when delete or create file

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -148,7 +148,7 @@ impl rspack_core::Plugin for JsHooksAdapter {
     &self,
     _ctx: rspack_core::PluginContext,
     _compilation: &mut rspack_core::Compilation,
-    _param: &mut rspack_core::MakeParam,
+    _params: &mut Vec<rspack_core::MakeParam>,
   ) -> rspack_core::PluginMakeHookOutput {
     if self.is_hook_disabled(&Hook::Make) {
       return Ok(());

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -10,20 +10,16 @@ pub use rebuild_deps_builder::RebuildDepsBuilder;
 #[derive(Debug)]
 pub enum MakeParam {
   ModifiedFiles(HashSet<PathBuf>),
+  DeletedFiles(HashSet<PathBuf>),
   ForceBuildDeps(HashSet<BuildDependency>),
   ForceBuildModules(HashSet<ModuleIdentifier>),
 }
 
 impl MakeParam {
-  pub fn add_force_build_dependency(
-    &mut self,
-    dep: DependencyId,
-    module: Option<ModuleIdentifier>,
-  ) -> bool {
-    match self {
-      MakeParam::ForceBuildDeps(set) => set.insert((dep, module)),
-      _ => false,
-    }
+  pub fn new_force_build_dep_param(dep: DependencyId, module: Option<ModuleIdentifier>) -> Self {
+    let mut data = HashSet::default();
+    data.insert((dep, module));
+    Self::ForceBuildDeps(data)
   }
 }
 

--- a/crates/rspack_core/src/compiler/make/rebuild_deps_builder.rs
+++ b/crates/rspack_core/src/compiler/make/rebuild_deps_builder.rs
@@ -27,6 +27,25 @@ impl RebuildDepsBuilder {
             }
           }))
         }
+        MakeParam::DeletedFiles(files) => {
+          builder.extend_force_build_modules(module_graph.modules().values().flat_map(|module| {
+            let mut res: Vec<ModuleIdentifier> = vec![];
+
+            // check has dependencies modified
+            if module_graph.has_dependencies(&module.identifier(), &files) {
+              // module id
+              res.push(module.identifier());
+              // parent module id
+              res.extend(
+                module_graph
+                  .get_incoming_connections(module)
+                  .iter()
+                  .filter_map(|connect| connect.original_module_identifier),
+              )
+            }
+            res
+          }))
+        }
         MakeParam::ForceBuildDeps(deps) => {
           builder.extend_force_build_deps(module_graph, deps);
         }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -111,7 +111,7 @@ where
     );
 
     self
-      .compile(MakeParam::ForceBuildDeps(Default::default()))
+      .compile(vec![MakeParam::ForceBuildDeps(Default::default())])
       .await?;
     self.cache.begin_idle();
     self.compile_done().await?;
@@ -119,7 +119,7 @@ where
   }
 
   #[instrument(name = "compile", skip_all)]
-  async fn compile(&mut self, params: MakeParam) -> Result<()> {
+  async fn compile(&mut self, params: Vec<MakeParam>) -> Result<()> {
     let compilation_params = self.new_compilation_params();
     self
       .plugin_driver

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -80,7 +80,7 @@ pub trait Plugin: Debug + Send + Sync {
     &self,
     _ctx: PluginContext,
     _compilation: &mut Compilation,
-    _param: &mut MakeParam,
+    _params: &mut Vec<MakeParam>,
   ) -> PluginMakeHookOutput {
     Ok(())
   }

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -541,11 +541,11 @@ impl PluginDriver {
   pub async fn make(
     &self,
     compilation: &mut Compilation,
-    param: &mut MakeParam,
+    params: &mut Vec<MakeParam>,
   ) -> PluginMakeHookOutput {
     for plugin in &self.plugins {
       plugin
-        .make(PluginContext::new(), compilation, param)
+        .make(PluginContext::new(), compilation, params)
         .await?;
     }
     Ok(())

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -40,7 +40,7 @@ impl Plugin for EntryPlugin {
     &self,
     _ctx: PluginContext,
     compilation: &mut Compilation,
-    param: &mut MakeParam,
+    params: &mut Vec<MakeParam>,
   ) -> PluginMakeHookOutput {
     if let Some(state) = compilation.options.get_incremental_rebuild_make_state()
       && !state.is_first()
@@ -53,7 +53,8 @@ impl Plugin for EntryPlugin {
     ));
     let dependency_id = *dependency.id();
     compilation.add_entry(dependency, self.options.clone())?;
-    param.add_force_build_dependency(dependency_id, None);
+
+    params.push(MakeParam::new_force_build_dep_param(dependency_id, None));
     Ok(())
   }
 }

--- a/crates/rspack_plugin_mf/src/container/container_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_plugin.rs
@@ -69,7 +69,7 @@ impl Plugin for ContainerPlugin {
     &self,
     _ctx: PluginContext,
     compilation: &mut Compilation,
-    param: &mut MakeParam,
+    params: &mut Vec<MakeParam>,
   ) -> PluginMakeHookOutput {
     let dep = ContainerEntryDependency::new(
       self.options.name.clone(),
@@ -87,7 +87,8 @@ impl Plugin for ContainerPlugin {
         ..Default::default()
       },
     )?;
-    param.add_force_build_dependency(dependency_id, None);
+
+    params.push(MakeParam::new_force_build_dep_param(dependency_id, None));
     Ok(())
   }
 

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -154,7 +154,7 @@ impl Plugin for ProgressPlugin {
     &self,
     _ctx: PluginContext,
     _compilation: &mut Compilation,
-    _param: &mut MakeParam,
+    _params: &mut Vec<MakeParam>,
   ) -> PluginMakeHookOutput {
     if !self.options.profile {
       self.progress_bar.reset();

--- a/packages/playground/cases/css/chunk-loading-order/rspack.config.js
+++ b/packages/playground/cases/css/chunk-loading-order/rspack.config.js
@@ -7,7 +7,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	plugins: [new rspack.HtmlRspackPlugin()],
 	watchOptions: {

--- a/packages/playground/cases/css/css-filename/rspack.config.js
+++ b/packages/playground/cases/css/css-filename/rspack.config.js
@@ -12,7 +12,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/css/import-double-css-files-with-empty/rspack.config.js
+++ b/packages/playground/cases/css/import-double-css-files-with-empty/rspack.config.js
@@ -8,7 +8,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/css/import-empty-css-file/rspack.config.js
+++ b/packages/playground/cases/css/import-empty-css-file/rspack.config.js
@@ -8,7 +8,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/css/render-to-body/rspack.config.js
+++ b/packages/playground/cases/css/render-to-body/rspack.config.js
@@ -8,7 +8,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/file/context-delete-file/rspack.config.js
+++ b/packages/playground/cases/file/context-delete-file/rspack.config.js
@@ -9,7 +9,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/file/missing-files/index.test.ts
+++ b/packages/playground/cases/file/missing-files/index.test.ts
@@ -4,38 +4,37 @@ test("missing files should be able to recover if being added back", async ({
 	page,
 	fileAction
 }) => {
-	return;
-	// let overlay = page.frameLocator("#webpack-dev-server-client-overlay");
-	// await expect(
-	// 	overlay.getByText("Can't resolve './missing-file-1'")
-	// ).toBeVisible();
-	// await expect(
-	// 	overlay.getByText("Can't resolve './missing-file-2'")
-	// ).toBeVisible();
+	let overlay = page.frameLocator("#webpack-dev-server-client-overlay");
+	await expect(
+		overlay.getByText("Can't resolve './missing-file-1'")
+	).toBeVisible();
+	await expect(
+		overlay.getByText("Can't resolve './missing-file-2'")
+	).toBeVisible();
 
-	// fileAction.updateFile(
-	// 	"src/missing-file-1.js",
-	// 	() => "export const a = 'missing-file-1'"
-	// );
+	fileAction.updateFile(
+		"src/missing-file-1.js",
+		() => "export const a = 'missing-file-1'"
+	);
 
-	// fileAction.updateFile(
-	// 	"src/missing-file-2.js",
-	// 	() => "export const b = 'missing-file-2'"
-	// );
+	fileAction.updateFile(
+		"src/missing-file-2.js",
+		() => "export const b = 'missing-file-2'"
+	);
 
-	// await expect(page.locator("#missing-file-1")).toHaveText("missing-file-1");
-	// await expect(page.locator("#missing-file-2")).toHaveText("missing-file-2");
+	await expect(page.locator("#missing-file-1")).toHaveText("missing-file-1");
+	await expect(page.locator("#missing-file-2")).toHaveText("missing-file-2");
 
-	// fileAction.deleteFile("src/missing-file-1.js");
+	fileAction.deleteFile("src/missing-file-1.js");
 
-	// await expect(
-	// 	overlay.getByText("Can't resolve './missing-file-1'")
-	// ).toBeVisible();
+	await expect(
+		overlay.getByText("Can't resolve './missing-file-1'")
+	).toBeVisible();
 
-	// fileAction.updateFile(
-	// 	"src/missing-file-1.js",
-	// 	() => "export const a = 'missing-file-1'"
-	// );
+	fileAction.updateFile(
+		"src/missing-file-1.js",
+		() => "export const a = 'missing-file-1'"
+	);
 
-	// await expect(page.locator("#missing-file-1")).toHaveText("missing-file-1");
+	await expect(page.locator("#missing-file-1")).toHaveText("missing-file-1");
 });

--- a/packages/playground/cases/file/missing-files/rspack.config.js
+++ b/packages/playground/cases/file/missing-files/rspack.config.js
@@ -1,3 +1,5 @@
+const { rspack } = require("@rspack/core");
+
 module.exports = {
 	context: __dirname,
 	mode: "development",
@@ -7,18 +9,15 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false
 	},
-	builtins: {
-		html: [
-			{
-				template: "./src/index.html"
-			}
-		]
-	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./src/index.html"
+		})
+	],
 	watchOptions: {
 		poll: 1000
 	}

--- a/packages/playground/cases/react/basic/rspack.config.js
+++ b/packages/playground/cases/react/basic/rspack.config.js
@@ -42,7 +42,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/react/class-component/rspack.config.js
+++ b/packages/playground/cases/react/class-component/rspack.config.js
@@ -41,7 +41,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/react/with-babel/rspack.config.js
+++ b/packages/playground/cases/react/with-babel/rspack.config.js
@@ -51,7 +51,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/react/worker/rspack.config.js
+++ b/packages/playground/cases/react/worker/rspack.config.js
@@ -41,7 +41,6 @@ module.exports = {
 	devServer: {
 		hot: true
 	},
-	cache: false,
 	stats: "none",
 	infrastructureLogging: {
 		debug: false

--- a/packages/playground/cases/vue3/rspack.config.js
+++ b/packages/playground/cases/vue3/rspack.config.js
@@ -44,7 +44,6 @@ module.exports = {
 			}
 		]
 	},
-	cache: false,
 	stats: "errors-warnings",
 	infrastructureLogging: {
 		debug: false


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR fix the module graph incorrect when delete or create file. There are some summary:

* Add parent module to `force_build_module` when module factorize failed instead of add deps to `force_build_deps`. if the module is entry module, we should still add deps to `force_build_deps`, because of it no parent module.
* Deleting the file should not only mark the affected module as `force_build_module` but also add its parent module to `force_build_module`

We can see a simply example:
``` js
// index.js
import a form "./a" // <-- HarmonyImportSideEffectDependency
console.log(a) // <-- HarmonyImportSpecifierDependency
```
the `index.js` have two deps `HarmonyImportSideEffectDependency` and `HarmonyImportSpecifierDependency` . 

If we don't have `a.js` and create it, we should not only create the module for `a.js` in HMR but also recreate `index.js` to make sure all dependencies are correct
if we have `a.js` and delete it, we should not only delete the module for `a.js` in HMR but also recreate `index.js` to make sure all dependencies are correct



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

* enable missing file e2e test

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
