### PR TITLE
fix: codegen cache should consider runtime

### DIFF
--- a/crates/rspack_core/src/cache/occasion/code_generate.rs
+++ b/crates/rspack_core/src/cache/occasion/code_generate.rs
@@ -2,7 +2,7 @@ use rspack_error::Result;
 use rspack_identifier::Identifier;
 
 use crate::{cache::storage, BoxModule, CodeGenerationResult, Compilation, NormalModuleSource};
-use crate::{RuntimeSpec, RuntimeSpecSet};
+use crate::{get_runtime_key, RuntimeSpec, RuntimeSpecSet};
 
 type Storage = dyn storage::Storage<Vec<(CodeGenerationResult, RuntimeSpec)>>;
 
@@ -45,6 +45,7 @@ impl CodeGenerateOccasion {
           Some(runtime),
           true,
         ));
+        id.push_str(&get_runtime_key(runtime.clone()));
       }
       let id = Identifier::from(id);
 

--- a/packages/rspack/tests/configCases/loader-import-module/codegen-cache/app.js
+++ b/packages/rspack/tests/configCases/loader-import-module/codegen-cache/app.js
@@ -1,0 +1,3 @@
+import v from "./foo";
+
+export default v;

--- a/packages/rspack/tests/configCases/loader-import-module/codegen-cache/foo.js
+++ b/packages/rspack/tests/configCases/loader-import-module/codegen-cache/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack/tests/configCases/loader-import-module/codegen-cache/index.js
+++ b/packages/rspack/tests/configCases/loader-import-module/codegen-cache/index.js
@@ -1,0 +1,7 @@
+import v1 from "./app-proxy";
+import v2 from "./app";
+
+it("should compile", () => {
+	expect(v1).toBe(42);
+	expect(v2).toBe(42);
+});

--- a/packages/rspack/tests/configCases/loader-import-module/codegen-cache/loader.js
+++ b/packages/rspack/tests/configCases/loader-import-module/codegen-cache/loader.js
@@ -1,0 +1,10 @@
+/** @type {import("../../../../").PitchLoaderDefinitionFunction} */
+module.exports = async function (remaining) {
+	try {
+		const result = await this.importModule("./app.js", this.getOptions());
+		return `export default ${result.default}`;
+	} catch (e) {
+		console.error(e);
+		throw e;
+	}
+};

--- a/packages/rspack/tests/configCases/loader-import-module/codegen-cache/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader-import-module/codegen-cache/webpack.config.js
@@ -1,0 +1,21 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	output: {
+		publicPath: "/public/"
+	},
+	entry: "./index.js",
+	module: {
+		rules: [
+			{
+				test: /app-proxy\.js/,
+				loader: "./loader",
+				options: {}
+			}
+		]
+	},
+	experiments: {
+		rspackFuture: {
+			newTreeshaking: true
+		}
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Different runtime may generates different content, so cache in codegen should consider runtime

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
