### PR TITLE
fix(cli): fix cts support

### DIFF
--- a/packages/rspack-cli/src/utils/isEsmFile.ts
+++ b/packages/rspack-cli/src/utils/isEsmFile.ts
@@ -5,6 +5,8 @@ const isEsmFile = (filePath: string, cwd = process.cwd()) => {
 	const ext = path.extname(filePath);
 	if (/\.(mjs|mts)$/.test(ext)) {
 		return true;
+	} else if (/\.(cjs|cts)/.test(ext)) {
+		return false;
 	} else {
 		const packageJson = readPackageUp(cwd);
 		return packageJson?.type === "module";

--- a/packages/rspack-cli/tests/build/config/cjs_in_esm/main.ts
+++ b/packages/rspack-cli/tests/build/config/cjs_in_esm/main.ts
@@ -1,0 +1,1 @@
+console.log("Main cjs file");

--- a/packages/rspack-cli/tests/build/config/cjs_in_esm/package.json
+++ b/packages/rspack-cli/tests/build/config/cjs_in_esm/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/packages/rspack-cli/tests/build/config/cjs_in_esm/rspack.config.cjs
+++ b/packages/rspack-cli/tests/build/config/cjs_in_esm/rspack.config.cjs
@@ -1,0 +1,10 @@
+const path = require("path");
+
+module.exports = {
+	mode: "production",
+	entry: path.resolve(__dirname, "main.ts"),
+	output: {
+		path: path.resolve(__dirname, "dist"),
+		filename: "cjs.bundle.js"
+	}
+};

--- a/packages/rspack-cli/tests/build/config/cjs_in_esm/rspack.config.cts
+++ b/packages/rspack-cli/tests/build/config/cjs_in_esm/rspack.config.cts
@@ -1,0 +1,10 @@
+const path = require("path");
+
+module.exports = {
+	mode: "production",
+	entry: path.resolve(__dirname, "main.ts"),
+	output: {
+		path: path.resolve(__dirname, "dist"),
+		filename: "cts.bundle.js"
+	}
+};

--- a/packages/rspack-cli/tests/build/config/config.test.ts
+++ b/packages/rspack-cli/tests/build/config/config.test.ts
@@ -9,7 +9,34 @@ describe("rspack cli", () => {
 			expect(stderr).toMatch(/not found/);
 		});
 	});
+	describe("should respect cjs in esm folder", () => {
+		const cwd = resolve(__dirname, "./cjs_in_esm");
+		it("should load config.cjs file", async () => {
+			const { exitCode, stderr, stdout } = await run(cwd, [
+				"-c",
+				"rspack.config.cjs"
+			]);
+			expect(stderr).toBeFalsy();
+			expect(stdout).toBeTruthy();
+			expect(exitCode).toBe(0);
+			expect(
+				readFile(resolve(cwd, "./dist/cjs.bundle.js"), { encoding: "utf-8" })
+			).resolves.toMatch(/Main cjs file/);
+		});
 
+		it("should load config.cts file", async () => {
+			const { exitCode, stderr, stdout } = await run(cwd, [
+				"-c",
+				"rspack.config.cts"
+			]);
+			expect(stderr).toBeFalsy();
+			expect(stdout).toBeTruthy();
+			expect(exitCode).toBe(0);
+			expect(
+				readFile(resolve(cwd, "./dist/cts.bundle.js"), { encoding: "utf-8" })
+			).resolves.toMatch(/Main cjs file/);
+		});
+	});
 	describe("should load cjs config", () => {
 		const cwd = resolve(__dirname, "./cjs");
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
currently rspack-cli will throw error when `.cts` in folder which contains `type:module` in package.json
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
