### PR TITLE
refactor: immutable module graph during code generation

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -203,6 +203,11 @@ impl ChunkGraph {
           )
         });
 
+      // NOTE:
+      // Webpack use module.getExportsType() to generate hash
+      // but the module graph may be modified in it
+      // and exports type is calculated from build meta and exports info
+      // so use them to generate hash directly to avoid mutable access to module graph
       if let Some(strict) = strict {
         if let Some(build_meta) = module.build_meta() {
           strict.dyn_hash(&mut hasher);

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1308,7 +1308,7 @@ impl Compilation {
 
     // FIXME:
     // Webpack may modify the moduleGraph in module.getExportsType()
-    // and it is widely called after compilaiton.finish()
+    // and it is widely called after compilation.finish()
     // so add this method to trigger moduleGraph modification and
     // then make sure that moduleGraph is immutable
     prepare_get_exports_type(&mut self.module_graph);

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -30,7 +30,7 @@ use super::{
 use crate::{
   build_chunk_graph::build_chunk_graph,
   cache::{use_code_splitting_cache, Cache, CodeSplittingCache},
-  get_chunk_from_ukey, get_mut_chunk_from_ukey, is_source_equal,
+  get_chunk_from_ukey, get_mut_chunk_from_ukey, is_source_equal, prepare_get_exports_type,
   tree_shaking::{optimizer, visitor::SymbolRef, BailoutFlag, OptimizeDependencyResult},
   AddQueue, AddQueueHandler, AddTask, AddTaskResult, AdditionalChunkRuntimeRequirementsArgs,
   AdditionalModuleRequirementsArgs, AsyncDependenciesBlock, BoxDependency, BoxModule, BuildQueue,
@@ -1305,6 +1305,13 @@ impl Compilation {
 
       Ok(())
     }
+
+    // FIXME:
+    // Webpack may modify the moduleGraph in module.getExportsType()
+    // and it is widely called after compilaiton.finish()
+    // so add this method to trigger moduleGraph modification and
+    // then make sure that moduleGraph is immutable
+    prepare_get_exports_type(&mut self.module_graph);
 
     run_iteration(self, &mut codegen_cache_counter, |(_, module)| {
       module.get_code_generation_dependencies().is_none()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1795,7 +1795,7 @@ impl ConcatenatedModule {
     let module = mg
       .module_by_identifier(&info.id())
       .expect("should have module");
-    let exports_type = module.get_exports_type(strict_harmony_module);
+    let exports_type = module.get_exports_type_readonly(mg, strict_harmony_module);
 
     if export_name.is_empty() {
       match exports_type {

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -542,7 +542,7 @@ pub fn get_exports_type(
   module_graph
     .module_by_identifier(module)
     .expect("should have mgm")
-    .get_exports_type(strict)
+    .get_exports_type_readonly(module_graph, strict)
 }
 
 pub fn get_exports_type_with_strict(
@@ -556,7 +556,7 @@ pub fn get_exports_type_with_strict(
   module_graph
     .module_by_identifier(module)
     .expect("should have module")
-    .get_exports_type(strict)
+    .get_exports_type_readonly(module_graph, strict)
 }
 
 pub fn module_id_expr(request: &str, module_id: &str) -> String {

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1538,7 +1538,7 @@ impl ExportInfo {
   }
 
   // NOTE:
-  // align with webpack _getMaxTarget(), the logic of creatation is implemented in _get_max_target()
+  // align with webpack _getMaxTarget(), the logic of creation is implemented in _get_max_target()
   // https://github.com/webpack/webpack/blob/b9fb99c63ca433b24233e0bbc9ce336b47872c08/lib/ExportsInfo.js#L1208
   fn get_max_target(&mut self) -> &HashMap<Option<DependencyId>, ExportInfoTargetValue> {
     if self.max_target_is_set {

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
+use std::sync::Mutex;
 
 use itertools::Itertools;
 use rspack_util::ext::DynHash;
@@ -15,6 +16,7 @@ use serde::Serialize;
 use swc_core::ecma::atoms::Atom;
 
 use crate::property_access;
+use crate::BuildMetaExportsType;
 use crate::Nullable;
 use crate::{
   ConnectionState, DependencyCondition, DependencyId, ModuleGraph, ModuleGraphConnection,
@@ -862,28 +864,28 @@ impl ExportInfoId {
     }
   }
 
-  pub fn get_target(
+  pub fn get_target<'a>(
     &self,
-    mg: &mut ModuleGraph,
+    module_graph_accessor: &'a dyn ModuleGraphAccessor<'a>,
     resolve_filter: Option<ResolveFilterFnTy>,
   ) -> Option<ResolvedExportInfoTarget> {
     let filter = resolve_filter.unwrap_or(Arc::new(|_, _| true));
 
     let mut already_visited = HashSet::default();
-    match self._get_target(mg, filter, &mut already_visited) {
+    match self._get_target(module_graph_accessor, filter, &mut already_visited) {
       Some(ResolvedExportInfoTargetWithCircular::Circular) => None,
       Some(ResolvedExportInfoTargetWithCircular::Target(target)) => Some(target),
       None => None,
     }
   }
 
-  pub fn _get_target(
+  pub fn _get_target<'a>(
     &self,
-    mg: &mut ModuleGraph,
+    mga: &'a dyn ModuleGraphAccessor<'a>,
     resolve_filter: ResolveFilterFnTy,
     already_visited: &mut HashSet<ExportInfoId>,
   ) -> Option<ResolvedExportInfoTargetWithCircular> {
-    let self_export_info = self.get_export_info(mg);
+    let self_export_info = mga.get_export_info(self);
     if self_export_info.target.is_empty() {
       return None;
     }
@@ -892,9 +894,8 @@ impl ExportInfoId {
     }
     already_visited.insert(*self);
 
-    let self_export_info_mut = self.get_export_info_mut(mg);
-    let values = self_export_info_mut
-      .get_max_target()
+    let values = mga
+      .get_max_target(self)
       .values()
       .map(|item| UnResolvedExportInfoTarget {
         connection: item.connection,
@@ -905,7 +906,7 @@ impl ExportInfoId {
       values.first().cloned(),
       already_visited,
       resolve_filter.clone(),
-      mg,
+      mga,
     );
 
     match target {
@@ -916,7 +917,7 @@ impl ExportInfoId {
       Some(ResolvedExportInfoTargetWithCircular::Target(target)) => {
         for val in values.into_iter().skip(1) {
           let resolved_target =
-            ExportInfo::resolve_target(Some(val), already_visited, resolve_filter.clone(), mg);
+            ExportInfo::resolve_target(Some(val), already_visited, resolve_filter.clone(), mga);
           match resolved_target {
             Some(ResolvedExportInfoTargetWithCircular::Circular) => {
               return Some(ResolvedExportInfoTargetWithCircular::Circular);
@@ -1004,7 +1005,11 @@ impl ExportInfoId {
     resolve_filter: ResolveFilterFnTy,
     update_original_connection: UpdateOriginalFunctionTy,
   ) -> Option<ResolvedExportInfoTarget> {
-    let target = self._get_target(mg, resolve_filter, &mut HashSet::default());
+    let target = self._get_target(
+      &MutableModuleGraph::new(mg),
+      resolve_filter,
+      &mut HashSet::default(),
+    );
     let target = match target {
       Some(ResolvedExportInfoTargetWithCircular::Circular) => return None,
       Some(ResolvedExportInfoTargetWithCircular::Target(target)) => target,
@@ -1501,6 +1506,28 @@ impl ExportInfo {
     }
   }
 
+  fn _get_max_target(&self) -> HashMap<Option<DependencyId>, ExportInfoTargetValue> {
+    if self.target.len() <= 1 {
+      return self.target.clone();
+    }
+    let mut max_priority = u8::MIN;
+    let mut min_priority = u8::MAX;
+    for value in self.target.values() {
+      max_priority = max_priority.max(value.priority);
+      min_priority = min_priority.min(value.priority);
+    }
+    if max_priority == min_priority {
+      return self.target.clone();
+    }
+    let mut map = HashMap::default();
+    for (k, v) in self.target.iter() {
+      if max_priority == v.priority {
+        map.insert(*k, v.clone());
+      }
+    }
+    map
+  }
+
   fn get_max_target_readonly(&self) -> &HashMap<Option<DependencyId>, ExportInfoTargetValue> {
     assert!(self.max_target_is_set);
     &self.max_target
@@ -1510,39 +1537,17 @@ impl ExportInfo {
     if self.max_target_is_set {
       return &self.max_target;
     }
-    if self.target.len() <= 1 {
-      self.max_target_is_set = true;
-      self.max_target = self.target.clone();
-      return &self.max_target;
-    }
-    let mut max_priority = u8::MIN;
-    let mut min_priority = u8::MAX;
-    for value in self.target.values() {
-      max_priority = max_priority.max(value.priority);
-      min_priority = min_priority.min(value.priority);
-    }
-    if max_priority == min_priority {
-      self.max_target_is_set = true;
-      self.max_target = self.target.clone();
-      return &self.max_target;
-    }
-    let mut map = HashMap::default();
-    for (k, v) in self.target.iter() {
-      if max_priority == v.priority {
-        map.insert(*k, v.clone());
-      }
-    }
+    self.max_target = self._get_max_target();
     self.max_target_is_set = true;
-    self.max_target = map;
     &self.max_target
   }
 
   #[allow(clippy::unwrap_in_result)]
-  fn resolve_target(
+  fn resolve_target<'a>(
     input_target: Option<UnResolvedExportInfoTarget>,
     already_visited: &mut HashSet<ExportInfoId>,
     resolve_filter: ResolveFilterFnTy,
-    mg: &mut ModuleGraph,
+    mga: &'a dyn ModuleGraphAccessor<'a>,
   ) -> Option<ResolvedExportInfoTargetWithCircular> {
     if let Some(input_target) = input_target {
       let mut target = ResolvedExportInfoTarget {
@@ -1557,7 +1562,7 @@ impl ExportInfo {
       if target.export.is_none() {
         return Some(ResolvedExportInfoTargetWithCircular::Target(target));
       }
-      if !resolve_filter(&target, mg) {
+      if !mga.run_resolve_filter(&target, &resolve_filter) {
         return Some(ResolvedExportInfoTargetWithCircular::Target(target));
       }
       loop {
@@ -1568,17 +1573,11 @@ impl ExportInfo {
           return Some(ResolvedExportInfoTargetWithCircular::Target(target));
         };
 
-        let export_info_id = {
-          let id = mg
-            .module_graph_module_by_identifier(&target.module)
-            .expect("should have mgm")
-            .exports;
-          id.get_export_info(name, mg)
-        };
+        let export_info_id = mga.get_export_info_id(name, &target.module);
         if already_visited.contains(&export_info_id) {
           return Some(ResolvedExportInfoTargetWithCircular::Circular);
         }
-        let new_target = export_info_id._get_target(mg, resolve_filter.clone(), already_visited);
+        let new_target = export_info_id._get_target(mga, resolve_filter.clone(), already_visited);
 
         match new_target {
           Some(ResolvedExportInfoTargetWithCircular::Circular) => {
@@ -1605,10 +1604,10 @@ impl ExportInfo {
             }
           }
         }
-        if !resolve_filter(&target, mg) {
+        if !mga.run_resolve_filter(&target, &resolve_filter) {
           return Some(ResolvedExportInfoTargetWithCircular::Target(target));
         }
-        already_visited.insert(export_info_id);
+        already_visited.insert(*export_info_id);
       }
     } else {
       None
@@ -1883,4 +1882,248 @@ macro_rules! debug_exports_info {
       dbg!(&export_info);
     }
   };
+}
+
+pub trait ModuleGraphAccessor<'a> {
+  fn run_resolve_filter(
+    &self,
+    target: &ResolvedExportInfoTarget,
+    resolve_filter: &ResolveFilterFnTy,
+  ) -> bool;
+  fn get_export_info(&self, export_info_id: &ExportInfoId) -> Arc<ExportInfo>;
+  fn get_export_info_id(
+    &self,
+    name: &Atom,
+    module_identifier: &ModuleIdentifier,
+  ) -> Arc<ExportInfoId>;
+  fn get_max_target(
+    &self,
+    export_info_id: &ExportInfoId,
+  ) -> Arc<HashMap<Option<DependencyId>, ExportInfoTargetValue>>;
+  fn get_module_meta_exports_type(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Arc<BuildMetaExportsType>>;
+  fn get_read_only_export_info(
+    &self,
+    name: &Atom,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Arc<ExportInfo>>;
+}
+
+pub struct MutableModuleGraph<'a> {
+  inner: Mutex<&'a mut ModuleGraph>,
+}
+
+impl<'a> MutableModuleGraph<'a> {
+  pub fn new(mg: &'a mut ModuleGraph) -> Self {
+    Self {
+      inner: Mutex::new(mg),
+    }
+  }
+}
+
+impl<'a> ModuleGraphAccessor<'a> for MutableModuleGraph<'a> {
+  fn get_export_info_id(
+    &self,
+    name: &Atom,
+    module_identifier: &ModuleIdentifier,
+  ) -> Arc<ExportInfoId> {
+    Arc::new(
+      self
+        .inner
+        .lock()
+        .map(|mut mg| {
+          let exports = mg
+            .module_graph_module_by_identifier(module_identifier)
+            .expect("should have mgm")
+            .exports;
+          exports.get_export_info(name, &mut mg)
+        })
+        .expect("Can get export info id"),
+    )
+  }
+
+  fn get_max_target(
+    &self,
+    export_info_id: &ExportInfoId,
+  ) -> Arc<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
+    Arc::new(
+      self
+        .inner
+        .lock()
+        .map(|mut mg| {
+          mg.get_export_info_mut_by_id(export_info_id)
+            .get_max_target()
+            .to_owned()
+        })
+        .expect("Can get export info id"),
+    )
+  }
+
+  fn run_resolve_filter(
+    &self,
+    target: &ResolvedExportInfoTarget,
+    resolve_filter: &ResolveFilterFnTy,
+  ) -> bool {
+    self
+      .inner
+      .lock()
+      .map(|mg| resolve_filter(target, &mg))
+      .expect("Can run resolve filter")
+  }
+
+  fn get_export_info(&self, export_info_id: &ExportInfoId) -> Arc<ExportInfo> {
+    Arc::new(
+      self
+        .inner
+        .lock()
+        .map(|mg| mg.get_export_info_by_id(export_info_id).to_owned())
+        .expect("Can get export info"),
+    )
+  }
+
+  fn get_read_only_export_info(
+    &self,
+    name: &Atom,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Arc<ExportInfo>> {
+    self
+      .inner
+      .lock()
+      .map(|mg| {
+        mg.get_read_only_export_info(module_identifier, name.to_owned())
+          .map(|i| Arc::new(i.to_owned()))
+      })
+      .expect("Can get read only export info")
+  }
+
+  fn get_module_meta_exports_type(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Arc<BuildMetaExportsType>> {
+    self
+      .inner
+      .lock()
+      .map(|mg: std::sync::MutexGuard<'_, &mut ModuleGraph>| {
+        mg.module_by_identifier(module_identifier)
+          .and_then(|m| m.build_meta())
+          .map(|meta| meta.exports_type)
+          .map(Arc::new)
+      })
+      .expect("Can get read only export info")
+  }
+}
+
+pub struct ImmutableModuleGraph<'a> {
+  inner: &'a ModuleGraph,
+}
+
+impl<'a> ImmutableModuleGraph<'a> {
+  pub fn new(mg: &'a ModuleGraph) -> Self {
+    Self { inner: mg }
+  }
+}
+
+impl<'a> ModuleGraphAccessor<'a> for ImmutableModuleGraph<'a> {
+  fn get_export_info_id(
+    &self,
+    name: &Atom,
+    module_identifier: &ModuleIdentifier,
+  ) -> Arc<ExportInfoId> {
+    Arc::new(
+      self
+        .inner
+        .module_graph_module_by_identifier(module_identifier)
+        .expect("should have mgm")
+        .exports
+        .get_read_only_export_info(name, self.inner)
+        .id,
+    )
+  }
+
+  fn get_max_target(
+    &self,
+    export_info_id: &ExportInfoId,
+  ) -> Arc<HashMap<Option<DependencyId>, ExportInfoTargetValue>> {
+    Arc::new({
+      let export_info_id = self.inner.get_export_info_by_id(export_info_id);
+
+      if export_info_id.max_target_is_set {
+        export_info_id.get_max_target_readonly().to_owned()
+      } else {
+        // FIXME:
+        // max target should be cached
+        // but when moduleGraph is immutable and no cached max target
+        // generate a new one, this should be removed
+        // when module graph in get_exports and get_referenced_exports
+        // is refactored to mutable
+        export_info_id._get_max_target()
+      }
+    })
+  }
+
+  fn run_resolve_filter(
+    &self,
+    target: &ResolvedExportInfoTarget,
+    resolve_filter: &ResolveFilterFnTy,
+  ) -> bool {
+    resolve_filter(target, self.inner)
+  }
+
+  fn get_export_info(&self, export_info_id: &ExportInfoId) -> Arc<ExportInfo> {
+    Arc::new(self.inner.get_export_info_by_id(export_info_id).to_owned())
+  }
+
+  fn get_read_only_export_info(
+    &self,
+    name: &Atom,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Arc<ExportInfo>> {
+    self
+      .inner
+      .get_read_only_export_info(module_identifier, name.to_owned())
+      .map(|i| Arc::new(i.to_owned()))
+  }
+
+  fn get_module_meta_exports_type(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Arc<BuildMetaExportsType>> {
+    self
+      .inner
+      .module_by_identifier(module_identifier)
+      .and_then(|m| m.build_meta())
+      .map(|meta| meta.exports_type)
+      .map(Arc::new)
+  }
+}
+
+pub fn prepare_get_exports_type(mg: &mut ModuleGraph) {
+  let export_info_ids = mg
+    .modules()
+    .values()
+    .filter_map(|module| {
+      let Some(export_type) = module.build_meta().as_ref().map(|m| &m.exports_type) else {
+        return None;
+      };
+      if !matches!(export_type, BuildMetaExportsType::Dynamic) {
+        return None;
+      }
+      let Some(export_info) =
+        mg.get_read_only_export_info(&module.identifier(), Atom::from("__esModule"))
+      else {
+        return None;
+      };
+      if !matches!(export_info.provided, Some(ExportInfoProvided::False)) {
+        Some(export_info.id)
+      } else {
+        None
+      }
+    })
+    .collect_vec();
+  let mga = MutableModuleGraph::new(mg);
+  for export_info_id in export_info_ids {
+    let _ = export_info_id.get_target(&mga, None);
+  }
 }

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1538,7 +1538,7 @@ impl ExportInfo {
   }
 
   // NOTE:
-  // align with webpack _getMaxTarget(), the logic of creatation is implemeneted in _get_max_target()
+  // align with webpack _getMaxTarget(), the logic of creatation is implemented in _get_max_target()
   // https://github.com/webpack/webpack/blob/b9fb99c63ca433b24233e0bbc9ce336b47872c08/lib/ExportsInfo.js#L1208
   fn get_max_target(&mut self) -> &HashMap<Option<DependencyId>, ExportInfoTargetValue> {
     if self.max_target_is_set {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -357,10 +357,10 @@ pub trait Module:
   }
 }
 
-fn get_exports_type_impl<'a>(
+fn get_exports_type_impl(
   _identifier: ModuleIdentifier,
   build_meta: Option<&BuildMeta>,
-  _mga: &dyn ModuleGraphAccessor,
+  _mga: &mut dyn ModuleGraphAccessor,
   strict: bool,
 ) -> ExportsType {
   if let Some((export_type, default_object)) = build_meta

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1034,6 +1034,16 @@ impl ModuleGraph {
       .expect("should have module graph module");
     mgm.optimization_bailout_mut()
   }
+
+  pub fn get_read_only_export_info(
+    &self,
+    module_identifier: &ModuleIdentifier,
+    name: Atom,
+  ) -> Option<&ExportInfo> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(|mgm| mgm.exports.get_read_only_export_info(&name, self))
+  }
 }
 
 fn get_connections_by_origin_module(

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   module_id, property_access, to_normal_comment, ExportsType, ExtendedReferencedExport,
-  RuntimeGlobals, UsedName,
+  ModuleGraph, RuntimeGlobals, RuntimeSpec, UsedName,
 };
 use rspack_core::{AsContextDependency, Dependency, DependencyCategory, DependencyLocation};
 use rspack_core::{DependencyId, DependencyTemplate};
@@ -81,14 +81,14 @@ impl ModuleDependency for CommonJsFullRequireDependency {
 
   fn get_referenced_exports(
     &self,
-    module_graph: &rspack_core::ModuleGraph,
-    _runtime: Option<&rspack_core::RuntimeSpec>,
+    module_graph: &ModuleGraph,
+    _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ExtendedReferencedExport> {
     if self.is_call
       && module_graph
         .module_graph_module_by_dependency_id(&self.id)
         .and_then(|mgm| module_graph.module_by_identifier(&mgm.module_identifier))
-        .map(|m| m.get_exports_type(false))
+        .map(|m| m.get_exports_type_readonly(module_graph, false))
         .is_some_and(|t| !matches!(t, ExportsType::Namespace))
     {
       if self.names.is_empty() {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   property_access, AsContextDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ExtendedReferencedExport, ModuleDependency, RuntimeGlobals,
-  TemplateContext, TemplateReplaceSource, UsedName,
+  DependencyTemplate, DependencyType, ExtendedReferencedExport, ModuleDependency, ModuleGraph,
+  RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName,
 };
 use swc_core::atoms::Atom;
 
@@ -49,9 +49,9 @@ impl Dependency for CommonJsSelfReferenceDependency {
 impl ModuleDependency for CommonJsSelfReferenceDependency {
   fn get_referenced_exports(
     &self,
-    _module_graph: &rspack_core::ModuleGraph,
-    _runtime: Option<&rspack_core::RuntimeSpec>,
-  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+    _module_graph: &ModuleGraph,
+    _runtime: Option<&RuntimeSpec>,
+  ) -> Vec<ExtendedReferencedExport> {
     if self.is_call {
       if self.names.is_empty() {
         vec![ExtendedReferencedExport::Array(vec![])]

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -1,6 +1,7 @@
 use rspack_core::{
   AsContextDependency, Dependency, DependencyId, DependencyTemplate, DependencyType,
-  ModuleDependency, TemplateContext, TemplateReplaceSource,
+  ExtendedReferencedExport, ModuleDependency, ModuleGraph, RuntimeSpec, TemplateContext,
+  TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
@@ -29,11 +30,11 @@ impl Dependency for WebpackIsIncludedDependency {
     "WebpackIsIncludedDependency"
   }
 
-  fn dependency_type(&self) -> &rspack_core::DependencyType {
+  fn dependency_type(&self) -> &DependencyType {
     &DependencyType::WebpackIsIncluded
   }
 
-  fn id(&self) -> &rspack_core::DependencyId {
+  fn id(&self) -> &DependencyId {
     &self.id
   }
 }
@@ -45,9 +46,9 @@ impl ModuleDependency for WebpackIsIncludedDependency {
 
   fn get_referenced_exports(
     &self,
-    _module_graph: &rspack_core::ModuleGraph,
-    _runtime: Option<&rspack_core::RuntimeSpec>,
-  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+    _module_graph: &ModuleGraph,
+    _runtime: Option<&RuntimeSpec>,
+  ) -> Vec<ExtendedReferencedExport> {
     vec![]
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use rspack_core::{
   BuildMetaExportsType, Compilation, DependenciesBlock, DependencyId, ExportInfoProvided,
   ExportNameOrSpec, ExportsInfoId, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier, Plugin,
+  ModuleGraphConnection, ModuleIdentifier, MutableModuleGraph, Plugin,
 };
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -314,7 +314,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
       }
 
       // Recalculate target exportsInfo
-      let target = export_info_id.get_target(self.mg, None);
+      let target = export_info_id.get_target(&MutableModuleGraph::new(self.mg), None);
 
       let mut target_exports_info: Option<ExportsInfoId> = None;
       if let Some(target) = target {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use rspack_core::{
   BuildMetaExportsType, Compilation, DependenciesBlock, DependencyId, ExportInfoProvided,
   ExportNameOrSpec, ExportsInfoId, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier, MutableModuleGraph, Plugin,
+  ModuleGraphConnection, ModuleIdentifier, MutexModuleGraph, Plugin,
 };
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -314,7 +314,8 @@ impl<'a> FlagDependencyExportsProxy<'a> {
       }
 
       // Recalculate target exportsInfo
-      let target = export_info_id.get_target(&MutableModuleGraph::new(self.mg), None);
+      let target = MutexModuleGraph::new(self.mg)
+        .with_lock(|mut mga| export_info_id.get_target(&mut mga, None));
 
       let mut target_exports_info: Option<ExportsInfoId> = None;
       if let Some(target) = target {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -10,8 +10,8 @@ use rspack_core::concatenated_module::{
 use rspack_core::{
   filter_runtime, merge_runtime, runtime_to_string, Compilation, CompilerContext,
   ExportInfoProvided, ExtendedReferencedExport, LibIdentOptions, Logger, Module, ModuleExt,
-  ModuleGraph, ModuleGraphModule, ModuleIdentifier, OptimizeChunksArgs, Plugin, ProvidedExports,
-  RuntimeCondition, RuntimeSpec, WrappedModuleIdentifier,
+  ModuleGraph, ModuleGraphModule, ModuleIdentifier, MutableModuleGraph, OptimizeChunksArgs, Plugin,
+  ProvidedExports, RuntimeCondition, RuntimeSpec, WrappedModuleIdentifier,
 };
 use rspack_error::Result;
 use rspack_util::fx_dashmap::FxDashMap;
@@ -603,7 +603,10 @@ impl Plugin for ModuleConcatenationPlugin {
           export_info.is_reexport()
             && export_info
               .id
-              .get_target(&mut compilation.module_graph, None)
+              .get_target(
+                &MutableModuleGraph::new(&mut compilation.module_graph),
+                None,
+              )
               .is_none()
         })
         .copied()

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use rspack_core::{
-  Compilation, ConnectionState, ModuleGraph, ModuleIdentifier, MutableModuleGraph, Plugin,
+  Compilation, ConnectionState, ModuleGraph, ModuleIdentifier, MutexModuleGraph, Plugin,
   ResolvedExportInfoTarget,
 };
 use rspack_error::Result;
@@ -556,17 +556,19 @@ impl Plugin for SideEffectsFlagPlugin {
         if !ids.is_empty() {
           let export_info_id = cur_exports_info_id.get_export_info(&ids[0], mg);
 
-          let target = export_info_id.get_target(
-            &MutableModuleGraph::new(mg),
-            Some(Arc::new(
-              |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
-                mg.module_by_identifier(&target.module)
-                  .expect("should have module graph")
-                  .get_side_effects_connection_state(mg, &mut HashSet::default())
-                  == ConnectionState::Bool(false)
-              },
-            )),
-          );
+          let target = MutexModuleGraph::new(mg).with_lock(|mut mga| {
+            export_info_id.get_target(
+              &mut mga,
+              Some(Arc::new(
+                |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
+                  mg.module_by_identifier(&target.module)
+                    .expect("should have module graph")
+                    .get_side_effects_connection_state(mg, &mut HashSet::default())
+                    == ConnectionState::Bool(false)
+                },
+              )),
+            )
+          });
           let Some(target) = target else {
             continue;
           };

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use rspack_core::{
-  Compilation, ConnectionState, ModuleGraph, ModuleIdentifier, Plugin, ResolvedExportInfoTarget,
+  Compilation, ConnectionState, ModuleGraph, ModuleIdentifier, MutableModuleGraph, Plugin,
+  ResolvedExportInfoTarget,
 };
 use rspack_error::Result;
 use rspack_identifier::IdentifierSet;
@@ -556,7 +557,7 @@ impl Plugin for SideEffectsFlagPlugin {
           let export_info_id = cur_exports_info_id.get_export_info(&ids[0], mg);
 
           let target = export_info_id.get_target(
-            mg,
+            &MutableModuleGraph::new(mg),
             Some(Arc::new(
               |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
                 mg.module_by_identifier(&target.module)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Using imutable module graph during code generation to prevent immutable&mutable issue while calling module.get_exports_type, which is used widely:
- Chunk module hash
- Runtime Template
- HarmonyExportImportedSpecifierDendency::get_mode, which may be called in code generation and FlagDependencyExportsPlugin
- HarmonyImportSpecifierDependency::get_referenced_exports, which may be called in FlagDependencyUsagePlugin and ModuleConcatenationPlugin

## Test Plan

- Reuse exists

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
