### PR TITLE
fix: hash exports info should not fall into inf recursive

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -187,7 +187,7 @@ impl ChunkGraph {
 
       module_graph
         .get_exports_info(&module.identifier())
-        .export_info_hash(&mut hasher, module_graph);
+        .export_info_hash(&mut hasher, module_graph, &mut HashSet::default());
 
       module
         .get_blocks()

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -25,7 +25,12 @@ use crate::{
 };
 
 pub trait ExportsHash {
-  fn export_info_hash(&self, hasher: &mut dyn Hasher, module_graph: &ModuleGraph);
+  fn export_info_hash(
+    &self,
+    hasher: &mut dyn Hasher,
+    module_graph: &ModuleGraph,
+    already_visited: &mut HashSet<ExportInfoId>,
+  );
 }
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
@@ -34,9 +39,14 @@ pub struct ExportsInfoId(u32);
 pub static EXPORTS_INFO_ID: AtomicU32 = AtomicU32::new(0);
 
 impl ExportsHash for ExportsInfoId {
-  fn export_info_hash(&self, hasher: &mut dyn Hasher, module_graph: &ModuleGraph) {
+  fn export_info_hash(
+    &self,
+    hasher: &mut dyn Hasher,
+    module_graph: &ModuleGraph,
+    already_visited: &mut HashSet<ExportInfoId>,
+  ) {
     if let Some(exports_info) = module_graph.exports_info_map.try_get(**self as usize) {
-      exports_info.export_info_hash(hasher, module_graph);
+      exports_info.export_info_hash(hasher, module_graph, already_visited);
     }
   }
 }
@@ -456,7 +466,12 @@ pub struct ExportsInfo {
 }
 
 impl ExportsHash for ExportsInfo {
-  fn export_info_hash(&self, hasher: &mut dyn Hasher, module_graph: &ModuleGraph) {
+  fn export_info_hash(
+    &self,
+    hasher: &mut dyn Hasher,
+    module_graph: &ModuleGraph,
+    already_visited: &mut HashSet<ExportInfoId>,
+  ) {
     if let Some(hash) = module_graph.exports_info_hash.get(&self.id) {
       hash.dyn_hash(hasher);
       return;
@@ -464,18 +479,18 @@ impl ExportsHash for ExportsInfo {
     let mut default_hash = DefaultHasher::default();
     for (name, export_info_id) in &self.exports {
       name.dyn_hash(&mut default_hash);
-      export_info_id.export_info_hash(&mut default_hash, module_graph);
+      export_info_id.export_info_hash(&mut default_hash, module_graph, already_visited);
     }
     self
       .other_exports_info
-      .export_info_hash(&mut default_hash, module_graph);
+      .export_info_hash(&mut default_hash, module_graph, already_visited);
     self
       ._side_effects_only_info
-      .export_info_hash(&mut default_hash, module_graph);
+      .export_info_hash(&mut default_hash, module_graph, already_visited);
     self._exports_are_ordered.dyn_hash(&mut default_hash);
 
     if let Some(redirect_to) = self.redirect_to {
-      redirect_to.export_info_hash(&mut default_hash, module_graph);
+      redirect_to.export_info_hash(&mut default_hash, module_graph, already_visited);
     }
     let hash = default_hash.finish();
     module_graph.exports_info_hash.insert(self.id, hash);
@@ -786,9 +801,19 @@ pub struct ExportInfoId(u32);
 pub static EXPORT_INFO_ID: AtomicU32 = AtomicU32::new(0);
 
 impl ExportsHash for ExportInfoId {
-  fn export_info_hash(&self, hasher: &mut dyn Hasher, module_graph: &ModuleGraph) {
+  fn export_info_hash(
+    &self,
+    hasher: &mut dyn Hasher,
+    module_graph: &ModuleGraph,
+    already_visited: &mut HashSet<ExportInfoId>,
+  ) {
+    if already_visited.contains(self) {
+      return;
+    }
+    already_visited.insert(*self);
+
     if let Some(export_info) = module_graph.export_info_map.try_get(**self as usize) {
-      export_info.export_info_hash(hasher, module_graph);
+      export_info.export_info_hash(hasher, module_graph, already_visited);
     }
   }
 }
@@ -1306,7 +1331,12 @@ pub struct ExportInfo {
 }
 
 impl ExportsHash for ExportInfo {
-  fn export_info_hash(&self, hasher: &mut dyn Hasher, module_graph: &ModuleGraph) {
+  fn export_info_hash(
+    &self,
+    hasher: &mut dyn Hasher,
+    module_graph: &ModuleGraph,
+    already_visited: &mut HashSet<ExportInfoId>,
+  ) {
     self.name.dyn_hash(hasher);
     self.module_identifier.dyn_hash(hasher);
     self.usage_state.dyn_hash(hasher);
@@ -1325,7 +1355,7 @@ impl ExportsHash for ExportInfo {
     self.target_is_set.dyn_hash(hasher);
     self.max_target_is_set.dyn_hash(hasher);
     if let Some(exports_info_id) = self.exports_info {
-      exports_info_id.export_info_hash(hasher, module_graph);
+      exports_info_id.export_info_hash(hasher, module_graph, already_visited);
     }
     self.exports_info_owned.dyn_hash(hasher);
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

should not rehash exportsInfo, otherwise it will fall into infinite recursive

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
