### PR TITLE
fix: fix test for consistent splitChunk

### DIFF
--- a/packages/rspack/tests/configCases/split-chunks/issue-5485/src/index.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-5485/src/index.js
@@ -1,0 +1,5 @@
+import val from "./lib/a";
+
+it("should compile", () => {
+	expect(val).toBe(42);
+});

--- a/packages/rspack/tests/configCases/split-chunks/issue-5485/src/lib/a.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-5485/src/lib/a.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack/tests/configCases/split-chunks/issue-5485/test.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-5485/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["lib1.js", "main.js"];
+	}
+};

--- a/packages/rspack/tests/configCases/split-chunks/issue-5485/webpack.config.js
+++ b/packages/rspack/tests/configCases/split-chunks/issue-5485/webpack.config.js
@@ -1,0 +1,27 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	entry: {
+		main: "./src/index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	optimization: {
+		splitChunks: {
+			chunks: "all",
+			minChunks: 1,
+			minSize: 0,
+			cacheGroups: {
+				lib_1: {
+					test: /lib[\/\\]a.js/,
+					name: "lib1"
+				},
+				lib_2: {
+					test: /lib[\/\\]a.js/,
+					name: "lib2"
+				}
+			}
+		}
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

#5510 added test for ensuring consistent splitChunks, however the tests failed on Windows platform because the path regex is incorrect.

`/path\/to/` should be `/path[\\\/]to`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Test Plan

<!-- Can you please describe how you tested the changes you made to the code? -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
