### PR TITLE
chore: renovate ignore more directories

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["github-actions", "cargo", "npm"],
   "ignorePaths": [
-    "**/tests/**",
     "**/fixtures/**",
+    "**/tests/**",
+    "diffcases/**",
+    "npm/**",
+    "packages/create-rspack/**",
     "webpack-examples/**",
     "webpack-test/**"
   ],


### PR DESCRIPTION
This ignores updating 

```
    "diffcases/**",
    "npm/**",
    "packages/create-rspack/**",
```