### PR TITLE
ci: setup renovatebot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "ignorePaths": [
+    "**/tests/**",
+    "**/fixtures/**",
+    "webpack-examples/**",
+    "webpack-test/**"
+  ],
+  "packageRules": [
+    {
+      "groupName": "github-actions",
+      "matchManagers": ["github-actions"],
+      "schedule": ["on wednesday"],
+      "assignees": ["@Boshen"]
+    }
+  ]
+}


### PR DESCRIPTION
Only `github-actions` is configured for this PR for testing purposes

relates #5387
