### PR TITLE
refactor: align external module and static exports dependency with webpack

### DIFF
--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -33,7 +33,7 @@ pub use module_dependency::*;
 pub use runtime_requirements_dependency::RuntimeRequirementsDependency;
 pub use runtime_template::*;
 pub use span::SpanExt;
-pub use static_exports_dependency::StaticExportsDependency;
+pub use static_exports_dependency::{StaticExportsDependency, StaticExportsSpec};
 use swc_core::ecma::atoms::Atom;
 
 use crate::{

--- a/crates/rspack_core/src/dependency/static_exports_dependency.rs
+++ b/crates/rspack_core/src/dependency/static_exports_dependency.rs
@@ -6,14 +6,20 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
+pub enum StaticExportsSpec {
+  True,
+  Array(Vec<Atom>),
+}
+
+#[derive(Debug, Clone)]
 pub struct StaticExportsDependency {
   id: DependencyId,
-  exports: Vec<Atom>,
+  exports: StaticExportsSpec,
   can_mangle: bool,
 }
 
 impl StaticExportsDependency {
-  pub fn new(exports: Vec<Atom>, can_mangle: bool) -> Self {
+  pub fn new(exports: StaticExportsSpec, can_mangle: bool) -> Self {
     Self {
       id: DependencyId::new(),
       exports,
@@ -37,13 +43,15 @@ impl Dependency for StaticExportsDependency {
 
   fn get_exports(&self, _mg: &ModuleGraph) -> Option<ExportsSpec> {
     Some(ExportsSpec {
-      exports: ExportsOfExportsSpec::Array(
-        self
-          .exports
-          .iter()
-          .map(|item| ExportNameOrSpec::String(item.clone()))
-          .collect::<Vec<_>>(),
-      ),
+      exports: match &self.exports {
+        StaticExportsSpec::Array(exports) => ExportsOfExportsSpec::Array(
+          exports
+            .iter()
+            .map(|item| ExportNameOrSpec::String(item.clone()))
+            .collect::<Vec<_>>(),
+        ),
+        StaticExportsSpec::True => ExportsOfExportsSpec::True,
+      },
       can_mangle: Some(self.can_mangle),
       ..Default::default()
     })

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -17,7 +17,8 @@ use crate::{
   BuildMetaExportsType, BuildResult, ChunkInitFragments, ChunkUkey, CodeGenerationDataUrl,
   CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId,
   ExternalType, InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module,
-  ModuleType, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
+  ModuleType, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
+  StaticExportsSpec,
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -390,6 +391,12 @@ impl Module for ExternalModule {
       }
       _ => build_result.build_meta.exports_type = BuildMetaExportsType::Dynamic,
     }
+    build_result
+      .dependencies
+      .push(Box::new(StaticExportsDependency::new(
+        StaticExportsSpec::True,
+        false,
+      )));
     Ok(build_result)
   }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -9,6 +9,7 @@ use rspack_core::{
   ChunkGroupOptions, CodeGenerationResult, Compilation, ConcatenationScope, Context,
   DependenciesBlock, DependencyId, GroupOptions, LibIdentOptions, Module, ModuleDependency,
   ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency,
+  StaticExportsSpec,
 };
 use rspack_error::{impl_empty_diagnosable_trait, Diagnostic, Result};
 use rspack_hash::RspackHash;
@@ -132,7 +133,7 @@ impl Module for ContainerEntryModule {
       blocks.push(block);
     }
     dependencies.push(Box::new(StaticExportsDependency::new(
-      vec!["get".into(), "init".into()],
+      StaticExportsSpec::Array(vec!["get".into(), "init".into()]),
       false,
     )));
 

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -7,7 +7,7 @@ use rspack_core::DependencyType::WasmImport;
 use rspack_core::{
   AssetInfo, BoxDependency, BuildMetaExportsType, Compilation, Filename, GenerateContext, Module,
   ModuleDependency, ModuleIdentifier, NormalModule, ParseContext, ParseResult, ParserAndGenerator,
-  PathData, RuntimeGlobals, SourceType, StaticExportsDependency, UsedName,
+  PathData, RuntimeGlobals, SourceType, StaticExportsDependency, StaticExportsSpec, UsedName,
 };
 use rspack_error::{Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_identifier::Identifier;
@@ -83,7 +83,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
     }
 
     dependencies.push(Box::new(StaticExportsDependency::new(
-      exports.iter().cloned().map(Atom::from).collect::<Vec<_>>(),
+      StaticExportsSpec::Array(exports.iter().cloned().map(Atom::from).collect::<Vec<_>>()),
       false,
     )));
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align ExternalModule and StaticExportsDependency with webpack 

## Test Plan

- Reuse exists

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
