### PR TITLE
refactor: remove async dependencies block identifier

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -484,7 +484,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
     let blocks = &item
       .block
-      .expect_get(&self.compilation)
+      .expect_get(self.compilation)
       .get_blocks()
       .to_vec();
     for block in blocks {
@@ -757,7 +757,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       return modules.clone();
     }
     // dbg!(&module, &runtime);
-    self.extract_block_modules(*module.get_root_block(&self.compilation), runtime);
+    self.extract_block_modules(*module.get_root_block(self.compilation), runtime);
     self
       .block_modules_runtime_map
       .get(&runtime.cloned().into())

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -7,7 +7,7 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use super::remove_parent_modules::RemoveParentModulesContext;
 use crate::dependencies_block::AsyncDependenciesToInitialChunkError;
 use crate::{
-  get_entry_runtime, AsyncDependenciesBlockIdentifier, BoxDependency, ChunkGroup, ChunkGroupInfo,
+  get_entry_runtime, AsyncDependenciesBlockId, BoxDependency, ChunkGroup, ChunkGroupInfo,
   ChunkGroupKind, ChunkGroupOptions, ChunkGroupUkey, ChunkLoading, ChunkUkey, Compilation,
   ConnectionState, DependenciesBlock, Dependency, GroupOptions, Logger, ModuleGraphConnection,
   ModuleIdentifier, RuntimeSpec,
@@ -33,7 +33,7 @@ pub(super) struct CodeSplitter<'me> {
   queue_delayed: Vec<QueueAction>,
   queue_connect: HashMap<ChunkGroupUkey, HashSet<ChunkGroupUkey>>,
   outdated_chunk_group_info: HashSet<ChunkGroupUkey>,
-  block_chunk_groups: HashMap<AsyncDependenciesBlockIdentifier, ChunkGroupUkey>,
+  block_chunk_groups: HashMap<AsyncDependenciesBlockId, ChunkGroupUkey>,
   named_chunk_groups: HashMap<String, ChunkGroupUkey>,
   named_async_entrypoints: HashMap<String, ChunkGroupUkey>,
   block_modules_runtime_map: HashMap<
@@ -482,15 +482,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         }));
       }
     }
-    let blocks = self
-      .compilation
-      .module_graph
-      .block_by_id(&item.block)
-      .expect("should have block")
+    let blocks = &item
+      .block
+      .expect_get(&self.compilation)
       .get_blocks()
       .to_vec();
     for block in blocks {
-      self.iterator_block(block, item.chunk_group, item.chunk);
+      self.iterator_block(*block, item.chunk_group, item.chunk);
     }
   }
 
@@ -536,7 +534,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   fn iterator_block(
     &mut self,
-    block_id: AsyncDependenciesBlockIdentifier,
+    block_id: AsyncDependenciesBlockId,
     item_chunk_group_ukey: ChunkGroupUkey,
     item_chunk_ukey: ChunkUkey,
   ) {
@@ -759,12 +757,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       return modules.clone();
     }
     // dbg!(&module, &runtime);
-    self.extract_block_modules(
-      *module.get_root_block().expect(
-        "block_modules_map must not empty when calling get_block_modules(AsyncDependenciesBlock)",
-      ),
-      runtime,
-    );
+    self.extract_block_modules(*module.get_root_block(&self.compilation), runtime);
     self
       .block_modules_runtime_map
       .get(&runtime.cloned().into())
@@ -984,7 +977,7 @@ struct ProcessBlock {
 
 #[derive(Debug, Clone)]
 struct ProcessEntryBlock {
-  block: AsyncDependenciesBlockIdentifier,
+  block: AsyncDependenciesBlockId,
   chunk_group: ChunkGroupUkey,
   chunk: ChunkUkey,
 }
@@ -992,19 +985,20 @@ struct ProcessEntryBlock {
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 enum DependenciesBlockIdentifier {
   Module(ModuleIdentifier),
-  AsyncDependenciesBlock(AsyncDependenciesBlockIdentifier),
+  AsyncDependenciesBlock(AsyncDependenciesBlockId),
 }
 
 impl DependenciesBlockIdentifier {
-  // hack for webpack get_root_block, refer TODO: https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/buildChunkGraph.js#L222
-  pub fn get_root_block(&self) -> Option<&ModuleIdentifier> {
+  pub fn get_root_block<'a>(&'a self, compilation: &'a Compilation) -> &'a ModuleIdentifier {
     match self {
-      DependenciesBlockIdentifier::Module(m) => Some(m),
-      DependenciesBlockIdentifier::AsyncDependenciesBlock(ident) => Some(&ident.from),
+      DependenciesBlockIdentifier::Module(m) => m,
+      DependenciesBlockIdentifier::AsyncDependenciesBlock(id) => {
+        id.expect_get(compilation).parent()
+      }
     }
   }
 
-  pub fn get_blocks(&self, compilation: &Compilation) -> Vec<AsyncDependenciesBlockIdentifier> {
+  pub fn get_blocks(&self, compilation: &Compilation) -> Vec<AsyncDependenciesBlockId> {
     match self {
       DependenciesBlockIdentifier::Module(m) => compilation
         .module_graph
@@ -1028,8 +1022,8 @@ impl From<ModuleIdentifier> for DependenciesBlockIdentifier {
   }
 }
 
-impl From<AsyncDependenciesBlockIdentifier> for DependenciesBlockIdentifier {
-  fn from(value: AsyncDependenciesBlockIdentifier) -> Self {
+impl From<AsyncDependenciesBlockId> for DependenciesBlockIdentifier {
+  fn from(value: AsyncDependenciesBlockId) -> Self {
     Self::AsyncDependenciesBlock(value)
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -10,7 +10,7 @@ use rustc_hash::FxHashSet as HashSet;
 use crate::update_hash::{UpdateHashContext, UpdateRspackHash};
 use crate::ChunkGraph;
 use crate::{
-  get_chunk_group_from_ukey, AsyncDependenciesBlockIdentifier, BoxModule, ChunkByUkey, ChunkGroup,
+  get_chunk_group_from_ukey, AsyncDependenciesBlockId, BoxModule, ChunkByUkey, ChunkGroup,
   ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, ExportsHash, ModuleIdentifier,
   RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, RuntimeSpecSet,
 };
@@ -149,7 +149,7 @@ impl ChunkGraph {
 
   pub fn get_block_chunk_group<'a>(
     &self,
-    block: &AsyncDependenciesBlockIdentifier,
+    block: &AsyncDependenciesBlockId,
     chunk_group_by_ukey: &'a ChunkGroupByUkey,
   ) -> Option<&'a ChunkGroup> {
     self
@@ -160,7 +160,7 @@ impl ChunkGraph {
 
   pub fn connect_block_and_chunk_group(
     &mut self,
-    block: AsyncDependenciesBlockIdentifier,
+    block: AsyncDependenciesBlockId,
     chunk_group: ChunkGroupUkey,
   ) {
     self.block_to_chunk_group_ukey.insert(block, chunk_group);

--- a/crates/rspack_core/src/chunk_graph/mod.rs
+++ b/crates/rspack_core/src/chunk_graph/mod.rs
@@ -1,7 +1,7 @@
 use rspack_identifier::IdentifierMap;
 use rustc_hash::FxHashMap as HashMap;
 
-use crate::AsyncDependenciesBlockIdentifier;
+use crate::AsyncDependenciesBlockId;
 use crate::{ChunkGroupUkey, ChunkUkey};
 
 pub mod chunk_graph_chunk;
@@ -15,7 +15,7 @@ pub struct ChunkGraph {
   pub split_point_module_identifier_to_chunk_ukey: IdentifierMap<ChunkUkey>,
 
   /// If a module is imported dynamically, it will be assigned to a unique ChunkGroup
-  pub(crate) block_to_chunk_group_ukey: HashMap<AsyncDependenciesBlockIdentifier, ChunkGroupUkey>,
+  pub(crate) block_to_chunk_group_ukey: HashMap<AsyncDependenciesBlockId, ChunkGroupUkey>,
 
   pub chunk_graph_module_by_module_identifier: IdentifierMap<ChunkGraphModule>,
   chunk_graph_chunk_by_chunk_ukey: HashMap<ChunkUkey, ChunkGraphChunk>,

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -876,14 +876,14 @@ impl Compilation {
                     module_graph.set_parents(
                       dependency_id,
                       DependencyParents {
-                        block: current_block.as_ref().map(|block| block.identifier()),
+                        block: current_block.as_ref().map(|block| block.id()),
                         module: module.identifier(),
                       },
                     );
                     module_graph.add_dependency(dependency);
                   }
                   if let Some(current_block) = current_block {
-                    module.add_block_id(current_block.identifier());
+                    module.add_block_id(current_block.id());
                     module_graph.add_block(current_block);
                   }
                   for block in blocks {

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -20,11 +20,11 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
   block_promise, contextify, get_exports_type_with_strict, impl_build_info_meta,
-  returning_function, stringify_map, to_path, AsyncDependenciesBlock,
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  ChunkGraph, ChunkGroupOptions, CodeGenerationResult, Compilation, ContextElementDependency,
-  DependenciesBlock, DependencyCategory, DependencyId, ExportsType, FakeNamespaceObjectMode,
-  GroupOptions, LibIdentOptions, Module, ModuleType, Resolve, ResolveInnerOptions,
+  returning_function, stringify_map, to_path, AsyncDependenciesBlock, AsyncDependenciesBlockId,
+  BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph, ChunkGroupOptions,
+  CodeGenerationResult, Compilation, ContextElementDependency, DependenciesBlock,
+  DependencyCategory, DependencyId, ExportsType, FakeNamespaceObjectMode, GroupOptions,
+  LibIdentOptions, Module, ModuleType, Resolve, ResolveInnerOptions,
   ResolveOptionsWithDependencyType, ResolverFactory, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
@@ -187,7 +187,7 @@ pub enum FakeMapValue {
 #[derive(Debug)]
 pub struct ContextModule {
   dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   identifier: Identifier,
   options: ContextModuleOptions,
   resolve_factory: Arc<ResolverFactory>,
@@ -364,7 +364,7 @@ impl ContextModule {
         .and_then(|d| d.as_module_dependency())
       {
         let getter = returning_function(
-          &block_promise(Some(&block.identifier()), runtime_requirements, compilation),
+          &block_promise(Some(&block.id()), runtime_requirements, compilation),
           "",
         );
         map.insert(dependency.user_request().to_string(), getter);
@@ -556,11 +556,11 @@ impl ContextModule {
 }
 
 impl DependenciesBlock for ContextModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 
@@ -801,7 +801,7 @@ impl ContextModule {
       && !context_element_dependencies.is_empty()
     {
       let name = self.options.context_options.chunk_name.clone();
-      let mut block = AsyncDependenciesBlock::new(self.identifier, "", None);
+      let mut block = AsyncDependenciesBlock::new(self.identifier, None);
       block.set_group_options(GroupOptions::ChunkGroup(ChunkGroupOptions::new(
         name, None, None,
       )));
@@ -831,11 +831,7 @@ impl ContextModule {
             });
             name.into_owned()
           });
-        let mut block = AsyncDependenciesBlock::new(
-          self.identifier,
-          &context_element_dependency.user_request,
-          None,
-        );
+        let mut block = AsyncDependenciesBlock::new(self.identifier, None);
         block.set_group_options(GroupOptions::ChunkGroup(ChunkGroupOptions::new(
           name, None, None,
         )));

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -1,11 +1,13 @@
-use std::hash::{Hash, Hasher};
+use std::{
+  hash::{Hash, Hasher},
+  sync::atomic::{AtomicU32, Ordering},
+};
 
 use rspack_error::{
   miette::{self, Diagnostic},
   thiserror::{self, Error},
 };
 use serde::Serialize;
-use ustr::Ustr;
 
 use crate::{
   update_hash::{UpdateHashContext, UpdateRspackHash},
@@ -13,24 +15,23 @@ use crate::{
 };
 
 pub trait DependenciesBlock {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier);
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId);
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier];
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId];
 
   fn add_dependency_id(&mut self, dependency: DependencyId);
 
   fn get_dependencies(&self) -> &[DependencyId];
 }
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
-pub struct AsyncDependenciesBlockIdentifier {
-  pub from: ModuleIdentifier,
-  modifier: Ustr,
-}
+pub static ASYNC_DEPENDENCIES_BLOCK_ID: AtomicU32 = AtomicU32::new(0);
 
-impl AsyncDependenciesBlockIdentifier {
-  pub fn new(from: ModuleIdentifier, modifier: Ustr) -> Self {
-    Self { from, modifier }
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
+pub struct AsyncDependenciesBlockId(u32);
+
+impl AsyncDependenciesBlockId {
+  pub fn new() -> Self {
+    Self(ASYNC_DEPENDENCIES_BLOCK_ID.fetch_add(1, Ordering::Relaxed))
   }
 
   pub fn get<'a>(&self, compilation: &'a Compilation) -> Option<&'a AsyncDependenciesBlock> {
@@ -69,39 +70,34 @@ impl DependencyLocation {
 
 #[derive(Debug, Clone)]
 pub struct AsyncDependenciesBlock {
-  id: AsyncDependenciesBlockIdentifier,
+  id: AsyncDependenciesBlockId,
   group_options: Option<GroupOptions>,
   blocks: Vec<AsyncDependenciesBlock>,
-  block_ids: Vec<AsyncDependenciesBlockIdentifier>,
+  block_ids: Vec<AsyncDependenciesBlockId>,
   dependency_ids: Vec<DependencyId>,
   dependencies: Vec<BoxDependency>,
   loc: Option<DependencyLocation>,
+  parent: ModuleIdentifier,
 }
 
 impl AsyncDependenciesBlock {
   /// modifier should be Dependency.span in most of time
-  pub fn new(
-    from: ModuleIdentifier,
-    modifier: impl AsRef<str>,
-    loc: Option<DependencyLocation>,
-  ) -> Self {
+  pub fn new(parent: ModuleIdentifier, loc: Option<DependencyLocation>) -> Self {
     Self {
-      id: AsyncDependenciesBlockIdentifier::new(from, modifier.as_ref().into()),
+      id: AsyncDependenciesBlockId::new(),
       group_options: Default::default(),
       blocks: Default::default(),
       block_ids: Default::default(),
       dependency_ids: Default::default(),
       dependencies: Default::default(),
       loc,
+      parent,
     }
   }
 }
 
 impl AsyncDependenciesBlock {
-  // represent an unique AsyncDependenciesBlock, we use this as the block_promise_key at codegen
-  // why not Id(u32)? Id(u32) is unstable since module is built concurrently
-  // why not ChunkGroup.id? ChunkGroup.id = ChunkGroup.chunks.map(c => c.id).join("+"), probably will break incremental build, same reason we create __webpack_require__.el
-  pub fn identifier(&self) -> AsyncDependenciesBlockIdentifier {
+  pub fn id(&self) -> AsyncDependenciesBlockId {
     self.id
   }
 
@@ -135,15 +131,19 @@ impl AsyncDependenciesBlock {
   pub fn loc(&self) -> Option<&DependencyLocation> {
     self.loc.as_ref()
   }
+
+  pub fn parent(&self) -> &ModuleIdentifier {
+    &self.parent
+  }
 }
 
 impl DependenciesBlock for AsyncDependenciesBlock {
-  fn add_block_id(&mut self, _block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, _block: AsyncDependenciesBlockId) {
     unimplemented!("Nested block are not implemented");
     // self.block_ids.push(block);
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.block_ids
   }
 

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -4,7 +4,7 @@ use serde_json::json;
 use swc_core::ecma::atoms::JsWord;
 
 use crate::{
-  get_import_var, property_access, to_comment, to_normal_comment, AsyncDependenciesBlockIdentifier,
+  get_import_var, property_access, to_comment, to_normal_comment, AsyncDependenciesBlockId,
   Compilation, DependenciesBlock, DependencyId, ExportsType, FakeNamespaceObjectMode,
   InitFragmentExt, InitFragmentKey, InitFragmentStage, ModuleGraph, ModuleIdentifier,
   NormalInitFragment, RuntimeGlobals, TemplateContext,
@@ -241,7 +241,7 @@ pub fn import_statement(
 pub fn module_namespace_promise(
   code_generatable_context: &mut TemplateContext,
   dep_id: &DependencyId,
-  block: Option<&AsyncDependenciesBlockIdentifier>,
+  block: Option<&AsyncDependenciesBlockId>,
   request: &str,
   _message: &str,
   weak: bool,
@@ -356,7 +356,7 @@ pub fn module_namespace_promise(
 }
 
 pub fn block_promise(
-  block: Option<&AsyncDependenciesBlockIdentifier>,
+  block: Option<&AsyncDependenciesBlockId>,
   runtime_requirements: &mut RuntimeGlobals,
   compilation: &Compilation,
 ) -> String {
@@ -485,15 +485,12 @@ pub fn sync_module_factory(
 }
 
 pub fn async_module_factory(
-  block_id: &AsyncDependenciesBlockIdentifier,
+  block_id: &AsyncDependenciesBlockId,
   request: &str,
   compilation: &Compilation,
   runtime_requirements: &mut RuntimeGlobals,
 ) -> String {
-  let block = compilation
-    .module_graph
-    .block_by_id(block_id)
-    .expect("should have block");
+  let block = block_id.expect_get(compilation);
   let dep = block.get_dependencies()[0];
   let ensure_chunk = block_promise(Some(block_id), runtime_requirements, compilation);
   let factory = returning_function(

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 use crate::{
   extract_url_and_global, impl_build_info_meta, property_access,
   rspack_sources::{BoxSource, RawSource, Source, SourceExt},
-  to_identifier, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta,
+  to_identifier, AsyncDependenciesBlockId, BuildContext, BuildInfo, BuildMeta,
   BuildMetaExportsType, BuildResult, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl,
   CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, ExternalType,
   InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleType,
@@ -82,7 +82,7 @@ fn get_source_for_default_case(_optional: bool, request: &ExternalRequestValue) 
 #[derive(Debug)]
 pub struct ExternalModule {
   dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   id: Identifier,
   pub request: ExternalRequest,
   external_type: ExternalType,
@@ -288,11 +288,11 @@ impl Identifiable for ExternalModule {
 }
 
 impl DependenciesBlock for ExternalModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -10,7 +10,7 @@ mod dependencies_block;
 pub mod diagnostics;
 mod update_hash;
 pub use dependencies_block::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, DependenciesBlock, DependencyLocation,
+  AsyncDependenciesBlock, AsyncDependenciesBlockId, DependenciesBlock, DependencyLocation,
 };
 mod fake_namespace_object;
 mod template;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -444,7 +444,7 @@ mod test {
 
   use super::Module;
   use crate::{
-    AsyncDependenciesBlockIdentifier, BuildContext, BuildResult, CodeGenerationResult, Compilation,
+    AsyncDependenciesBlockId, BuildContext, BuildResult, CodeGenerationResult, Compilation,
     Context, DependenciesBlock, DependencyId, ModuleExt, ModuleType, RuntimeSpec, SourceType,
   };
 
@@ -489,11 +489,11 @@ mod test {
       impl Diagnosable for $ident {}
 
       impl DependenciesBlock for $ident {
-        fn add_block_id(&mut self, _: AsyncDependenciesBlockIdentifier) {
+        fn add_block_id(&mut self, _: AsyncDependenciesBlockId) {
           unreachable!()
         }
 
-        fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+        fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -9,7 +9,7 @@ use rspack_identifier::{Identifiable, IdentifierMap};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::ecma::atoms::JsWord;
 mod vec_map;
-use crate::{AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier};
+use crate::{AsyncDependenciesBlock, AsyncDependenciesBlockId};
 mod connection;
 pub use connection::*;
 
@@ -25,7 +25,7 @@ pub type ImportVarMap = HashMap<Option<String> /* request */, String /* import_v
 
 #[derive(Debug, Default)]
 pub struct DependencyParents {
-  pub block: Option<AsyncDependenciesBlockIdentifier>,
+  pub block: Option<AsyncDependenciesBlockId>,
   pub module: ModuleIdentifier,
 }
 
@@ -42,7 +42,7 @@ pub struct ModuleGraph {
   /// Module identifier to its module graph module
   pub module_identifier_to_module_graph_module: IdentifierMap<ModuleGraphModule>,
 
-  blocks: HashMap<AsyncDependenciesBlockIdentifier, AsyncDependenciesBlock>,
+  blocks: HashMap<AsyncDependenciesBlockId, AsyncDependenciesBlock>,
 
   dependency_id_to_connection_id: HashMap<DependencyId, ConnectionId>,
   connection_id_to_dependency_id: HashMap<ConnectionId, DependencyId>,
@@ -106,7 +106,7 @@ impl ModuleGraph {
   }
 
   pub fn add_block(&mut self, block: AsyncDependenciesBlock) {
-    self.blocks.insert(block.identifier(), block);
+    self.blocks.insert(block.id(), block);
   }
 
   pub fn set_parents(&mut self, dependency: DependencyId, parents: DependencyParents) {
@@ -120,10 +120,7 @@ impl ModuleGraph {
       .map(|p| &p.module)
   }
 
-  pub fn get_parent_block(
-    &self,
-    dependency: &DependencyId,
-  ) -> Option<&AsyncDependenciesBlockIdentifier> {
+  pub fn get_parent_block(&self, dependency: &DependencyId) -> Option<&AsyncDependenciesBlockId> {
     self
       .dependency_id_to_parents
       .get(dependency)
@@ -132,7 +129,7 @@ impl ModuleGraph {
 
   pub fn block_by_id(
     &self,
-    block_id: &AsyncDependenciesBlockIdentifier,
+    block_id: &AsyncDependenciesBlockId,
   ) -> Option<&AsyncDependenciesBlock> {
     self.blocks.get(block_id)
   }
@@ -390,7 +387,7 @@ impl ModuleGraph {
   pub(crate) fn get_module_dependencies_modules_and_blocks(
     &self,
     module_identifier: &ModuleIdentifier,
-  ) -> (Vec<&ModuleIdentifier>, &[AsyncDependenciesBlockIdentifier]) {
+  ) -> (Vec<&ModuleIdentifier>, &[AsyncDependenciesBlockId]) {
     let Some(m) = self.module_by_identifier(module_identifier) else {
       unreachable!("cannot find the module correspanding to {module_identifier}");
     };
@@ -752,10 +749,10 @@ mod test {
   use rspack_sources::Source;
 
   use crate::{
-    AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta,
-    BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock, Dependency,
-    DependencyId, ExportInfo, ExportsInfo, Module, ModuleDependency, ModuleGraph,
-    ModuleGraphModule, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, UsageState,
+    AsyncDependenciesBlockId, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
+    CodeGenerationResult, Compilation, Context, DependenciesBlock, Dependency, DependencyId,
+    ExportInfo, ExportsInfo, Module, ModuleDependency, ModuleGraph, ModuleGraphModule,
+    ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, UsageState,
   };
 
   // Define a detailed node type for `ModuleGraphModule`s
@@ -773,11 +770,11 @@ mod test {
       impl Diagnosable for $ident {}
 
       impl DependenciesBlock for $ident {
-        fn add_block_id(&mut self, _: AsyncDependenciesBlockIdentifier) {
+        fn add_block_id(&mut self, _: AsyncDependenciesBlockId) {
           unreachable!()
         }
 
-        fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+        fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -25,12 +25,12 @@ use serde_json::json;
 
 use crate::{
   add_connection_states, contextify, diagnostics::ModuleBuildError, get_context,
-  impl_build_info_meta, AsyncDependenciesBlockIdentifier, BoxLoader, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Compilation, CompilerOptions,
-  ConnectionState, Context, DependenciesBlock, DependencyId, DependencyTemplate, GenerateContext,
-  GeneratorOptions, LibIdentOptions, Module, ModuleDependency, ModuleGraph, ModuleIdentifier,
-  ModuleType, ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve,
-  RspackLoaderRunnerPlugin, RuntimeSpec, SourceType,
+  impl_build_info_meta, AsyncDependenciesBlockId, BoxLoader, BoxModule, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, CodeGenerationResult, Compilation, CompilerOptions, ConnectionState,
+  Context, DependenciesBlock, DependencyId, DependencyTemplate, GenerateContext, GeneratorOptions,
+  LibIdentOptions, Module, ModuleDependency, ModuleGraph, ModuleIdentifier, ModuleType,
+  ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve, RspackLoaderRunnerPlugin,
+  RuntimeSpec, SourceType,
 };
 
 bitflags! {
@@ -77,7 +77,7 @@ impl ModuleIssuer {
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct NormalModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
 
   id: ModuleIdentifier,
@@ -290,11 +290,11 @@ impl Identifiable for NormalModule {
 }
 
 impl DependenciesBlock for NormalModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -7,14 +7,14 @@ use rspack_identifier::Identifiable;
 use rspack_sources::{BoxSource, RawSource, Source, SourceExt};
 
 use crate::{
-  dependencies_block::AsyncDependenciesBlockIdentifier, impl_build_info_meta, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResult, Context, DependenciesBlock,
-  DependencyId, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  dependencies_block::AsyncDependenciesBlockId, impl_build_info_meta, BuildContext, BuildInfo,
+  BuildMeta, BuildResult, CodeGenerationResult, Context, DependenciesBlock, DependencyId, Module,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
 pub struct RawModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   source: BoxSource,
   identifier: ModuleIdentifier,
@@ -54,11 +54,11 @@ impl Identifiable for RawModule {
 }
 
 impl DependenciesBlock for RawModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -62,11 +62,11 @@ macro_rules! impl_runtime_module {
     }
 
     impl $crate::DependenciesBlock for $ident {
-      fn add_block_id(&mut self, _: $crate::AsyncDependenciesBlockIdentifier) {
+      fn add_block_id(&mut self, _: $crate::AsyncDependenciesBlockId) {
         unreachable!()
       }
 
-      fn get_blocks(&self) -> &[$crate::AsyncDependenciesBlockIdentifier] {
+      fn get_blocks(&self) -> &[$crate::AsyncDependenciesBlockId] {
         unreachable!()
       }
 

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -8,16 +8,16 @@ use rspack_identifier::{Identifiable, Identifier};
 use rspack_sources::Source;
 
 use crate::{
-  impl_build_info_meta, AsyncDependenciesBlockIdentifier, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock,
-  DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
+  impl_build_info_meta, AsyncDependenciesBlockId, BuildContext, BuildInfo, BuildMeta, BuildResult,
+  ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
+  LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
 };
 
 #[derive(Debug)]
 pub struct SelfModule {
   identifier: ModuleIdentifier,
   readable_identifier: String,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   build_info: Option<BuildInfo>,
   build_meta: Option<BuildMeta>,
@@ -44,11 +44,11 @@ impl Identifiable for SelfModule {
 }
 
 impl DependenciesBlock for SelfModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -8,8 +8,8 @@ use rspack_core::tree_shaking::analyzer::OptimizeAnalyzer;
 use rspack_core::tree_shaking::js_module::JsModule;
 use rspack_core::tree_shaking::visitor::OptimizeAnalyzeResult;
 use rspack_core::{
-  render_init_fragments, AsyncDependenciesBlockIdentifier, Compilation, DependenciesBlock,
-  DependencyId, GenerateContext, Module, ParseContext, ParseResult, ParserAndGenerator, SourceType,
+  render_init_fragments, AsyncDependenciesBlockId, Compilation, DependenciesBlock, DependencyId,
+  GenerateContext, Module, ParseContext, ParseResult, ParserAndGenerator, SourceType,
   TemplateContext, TemplateReplaceSource,
 };
 use rspack_error::miette::Diagnostic;
@@ -35,14 +35,11 @@ impl JavaScriptParserAndGenerator {
   fn source_block(
     &self,
     compilation: &Compilation,
-    block_id: &AsyncDependenciesBlockIdentifier,
+    block_id: &AsyncDependenciesBlockId,
     source: &mut TemplateReplaceSource,
     context: &mut TemplateContext,
   ) {
-    let block = compilation
-      .module_graph
-      .block_by_id(block_id)
-      .expect("should have block");
+    let block = block_id.expect_get(compilation);
     block.get_dependencies().iter().for_each(|dependency_id| {
       self.source_dependency(compilation, dependency_id, source, context)
     });

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -2,10 +2,10 @@ use std::collections::hash_map::Entry;
 use std::collections::VecDeque;
 
 use rspack_core::{
-  is_exports_object_referenced, is_no_exports_referenced, merge_runtime,
-  AsyncDependenciesBlockIdentifier, BuildMetaExportsType, Compilation, ConnectionState,
-  DependenciesBlock, DependencyId, ExportsInfoId, ExtendedReferencedExport, GroupOptions,
-  ModuleIdentifier, Plugin, ReferencedExport, RuntimeSpec, UsageState,
+  is_exports_object_referenced, is_no_exports_referenced, merge_runtime, AsyncDependenciesBlockId,
+  BuildMetaExportsType, Compilation, ConnectionState, DependenciesBlock, DependencyId,
+  ExportsInfoId, ExtendedReferencedExport, GroupOptions, ModuleIdentifier, Plugin,
+  ReferencedExport, RuntimeSpec, UsageState,
 };
 use rspack_error::Result;
 use rspack_identifier::IdentifierMap;
@@ -15,7 +15,7 @@ use rustc_hash::FxHashMap as HashMap;
 #[derive(Debug)]
 enum ModuleOrAsyncDependenciesBlock {
   Module(ModuleIdentifier),
-  AsyncDependenciesBlock(AsyncDependenciesBlockIdentifier),
+  AsyncDependenciesBlock(AsyncDependenciesBlockId),
 }
 #[allow(unused)]
 pub struct FlagDependencyUsagePluginProxy<'a> {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -225,7 +225,6 @@ impl Visit for ImportScanner<'_> {
         ));
         let mut block = AsyncDependenciesBlock::new(
           self.module_identifier,
-          format!("{}:{}", span.start, span.end),
           Some(DependencyLocation::new(span.start, span.end)),
         );
         block.set_group_options(GroupOptions::ChunkGroup(ChunkGroupOptions::new(
@@ -271,7 +270,6 @@ impl Visit for ImportScanner<'_> {
         ));
         let mut block = AsyncDependenciesBlock::new(
           self.module_identifier,
-          format!("{}:{}", span.start, span.end),
           Some(DependencyLocation::new(span.start, span.end)),
         );
         block.set_group_options(GroupOptions::ChunkGroup(ChunkGroupOptions::new(

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -73,7 +73,6 @@ impl<'a> WorkerScanner<'a> {
     ));
     let mut block = AsyncDependenciesBlock::new(
       *self.module_identifier,
-      format!("{}:{}", span.start, span.end),
       Some(DependencyLocation::new(span.start, span.end)),
     );
     block.set_group_options(GroupOptions::Entrypoint(Box::new(EntryOptions {

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use rspack_core::{
   block_promise, impl_build_info_meta, module_raw, returning_function,
   rspack_sources::{RawSource, Source, SourceExt},
-  throw_missing_module_error_block, AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier,
+  throw_missing_module_error_block, AsyncDependenciesBlock, AsyncDependenciesBlockId,
   BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult,
   ChunkGroupOptions, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
   GroupOptions, LibIdentOptions, Module, ModuleDependency, ModuleIdentifier, ModuleType,
@@ -22,7 +22,7 @@ use crate::utils::json_stringify;
 
 #[derive(Debug)]
 pub struct ContainerEntryModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,
   lib_ident: String,
@@ -59,11 +59,11 @@ impl Identifiable for ContainerEntryModule {
 }
 
 impl DependenciesBlock for ContainerEntryModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 
@@ -112,7 +112,7 @@ impl Module for ContainerEntryModule {
     let mut blocks = vec![];
     let mut dependencies: Vec<BoxDependency> = vec![];
     for (name, options) in &self.exposes {
-      let mut block = AsyncDependenciesBlock::new(self.identifier, name, None);
+      let mut block = AsyncDependenciesBlock::new(self.identifier, None);
       block.set_group_options(GroupOptions::ChunkGroup(
         ChunkGroupOptions::default().name_optional(options.name.clone()),
       ));

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use rspack_core::{
   impl_build_info_meta,
   rspack_sources::{RawSource, Source, SourceExt},
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
+  AsyncDependenciesBlockId, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   ChunkUkey, CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId,
   LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
 };
@@ -18,7 +18,7 @@ use crate::utils::json_stringify;
 
 #[derive(Debug)]
 pub struct FallbackModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,
   readable_identifier: String,
@@ -58,11 +58,11 @@ impl Identifiable for FallbackModule {
 }
 
 impl DependenciesBlock for FallbackModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use rspack_core::{
   impl_build_info_meta,
   rspack_sources::{RawSource, Source, SourceExt},
-  AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
+  AsyncDependenciesBlockId, BoxDependency, BuildContext, BuildInfo, BuildMeta, BuildResult,
   CodeGenerationResult, Compilation, Context, DependenciesBlock, DependencyId, LibIdentOptions,
   Module, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
 };
@@ -23,7 +23,7 @@ use crate::{
 
 #[derive(Debug)]
 pub struct RemoteModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,
   readable_identifier: String,
@@ -76,11 +76,11 @@ impl Identifiable for RemoteModule {
 }
 
 impl DependenciesBlock for RemoteModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, hash::Hash};
 use async_trait::async_trait;
 use rspack_core::{
   async_module_factory, impl_build_info_meta, rspack_sources::Source, sync_module_factory,
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
+  AsyncDependenciesBlock, AsyncDependenciesBlockId, BoxDependency, BuildContext, BuildInfo,
   BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
   DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
   SourceType,
@@ -20,7 +20,7 @@ use crate::{utils::json_stringify, ConsumeOptions};
 
 #[derive(Debug)]
 pub struct ConsumeSharedModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,
   lib_ident: String,
@@ -84,11 +84,11 @@ impl Identifiable for ConsumeSharedModule {
 }
 
 impl DependenciesBlock for ConsumeSharedModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 
@@ -145,7 +145,7 @@ impl Module for ConsumeSharedModule {
       if self.options.eager {
         dependencies.push(dep as BoxDependency);
       } else {
-        let mut block = AsyncDependenciesBlock::new(self.identifier, "", None);
+        let mut block = AsyncDependenciesBlock::new(self.identifier, None);
         block.add_dependency(dep);
         blocks.push(block);
       }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, hash::Hash};
 use async_trait::async_trait;
 use rspack_core::{
   async_module_factory, impl_build_info_meta, rspack_sources::Source, sync_module_factory,
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BuildContext, BuildInfo,
+  AsyncDependenciesBlock, AsyncDependenciesBlockId, BoxDependency, BuildContext, BuildInfo,
   BuildMeta, BuildResult, CodeGenerationResult, Compilation, Context, DependenciesBlock,
   DependencyId, LibIdentOptions, Module, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec,
   SourceType,
@@ -22,7 +22,7 @@ use super::{
 
 #[derive(Debug)]
 pub struct ProvideSharedModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   dependencies: Vec<DependencyId>,
   identifier: ModuleIdentifier,
   lib_ident: String,
@@ -72,11 +72,11 @@ impl Identifiable for ProvideSharedModule {
 }
 
 impl DependenciesBlock for ProvideSharedModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 
@@ -128,7 +128,7 @@ impl Module for ProvideSharedModule {
     if self.eager {
       dependencies.push(dep as BoxDependency);
     } else {
-      let mut block = AsyncDependenciesBlock::new(self.identifier, "", None);
+      let mut block = AsyncDependenciesBlock::new(self.identifier, None);
       block.add_dependency(dep);
       blocks.push(block);
     }

--- a/crates/rspack_plugin_runtime/src/lazy_compilation.rs
+++ b/crates/rspack_plugin_runtime/src/lazy_compilation.rs
@@ -5,8 +5,8 @@ use async_trait::async_trait;
 use rspack_core::{
   impl_build_info_meta,
   rspack_sources::{RawSource, Source, SourceExt},
-  AsyncDependenciesBlockIdentifier, BuildInfo, BuildMeta, Compilation, DependenciesBlock,
-  DependencyId, Module, ModuleType, NormalModuleCreateData, Plugin, PluginContext,
+  AsyncDependenciesBlockId, BuildInfo, BuildMeta, Compilation, DependenciesBlock, DependencyId,
+  Module, ModuleType, NormalModuleCreateData, Plugin, PluginContext,
   PluginNormalModuleFactoryCreateModuleHookOutput, RuntimeGlobals, RuntimeSpec, SourceType,
 };
 use rspack_core::{CodeGenerationResult, Context, ModuleIdentifier};
@@ -16,18 +16,18 @@ use rspack_identifier::Identifiable;
 #[derive(Debug)]
 pub struct LazyCompilationProxyModule {
   dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  blocks: Vec<AsyncDependenciesBlockId>,
   pub module_identifier: ModuleIdentifier,
   build_info: Option<BuildInfo>,
   build_meta: Option<BuildMeta>,
 }
 
 impl DependenciesBlock for LazyCompilationProxyModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
+  fn add_block_id(&mut self, block: AsyncDependenciesBlockId) {
     self.blocks.push(block)
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockId] {
     &self.blocks
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

After remove `__webpack_require__.el`, we don't need AsyncDependenciesBlockIdentifier to generate the `__webpack_require__.el` code anymore

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
