### PR TITLE
fix: hit cache when imports connection not changed

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -504,7 +504,7 @@ impl Compilation {
       let (deps, blocks) = compalition
         .module_graph
         .get_module_dependencies_modules_and_blocks(module_identifier);
-      let deps: Vec<_> = deps.into_iter().cloned().collect();
+
       let blocks_with_option: Vec<_> = blocks
         .iter()
         .map(|block| {
@@ -1143,14 +1143,11 @@ impl Compilation {
           if self.module_graph.module_by_identifier(&module_id).is_none() {
             false
           } else {
-            let (mut now_deps, mut now_blocks) = module_deps(self, &module_id);
-            let (mut origin_deps, mut origin_blocks) = deps;
+            let (now_deps, mut now_blocks) = module_deps(self, &module_id);
+            let (origin_deps, mut origin_blocks) = deps;
             if now_deps.len() != origin_deps.len() || now_blocks.len() != origin_blocks.len() {
               false
             } else {
-              now_deps.sort_unstable();
-              origin_deps.sort_unstable();
-
               for index in 0..origin_deps.len() {
                 if origin_deps[index] != now_deps[index] {
                   return false;

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -3,6 +3,7 @@ use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 
 use dashmap::DashMap;
+use itertools::Itertools;
 use rspack_error::Result;
 use rspack_hash::RspackHashDigest;
 use rspack_identifier::{Identifiable, IdentifierMap};
@@ -647,14 +648,33 @@ impl ModuleGraph {
   pub(crate) fn get_module_dependencies_modules_and_blocks(
     &self,
     module_identifier: &ModuleIdentifier,
-  ) -> (Vec<&ModuleIdentifier>, &[AsyncDependenciesBlockIdentifier]) {
+  ) -> (Vec<ModuleIdentifier>, &[AsyncDependenciesBlockIdentifier]) {
     let Some(m) = self.module_by_identifier(module_identifier) else {
       unreachable!("cannot find the module correspanding to {module_identifier}");
     };
-    let modules = m
+    let mut deps = m
       .get_dependencies()
       .iter()
-      .filter_map(|id| self.module_identifier_by_dependency_id(id))
+      .filter_map(|id| self.dependency_by_id(id))
+      .filter(|dep| dep.as_module_dependency().is_some())
+      .collect::<Vec<_>>();
+
+    // sort by span, so user change import order can recalculate chunk graph
+    deps.sort_by(|a, b| {
+      if let (Some(span_a), Some(span_b)) = (a.span(), b.span()) {
+        span_a.cmp(&span_b)
+      } else if let (Some(a), Some(b)) = (a.source_order(), b.source_order()) {
+        a.cmp(&b)
+      } else {
+        a.id().cmp(b.id())
+      }
+    });
+
+    let modules = deps
+      .into_iter()
+      .filter_map(|dep| self.module_identifier_by_dependency_id(dep.id()))
+      .dedup_by(|a, b| a.as_str() == b.as_str())
+      .copied()
       .collect();
     let blocks = m.get_blocks();
     (modules, blocks)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

## Current issue

If module's all dependencies and blocks stay the same, Rspack skips building chunk graph. However dependencies can change easily, for example:

```js
import {foo} from 'bar';
```

there is 1 dependency which is `ImportSideEffectDependency`. However if I add one line like:

```js
import {foo} from 'bar';
console.log(foo);
```

We don't need to rebuild chunk graph, as there are no connections change. But we do have dependencies change, we have 
`ImportSideEffectDependency` and `ImportSpecifierDependency` now, so cache miss.

## Solution
I choose to sort all outgoings by there span location first, this step ensures dependency orders change can make cache invalidate.
Then I dedupe them by there target module, so I add extra import to the same module or I make access to import specifier should hit cache as well



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
