### PR TITLE
fix: use `eval.as_string()` lazily

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -78,16 +78,16 @@ impl CommonJsImportsParserPlugin {
     };
 
     let param = parser.evaluate_expression(&first_arg.expr);
-    param
-      .is_string()
-      .then_some(CommonJsFullRequireDependency::new(
+    param.is_string().then(|| {
+      CommonJsFullRequireDependency::new(
         param.string().to_string(),
         members.iter().map(|i| i.to_owned()).collect_vec(),
         loc,
         Some(mem_expr.span.into()),
         is_call,
         parser.in_try,
-      ))
+      )
+    })
   }
 
   fn require_handler(

--- a/packages/rspack/tests/cases/parsing/issue-5426/index.js
+++ b/packages/rspack/tests/cases/parsing/issue-5426/index.js
@@ -1,0 +1,9 @@
+it("not panic for require when args is not string ", function () {
+	let count = 0;
+	try {
+		require(1).__expression;
+	} catch (_err) {
+		count += 1;
+	}
+	expect(count).toBe(1);
+});


### PR DESCRIPTION
Fixes #5426