### PR TITLE
fix: assign depth for include dependencies

### DIFF
--- a/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/a/index.js
+++ b/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/a/index.js
@@ -1,0 +1,4 @@
+import { b } from "./util";
+
+export const a = b + 1;
+export var c = 1;

--- a/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/a/util.js
+++ b/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/a/util.js
@@ -1,0 +1,2 @@
+import { c } from "./index";
+export const b = c + 1;

--- a/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/index.js
+++ b/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/index.js
@@ -1,0 +1,5 @@
+import * as a from "./reexport";
+
+it("should not suspend when assign depth for include dependencies", async () => {
+	expect(a.a).toBe(NaN);
+});

--- a/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/reexport.js
+++ b/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/reexport.js
@@ -1,0 +1,1 @@
+export * from "./a";

--- a/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/webpack.config.js
+++ b/packages/rspack/tests/configCases/container-1-5/assign-depth-for-add-include/webpack.config.js
@@ -1,0 +1,9 @@
+const rspack = require("@rspack/core");
+
+module.exports = {
+	plugins: [
+		new rspack.sharing.ProvideSharedPlugin({
+			provides: ["./a/index.js"]
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

build should not suspend when assign depth for include dependencies

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
