### PR TITLE
fix: skip release rspack-test-tools and webpack-cli-test

### DIFF
--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@rspack/test-tools",
+  "private": true,
   "version": "0.5.5",
   "license": "MIT",
   "description": "Test tools for rspack",
@@ -18,11 +19,7 @@
     "dev": "tsc -b -w",
     "test:diff": "cross-env RSPACK_DIFF=true NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --runInBand --logHeapUsage --testPathPattern \".diff.test.ts\""
   },
-  "files": [
-    "client",
-    "dist",
-    "template"
-  ],
+  "files": ["client", "dist", "template"],
   "publishConfig": {
     "access": "public"
   },

--- a/webpack-cli-test/package.json
+++ b/webpack-cli-test/package.json
@@ -1,5 +1,6 @@
 {
   "name": "webpack-cli-test",
+  "private": true,
   "scripts": {
     "test:cli": "jest test --reporters=default"
   },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

set rspack-test-tools and webpack-cli-test as private

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
