### PR TITLE
refactor: traceable magic comments warnings

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use rspack_core::{
   clean_regexp_in_context_module, context_reg_exp, AsyncDependenciesBlock, DependencyLocation,
   DynamicImportMode, ErrorSpan, GroupOptions, JavascriptParserOptions, ModuleIdentifier,
@@ -7,7 +9,7 @@ use rspack_core::{ContextNameSpaceObject, ContextOptions, DependencyCategory, Sp
 use rspack_error::miette::Diagnostic;
 use rspack_regex::{regexp_as_str, RspackRegex};
 use swc_core::common::comments::Comments;
-use swc_core::common::Spanned;
+use swc_core::common::{SourceFile, Spanned};
 use swc_core::ecma::ast::{CallExpr, Callee, Expr, Lit};
 use swc_core::ecma::atoms::JsWord;
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
@@ -21,7 +23,8 @@ use crate::utils::{get_bool_by_obj_prop, get_literal_str_by_obj_prop, get_regex_
 use crate::webpack_comment::try_extract_webpack_magic_comment;
 
 pub struct ImportScanner<'a> {
-  module_identifier: ModuleIdentifier,
+  pub source_file: Arc<SourceFile>,
+  pub module_identifier: ModuleIdentifier,
   pub dependencies: &'a mut Vec<BoxDependency>,
   pub blocks: &'a mut Vec<AsyncDependenciesBlock>,
   pub comments: Option<&'a dyn Comments>,
@@ -111,6 +114,7 @@ fn create_import_meta_context_dependency(node: &CallExpr) -> Option<ImportMetaCo
 impl<'a> ImportScanner<'a> {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
+    source_file: Arc<SourceFile>,
     module_identifier: ModuleIdentifier,
     dependencies: &'a mut Vec<BoxDependency>,
     blocks: &'a mut Vec<AsyncDependenciesBlock>,
@@ -121,6 +125,7 @@ impl<'a> ImportScanner<'a> {
     ignored: &'a mut Vec<DependencyLocation>,
   ) -> Self {
     Self {
+      source_file,
       module_identifier,
       dependencies,
       blocks,
@@ -188,7 +193,9 @@ impl Visit for ImportScanner<'_> {
           return;
         }
         let magic_comment_options = try_extract_webpack_magic_comment(
+          &self.source_file,
           &self.comments,
+          node.span,
           imported.span,
           self.warning_diagnostics,
         );
@@ -230,8 +237,13 @@ impl Visit for ImportScanner<'_> {
         self.blocks.push(block);
       }
       Expr::Tpl(tpl) if tpl.quasis.len() == 1 => {
-        let magic_comment_options =
-          try_extract_webpack_magic_comment(&self.comments, tpl.span, self.warning_diagnostics);
+        let magic_comment_options = try_extract_webpack_magic_comment(
+          &self.source_file,
+          &self.comments,
+          node.span,
+          tpl.span,
+          self.warning_diagnostics,
+        );
         let chunk_name = magic_comment_options
           .get_webpack_chunk_name()
           .map(|x| x.to_owned());
@@ -275,7 +287,9 @@ impl Visit for ImportScanner<'_> {
           return;
         };
         let magic_comment_options = try_extract_webpack_magic_comment(
+          &self.source_file,
           &self.comments,
+          node.span,
           dyn_imported.span(),
           self.warning_diagnostics,
         );

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -97,7 +97,7 @@ pub fn scan_dependencies(
   // TODO it should enable at js/auto or js/dynamic, but builtins provider will inject require at esm
   // https://github.com/web-infra-dev/rspack/issues/3544
   program.visit_with(&mut CommonJsImportDependencyScanner::new(
-    source_file,
+    source_file.clone(),
     &mut dependencies,
     &mut presentational_dependencies,
     unresolved_ctxt,
@@ -239,6 +239,7 @@ pub fn scan_dependencies(
   }
 
   program.visit_with(&mut ImportScanner::new(
+    source_file.clone(),
     module_identifier,
     &mut dependencies,
     &mut blocks,

--- a/packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning/a.js
+++ b/packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning/a.js
@@ -1,0 +1,1 @@
+console.log(1);

--- a/packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning/index.js
+++ b/packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning/index.js
@@ -1,0 +1,4 @@
+import(/*
+  webpackPrefetch: "aaa",
+  webpackPreload: "aaa"
+*/'./a');

--- a/packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning/stats.err
+++ b/packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning/stats.err
@@ -1,0 +1,23 @@
+WARNING in ./index.js
+ModuleParseWarning
+
+  ⚠ Module parse warning:
+  ╰─▶   ⚠ Magic comments parse failed: `webpackPrefetch` expected true or a number, but received: "aaa".
+         ╭─[1:1]
+       1 │ ╭─▶ import(/*
+       2 │ │     webpackPrefetch: "aaa",
+       3 │ │     webpackPreload: "aaa"
+       4 │ ╰─▶ */ './a');
+         ╰────
+
+WARNING in ./index.js
+ModuleParseWarning
+
+  ⚠ Module parse warning:
+  ╰─▶   ⚠ Magic comments parse failed: `webpackPreload` expected true or a number, but received: "aaa".
+         ╭─[1:1]
+       1 │ ╭─▶ import(/*
+       2 │ │     webpackPrefetch: "aaa",
+       3 │ │     webpackPreload: "aaa"
+       4 │ ╰─▶ */ './a');
+         ╰────

--- a/packages/rspack/tests/diagnostics/module-parse-failed/non_support_warning/stats.err
+++ b/packages/rspack/tests/diagnostics/module-parse-failed/non_support_warning/stats.err
@@ -1,1 +1,0 @@
-ERROR in × Resolve error: Can't resolve './' in '<PROJECT_ROOT>/tests/diagnostics/module-parse-failed/non_support_warning'

--- a/packages/rspack/tests/diagnostics/module-parse-failed/non_support_warning/stats.err
+++ b/packages/rspack/tests/diagnostics/module-parse-failed/non_support_warning/stats.err
@@ -1,0 +1,1 @@
+ERROR in × Resolve error: Can't resolve './' in '<PROJECT_ROOT>/tests/diagnostics/module-parse-failed/non_support_warning'


### PR DESCRIPTION
## Summary

Make warnings of magic comments traceable

## Test Plan

- Add `packages/rspack/tests/diagnostics/module-parse-failed/magic_comment_warning`

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
