### PR TITLE
fix: should not contain duplicate initFragments for namespace_cache

### DIFF
--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -161,12 +161,14 @@ pub fn export_from_import(
       ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
     ) {
       runtime_requirements.insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
+
+      let name = format!("var {import_var}_namespace_cache;\n");
       init_fragments.push(
         NormalInitFragment::new(
-          format!("var {import_var}_namespace_cache;\n",),
+          name.clone(),
           InitFragmentStage::StageHarmonyExports,
           -1,
-          InitFragmentKey::unique(),
+          InitFragmentKey::HarmonyFakeNamespaceObjectFragment(name),
           None,
         )
         .boxed(),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -768,14 +768,17 @@ impl HarmonyExportImportedSpecifierDependency {
     );
     export_map.push((key.into(), value.into()));
     let frags = vec![
-      NormalInitFragment::new(
-        format!("var {name}_namespace_cache;\n"),
-        InitFragmentStage::StageConstants,
-        -1,
-        InitFragmentKey::unique(),
-        None,
-      )
-      .boxed(),
+      {
+        let name = format!("var {name}_namespace_cache;\n");
+        NormalInitFragment::new(
+          name.clone(),
+          InitFragmentStage::StageConstants,
+          -1,
+          InitFragmentKey::HarmonyFakeNamespaceObjectFragment(name),
+          None,
+        )
+        .boxed()
+      },
       HarmonyExportInitFragment::new(module.get_exports_argument(), export_map).boxed(),
     ];
     ctxt.init_fragments.extend_from_slice(&frags);

--- a/packages/rspack/tests/configCases/runtime/namespace-cache/index.mjs
+++ b/packages/rspack/tests/configCases/runtime/namespace-cache/index.mjs
@@ -1,0 +1,19 @@
+import * as utils from './proxy.js'
+import value from './proxy.js'
+
+import fs from 'fs'
+
+it('should not contain duplicate initFragment for namespace_cache', () => {
+  const { foo } = utils;
+  access(utils)
+  access(utils.bar)
+  access(value)
+  access(value.bar)
+  access(foo)
+
+  expect([...fs.readFileSync(__filename).toString().matchAll(/var _proxy_js__WEBPACK_IMPORTED_MODULE_0___namespace_cache/g)].length).toBe(2);
+})
+
+function access(a) {
+  a
+}

--- a/packages/rspack/tests/configCases/runtime/namespace-cache/proxy.js
+++ b/packages/rspack/tests/configCases/runtime/namespace-cache/proxy.js
@@ -1,0 +1,1 @@
+module.exports = require('./utils.js');

--- a/packages/rspack/tests/configCases/runtime/namespace-cache/utils.js
+++ b/packages/rspack/tests/configCases/runtime/namespace-cache/utils.js
@@ -1,0 +1,3 @@
+exports.foo = 1;
+exports.bar = 2;
+exports.baz = 3;

--- a/packages/rspack/tests/configCases/runtime/namespace-cache/webpack.config.js
+++ b/packages/rspack/tests/configCases/runtime/namespace-cache/webpack.config.js
@@ -1,0 +1,23 @@
+const path = require("path");
+module.exports = {
+	entry: "./index.mjs",
+	resolve: {
+		alias: {
+			"@b": path.resolve(__dirname, "./a"),
+			xx: path.resolve(__dirname, "./a"),
+			ignored: path.resolve(__dirname, "./a")
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				resolve: {
+					alias: {
+						ignored: false
+					}
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Give correct key for namespace_cache initFragment 

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
