### PR TITLE
fix: evaluate if stmt should skip import specifier in dead branch

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/harmony_import_dependency_scanner.rs
@@ -184,6 +184,7 @@ impl Visit for HarmonyImportDependencyScanner<'_> {
       self.import_map,
       self.dependencies,
       self.rewrite_usage_span,
+      self.ignored,
     ));
   }
 
@@ -356,6 +357,7 @@ pub struct HarmonyImportRefDependencyScanner<'a> {
   pub dependencies: &'a mut Vec<BoxDependency>,
   pub properties_in_destructuring: HashMap<Atom, HashSet<Atom>>,
   pub rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
+  pub ignored: &'a mut HashSet<DependencyLocation>,
 }
 
 impl<'a> HarmonyImportRefDependencyScanner<'a> {
@@ -363,6 +365,7 @@ impl<'a> HarmonyImportRefDependencyScanner<'a> {
     import_map: &'a ImportMap,
     dependencies: &'a mut Vec<BoxDependency>,
     rewrite_usage_span: &'a mut HashMap<Span, ExtraSpanInfo>,
+    ignored: &'a mut HashSet<DependencyLocation>,
   ) -> Self {
     Self {
       import_map,
@@ -371,12 +374,14 @@ impl<'a> HarmonyImportRefDependencyScanner<'a> {
       enter_new_expr: false,
       properties_in_destructuring: HashMap::default(),
       rewrite_usage_span,
+      ignored,
     }
   }
 }
 
 impl Visit for HarmonyImportRefDependencyScanner<'_> {
   noop_visit_type!();
+  no_visit_ignored_stmt!();
 
   // collect referenced properties in destructuring
   // import * as a from 'a';

--- a/packages/rspack/tests/cases/parsing/evaluate-if/foo.js
+++ b/packages/rspack/tests/cases/parsing/evaluate-if/foo.js
@@ -1,0 +1,1 @@
+export const foo = 1;

--- a/packages/rspack/tests/cases/parsing/evaluate-if/index.js
+++ b/packages/rspack/tests/cases/parsing/evaluate-if/index.js
@@ -1,0 +1,8 @@
+import { foo } from "./foo";
+
+// see issue https://github.com/web-infra-dev/rspack/issues/5430
+it("should compile", () => {
+	if (typeof require === "undefined") {
+		foo;
+	}
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #5430 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

before:
```js
it('should have correct syntax', () => {
        if (true) console.log('hello');
        else _foo__WEBPACK_IMPORTED_MODULE_0__.foo{ }
      });
```
after:
```js
it('should have correct syntax', () => {
        if (true) console.log('hello');
        else { }
      });
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
