### PR TITLE
chore: stop updating miette from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
       "matchManagers": ["cargo"],
       "assignees": ["@Boshen"],
       "excludePackagePrefixes": ["swc"],
-      "excludePackageNames": ["ustr", "textwrap", "styled_components", "owo-colors"]
+      "excludePackageNames": ["ustr", "textwrap", "styled_components", "owo-colors", "miette"]
     },
     {
       "groupName": "swc",
@@ -39,7 +39,7 @@
     {
       "groupName": "ignored crates",
       "matchManagers": ["cargo"],
-      "matchPackageNames": ["ustr", "textwrap", "owo-colors"],
+      "matchPackageNames": ["ustr", "textwrap", "owo-colors", "miette"],
       "enabled": false
     },
     {


### PR DESCRIPTION
we are currently forking the graphical reporter, which makes it hard to upgrade right now. cc @h-a-n-a 
