### PR TITLE
chore: use `cargo machete` for checking unused dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,34 @@ jobs:
           command: fmt
           args: --all -- --check
 
+  rust_unused_dependencies:
+    name: Check Rust Unused Dependencies
+    needs: [get-runner-labels, rust_changes]
+    if: ${{ needs.rust_changes.outputs.changed == 'true' }}
+    runs-on: ${{ fromJSON(needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            src:
+              - 'Cargo.toml'
+              - '**/Cargo.toml'
+
+      - name: Install cargo-machete
+        if: steps.filter.outputs.src == 'true'
+        uses: taiki-e/install-action@cargo-machete
+
+      - name: Install Rust Toolchain
+        uses: ./.github/actions/rustup
+        with:
+          shared-key: check
+
+      - if: steps.filter.outputs.src == 'true'
+        run: cargo machete
+
   rust_test:
     name: Rust test
     needs: [get-runner-labels, rust_changes]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,7 +2500,6 @@ dependencies = [
 name = "rspack_core_macros"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.48",
 ]
@@ -2772,11 +2771,9 @@ dependencies = [
 name = "rspack_plugin_devtool"
 version = "0.1.0"
 dependencies = [
- "async-recursion",
  "async-trait",
  "dashmap",
  "derivative",
- "futures",
  "once_cell",
  "pathdiff",
  "rayon",
@@ -2785,7 +2782,6 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hash",
- "rspack_regex",
  "rspack_util",
  "rustc-hash",
  "serde_json",
@@ -2865,7 +2861,6 @@ dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "either",
- "hex",
  "indexmap 1.9.3",
  "itertools",
  "linked_hash_set",
@@ -2997,7 +2992,6 @@ dependencies = [
  "indexmap 1.9.3",
  "itertools",
  "once_cell",
- "rayon",
  "regex",
  "rspack_core",
  "rspack_error",

--- a/crates/rspack_core_macros/Cargo.toml
+++ b/crates/rspack_core_macros/Cargo.toml
@@ -10,6 +10,5 @@ version    = "0.1.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { workspace = true }
-quote       = { workspace = true }
-syn         = { workspace = true }
+quote = { workspace = true }
+syn   = { workspace = true }

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -8,20 +8,17 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-recursion = { workspace = true }
-async-trait     = { workspace = true }
-dashmap         = { workspace = true }
-derivative      = { workspace = true }
-futures         = { workspace = true }
-once_cell       = { workspace = true }
-pathdiff        = { workspace = true }
-rayon           = { workspace = true }
-regex           = { workspace = true }
-rspack_base64   = { path = "../rspack_base64" }
-rspack_core     = { path = "../rspack_core" }
-rspack_error    = { path = "../rspack_error" }
-rspack_hash     = { path = "../rspack_hash" }
-rspack_regex    = { path = "../rspack_regex" }
-rspack_util     = { path = "../rspack_util" }
-rustc-hash      = { workspace = true }
-serde_json      = { workspace = true }
+async-trait   = { workspace = true }
+dashmap       = { workspace = true }
+derivative    = { workspace = true }
+once_cell     = { workspace = true }
+pathdiff      = { workspace = true }
+rayon         = { workspace = true }
+regex         = { workspace = true }
+rspack_base64 = { path = "../rspack_base64" }
+rspack_core   = { path = "../rspack_core" }
+rspack_error  = { path = "../rspack_error" }
+rspack_hash   = { path = "../rspack_hash" }
+rspack_util   = { path = "../rspack_util" }
+rustc-hash    = { workspace = true }
+serde_json    = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -12,7 +12,6 @@ rspack_testing = { path = "../rspack_testing" }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 either = "1"
-hex = "0.4.3"
 indexmap = { workspace = true }
 itertools = { workspace = true }
 linked_hash_set = { workspace = true }

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -12,7 +12,6 @@ async-trait              = { workspace = true }
 indexmap                 = { workspace = true }
 itertools                = { workspace = true }
 once_cell                = { workspace = true }
-rayon                    = { workspace = true }
 regex                    = { workspace = true }
 rspack_core              = { path = "../rspack_core" }
 rspack_error             = { path = "../rspack_error" }

--- a/crates/swc_plugin_import/Cargo.toml
+++ b/crates/swc_plugin_import/Cargo.toml
@@ -11,3 +11,6 @@ handlebars = "4.3.7"
 rustc-hash = { workspace = true }
 serde      = { workspace = true }
 swc_core   = { workspace = true, features = ["common", "ecma_ast", "ecma_visit"] }
+
+[package.metadata.cargo-machete]
+ignored = ["Inflector"]


### PR DESCRIPTION
## Summary

https://github.com/est31/cargo-udeps is outdated and broken.

https://github.com/bnjbvr/cargo-machete makes everything easy by using greping for the dependency, which is correct 99% of the time for a Rust project :-)