### PR TITLE
chore: avoid const enum in node binding dts

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -139,7 +139,7 @@ export interface BuiltinPlugin {
   canInherentFromParent?: boolean
 }
 
-export const enum BuiltinPluginName {
+export enum BuiltinPluginName {
   DefinePlugin = 'DefinePlugin',
   ProvidePlugin = 'ProvidePlugin',
   BannerPlugin = 'BannerPlugin',

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -21,7 +21,8 @@ async function build() {
 			"--platform",
 			"--dts",
 			"binding.d.ts",
-			"--no-js"
+			"--no-js",
+			"--no-const-enum"
 		];
 		if (release) {
 			args.push("--release");

--- a/packages/rspack/src/builtin-plugin/ArrayPushCallbackChunkFormatPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ArrayPushCallbackChunkFormatPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const ArrayPushCallbackChunkFormatPlugin = create(
 	BuiltinPluginName.ArrayPushCallbackChunkFormatPlugin,

--- a/packages/rspack/src/builtin-plugin/AssetModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/AssetModulesPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const AssetModulesPlugin = create(
 	BuiltinPluginName.AssetModulesPlugin,

--- a/packages/rspack/src/builtin-plugin/AsyncWebAssemblyModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/AsyncWebAssemblyModulesPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const AsyncWebAssemblyModulesPlugin = create(
 	BuiltinPluginName.AsyncWebAssemblyModulesPlugin,

--- a/packages/rspack/src/builtin-plugin/BannerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/BannerPlugin.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import { JsChunk, RawBannerPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	JsChunk,
+	RawBannerPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 
 const rule = z.string().or(z.instanceof(RegExp));
 export type Rule = z.infer<typeof rule>;

--- a/packages/rspack/src/builtin-plugin/BundlerInfoPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/BundlerInfoPlugin.ts
@@ -1,5 +1,8 @@
-import { RawBundlerInfoPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawBundlerInfoPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 
 export type BundleInfoOptions = {
 	version?: string;

--- a/packages/rspack/src/builtin-plugin/ChunkPrefetchPreloadPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ChunkPrefetchPreloadPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const ChunkPrefetchPreloadPlugin = create(
 	BuiltinPluginName.ChunkPrefetchPreloadPlugin,

--- a/packages/rspack/src/builtin-plugin/CommonJsChunkFormatPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CommonJsChunkFormatPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const CommonJsChunkFormatPlugin = create(
 	BuiltinPluginName.CommonJsChunkFormatPlugin,

--- a/packages/rspack/src/builtin-plugin/CopyRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/CopyRspackPlugin.ts
@@ -1,5 +1,9 @@
-import { RawCopyPattern, RawCopyRspackPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawCopyPattern,
+	RawCopyRspackPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 
 export type CopyRspackPluginOptions = {
 	patterns: (

--- a/packages/rspack/src/builtin-plugin/DataUriPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DataUriPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const DataUriPlugin = create(
 	BuiltinPluginName.DataUriPlugin,

--- a/packages/rspack/src/builtin-plugin/DefinePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DefinePlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export type DefinePluginOptions = Record<string, string | boolean | undefined>;
 export const DefinePlugin = create(

--- a/packages/rspack/src/builtin-plugin/DeterministicChunkIdsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DeterministicChunkIdsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const DeterministicChunkIdsPlugin = create(
 	BuiltinPluginName.DeterministicChunkIdsPlugin,

--- a/packages/rspack/src/builtin-plugin/DeterministicModuleIdsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DeterministicModuleIdsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const DeterministicModuleIdsPlugin = create(
 	BuiltinPluginName.DeterministicModuleIdsPlugin,

--- a/packages/rspack/src/builtin-plugin/ElectronTargetPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ElectronTargetPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const ElectronTargetPlugin = create(
 	BuiltinPluginName.ElectronTargetPlugin,

--- a/packages/rspack/src/builtin-plugin/EnableChunkLoadingPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EnableChunkLoadingPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const EnableChunkLoadingPlugin = create(
 	BuiltinPluginName.EnableChunkLoadingPlugin,

--- a/packages/rspack/src/builtin-plugin/EnableLibraryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EnableLibraryPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const EnableLibraryPlugin = create(
 	BuiltinPluginName.EnableLibraryPlugin,

--- a/packages/rspack/src/builtin-plugin/EnableWasmLoadingPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EnableWasmLoadingPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const EnableWasmLoadingPlugin = create(
 	BuiltinPluginName.EnableWasmLoadingPlugin,

--- a/packages/rspack/src/builtin-plugin/EnsureChunkConditionsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EnsureChunkConditionsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const EnsureChunkConditionsPlugin = create(
 	BuiltinPluginName.EnsureChunkConditionsPlugin,

--- a/packages/rspack/src/builtin-plugin/EntryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EntryPlugin.ts
@@ -1,5 +1,9 @@
-import { RawEntryOptions, RawEntryPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawEntryOptions,
+	RawEntryPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 import {
 	ChunkLoading,
 	EntryRuntime,

--- a/packages/rspack/src/builtin-plugin/EvalDevToolModulePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EvalDevToolModulePlugin.ts
@@ -1,5 +1,8 @@
-import { RawEvalDevToolModulePluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawEvalDevToolModulePluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 
 export type { RawEvalDevToolModulePluginOptions as EvalDevToolModulePluginOptions };
 

--- a/packages/rspack/src/builtin-plugin/EvalSourceMapDevToolPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EvalSourceMapDevToolPlugin.ts
@@ -1,5 +1,8 @@
-import { RawSourceMapDevToolPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawSourceMapDevToolPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 import { SourceMapDevToolPluginOptions } from "./SourceMapDevToolPlugin";
 
 export const EvalSourceMapDevToolPlugin = create(

--- a/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ExternalsPlugin.ts
@@ -1,5 +1,5 @@
-import { RawExternalsPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName, RawExternalsPluginOptions } from "@rspack/binding";
+import { create } from "./base";
 import { ExternalItem, ExternalItemValue, Externals } from "..";
 
 export const ExternalsPlugin = create(

--- a/packages/rspack/src/builtin-plugin/FileUriPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/FileUriPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const FileUriPlugin = create(
 	BuiltinPluginName.FileUriPlugin,

--- a/packages/rspack/src/builtin-plugin/FlagDependencyExportsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/FlagDependencyExportsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const FlagDependencyExportsPlugin = create(
 	BuiltinPluginName.FlagDependencyExportsPlugin,

--- a/packages/rspack/src/builtin-plugin/FlagDependencyUsagePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/FlagDependencyUsagePlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const FlagDependencyUsagePlugin = create(
 	BuiltinPluginName.FlagDependencyUsagePlugin,

--- a/packages/rspack/src/builtin-plugin/HotModuleReplacementPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HotModuleReplacementPlugin.ts
@@ -1,10 +1,6 @@
-import { BuiltinPlugin } from "@rspack/binding";
+import { BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
 import { Compiler } from "../Compiler";
-import {
-	BuiltinPluginName,
-	RspackBuiltinPlugin,
-	createBuiltinPlugin
-} from "./base";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
 export class HotModuleReplacementPlugin extends RspackBuiltinPlugin {
 	name = BuiltinPluginName.HotModuleReplacementPlugin;

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { RawHtmlRspackPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName, RawHtmlRspackPluginOptions } from "@rspack/binding";
+import { create } from "./base";
 import { validate } from "../util/validate";
 
 const htmlRspackPluginOptions = z.strictObject({

--- a/packages/rspack/src/builtin-plugin/HttpExternalsRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HttpExternalsRspackPlugin.ts
@@ -1,5 +1,8 @@
-import { RawHttpExternalsRspackPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawHttpExternalsRspackPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 
 export const HttpExternalsRspackPlugin = create(
 	BuiltinPluginName.HttpExternalsRspackPlugin,

--- a/packages/rspack/src/builtin-plugin/InferAsyncModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/InferAsyncModulesPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const InferAsyncModulesPlugin = create(
 	BuiltinPluginName.InferAsyncModulesPlugin,

--- a/packages/rspack/src/builtin-plugin/JavascriptModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/JavascriptModulesPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const JavascriptModulesPlugin = create(
 	BuiltinPluginName.JavascriptModulesPlugin,

--- a/packages/rspack/src/builtin-plugin/JsonModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/JsonModulesPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const JsonModulesPlugin = create(
 	BuiltinPluginName.JsonModulesPlugin,

--- a/packages/rspack/src/builtin-plugin/LimitChunkCountPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/LimitChunkCountPlugin.ts
@@ -1,5 +1,8 @@
-import { RawLimitChunkCountPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import {
+	BuiltinPluginName,
+	RawLimitChunkCountPluginOptions
+} from "@rspack/binding";
+import { create } from "./base";
 
 export type LimitChunkCountOptions = {
 	chunkOverhead?: number;

--- a/packages/rspack/src/builtin-plugin/MangleExportsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/MangleExportsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const MangleExportsPlugin = create(
 	BuiltinPluginName.MangleExportsPlugin,

--- a/packages/rspack/src/builtin-plugin/MergeDuplicateChunksPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/MergeDuplicateChunksPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const MergeDuplicateChunksPlugin = create(
 	BuiltinPluginName.MergeDuplicateChunksPlugin,

--- a/packages/rspack/src/builtin-plugin/ModuleChunkFormatPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ModuleChunkFormatPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const ModuleChunkFormatPlugin = create(
 	BuiltinPluginName.ModuleChunkFormatPlugin,

--- a/packages/rspack/src/builtin-plugin/ModuleConcatenationPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ModuleConcatenationPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const ModuleConcatenationPlugin = create(
 	BuiltinPluginName.ModuleConcatenationPlugin,

--- a/packages/rspack/src/builtin-plugin/NamedChunkIdsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/NamedChunkIdsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const NamedChunkIdsPlugin = create(
 	BuiltinPluginName.NamedChunkIdsPlugin,

--- a/packages/rspack/src/builtin-plugin/NamedModuleIdsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/NamedModuleIdsPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const NamedModuleIdsPlugin = create(
 	BuiltinPluginName.NamedModuleIdsPlugin,

--- a/packages/rspack/src/builtin-plugin/NodeTargetPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/NodeTargetPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const NodeTargetPlugin = create(
 	BuiltinPluginName.NodeTargetPlugin,

--- a/packages/rspack/src/builtin-plugin/ProgressPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ProgressPlugin.ts
@@ -1,5 +1,5 @@
-import { RawProgressPluginOptions } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName, RawProgressPluginOptions } from "@rspack/binding";
+import { create } from "./base";
 
 export type ProgressPluginArgument =
 	| Partial<RawProgressPluginOptions>

--- a/packages/rspack/src/builtin-plugin/ProvidePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ProvidePlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export type ProvidePluginOptions = Record<string, string | string[]>;
 export const ProvidePlugin = create(

--- a/packages/rspack/src/builtin-plugin/RealContentHashPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RealContentHashPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const RealContentHashPlugin = create(
 	BuiltinPluginName.RealContentHashPlugin,

--- a/packages/rspack/src/builtin-plugin/RemoveEmptyChunksPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RemoveEmptyChunksPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const RemoveEmptyChunksPlugin = create(
 	BuiltinPluginName.RemoveEmptyChunksPlugin,

--- a/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RuntimePlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const RuntimePlugin = create(
 	BuiltinPluginName.RuntimePlugin,

--- a/packages/rspack/src/builtin-plugin/SideEffectsFlagPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SideEffectsFlagPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const SideEffectsFlagPlugin = create(
 	BuiltinPluginName.SideEffectsFlagPlugin,

--- a/packages/rspack/src/builtin-plugin/SourceMapDevToolPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SourceMapDevToolPlugin.ts
@@ -1,6 +1,9 @@
-import { RawSourceMapDevToolPluginOptions } from "@rspack/binding";
+import {
+	BuiltinPluginName,
+	RawSourceMapDevToolPluginOptions
+} from "@rspack/binding";
 import { matchObject } from "../ModuleFilenameHelpers";
-import { BuiltinPluginName, create } from "./base";
+import { create } from "./base";
 
 /**
  * Include source maps for modules based on their extension (defaults to .js and .css).

--- a/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
@@ -1,14 +1,10 @@
 import assert from "assert";
 import { type OptimizationSplitChunksOptions } from "../config/zod";
-import {
-	BuiltinPluginName,
-	RspackBuiltinPlugin,
-	create,
-	createBuiltinPlugin
-} from "./base";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 import { Compiler } from "../Compiler";
 import {
 	BuiltinPlugin,
+	BuiltinPluginName,
 	JsChunk,
 	JsModule,
 	RawCacheGroupOptions,

--- a/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const SwcCssMinimizerRspackPlugin = create(
 	BuiltinPluginName.SwcCssMinimizerRspackPlugin,

--- a/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
@@ -1,8 +1,9 @@
 import {
+	BuiltinPluginName,
 	RawExtractComments,
 	RawSwcJsMinimizerRspackPluginOptions
 } from "@rspack/binding";
-import { BuiltinPluginName, create } from "./base";
+import { create } from "./base";
 
 type MinifyCondition = string | RegExp;
 type MinifyConditions = MinifyCondition | MinifyCondition[];

--- a/packages/rspack/src/builtin-plugin/WarnCaseSensitiveModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/WarnCaseSensitiveModulesPlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const WarnCaseSensitiveModulesPlugin = create(
 	BuiltinPluginName.WarnCaseSensitiveModulesPlugin,

--- a/packages/rspack/src/builtin-plugin/WebWorkerTemplatePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/WebWorkerTemplatePlugin.ts
@@ -1,4 +1,5 @@
-import { BuiltinPluginName, create } from "./base";
+import { BuiltinPluginName } from "@rspack/binding";
+import { create } from "./base";
 
 export const WebWorkerTemplatePlugin = create(
 	BuiltinPluginName.WebWorkerTemplatePlugin,

--- a/packages/rspack/src/builtin-plugin/WorkerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/WorkerPlugin.ts
@@ -1,9 +1,5 @@
-import { BuiltinPlugin } from "@rspack/binding";
-import {
-	BuiltinPluginName,
-	RspackBuiltinPlugin,
-	createBuiltinPlugin
-} from "./base";
+import { BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 import {
 	ChunkLoading,
 	OutputModule,

--- a/packages/rspack/src/builtin-plugin/base.ts
+++ b/packages/rspack/src/builtin-plugin/base.ts
@@ -1,66 +1,6 @@
 import * as binding from "@rspack/binding";
 import { Compiler, RspackPluginInstance } from "..";
 
-// TODO: workaround for https://github.com/napi-rs/napi-rs/pull/1690
-export enum BuiltinPluginName {
-	DefinePlugin = "DefinePlugin",
-	ProvidePlugin = "ProvidePlugin",
-	BannerPlugin = "BannerPlugin",
-	ProgressPlugin = "ProgressPlugin",
-	EntryPlugin = "EntryPlugin",
-	ExternalsPlugin = "ExternalsPlugin",
-	NodeTargetPlugin = "NodeTargetPlugin",
-	ElectronTargetPlugin = "ElectronTargetPlugin",
-	EnableChunkLoadingPlugin = "EnableChunkLoadingPlugin",
-	EnableLibraryPlugin = "EnableLibraryPlugin",
-	EnableWasmLoadingPlugin = "EnableWasmLoadingPlugin",
-	ChunkPrefetchPreloadPlugin = "ChunkPrefetchPreloadPlugin",
-	CommonJsChunkFormatPlugin = "CommonJsChunkFormatPlugin",
-	ArrayPushCallbackChunkFormatPlugin = "ArrayPushCallbackChunkFormatPlugin",
-	ModuleChunkFormatPlugin = "ModuleChunkFormatPlugin",
-	HotModuleReplacementPlugin = "HotModuleReplacementPlugin",
-	HttpExternalsRspackPlugin = "HttpExternalsRspackPlugin",
-	CopyRspackPlugin = "CopyRspackPlugin",
-	HtmlRspackPlugin = "HtmlRspackPlugin",
-	SwcJsMinimizerRspackPlugin = "SwcJsMinimizerRspackPlugin",
-	SwcCssMinimizerRspackPlugin = "SwcCssMinimizerRspackPlugin",
-	LimitChunkCountPlugin = "LimitChunkCountPlugin",
-	WorkerPlugin = "WorkerPlugin",
-	WebWorkerTemplatePlugin = "WebWorkerTemplatePlugin",
-	MergeDuplicateChunksPlugin = "MergeDuplicateChunksPlugin",
-	SplitChunksPlugin = "SplitChunksPlugin",
-	ShareRuntimePlugin = "ShareRuntimePlugin",
-	ContainerPlugin = "ContainerPlugin",
-	ContainerReferencePlugin = "ContainerReferencePlugin",
-	ProvideSharedPlugin = "ProvideSharedPlugin",
-	ConsumeSharedPlugin = "ConsumeSharedPlugin",
-	NamedModuleIdsPlugin = "NamedModuleIdsPlugin",
-	DeterministicModuleIdsPlugin = "DeterministicModuleIdsPlugin",
-	NamedChunkIdsPlugin = "NamedChunkIdsPlugin",
-	DeterministicChunkIdsPlugin = "DeterministicChunkIdsPlugin",
-	RealContentHashPlugin = "RealContentHashPlugin",
-	RemoveEmptyChunksPlugin = "RemoveEmptyChunksPlugin",
-	EnsureChunkConditionsPlugin = "EnsureChunkConditionsPlugin",
-	WarnCaseSensitiveModulesPlugin = "WarnCaseSensitiveModulesPlugin",
-	DataUriPlugin = "DataUriPlugin",
-	FileUriPlugin = "FileUriPlugin",
-	RuntimePlugin = "RuntimePlugin",
-	JsonModulesPlugin = "JsonModulesPlugin",
-	InferAsyncModulesPlugin = "InferAsyncModulesPlugin",
-	JavascriptModulesPlugin = "JavascriptModulesPlugin",
-	AsyncWebAssemblyModulesPlugin = "AsyncWebAssemblyModulesPlugin",
-	AssetModulesPlugin = "AssetModulesPlugin",
-	SourceMapDevToolPlugin = "SourceMapDevToolPlugin",
-	EvalSourceMapDevToolPlugin = "EvalSourceMapDevToolPlugin",
-	EvalDevToolModulePlugin = "EvalDevToolModulePlugin",
-	SideEffectsFlagPlugin = "SideEffectsFlagPlugin",
-	FlagDependencyExportsPlugin = "FlagDependencyExportsPlugin",
-	FlagDependencyUsagePlugin = "FlagDependencyUsagePlugin",
-	MangleExportsPlugin = "MangleExportsPlugin",
-	BundlerInfoPlugin = "BundlerInfoPlugin",
-	ModuleConcatenationPlugin = "ModuleConcatenationPlugin"
-}
-
 type AffectedHooks = keyof Compiler["hooks"];
 
 export const HOOKS_CAN_NOT_INHERENT_FROM_PARENT = [
@@ -84,7 +24,7 @@ export function canInherentFromParent(affectedHooks?: AffectedHooks): boolean {
 
 export abstract class RspackBuiltinPlugin implements RspackPluginInstance {
 	abstract raw(compiler: Compiler): binding.BuiltinPlugin | null;
-	abstract name: BuiltinPluginName;
+	abstract name: binding.BuiltinPluginName;
 
 	affectedHooks?: AffectedHooks;
 	apply(compiler: Compiler) {
@@ -97,7 +37,7 @@ export abstract class RspackBuiltinPlugin implements RspackPluginInstance {
 }
 
 export function createBuiltinPlugin<R>(
-	name: BuiltinPluginName,
+	name: binding.BuiltinPluginName,
 	options: R
 ): binding.BuiltinPlugin {
 	return {
@@ -107,7 +47,7 @@ export function createBuiltinPlugin<R>(
 }
 
 export function create<T extends any[], R>(
-	name: BuiltinPluginName,
+	name: binding.BuiltinPluginName,
 	resolve: (...args: T) => R,
 	// `affectedHooks` is used to inform `createChildCompile` about which builtin plugin can be reversed.
 	// However, this has a drawback as it doesn't represent the actual condition but merely serves as an indicator.

--- a/packages/rspack/src/container/ContainerPlugin.ts
+++ b/packages/rspack/src/container/ContainerPlugin.ts
@@ -1,6 +1,9 @@
-import { RawContainerPluginOptions, BuiltinPlugin } from "@rspack/binding";
 import {
-	BuiltinPluginName,
+	RawContainerPluginOptions,
+	BuiltinPlugin,
+	BuiltinPluginName
+} from "@rspack/binding";
+import {
 	RspackBuiltinPlugin,
 	createBuiltinPlugin
 } from "../builtin-plugin/base";

--- a/packages/rspack/src/container/ContainerReferencePlugin.ts
+++ b/packages/rspack/src/container/ContainerReferencePlugin.ts
@@ -1,9 +1,9 @@
 import {
 	BuiltinPlugin,
+	BuiltinPluginName,
 	RawContainerReferencePluginOptions
 } from "@rspack/binding";
 import {
-	BuiltinPluginName,
 	RspackBuiltinPlugin,
 	createBuiltinPlugin
 } from "../builtin-plugin/base";

--- a/packages/rspack/src/sharing/ConsumeSharedPlugin.ts
+++ b/packages/rspack/src/sharing/ConsumeSharedPlugin.ts
@@ -1,11 +1,11 @@
 import {
 	BuiltinPlugin,
+	BuiltinPluginName,
 	RawConsumeOptions,
 	RawConsumeSharedPluginOptions
 } from "@rspack/binding";
 import { Compiler } from "../Compiler";
 import {
-	BuiltinPluginName,
 	RspackBuiltinPlugin,
 	createBuiltinPlugin
 } from "../builtin-plugin/base";

--- a/packages/rspack/src/sharing/ProvideSharedPlugin.ts
+++ b/packages/rspack/src/sharing/ProvideSharedPlugin.ts
@@ -1,6 +1,9 @@
-import { BuiltinPlugin, RawProvideOptions } from "@rspack/binding";
 import {
+	BuiltinPlugin,
 	BuiltinPluginName,
+	RawProvideOptions
+} from "@rspack/binding";
+import {
 	RspackBuiltinPlugin,
 	createBuiltinPlugin
 } from "../builtin-plugin/base";

--- a/packages/rspack/src/sharing/ShareRuntimePlugin.ts
+++ b/packages/rspack/src/sharing/ShareRuntimePlugin.ts
@@ -1,6 +1,5 @@
-import { BuiltinPlugin } from "@rspack/binding";
+import { BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
 import {
-	BuiltinPluginName,
 	RspackBuiltinPlugin,
 	createBuiltinPlugin
 } from "../builtin-plugin/base";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

avoid const enum since Rspack is using `isolatedModules: true`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
