### PR TITLE
perf: lazy calculate compilation.modules and compilation.chunks

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -55,8 +55,9 @@ import {
 } from "./util/fake";
 import { NormalizedJsModule, normalizeJsModule } from "./util/normalization";
 import MergeCaller from "./util/MergeCaller";
+import { memoizeValue } from "./util/memoize";
 import { Chunk } from "./Chunk";
-import { CodeGenerationResult, Module } from "./Module";
+import { CodeGenerationResult } from "./Module";
 import { ChunkGraph } from "./ChunkGraph";
 
 export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
@@ -722,12 +723,16 @@ export class Compilation {
 	);
 
 	get modules() {
-		return this.__internal__getModules().map(item => normalizeJsModule(item));
+		return memoizeValue(() => {
+			return this.__internal__getModules().map(item => normalizeJsModule(item));
+		});
 	}
 
 	// FIXME: This is not aligned with Webpack.
 	get chunks() {
-		return this.__internal__getChunks();
+		return memoizeValue(() => {
+			return this.__internal__getChunks();
+		});
 	}
 
 	/**

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -792,7 +792,7 @@ class Compiler {
 
 	async #optimizeChunkModules() {
 		await this.compilation.hooks.optimizeChunkModules.promise(
-			this.compilation.__internal__getChunks(),
+			this.compilation.chunks,
 			this.compilation.modules
 		);
 		this.#updateDisabledHooks();
@@ -800,7 +800,7 @@ class Compiler {
 
 	async #optimizeTree() {
 		await this.compilation.hooks.optimizeTree.promise(
-			this.compilation.__internal__getChunks(),
+			this.compilation.chunks,
 			this.compilation.modules
 		);
 		this.#updateDisabledHooks();

--- a/packages/rspack/src/util/memoize.ts
+++ b/packages/rspack/src/util/memoize.ts
@@ -30,3 +30,29 @@ export const memoizeFn = <const T extends readonly unknown[], const P>(
 		return cache(...args);
 	};
 };
+
+export function memoizeValue<T>(fn: () => T): T {
+	const getValue: () => any = memoize(fn);
+	return new Proxy({} as any, {
+		get(_, property) {
+			return getValue()[property];
+		},
+		set(_, property, newValue) {
+			getValue()[property] = newValue;
+			return true;
+		},
+		deleteProperty(_, property) {
+			const value = getValue();
+			return delete value[property];
+		},
+		has: (_, property) => {
+			return property in getValue();
+		},
+		ownKeys: _ => {
+			return Object.keys(getValue());
+		},
+		getOwnPropertyDescriptor(_, property) {
+			return Object.getOwnPropertyDescriptor(getValue(), property);
+		}
+	});
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Rspack spent a lot of time on `optimizeTree` when use html-webpack-plugin. This is caused by move `compilation.modules` and `compilation.chunks` from rust side to node js side. 

![image](https://github.com/web-infra-dev/rspack/assets/9291503/3cc6b9c1-1411-4309-9a92-dbc68e40afac)

This PR add lazy calculation for `compilation.modules` and `compilation.chunks` to make html-webpack-plugin faster


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
