### PR TITLE
perf: set default WATCHPACK_WATCHER_LIMIT to 20

### DIFF
--- a/packages/rspack-cli/src/rspack-cli.ts
+++ b/packages/rspack-cli/src/rspack-cli.ts
@@ -43,6 +43,8 @@ export class RspackCLI {
 		callback?: (e: Error | null, res?: Stats | MultiStats) => void
 	) {
 		process.env.RSPACK_CONFIG_VALIDATE = "loose";
+		process.env.WATCHPACK_WATCHER_LIMIT =
+			process.env.WATCHPACK_WATCHER_LIMIT || "20";
 		let nodeEnv = process?.env?.NODE_ENV;
 		let rspackCommandDefaultEnv =
 			rspackCommand === "build" ? "production" : "development";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
set default WATCHPACK_WATCHER_LIMIT to 20 to improve kill process performance, related to https://github.com/vercel/next.js/pull/51826/files
It takes about 5s+ to kill `rspack dev` before and instantly kill after set `WATCHPACK_WATCHER_LIMIT=20` in my project
Rsbuild seems need this too @chenjiahan 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan
No Need
<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
