### PR TITLE
chore: enable most of the tests from webpack-examples

### DIFF
--- a/webpack-examples/aggressive-merging/test.filter.js
+++ b/webpack-examples/aggressive-merging/test.filter.js
@@ -1,3 +1,3 @@
 
 module.exports = () =>{return false}
-			
+

--- a/webpack-examples/asset-simple/test.filter.js
+++ b/webpack-examples/asset-simple/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/build-http/test.filter.js
+++ b/webpack-examples/build-http/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/chunkhash/test.filter.js
+++ b/webpack-examples/chunkhash/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitted-require.context-amd/test.filter.js
+++ b/webpack-examples/code-splitted-require.context-amd/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitted-require.context/test.filter.js
+++ b/webpack-examples/code-splitted-require.context/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting-depend-on-advanced/test.filter.js
+++ b/webpack-examples/code-splitting-depend-on-advanced/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting-depend-on-simple/test.filter.js
+++ b/webpack-examples/code-splitting-depend-on-simple/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting-harmony/test.filter.js
+++ b/webpack-examples/code-splitting-harmony/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting-native-import-context-filter/test.filter.js
+++ b/webpack-examples/code-splitting-native-import-context-filter/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting-native-import-context/test.filter.js
+++ b/webpack-examples/code-splitting-native-import-context/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting-specify-chunk-name/test.filter.js
+++ b/webpack-examples/code-splitting-specify-chunk-name/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/code-splitting/test.filter.js
+++ b/webpack-examples/code-splitting/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/coffee-script/test.filter.js
+++ b/webpack-examples/coffee-script/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/common-chunk-and-vendor-chunk/test.filter.js
+++ b/webpack-examples/common-chunk-and-vendor-chunk/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/commonjs/test.filter.js
+++ b/webpack-examples/commonjs/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/css/test.filter.js
+++ b/webpack-examples/css/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/externals/test.filter.js
+++ b/webpack-examples/externals/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/extra-async-chunk-advanced/test.filter.js
+++ b/webpack-examples/extra-async-chunk-advanced/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/extra-async-chunk/test.filter.js
+++ b/webpack-examples/extra-async-chunk/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/harmony-interop/test.filter.js
+++ b/webpack-examples/harmony-interop/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/harmony-library/test.filter.js
+++ b/webpack-examples/harmony-library/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/harmony-unused/test.filter.js
+++ b/webpack-examples/harmony-unused/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/harmony/test.filter.js
+++ b/webpack-examples/harmony/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/hybrid-routing/test.filter.js
+++ b/webpack-examples/hybrid-routing/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/loader/test.filter.js
+++ b/webpack-examples/loader/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/many-pages/test.filter.js
+++ b/webpack-examples/many-pages/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/mixed/test.filter.js
+++ b/webpack-examples/mixed/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/module-code-splitting/test.filter.js
+++ b/webpack-examples/module-code-splitting/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/module-library/test.filter.js
+++ b/webpack-examples/module-library/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/module-worker/test.filter.js
+++ b/webpack-examples/module-worker/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/module/test.filter.js
+++ b/webpack-examples/module/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/multi-compiler/test.filter.js
+++ b/webpack-examples/multi-compiler/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/multi-part-library/test.filter.js
+++ b/webpack-examples/multi-part-library/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/multiple-entry-points/test.filter.js
+++ b/webpack-examples/multiple-entry-points/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/named-chunks/test.filter.js
+++ b/webpack-examples/named-chunks/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/reexport-components/test.filter.js
+++ b/webpack-examples/reexport-components/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/require.context/test.filter.js
+++ b/webpack-examples/require.context/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/require.resolve/test.filter.js
+++ b/webpack-examples/require.resolve/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/scope-hoisting/test.filter.js
+++ b/webpack-examples/scope-hoisting/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/side-effects/test.filter.js
+++ b/webpack-examples/side-effects/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/source-map/test.filter.js
+++ b/webpack-examples/source-map/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/top-level-await/test.filter.js
+++ b/webpack-examples/top-level-await/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/two-explicit-vendor-chunks/test.filter.js
+++ b/webpack-examples/two-explicit-vendor-chunks/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-examples/wasm-complex/test.filter.js
+++ b/webpack-examples/wasm-complex/test.filter.js
@@ -1,9 +1,0 @@
-
-/** var supportsWebAssembly = require("../../test/helpers/supportsWebAssembly");
-
-module.exports = function(config) {
-	return supportsWebAssembly();
-};
-*/
-module.exports = () =>{return false}
-			

--- a/webpack-examples/wasm-simple/test.filter.js
+++ b/webpack-examples/wasm-simple/test.filter.js
@@ -1,9 +1,0 @@
-
-/** var supportsWebAssembly = require("../../test/helpers/supportsWebAssembly");
-
-module.exports = function(config) {
-	return supportsWebAssembly();
-};
-*/
-module.exports = () =>{return false}
-			

--- a/webpack-examples/worker/test.filter.js
+++ b/webpack-examples/worker/test.filter.js
@@ -1,3 +1,0 @@
-
-module.exports = () =>{return false}
-			

--- a/webpack-test/Examples.test.js
+++ b/webpack-test/Examples.test.js
@@ -6,7 +6,7 @@ const path = require("path");
 const fs = require("graceful-fs");
 const { normalizeFilteredTestName } = require("./lib/util/filterUtil")
 
-describe.skip("Examples", () => {
+describe("Examples", () => {
 	const basePath = path.join(__dirname, "..", "webpack-examples");
 	const examples = require("../webpack-examples/examples.js");
 

--- a/webpack-test/jest.config.js
+++ b/webpack-test/jest.config.js
@@ -11,6 +11,7 @@ module.exports =  {
       // "<rootDir>/*.basictest.js",
       // "<rootDir>/*.longtest.js",
       // "<rootDir>/*.unittest.js",
+      "<rootDir>/Examples.test.js",
       "<rootDir>/TestCasesNormal.basictest.js",
       "<rootDir>/ConfigTestCases.basictest.js"
     ],


### PR DESCRIPTION
## Summary

We managed to pass some of the webpack example tests!

```
Test Suites: 1 passed, 1 total
Tests:       17 skipped, 46 passed, 63 total
Snapshots:   0 total
Time:        1.511 s, estimated 2 s
```

<details>

```
 PASS  ./Examples.test.js
  Examples
    ✓ should compile asset-simple (168 ms)
    ✓ should compile build-http (4 ms)
    ✓ should compile chunkhash (5 ms)
    ✓ should compile code-splitted-require.context (3 ms)
    ✓ should compile code-splitted-require.context-amd (3 ms)
    ✓ should compile code-splitting (3 ms)
    ✓ should compile code-splitting-depend-on-advanced (7 ms)
    ✓ should compile code-splitting-depend-on-simple (122 ms)
    ✓ should compile code-splitting-harmony (7 ms)
    ✓ should compile code-splitting-native-import-context (5 ms)
    ✓ should compile code-splitting-native-import-context-filter (7 ms)
    ✓ should compile code-splitting-specify-chunk-name (5 ms)
    ✓ should compile coffee-script (137 ms)
    ✓ should compile common-chunk-and-vendor-chunk (5 ms)
    ✓ should compile commonjs (3 ms)
    ✓ should compile css (5 ms)
    ✓ should compile externals (3 ms)
    ✓ should compile extra-async-chunk (3 ms)
    ✓ should compile extra-async-chunk-advanced (3 ms)
    ✓ should compile harmony (4 ms)
    ✓ should compile harmony-interop (2 ms)
    ✓ should compile harmony-library (3 ms)
    ✓ should compile harmony-unused (3 ms)
    ✓ should compile hybrid-routing (5 ms)
    ✓ should compile loader (87 ms)
    ✓ should compile many-pages (7 ms)
    ✓ should compile mixed (3 ms)
    ✓ should compile module (4 ms)
    ✓ should compile module-code-splitting (49 ms)
    ✓ should compile module-library (4 ms)
    ✓ should compile module-worker (8 ms)
    ✓ should compile multi-compiler (5 ms)
    ✓ should compile multi-part-library (3 ms)
    ✓ should compile multiple-entry-points (4 ms)
    ✓ should compile named-chunks (3 ms)
    ✓ should compile reexport-components (427 ms)
    ✓ should compile require.context (3 ms)
    ✓ should compile require.resolve (2 ms)
    ✓ should compile scope-hoisting (5 ms)
    ✓ should compile side-effects (4 ms)
    ✓ should compile source-map (127 ms)
    ✓ should compile top-level-await (5 ms)
    ✓ should compile two-explicit-vendor-chunks (4 ms)
    ✓ should compile wasm-complex (33 ms)
    ✓ should compile wasm-simple (5 ms)
    ✓ should compile worker (6 ms)
    aggressive-merging
      ○ skipped {{ status = TODO, reason = TODO }}
    asset-advanced
      ○ skipped {{ status = TODO, reason = TODO }}
    cjs-tree-shaking
      ○ skipped {{ status = TODO, reason = TODO }}
    code-splitting-bundle-loader
      ○ skipped {{ status = TODO, reason = TODO }}
    common-chunk-grandchildren
      ○ skipped {{ status = TODO, reason = TODO }}
    custom-json-modules
      ○ skipped {{ status = TODO, reason = TODO }}
    dll
      ○ skipped {{ status = TODO, reason = TODO }}
    dll-app-and-vendor/0-vendor
      ○ skipped {{ status = TODO, reason = TODO }}
    dll-app-and-vendor/1-app
      ○ skipped {{ status = TODO, reason = TODO }}
    dll-entry-only
      ○ skipped {{ status = TODO, reason = TODO }}
    dll-user
      ○ skipped {{ status = TODO, reason = TODO }}
    explicit-vendor-chunk
      ○ skipped {{ status = TODO, reason = TODO }}
    http2-aggressive-splitting
      ○ skipped {{ status = TODO, reason = TODO }}
    lazy-compilation
      ○ skipped {{ status = TODO, reason = TODO }}
    module-federation
      ○ skipped {{ status = TODO, reason = TODO }}
    persistent-caching
      ○ skipped {{ status = TODO, reason = TODO }}
    typescript
      ○ skipped {{ status = TODO, reason = TODO }}
```

</details>

We can create a tracking issue for these tests, and get some help to figure out why they are failing.
