### PR TITLE
refactor(code-splitting): using raw dependencies order

### DIFF
--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -600,6 +600,20 @@ impl ModuleGraph {
       .and_then(|connection_id| self.connection_by_connection_id_mut(&connection_id))
   }
 
+  pub(crate) fn get_ordered_connections(
+    &self,
+    module_identifier: &ModuleIdentifier,
+  ) -> Option<Vec<&ConnectionId>> {
+    self
+      .module_graph_module_by_identifier(module_identifier)
+      .map(|m| {
+        m.__deprecated_all_dependencies
+          .iter()
+          .filter_map(|dep_id| self.connection_id_by_dependency_id(dep_id))
+          .collect()
+      })
+  }
+
   /// # Deprecated!!!
   /// # Don't use this anymore!!!
   /// A module is a DependenciesBlock, which means it has some Dependencies and some AsyncDependenciesBlocks


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Using dependencies order as blockModules order

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
