### PR TITLE
fix: module_graph update module align with webpack

### DIFF
--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -39,7 +39,6 @@ impl Hash for ModuleGraphConnection {
     self.original_module_identifier.hash(state);
     self.module_identifier.hash(state);
     self.dependency_id.hash(state);
-    self.conditional.hash(state);
   }
 }
 impl PartialEq for ModuleGraphConnection {
@@ -47,7 +46,6 @@ impl PartialEq for ModuleGraphConnection {
     self.original_module_identifier == other.original_module_identifier
       && self.module_identifier == other.module_identifier
       && self.dependency_id == other.dependency_id
-      && self.conditional == other.conditional
   }
 }
 
@@ -70,6 +68,7 @@ impl ModuleGraphConnection {
   }
 
   pub fn set_active(&mut self, value: bool) {
+    self.conditional = false;
     self.active = value;
   }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -902,7 +902,7 @@ impl Plugin for ModuleConcatenationPlugin {
         Some(rspack_hash::HashFunction::MD4),
         config.runtime.clone(),
       );
-      new_module
+      let build_result = new_module
         .build(
           rspack_core::BuildContext {
             compiler_context: CompilerContext {
@@ -925,6 +925,7 @@ impl Plugin for ModuleConcatenationPlugin {
           Some(compilation),
         )
         .await?;
+      new_module.set_module_build_info_and_meta(build_result.build_info, build_result.build_meta);
       let root_mgm_epxorts = compilation
         .module_graph
         .module_graph_module_by_identifier(&root_module_id)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

* update module align with webpack [module_graph.updateModule](https://github.com/webpack/webpack/blob/eaa685e1310e2abc882adc269e9fd6e264bf3f06/lib/ModuleGraph.js#L225)
* module_graph.revokeConnection should remove active connection if current connection not active

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
