### PR TITLE
fix: should visit prop-name in getter/setter

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -547,6 +547,7 @@ impl<'parser> JavascriptParser<'parser> {
       Prop::KeyValue(kv) => self.walk_key_value_prop(kv),
       Prop::Assign(assign) => self.walk_expression(&assign.value),
       Prop::Getter(getter) => {
+        self.walk_prop_name(&getter.key);
         let was_top_level = self.top_level_scope;
         self.top_level_scope = TopLevelScope::False;
         if let Some(body) = &getter.body {
@@ -554,10 +555,11 @@ impl<'parser> JavascriptParser<'parser> {
         }
         self.top_level_scope = was_top_level;
       }
-      Prop::Setter(seeter) => {
+      Prop::Setter(setter) => {
+        self.walk_prop_name(&setter.key);
         let was_top_level = self.top_level_scope;
         self.top_level_scope = TopLevelScope::False;
-        if let Some(body) = &seeter.body {
+        if let Some(body) = &setter.body {
           self.walk_block_statement(body);
         }
         self.top_level_scope = was_top_level;

--- a/packages/rspack/tests/configCases/parsing/getter-import-specifier/a.js
+++ b/packages/rspack/tests/configCases/parsing/getter-import-specifier/a.js
@@ -1,0 +1,1 @@
+module.exports = "a";

--- a/packages/rspack/tests/configCases/parsing/getter-import-specifier/index.js
+++ b/packages/rspack/tests/configCases/parsing/getter-import-specifier/index.js
@@ -1,0 +1,11 @@
+import a from "./a";
+
+const obj = {
+	get [a]() {
+		return "success";
+	}
+};
+
+it("should compile", () => {
+	expect(obj[a]).toBe("success");
+});

--- a/packages/rspack/tests/configCases/parsing/getter-import-specifier/webpack.config.js
+++ b/packages/rspack/tests/configCases/parsing/getter-import-specifier/webpack.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	mode: "none"
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

should visit propName in getter/setter

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
