### PR TITLE
chore: enable newTreeshaking on arco-pro diff case

### DIFF
--- a/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.js
+++ b/crates/rspack_plugin_hmr/src/runtime/hot_module_replacement.js
@@ -79,8 +79,8 @@ function createRequire(require, moduleId) {
 		}
 	}
 
-	fn.e = function (chunkId) {
-		return trackBlockingPromise(require.e(chunkId));
+	fn.e = function (chunkId, fetchPriority) {
+		return trackBlockingPromise(require.e(chunkId, fetchPriority));
 	};
 
 	return fn;

--- a/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/import_scripts_chunk_loading.rs
@@ -173,7 +173,7 @@ impl RuntimeModule for ImportScriptsChunkLoadingRuntimeModule {
       ));
       source.add(RawSource::from(
         include_str!("runtime/javascript_hot_module_replacement.js")
-          .replace("$key$", "importScrips"),
+          .replace("$key$", "importScripts"),
       ));
     }
 

--- a/diffcases/arco-pro/package.json
+++ b/diffcases/arco-pro/package.json
@@ -54,7 +54,7 @@
     "serve": "14.2.1",
     "style-loader": "^3.3.3",
     "swc-loader": "^0.2.3",
-    "webpack": "^5.89.0"
+    "webpack": "^5.90.0"
   },
   "browserslist": {
     "production": [

--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -87,7 +87,9 @@ const config = {
 	output: {
 		publicPath: "/",
 		filename: "[name].js",
-		chunkFilename: "[name].js"
+		chunkFilename: "[name].js",
+		cssChunkFilename: "[name].css",
+		cssFilename: "[name].css"
 	},
 	optimization: {
 		minimize: false, // Disabling minification because it takes too long on CI
@@ -100,7 +102,9 @@ const config = {
 			cacheGroups: {
 				someVendor: {
 					chunks: "all",
-					minChunks: 2
+					minChunks: 2,
+					filename: "someVencor-[name].js",
+					name: "vendor"
 				}
 			}
 		}

--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -92,7 +92,10 @@ const config = {
 	optimization: {
 		minimize: false, // Disabling minification because it takes too long on CI
 		realContentHash: true,
-		usedExports: false,
+		providedExports: true,
+		usedExports: true,
+		sideEffects: true,
+		mangleExports: false,
 		splitChunks: {
 			cacheGroups: {
 				someVendor: {
@@ -113,7 +116,10 @@ const config = {
 		debug: false
 	},
 	experiments: {
-		css: true
+		css: true,
+		rspackFuture: {
+			newTreeshaking: true
+		}
 	},
 	builtins: {
 		css: {

--- a/diffcases/arco-pro/webpack.config.js
+++ b/diffcases/arco-pro/webpack.config.js
@@ -90,7 +90,10 @@ const config = {
 	optimization: {
 		minimize: false, // Disabling minification because it takes too long on CI
 		realContentHash: true,
-		usedExports: false,
+		providedExports: true,
+		usedExports: true,
+		sideEffects: true,
+		mangleExports: false,
 		splitChunks: {
 			cacheGroups: {
 				someVendor: {

--- a/diffcases/arco-pro/webpack.config.js
+++ b/diffcases/arco-pro/webpack.config.js
@@ -12,11 +12,23 @@ const config = {
 			{
 				test: /\.less$/,
 				use: "less-loader",
+				parser: {
+					namedExports: false,
+				},
+				generator: {
+					exportsOnly: true
+				},
 				type: "css"
 			},
 			{
 				test: /\.module\.less$/,
 				use: "less-loader",
+				parser: {
+					namedExports: false
+				},
+				generator: {
+					exportsOnly: true
+				},
 				type: "css/module"
 			},
 			{
@@ -85,7 +97,9 @@ const config = {
 	output: {
 		publicPath: "/",
 		filename: "[name].js",
-		chunkFilename: "[name].js"
+		chunkFilename: "[name].js",
+		cssChunkFilename: "[name].css",
+		cssFilename: "[name].css"
 	},
 	optimization: {
 		minimize: false, // Disabling minification because it takes too long on CI
@@ -98,15 +112,15 @@ const config = {
 			cacheGroups: {
 				someVendor: {
 					chunks: "all",
-					minChunks: 2
+					minChunks: 2,
+					filename: "someVencor-[name].js",
+					name: "vendor"
 				}
 			}
 		}
 	},
 	experiments: {
-		css: {
-			exportsOnly: true
-		}
+		css: true
 	},
 	plugins: [
 		new HtmlWebpackPlugin({

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "rimraf": "3.0.2",
     "ts-jest": "29.1.2",
     "typescript": "5.3.3",
-    "webpack": "5.89.0",
+    "webpack": "5.90.0",
     "webpack-cli": "4.10.0",
     "why-is-node-running": "2.2.2"
   },

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -46,7 +46,7 @@
     "fs-extra": "^11.1.1",
     "glob": "^10.3.10",
     "jest-diff": "^29.7.0",
-    "webpack": "5.89.0",
+    "webpack": "^5.90.0",
     "webpack-sources": "3.2.3",
     "which-module": "2.0.1"
   },

--- a/packages/rspack-test-tools/src/compare/format-code.ts
+++ b/packages/rspack-test-tools/src/compare/format-code.ts
@@ -91,6 +91,14 @@ export function formatCode(
 				}
 			}
 		},
+		SwitchCase(path) {
+			if (
+				path.node.consequent.length === 1 &&
+				path.node.consequent[0].type === "BlockStatement"
+			) {
+				path.node.consequent = path.node.consequent[0].body;
+			}
+		},
 		ObjectExpression(path) {
 			if (options.ignoreObjectPropertySequence) {
 				let result = [];

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -808,7 +808,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
         "hotModuleReplacement": false,
       },
       "name": "bundle.js",
-      "size": 9107,
+      "size": 9111,
       "type": "asset",
     },
   ],
@@ -873,10 +873,10 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
       "assets": [
         {
           "name": "bundle.js",
-          "size": 9107,
+          "size": 9111,
         },
       ],
-      "assetsSize": 9107,
+      "assetsSize": 9111,
       "chunks": [
         "909",
       ],
@@ -886,7 +886,7 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "5f9f75789352d7c6b706",
+  "hash": "a210589f4b012d53aa0a",
   "logging": {},
   "modules": [
     {
@@ -1044,10 +1044,10 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
       "assets": [
         {
           "name": "bundle.js",
-          "size": 9107,
+          "size": 9111,
         },
       ],
-      "assetsSize": 9107,
+      "assetsSize": 9111,
       "chunks": [
         "909",
       ],
@@ -1063,8 +1063,8 @@ exports[`StatsTestCases should print correct stats for hot+production 1`] = `
 
 exports[`StatsTestCases should print correct stats for hot+production 2`] = `
 "PublicPath: (none)
-asset bundle.js 8.89 KiB {909} [emitted] (name: main)
-Entrypoint main 8.89 KiB = bundle.js
+asset bundle.js 8.9 KiB {909} [emitted] (name: main)
+Entrypoint main 8.9 KiB = bundle.js
 chunk {909} bundle.js (main) [entry]
   ./index.js [10] {909}
     entry ./index.js
@@ -1077,7 +1077,7 @@ webpack/runtime/hot_module_replacement {909}
 webpack/runtime/get_chunk_update_filename {909}
 webpack/runtime/get_main_filename/update manifest {909}
   
-Rspack compiled successfully (5f9f75789352d7c6b706)"
+Rspack compiled successfully (a210589f4b012d53aa0a)"
 `;
 
 exports[`StatsTestCases should print correct stats for identifier-let-strict-mode 1`] = `

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,11 +66,11 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       webpack:
-        specifier: 5.89.0
-        version: 5.89.0(webpack-cli@4.10.0)
+        specifier: 5.90.0
+        version: 5.90.0(webpack-cli@4.10.0)
       webpack-cli:
         specifier: 4.10.0
-        version: 4.10.0(webpack@5.89.0)
+        version: 4.10.0(webpack@5.90.0)
       why-is-node-running:
         specifier: 2.2.2
         version: 2.2.2
@@ -216,22 +216,22 @@ importers:
         version: 4.1.6
       css-loader:
         specifier: ^6.8.1
-        version: 6.8.1(webpack@5.89.0)
+        version: 6.8.1(webpack@5.90.0)
       html-webpack-plugin:
         specifier: ^5.5.0
-        version: 5.5.0(webpack@5.89.0)
+        version: 5.5.0(webpack@5.90.0)
       less:
         specifier: ^4.1.3
         version: 4.1.3
       less-loader:
         specifier: ^11.1.0
-        version: 11.1.0(less@4.1.3)(webpack@5.89.0)
+        version: 11.1.0(less@4.1.3)(webpack@5.90.0)
       mini-css-extract-plugin:
         specifier: ^2.6.1
-        version: 2.7.2(webpack@5.89.0)
+        version: 2.7.2(webpack@5.90.0)
       postcss-loader:
         specifier: 7.3.4
-        version: 7.3.4(postcss@8.4.31)(typescript@5.3.3)(webpack@5.89.0)
+        version: 7.3.4(postcss@8.4.31)(typescript@5.3.3)(webpack@5.90.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -240,13 +240,13 @@ importers:
         version: 14.2.1
       style-loader:
         specifier: ^3.3.3
-        version: 3.3.3(webpack@5.89.0)
+        version: 3.3.3(webpack@5.90.0)
       swc-loader:
         specifier: ^0.2.3
-        version: 0.2.3(@swc/core@1.3.23)(webpack@5.89.0)
+        version: 0.2.3(@swc/core@1.3.23)(webpack@5.90.0)
       webpack:
-        specifier: ^5.89.0
-        version: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+        specifier: ^5.90.0
+        version: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
 
   npm/darwin-arm64: {}
 
@@ -347,7 +347,7 @@ importers:
         version: link:../../rspack
       vue-loader:
         specifier: ^17.2.2
-        version: 17.3.1(vue@3.2.45)(webpack@5.89.0)
+        version: 17.3.1(vue@3.2.45)(webpack@5.90.0)
 
   packages/playground:
     devDependencies:
@@ -377,7 +377,7 @@ importers:
         version: 11.0.4
       babel-loader:
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.22.20)(webpack@5.89.0)
+        version: 9.1.3(@babel/core@7.22.20)(webpack@5.90.0)
       fs-extra:
         specifier: 11.2.0
         version: 11.2.0
@@ -386,7 +386,7 @@ importers:
         version: 8.4.21
       postcss-loader:
         specifier: ^7.3.0
-        version: 7.3.3(postcss@8.4.21)(webpack@5.89.0)
+        version: 7.3.3(postcss@8.4.21)(webpack@5.90.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -404,10 +404,10 @@ importers:
         version: 3.4.15(typescript@5.3.3)
       vue-loader:
         specifier: ^17.3.1
-        version: 17.3.1(vue@3.4.15)(webpack@5.89.0)
+        version: 17.3.1(vue@3.4.15)(webpack@5.90.0)
       webpack-dev-server:
         specifier: 4.13.1
-        version: 4.13.1(webpack-cli@4.10.0)(webpack@5.89.0)
+        version: 4.13.1(webpack-cli@4.10.0)(webpack@5.90.0)
       ws:
         specifier: 8.16.0
         version: 8.16.0
@@ -486,28 +486,28 @@ importers:
         version: 8.5.10
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.2(@babel/core@7.23.2)(webpack@5.89.0)
+        version: 9.1.2(@babel/core@7.23.2)(webpack@5.90.0)
       babel-plugin-import:
         specifier: ^1.13.5
         version: 1.13.5
       copy-webpack-plugin:
         specifier: 5.1.2
-        version: 5.1.2(webpack@5.89.0)
+        version: 5.1.2(webpack@5.90.0)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.89.0)
+        version: 6.2.0(webpack@5.90.0)
       glob:
         specifier: ^10.3.10
         version: 10.3.10
       html-loader:
         specifier: ^4.2.0
-        version: 4.2.0(webpack@5.89.0)
+        version: 4.2.0(webpack@5.90.0)
       html-webpack-plugin:
         specifier: ^5.5.0
-        version: 5.5.0(webpack@5.89.0)
+        version: 5.5.0(webpack@5.90.0)
       jest-serializer-path:
         specifier: ^0.1.15
         version: 0.1.15
@@ -516,10 +516,10 @@ importers:
         version: 4.2.0
       less-loader:
         specifier: ^11.1.0
-        version: 11.1.0(less@4.2.0)(webpack@5.89.0)
+        version: 11.1.0(less@4.2.0)(webpack@5.90.0)
       postcss-loader:
         specifier: ^7.0.2
-        version: 7.0.2(postcss@8.4.31)(webpack@5.89.0)
+        version: 7.0.2(postcss@8.4.31)(webpack@5.90.0)
       postcss-pxtorem:
         specifier: ^6.0.0
         version: 6.0.0(postcss@8.4.31)
@@ -534,7 +534,7 @@ importers:
         version: 1.56.2
       sass-loader:
         specifier: ^13.2.0
-        version: 13.2.0(sass@1.56.2)(webpack@5.89.0)
+        version: 13.2.0(sass@1.56.2)(webpack@5.90.0)
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
@@ -631,10 +631,10 @@ importers:
         version: 2.1.35
       webpack-dev-middleware:
         specifier: 6.0.2
-        version: 6.0.2(webpack@5.89.0)
+        version: 6.0.2(webpack@5.90.0)
       webpack-dev-server:
         specifier: 4.13.1
-        version: 4.13.1(webpack-cli@4.10.0)(webpack@5.89.0)
+        version: 4.13.1(webpack-cli@4.10.0)(webpack@5.90.0)
       ws:
         specifier: 8.8.1
         version: 8.8.1
@@ -693,7 +693,7 @@ importers:
         version: 2.0.6
       html-loader:
         specifier: ^4.2.0
-        version: 4.2.0(webpack@5.89.0)
+        version: 4.2.0(webpack@5.90.0)
       loader-runner:
         specifier: ^4.3.0
         version: 4.3.0
@@ -845,8 +845,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0
       webpack:
-        specifier: 5.89.0
-        version: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+        specifier: ^5.90.0
+        version: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
       webpack-sources:
         specifier: 3.2.3
         version: 3.2.3
@@ -892,7 +892,7 @@ importers:
         version: 0.45.0
       monaco-editor-webpack-plugin:
         specifier: 7.1.0
-        version: 7.1.0(monaco-editor@0.45.0)(webpack@5.89.0)
+        version: 7.1.0(monaco-editor@0.45.0)(webpack@5.90.0)
       normalize.css:
         specifier: ^8.0.0
         version: 8.0.1
@@ -999,7 +999,7 @@ importers:
         version: 8.12.0
       babel-loader:
         specifier: ^9.1.0
-        version: 9.1.2(@babel/core@7.23.2)(webpack@5.89.0)
+        version: 9.1.2(@babel/core@7.23.2)(webpack@5.90.0)
       babel-plugin-import:
         specifier: ^1.13.5
         version: 1.13.5
@@ -1008,16 +1008,16 @@ importers:
         version: 3.5.3
       coffee-loader:
         specifier: ^1.0.0
-        version: 1.0.0(coffeescript@2.7.0)(webpack@5.89.0)
+        version: 1.0.0(coffeescript@2.7.0)(webpack@5.90.0)
       coffeescript:
         specifier: ^2.5.1
         version: 2.7.0
       copy-webpack-plugin:
         specifier: '5'
-        version: 5.1.2(webpack@5.89.0)
+        version: 5.1.2(webpack@5.90.0)
       css-loader:
         specifier: ^5.0.1
-        version: 5.0.1(webpack@5.89.0)
+        version: 5.0.1(webpack@5.90.0)
       csv-to-markdown-table:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1026,7 +1026,7 @@ importers:
         version: 0.10.53
       file-loader:
         specifier: ^6.2.0
-        version: 6.2.0(webpack@5.89.0)
+        version: 6.2.0(webpack@5.90.0)
       is-ci:
         specifier: 3.0.1
         version: 3.0.1
@@ -1038,10 +1038,10 @@ importers:
         version: 4.1.3
       less-loader:
         specifier: ^11.1.0
-        version: 11.1.0(less@4.1.3)(webpack@5.89.0)
+        version: 11.1.0(less@4.1.3)(webpack@5.90.0)
       postcss-loader:
         specifier: ^7.0.2
-        version: 7.0.2(postcss@8.4.31)(webpack@5.89.0)
+        version: 7.0.2(postcss@8.4.31)(webpack@5.90.0)
       postcss-pxtorem:
         specifier: ^6.0.0
         version: 6.0.0(postcss@8.4.31)
@@ -1050,7 +1050,7 @@ importers:
         version: 2.4.0(pug@2.0.4)
       raw-loader:
         specifier: ^4.0.2
-        version: 4.0.2(webpack@5.89.0)
+        version: 4.0.2(webpack@5.90.0)
       react-relay:
         specifier: ^14.1.0
         version: 14.1.0(react@18.2.0)
@@ -1062,7 +1062,7 @@ importers:
         version: 1.56.2
       sass-loader:
         specifier: ^13.2.0
-        version: 13.2.0(sass@1.56.2)(webpack@5.89.0)
+        version: 13.2.0(sass@1.56.2)(webpack@5.90.0)
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
@@ -1086,7 +1086,7 @@ importers:
         version: 1.3.0
       webpack-dev-server:
         specifier: 4.13.1
-        version: 4.13.1(webpack-cli@4.10.0)(webpack@5.89.0)
+        version: 4.13.1(webpack-cli@4.10.0)(webpack@5.90.0)
 
 packages:
 
@@ -1108,7 +1108,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@antv/adjust@0.2.5:
     resolution: {integrity: sha512-MfWZOkD9CqXRES6MBGRNe27Q577a72EIwyMnE29wIlPliFvJfWwsrONddpGU7lilMpVKecS3WAzOoip3RfPTRQ==}
@@ -1304,7 +1304,7 @@ packages:
   /@antv/util@2.0.17:
     resolution: {integrity: sha512-o6I9hi5CIUvLGDhth0RxNSFDRwXeywmt6ExR4+RmVAzIi48ps6HUy+svxOCayvrPBN37uE6TAc2KDofRo0nK9Q==}
     dependencies:
-      csstype: 3.1.2
+      csstype: 3.1.1
       tslib: 2.5.0
     dev: false
 
@@ -1405,6 +1405,15 @@ packages:
       '@babel/highlight': 7.22.20
       chalk: 2.4.2
 
+  /@babel/compat-data@7.20.14:
+    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/compat-data@7.21.7:
+    resolution: {integrity: sha512-KYMqFYTaenzMK4yUtf4EW9wc4N9ef80FsbMtkwool5zpwl4YrT1SdWYSTRcT94KO4hannogdS+LxY7L+arP3gA==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/compat-data@7.23.2:
     resolution: {integrity: sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==}
     engines: {node: '>=6.9.0'}
@@ -1483,7 +1492,7 @@ packages:
     dependencies:
       '@babel/types': 7.23.0
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.20
+      '@jridgewell/trace-mapping': 0.3.17
       jsesc: 2.5.2
     dev: true
 
@@ -1524,9 +1533,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.23.2
+      '@babel/compat-data': 7.21.7
       '@babel/core': 7.21.0
-      '@babel/helper-validator-option': 7.22.15
+      '@babel/helper-validator-option': 7.21.0
       browserslist: 4.21.10
       lru-cache: 5.1.1
       semver: 6.3.1
@@ -1671,6 +1680,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-environment-visitor@7.21.5:
+    resolution: {integrity: sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-environment-visitor@7.22.20:
     resolution: {integrity: sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==}
     engines: {node: '>=6.9.0'}
@@ -1730,6 +1744,12 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.0
+
+  /@babel/helper-module-imports@7.21.4:
+    resolution: {integrity: sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
     dev: true
 
   /@babel/helper-module-imports@7.22.15:
@@ -1747,6 +1767,22 @@ packages:
 
   /@babel/helper-module-transforms@7.21.5:
     resolution: {integrity: sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.21.5
+      '@babel/helper-module-imports': 7.21.4
+      '@babel/helper-simple-access': 7.21.5
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/template': 7.22.15
+      '@babel/traverse': 7.23.2
+      '@babel/types': 7.23.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms@7.22.5:
+    resolution: {integrity: sha512-+hGKDt/Ze8GFExiVHno/2dvG5IdstpzCq0y4Qc9OJ25D4q3pKfiIP/4Vp3/JvhDkLKsDK2api3q3fpIgiIF5bw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.22.20
@@ -1882,6 +1918,20 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-simple-access@7.20.2:
+    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: false
+
+  /@babel/helper-simple-access@7.21.5:
+    resolution: {integrity: sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
   /@babel/helper-simple-access@7.22.5:
     resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
@@ -1895,15 +1945,32 @@ packages:
       '@babel/types': 7.23.0
     dev: true
 
+  /@babel/helper-split-export-declaration@7.18.6:
+    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
   /@babel/helper-split-export-declaration@7.22.6:
     resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.0
 
+  /@babel/helper-string-parser@7.21.5:
+    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-string-parser@7.22.5:
     resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-identifier@7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
@@ -1911,6 +1978,11 @@ packages:
 
   /@babel/helper-validator-option@7.18.6:
     resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-option@7.21.0:
+    resolution: {integrity: sha512-rmL/B8/f0mKS2baE9ZpyTcTavvEuWhTTW8amjzXNvYG4AwBsqTLikfXsEofsJEfKHf+HQVQbFOHy6o+4cnC/fQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -2358,7 +2430,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.0
       '@babel/helper-create-class-features-plugin': 7.20.5(@babel/core@7.21.0)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2371,7 +2443,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-create-class-features-plugin': 7.20.5(@babel/core@7.23.2)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2438,7 +2510,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2):
@@ -2447,7 +2519,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.2):
@@ -2465,7 +2537,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2):
@@ -2474,7 +2546,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.21.0):
@@ -2568,7 +2640,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.2):
@@ -2577,7 +2649,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.21.0):
@@ -2616,7 +2688,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.2):
@@ -2625,7 +2697,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.21.0):
@@ -2634,7 +2706,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.2):
@@ -2643,7 +2715,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.21.0):
@@ -2652,7 +2724,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.2):
@@ -2661,7 +2733,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.0):
@@ -2670,7 +2742,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.2):
@@ -2679,7 +2751,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.21.0):
@@ -2688,7 +2760,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.2):
@@ -2697,7 +2769,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.21.0):
@@ -2706,7 +2778,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.2):
@@ -2715,7 +2787,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.21.0):
@@ -2745,7 +2817,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.2):
@@ -2755,7 +2827,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.21.0):
@@ -3127,7 +3199,7 @@ packages:
       '@babel/core': 7.23.2
       '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-simple-access': 7.20.2
     dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.21.0):
@@ -3137,9 +3209,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.21.0
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.21.0)
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-commonjs@7.22.5(@babel/core@7.23.2):
@@ -3149,9 +3223,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-module-transforms': 7.23.0(@babel/core@7.23.2)
+      '@babel/helper-module-transforms': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.21.0):
@@ -3504,7 +3580,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.23.2)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.23.2)
@@ -4040,8 +4116,8 @@ packages:
     resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/helper-string-parser': 7.21.5
+      '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
     dev: true
 
@@ -7197,16 +7273,16 @@ packages:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
       '@types/eslint': 8.37.0
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
 
   /@types/eslint@8.37.0:
     resolution: {integrity: sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==}
     dependencies:
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@types/json-schema': 7.0.11
 
-  /@types/estree@1.0.0:
-    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+  /@types/estree@1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
   /@types/express-serve-static-core@4.17.31:
     resolution: {integrity: sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==}
@@ -7492,7 +7568,7 @@ packages:
     dependencies:
       '@types/node': 18.15.11
       tapable: 2.2.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7521,7 +7597,7 @@ packages:
     dependencies:
       '@types/node': 20.9.4
       tapable: 2.2.1
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -7795,14 +7871,14 @@ packages:
       '@webassemblyjs/ast': 1.11.5
       '@xtuc/long': 4.2.2
 
-  /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.89.0):
+  /@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.90.0):
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.89.0(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@5.89.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
 
   /@webpack-cli/info@1.5.0(webpack-cli@4.10.0):
     resolution: {integrity: sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==}
@@ -7810,7 +7886,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0(webpack@5.89.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
 
   /@webpack-cli/serve@1.7.0(webpack-cli@4.10.0):
     resolution: {integrity: sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==}
@@ -7821,7 +7897,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0(webpack@5.89.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -8236,7 +8312,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader@9.1.2(@babel/core@7.23.2)(webpack@5.89.0):
+  /babel-loader@9.1.2(@babel/core@7.23.2)(webpack@5.90.0):
     resolution: {integrity: sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -8246,10 +8322,10 @@ packages:
       '@babel/core': 7.23.2
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
-  /babel-loader@9.1.3(@babel/core@7.22.20)(webpack@5.89.0):
+  /babel-loader@9.1.3(@babel/core@7.22.20)(webpack@5.90.0):
     resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -8259,7 +8335,7 @@ packages:
       '@babel/core': 7.22.20
       find-cache-dir: 4.0.0
       schema-utils: 4.0.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
   /babel-plugin-import@1.13.5:
@@ -8296,7 +8372,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.23.2
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.21.0
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.21.0)
       semver: 6.3.1
@@ -8309,7 +8385,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.23.2
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.23.2
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.23.2)
       semver: 6.3.1
@@ -8366,7 +8442,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-module-imports': 7.18.6
     dev: false
 
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.2):
@@ -9172,7 +9248,7 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /coffee-loader@1.0.0(coffeescript@2.7.0)(webpack@5.89.0):
+  /coffee-loader@1.0.0(coffeescript@2.7.0)(webpack@5.90.0):
     resolution: {integrity: sha512-/fjJBA842cpoN2upABQFO45ALS0clTHM8WsAbvDrArn6y4TaZikKgSPyMZxwqAkkz6zTV7MgS4RuxU3wS4XUvw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9182,7 +9258,7 @@ packages:
       coffeescript: 2.7.0
       loader-utils: 2.0.4
       schema-utils: 2.7.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
   /coffeescript@2.7.0:
@@ -9443,7 +9519,7 @@ packages:
       toggle-selection: 1.0.6
     dev: false
 
-  /copy-webpack-plugin@5.1.2(webpack@5.89.0):
+  /copy-webpack-plugin@5.1.2(webpack@5.90.0):
     resolution: {integrity: sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==}
     engines: {node: '>= 6.9.0'}
     peerDependencies:
@@ -9460,7 +9536,7 @@ packages:
       p-limit: 2.3.0
       schema-utils: 1.0.0
       serialize-javascript: 4.0.0
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
       webpack-log: 2.0.0
     dev: true
 
@@ -9632,7 +9708,7 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /css-loader@5.0.1(webpack@5.89.0):
+  /css-loader@5.0.1(webpack@5.90.0):
     resolution: {integrity: sha512-cXc2ti9V234cq7rJzFKhirb2L2iPy8ZjALeVJAozXYz9te3r4eqLSixNAbMDJSgJEQywqXzs8gonxaboeKqwiw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -9650,10 +9726,10 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.5.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
-  /css-loader@6.8.1(webpack@5.89.0):
+  /css-loader@6.8.1(webpack@5.90.0):
     resolution: {integrity: sha512-xDAXtEVGlD0gJ07iclwWVkLoZOpEvAWaSyf6W18S2pOC//K8+qUDIx8IIT3D+HjnmkJPQeesOPv5aiUaJsCM2g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -9667,7 +9743,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.23)
       postcss-value-parser: 4.2.0
       semver: 7.5.1
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
   /css-select@4.3.0:
@@ -9716,6 +9792,10 @@ packages:
 
   /csstype@2.6.21:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
+
+  /csstype@3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+    dev: false
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
@@ -10731,7 +10811,7 @@ packages:
       is-unicode-supported: 1.3.0
     dev: true
 
-  /file-loader@6.2.0(webpack@5.89.0):
+  /file-loader@6.2.0(webpack@5.90.0):
     resolution: {integrity: sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -10739,7 +10819,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
   /fill-range@7.0.1:
@@ -11296,7 +11376,7 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /html-loader@4.2.0(webpack@5.89.0):
+  /html-loader@4.2.0(webpack@5.90.0):
     resolution: {integrity: sha512-OxCHD3yt+qwqng2vvcaPApCEvbx+nXWu+v69TYHx1FO8bffHn/JjHtE3TTQZmHjwvnJe4xxzuecetDVBrQR1Zg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -11304,7 +11384,7 @@ packages:
     dependencies:
       html-minifier-terser: 7.0.0
       parse5: 7.1.1
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
   /html-minifier-terser@6.1.0:
@@ -11334,7 +11414,7 @@ packages:
       relateurl: 0.2.7
       terser: 5.27.0
 
-  /html-webpack-plugin@5.5.0(webpack@5.89.0):
+  /html-webpack-plugin@5.5.0(webpack@5.90.0):
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -11345,7 +11425,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
   /htmlescape@1.1.1:
@@ -12677,7 +12757,7 @@ packages:
     resolution: {integrity: sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ==}
     engines: {node: '>=0.10.0'}
 
-  /less-loader@11.1.0(less@4.1.3)(webpack@5.89.0):
+  /less-loader@11.1.0(less@4.1.3)(webpack@5.90.0):
     resolution: {integrity: sha512-C+uDBV7kS7W5fJlUjq5mPBeBVhYpTIm5gB09APT9o3n/ILeaXVsiSFTbZpTJCJwQ/Crczfn3DmfQFwxYusWFug==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -12686,10 +12766,10 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
-  /less-loader@11.1.0(less@4.2.0)(webpack@5.89.0):
+  /less-loader@11.1.0(less@4.2.0)(webpack@5.90.0):
     resolution: {integrity: sha512-C+uDBV7kS7W5fJlUjq5mPBeBVhYpTIm5gB09APT9o3n/ILeaXVsiSFTbZpTJCJwQ/Crczfn3DmfQFwxYusWFug==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -12698,7 +12778,7 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
   /less@4.1.3:
@@ -13225,14 +13305,14 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /mini-css-extract-plugin@2.7.2(webpack@5.89.0):
+  /mini-css-extract-plugin@2.7.2(webpack@5.90.0):
     resolution: {integrity: sha512-EdlUizq13o0Pd+uCp+WO/JpkLvHRVGt97RqfeGhXqAcorYo1ypJSpkV+WDT0vY/kmh/p7wRdJNJtuyK540PXDw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.0.0
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
   /minimalistic-assert@1.0.1:
@@ -13319,7 +13399,7 @@ packages:
       xtend: 4.0.2
     dev: true
 
-  /monaco-editor-webpack-plugin@7.1.0(monaco-editor@0.45.0)(webpack@5.89.0):
+  /monaco-editor-webpack-plugin@7.1.0(monaco-editor@0.45.0)(webpack@5.90.0):
     resolution: {integrity: sha512-ZjnGINHN963JQkFqjjcBtn1XBtUATDZBMgNQhDQwd78w2ukRhFXAPNgWuacaQiDZsUr4h1rWv5Mv6eriKuOSzA==}
     peerDependencies:
       monaco-editor: '>= 0.31.0'
@@ -13327,7 +13407,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       monaco-editor: 0.45.0
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
   /monaco-editor@0.45.0:
@@ -14106,7 +14186,7 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-loader@7.0.2(postcss@8.4.31)(webpack@5.89.0):
+  /postcss-loader@7.0.2(postcss@8.4.31)(webpack@5.90.0):
     resolution: {integrity: sha512-fUJzV/QH7NXUAqV8dWJ9Lg4aTkDCezpTS5HgJ2DvqznexTbSTxgi/dTECvTZ15BwKTtk8G/bqI/QTu2HPd3ZCg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -14117,10 +14197,10 @@ packages:
       klona: 2.0.5
       postcss: 8.4.31
       semver: 7.3.8
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
-  /postcss-loader@7.3.3(postcss@8.4.21)(webpack@5.89.0):
+  /postcss-loader@7.3.3(postcss@8.4.21)(webpack@5.90.0):
     resolution: {integrity: sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -14131,10 +14211,10 @@ packages:
       jiti: 1.18.2
       postcss: 8.4.21
       semver: 7.5.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
-  /postcss-loader@7.3.4(postcss@8.4.31)(typescript@5.3.3)(webpack@5.89.0):
+  /postcss-loader@7.3.4(postcss@8.4.31)(typescript@5.3.3)(webpack@5.90.0):
     resolution: {integrity: sha512-iW5WTTBSC5BfsBJ9daFMPVrLT36MrNiC6fqOZTTaHjBNX6Pfd5p+hSBqe/fEeNd7pc13QiAyGt7VdGMw4eRC4A==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -14145,7 +14225,7 @@ packages:
       jiti: 1.21.0
       postcss: 8.4.31
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -14749,7 +14829,7 @@ packages:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  /raw-loader@4.0.2(webpack@5.89.0):
+  /raw-loader@4.0.2(webpack@5.90.0):
     resolution: {integrity: sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -14757,7 +14837,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
   /rbush@2.0.2:
@@ -15460,7 +15540,7 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  /sass-loader@13.2.0(sass@1.56.2)(webpack@5.89.0):
+  /sass-loader@13.2.0(sass@1.56.2)(webpack@5.90.0):
     resolution: {integrity: sha512-JWEp48djQA4nbZxmgC02/Wh0eroSUutulROUusYJO9P9zltRbNN80JCBHqRGzjd4cmZCa/r88xgfkjGD0TXsHg==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -15482,7 +15562,7 @@ packages:
       klona: 2.0.5
       neo-async: 2.6.2
       sass: 1.56.2
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
     dev: true
 
   /sass@1.56.2:
@@ -16232,13 +16312,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /style-loader@3.3.3(webpack@5.89.0):
+  /style-loader@3.3.3(webpack@5.90.0):
     resolution: {integrity: sha512-53BiGLXAcll9maCYtZi2RCQZKa8NQQai5C4horqKyRmHj9H7QmcUyucrH+4KW/gBQbXM2AsB0axoEcFZPlfPcw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
   /styled-components@6.0.8(react-dom@18.2.0)(react@18.2.0):
@@ -16362,14 +16442,14 @@ packages:
       stable: 0.1.8
     dev: true
 
-  /swc-loader@0.2.3(@swc/core@1.3.23)(webpack@5.89.0):
+  /swc-loader@0.2.3(@swc/core@1.3.23)(webpack@5.90.0):
     resolution: {integrity: sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==}
     peerDependencies:
       '@swc/core': ^1.2.147
       webpack: '>=2'
     dependencies:
       '@swc/core': 1.3.23
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
   /syntax-error@1.4.0:
@@ -16446,8 +16526,8 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: false
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.23)(webpack@5.89.0):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+  /terser-webpack-plugin@5.3.10(@swc/core@1.3.23)(webpack@5.90.0):
+    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -16468,11 +16548,11 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.27.0
-      webpack: 5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0)
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.99)(webpack@5.89.0):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+  /terser-webpack-plugin@5.3.10(@swc/core@1.3.99)(webpack@5.90.0):
+    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -16493,10 +16573,10 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.27.0
-      webpack: 5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
+      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
 
-  /terser-webpack-plugin@5.3.9(webpack@5.89.0):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+  /terser-webpack-plugin@5.3.10(webpack@5.90.0):
+    resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -16516,7 +16596,7 @@ packages:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.27.0
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
 
   /terser@5.16.1:
     resolution: {integrity: sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==}
@@ -17181,7 +17261,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /vue-loader@17.3.1(vue@3.2.45)(webpack@5.89.0):
+  /vue-loader@17.3.1(vue@3.2.45)(webpack@5.90.0):
     resolution: {integrity: sha512-nmVu7KU8geOyzsStyyaxID/uBGDMS8BkPXb6Lu2SNkMawriIbb+hYrNtgftHMKxOSkjjjTF5OSSwPo3KP59egg==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
@@ -17197,10 +17277,10 @@ packages:
       hash-sum: 2.0.0
       vue: 3.2.45
       watchpack: 2.4.0
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
-  /vue-loader@17.3.1(vue@3.4.15)(webpack@5.89.0):
+  /vue-loader@17.3.1(vue@3.4.15)(webpack@5.90.0):
     resolution: {integrity: sha512-nmVu7KU8geOyzsStyyaxID/uBGDMS8BkPXb6Lu2SNkMawriIbb+hYrNtgftHMKxOSkjjjTF5OSSwPo3KP59egg==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
@@ -17216,7 +17296,7 @@ packages:
       hash-sum: 2.0.0
       vue: 3.4.15(typescript@5.3.3)
       watchpack: 2.4.0
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: true
 
   /vue@3.2.45:
@@ -17315,7 +17395,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /webpack-cli@4.10.0(webpack@5.89.0):
+  /webpack-cli@4.10.0(webpack@5.90.0):
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -17336,7 +17416,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.89.0)
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.90.0)
       '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
       '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
       colorette: 2.0.19
@@ -17346,10 +17426,10 @@ packages:
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
       webpack-merge: 5.9.0
 
-  /webpack-dev-middleware@5.3.3(webpack@5.89.0):
+  /webpack-dev-middleware@5.3.3(webpack@5.90.0):
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -17360,9 +17440,9 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
 
-  /webpack-dev-middleware@6.0.2(webpack@5.89.0):
+  /webpack-dev-middleware@6.0.2(webpack@5.90.0):
     resolution: {integrity: sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -17376,10 +17456,10 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.1
-      webpack: 5.89.0(webpack-cli@4.10.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
     dev: false
 
-  /webpack-dev-server@4.13.1(webpack-cli@4.10.0)(webpack@5.89.0):
+  /webpack-dev-server@4.13.1(webpack-cli@4.10.0)(webpack@5.90.0):
     resolution: {integrity: sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -17420,9 +17500,9 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.89.0(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack@5.89.0)
-      webpack-dev-middleware: 5.3.3(webpack@5.89.0)
+      webpack: 5.90.0(webpack-cli@4.10.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
+      webpack-dev-middleware: 5.3.3(webpack@5.90.0)
       ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
@@ -17449,8 +17529,8 @@ packages:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
 
-  /webpack@5.89.0(@swc/core@1.3.23)(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+  /webpack@5.90.0(@swc/core@1.3.23)(webpack-cli@4.10.0):
+    resolution: {integrity: sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -17460,7 +17540,7 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.11.5
       '@webassemblyjs/wasm-edit': 1.11.5
       '@webassemblyjs/wasm-parser': 1.11.5
@@ -17480,9 +17560,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.23)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.23)(webpack@5.90.0)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack@5.89.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -17490,8 +17570,8 @@ packages:
       - uglify-js
     dev: true
 
-  /webpack@5.89.0(@swc/core@1.3.99)(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+  /webpack@5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0):
+    resolution: {integrity: sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -17501,7 +17581,7 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.11.5
       '@webassemblyjs/wasm-edit': 1.11.5
       '@webassemblyjs/wasm-parser': 1.11.5
@@ -17521,17 +17601,17 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.99)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.3.99)(webpack@5.90.0)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack@5.89.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
       - uglify-js
 
-  /webpack@5.89.0(webpack-cli@4.10.0):
-    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+  /webpack@5.90.0(webpack-cli@4.10.0):
+    resolution: {integrity: sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -17541,7 +17621,7 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.5
       '@webassemblyjs/ast': 1.11.5
       '@webassemblyjs/wasm-edit': 1.11.5
       '@webassemblyjs/wasm-parser': 1.11.5
@@ -17561,9 +17641,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.10(webpack@5.90.0)
       watchpack: 2.4.0
-      webpack-cli: 4.10.0(webpack@5.89.0)
+      webpack-cli: 4.10.0(webpack@5.90.0)
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7251,7 +7251,7 @@ packages:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
       '@types/express-serve-static-core': 4.17.31
-      '@types/node': 20.9.4
+      '@types/node': 16.11.7
 
   /@types/connect-history-api-fallback@1.5.4:
     resolution: {integrity: sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==}
@@ -7431,6 +7431,9 @@ packages:
   /@types/minimist@1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: false
+
+  /@types/node@16.11.7:
+    resolution: {integrity: sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==}
 
   /@types/node@18.15.11:
     resolution: {integrity: sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==}

--- a/scripts/diff.cjs
+++ b/scripts/diff.cjs
@@ -41,6 +41,7 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
         ignoreSwcHelpersPath: true,
         ignoreObjectPropertySequence: true,
         ignoreCssFilePath: true,
+        detail: false,
         onCompareModules: function (file, results) {
           htmlReporter.increment(name, results);
           statsReporter.increment(name, results);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Modify configuration of diff repo:
1. Enable newTreeshaking
2. Bump webpack to 5.90.0 to support namedExports of experiments.css
3. Add generator and parser config to config file to prevent difference between less files
4. Align runtime module code with webpack 5.90.0 (fetchPritority)


## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
