### PR TITLE
feat: eval more unary expr

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -12,7 +12,6 @@ const WEBPACK_HASH: &str = "__webpack_hash__";
 const WEBPACK_PUBLIC_PATH: &str = "__webpack_public_path__";
 const WEBPACK_MODULES: &str = "__webpack_modules__";
 const WEBPACK_MODULE: &str = "__webpack_module__";
-pub const WEBPACK_RESOURCE_QUERY: &str = "__resourceQuery";
 const WEBPACK_CHUNK_LOAD: &str = "__webpack_chunk_load__";
 const WEBPACK_BASE_URI: &str = "__webpack_base_uri__";
 const NON_WEBPACK_REQUIRE: &str = "__non_webpack_require__";
@@ -47,7 +46,6 @@ fn get_typeof_evaluate_of_api(sym: &str) -> Option<&str> {
     WEBPACK_PUBLIC_PATH => Some("string"),
     WEBPACK_MODULES => Some("object"),
     WEBPACK_MODULE => Some("object"),
-    WEBPACK_RESOURCE_QUERY => Some("string"),
     WEBPACK_CHUNK_LOAD => Some("function"),
     WEBPACK_BASE_URI => Some("string"),
     NON_WEBPACK_REQUIRE => None,
@@ -130,19 +128,6 @@ impl JavascriptParserPlugin for APIPlugin {
             ident.span.real_hi(),
             RuntimeGlobals::MODULE_FACTORIES.name().into(),
             Some(RuntimeGlobals::MODULE_FACTORIES),
-          )));
-      }
-      WEBPACK_RESOURCE_QUERY => {
-        let resource_query = parser.resource_data.resource_query.as_deref().unwrap_or("");
-        parser
-          .presentational_dependencies
-          .push(Box::new(ConstDependency::new(
-            ident.span.real_lo(),
-            ident.span.real_hi(),
-            serde_json::to_string(resource_query)
-              .expect("should render module id")
-              .into(),
-            None,
           )));
       }
       WEBPACK_CHUNK_LOAD => {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -18,7 +18,7 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     _for_name: &str,
   ) -> Option<bool> {
     let Some(node_option) = parser.compiler_options.node.as_ref() else {
-      return None;
+      unreachable!("ensure only invoke `NodeStuffPlugin` when node options is enabled");
     };
     let str = ident.sym.as_str();
     if !parser.is_unresolved_ident(str) {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -6,13 +6,13 @@ use crate::parser_plugin::JavascriptParserPlugin;
 use crate::visitors::JavascriptParser;
 
 fn eval_typeof(
-  scanner: &mut JavascriptParser,
+  parser: &mut JavascriptParser,
   expr: &UnaryExpr,
 ) -> Option<BasicEvaluatedExpression> {
   assert!(expr.op == UnaryOp::TypeOf);
   if let Some(ident) = expr.arg.as_ident()
-    && let res = scanner.plugin_drive.clone().evaluate_typeof(
-      scanner,
+    && /* FIXME: should use call hooks for name */ let res = parser.plugin_drive.clone().evaluate_typeof(
+      parser,
       ident,
       expr.span.real_lo(),
       expr.span.hi().0,
@@ -23,7 +23,17 @@ fn eval_typeof(
   }
 
   // TODO: if let `MetaProperty`, `MemberExpression` ...
-  None
+  let arg = parser.evaluate_expression(&expr.arg);
+  if arg.is_unknown() {
+    None
+  } else if arg.is_string() {
+    let mut res = BasicEvaluatedExpression::with_range(expr.span.real_lo(), expr.span.hi.0);
+    res.set_string("string".to_string());
+    Some(res)
+  } else {
+    // TODO: `arg.is_wrapped()`...
+    None
+  }
 }
 
 pub fn eval_unary_expression(

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -126,6 +126,10 @@ impl BasicEvaluatedExpression {
     matches!(self.ty, Ty::Null)
   }
 
+  pub fn is_unknown(&self) -> bool {
+    matches!(self.ty, Ty::Unknown)
+  }
+
   pub fn is_undefined(&self) -> bool {
     matches!(self.ty, Ty::Undefined)
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -286,7 +286,9 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(parser_plugin::CommonJsImportsParserPlugin));
       plugins.push(Box::new(parser_plugin::CommonJsPlugin));
       plugins.push(Box::new(parser_plugin::CommonJsExportsParserPlugin));
-      plugins.push(Box::new(parser_plugin::NodeStuffPlugin));
+      if compiler_options.node.is_some() {
+        plugins.push(Box::new(parser_plugin::NodeStuffPlugin));
+      }
     }
 
     if compiler_options.dev_server.hot {

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.test.ts.snap
@@ -6321,7 +6321,7 @@ exports[`StatsTestCases should print correct stats for runtime-specific-exports 
   "errors": [],
   "errorsCount": 0,
   "filteredModules": undefined,
-  "hash": "a70d51933f0b44467f41",
+  "hash": "5491370cb8e3b8b37e5f",
   "logging": {},
   "modules": [
     {
@@ -6475,7 +6475,7 @@ Entrypoint main 391 bytes = bundle.js
 ./increment.js
   [exports: decrement, increment, incrementBy2]
   [only some exports used: increment]
-Rspack compiled successfully (a70d51933f0b44467f41)"
+Rspack compiled successfully (5491370cb8e3b8b37e5f)"
 `;
 
 exports[`StatsTestCases should print correct stats for simple-export 1`] = `


### PR DESCRIPTION
This PR introduces:
- remove eval `typeof __resourceQuery` in `api_plugin`, this can help us alian to webpack.
- some test for js slice