### PR TITLE
chore: disable jest sourcemap support

### DIFF
--- a/packages/rspack/jest.config.js
+++ b/packages/rspack/jest.config.js
@@ -15,7 +15,9 @@ const config = {
 	prettierPath: require.resolve("prettier-2"),
 	moduleNameMapper: {
 		// Fixed jest-serialize-path not working when non-ascii code contains.
-		slash: path.join(__dirname, "../../scripts/test/slash.cjs")
+		slash: path.join(__dirname, "../../scripts/test/slash.cjs"),
+		// disable sourcmap remapping for ts file
+		"source-map-support/register": "identity-obj-proxy"
 	},
 	transformIgnorePatterns: ["<rootDir>/tests"],
 	snapshotFormat: {

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -60,7 +60,8 @@
     "source-map": "^0.7.4",
     "styled-components": "^6.0.8",
     "terser": "5.27.2",
-    "wast-loader": "^1.11.4"
+    "wast-loader": "^1.11.4",
+    "identity-obj-proxy": "3.0.0"
   },
   "dependencies": {
     "@module-federation/runtime-tools": "0.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,6 +502,9 @@ importers:
       html-webpack-plugin:
         specifier: ^5.5.0
         version: 5.5.0(webpack@5.90.0)
+      identity-obj-proxy:
+        specifier: 3.0.0
+        version: 3.0.0
       jest-serializer-path:
         specifier: ^0.1.15
         version: 0.1.15
@@ -10194,6 +10197,10 @@ packages:
   /handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
+  /harmony-reflect@1.6.2:
+    resolution: {integrity: sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==}
+    dev: true
+
   /has-ansi@2.0.0:
     resolution: {integrity: sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==}
     engines: {node: '>=0.10.0'}
@@ -10547,6 +10554,13 @@ packages:
   /idb-wrapper@1.7.2:
     resolution: {integrity: sha512-zfNREywMuf0NzDo9mVsL0yegjsirJxHpKHvWcyRozIqQy89g0a3U+oBPOCN4cc0oCiOuYgZHimzaW/R46G1Mpg==}
     dev: false
+
+  /identity-obj-proxy@3.0.0:
+    resolution: {integrity: sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==}
+    engines: {node: '>=4'}
+    dependencies:
+      harmony-reflect: 1.6.2
+    dev: true
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
source remapping will cause uncertainty about snapshot code, so we need to disable it for snapshot, 
see https://github.com/kulshekhar/ts-jest/issues/727#issuecomment-1022957909
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
