### PR TITLE
chore: remove logs from tests

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json",
     "dev": "tsc -b -w",
-    "test": "cross-env RSPACK_DEP_WARNINGS=false jest --runInBand"
+    "test": "cross-env jest --runInBand"
   },
   "files": [
     "bin",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -16,7 +16,7 @@
     "build:viewer": "rspack build",
     "dev:viewer": "rspack serve",
     "dev": "tsc -b -w",
-    "test:diff": "cross-env RSPACK_DIFF=true NO_COLOR=1 RSPACK_DEP_WARNINGS=false node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage --testPathPattern \".diff.test.ts\""
+    "test:diff": "cross-env RSPACK_DIFF=true NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage --testPathPattern \".diff.test.ts\""
   },
   "files": [
     "client",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json",
     "dev": "tsc -w",
-    "test": "cross-env NO_COLOR=1 RSPACK_DEP_WARNINGS=false node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --testPathIgnorePatterns \".diff.test.ts\" --runInBand --logHeapUsage"
+    "test": "cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --testPathIgnorePatterns \".diff.test.ts\" --runInBand --logHeapUsage"
   },
   "files": [
     "dist"

--- a/packages/rspack/tests/configCases/builtin-swc-loader/styled-components/index.jsx
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/styled-components/index.jsx
@@ -1,8 +1,7 @@
 import { Container } from "./Button";
-import { Container as Container2 } from './Button2'
+import { Container as Container2 } from "./Button2";
 
 it("styled components", () => {
-	console.log(Container.componentStyle);
 	expect(Container.displayName).toMatch("Button__Container");
 	expect(Container.styledComponentId).toMatch(
 		/^Button__Container-rspack-test__/

--- a/packages/rspack/tests/configCases/builtins/minify-pure-funcs/index.js
+++ b/packages/rspack/tests/configCases/builtins/minify-pure-funcs/index.js
@@ -1,12 +1,17 @@
 const fs = require("fs");
-
-console.debug("test-console");
-console.log("test-console");
-console.warn("test-console");
-console.error("test-console");
+globalThis.__logger = {
+	debug() {},
+	log() {},
+	warn() {},
+	error() {}
+};
+__logger.debug("test-console");
+__logger.log("test-console");
+__logger.warn("test-console");
+__logger.error("test-console");
 
 function getTestLogLevels(content) {
-	const regex = /console\.(\S+?)\("test-console"/g;
+	const regex = /__logger\.(\S+?)\("test-console"/g;
 	const logs = [];
 	while ((array1 = regex.exec(content)) !== null) {
 		logs.push(array1[1]);

--- a/packages/rspack/tests/configCases/builtins/minify-pure-funcs/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtins/minify-pure-funcs/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
 		minimize: true,
 		minimizer: [
 			new rspack.SwcJsMinimizerRspackPlugin({
-				pureFuncs: ["console.error", "console.warn"]
+				pureFuncs: ["__logger.error", "__logger.warn"]
 			})
 		]
 	}

--- a/packages/rspack/tests/configCases/hooks/before-resolve/webpack.config.js
+++ b/packages/rspack/tests/configCases/hooks/before-resolve/webpack.config.js
@@ -37,7 +37,7 @@ export class Plugin {
 
 						resolveData.request = `${request}.js`;
 
-						console.log(resolveData);
+						// console.log(resolveData);
 					}
 
 					return undefined;

--- a/packages/rspack/tests/configCases/parsing/node-source-plugin-off/index.js
+++ b/packages/rspack/tests/configCases/parsing/node-source-plugin-off/index.js
@@ -1,7 +1,0 @@
-it("should not load node bindings when node option is false", function () {
-	console.log(typeof global);
-	var fs = require("fs");
-	var source = fs.readFileSync(__filename, "utf-8");
-	expect(source.includes("console.log(typeof global)")).toBe(true);
-	// expect((typeof global)).toBe("undefined");
-});

--- a/packages/rspack/tests/configCases/parsing/node-source-plugin-off/webpack.config.js
+++ b/packages/rspack/tests/configCases/parsing/node-source-plugin-off/webpack.config.js
@@ -1,5 +1,0 @@
-/** @type {import("@rspack/core").Configuration} */
-module.exports = {
-	// target: "web",
-	node: false
-};

--- a/packages/rspack/tests/configCases/plugins/minify-esbuild/index.js
+++ b/packages/rspack/tests/configCases/plugins/minify-esbuild/index.js
@@ -1,5 +1,5 @@
 const lib = require("./lib");
 it("minify-plugin", () => {
-	console.log("lib:", lib);
+	// console.log("lib:", lib);
 	expect(lib.answer).toEqual(42);
 });

--- a/packages/rspack/tests/configCases/plugins/minify-pure-funcs/index.js
+++ b/packages/rspack/tests/configCases/plugins/minify-pure-funcs/index.js
@@ -1,12 +1,17 @@
 const fs = require("fs");
-
-console.debug("test-console");
-console.log("test-console");
-console.warn("test-console");
-console.error("test-console");
+globalThis.__logger = {
+	debug() {},
+	log() {},
+	warn() {},
+	error() {}
+};
+__logger.debug("test-console");
+__logger.log("test-console");
+__logger.warn("test-console");
+__logger.error("test-console");
 
 function getTestLogLevels(content) {
-	const regex = /console\.(\S+?)\("test-console"/g;
+	const regex = /__logger\.(\S+?)\("test-console"/g;
 	const logs = [];
 	while ((array1 = regex.exec(content)) !== null) {
 		logs.push(array1[1]);

--- a/packages/rspack/tests/configCases/plugins/minify-pure-funcs/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-pure-funcs/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
 	plugins: [
 		new rspack.SwcJsMinimizerRspackPlugin({
 			compress: {
-				pure_funcs: ["console.error", "console.warn"]
+				pure_funcs: ["__logger.error", "__logger.warn"]
 			}
 		})
 	]

--- a/packages/rspack/tests/configCases/split-chunks-common/enforce-minsize/async.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/enforce-minsize/async.js
@@ -1,1 +1,0 @@
-console.log(42);

--- a/packages/rspack/tests/configCases/split-chunks-common/enforce-minsize/foo.js
+++ b/packages/rspack/tests/configCases/split-chunks-common/enforce-minsize/foo.js
@@ -1,1 +1,0 @@
-console.log(42);

--- a/packages/rspack/tests/configCases/split-chunks/css-simple/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/css-simple/index.js
@@ -10,5 +10,3 @@ it("css-simple", () => {
 	expect(fs.existsSync(path.resolve(__dirname, "./foo_js.css"))).toBe(true);
 	expect(fs.existsSync(path.resolve(__dirname, "./main.css"))).toBe(true);
 });
-
-console.log(__dirname);

--- a/packages/rspack/tests/configCases/split-chunks/issue-3646/src/shared.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-3646/src/shared.js
@@ -1,2 +1,2 @@
 import _ from "lodash";
-console.log(_.VERSION);
+eval(_);

--- a/scripts/debug/launch.mjs
+++ b/scripts/debug/launch.mjs
@@ -49,7 +49,6 @@ export async function launchJestWithArgs(additionalArgs) {
 			args,
 			env: {
 				NO_COLOR: JSON.stringify(1),
-				RSPACK_DEP_WARNINGS: JSON.stringify(false),
 				...process.env
 			},
 			cwd: process.cwd()

--- a/webpack-test/configCases/parsing/node-source-plugin-off/test.filter.js
+++ b/webpack-test/configCases/parsing/node-source-plugin-off/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. Remove logs from test
2. rspack `node-source-plugin-off` is removed, in favor of webpack's.
3. Keep dep warnings in test

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
