### PR TITLE
chore: turn off `--bail` `--forceExit` `--logHeapUsage` from webpack test

### DIFF
--- a/webpack-test/jest.config.js
+++ b/webpack-test/jest.config.js
@@ -1,5 +1,5 @@
 module.exports =  {
-    "forceExit": true,
+    "forceExit": false,
     "setupFiles": [
       "<rootDir>/setupEnv.js"
     ],

--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "main": "./dist/index.d.ts",
   "scripts": {
-    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest  --logHeapUsage --bail --forceExit",
-    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --bail --forceExit --json | node scripts/test-metric.js",
-    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096  --trace-deprecation\" jest --logHeapUsage --bail --json --forceExit"
+    "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest",
+    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --json | node scripts/test-metric.js",
+    "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --logHeapUsage --json"
   },
   "files": [
     "dist"


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

For targeting 1.0, I think we should make the test suite as stable as possible.

## Test Plan

I tried a local debug build and it ran successfully.

