### PR TITLE
fix: eval `typeof aliasRequire` should work

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -99,7 +99,7 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
     start: u32,
     end: u32,
   ) -> Option<crate::utils::eval::BasicEvaluatedExpression> {
-    if ident == DIR_NAME && parser.is_unresolved_ident(DIR_NAME) {
+    if ident == DIR_NAME {
       Some(eval::evaluate_to_string(
         get_context(parser.resource_data).as_str().to_string(),
         start,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -82,8 +82,6 @@ pub(crate) mod expr_matcher {
     is_require: "require",
     is_require_main: "require.main",
     is_require_context: "require.context",
-    is_require_resolve: "require.resolve",
-    is_require_resolve_weak: "require.resolveWeak",
     is_require_cache: "require.cache",
     is_module: "module",
     is_module_id: "module.id",
@@ -110,6 +108,9 @@ pub mod expr_name {
   pub const MODULE_HOT: &str = "module.hot";
   pub const MODULE_HOT_ACCEPT: &str = "module.hot.accept";
   pub const MODULE_HOT_DECLINE: &str = "module.hot.decline";
+  pub const REQUIRE: &str = "require";
+  pub const REQUIRE_RESOLVE: &str = "require.resolve";
+  pub const REQUIRE_RESOLVE_WEAK: &str = "require.resolveWeak";
   pub const IMPORT_META: &str = "import.meta";
   pub const IMPORT_META_URL: &str = "import.meta.url";
   pub const IMPORT_META_WEBPACK_HOT: &str = "import.meta.webpackHot";

--- a/packages/rspack/tests/cases/parsing/renaming/index.js
+++ b/packages/rspack/tests/cases/parsing/renaming/index.js
@@ -2,8 +2,8 @@ it("should be able to rename require by var", function () {
 	var cjsRequire; // just to make it difficult
 	var cjsRequire = require,
 		cjsRequire2 = typeof require !== "undefined" && require;
-	expect(typeof cjsRequire).toBe("undefined");
-	expect(typeof cjsRequire2).toBe("undefined");
+	expect(typeof cjsRequire).toBe("function");
+	expect(typeof cjsRequire2).toBe("function");
 	expect(cjsRequire("./file")).toBe("ok");
 	expect(cjsRequire2("./file")).toBe("ok");
 });


### PR DESCRIPTION
This PR introduces:
- Delete some useless `expr_match::xxxx`
- make `typeof aliasRequire` return `fcuntion`.