### PR TITLE
fix: loaderCtx.hot should be injected by HMRPlugin

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -420,6 +420,7 @@ export interface JsLoaderContext {
    */
   diagnosticsExternal: ExternalObject<'Diagnostic[]'>
   _moduleIdentifier: string
+  hot: boolean
 }
 
 export interface JsModule {

--- a/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/js_loader.rs
@@ -260,6 +260,8 @@ pub struct JsLoaderContext {
 
   #[napi(js_name = "_moduleIdentifier")]
   pub module_identifier: String,
+
+  pub hot: bool,
 }
 
 impl TryFrom<&mut rspack_core::LoaderContext<'_, rspack_core::LoaderRunnerContext>>
@@ -321,6 +323,7 @@ impl TryFrom<&mut rspack_core::LoaderContext<'_, rspack_core::LoaderRunnerContex
       context_external: External::new(cx.context.clone()),
       diagnostics_external: External::new(cx.__diagnostics.drain(..).collect()),
       module_identifier: cx.context.module.to_string(),
+      hot: cx.hot,
     })
   }
 }
@@ -347,6 +350,7 @@ pub async fn run_builtin_loader(
   };
 
   let mut cx = LoaderContext {
+    hot: loader_context.hot,
     content: loader_context
       .content
       .map(|c| Content::from(c.as_ref().to_owned())),

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -138,6 +138,8 @@ pub type AdditionalData = anymap::Map<dyn CloneAny + Send + Sync>;
 #[derive(Derivative)]
 #[derivative(Debug)]
 pub struct LoaderContext<'c, C> {
+  pub hot: bool,
+
   /// Content of loader, represented by string or buffer
   /// Content should always be exist if at normal stage,
   /// It will be `None` at pitching stage.
@@ -279,6 +281,7 @@ async fn create_loader_context<'c, C: 'c>(
   }
 
   let mut loader_context = LoaderContext {
+    hot: false,
     cacheable: true,
     file_dependencies,
     context_dependencies: Default::default(),

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -9,9 +9,9 @@ use rspack_core::{
   rspack_sources::{RawSource, SourceExt},
   AdditionalChunkRuntimeRequirementsArgs, ApplyContext, AssetInfo, Chunk, ChunkKind, Compilation,
   CompilationAsset, CompilationParams, CompilationRecords, CompilerOptions, DependencyType,
-  ModuleIdentifier, PathData, Plugin, PluginAdditionalChunkRuntimeRequirementsOutput,
-  PluginContext, PluginProcessAssetsOutput, ProcessAssetsArgs, RenderManifestArgs, RuntimeGlobals,
-  RuntimeModuleExt, RuntimeSpec, SourceType,
+  LoaderContext, LoaderRunnerContext, ModuleIdentifier, NormalModule, PathData, Plugin,
+  PluginAdditionalChunkRuntimeRequirementsOutput, PluginContext, PluginProcessAssetsOutput,
+  ProcessAssetsArgs, RenderManifestArgs, RuntimeGlobals, RuntimeModuleExt, RuntimeSpec, SourceType,
 };
 use rspack_error::Result;
 use rspack_hash::RspackHash;
@@ -65,6 +65,16 @@ impl Plugin for HotModuleReplacementPlugin {
       .tap(Box::new(HotModuleReplacementPluginCompilationHook));
 
     options.dev_server.hot = true;
+    Ok(())
+  }
+
+  fn normal_module_loader(
+    &self,
+    _ctx: PluginContext,
+    loader_context: &mut LoaderContext<LoaderRunnerContext>,
+    _module: &NormalModule,
+  ) -> Result<()> {
+    loader_context.hot = true;
     Ok(())
   }
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -203,6 +203,7 @@ export async function runLoaders(
 	});
 
 	loaderContext.__internal__context = rawContext;
+	loaderContext.hot = rawContext.hot;
 	loaderContext.context = contextDirectory;
 	loaderContext.loaderIndex = 0;
 	loaderContext.loaders = loaders;
@@ -407,7 +408,6 @@ export async function runLoaders(
 		? isUseSourceMap(compiler.options.devtool)
 		: false;
 	loaderContext.mode = compiler.options.mode;
-	loaderContext.hot = !!compiler.options.devServer?.hot;
 
 	const getResolveContext = () => {
 		// FIXME: resolve's fileDependencies will includes lots of dir, '/', etc

--- a/packages/rspack/tests/configCases/loader/hot/index.js
+++ b/packages/rspack/tests/configCases/loader/hot/index.js
@@ -1,0 +1,3 @@
+it("should compile", done => {
+	done();
+});

--- a/packages/rspack/tests/configCases/loader/hot/loader.js
+++ b/packages/rspack/tests/configCases/loader/hot/loader.js
@@ -1,0 +1,6 @@
+function loader(content) {
+	expect(this.hot).toBe(true);
+	return content;
+}
+
+module.exports = loader;

--- a/packages/rspack/tests/configCases/loader/hot/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/hot/webpack.config.js
@@ -1,0 +1,14 @@
+const HmrPlugin = require("@rspack/core").HotModuleReplacementPlugin;
+
+module.exports = {
+	context: __dirname,
+	mode: "development",
+	plugins: [new HmrPlugin()],
+	module: {
+		rules: [
+			{
+				loader: "./loader.js"
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

loaderContext.hot should be determine by HotModuleReplacementPlugin

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
