### PR TITLE
perf: lazy calculate asset.source

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -211,7 +211,6 @@ export interface FactoryMeta {
 
 export interface JsAsset {
   name: string
-  source?: JsCompatSource
   info: JsAssetInfo
 }
 
@@ -1276,6 +1275,14 @@ export function registerGlobalTrace(filter: string, layer: "chrome" | "logger", 
 
 /** Builtin loader runner */
 export function runBuiltinLoader(builtin: string, options: string | undefined | null, loaderContext: JsLoaderContext): Promise<JsLoaderContext>
+
+export interface ThreadsafeNodeFS {
+  writeFile: (...args: any[]) => any
+  removeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+  removeDirAll: (...args: any[]) => any
+}
 
 export interface ThreadsafeNodeFS {
   writeFile: (...args: any[]) => any

--- a/crates/rspack_binding_values/src/asset.rs
+++ b/crates/rspack_binding_values/src/asset.rs
@@ -1,7 +1,5 @@
 use napi_derive::napi;
 
-use super::JsCompatSource;
-
 #[napi(object)]
 pub struct JsAssetInfoRelated {
   pub source_map: Option<String>,
@@ -62,7 +60,6 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
 #[napi(object)]
 pub struct JsAsset {
   pub name: String,
-  pub source: Option<JsCompatSource>,
   pub info: JsAssetInfo,
 }
 

--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -101,11 +101,6 @@ impl JsCompilation {
     for (filename, asset) in self.inner.assets() {
       assets.push(JsAsset {
         name: filename.clone(),
-        source: asset
-          .source
-          .as_ref()
-          .map(|s| s.to_js_compat_source())
-          .transpose()?,
         info: asset.info.clone().into(),
       });
     }
@@ -118,11 +113,6 @@ impl JsCompilation {
     match self.inner.assets().get(&name) {
       Some(asset) => Ok(Some(JsAsset {
         name,
-        source: asset
-          .source
-          .as_ref()
-          .map(|s| s.to_js_compat_source())
-          .transpose()?,
         info: asset.info.clone().into(),
       })),
       None => Ok(None),

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -465,25 +465,20 @@ export class Compilation {
 		const assets = this.#inner.getAssets();
 
 		return assets.map(asset => {
-			return {
-				...asset,
-				get source() {
-					return asset.source ? createSourceFromRaw(asset.source) : undefined;
-				}
-			};
+			return Object.defineProperty(asset, "source", {
+				get: () => this.__internal__getAssetSource(asset.name)
+			});
 		});
 	}
 
-	getAsset(name: string) {
+	getAsset(name: string): Asset | undefined {
 		const asset = this.#inner.getAsset(name);
 		if (!asset) {
 			return;
 		}
-		return {
-			...asset,
-			// @ts-expect-error
-			source: createSourceFromRaw(asset.source)
-		};
+		return Object.defineProperty(asset, "source", {
+			get: () => this.__internal__getAssetSource(asset.name)
+		});
 	}
 
 	pushDiagnostic(
@@ -870,10 +865,10 @@ export class Compilation {
 	 *
 	 * @internal
 	 */
-	__internal__getAssetSource(filename: string): Source | null {
+	__internal__getAssetSource(filename: string): Source | undefined {
 		const rawSource = this.#inner.getAssetSource(filename);
 		if (!rawSource) {
-			return null;
+			return;
 		}
 		return createSourceFromRaw(rawSource);
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will add lazy calculation for asset.source which will make html-webpack-plugin faster.

Here is some data from my project.

| html-webpack-plugin | pr + html-webpack-plugin | rspack.HtmlRspackPlugin |
|--|--|--|
| 1s 636ms | 640ms | 580ms |
| ![image](https://github.com/web-infra-dev/rspack/assets/9291503/fddb36d2-b5bc-49d2-8153-7a7037096058) | ![image](https://github.com/web-infra-dev/rspack/assets/9291503/91f3b433-33db-436f-884c-fe9a0206da43) | ![image](https://github.com/web-infra-dev/rspack/assets/9291503/673388c8-4edf-48fe-a03b-d7ebd7863591) |



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
