### PR TITLE
perf: use hashset to compare ignore

### DIFF
--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -46,7 +46,7 @@ impl AsyncDependenciesBlockId {
   }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct DependencyLocation {
   start: u32,
   end: u32,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
@@ -169,7 +169,7 @@ pub fn statement_if(scanner: &mut JavascriptParser, stmt: &IfStmt) -> Option<boo
       )
     };
 
-    scanner.ignored.push(DependencyLocation::new(
+    scanner.ignored.insert(DependencyLocation::new(
       branch_to_remove.span().real_lo(),
       branch_to_remove.span().real_hi(),
     ));

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/api_scanner.rs
@@ -5,6 +5,7 @@ use rspack_core::{
   RuntimeGlobals, RuntimeRequirementsDependency, SpanExt,
 };
 use rspack_error::miette::Diagnostic;
+use rustc_hash::FxHashSet;
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
 use swc_core::{
   common::{SourceFile, Spanned, SyntaxContext},
@@ -86,7 +87,7 @@ pub struct ApiScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   pub dependencies: &'a mut Vec<Box<dyn Dependency>>,
   pub warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> ApiScanner<'a> {
@@ -100,7 +101,7 @@ impl<'a> ApiScanner<'a> {
     module: bool,
     build_info: &'a mut BuildInfo,
     warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       source_file,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_export_scanner.rs
@@ -3,6 +3,7 @@ use rspack_core::{
   BuildMetaExportsType, DependencyLocation, DependencyTemplate, ModuleType, RuntimeGlobals,
   SpanExt,
 };
+use rustc_hash::FxHashSet;
 use swc_core::{
   atoms::Atom,
   common::{Spanned, SyntaxContext},
@@ -40,7 +41,7 @@ pub struct CommonJsExportDependencyScanner<'a> {
   stmt_level: u32,
   last_stmt_is_expr_stmt: bool,
   is_top_level: bool,
-  ignored: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> CommonJsExportDependencyScanner<'a> {
@@ -51,7 +52,7 @@ impl<'a> CommonJsExportDependencyScanner<'a> {
     build_meta: &'a mut BuildMeta,
     module_type: ModuleType,
     parser_exports_state: &'a mut Option<bool>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/common_js_scanner.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
   DependencyLocation, DependencyTemplate, RuntimeGlobals, RuntimeRequirementsDependency,
 };
+use rustc_hash::FxHashSet;
 use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{Expr, Ident};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
@@ -12,14 +13,14 @@ pub struct CommonJsScanner<'a> {
   unresolved_ctxt: SyntaxContext,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   has_module_ident: bool,
-  ignored: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> CommonJsScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/compatibility_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/compatibility_scanner.rs
@@ -1,5 +1,5 @@
 use rspack_core::{ConstDependency, DependencyLocation, DependencyTemplate, SpanExt};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::{FnDecl, Ident, Program};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
@@ -11,14 +11,14 @@ pub struct CompatibilityScanner<'a> {
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   count: u8, // flag __webpack_require__ count
   name_map: FxHashMap<SyntaxContext, u8>,
-  ignored: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> CompatibilityScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,
@@ -61,7 +61,7 @@ pub struct ReplaceNestWebpackRequireVisitor<'a> {
   unresolved_ctxt: SyntaxContext,
   name_map: &'a FxHashMap<SyntaxContext, u8>,
   presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  ignored: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl Visit for ReplaceNestWebpackRequireVisitor<'_> {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/export_info_api_scanner.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
   extract_member_expression_chain, ConstDependency, DependencyLocation, DependencyTemplate, SpanExt,
 };
+use rustc_hash::FxHashSet;
 use swc_core::{
   common::SyntaxContext,
   ecma::{
@@ -14,7 +15,7 @@ use crate::{dependency::ExportInfoApiDependency, no_visit_ignored_stmt};
 pub struct ExportInfoApiScanner<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   unresolved_ctxt: SyntaxContext,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 //__webpack_exports_info__.a.used
@@ -22,7 +23,7 @@ impl<'a> ExportInfoApiScanner<'a> {
   pub fn new(
     presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     unresolved_ctxt: SyntaxContext,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_detection_scanner.rs
@@ -5,6 +5,7 @@ use rspack_core::{
   ExportsArgument, ModuleArgument, ModuleType,
 };
 use rspack_error::miette::Diagnostic;
+use rustc_hash::FxHashSet;
 use swc_core::common::source_map::Pos;
 use swc_core::common::{BytePos, SourceFile, Span, Spanned};
 use swc_core::ecma::ast::{ArrowExpr, AwaitExpr, Constructor, Function, ModuleItem, Program};
@@ -23,7 +24,7 @@ pub struct HarmonyDetectionScanner<'a> {
   top_level_await: bool,
   code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
   errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  ignored: &'a mut Vec<DependencyLocation>,
+  ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> HarmonyDetectionScanner<'a> {
@@ -36,7 +37,7 @@ impl<'a> HarmonyDetectionScanner<'a> {
     top_level_await: bool,
     code_generable_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
     errors: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       source_file,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_export_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_export_dependency_scanner.rs
@@ -2,7 +2,7 @@ use rspack_core::{
   tree_shaking::symbol::DEFAULT_JS_WORD, BoxDependency, BoxDependencyTemplate, BuildInfo,
   ConstDependency, DependencyLocation, SpanExt,
 };
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use swc_core::{
   common::{Span, Spanned},
   ecma::{
@@ -33,7 +33,7 @@ pub struct HarmonyExportDependencyScanner<'a, 'b> {
   pub build_info: &'a mut BuildInfo,
   pub rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
   pub comments: Option<&'b SwcComments>,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a, 'b> HarmonyExportDependencyScanner<'a, 'b> {
@@ -44,7 +44,7 @@ impl<'a, 'b> HarmonyExportDependencyScanner<'a, 'b> {
     build_info: &'a mut BuildInfo,
     rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
     comments: Option<&'b SwcComments>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -75,7 +75,7 @@ pub struct HarmonyImportDependencyScanner<'a> {
   pub build_info: &'a mut BuildInfo,
   pub rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
   pub last_harmony_import_order: i32,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut HashSet<DependencyLocation>,
 }
 
 impl<'a> HarmonyImportDependencyScanner<'a> {
@@ -85,7 +85,7 @@ impl<'a> HarmonyImportDependencyScanner<'a> {
     import_map: &'a mut ImportMap,
     build_info: &'a mut BuildInfo,
     rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut HashSet<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,
@@ -590,6 +590,7 @@ impl Visit for HarmonyImportRefDependencyScanner<'_> {
 mod test {
   use rspack_ast::javascript::Program;
   use rspack_core::{BuildInfo, Dependency, ModuleType};
+  use rustc_hash::FxHashSet;
 
   use super::HarmonyImportDependencyScanner;
   use crate::{ast::parse, dependency::HarmonyImportSpecifierDependency};
@@ -613,7 +614,7 @@ mod test {
     let mut deps = vec![];
     let mut presentation_deps = vec![];
     let mut rewrite_usage_span = Default::default();
-    let mut ignored = vec![];
+    let mut ignored = FxHashSet::default();
     let mut scanner = HarmonyImportDependencyScanner::new(
       &mut deps,
       &mut presentation_deps,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_top_level_this.rs
@@ -1,4 +1,5 @@
 use rspack_core::{ConstDependency, DependencyLocation, DependencyTemplate, SpanExt};
+use rustc_hash::FxHashSet;
 use swc_core::ecma::{
   ast::{
     ClassMember, ClassMethod, ClassProp, Expr, Function, GetterProp, MethodProp, Prop, PropName,
@@ -11,7 +12,7 @@ use crate::no_visit_ignored_stmt;
 
 pub struct HarmonyTopLevelThis<'a> {
   pub presentational_dependencies: &'a mut Vec<Box<dyn DependencyTemplate>>,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl Visit for HarmonyTopLevelThis<'_> {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/hot_module_replacement_scanner.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
   BoxDependency, BoxDependencyTemplate, BuildMeta, DependencyLocation, ErrorSpan, SpanExt,
 };
+use rustc_hash::FxHashSet;
 use swc_core::{
   common::Spanned,
   ecma::{
@@ -24,7 +25,7 @@ pub struct HotModuleReplacementScanner<'a> {
   pub dependencies: &'a mut Vec<BoxDependency>,
   pub presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,
   pub build_meta: &'a BuildMeta,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 type CreateDependency = fn(u32, u32, JsWord, Option<ErrorSpan>) -> BoxDependency;
@@ -34,7 +35,7 @@ impl<'a> HotModuleReplacementScanner<'a> {
     dependencies: &'a mut Vec<BoxDependency>,
     presentational_dependencies: &'a mut Vec<BoxDependencyTemplate>,
     build_meta: &'a BuildMeta,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_meta_scanner.rs
@@ -4,6 +4,7 @@ use rspack_core::{
   CompilerOptions, ConstDependency, DependencyLocation, DependencyTemplate, ResourceData, SpanExt,
 };
 use rspack_error::miette::{Diagnostic, Severity};
+use rustc_hash::FxHashSet;
 use swc_core::common::{SourceFile, Spanned};
 use swc_core::ecma::ast::{Expr, NewExpr, UnaryExpr, UnaryOp};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
@@ -27,7 +28,7 @@ pub struct ImportMetaScanner<'a> {
   pub compiler_options: &'a CompilerOptions,
   pub resource_data: &'a ResourceData,
   pub warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> ImportMetaScanner<'a> {
@@ -37,7 +38,7 @@ impl<'a> ImportMetaScanner<'a> {
     resource_data: &'a ResourceData,
     compiler_options: &'a CompilerOptions,
     warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       source_file,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/import_scanner.rs
@@ -8,6 +8,7 @@ use rspack_core::{BoxDependency, BuildMeta, ChunkGroupOptions, ContextMode};
 use rspack_core::{ContextNameSpaceObject, ContextOptions, DependencyCategory, SpanExt};
 use rspack_error::miette::Diagnostic;
 use rspack_regex::{regexp_as_str, RspackRegex};
+use rustc_hash::FxHashSet;
 use swc_core::common::comments::Comments;
 use swc_core::common::{SourceFile, Spanned};
 use swc_core::ecma::ast::{CallExpr, Callee, Expr, Lit};
@@ -31,7 +32,7 @@ pub struct ImportScanner<'a> {
   pub build_meta: &'a BuildMeta,
   pub options: Option<&'a JavascriptParserOptions>,
   pub warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 fn create_import_meta_context_dependency(node: &CallExpr) -> Option<ImportMetaContextDependency> {
@@ -122,7 +123,7 @@ impl<'a> ImportScanner<'a> {
     build_meta: &'a BuildMeta,
     options: Option<&'a JavascriptParserOptions>,
     warning_diagnostics: &'a mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       source_file,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -20,10 +20,12 @@ use std::sync::Arc;
 
 pub use context_helper::scanner_context_module;
 use rspack_ast::javascript::Program;
-use rspack_core::{AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo};
+use rspack_core::{
+  AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, DependencyLocation,
+};
 use rspack_core::{BuildMeta, CompilerOptions, ModuleIdentifier, ModuleType, ResourceData};
 use rspack_error::miette::Diagnostic;
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use swc_core::common::{comments::Comments, Mark, SyntaxContext};
 use swc_core::common::{SourceFile, Span};
 use swc_core::ecma::atoms::JsWord;
@@ -83,7 +85,7 @@ pub fn scan_dependencies(
   let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
   let comments = program.comments.clone();
   let mut parser_exports_state = None;
-  let mut ignored = vec![];
+  let mut ignored: FxHashSet<DependencyLocation> = FxHashSet::default();
 
   let mut rewrite_usage_span = HashMap::default();
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/node_stuff_scanner.rs
@@ -2,6 +2,7 @@ use rspack_core::{
   CompilerOptions, ConstDependency, DependencyLocation, DependencyTemplate, NodeOption,
   ResourceData, RuntimeGlobals, SpanExt,
 };
+use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 use swc_core::common::SyntaxContext;
 use swc_core::ecma::ast::Ident;
@@ -19,7 +20,7 @@ pub struct NodeStuffScanner<'a> {
   pub compiler_options: &'a CompilerOptions,
   pub node_option: &'a NodeOption,
   pub resource_data: &'a ResourceData,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 impl<'a> NodeStuffScanner<'a> {
@@ -29,7 +30,7 @@ impl<'a> NodeStuffScanner<'a> {
     compiler_options: &'a CompilerOptions,
     node_option: &'a NodeOption,
     resource_data: &'a ResourceData,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -300,8 +300,7 @@ macro_rules! no_visit_ignored_stmt {
       let span = stmt.span();
       if self
         .ignored
-        .iter()
-        .any(|r| r.start() <= span.real_lo() && span.real_hi() <= r.end())
+        .contains(&DependencyLocation::new(span.real_lo(), span.real_hi()))
       {
         return;
       }
@@ -320,8 +319,7 @@ macro_rules! no_visit_ignored_expr {
       let span = expr.span();
       if self
         .ignored
-        .iter()
-        .any(|r| r.start() <= span.real_lo() && span.real_hi() <= r.end())
+        .contains(&DependencyLocation::new(span.real_lo(), span.real_hi()))
       {
         return;
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/worker_scanner.rs
@@ -6,6 +6,7 @@ use rspack_core::{
   SpanExt,
 };
 use rspack_hash::RspackHash;
+use rustc_hash::FxHashSet;
 use swc_core::common::Spanned;
 use swc_core::ecma::ast::{Expr, ExprOrSpread, NewExpr};
 use swc_core::ecma::visit::{noop_visit_type, Visit, VisitWith};
@@ -23,7 +24,7 @@ pub struct WorkerScanner<'a> {
   module_identifier: &'a ModuleIdentifier,
   output_options: &'a OutputOptions,
   syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
-  pub ignored: &'a mut Vec<DependencyLocation>,
+  pub ignored: &'a mut FxHashSet<DependencyLocation>,
 }
 
 // new Worker(new URL("./foo.worker.js", import.meta.url));
@@ -32,7 +33,7 @@ impl<'a> WorkerScanner<'a> {
     module_identifier: &'a ModuleIdentifier,
     output_options: &'a OutputOptions,
     syntax_list: &'a rspack_core::needs_refactor::WorkerSyntaxList,
-    ignored: &'a mut Vec<DependencyLocation>,
+    ignored: &'a mut FxHashSet<DependencyLocation>,
   ) -> Self {
     Self {
       presentational_dependencies: Vec::new(),


### PR DESCRIPTION
before 4.7s:

![img_v3_0277_f2d07bea-fdbb-49ad-bdf2-6698d843eb8g](https://github.com/web-infra-dev/rspack/assets/30187863/00335bc2-03bb-4d7c-952b-7202d50bc80f)


after 3.4s:

<img width="504" alt="image" src="https://github.com/web-infra-dev/rspack/assets/30187863/72e9d92f-fe1a-46b0-befe-63e235d243ac">


----

The performance regression is caused by the linear search operation within ﻿`self.ignored`. The time cost escalates linearly as the size increases. To counter this, I have replaced it with a `﻿HashSet` to transform the time complexity to logarithmic, thereby enhancing performance