### PR TITLE
refactor: align get_exports of CommonJsExportRequireDependency

### DIFF
--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -27,6 +27,7 @@ pub enum InitFragmentKey {
   HarmonyImport(String),
   HarmonyExportStar(String), // TODO: align with webpack and remove this
   HarmonyExports,
+  CommonJsExports(String),
   ExternalModule(String),
   AwaitDependencies,
   HarmonyCompatibility,
@@ -80,7 +81,8 @@ impl InitFragmentKey {
       | InitFragmentKey::HarmonyFakeNamespaceObjectFragment(_)
       | InitFragmentKey::HarmonyExportStar(_)
       | InitFragmentKey::ExternalModule(_)
-      | InitFragmentKey::ModuleDecorator(_) => first(fragments),
+      | InitFragmentKey::ModuleDecorator(_)
+      | InitFragmentKey::CommonJsExports(_) => first(fragments),
       InitFragmentKey::HarmonyCompatibility | InitFragmentKey::Unique(_) => {
         debug_assert!(fragments.len() == 1, "fragment = {:?}", self);
         first(fragments)

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -1,8 +1,12 @@
+use itertools::Itertools;
 use rspack_core::{
   module_raw, property_access, AsContextDependency, Dependency, DependencyCategory, DependencyId,
-  DependencyTemplate, DependencyType, ErrorSpan, ExportsOfExportsSpec, ExportsSpec,
-  ModuleDependency, ModuleGraph, RuntimeGlobals, TemplateContext, TemplateReplaceSource, UsedName,
+  DependencyTemplate, DependencyType, ErrorSpan, ExportInfoProvided, ExportNameOrSpec, ExportSpec,
+  ExportsOfExportsSpec, ExportsSpec, ExportsType, ModuleDependency, ModuleGraph, ModuleIdentifier,
+  Nullable, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsageState,
+  UsedName,
 };
+use rustc_hash::FxHashSet;
 use swc_core::atoms::Atom;
 
 use super::ExportsBase;
@@ -45,6 +49,125 @@ impl CommonJsExportRequireDependency {
   }
 }
 
+impl CommonJsExportRequireDependency {
+  // NOTE:
+  // webpack return checked set but never use it
+  // https://github.com/webpack/webpack/blob/08770761c8c7aa1e6e18b77d3deee8cc9871bd87/lib/dependencies/CommonJsExportRequireDependency.js#L283
+  fn get_star_reexports(
+    &self,
+    mg: &ModuleGraph,
+    runtime: Option<&RuntimeSpec>,
+    imported_module: &ModuleIdentifier,
+  ) -> Option<FxHashSet<Atom>> {
+    let mut imported_exports_info = Some(mg.get_exports_info(imported_module));
+    let ids = self.get_ids(mg);
+    if !ids.is_empty() {
+      imported_exports_info = imported_exports_info
+        .expect("Should get exports info from imported module")
+        .id
+        .get_nested_exports_info(Some(ids), mg)
+        .map(|id| id.get_exports_info(mg));
+    }
+
+    let mut exports_info = Some(
+      mg.get_exports_info(
+        mg.get_parent_module(&self.id)
+          .expect("Should get parent module"),
+      ),
+    );
+
+    if !self.names.is_empty() {
+      exports_info = exports_info
+        .expect("Should get exports info from imported module")
+        .id
+        .get_nested_exports_info(Some(self.names.clone()), mg)
+        .map(|id| id.get_exports_info(mg));
+    }
+
+    let no_extra_exports = imported_exports_info.is_some_and(|imported_exports_info| {
+      imported_exports_info
+        .other_exports_info
+        .get_export_info(mg)
+        .provided
+        .is_some_and(|provided| matches!(provided, ExportInfoProvided::False))
+    });
+
+    let no_extra_imports = exports_info.is_some_and(|exports_info| {
+      exports_info.other_exports_info.get_used(mg, runtime) == UsageState::Unused
+    });
+
+    if !no_extra_exports && !no_extra_imports {
+      return None;
+    }
+
+    let is_namespace_import = matches!(
+      mg.module_by_identifier(imported_module)
+        .expect("Should get imported module")
+        .get_exports_type_readonly(mg, false),
+      ExportsType::Namespace
+    );
+
+    let mut exports = FxHashSet::default();
+
+    if no_extra_imports {
+      let Some(exports_info) = exports_info else {
+        unreachable!();
+      };
+      for export_info_id in exports_info.get_ordered_exports() {
+        let export_info = export_info_id.get_export_info(mg);
+        let name = &export_info.name;
+        if matches!(export_info.get_used(runtime), UsageState::Unused) {
+          continue;
+        }
+        if let Some(name) = name {
+          if name == "__esModule" && is_namespace_import {
+            exports.insert(name.to_owned());
+          } else if let Some(imported_exports_info) = imported_exports_info {
+            let imported_export_info = imported_exports_info.id.get_read_only_export_info(name, mg);
+            if matches!(
+              imported_export_info.provided,
+              Some(ExportInfoProvided::False)
+            ) {
+              continue;
+            }
+            exports.insert(name.to_owned());
+          } else {
+            exports.insert(name.to_owned());
+          }
+        }
+      }
+    } else if no_extra_exports {
+      let Some(imported_exports_info) = imported_exports_info else {
+        unreachable!();
+      };
+      for imported_export_info_id in imported_exports_info.get_ordered_exports() {
+        let imported_export_info = imported_export_info_id.get_export_info(mg);
+        let name = &imported_export_info.name;
+        if let Some(name) = name {
+          if matches!(
+            imported_export_info.provided,
+            Some(ExportInfoProvided::False)
+          ) {
+            continue;
+          }
+          if let Some(exports_info) = exports_info {
+            let export_info = exports_info.id.get_read_only_export_info(name, mg);
+            if matches!(export_info.get_used(runtime), UsageState::Unused) {
+              continue;
+            }
+            exports.insert(name.to_owned());
+          }
+        }
+      }
+      if is_namespace_import {
+        exports.insert(Atom::from("__esModule"));
+      }
+    }
+
+    Some(exports)
+  }
+}
+
 impl Dependency for CommonJsExportRequireDependency {
   fn dependency_debug_name(&self) -> &'static str {
     "CommonJsExportRequireDependency"
@@ -63,18 +186,82 @@ impl Dependency for CommonJsExportRequireDependency {
   }
 
   fn get_exports(&self, mg: &ModuleGraph) -> Option<ExportsSpec> {
-    let con = mg.connection_by_dependency(&self.id)?;
-    Some(ExportsSpec {
-      exports: ExportsOfExportsSpec::True,
-      can_mangle: Some(false),
-      from: if self.ids.is_empty() {
-        Some(*con)
+    let ids = self.get_ids(mg);
+
+    if self.names.len() == 1 {
+      let Some(name) = self.names.first() else {
+        unreachable!();
+      };
+      let Some(from) = mg.connection_by_dependency(&self.id) else {
+        return None;
+      };
+      Some(ExportsSpec {
+        exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
+          name: name.to_owned(),
+          from: Some(from.to_owned()),
+          can_mangle: Some(false),
+          export: Some(if ids.is_empty() {
+            Nullable::Null
+          } else {
+            Nullable::Value(ids)
+          }),
+          ..Default::default()
+        })]),
+        dependencies: Some(vec![from.module_identifier]),
+        ..Default::default()
+      })
+    } else if self.names.is_empty() {
+      let Some(from) = mg.connection_by_dependency(&self.id) else {
+        return None;
+      };
+      if let Some(reexport_info) = self.get_star_reexports(mg, None, &from.module_identifier) {
+        Some(ExportsSpec {
+          exports: ExportsOfExportsSpec::Array(
+            reexport_info
+              .iter()
+              .map(|name| {
+                let mut export = ids.clone();
+                export.extend(vec![name.to_owned()]);
+                ExportNameOrSpec::ExportSpec(ExportSpec {
+                  name: name.to_owned(),
+                  from: Some(from.to_owned()),
+                  export: Some(Nullable::Value(export)),
+                  can_mangle: Some(false),
+                  ..Default::default()
+                })
+              })
+              .collect_vec(),
+          ),
+          dependencies: Some(vec![from.module_identifier]),
+          ..Default::default()
+        })
       } else {
-        None
-      },
-      dependencies: Some(vec![con.module_identifier]),
-      ..Default::default()
-    })
+        Some(ExportsSpec {
+          exports: ExportsOfExportsSpec::True,
+          from: if ids.is_empty() {
+            Some(from.to_owned())
+          } else {
+            None
+          },
+          can_mangle: Some(false),
+          dependencies: Some(vec![from.module_identifier]),
+          ..Default::default()
+        })
+      }
+    } else {
+      let Some(name) = self.names.first() else {
+        unreachable!();
+      };
+      Some(ExportsSpec {
+        exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
+          name: name.to_owned(),
+          can_mangle: Some(false),
+          ..Default::default()
+        })]),
+        dependencies: None,
+        ..Default::default()
+      })
+    }
   }
 
   fn get_ids(&self, mg: &ModuleGraph) -> Vec<Atom> {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -192,7 +192,10 @@ impl Dependency for CommonJsExportRequireDependency {
       let Some(name) = self.names.first() else {
         unreachable!();
       };
-      let Some(from) = mg.connection_by_dependency(&self.id) else {
+      let Some(from) = self
+        .require_dep
+        .and_then(|dep_id| mg.connection_by_dependency(&dep_id))
+      else {
         return None;
       };
       Some(ExportsSpec {
@@ -211,7 +214,10 @@ impl Dependency for CommonJsExportRequireDependency {
         ..Default::default()
       })
     } else if self.names.is_empty() {
-      let Some(from) = mg.connection_by_dependency(&self.id) else {
+      let Some(from) = self
+        .require_dep
+        .and_then(|dep_id| mg.connection_by_dependency(&dep_id))
+      else {
         return None;
       };
       if let Some(reexport_info) = self.get_star_reexports(mg, None, &from.module_identifier) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -192,10 +192,7 @@ impl Dependency for CommonJsExportRequireDependency {
       let Some(name) = self.names.first() else {
         unreachable!();
       };
-      let Some(from) = self
-        .require_dep
-        .and_then(|dep_id| mg.connection_by_dependency(&dep_id))
-      else {
+      let Some(from) = mg.connection_by_dependency(&self.id) else {
         return None;
       };
       Some(ExportsSpec {
@@ -214,10 +211,7 @@ impl Dependency for CommonJsExportRequireDependency {
         ..Default::default()
       })
     } else if self.names.is_empty() {
-      let Some(from) = self
-        .require_dep
-        .and_then(|dep_id| mg.connection_by_dependency(&dep_id))
-      else {
+      let Some(from) = mg.connection_by_dependency(&self.id) else {
         return None;
       };
       if let Some(reexport_info) = self.get_star_reexports(mg, None, &from.module_identifier) {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -173,7 +173,7 @@ impl DependencyTemplate for CommonJsExportsDependency {
             "var __webpack_unused_export__;\n".to_string(),
             InitFragmentStage::StageConstants,
             0,
-            InitFragmentKey::unique(),
+            InitFragmentKey::CommonJsExports("__webpack_unused_export__".to_owned()),
             None,
           )
           .boxed(),
@@ -211,7 +211,7 @@ impl DependencyTemplate for CommonJsExportsDependency {
               "var __webpack_unused_export__;\n".to_string(),
               InitFragmentStage::StageConstants,
               0,
-              InitFragmentKey::unique(),
+              InitFragmentKey::CommonJsExports("__webpack_unused_export__".to_owned()),
               None,
             )
             .boxed(),

--- a/packages/rspack-test-tools/src/case/diff.ts
+++ b/packages/rspack-test-tools/src/case/diff.ts
@@ -121,6 +121,7 @@ function createDiffProcessor(config: IDiffProcessorOptions) {
 		ignoreModuleArguments: config.ignoreModuleArguments ?? true,
 		ignorePropertyQuotationMark: config.ignorePropertyQuotationMark ?? true,
 		ignoreBlockOnlyStatement: config.ignoreBlockOnlyStatement ?? true,
+		ignoreIfCertainCondition: config.ignoreIfCertainCondition ?? true,
 		ignoreSwcHelpersPath: config.ignoreSwcHelpersPath ?? true,
 		ignoreObjectPropertySequence: config.ignoreObjectPropertySequence ?? true,
 		ignoreCssFilePath: config.ignoreCssFilePath ?? true,

--- a/packages/rspack-test-tools/src/compare/comparator.ts
+++ b/packages/rspack-test-tools/src/compare/comparator.ts
@@ -34,6 +34,7 @@ export class DiffComparator {
 								ignoreModuleId: true,
 								ignoreModuleArguments: true,
 								ignoreBlockOnlyStatement: true,
+								ignoreIfCertainCondition: true,
 								ignoreSwcHelpersPath: true,
 								ignoreObjectPropertySequence: true,
 								ignoreCssFilePath: true

--- a/packages/rspack-test-tools/src/processor/diff.ts
+++ b/packages/rspack-test-tools/src/processor/diff.ts
@@ -160,6 +160,7 @@ export class DiffProcessor implements ITestProcessor {
 			ignoreModuleId: this.options.ignoreModuleId,
 			ignorePropertyQuotationMark: this.options.ignorePropertyQuotationMark,
 			ignoreBlockOnlyStatement: this.options.ignoreBlockOnlyStatement,
+			ignoreIfCertainCondition: this.options.ignoreIfCertainCondition,
 			ignoreSwcHelpersPath: this.options.ignoreSwcHelpersPath,
 			ignoreObjectPropertySequence: this.options.ignoreObjectPropertySequence,
 			ignoreCssFilePath: this.options.ignoreCssFilePath,

--- a/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/index.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/index.js
@@ -1,0 +1,13 @@
+import { useMemo } from "./reexport";
+
+it("should import by export require", () => {
+	expect(useMemo).toBe("useMemo");
+});
+
+it("should flag other unused items with __webpack_unused_export__", () => {
+	const mainFile = require("fs").readFileSync(__filename, "utf-8");
+	const flag = "__webpack_unused_export__";
+	for (let i of ["useState", "useEffect"]) {
+		expect(mainFile.includes(`${flag} = "${i}"`)).toBeTruthy();
+	}
+});

--- a/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/react.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/react.js
@@ -1,0 +1,3 @@
+exports.useMemo = "useMemo";
+exports.useState = "useState";
+exports.useEffect = "useEffect";

--- a/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/reexport.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/reexport.js
@@ -1,0 +1,1 @@
+module.exports = require("./react");

--- a/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/webpack.config.js
+++ b/packages/rspack/tests/cases/cjs-tree-shaking/export-require-unused/webpack.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	optimization: {
+		usedExports: true
+	},
+	experiments: {
+		rspackFuture: {
+			newTreeshaking: true
+		}
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align get_exports and get_referenced_exports of CommonJsExportRequireDependency to make tree shaking works

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
