### PR TITLE
chore: bump bitflags to v2.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ dependencies = [
  "anymap",
  "async-recursion",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "dashmap",
  "derivative",
  "dyn-clone",
@@ -2663,7 +2663,7 @@ dependencies = [
  "anymap",
  "async-recursion",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "derivative",
  "once_cell",
  "regex",
@@ -2796,7 +2796,7 @@ name = "rspack_plugin_css"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "heck",
  "hrx-parser",
  "indexmap 1.9.3",
@@ -2913,7 +2913,7 @@ name = "rspack_plugin_javascript"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.4.2",
  "indexmap 2.1.0",
  "itertools 0.12.0",
  "linked_hash_set",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ async-scoped       = { version = "0.8.0" }
 async-trait        = { version = "0.1.77" }
 backtrace          = "0.3"
 better_scoped_tls  = { version = "0.1.1" }
-bitflags           = { version = "1.3.2" }
+bitflags           = { version = "2.4.2" }
 colored            = { version = "2.1.0" }
 concat-string      = "1.0.1"
 dashmap            = { version = "5.5.3" }

--- a/crates/rspack_core/src/fake_namespace_object.rs
+++ b/crates/rspack_core/src/fake_namespace_object.rs
@@ -3,15 +3,16 @@ use std::fmt;
 use bitflags::bitflags;
 
 bitflags! {
+  #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct FakeNamespaceObjectMode: u8 {
         const MODULE_ID = 1 << 0; // value is a module id, require it
         const MERGE_PROPERTIES = 1 << 1; // merge all properties of value into the ns
         const RETURN_VALUE = 1 << 2; // return value when already ns object
         const REQUIRE =  1 << 3;
         const PROMISE_LIKE = 1 << 4; // return value when it's Promise-like
-        const NAMESPACE = Self::MODULE_ID.bits | Self::REQUIRE.bits;
-        const DYNAMIC = Self::MODULE_ID.bits | Self::MERGE_PROPERTIES.bits | Self::RETURN_VALUE.bits;
-        const DEFAULT_WITH_NAMED = Self::MODULE_ID.bits | Self::MERGE_PROPERTIES.bits;
+        const NAMESPACE = Self::MODULE_ID.bits() | Self::REQUIRE.bits();
+        const DYNAMIC = Self::MODULE_ID.bits() | Self::MERGE_PROPERTIES.bits() | Self::RETURN_VALUE.bits();
+        const DEFAULT_WITH_NAMED = Self::MODULE_ID.bits() | Self::MERGE_PROPERTIES.bits();
     }
 }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -36,7 +36,7 @@ use crate::{
 };
 
 bitflags! {
-  #[derive(Default)]
+  #[derive(Debug, Default, Clone, Copy)]
   pub struct ModuleSyntax: u8 {
     const COMMONJS = 1 << 0;
     const ESM = 1 << 1;

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -4,6 +4,7 @@ use bitflags::bitflags;
 use swc_core::ecma::atoms::Atom;
 
 bitflags! {
+  #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
   pub struct RuntimeGlobals: u64 {
     const REQUIRE_SCOPE = 1 << 0;
 
@@ -328,22 +329,6 @@ impl RuntimeGlobals {
       R::RSPACK_VERSION => "__webpack_require__.rv",
       _ => unreachable!(),
     }
-  }
-
-  /// A stub function for bitflags `iter` in 2.0.0, we are stuck to 1.3.0 now
-  pub fn iter(&self) -> impl Iterator<Item = Self> {
-    let mut bit = 0;
-    let bits = self.bits();
-    std::iter::from_fn(move || {
-      while bit < 64 {
-        let flag = 1 << bit;
-        bit += 1;
-        if bits & flag != 0 {
-          return Self::from_bits(flag);
-        }
-      }
-      None
-    })
   }
 }
 

--- a/crates/rspack_core/src/tree_shaking/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/mod.rs
@@ -18,6 +18,7 @@ pub mod visitor;
 pub mod webpack_ext;
 
 mod test;
+
 #[derive(Debug)]
 pub struct OptimizeDependencyResult {
   pub used_symbol_ref: HashSet<SymbolRef>,
@@ -62,6 +63,7 @@ pub fn debug_care_module_id<T: AsRef<str>>(id: T) -> bool {
 }
 
 bitflags::bitflags! {
+  #[derive(Debug, Clone, Copy)]
   pub struct BailoutFlag: u8 {
       const COMMONJS_REQUIRE = 1 << 1;
       const COMMONJS_EXPORTS = 1 << 2;

--- a/crates/rspack_core/src/tree_shaking/symbol/mod.rs
+++ b/crates/rspack_core/src/tree_shaking/symbol/mod.rs
@@ -9,6 +9,7 @@ use swc_core::{common::SyntaxContext, ecma::atoms::js_word};
 use crate::DependencyId;
 
 bitflags! {
+  #[derive(Debug, Clone, Copy, Eq, PartialEq)]
     pub struct SymbolFlag: u8 {
         const DEFAULT =  1 << 0;
         const EXPORT =  1 << 1;
@@ -17,7 +18,7 @@ bitflags! {
         const FUNCTION_EXPR = 1 << 4;
         const CLASS_EXPR = 1 << 5;
         const ALIAS = 1 << 6;
-        const EXPORT_DEFAULT = Self::DEFAULT.bits | Self::EXPORT.bits;
+        const EXPORT_DEFAULT = Self::DEFAULT.bits() | Self::EXPORT.bits();
     }
 }
 #[derive(Debug, Hash, Clone, PartialEq, Eq, Serialize)]

--- a/crates/rspack_core/src/tree_shaking/visitor.rs
+++ b/crates/rspack_core/src/tree_shaking/visitor.rs
@@ -149,7 +149,7 @@ impl SymbolRef {
 }
 
 bitflags! {
-  #[derive(Default)]
+  #[derive(Debug, Default, Clone, Copy)]
   struct AnalyzeState: u8 {
     const EXPORT_DECL = 1 << 0;
     const EXPORT_DEFAULT = 1 << 1;

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -102,6 +102,7 @@ impl<C> LoaderItem<C> {
 }
 
 bitflags::bitflags! {
+  #[derive(Debug)]
   struct LoaderItemDataMeta: u8 {
     /// Builtin loader
     const BUILTIN = 1 << 0;

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -53,6 +53,7 @@ pub struct LocalIdentNameRenderOptions<'a> {
 }
 
 bitflags! {
+  #[derive(Debug, Clone, Copy)]
   struct LocalsConventionFlags: u8 {
     const ASIS = 1 << 0;
     const CAMELCASE = 1 << 1;
@@ -60,7 +61,7 @@ bitflags! {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct LocalsConvention(LocalsConventionFlags);
 
 impl LocalsConvention {


### PR DESCRIPTION
The breaking changes are API only, see https://github.com/bitflags/bitflags/releases/tag/2.0.0