### PR TITLE
fix: resolve error with inline loader without module specifier

### DIFF
--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -230,7 +230,13 @@ async fn process_resource<C: Send>(loader_context: &mut LoaderContext<'_, C>) ->
     }
   }
 
-  if loader_context.content.is_none() {
+  if loader_context.content.is_none()
+    && !loader_context
+      .__resource_data
+      .resource_path
+      .to_string_lossy()
+      .is_empty()
+  {
     let result = tokio::fs::read(&loader_context.__resource_data.resource_path)
       .await
       .map_err(|e| {

--- a/packages/rspack/tests/configCases/source-map/relative-source-maps-by-loader/index.js
+++ b/packages/rspack/tests/configCases/source-map/relative-source-maps-by-loader/index.js
@@ -1,11 +1,11 @@
 // TODO: Rspack is not support inline loader like `require("./loader-source-root!")`
 it("should run", () => {
-	require("./loader-source-root!./foo.js");
-	// require("./loader-source-root-slash!./foo.js");
-	// require("./loader-source-root-source-slash!./foo.js");
-	// require("./loader-source-root-2-slash!./foo.js");
-	// require("./loader-no-source-root!./foo.js");
-	// require("./loader-pre-relative!./foo.js");
+	require("./loader-source-root!");
+	// require("./loader-source-root-slash!");
+	// require("./loader-source-root-source-slash!");
+	// require("./loader-source-root-2-slash!");
+	// require("./loader-no-source-root!");
+	// require("./loader-pre-relative!");
 });
 
 it("should generate the correct SourceMap", function () {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Resolved an issue where using an inline loader without a module specifier resulted in an error, as demonstrated below:

```js
require("./loader-source-root!");
```

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
