### PR TITLE
perf: cleanup `ApiScanner`

### DIFF
--- a/crates/rspack_ast/src/ast/javascript.rs
+++ b/crates/rspack_ast/src/ast/javascript.rs
@@ -5,8 +5,7 @@ use swc_core::common::{
   errors::Handler, sync::Lrc, util::take::Take, Globals, Mark, SourceMap, GLOBALS,
 };
 use swc_core::ecma::ast::{Module, Program as SwcProgram};
-use swc_core::ecma::transforms::base::helpers;
-use swc_core::ecma::transforms::base::helpers::Helpers;
+use swc_core::ecma::transforms::base::helpers::{Helpers, HELPERS};
 use swc_core::ecma::visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith};
 use swc_error_reporters::handler::try_with_handler;
 use swc_node_comments::SwcComments;
@@ -171,7 +170,7 @@ impl Ast {
   {
     let Self { program, context } = self;
     GLOBALS.set(&context.globals, || {
-      helpers::HELPERS.set(&context.helpers, || f(program, context))
+      HELPERS.set(&context.helpers, || f(program, context))
     })
   }
 
@@ -192,7 +191,7 @@ impl Ast {
   {
     let Self { program, context } = self;
     GLOBALS.set(&context.globals, || {
-      helpers::HELPERS.set(&context.helpers, || f(program, context))
+      HELPERS.set(&context.helpers, || f(program, context))
     })
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -1,3 +1,4 @@
+mod api_plugin;
 mod check_var_decl;
 mod common_js_imports_parse_plugin;
 mod r#const;
@@ -8,6 +9,7 @@ mod r#trait;
 mod url_plugin;
 mod webpack_included_plugin;
 
+pub use self::api_plugin::APIPlugin;
 pub use self::check_var_decl::CheckVarDeclaratorIdent;
 pub use self::common_js_imports_parse_plugin::CommonJsImportsParserPlugin;
 pub use self::drive::JavaScriptParserPluginDrive;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -1,4 +1,3 @@
-mod api_scanner;
 mod common_js_export_scanner;
 mod common_js_scanner;
 mod compatibility_scanner;
@@ -33,9 +32,8 @@ use self::harmony_import_dependency_scanner::ImportMap;
 pub use self::parser::JavascriptParser;
 pub use self::util::*;
 use self::{
-  api_scanner::ApiScanner, common_js_export_scanner::CommonJsExportDependencyScanner,
-  common_js_scanner::CommonJsScanner, compatibility_scanner::CompatibilityScanner,
-  harmony_detection_scanner::HarmonyDetectionScanner,
+  common_js_export_scanner::CommonJsExportDependencyScanner, common_js_scanner::CommonJsScanner,
+  compatibility_scanner::CompatibilityScanner, harmony_detection_scanner::HarmonyDetectionScanner,
   harmony_export_dependency_scanner::HarmonyExportDependencyScanner,
   harmony_import_dependency_scanner::HarmonyImportDependencyScanner,
   harmony_top_level_this::HarmonyTopLevelThis,
@@ -105,22 +103,13 @@ pub fn scan_dependencies(
     &mut ignored,
     module_type,
     &worker_syntax_list,
+    resource_data,
+    build_info,
     &mut errors,
+    &mut warning_diagnostics,
   );
 
   parser.visit(program.get_inner_program());
-
-  program.visit_with(&mut ApiScanner::new(
-    source_file.clone(),
-    unresolved_ctxt,
-    resource_data,
-    &mut dependencies,
-    &mut presentational_dependencies,
-    compiler_options.output.module,
-    build_info,
-    &mut warning_diagnostics,
-    &mut ignored,
-  ));
 
   program.visit_with(&mut CompatibilityScanner::new(
     &mut presentational_dependencies,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -43,10 +43,8 @@ pub(crate) mod expr_matcher {
   use std::sync::Arc;
 
   use once_cell::sync::Lazy;
-  use swc_core::{
-    common::{EqIgnoreSpan, SourceMap},
-    ecma::{ast::Ident, parser::parse_file_as_expr},
-  };
+  use swc_core::common::{EqIgnoreSpan, SourceMap};
+  use swc_core::ecma::{ast::Ident, parser::parse_file_as_expr};
 
   static PARSED_MEMBER_EXPR_CM: Lazy<Arc<SourceMap>> = Lazy::new(Default::default);
 

--- a/packages/rspack-cli/tests/build/basic/public/main.js.map
+++ b/packages/rspack-cli/tests/build/basic/public/main.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"main.js","sources":["./src/entry.js"],"sourcesContent":["console.log(\"CONFIG\");\n"],"names":[],"mappings":";;;AAAA,QAAQ,GAAG,CAAC"}
+{"version":3,"file":"main.js","sources":["webpack:///./src/entry.js"],"sourcesContent":["console.log(\"CONFIG\");\n"],"names":[],"mappings":";;;AAAA,QAAQ,GAAG,CAAC"}

--- a/packages/rspack/tests/cases/parsing/typeof-api-2/index.js
+++ b/packages/rspack/tests/cases/parsing/typeof-api-2/index.js
@@ -1,0 +1,6 @@
+it("should parsed into const dependency", function () {
+	const mock = "http://www.mock.com";
+	__webpack_public_path__ = __webpack_base_uri__ = mock;
+	expect(__webpack_public_path__).toBe(mock);
+	expect(__webpack_base_uri__).toBe(mock);
+});


### PR DESCRIPTION
Visiting each identifier incurs a significant amount of time. Therefore, optimizing the `﻿ApiScanner` can aid in improving performance.

before 3.3s:

![img_v3_027b_d0f441f4-9595-4c5f-a925-0b4d629f790g](https://github.com/web-infra-dev/rspack/assets/30187863/82e417fc-6a42-42da-a046-1187eaf104fa)

after this PR, 2.7s:

![img_v3_027b_dd4534ad-56d3-4b7f-b6ff-2605d46a968g](https://github.com/web-infra-dev/rspack/assets/30187863/67528dfd-f78c-4260-bb25-09859f89e81a)
