### PR TITLE
chore: bump indexmap from 1.9.3 to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2512,7 +2512,7 @@ dependencies = [
  "glob-match",
  "hashlink",
  "hex",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "json",
  "mime_guess",
@@ -2684,7 +2684,7 @@ dependencies = [
  "async-trait",
  "dashmap",
  "either",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "jsonc-parser 0.23.0",
  "once_cell",
  "rspack_ast",
@@ -2914,7 +2914,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "linked_hash_set",
  "num-bigint",
@@ -3020,7 +3020,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "derivative",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "once_cell",
  "rayon",
  "regex",
@@ -3042,7 +3042,7 @@ name = "rspack_plugin_runtime"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "once_cell",
  "regex",
@@ -3133,7 +3133,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "dashmap",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "rayon",
  "rspack_core",
  "rspack_error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ futures            = { version = "0.3.30" }
 futures-util       = { version = "0.3.30" }
 glob               = { version = "0.3.1" }
 hashlink           = { version = "0.9.0" }
-indexmap           = { version = "=1.9.3", features = ["serde-1"] }
+indexmap           = { version = "2.1.0" }
 insta              = { version = "1.34.0" }
 itertools          = { version = "0.12.0" }
 json               = { version = "0.12.4" }

--- a/crates/rspack_plugin_css/Cargo.toml
+++ b/crates/rspack_plugin_css/Cargo.toml
@@ -9,7 +9,7 @@ version    = "0.1.0"
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 heck = "0.4.1"
-indexmap = { workspace = true }
+indexmap = { version = "=1.9.3", features = ["serde-1"] } # pinned by rkyv
 once_cell = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }


### PR DESCRIPTION
The upgrade is safe because it's a only a Rust MSRV change.

See https://github.com/indexmap-rs/indexmap/blob/master/RELEASES.md
