### PR TITLE
perf: enable "thin" LTO for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ panic         = "abort"
 [profile.release]
 codegen-units = 1
 debug         = false
-lto           = false   # disabled by now, because it will significantly increase our compile time.
+lto           = "thin"  # Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
 opt-level     = 3
 panic         = "abort"
 strip         = true


### PR DESCRIPTION
## Summary

We now have better machines, let's try "thin" LTO. If this satisfactory, we'll try "fat" LTO in a later PR.