### PR TITLE
feat(rspack): add `roots: [context]` to defaultResolveOptions

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -125,6 +125,7 @@ export const applyRspackOptionsDefaults = (
 
 	options.resolve = cleverMerge(
 		getResolveDefaults({
+			context: options.context!,
 			targetProperties,
 			mode: options.mode
 		}),
@@ -787,9 +788,11 @@ const getResolveLoaderDefaults = () => {
 // The values are aligned with webpack
 // https://github.com/webpack/webpack/blob/b9fb99c63ca433b24233e0bbc9ce336b47872c08/lib/config/defaults.js#L1431
 const getResolveDefaults = ({
+	context,
 	targetProperties,
 	mode
 }: {
+	context: Context;
 	targetProperties: any;
 	mode?: Mode;
 }) => {
@@ -836,6 +839,7 @@ const getResolveDefaults = ({
 		extensions: [],
 		aliasFields: [],
 		exportsFields: ["exports"],
+		roots: [context],
 		mainFields: ["main"],
 		byDependency: {
 			wasm: esmDeps(),


### PR DESCRIPTION
## Summary

To align with Webpack

https://github.com/webpack/webpack/blob/08770761c8c7aa1e6e18b77d3deee8cc9871bd87/lib/config/defaults.js#L1481