### PR TITLE
perf(deps): remove terminal-link package

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -72,7 +72,6 @@
     "json-parse-even-better-errors": "^3.0.0",
     "neo-async": "2.6.2",
     "tapable": "2.2.1",
-    "terminal-link": "^2.1.1",
     "watchpack": "^2.4.0",
     "webpack-sources": "3.2.3",
     "zod": "^3.21.4",

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -11,7 +11,7 @@ import { Logger } from "../logging/Logger";
 import Hash from "../util/hash";
 import { Mode, Resolve, RuleSetUseItem, RuleSetLoaderWithOptions } from "./zod";
 import { parsePathQueryFragment } from "../loader-runner";
-import { deprecatedWarn, isNil, termlink } from "../util";
+import { isNil } from "../util";
 import {
 	resolveEmotion,
 	resolvePluginImport,

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { Compilation, Compiler } from "..";
 import type * as oldBuiltins from "../builtin-plugin";
 import type * as webpackDevServer from "webpack-dev-server";
-import { deprecatedWarn, termlink } from "../util";
+import { deprecatedWarn } from "../util";
 import { Module } from "../Module";
 import { Chunk } from "../Chunk";
 
@@ -1094,10 +1094,7 @@ const experiments = z.strictObject({
 					`'experiments.newSplitChunks = ${JSON.stringify(
 						val
 					)}' has been deprecated, please switch to 'experiments.newSplitChunks = true' to use webpack's behavior.
- 	See the discussion ${termlink(
-		"here",
-		"https://github.com/web-infra-dev/rspack/discussions/4168"
-	)}`
+ 	See the discussion here (https://github.com/web-infra-dev/rspack/discussions/4168)`
 				);
 			}
 			return true;

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -63,7 +63,7 @@ import {
 	ModuleConcatenationPlugin,
 	EvalDevToolModulePlugin
 } from "./builtin-plugin";
-import { deprecatedWarn, termlink } from "./util";
+import { deprecatedWarn } from "./util";
 
 export function applyEntryOptions(
 	compiler: Compiler,
@@ -71,10 +71,7 @@ export function applyEntryOptions(
 ) {
 	if (!options.experiments.rspackFuture!.disableApplyEntryLazily) {
 		deprecatedWarn(
-			`You are depending on ${termlink(
-				"apply entry lazily",
-				"https://rspack.dev/config/experiments.html#experimentsrspackfuturedisableapplyentrylazily"
-			)}, this behavior has been deprecated, you can setup 'experiments.rspackFuture.disableApplyEntryLazily = true' to disable this behavior, and this will be enabled by default in v0.5`
+			`You are depending on apply entry lazily (https://rspack.dev/config/experiments.html#experimentsrspackfuturedisableapplyentrylazily), this behavior has been deprecated, you can setup 'experiments.rspackFuture.disableApplyEntryLazily = true' to disable this behavior, and this will be enabled by default in v0.5`
 		);
 	}
 	if (compiler.parentCompilation === undefined) {

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -1,5 +1,3 @@
-import terminalLink from "terminal-link";
-
 import type { JsAssetInfo, JsStatsError } from "@rspack/binding";
 
 import { AssetInfo } from "../Compilation";
@@ -79,10 +77,10 @@ export function concatErrorMsgAndStack(err: Error | JsStatsError): string {
 	return isJsStatsError(err)
 		? err.formatted
 		: err.stack
-			? err.stack.startsWith(`${stackStartPrefix}${err.message}`)
-				? `${err.stack}`
-				: `${err.message}\n${err.stack}`
-			: `${err.message}`;
+		? err.stack.startsWith(`${stackStartPrefix}${err.message}`)
+			? `${err.stack}`
+			: `${err.message}\n${err.stack}`
+		: `${err.message}`;
 }
 
 export function indent(str: string, prefix: string) {
@@ -142,4 +140,3 @@ export const deprecatedWarn = (
 		);
 	}
 };
-export const termlink = terminalLink;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,9 +447,6 @@ importers:
       tapable:
         specifier: 2.2.1
         version: 2.2.1
-      terminal-link:
-        specifier: ^2.1.1
-        version: 2.1.1
       watchpack:
         specifier: ^2.4.0
         version: 2.4.0
@@ -14771,6 +14768,7 @@ packages:
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
+    requiresBuild: true
     dev: true
 
   /semver@6.3.1:
@@ -15519,14 +15517,6 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
-  /supports-hyperlinks@2.3.0:
-    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
-    engines: {node: '>=8'}
-    dependencies:
-      has-flag: 4.0.0
-      supports-color: 7.2.0
-    dev: false
-
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -15620,14 +15610,6 @@ packages:
       resumer: 0.0.0
       string.prototype.trim: 1.2.7
       through: 2.3.8
-    dev: false
-
-  /terminal-link@2.1.1:
-    resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
-    engines: {node: '>=8'}
-    dependencies:
-      ansi-escapes: 4.3.2
-      supports-hyperlinks: 2.3.0
     dev: false
 
   /terser-webpack-plugin@5.3.10(@swc/core@1.4.2)(webpack@5.90.0):


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove the terminal-link package to reduce the install size of Rspack, see https://github.com/web-infra-dev/rspack/issues/5097.

The terminal-link package can be directly removed as most of the modern terminals have supported hyperlinks, refer to: https://www.npmjs.com/package/supports-hyperlinks.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
