### PR TITLE
chore: remove unused dev dependencies

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -36,8 +36,7 @@
     "cross-env": "^7.0.3",
     "execa": "^5.0.0",
     "internal-ip": "6.2.0",
-    "source-map-support": "^0.5.19",
-    "ts-node": "10.9.2"
+    "source-map-support": "^0.5.19"
   },
   "dependencies": {
     "@discoveryjs/json-ext": "^0.5.7",

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -36,8 +36,7 @@
     "@types/connect-history-api-fallback": "1.5.4",
     "@types/express": "4.17.21",
     "@types/mime-types": "2.1.4",
-    "@types/ws": "8.5.10",
-    "fs-extra": "11.2.0"
+    "@types/ws": "8.5.10"
   },
   "dependencies": {
     "chokidar": "3.5.3",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -68,6 +68,5 @@
     "react": "18.0.0",
     "react-dom": "18.0.0",
     "react-refresh": "0.14.0"
-  },
-  "peerDependenciesMeta": {}
+  }
 }

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -62,7 +62,6 @@
     "source-map": "^0.7.4",
     "styled-components": "^6.0.8",
     "terser": "5.27.0",
-    "ts-node": "10.9.2",
     "wast-loader": "^1.11.4"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,7 +519,7 @@ importers:
         version: 12.2.0(@rspack/core@packages+rspack)(less@4.2.0)(webpack@5.90.0)
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.0(@rspack/core@packages+rspack)(postcss@8.4.33)(typescript@4.9.4)(webpack@5.90.0)
+        version: 8.1.0(@rspack/core@packages+rspack)(postcss@8.4.33)(typescript@5.0.2)(webpack@5.90.0)
       postcss-pxtorem:
         specifier: ^6.0.0
         version: 6.0.0(postcss@8.4.33)
@@ -544,12 +544,9 @@ importers:
       terser:
         specifier: 5.27.0
         version: 5.27.0
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.3.99)(@types/node@20.9.4)(typescript@4.9.4)
       wast-loader:
         specifier: ^1.11.4
-        version: 1.11.4
+        version: 1.11.6
 
   packages/rspack-cli:
     dependencies:
@@ -608,9 +605,6 @@ importers:
       source-map-support:
         specifier: ^0.5.19
         version: 0.5.21
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.3.99)(@types/node@20.9.4)(typescript@4.9.4)
 
   packages/rspack-dev-server:
     dependencies:
@@ -660,9 +654,6 @@ importers:
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10
-      fs-extra:
-        specifier: 11.2.0
-        version: 11.2.0
 
   packages/rspack-plugin-html:
     dependencies:
@@ -8326,22 +8317,6 @@ packages:
       typescript: 5.0.2
     dev: true
 
-  /cosmiconfig@9.0.0(typescript@4.9.4):
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      typescript: '>=4.9.5'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-      typescript: 4.9.4
-    dev: true
-
   /cosmiconfig@9.0.0(typescript@5.0.2):
     resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
     engines: {node: '>=14'}
@@ -13187,29 +13162,6 @@ packages:
       - typescript
     dev: true
 
-  /postcss-loader@8.1.0(@rspack/core@packages+rspack)(postcss@8.4.33)(typescript@4.9.4)(webpack@5.90.0):
-    resolution: {integrity: sha512-AbperNcX3rlob7Ay7A/HQcrofug1caABBkopoFeOQMspZBqcqj6giYn1Bwey/0uiOPAcR+NQD0I2HC7rXzk91w==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-      postcss: ^7.0.0 || ^8.0.1
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      '@rspack/core': link:packages/rspack
-      cosmiconfig: 9.0.0(typescript@4.9.4)
-      jiti: 1.21.0
-      postcss: 8.4.33
-      semver: 7.5.4
-      webpack: 5.90.0(@swc/core@1.3.99)(webpack-cli@4.10.0)
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
   /postcss-loader@8.1.0(@rspack/core@packages+rspack)(postcss@8.4.33)(typescript@5.0.2)(webpack@5.90.0):
     resolution: {integrity: sha512-AbperNcX3rlob7Ay7A/HQcrofug1caABBkopoFeOQMspZBqcqj6giYn1Bwey/0uiOPAcR+NQD0I2HC7rXzk91w==}
     engines: {node: '>= 18.12.0'}
@@ -15881,38 +15833,6 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-node@10.9.2(@swc/core@1.3.99)(@types/node@20.9.4)(typescript@4.9.4):
-    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
-    hasBin: true
-    peerDependencies:
-      '@swc/core': '>=1.2.50'
-      '@swc/wasm': '>=1.2.50'
-      '@types/node': '*'
-      typescript: '>=2.7'
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      '@swc/wasm':
-        optional: true
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@swc/core': 1.3.99(@swc/helpers@0.5.3)
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 20.9.4
-      acorn: 8.11.2
-      acorn-walk: 8.2.0
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 4.9.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    dev: true
-
   /tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
     dev: false
@@ -16395,8 +16315,8 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /wast-loader@1.11.4:
-    resolution: {integrity: sha512-Cl86ihG/Ct0nDLr2IyK55eSb0Ru+N7tUrrFVv3JG05IuUOZvKBgENMHfbQgirlvOoFZ+tmyCdxx4N7YsA+EN5g==}
+  /wast-loader@1.11.6:
+    resolution: {integrity: sha512-V0DRsaTKmnuvExSheKRZpX0c+ztCvG7NtDhjOviDPki8ahi6hFsoI3S9RVBRPNv7L1tjzAYzrFVhbeS9HFhJZw==}
     dependencies:
       wabt: 1.0.0-nightly.20180421
     dev: true


### PR DESCRIPTION
I wrote a script ...

pnpm -r -c exec 'node /path/to/script.js'

```javascript
const util = require('util');
const exec = util.promisify(require('child_process').exec);
const process = require('process');
const path = require('path');


async function main() {
  const cwd = process.cwd();

  const packageJsonPath = path.join(cwd, "package.json");
  const packageJson = require(packageJsonPath);
  if (packageJson.devDependencies === undefined) {
    return
  }
  const deps = Object.keys(packageJson.devDependencies);
  const scripts = packageJson.scripts || {};

  const results = [];
  const tasks = deps
    .filter((dep) => !dep.startsWith('@types'))
    .filter((dep) => !Object.values(scripts).some((s) => s.includes(dep)))
    .map(async (dep) => {
      try {
        const { stdout } = await exec(`git grep ${dep} | grep -e import -e require`, {maxBuffer: 1024 * 1000})
        if (stdout.length === 0) {
          results.push(dep);
        }
      } catch (e) {
        results.push(dep);
      }
    });

  await Promise.all(tasks);

  if (results.length > 0) {
    console.log('-------------')
    console.log('cwd:', cwd);
    console.log(results)
  }
}

main()
```