### PR TITLE
refactor: move chunk_group_info to code splitting

### DIFF
--- a/crates/rspack_core/src/chunk_group.rs
+++ b/crates/rspack_core/src/chunk_group.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet as HashSet;
 
 use crate::{get_chunk_from_ukey, Chunk, ChunkByUkey, ChunkGroupByUkey, ChunkGroupUkey};
 use crate::{ChunkLoading, ChunkUkey, Compilation, Filename};
-use crate::{LibraryOptions, ModuleIdentifier, PublicPath, RuntimeSpec};
+use crate::{LibraryOptions, ModuleIdentifier, PublicPath};
 
 impl DatabaseItem for ChunkGroup {
   fn ukey(&self) -> rspack_database::Ukey<Self> {
@@ -21,7 +21,6 @@ pub struct ChunkGroup {
   pub ukey: ChunkGroupUkey,
   pub kind: ChunkGroupKind,
   pub chunks: Vec<ChunkUkey>,
-  pub info: ChunkGroupInfo,
   pub index: Option<u32>,
   pub parents: HashSet<ChunkGroupUkey>,
   pub(crate) module_pre_order_indices: IdentifierMap<usize>,
@@ -37,11 +36,10 @@ pub struct ChunkGroup {
 }
 
 impl ChunkGroup {
-  pub fn new(kind: ChunkGroupKind, info: ChunkGroupInfo) -> Self {
+  pub fn new(kind: ChunkGroupKind) -> Self {
     Self {
       ukey: ChunkGroupUkey::new(),
       chunks: vec![],
-      info,
       module_post_order_indices: Default::default(),
       module_pre_order_indices: Default::default(),
       parents: Default::default(),
@@ -416,11 +414,4 @@ impl GroupOptions {
       GroupOptions::ChunkGroup(e) => Some(e),
     }
   }
-}
-
-#[derive(Debug, Default, Clone)]
-pub struct ChunkGroupInfo {
-  pub chunk_loading: bool,
-  pub async_chunks: bool,
-  pub runtime: RuntimeSpec,
 }

--- a/crates/rspack_core/src/compiler/execute_module.rs
+++ b/crates/rspack_core/src/compiler/execute_module.rs
@@ -75,26 +75,19 @@ impl Compilation {
 
     chunk.runtime = runtime.clone();
 
-    let mut entrypoint = Entrypoint::new(
-      crate::ChunkGroupKind::Entrypoint {
-        initial: true,
-        options: Box::new(EntryOptions {
-          name: Some("build time".into()),
-          runtime: Some("runtime".into()),
-          chunk_loading: Some(crate::ChunkLoading::Disable),
-          async_chunks: None,
-          public_path: options.public_path.clone().map(crate::PublicPath::String),
-          base_uri: options.base_uri.clone(),
-          filename: None,
-          library: None,
-        }),
-      },
-      crate::ChunkGroupInfo {
-        chunk_loading: false,
-        async_chunks: false,
-        runtime: runtime.clone(),
-      },
-    );
+    let mut entrypoint = Entrypoint::new(crate::ChunkGroupKind::Entrypoint {
+      initial: true,
+      options: Box::new(EntryOptions {
+        name: Some("build time".into()),
+        runtime: Some("runtime".into()),
+        chunk_loading: Some(crate::ChunkLoading::Disable),
+        async_chunks: None,
+        public_path: options.public_path.clone().map(crate::PublicPath::String),
+        base_uri: options.base_uri.clone(),
+        filename: None,
+        library: None,
+      }),
+    });
 
     // add chunk to this compilation
     let chunk_by_ukey = ChunkByUkey::default();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

move chunk_group_info into CodeSplitter

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
