### PR TITLE
chore: rename bundler info plugin

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -195,7 +195,7 @@ export enum BuiltinPluginName {
   HtmlRspackPlugin = 'HtmlRspackPlugin',
   SwcJsMinimizerRspackPlugin = 'SwcJsMinimizerRspackPlugin',
   SwcCssMinimizerRspackPlugin = 'SwcCssMinimizerRspackPlugin',
-  BundlerInfoPlugin = 'BundlerInfoPlugin'
+  BundlerInfoRspackPlugin = 'BundlerInfoRspackPlugin'
 }
 
 export function cleanupGlobalTrace(): void

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -131,12 +131,13 @@ pub enum BuiltinPluginName {
   ModuleConcatenationPlugin,
 
   // rspack specific plugins
+  // naming format follow XxxRspackPlugin
   HttpExternalsRspackPlugin,
   CopyRspackPlugin,
   HtmlRspackPlugin,
   SwcJsMinimizerRspackPlugin,
   SwcCssMinimizerRspackPlugin,
-  BundlerInfoPlugin,
+  BundlerInfoRspackPlugin,
 }
 
 #[napi(object)]
@@ -380,7 +381,7 @@ impl BuiltinPlugin {
             .boxed();
         plugins.push(plugin);
       }
-      BuiltinPluginName::BundlerInfoPlugin => {
+      BuiltinPluginName::BundlerInfoRspackPlugin => {
         let plugin_options = downcast_into::<RawBundlerInfoPluginOptions>(self.options)?;
         plugins.push(
           BundlerInfoPlugin::new(

--- a/packages/rspack/src/builtin-plugin/BundlerInfoRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/BundlerInfoRspackPlugin.ts
@@ -9,8 +9,8 @@ export type BundleInfoOptions = {
 	force?: boolean | string[];
 };
 
-export const BundlerInfoPlugin = create(
-	BuiltinPluginName.BundlerInfoPlugin,
+export const BundlerInfoRspackPlugin = create(
+	BuiltinPluginName.BundlerInfoRspackPlugin,
 	(options: BundleInfoOptions): RawBundlerInfoPluginOptions => {
 		return {
 			version: options.version || "unknown",

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -45,7 +45,7 @@ export * from "./SideEffectsFlagPlugin";
 export * from "./FlagDependencyExportsPlugin";
 export * from "./FlagDependencyUsagePlugin";
 export * from "./MangleExportsPlugin";
-export * from "./BundlerInfoPlugin";
+export * from "./BundlerInfoRspackPlugin";
 export * from "./ModuleConcatenationPlugin";
 
 export * from "./HtmlRspackPlugin";

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -59,7 +59,7 @@ import {
 	FlagDependencyExportsPlugin,
 	FlagDependencyUsagePlugin,
 	SideEffectsFlagPlugin,
-	BundlerInfoPlugin,
+	BundlerInfoRspackPlugin,
 	ModuleConcatenationPlugin,
 	EvalDevToolModulePlugin
 } from "./builtin-plugin";
@@ -251,7 +251,7 @@ export class RspackOptionsApply {
 		new RuntimePlugin().apply(compiler);
 
 		if (options.experiments.rspackFuture!.bundlerInfo) {
-			new BundlerInfoPlugin(
+			new BundlerInfoRspackPlugin(
 				options.experiments.rspackFuture!.bundlerInfo
 			).apply(compiler);
 		}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

rename BundlerInfoPlugin to BundlerInfoRspackPlugin
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
