### PR TITLE
fix: skip code splitting if asyncDependenciesBlock is the same

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1161,9 +1161,18 @@ impl Compilation {
               origin_blocks.sort_unstable();
 
               for index in 0..origin_blocks.len() {
-                if origin_blocks[index].0 != now_blocks[index].0 {
-                  return false;
+                match (
+                  origin_blocks[index].0.get(self),
+                  now_blocks[index].0.get(self),
+                ) {
+                  (Some(origin), Some(now)) => {
+                    if origin.identifier() != now.identifier() {
+                      return false;
+                    }
+                  }
+                  _ => return false,
                 }
+
                 if origin_blocks[index].1 != now_blocks[index].1 {
                   return false;
                 }

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -7,6 +7,7 @@ use rspack_error::{
   miette::{self, Diagnostic},
   thiserror::{self, Error},
 };
+use rspack_identifier::Identifiable;
 
 use crate::{
   update_hash::{UpdateHashContext, UpdateRspackHash},
@@ -81,6 +82,7 @@ pub struct AsyncDependenciesBlock {
   dependencies: Vec<BoxDependency>,
   loc: Option<DependencyLocation>,
   parent: ModuleIdentifier,
+  identifier: ModuleIdentifier,
 }
 
 impl AsyncDependenciesBlock {
@@ -95,6 +97,14 @@ impl AsyncDependenciesBlock {
       dependencies: Default::default(),
       loc,
       parent,
+      identifier: format!(
+        "{}|{}",
+        parent,
+        loc
+          .map(|loc| format!("{}:{}", loc.start, loc.end))
+          .unwrap_or_default()
+      )
+      .into(),
     }
   }
 }
@@ -156,6 +166,12 @@ impl DependenciesBlock for AsyncDependenciesBlock {
 
   fn get_dependencies(&self) -> &[DependencyId] {
     &self.dependency_ids
+  }
+}
+
+impl Identifiable for AsyncDependenciesBlock {
+  fn identifier(&self) -> rspack_identifier::Identifier {
+    self.identifier
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

AsyncDpendenciesId changes every compilation, so compare the asyncDependenciesBlock with their identifier, not ID

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
