### PR TITLE
fix: runtime module hook after tree runtime requirements

### DIFF
--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -13,6 +13,7 @@ use rspack_binding_values::{
 use rspack_binding_values::{BeforeResolveData, JsAssetEmittedArgs, ToJsModule};
 use rspack_binding_values::{CreateModuleData, JsBuildTimeExecutionOption, JsExecuteModuleArg};
 use rspack_binding_values::{JsResolveForSchemeInput, JsResolveForSchemeResult};
+use rspack_core::rspack_sources::Source;
 use rspack_core::{
   ApplyContext, BuildTimeExecutionOption, Chunk, ChunkAssetArgs, Compilation, CompilationParams,
   CompilerOptions, ModuleIdentifier, NormalModuleAfterResolveArgs, PluginContext, RuntimeModule,
@@ -909,8 +910,8 @@ impl rspack_core::Plugin for JsHooksAdapterPlugin {
   async fn runtime_module(
     &self,
     module: &mut dyn RuntimeModule,
+    source: Arc<dyn Source>,
     chunk: &Chunk,
-    compilation: &Compilation,
   ) -> rspack_error::Result<Option<String>> {
     if self.is_hook_disabled(&Hook::RuntimeModule) {
       return Ok(None);
@@ -922,8 +923,7 @@ impl rspack_core::Plugin for JsHooksAdapterPlugin {
         JsRuntimeModuleArg {
           module: JsRuntimeModule {
             source: Some(
-              module
-                .generate(compilation)
+              source
                 .to_js_compat_source()
                 .unwrap_or_else(|err| panic!("Failed to generate runtime module source: {err}")),
             ),

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1845,6 +1845,34 @@ impl Compilation {
         .chunk_graph
         .add_tree_runtime_requirements(&entry_ukey, set);
     }
+
+    // NOTE: webpack runs hooks.runtime_module in compilation.add_runtime_module
+    // and overwrite the runtime_module.generate() to get new source in create_chunk_assets
+    // this needs full runtime requirements, so run hooks.runtime_module after runtime_requirements_in_tree
+    for entry_ukey in self.get_chunk_graph_entries() {
+      let chunk = self.chunk_by_ukey.expect_get(&entry_ukey);
+      for runtime_module_id in self
+        .chunk_graph
+        .get_chunk_runtime_modules_iterable(&entry_ukey)
+      {
+        let Some((origin_source, name)) = self
+          .runtime_modules
+          .get(runtime_module_id)
+          .map(|m| (m.generate(self), m.name().to_string()))
+        else {
+          continue;
+        };
+        if let Some(runtime_module) = self.runtime_modules.get_mut(runtime_module_id)
+          && let Some(new_source) = self
+            .plugin_driver
+            .runtime_module(runtime_module.as_mut(), origin_source, chunk)
+            .await?
+        {
+          runtime_module.set_custom_source(OriginalSource::new(new_source, name));
+        }
+      }
+    }
+
     logger.time_end(start);
     Ok(())
   }
@@ -2034,14 +2062,6 @@ impl Compilation {
     self
       .chunk_graph
       .connect_chunk_and_runtime_module(*chunk_ukey, runtime_module_identifier);
-
-    if let Some(new_source) = self
-      .plugin_driver
-      .runtime_module(module.as_mut(), chunk, self)
-      .await?
-    {
-      module.set_custom_source(OriginalSource::new(new_source, module.name().to_string()));
-    }
 
     self
       .runtime_modules

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -1,9 +1,9 @@
-use std::{fmt::Debug, path::Path};
+use std::{fmt::Debug, path::Path, sync::Arc};
 
 use rspack_error::{IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
 use rspack_hash::RspackHashDigest;
 use rspack_loader_runner::{Content, LoaderContext, ResourceData};
-use rspack_sources::BoxSource;
+use rspack_sources::{BoxSource, Source};
 use rustc_hash::FxHashMap;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -484,8 +484,8 @@ pub trait Plugin: Debug + Send + Sync {
   async fn runtime_module(
     &self,
     _module: &mut dyn RuntimeModule,
+    _source: Arc<dyn Source>,
     _chunk: &Chunk,
-    _compilation: &Compilation,
   ) -> Result<Option<String>> {
     Ok(None)
   }

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -5,6 +5,7 @@ use std::{
 
 use rspack_error::{Diagnostic, Result, TWithDiagnosticArray};
 use rspack_loader_runner::{LoaderContext, ResourceData};
+use rspack_sources::Source;
 use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::instrument;
@@ -633,11 +634,11 @@ impl PluginDriver {
   pub async fn runtime_module(
     &self,
     module: &mut dyn RuntimeModule,
+    source: Arc<dyn Source>,
     chunk: &Chunk,
-    compilation: &Compilation,
   ) -> Result<Option<String>> {
     for plugin in &self.plugins {
-      if let Some(t) = plugin.runtime_module(module, chunk, compilation).await? {
+      if let Some(t) = plugin.runtime_module(module, source.clone(), chunk).await? {
         return Ok(Some(t));
       };
     }

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -816,8 +816,8 @@ impl Plugin for SourceMapDevToolModuleOptionsPlugin {
   async fn runtime_module(
     &self,
     module: &mut dyn RuntimeModule,
+    _source: Arc<dyn Source>,
     _chunk: &Chunk,
-    _compilation: &Compilation,
   ) -> Result<Option<String>> {
     if self.module {
       module.set_source_map_kind(SourceMapKind::SourceMap);

--- a/packages/rspack/tests/configCases/hooks/issue-5571/index.css
+++ b/packages/rspack/tests/configCases/hooks/issue-5571/index.css
@@ -1,0 +1,3 @@
+.class {
+  background: #fff;
+}

--- a/packages/rspack/tests/configCases/hooks/issue-5571/index.js
+++ b/packages/rspack/tests/configCases/hooks/issue-5571/index.js
@@ -1,0 +1,16 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+it("should modify runtime module source in main", () => {
+	const name = "APP_ROOT";
+	expect(fs.readFileSync(path.join(__dirname, "./main.js"), "utf-8")).toContain(
+		"globalThis." + name
+	);
+});
+
+it("should has css loading hmr runtime requirements", () => {
+	const name = "hmrC.css";
+	expect(fs.readFileSync(path.join(__dirname, "./main.js"), "utf-8")).toContain(
+		"__webpack_require__." + name + " = "
+	);
+});

--- a/packages/rspack/tests/configCases/hooks/issue-5571/webpack.config.js
+++ b/packages/rspack/tests/configCases/hooks/issue-5571/webpack.config.js
@@ -1,0 +1,47 @@
+const rspack = require("@rspack/core");
+const path = require("path");
+
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("TestFakePlugin", compilation => {
+			compilation.hooks.runtimeModule.tap("TestFakePlugin", module => {
+				if (module.name !== "css_loading" || !module.source) return;
+				const originCode = module.source.source.toString("utf-8");
+
+				module.source.source = Buffer.from(
+					originCode
+						.replace(
+							/document\.(getElementsByTagName|querySelectorAll)/g,
+							`(globalThis.APP_ROOT||document).$1`
+						)
+						.replace(
+							/document\.head/g,
+							`(globalThis.APP_STYLE_ROOT||document.head)`
+						),
+					"utf-8"
+				);
+			});
+		});
+	}
+}
+
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	target: "web",
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				type: "css/module"
+			}
+		]
+	},
+	plugins: [
+		new Plugin(),
+		new rspack.DefinePlugin({
+			__dirname: JSON.stringify(path.join(__dirname, "./dist"))
+		}),
+		new rspack.HotModuleReplacementPlugin()
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix #5571, run runtime_module hook after runtime_requirements_in_tree to make sure the code generation can use full runtime requirements

## Require Documentation?

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
