### PR TITLE
chore: remove source-map-support

### DIFF
--- a/packages/rspack-cli/bin/rspack
+++ b/packages/rspack-cli/bin/rspack
@@ -1,8 +1,3 @@
 #!/usr/bin/env node
-try {
-	require("source-map-support").install({
-		handleUncaughtExceptions: false
-	});
-} catch (err) {}
 const runCLI = require("../dist/bootstrap").runCLI;
 runCLI(process.argv);

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -35,8 +35,7 @@
     "concat-stream": "^2.0.0",
     "cross-env": "^7.0.3",
     "execa": "^5.0.0",
-    "internal-ip": "6.2.0",
-    "source-map-support": "^0.5.19"
+    "internal-ip": "6.2.0"
   },
   "dependencies": {
     "@discoveryjs/json-ext": "^0.5.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,9 +596,6 @@ importers:
       internal-ip:
         specifier: 6.2.0
         version: 6.2.0
-      source-map-support:
-        specifier: ^0.5.19
-        version: 0.5.21
 
   packages/rspack-dev-server:
     dependencies:


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
source-map-suport is used to decode js error frame to ts error frame which is not necessary(can be replaced with [enable-source-maps](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html) and may introduce unexpected behaivor
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
