### PR TITLE
refactor: align HarmonyCompatibiltyDependency with webpack

### DIFF
--- a/crates/rspack/tests/samples/mangle-exports-demo/snapshot/output.snap
+++ b/crates/rspack/tests/samples/mangle-exports-demo/snapshot/output.snap
@@ -5,22 +5,19 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./answer.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   K: function() { return answer; }
 });
 const answer = 103330;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./lib.js");
 
 _lib__WEBPACK_IMPORTED_MODULE_0__/* .answer */.K;
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   K: function() { return /* reexport safe */ _answer__WEBPACK_IMPORTED_MODULE_0__.K; }
 });

--- a/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/snapshot/output.snap
+++ b/crates/rspack/tests/samples/remove-parent-modules/ancestor-has-all-modules/snapshot/output.snap
@@ -6,9 +6,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 "./foo.js": (function (module) {
 module.exports = 'foo';
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo.js */"./foo.js");
 /* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_foo_js__WEBPACK_IMPORTED_MODULE_0__);
 

--- a/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/snapshot/output.snap
+++ b/crates/rspack/tests/samples/remove-parent-modules/cycle-entry/snapshot/output.snap
@@ -26,9 +26,8 @@ var __webpack_exports__ = (__webpack_exec__("./index.js"));
 
 ```js title=index2.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["index2"], {
-"./index2.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index2.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./shared */"./shared.js");
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 __webpack_require__.e("index_js").then(__webpack_require__.bind(__webpack_require__, /*! ./index */"./index.js"));

--- a/crates/rspack/tests/samples/remove-parent-modules/intersection/snapshot/output.snap
+++ b/crates/rspack/tests/samples/remove-parent-modules/intersection/snapshot/output.snap
@@ -52,9 +52,8 @@ console.log('i-2');
 "./i-1.js": (function () {
 console.log('i-1');
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./shared */"./shared.js");
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */var _i_1__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./i-1 */"./i-1.js");
@@ -81,9 +80,8 @@ var __webpack_exports__ = (__webpack_exec__("./index.js"));
 "./i-2.js": (function () {
 console.log('i-2');
 }),
-"./index2.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index2.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./shared */"./shared.js");
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 /* harmony import */var _i_2__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./i-2 */"./i-2.js");

--- a/crates/rspack/tests/samples/remove-parent-modules/simple/snapshot/output.snap
+++ b/crates/rspack/tests/samples/remove-parent-modules/simple/snapshot/output.snap
@@ -17,9 +17,8 @@ console.log('a');
 
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./shared */"./shared.js");
 /* harmony import */var _shared__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_shared__WEBPACK_IMPORTED_MODULE_0__);
 

--- a/crates/rspack/tests/tree-shaking/array-side-effects/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/array-side-effects/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   app: function() { return app; }
 });
@@ -14,16 +13,14 @@ __webpack_require__.d(__webpack_exports__, {
 function app() {}
 app.prototype.result = _lib__WEBPACK_IMPORTED_MODULE_0__.result;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _src_a__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./src/a */"./src/a.js");
 
 
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   result: function() { return result; }
 });
@@ -31,9 +28,8 @@ const secret = "888";
 const result = 20000;
 const something = function() {};
 }),
-"./src/a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./src/a.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.app;

--- a/crates/rspack/tests/tree-shaking/assign-with-side-effects/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/assign-with-side-effects/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   app: function() { return app; }
 });
@@ -14,16 +13,14 @@ __webpack_require__.d(__webpack_exports__, {
 function app() {}
 app.prototype.result = _lib__WEBPACK_IMPORTED_MODULE_0__.result;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__.app)();
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   result: function() { return result; }
 });

--- a/crates/rspack/tests/tree-shaking/basic/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/basic/snapshot/new_treeshaking.snap
@@ -5,15 +5,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./answer.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   answer: function() { return answer; }
 });
 const answer = 103330;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./answer.js");
 
 _lib__WEBPACK_IMPORTED_MODULE_0__.answer;

--- a/crates/rspack/tests/tree-shaking/bb/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/bb/snapshot/new_treeshaking.snap
@@ -5,15 +5,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   ccc: function() { return ccc; }
 });
 const ccc = 30;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./c.js");
 
 _a_js__WEBPACK_IMPORTED_MODULE_0__.ccc;

--- a/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-export-computed-property/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./antd/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   locales: function() { return locales; }
 });
@@ -16,9 +15,8 @@ const locales = {
 };
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _antd_index__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./antd/index */"./antd/index.js");
 
 _antd_index__WEBPACK_IMPORTED_MODULE_0__.locales.zh_CN;
@@ -26,7 +24,6 @@ function test() {}
 }),
 "./locale_zh.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _zh_locale__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./zh_locale */"./zh_locale.js");
 
 /* harmony default export */ __webpack_exports__["default"] = (_zh_locale__WEBPACK_IMPORTED_MODULE_0__["default"]);

--- a/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/cjs-tree-shaking-basic/snapshot/new_treeshaking.snap
@@ -12,9 +12,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 const answer = 42;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./lib.js");
 
 __webpack_require__(/*! ./answer */"./answer.js");
@@ -22,7 +21,6 @@ __webpack_require__(/*! ./answer */"./answer.js");
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   myanswer: function() { return myanswer; }
 });

--- a/crates/rspack/tests/tree-shaking/class-extend/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/class-extend/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   v: function() { return v; }
 });
@@ -20,16 +19,14 @@ function foo() {
 }
 const v = _lib__WEBPACK_IMPORTED_MODULE_0__.value;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.v;
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   value: function() { return value; }
 });

--- a/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/conflicted_name_by_re_export_all_should_be_hidden/snapshot/new_treeshaking.snap
@@ -3,20 +3,17 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./bar.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const a = 'bar';
 }),
-"./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./foo.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const a = 'foo';
 const b = 'foo';
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./bar */"./bar.js");
 

--- a/crates/rspack/tests/tree-shaking/context-module-elimated/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/context-module-elimated/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 
 function test() {
     a;

--- a/crates/rspack/tests/tree-shaking/cyclic-reference-export-all/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/cyclic-reference-export-all/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./src/App.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _containers__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./containers */"./src/containers/containers.js");
 
 const { PlatformProvider } = _containers__WEBPACK_IMPORTED_MODULE_0__;
@@ -28,7 +27,6 @@ __webpack_require__.d(__webpack_exports__, {
 }),
 "./src/containers/platform-container/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   PlatformProvider: function() { return PlatformProvider; },
   usePlatform: function() { return usePlatform; }
@@ -36,9 +34,8 @@ __webpack_require__.d(__webpack_exports__, {
 const usePlatform = 3;
 const PlatformProvider = 1000;
 }),
-"./src/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./src/index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _App__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./App */"./src/App.js");
 
 (0, _App__WEBPACK_IMPORTED_MODULE_0__["default"])();

--- a/crates/rspack/tests/tree-shaking/default_export/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/default_export/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./answer.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   answer: function() { return answer; }
 });
@@ -13,7 +12,6 @@ const answer = 103330; // export default answer;
 }),
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return result; },
   render: function() { return render; }
@@ -28,16 +26,14 @@ function render() {
 }
 function result() {}
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__.render)(_app__WEBPACK_IMPORTED_MODULE_0__["default"]);
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   myanswer: function() { return myanswer; },
   secret: function() { return secret; }

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_1/snapshot/new_treeshaking.snap
@@ -3,14 +3,12 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./bar.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const a = 'bar';
 }),
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -18,9 +16,8 @@ __webpack_require__.d(__webpack_exports__, {
 const a = 'foo';
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 console.log(_foo__WEBPACK_IMPORTED_MODULE_0__.a);

--- a/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/explicit_named_export_higher_priority_2/snapshot/new_treeshaking.snap
@@ -3,14 +3,12 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./bar.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const a = 'bar';
 }),
 "./baz.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -18,7 +16,6 @@ const a = 'baz';
 }),
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return /* reexport safe */ _baz__WEBPACK_IMPORTED_MODULE_0__.a; }
 });
@@ -27,9 +24,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 console.log(_foo__WEBPACK_IMPORTED_MODULE_0__.a);

--- a/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export-all-from-side-effects-free-commonjs/snapshot/new_treeshaking.snap
@@ -3,10 +3,9 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
 var _lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache;
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./lib.js");
 
 /*#__PURE__*/ (_lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache || (_lib__WEBPACK_IMPORTED_MODULE_0___namespace_cache = __webpack_require__.t(_lib__WEBPACK_IMPORTED_MODULE_0__, 2)));

--- a/crates/rspack/tests/tree-shaking/export-imported-import-all-as/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export-imported-import-all-as/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./answer */"./test.js");
 
 _answer__WEBPACK_IMPORTED_MODULE_0__;

--- a/crates/rspack/tests/tree-shaking/export-named-decl-as/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export-named-decl-as/snapshot/new_treeshaking.snap
@@ -13,16 +13,14 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 }),
-"./src/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./src/index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./answer */"./src/answer.js");
 
 console.log(_answer__WEBPACK_IMPORTED_MODULE_0__);
 }),
 "./src/plugin/formatNumber.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return formatNumber_default; }
 });

--- a/crates/rspack/tests/tree-shaking/export-star-chain/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export-star-chain/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./colors/a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   red: function() { return red; }
 });
@@ -13,7 +12,6 @@ const red = 'red';
 }),
 "./colors/b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   blue: function() { return blue; }
 });
@@ -21,7 +19,6 @@ const blue = 'blue';
 }),
 "./colors/c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   result: function() { return /* reexport safe */ _result__WEBPACK_IMPORTED_MODULE_0__.result; }
 });
@@ -45,15 +42,13 @@ __webpack_require__.d(__webpack_exports__, {
 }),
 "./colors/result.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   result: function() { return result; }
 });
 const result = 'ssss';
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./export */"./colors/index.js");
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./export */"./something/Something.js");
 
@@ -62,7 +57,6 @@ _export__WEBPACK_IMPORTED_MODULE_1__.Something;
 }),
 "./something/Something.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   Something: function() { return Something; }
 });

--- a/crates/rspack/tests/tree-shaking/export_star/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export_star/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   b: function() { return b; },
   bar: function() { return /* reexport module object */ _foo__WEBPACK_IMPORTED_MODULE_0__; },
@@ -34,9 +33,8 @@ const foo = 3;
 
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 _foo__WEBPACK_IMPORTED_MODULE_0__.bar.a;
@@ -44,7 +42,6 @@ _foo__WEBPACK_IMPORTED_MODULE_0__.bar.a;
 }),
 "./result.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   c: function() { return c; }
 });

--- a/crates/rspack/tests/tree-shaking/export_star2/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export_star2/snapshot/new_treeshaking.snap
@@ -3,27 +3,24 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./bar.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 /* harmony import */var _result__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./result */"./result.js");
 function b() {}
 
 
 }),
-"./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./foo.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./bar */"./bar.js");
 /* harmony import */var _result__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./result */"./result.js");
 const a = 3;
 
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./bar */"./bar.js");
 /* harmony import */var _result__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./result */"./result.js");
@@ -31,9 +28,8 @@ __webpack_require__.r(__webpack_exports__);
 
 
 }),
-"./result.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./result.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./bar */"./bar.js");
 const c = 103330;

--- a/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/export_star_conflict_export_no_error/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   b: function() { return b; }
 });
@@ -15,9 +14,8 @@ function b() {}
 
 
 }),
-"./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./foo.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _bar_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./bar.js */"./bar.js");
 /* harmony import */var _result_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./result.js */"./result.js");
 const a = 3;
@@ -25,16 +23,14 @@ const b = 3;
 
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _bar_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./bar.js */"./bar.js");
 
 (0, _bar_js__WEBPACK_IMPORTED_MODULE_0__.b)();
 }),
-"./result.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./result.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo.js */"./foo.js");
 /* harmony import */var _bar_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./bar.js */"./bar.js");
 const c = 103330;

--- a/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-imported-unused/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/handle-side-effects-commonjs-imported-unused/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 
 console.log('something');
 }),

--- a/crates/rspack/tests/tree-shaking/import-as-default/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/import-as-default/snapshot/new_treeshaking.snap
@@ -3,15 +3,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./app.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 var a = 1;
 /* harmony default export */ __webpack_exports__["default"] = (a);
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__["default"];

--- a/crates/rspack/tests/tree-shaking/import-export-all-as-a-empty-module/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/import-export-all-as-a-empty-module/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   aaa: function() { return /* reexport module object */ _app__WEBPACK_IMPORTED_MODULE_0__; },
   routes: function() { return routes; }
@@ -24,9 +23,8 @@ const routes = {
 }),
 "./app.js": (function () {
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./a.js");
 
 _a_js__WEBPACK_IMPORTED_MODULE_0__.routes;

--- a/crates/rspack/tests/tree-shaking/import-optional-chaining/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/import-optional-chaining/snapshot/new_treeshaking.snap
@@ -5,15 +5,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   app: function() { return app; }
 });
 const app = "app";
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 function a() {

--- a/crates/rspack/tests/tree-shaking/import-star-as-and-export/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/import-star-as-and-export/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./lib.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__;

--- a/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/import-var-assign-side-effects/snapshot/new_treeshaking.snap
@@ -5,16 +5,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./Something.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return Something; }
 });
 class Something {
 }
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./export */"./Something.js");
 
 (0, _export__WEBPACK_IMPORTED_MODULE_0__["default"])();

--- a/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/inherit_export_map_should_lookup_in_dfs_order/snapshot/new_treeshaking.snap
@@ -5,21 +5,18 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   c: function() { return c; }
 });
 const c = 'a';
 }),
-"./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./bar.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const a = 'bar';
 const c = 'bar';
 }),
 "./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; },
   b: function() { return /* reexport safe */ _foo__WEBPACK_IMPORTED_MODULE_0__.b; },
@@ -33,7 +30,6 @@ const a = 3;
 }),
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   b: function() { return b; },
   c: function() { return /* reexport safe */ _a_js__WEBPACK_IMPORTED_MODULE_0__.c; }
@@ -43,9 +39,8 @@ __webpack_require__.d(__webpack_exports__, {
 const a = 'foo';
 const b = 'foo';
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _c_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./c.js */"./c.js");
 // require("./c.js");
 

--- a/crates/rspack/tests/tree-shaking/issue-4637/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/issue-4637/snapshot/new_treeshaking.snap
@@ -3,15 +3,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _util_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./util.js */"./util.js");
 
 }),
-"./util.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./util.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _swc_helpers_create_class__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! @swc/helpers/_/_create_class */"../../../../../node_modules/@swc/helpers/esm/_create_class.js");
 
 var ConsoleExporterWeb;
@@ -42,7 +40,6 @@ ConsoleExporterWeb = function() {
 }),
 "../../../../../node_modules/@swc/helpers/esm/_create_class.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   _: function() { return _create_class; }
 });

--- a/crates/rspack/tests/tree-shaking/issues_3198/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/issues_3198/snapshot/new_treeshaking.snap
@@ -3,16 +3,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _test__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./test */"./test.js");
 
 _test__WEBPACK_IMPORTED_MODULE_0__.obj.test = 1;
 }),
 "./test.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   obj: function() { return obj; }
 });

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable1/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable1/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./Layout.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   defaults: function() { return defaults; }
 });
@@ -15,7 +14,6 @@ const defaults = {
 }),
 "./export.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   Something: function() { return Something; }
 });
@@ -27,9 +25,8 @@ function callit() {
 var Sider = callit();
 var Something = 20000;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./export */"./export.js");
 
 (0, _export__WEBPACK_IMPORTED_MODULE_0__.Something)();

--- a/crates/rspack/tests/tree-shaking/local-binding-reachable2/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/local-binding-reachable2/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./Layout.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   defaults: function() { return defaults; }
 });
@@ -15,7 +14,6 @@ const defaults = {
 }),
 "./export.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   Something: function() { return Something; }
 });
@@ -27,9 +25,8 @@ class Test {
 var Sider = new Test();
 var Something = 333;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./export */"./export.js");
 
 (0, _export__WEBPACK_IMPORTED_MODULE_0__.Something)();

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects1/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects1/snapshot/new_treeshaking.snap
@@ -5,20 +5,17 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 const a = 3;
 }),
-"./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./c.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const c = 300;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./a.js");
 /* harmony import */var _c_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./c.js */"./c.js");
 

--- a/crates/rspack/tests/tree-shaking/module-rule-side-effects2/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/module-rule-side-effects2/snapshot/new_treeshaking.snap
@@ -5,20 +5,17 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 const a = 3;
 }),
-"./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./b.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const b = 30;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./a.js */"./a.js");
 /* harmony import */var _b_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./b.js */"./b.js");
 

--- a/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/named-export-decl-with-src-eval/snapshot/new_treeshaking.snap
@@ -5,15 +5,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   cccc: function() { return cccc; }
 });
 function cccc() {}
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./export */"./c.js");
 
 (0, _export__WEBPACK_IMPORTED_MODULE_0__.cccc)();

--- a/crates/rspack/tests/tree-shaking/named_export_alias/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/named_export_alias/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./Something.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   something: function() { return something; }
 });
@@ -13,7 +12,6 @@ function something() {}
 }),
 "./export.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return a; }
 });
@@ -25,9 +23,8 @@ var a = function test() {
 };
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _export__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./export */"./export.js");
 
 _export__WEBPACK_IMPORTED_MODULE_0__["default"];

--- a/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/namespace-access-var-decl-rhs/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -15,7 +14,6 @@ const a = {
 }),
 "./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   b: function() { return b; }
 });
@@ -23,16 +21,14 @@ const b = {
     b: ""
 };
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./lib.js");
 
 console.log(_lib__WEBPACK_IMPORTED_MODULE_0__.getDocPermissionTextSendMe);
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   getDocPermissionTextSendMe: function() { return getDocPermissionTextSendMe; }
 });

--- a/crates/rspack/tests/tree-shaking/nested-import-3/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/nested-import-3/snapshot/new_treeshaking.snap
@@ -5,16 +5,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./answer.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 const a = 103330;
 const b = 103330;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./answer.js");
 
 _lib__WEBPACK_IMPORTED_MODULE_0__.a;

--- a/crates/rspack/tests/tree-shaking/nested-import-4/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/nested-import-4/snapshot/new_treeshaking.snap
@@ -5,16 +5,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./answer.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 const a = 103330;
 const b = 103330;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./answer.js");
 
 _lib__WEBPACK_IMPORTED_MODULE_0__.a;

--- a/crates/rspack/tests/tree-shaking/prune-bailout-module/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/prune-bailout-module/snapshot/new_treeshaking.snap
@@ -3,14 +3,12 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./a.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony default export */ __webpack_exports__["default"] = (300);
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _lib__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./lib */"./a.js");
 
 _lib__WEBPACK_IMPORTED_MODULE_0__["default"];

--- a/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/pure_comments_magic_comments/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -16,9 +15,8 @@ function res() {
 const a = 3;
 /* unused harmony default export */ var __WEBPACK_DEFAULT_EXPORT__ = ((/* unused pure expression or super */ null && (res())));
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.a;

--- a/crates/rspack/tests/tree-shaking/react-redux-like/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/react-redux-like/snapshot/new_treeshaking.snap
@@ -3,24 +3,21 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./lib.js");
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./foo */"./selector.js");
 
 _foo__WEBPACK_IMPORTED_MODULE_0__["default"];
 _foo__WEBPACK_IMPORTED_MODULE_1__["default"];
 }),
-"./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./lib.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 function Provider() {}
 /* harmony default export */ __webpack_exports__["default"] = (Provider);
 }),
 "./selector.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return useSelector; }
 });

--- a/crates/rspack/tests/tree-shaking/reexport-all-as-multi-level-nested/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/reexport-all-as-multi-level-nested/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./package/autogen/a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -16,16 +15,14 @@ function dddd() {}
 }),
 "./package/autogen/aa.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   aa: function() { return aa; }
 });
 const aa = 3;
 const cc = 3;
 }),
-"./src/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./src/index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _package_src_index_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../package/src/index.js */"./package/autogen/a.js");
 /* harmony import */var _package_src_index_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../package/src/index.js */"./package/autogen/aa.js");
 

--- a/crates/rspack/tests/tree-shaking/reexport-all-as/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/reexport-all-as/snapshot/new_treeshaking.snap
@@ -5,16 +5,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./package/autogen/a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 function a() {}
 function dddd() {}
 }),
-"./src/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./src/index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _package_src_index_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ../package/src/index.js */"./package/autogen/a.js");
 
 _package_src_index_js__WEBPACK_IMPORTED_MODULE_0__.a;

--- a/crates/rspack/tests/tree-shaking/reexport_default_as/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/reexport_default_as/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./bar.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return test; }
 });
@@ -13,16 +12,14 @@ function test() {}
 }),
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   Select: function() { return /* reexport safe */ _bar__WEBPACK_IMPORTED_MODULE_0__["default"]; }
 });
 /* harmony import */var _bar__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./bar */"./bar.js");
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 (0, _foo__WEBPACK_IMPORTED_MODULE_0__.Select)();

--- a/crates/rspack/tests/tree-shaking/reexport_entry_elimination/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/reexport_entry_elimination/snapshot/new_treeshaking.snap
@@ -5,19 +5,16 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _c_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./c.js */"./c.js");
 
 /* harmony default export */ __webpack_exports__["default"] = (2000 + _c_js__WEBPACK_IMPORTED_MODULE_0__["default"]);
 }),
-"./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./c.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony default export */ __webpack_exports__["default"] = (10);
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./b.js");
 
 _a_js__WEBPACK_IMPORTED_MODULE_0__["default"];

--- a/crates/rspack/tests/tree-shaking/rename-export-from-import/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rename-export-from-import/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   q: function() { return /* reexport safe */ _lib__WEBPACK_IMPORTED_MODULE_0__.question; }
 });
@@ -13,16 +12,14 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.q;
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   question: function() { return question; }
 });

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports-function-argument/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   bar: function() { return bar; }
 });
@@ -17,9 +16,8 @@ function bar() {
     return contrivedExample(foo);
 }
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 var answer = (0, _foo__WEBPACK_IMPORTED_MODULE_0__["default"])();

--- a/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unmodified-default-exports/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./foo.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 var Foo = function() {
     console.log("side effect");
     this.isFoo = true;
@@ -17,9 +16,8 @@ Foo.prototype = {
     }
 };
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 var foo = new _foo__WEBPACK_IMPORTED_MODULE_0__["default"]();

--- a/crates/rspack/tests/tree-shaking/rollup-unused-called-import/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-called-import/snapshot/new_treeshaking.snap
@@ -3,16 +3,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./dead.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./dead.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony default export */ function __WEBPACK_DEFAULT_EXPORT__() {
     return "dead";
 }
 }),
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return /* export default binding */ __WEBPACK_DEFAULT_EXPORT__; }
 });
@@ -25,9 +23,8 @@ function foodead() {
     return "foo" + dead();
 }
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 assert.equal((0, _foo__WEBPACK_IMPORTED_MODULE_0__["default"])(), "foo");

--- a/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-default-exports/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   foo: function() { return foo; }
 });
@@ -18,9 +17,8 @@ function mutate(obj) {
 }
 /* unused harmony default export */ var __WEBPACK_DEFAULT_EXPORT__ = (mutate(foo));
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 
 assert.equal(_foo__WEBPACK_IMPORTED_MODULE_0__.foo.value, 2);

--- a/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-inner-functions-and-classes/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _stuff__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./stuff */"./stuff.js");
 
 (0, _stuff__WEBPACK_IMPORTED_MODULE_0__.bar)();
@@ -24,7 +23,6 @@ console.log(getClass().name);
 }),
 "./stuff.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   bar: function() { return bar; },
   baz: function() { return Baz; }

--- a/crates/rspack/tests/tree-shaking/rollup-unused-var/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/rollup-unused-var/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./foo.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   foo: function() { return foo; }
 });
@@ -14,9 +13,8 @@ var bar = "wut";
 var baz = (/* unused pure expression or super */ null && (bar || foo));
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo.js */"./foo.js");
 
 console.log(_foo_js__WEBPACK_IMPORTED_MODULE_0__.foo);

--- a/crates/rspack/tests/tree-shaking/side-effects-analyzed/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-analyzed/snapshot/new_treeshaking.snap
@@ -3,16 +3,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./lib.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__["default"])();
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return /* export default binding */ __WEBPACK_DEFAULT_EXPORT__; }
 });

--- a/crates/rspack/tests/tree-shaking/side-effects-export-default-expr/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-export-default-expr/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   b: function() { return b; }
 });
@@ -13,9 +12,8 @@ __webpack_require__.d(__webpack_exports__, {
 /* unused harmony default export */ var __WEBPACK_DEFAULT_EXPORT__ = ((/* unused pure expression or super */ null && (a)));
 const b = 1;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.b;

--- a/crates/rspack/tests/tree-shaking/side-effects-flagged-only/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-flagged-only/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   something: function() { return /* reexport safe */ _lib__WEBPACK_IMPORTED_MODULE_0__["default"]; }
 });
@@ -14,16 +13,14 @@ __webpack_require__.d(__webpack_exports__, {
 
 
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__.something)();
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return /* export default binding */ __WEBPACK_DEFAULT_EXPORT__; }
 });
@@ -32,9 +29,8 @@ const result = 20000;
 const something = function() {};
 /* harmony default export */ function __WEBPACK_DEFAULT_EXPORT__() {}
 }),
-"./src/a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./src/a.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* unused harmony default export */ var __WEBPACK_DEFAULT_EXPORT__ = ((()=>{
     console.log("");
 }));

--- a/crates/rspack/tests/tree-shaking/side-effects-prune/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-prune/snapshot/new_treeshaking.snap
@@ -3,16 +3,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./lib.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__.something)(); // a;
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   something: function() { return something; }
 });

--- a/crates/rspack/tests/tree-shaking/side-effects-two/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/side-effects-two/snapshot/new_treeshaking.snap
@@ -3,16 +3,14 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./lib.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__["default"])();
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return /* export default binding */ __WEBPACK_DEFAULT_EXPORT__; }
 });

--- a/crates/rspack/tests/tree-shaking/simple-namespace-access/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/simple-namespace-access/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _maths_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./maths.js */"./maths.js");
 /* TREE-SHAKING */ 
 console.log(_maths_js__WEBPACK_IMPORTED_MODULE_0__.xxx.test);
@@ -13,7 +12,6 @@ console.log(_maths_js__WEBPACK_IMPORTED_MODULE_0__.square);
 }),
 "./maths.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   square: function() { return square; },
   xxx: function() { return /* reexport module object */ _test_js__WEBPACK_IMPORTED_MODULE_0__; }
@@ -35,7 +33,6 @@ function cube(x) {
 }),
 "./test.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   test: function() { return test; }
 });

--- a/crates/rspack/tests/tree-shaking/static-class/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/static-class/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -26,16 +25,14 @@ const a = 3;
 }),
 "./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   bb: function() { return bb; }
 });
 const bb = 2;
 const cc = 3;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./a.js");
 
 _a_js__WEBPACK_IMPORTED_MODULE_0__.a;

--- a/crates/rspack/tests/tree-shaking/transitive-bailout/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/transitive-bailout/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; },
   b: function() { return b; }
@@ -19,9 +18,8 @@ exports.test = function() {
     res;
 };
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _answer__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./answer */"./answer.js");
 
 _answer__WEBPACK_IMPORTED_MODULE_0__.test;

--- a/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/transitive_side_effects_when_analyze/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -15,9 +14,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 const a = 3;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.a;

--- a/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-false-with-side-effect-true/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./ b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   b: function() { return b; }
 });
@@ -13,15 +12,13 @@ const b = 3;
 }),
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 const a = 3;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./a.js");
 /* harmony import */var _b_js__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./ b.js */"./ b.js");
 

--- a/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-interop/snapshot/new_treeshaking.snap
@@ -35,9 +35,8 @@ exports.test = 30;
     module.exports = res;
 } // export default function () {}
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */"./foo.js");
 /* harmony import */var _foo__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(_foo__WEBPACK_IMPORTED_MODULE_0__);
 

--- a/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/tree-shaking-lazy-import/snapshot/new_treeshaking.snap
@@ -13,9 +13,8 @@ function myanswer() {
 }
 /* harmony default export */ __webpack_exports__["default"] = (myanswer);
 }),
-"./test.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./test.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 function test() {}
 /* harmony default export */ __webpack_exports__["default"] = (test);
 }),
@@ -27,15 +26,13 @@ function test() {}
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   answer: function() { return answer; }
 });
 const answer = 30;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 const a = test(()=>__webpack_require__.e("lib_js").then(__webpack_require__.bind(__webpack_require__, /*! ./lib */"./lib.js")));

--- a/crates/rspack/tests/tree-shaking/ts-target-es5/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/ts-target-es5/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 async function test() {}
 test();
 }),

--- a/crates/rspack/tests/tree-shaking/unused-class-rename/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/unused-class-rename/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./app.js": (function () {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 function test() {}
 class Cls {
     constructor(){}
@@ -15,9 +14,8 @@ if (__AAA__) {
     __Cls.prototype.aaa = function(a, b) {};
 }
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 _app__WEBPACK_IMPORTED_MODULE_0__.Test;

--- a/crates/rspack/tests/tree-shaking/var-function-expr/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/var-function-expr/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./app.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   app: function() { return app; }
 });
@@ -20,16 +19,14 @@ var app2 = ()=>{
 var app4 = (0, _lib__WEBPACK_IMPORTED_MODULE_0__.something)('app4'), app5 = 10000;
 var app3 = (0, _lib__WEBPACK_IMPORTED_MODULE_0__.something)('app3');
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _app__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./app */"./app.js");
 
 (0, _app__WEBPACK_IMPORTED_MODULE_0__.app)();
 }),
 "./lib.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   result: function() { return result; },
   something: function() { return something; }

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-export-default-named/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return abc; }
 });
@@ -15,18 +14,16 @@ function abc() {
     return _dep_a__WEBPACK_IMPORTED_MODULE_0__.x;
 }
 }),
-"./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./b.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _dep_b__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dep?b */"./dep.js?b");
 
 function abc() {
     return x;
 }
 }),
-"./c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./c.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _dep_c__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dep?c */"./dep.js?c");
 
 function abc() {
@@ -36,7 +33,6 @@ abc();
 }),
 "./d.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   "default": function() { return def; }
 });
@@ -50,22 +46,19 @@ class def {
 }),
 "./dep.js?a": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   x: function() { return x; }
 });
 const x = "x";
 /* harmony default export */ __webpack_exports__["default"] = (true);
 }),
-"./dep.js?b": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./dep.js?b": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const x = "x";
 /* harmony default export */ __webpack_exports__["default"] = (false);
 }),
 "./dep.js?c": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   x: function() { return x; }
 });
@@ -74,31 +67,27 @@ const x = "x";
 }),
 "./dep.js?d": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   x: function() { return x; }
 });
 const x = "x";
 /* harmony default export */ __webpack_exports__["default"] = (true);
 }),
-"./dep.js?e": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./dep.js?e": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 const x = "x";
 /* harmony default export */ __webpack_exports__["default"] = (false);
 }),
 "./dep.js?f": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   x: function() { return x; }
 });
 const x = "x";
 /* harmony default export */ __webpack_exports__["default"] = (true);
 }),
-"./e.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./e.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _dep_e__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dep?e */"./dep.js?e");
 
 class def {
@@ -107,9 +96,8 @@ class def {
     }
 }
 }),
-"./f.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./f.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _dep_f__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./dep?f */"./dep.js?f");
 
 class def {
@@ -119,9 +107,8 @@ class def {
 }
 new def().method();
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a */"./a.js");
 /* harmony import */var _b__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./b */"./b.js");
 /* harmony import */var _c__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./c */"./c.js");

--- a/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-inner-graph-switch/snapshot/new_treeshaking.snap
@@ -16,7 +16,6 @@ __webpack_require__.r(__webpack_exports__);
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./import-module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   test: function() { return test; }
 });
@@ -39,7 +38,6 @@ it("should generate correct code when pure expressions are in dead branches", ()
 }),
 "./module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _some_module__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./some-module */"./some-module.js");
 
 function getType(obj) {

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular/snapshot/new_treeshaking.snap
@@ -15,9 +15,8 @@ __webpack_require__.r(__webpack_exports__);
 
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _inner__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./inner */"./inner.js");
 /* harmony import */var _module__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./module */"./module.js");
 
@@ -32,7 +31,6 @@ it("export should be unused when only unused functions use it", ()=>{
 }),
 "./inner.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   A: function() { return A; },
   B: function() { return B; },
@@ -55,7 +53,6 @@ const exportCUsed = false;
 }),
 "./module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   y: function() { return y; }
 });

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-circular2/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _module__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./module */"./module.js");
 
 it("should be able to handle circular referenced", ()=>{
@@ -41,7 +40,6 @@ it("should be able to handle circular referenced", ()=>{
 }),
 "./module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; },
   f3: function() { return f3; },

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-no-side-effects/snapshot/new_treeshaking.snap
@@ -21,7 +21,6 @@ function test() {}
 }),
 "./package/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });

--- a/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-innergraph-try-globals/snapshot/new_treeshaking.snap
@@ -18,7 +18,6 @@ it("should not threat globals as pure", ()=>{
 }),
 "./module.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   ok: function() { return ok; },
   ok2: function() { return ok2; }

--- a/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-reexport-namespace-and-default/snapshot/new_treeshaking.snap
@@ -3,9 +3,8 @@ source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```js title=main.js
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _package1_script__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./package1/script */"./package1/script.js");
 /* harmony import */var _package1_script2__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./package1/script2 */"./package1/script2.js");
 /* harmony import */var _package2_script__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./package2/script */"./package2/script.js");
@@ -39,7 +38,6 @@ const mod = _package2_script__WEBPACK_IMPORTED_MODULE_1__["default"];
 }),
 "./package1/script.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   exportDefaultUsed: function() { return exportDefaultUsed; }
 });
@@ -49,16 +47,14 @@ __webpack_require__.d(__webpack_exports__, {
 
 const exportDefaultUsed = false;
 }),
-"./package1/script1.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./package1/script1.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _script2__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./script2 */"./package1/script2.js");
 
 /* unused harmony default export */ var __WEBPACK_DEFAULT_EXPORT__ = (1);
 }),
 "./package1/script2.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   exportDefaultUsed: function() { return exportDefaultUsed; }
 });
@@ -71,7 +67,6 @@ const exportDefaultUsed = false;
 }),
 "./package2/script.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   exportDefaultUsed: function() { return exportDefaultUsed; }
 });
@@ -81,9 +76,8 @@ __webpack_require__.d(__webpack_exports__, {
 
 const exportDefaultUsed = true;
 }),
-"./package2/script1.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./package2/script1.js": (function (__unused_webpack_module, __webpack_exports__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony default export */ __webpack_exports__["default"] = (1);
 }),
 

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-all-used/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "../node_modules/pmodule/a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
@@ -19,7 +18,6 @@ var c = "c";
 }),
 "../node_modules/pmodule/b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   x: function() { return x; }
 });
@@ -33,7 +31,6 @@ var y = "y";
 }),
 "../node_modules/pmodule/c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   z: function() { return z; }
 });
@@ -45,7 +42,6 @@ var z = "z";
 }),
 "../node_modules/pmodule/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./tracker */"../node_modules/pmodule/tracker.js");
 
 
@@ -55,7 +51,6 @@ __webpack_require__.r(__webpack_exports__);
 }),
 "../node_modules/pmodule/tracker.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   log: function() { return log; },
   track: function() { return track; }
@@ -69,9 +64,8 @@ function reset() {
     log.length = 0;
 }
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var pmodule_tracker__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! pmodule/tracker */"../node_modules/pmodule/tracker.js");
 /* harmony import */var pmodule__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! pmodule */"../node_modules/pmodule/a.js");
 /* harmony import */var pmodule__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! pmodule */"../node_modules/pmodule/b.js");

--- a/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/webpack-side-effects-simple-unused/snapshot/new_treeshaking.snap
@@ -5,7 +5,6 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "../node_modules/pmodule/b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   x: function() { return x; }
 });
@@ -19,7 +18,6 @@ var y = "y";
 }),
 "../node_modules/pmodule/c.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   z: function() { return z; }
 });
@@ -31,7 +29,6 @@ var z = "z";
 }),
 "../node_modules/pmodule/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _tracker__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./tracker */"../node_modules/pmodule/tracker.js");
 
 
@@ -41,7 +38,6 @@ __webpack_require__.r(__webpack_exports__);
 }),
 "../node_modules/pmodule/tracker.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   log: function() { return log; },
   track: function() { return track; }
@@ -55,9 +51,8 @@ function reset() {
     log.length = 0;
 }
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var pmodule_tracker__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! pmodule/tracker */"../node_modules/pmodule/tracker.js");
 /* harmony import */var pmodule__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! pmodule */"../node_modules/pmodule/b.js");
 /* harmony import */var pmodule__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! pmodule */"../node_modules/pmodule/c.js");

--- a/crates/rspack/tests/tree-shaking/with-assets/snapshot/new_treeshaking.snap
+++ b/crates/rspack/tests/tree-shaking/with-assets/snapshot/new_treeshaking.snap
@@ -5,15 +5,13 @@ source: crates/rspack_testing/src/run_fixture.rs
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
   a: function() { return a; }
 });
 const a = 3;
 }),
-"./index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
 "use strict";
-__webpack_require__.r(__webpack_exports__);
 /* harmony import */var _a_js__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.js */"./a.js");
 /* harmony import */var _a_svg__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./a.svg */"./a.svg");
 

--- a/packages/rspack-test-tools/src/compare/format-code.ts
+++ b/packages/rspack-test-tools/src/compare/format-code.ts
@@ -153,5 +153,19 @@ export function formatCode(
 		}
 	}
 
-	return result.trim();
+	// result of generate() is not stable with comments sometimes
+	// so do it again
+	return generate(
+		parse(result, {
+			sourceType: "unambiguous"
+		}),
+		{
+			comments: false,
+			compact: false,
+			concise: false,
+			jsescOption: {
+				quotes: "double"
+			}
+		}
+	).code.trim();
 }

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/rspack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	mode: "production",
+	optimization: {
+		minimize: false,
+		usedExports: true
+	},
+	experiments: {
+		rspackFuture: {
+			newTreeshaking: true
+		}
+	}
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/a.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/a.js
@@ -1,0 +1,1 @@
+export const a = "a";

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/b.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/b.js
@@ -1,0 +1,1 @@
+export const b = "b";

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/index.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/index.js
@@ -1,0 +1,6 @@
+import { a, __esModule as __esModuleA } from "./a";
+import { b } from "./b";
+
+require("./no-strict");
+
+__esModuleA, a, b;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/no-strict.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/src/no-strict.js
@@ -1,0 +1,1 @@
+module.exports.aaa = 1;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	modules: true,
+	runtimeModules: false,
+	ignoreModuleArguments: false
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage/webpack.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+	mode: "production",
+	optimization: {
+		usedExports: true,
+		minimize: false
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align `__esModule` usage checking logic of [HarmonyCompatibilityDependency](HarmonyCompatibilityDependency) with Webpack, there is no need to add `RuntimeGlobals::MAKE_NAMESPACE_OBJECT` for every esm module, only add when `__esModule` is used


## Test Plan

- Added `packages/rspack-test-tools/tests/runtimeDiffCases/module-esmodule-usage`

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
