### PR TITLE
fix: minChunks should be greater than 0

### DIFF
--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -989,7 +989,7 @@ const optimizationSplitChunksChunks = z
 const optimizationSplitChunksSizes = z.number();
 const sharedOptimizationSplitChunksCacheGroup = {
 	chunks: optimizationSplitChunksChunks.optional(),
-	minChunks: z.number().optional(),
+	minChunks: z.number().min(1).optional(),
 	name: optimizationSplitChunksName.optional(),
 	minSize: optimizationSplitChunksSizes.optional(),
 	maxSize: optimizationSplitChunksSizes.optional(),

--- a/packages/rspack/tests/Compiler.test.ts
+++ b/packages/rspack/tests/Compiler.test.ts
@@ -1392,4 +1392,27 @@ describe("Compiler", () => {
 			});
 		});
 	});
+
+	describe("should print error", () => {
+		it("splitChunks.minChunks equals 0", done => {
+			try {
+				rspack({
+					entry: "./a",
+					context: path.join(__dirname, "fixtures"),
+					optimization: {
+						splitChunks: {
+							minChunks: 0
+						}
+					}
+				});
+			} catch (err) {
+				expect(err.toString()).toContain(
+					'Number must be greater than or equal to 1 at "optimization.splitChunks.minChunks"'
+				);
+				done();
+			}
+
+			expect.assertions(1);
+		});
+	});
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Fix #4887

minChunks zero breaks the contract of splitChunks, Webpack disable minChunks less than 1 as well
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
