### PR TITLE
fix: tree shaking size differentiation between webpack

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -279,7 +279,7 @@ pub fn is_pure_expression<'a>(
     Expr::Call(call) => is_pure_call_expr(call, unresolved_ctxt, comments),
     _ => !expr.may_have_side_effects(&ExprCtx {
       unresolved_ctxt,
-      is_unresolved_ref_safe: false,
+      is_unresolved_ref_safe: true,
     }),
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. Part of https://github.com/web-infra-dev/rspack/issues/5317
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
