### PR TITLE
refactor: align get_exports_type with webpack

### DIFF
--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -395,7 +395,7 @@ fn get_exports_type_impl(
                 else {
                   return ExportsType::Dynamic;
                 };
-                match target_exports_type.as_ref() {
+                match target_exports_type {
                   BuildMetaExportsType::Flagged => ExportsType::Namespace,
                   BuildMetaExportsType::Namespace => ExportsType::Namespace,
                   BuildMetaExportsType::Default => handle_default(default_object),

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -329,7 +329,7 @@ pub trait Module:
   }
 }
 
-fn get_exports_type_impl<'a>(
+fn get_exports_type_impl(
   identifier: ModuleIdentifier,
   build_meta: Option<&BuildMeta>,
   mga: &mut dyn ModuleGraphAccessor,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align `module.get_exports_type()` with [webpack](https://github.com/webpack/webpack/blob/4a2662381ed8e6a9d849b494511459f5858d4e82/lib/Module.js#L470-L510) to prevent generating unnecessary code.

## Test Plan

- Reuse current

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
