### PR TITLE
chore: renovate bot turn on npm devDependencies update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["github-actions", "cargo"],
+  "enabledManagers": ["github-actions", "cargo", "npm"],
   "ignorePaths": [
     "**/tests/**",
     "**/fixtures/**",
@@ -27,7 +27,7 @@
       "schedule": ["on wednesday"],
       "assignees": ["@Boshen"],
       "excludePackagePrefixes": ["swc"],
-      "excludePackageNames": ["ustr", "textwrap", "styled_components"]
+      "excludePackageNames": ["ustr", "textwrap", "styled_components", "owo-colors"]
     },
     {
       "groupName": "swc",
@@ -39,7 +39,27 @@
     {
       "groupName": "ignored-crates",
       "matchManagers": ["cargo"],
-      "matchPackageNames": ["ustr", "textwrap"],
+      "matchPackageNames": ["ustr", "textwrap", "owo-colors"],
+      "enabled": false
+    },
+    {
+      "groupName": "ignored-indexmap",
+      "matchManagers": ["cargo"],
+      "matchFileNames": ["crates/rspack_plugin_css/Cargo.toml"],
+      "matchPackageNames": ["indexmap"],
+      "enabled": false
+    },
+    {
+      "groupName": "npm-devDependencies",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "schedule": ["on wednesday"],
+      "assignees": ["@Boshen"]
+    },
+    {
+      "groupName": "npm-dependencies",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Turn on `devDependencies` first ... I've got no clue on how to deal with `dependencies`