### PR TITLE
chore: upgrade Rust to v1.75.0 (nightly)

### DIFF
--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -1561,8 +1561,7 @@ fn is_js_like_uri(uri: &str) -> bool {
   fn resolve_module_type_by_uri(uri: &str) -> Option<ModuleType> {
     let uri = std::path::Path::new(uri);
     let ext = uri.extension()?.to_str()?;
-    let module_type: Option<ModuleType> = ext.try_into().ok();
-    module_type
+    Some(ModuleType::from(ext))
   }
   match resolve_module_type_by_uri(uri) {
     Some(module_type) => matches!(

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -418,8 +418,9 @@ impl CopyRspackPlugin {
           .collect();
 
         if need_add_context_to_dependency
-          && let Some(common_dir) =
-            get_closest_common_parent_dir(&entries.iter().map(|it| it.as_path()).collect())
+          && let Some(common_dir) = get_closest_common_parent_dir(
+            &entries.iter().map(|it| it.as_path()).collect::<Vec<_>>(),
+          )
         {
           context_dependencies.insert(common_dir);
         }
@@ -602,7 +603,7 @@ impl Plugin for CopyRspackPlugin {
   }
 }
 
-fn get_closest_common_parent_dir(paths: &Vec<&Path>) -> Option<PathBuf> {
+fn get_closest_common_parent_dir(paths: &[&Path]) -> Option<PathBuf> {
   // If there are no matching files, return `None`.
   if paths.is_empty() {
     return None;

--- a/crates/rspack_plugin_javascript/src/lib.rs
+++ b/crates/rspack_plugin_javascript/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(result_option_inspect)]
 #![feature(option_get_or_insert_default)]
 #![feature(if_let_guard)]
 #![feature(let_chains)]

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -318,7 +318,7 @@ impl Plugin for AssignLibraryPlugin {
   }
 }
 
-fn access_with_init(accessor: &Vec<String>, existing_length: usize, init_last: bool) -> String {
+fn access_with_init(accessor: &[String], existing_length: usize, init_last: bool) -> String {
   let base = accessor[0].clone();
   if accessor.len() == 1 && !init_last {
     return base;

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -327,7 +327,7 @@ fn accessor_to_object_access<S: AsRef<str>>(accessor: impl IntoIterator<Item = S
     .join("")
 }
 
-fn accessor_access(base: Option<&str>, accessor: &Vec<String>) -> String {
+fn accessor_access(base: Option<&str>, accessor: &[String]) -> String {
   accessor
     .iter()
     .enumerate()

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -309,7 +309,7 @@ where
   format!("\" + {content} + \"")
 }
 
-pub fn stringify_static_chunk_map(filename: &String, chunk_ids: &Vec<&String>) -> String {
+pub fn stringify_static_chunk_map(filename: &String, chunk_ids: &[&String]) -> String {
   let condition = if chunk_ids.len() == 1 {
     format!(
       "chunkId === {}",

--- a/crates/rspack_testing/src/test_config.rs
+++ b/crates/rspack_testing/src/test_config.rs
@@ -329,22 +329,16 @@ impl TestConfig {
       rule!("\\.css$", "css"),
       rule!("\\.wasm$", "webassembly/async"),
     ];
-    rules.extend(self.module.rules.into_iter().map(|rule| {
-      c::ModuleRule {
-        test: rule.test.map(|test| match test {
-          ModuleRuleTest::Regexp { matcher } => {
-            c::RuleSetCondition::Regexp(RspackRegex::new(&matcher).expect("should be valid regex"))
-          }
-        }),
-        r#use: c::ModuleRuleUse::Array(
-          rule.r#use.into_iter().map(|i| i.into()).collect::<Vec<_>>(),
-        ),
-        side_effects: rule.side_effect,
-        r#type: rule
-          .r#type
-          .map(|i| ModuleType::try_from(i.as_str()).expect("should give a right module_type")),
-        ..Default::default()
-      }
+    rules.extend(self.module.rules.into_iter().map(|rule| c::ModuleRule {
+      test: rule.test.map(|test| match test {
+        ModuleRuleTest::Regexp { matcher } => {
+          c::RuleSetCondition::Regexp(RspackRegex::new(&matcher).expect("should be valid regex"))
+        }
+      }),
+      r#use: c::ModuleRuleUse::Array(rule.r#use.into_iter().map(|i| i.into()).collect::<Vec<_>>()),
+      side_effects: rule.side_effect,
+      r#type: rule.r#type.map(|i| ModuleType::from(i.as_str())),
+      ..Default::default()
     }));
 
     assert!(context.is_absolute());

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 profile = "default"
 # Use nightly for better access to the latest Rust features.
 # This date is aligned to stable release dates.
-channel = "nightly-2023-10-24"
+channel = "nightly-2023-12-28" # v1.75.0


### PR DESCRIPTION
## Summary

Upgrade to the latest Rust v1.75.0 release https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html

