### PR TITLE
fix: @rspack/dev-server Cannot find module

### DIFF
--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -413,17 +413,17 @@ export class RspackDevServer extends WebpackDevServer {
 
 			additionalEntries.push(
 				`${require.resolve(
-					"@rspack/dev-server/client/index.js"
+					"@rspack/dev-server/client/index"
 				)}?${webSocketURLStr}`
 			);
 		}
 
 		if (this.options.hot === "only") {
 			additionalEntries.push(
-				require.resolve("@rspack/core/hot/only-dev-server.js")
+				require.resolve("@rspack/core/hot/only-dev-server")
 			);
 		} else if (this.options.hot) {
-			additionalEntries.push(require.resolve("@rspack/core/hot/dev-server.js"));
+			additionalEntries.push(require.resolve("@rspack/core/hot/dev-server"));
 		}
 
 		const webpack = compiler.webpack;


### PR DESCRIPTION
修复在 node 16.9 以下版本中，启动  @rspack/dev-server 报错的问题。

报错内容如下：

```
[rspack-cli] Error: Cannot find module '/Users/xxx/app/node_modules/@rspack/dev-server/client/index.js.js'
    at createEsmNotFoundErr (node:internal/modules/cjs/loader:960:15)
    at finalizeEsmResolution (node:internal/modules/cjs/loader:953:15)
    at trySelf (node:internal/modules/cjs/loader:458:12)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:910:24)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (/Users/xxx/app/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
    at Function.resolve (node:internal/modules/cjs/helpers:100:19)
    at RspackDevServer.addAdditionalEntries (/Users/xxx/app/node_modules/@rspack/dev-server/src/server.ts:416:16)
    at /Users/xxx/app/node_modules/@rspack/dev-server/src/server.ts:147:10
    at Array.forEach (<anonymous>)
    at RspackDevServer.initialize (/Users/xxx/app/node_modules/@rspack/dev-server/src/server.ts:146:14) {
  code: 'MODULE_NOT_FOUND',
  path: '/Users/xxx/app/node_modules/@rspack/dev-server/package.json'
}
```

原因是 require.resolve("@rspack/core/hot/only-dev-server.js") 这类写法，node v16.9 以下会找 @rspack/core/hot/only-dev-server.js.js 模块文件，自动追加了 js 扩展名。
