### PR TITLE
feat(rspack): align default resolveOptions with webpack

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -784,6 +784,8 @@ const getResolveLoaderDefaults = () => {
 	return resolveOptions;
 };
 
+// The values are aligned with webpack
+// https://github.com/webpack/webpack/blob/b9fb99c63ca433b24233e0bbc9ce336b47872c08/lib/config/defaults.js#L1431
 const getResolveDefaults = ({
 	targetProperties,
 	mode
@@ -805,19 +807,24 @@ const getResolveDefaults = ({
 	const jsExtensions = [".js", ".json", ".wasm"];
 
 	const tp = targetProperties;
+
 	const browserField =
 		tp && tp.web && (!tp.node || (tp.electron && tp.electronRenderer));
 	const aliasFields = browserField ? ["browser"] : [];
+	const mainFields = browserField
+		? ["browser", "module", "..."]
+		: ["module", "..."];
 
 	const cjsDeps = () => ({
 		aliasFields,
-		mainFields: browserField ? ["browser", "module", "..."] : ["module", "..."],
+		mainFields,
 		conditionNames: ["require", "module", "..."],
 		extensions: [...jsExtensions]
 	});
+
 	const esmDeps = () => ({
 		aliasFields,
-		mainFields: browserField ? ["browser", "module", "..."] : ["module", "..."],
+		mainFields,
 		conditionNames: ["import", "module", "..."],
 		extensions: [...jsExtensions]
 	});
@@ -827,9 +834,9 @@ const getResolveDefaults = ({
 		conditionNames: conditions,
 		mainFiles: ["index"],
 		extensions: [],
-		aliasFields,
-		mainFields: ["main"].filter(Boolean),
+		aliasFields: [],
 		exportsFields: ["exports"],
+		mainFields: ["main"],
 		byDependency: {
 			wasm: esmDeps(),
 			esm: esmDeps(),

--- a/packages/rspack/tests/Defaults.unittest.ts
+++ b/packages/rspack/tests/Defaults.unittest.ts
@@ -665,11 +665,6 @@ describe("snapshots", () => {
 		-     "workerWasmLoading": "fetch",
 		+     "workerWasmLoading": "async-node",
 		@@ ... @@
-		-     "aliasFields": Array [
-		-       "browser",
-		-     ],
-		+     "aliasFields": Array [],
-		@@ ... @@
 		-         "aliasFields": Array [
 		-           "browser",
 		-         ],
@@ -779,11 +774,6 @@ describe("snapshots", () => {
 		-     "workerWasmLoading": "fetch",
 		+     "workerWasmLoading": "async-node",
 		@@ ... @@
-		-     "aliasFields": Array [
-		-       "browser",
-		-     ],
-		+     "aliasFields": Array [],
-		@@ ... @@
 		-         "aliasFields": Array [
 		-           "browser",
 		-         ],
@@ -875,11 +865,6 @@ describe("snapshots", () => {
 		@@ ... @@
 		-     "workerWasmLoading": "fetch",
 		+     "workerWasmLoading": "async-node",
-		@@ ... @@
-		-     "aliasFields": Array [
-		-       "browser",
-		-     ],
-		+     "aliasFields": Array [],
 		@@ ... @@
 		-         "aliasFields": Array [
 		-           "browser",

--- a/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
+++ b/packages/rspack/tests/__snapshots__/Defaults.unittest.ts.snap
@@ -288,9 +288,7 @@ exports[`snapshots should have the correct base config 1`] = `
   "plugins": [],
   "profile": false,
   "resolve": {
-    "aliasFields": [
-      "browser",
-    ],
+    "aliasFields": [],
     "byDependency": {
       "commonjs": {
         "aliasFields": [


### PR DESCRIPTION
## Summary

relates #5314

This PR syncs our default resolve options with webpack.

Except `roots: [context]`, which has failing test cases, I'll update them in another PR.

## Test Plan

CI passes.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
