### PR TITLE
fix: add context module afterResolve hook

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -365,6 +365,7 @@ export interface JsHooks {
   beforeResolve: (...args: any[]) => any
   afterResolve: (...args: any[]) => any
   contextModuleFactoryBeforeResolve: (...args: any[]) => any
+  contextModuleFactoryAfterResolve: (...args: any[]) => any
   normalModuleFactoryCreateModule: (...args: any[]) => any
   normalModuleFactoryResolveForScheme: (...args: any[]) => any
   chunkAsset: (...args: any[]) => any

--- a/crates/node_binding/src/hook.rs
+++ b/crates/node_binding/src/hook.rs
@@ -37,6 +37,7 @@ pub enum Hook {
   /// webpack `compilation.hooks.chunkAsset`
   ChunkAsset,
   ContextModuleFactoryBeforeResolve,
+  ContextModuleFactoryAfterResolve,
   NormalModuleFactoryResolveForScheme,
   NormalModuleFactoryCreateModule,
   AfterResolve,
@@ -83,6 +84,7 @@ impl From<String> for Hook {
       "optimizeTree" => Hook::OptimizeTree,
       "chunkAsset" => Hook::ChunkAsset,
       "contextModuleFactoryBeforeResolve" => Hook::ContextModuleFactoryBeforeResolve,
+      "contextModuleFactoryAfterResolve" => Hook::ContextModuleFactoryAfterResolve,
       "normalModuleFactoryCreateModule" => Hook::NormalModuleFactoryCreateModule,
       "normalModuleFactoryResolveForScheme" => Hook::NormalModuleFactoryResolveForScheme,
       "afterResolve" => Hook::AfterResolve,

--- a/crates/rspack_binding_values/src/hooks.rs
+++ b/crates/rspack_binding_values/src/hooks.rs
@@ -37,6 +37,7 @@ pub struct JsHooks {
   pub before_resolve: JsFunction,
   pub after_resolve: JsFunction,
   pub context_module_factory_before_resolve: JsFunction,
+  pub context_module_factory_after_resolve: JsFunction,
   pub normal_module_factory_create_module: JsFunction,
   pub normal_module_factory_resolve_for_scheme: JsFunction,
   pub chunk_asset: JsFunction,

--- a/crates/rspack_core/src/plugin/api.rs
+++ b/crates/rspack_core/src/plugin/api.rs
@@ -118,6 +118,14 @@ pub trait Plugin: Debug + Send + Sync {
     Ok(None)
   }
 
+  async fn context_module_after_resolve(
+    &self,
+    _ctx: PluginContext,
+    _args: &mut NormalModuleAfterResolveArgs<'_>,
+  ) -> PluginNormalModuleFactoryAfterResolveOutput {
+    Ok(None)
+  }
+
   async fn normal_module_factory_create_module(
     &self,
     _ctx: PluginContext,

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -372,6 +372,22 @@ impl PluginDriver {
     Ok(None)
   }
 
+  pub async fn context_module_after_resolve(
+    &self,
+    args: &mut NormalModuleAfterResolveArgs<'_>,
+  ) -> PluginNormalModuleFactoryAfterResolveOutput {
+    for plugin in &self.plugins {
+      tracing::trace!("running resolve for scheme:{}", plugin.name());
+      if let Some(data) = plugin
+        .context_module_after_resolve(PluginContext::new(), args)
+        .await?
+      {
+        return Ok(Some(data));
+      }
+    }
+    Ok(None)
+  }
+
   pub async fn normal_module_factory_resolve_for_scheme(
     &self,
     args: ResourceData,

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -327,6 +327,8 @@ class Compiler {
 				afterResolve: this.#afterResolve.bind(this),
 				contextModuleFactoryBeforeResolve:
 					this.#contextModuleFactoryBeforeResolve.bind(this),
+				contextModuleFactoryAfterResolve:
+					this.#contextModuleFactoryAfterResolve.bind(this),
 				succeedModule: this.#succeedModule.bind(this),
 				stillValidModule: this.#stillValidModule.bind(this),
 				buildModule: this.#buildModule.bind(this),
@@ -645,6 +647,8 @@ class Compiler {
 			optimizeChunkModules: this.compilation.hooks.optimizeChunkModules,
 			contextModuleFactoryBeforeResolve:
 				this.compilation.contextModuleFactory?.hooks.beforeResolve,
+			contextModuleFactoryAfterResolve:
+				this.compilation.contextModuleFactory?.hooks.afterResolve,
 			normalModuleFactoryCreateModule:
 				this.compilation.normalModuleFactory?.hooks.createModule,
 			normalModuleFactoryResolveForScheme:
@@ -757,6 +761,18 @@ class Compiler {
 	) {
 		let res =
 			await this.compilation.contextModuleFactory?.hooks.beforeResolve.promise(
+				resourceData
+			);
+
+		this.#updateDisabledHooks();
+		return res;
+	}
+
+	async #contextModuleFactoryAfterResolve(
+		resourceData: binding.AfterResolveData
+	) {
+		let res =
+			await this.compilation.contextModuleFactory?.hooks.afterResolve.promise(
 				resourceData
 			);
 

--- a/packages/rspack/src/ContextModuleFactory.ts
+++ b/packages/rspack/src/ContextModuleFactory.ts
@@ -25,6 +25,7 @@ export class ContextModuleFactory {
 		// 	AsyncSeriesBailHook<[ResourceDataWithData], true | void>
 		// >;
 		beforeResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
+		afterResolve: AsyncSeriesBailHook<[ResolveData], boolean | void>;
 	};
 	constructor() {
 		this.hooks = {
@@ -41,9 +42,8 @@ export class ContextModuleFactory {
 			// /** @type {AsyncSeriesBailHook<[ResolveData], Module>} */
 			// factorize: new AsyncSeriesBailHook(["resolveData"]),
 			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			beforeResolve: new AsyncSeriesBailHook(["resolveData"])
-			// /** @type {AsyncSeriesBailHook<[ResolveData], false | void>} */
-			// afterResolve: new AsyncSeriesBailHook(["resolveData"]),
+			beforeResolve: new AsyncSeriesBailHook(["resolveData"]),
+			afterResolve: new AsyncSeriesBailHook(["resolveData"])
 			// /** @type {AsyncSeriesBailHook<[ResolveData["createData"], ResolveData], Module | void>} */
 			// createModule: new AsyncSeriesBailHook(["createData", "resolveData"]),
 			// /** @type {SyncWaterfallHook<[Module, ResolveData["createData"], ResolveData], Module>} */

--- a/packages/rspack/tests/configCases/hooks/context-module-after-resolve/dir/foo.js
+++ b/packages/rspack/tests/configCases/hooks/context-module-after-resolve/dir/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack/tests/configCases/hooks/context-module-after-resolve/index.js
+++ b/packages/rspack/tests/configCases/hooks/context-module-after-resolve/index.js
@@ -1,0 +1,11 @@
+it("should compile", () => {
+	try {
+		["foo.js"].map(file => {
+			require("./dir/" + file);
+		});
+	} catch (e) {
+		expect(e.message).toContain("Cannot find module './dir'")
+	}
+
+	expect.assertions(1)
+});

--- a/packages/rspack/tests/configCases/hooks/context-module-after-resolve/webpack.config.js
+++ b/packages/rspack/tests/configCases/hooks/context-module-after-resolve/webpack.config.js
@@ -1,0 +1,25 @@
+const pluginName = "plugin";
+
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.contextModuleFactory.tap(
+			pluginName,
+			contextModuleFactory => {
+				contextModuleFactory.hooks.afterResolve.tap(pluginName, resolveData => {
+					if (resolveData.request.includes("./dir")) {
+						return false;
+					}
+				});
+			}
+		);
+	}
+}
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	context: __dirname,
+	entry: "./index.js",
+	module: {
+		rules: []
+	},
+	plugins: [new Plugin()]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Before Rspack has a bug that uses normalModuleFactory as argument, and is passed to contextModuleFactory hook, after fixing this, some users have used the afterResolve hook from normalModuleFactory, so add this hook to contextModuleFactory

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
