### PR TITLE
chore: ignore react upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,7 @@
       "matchDepTypes": ["devDependencies"],
       "schedule": ["on wednesday"],
       "excludePackagePrefixes": ["webpack"],
-      "excludePackageNames": ["@playwright/test"],
+      "excludePackageNames": ["@playwright/test", "react", "react-dom"],
       "assignees": ["@Boshen"]
     },
     {
@@ -68,7 +68,7 @@
     {
       "groupName": "npm ignored dependencies",
       "matchManagers": ["npm"],
-      "matchPackageNames": ["@playwright/test"],
+      "matchPackageNames": ["@playwright/test", "react", "react-dom"],
       "enabled": false
     },
     {


### PR DESCRIPTION
Otherwise e2e will error out with:

```
main.js:31267 Warning: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://reactjs.org/link/invalid-hook-call for tips about how to debug and fix this problem.
```
