### PR TITLE
refactor: cleanup `expr_mather::import_meta`

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -245,6 +245,7 @@ impl JavascriptParserPlugin for CommonJsImportsParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::UnaryExpr,
+    _for_name: &str,
   ) -> Option<bool> {
     if (expr_matcher::is_require(&expr.arg)
       || expr_matcher::is_require_resolve(&expr.arg)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_plugin.rs
@@ -11,6 +11,7 @@ impl JavascriptParserPlugin for CommonJsPlugin {
     &self,
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::UnaryExpr,
+    _for_name: &str,
   ) -> Option<bool> {
     if expr_matcher::is_module(&expr.arg) && parser.is_unresolved_ident("module") {
       parser

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -1,5 +1,5 @@
 use swc_core::common::Span;
-use swc_core::ecma::ast::{BinExpr, CallExpr, IfStmt, VarDecl, VarDeclarator};
+use swc_core::ecma::ast::{BinExpr, CallExpr, IfStmt, UnaryOp, VarDecl, VarDeclarator};
 
 use super::{BoxJavascriptParserPlugin, JavascriptParserPlugin};
 use crate::parser_plugin::r#const::is_logic_op;
@@ -147,9 +147,11 @@ impl JavascriptParserPlugin for JavaScriptParserPluginDrive {
     &self,
     parser: &mut JavascriptParser,
     expr: &swc_core::ecma::ast::UnaryExpr,
+    for_name: &str,
   ) -> Option<bool> {
+    assert!(expr.op == UnaryOp::TypeOf);
     for plugin in &self.plugins {
-      let res = plugin.r#typeof(parser, expr);
+      let res = plugin.r#typeof(parser, expr, for_name);
       // `SyncBailHook`
       if res.is_some() {
         return res;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -5,7 +5,6 @@ use url::Url;
 
 use super::JavascriptParserPlugin;
 use crate::visitors::create_traceable_error;
-use crate::visitors::expr_matcher;
 use crate::visitors::expr_name;
 use crate::visitors::ExportedVariableInfo;
 
@@ -22,9 +21,9 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
     &self,
     parser: &mut crate::visitors::JavascriptParser,
     unary_expr: &swc_core::ecma::ast::UnaryExpr,
+    for_name: &str,
   ) -> Option<bool> {
-    let expr = unary_expr.arg.as_ref();
-    if expr_matcher::is_import_meta(expr) {
+    if for_name == expr_name::IMPORT_META {
       parser
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(
@@ -34,7 +33,7 @@ impl JavascriptParserPlugin for ImportMetaPlugin {
           None,
         )));
       Some(true)
-    } else if expr_matcher::is_import_meta_url(expr) {
+    } else if for_name == expr_name::IMPORT_META_URL {
       parser
         .presentational_dependencies
         .push(Box::new(ConstDependency::new(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -115,7 +115,12 @@ pub trait JavascriptParserPlugin {
     None
   }
 
-  fn r#typeof(&self, _parser: &mut JavascriptParser, _expr: &UnaryExpr) -> Option<bool> {
+  fn r#typeof(
+    &self,
+    _parser: &mut JavascriptParser,
+    _expr: &UnaryExpr,
+    _for_name: &str,
+  ) -> Option<bool> {
     None
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -91,8 +91,6 @@ pub(crate) mod expr_matcher {
     is_module_exports: "module.exports",
     is_module_require: "module.require",
     is_webpack_module_id: "__webpack_module__.id",
-    is_import_meta_url: "import.meta.url",
-    is_import_meta: "import.meta",
     is_object_define_property: "Object.defineProperty",
     // unsupported
     is_require_extensions: "require.extensions",


### PR DESCRIPTION
And support `for_name` for `typeof` hooks