### PR TITLE
fix: fix some "changes didn't emit a rebuild" issues

### DIFF
--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -2,6 +2,7 @@ use std::{fmt::Debug, path::PathBuf};
 
 use rspack_error::{Diagnostic, Result};
 use rustc_hash::FxHashSet as HashSet;
+use sugar_path::SugarPathBuf;
 
 use crate::{BoxDependency, BoxModule, Context, FactoryMeta, ModuleIdentifier, Resolve};
 
@@ -22,28 +23,34 @@ pub struct ModuleFactoryCreateData {
 impl ModuleFactoryCreateData {
   pub fn add_file_dependency(&mut self, file: PathBuf) {
     if file.is_absolute() {
-      self.file_dependencies.insert(file);
+      self.file_dependencies.insert(file.into_normalize());
     }
   }
 
   pub fn add_file_dependencies(&mut self, files: impl IntoIterator<Item = PathBuf>) {
-    self.file_dependencies.extend(files);
+    self
+      .file_dependencies
+      .extend(files.into_iter().map(|x| x.into_normalize()));
   }
 
   pub fn add_context_dependency(&mut self, context: PathBuf) {
-    self.context_dependencies.insert(context);
+    self.context_dependencies.insert(context.into_normalize());
   }
 
   pub fn add_context_dependencies(&mut self, contexts: impl IntoIterator<Item = PathBuf>) {
-    self.context_dependencies.extend(contexts);
+    self
+      .context_dependencies
+      .extend(contexts.into_iter().map(|x| x.into_normalize()));
   }
 
   pub fn add_missing_dependency(&mut self, missing: PathBuf) {
-    self.missing_dependencies.insert(missing);
+    self.missing_dependencies.insert(missing.into_normalize());
   }
 
   pub fn add_missing_dependencies(&mut self, missing: impl IntoIterator<Item = PathBuf>) {
-    self.missing_dependencies.extend(missing);
+    self
+      .missing_dependencies
+      .extend(missing.into_iter().map(|x| x.into_normalize()));
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

- fixes: web-infra-dev/rsbuild#1704
- fixes: web-infra-dev/rspress#464

### about watchpack 

when the a file path in `file_dependencies`/`fileDependencies` differs from the one watchpack resolved, it will be removed from the watch list.

examples:

| fileDependencies | watchpack resolved |
|---|---|
| `/path/to/./src/Operation.graphql.ts` |`/path/to/src/Operation.graphql.ts` |
| `/path/to/foo/../src/Operation.graphql.ts` |  `/path/to/src/Operation.graphql.ts` |
| `C:/path/to/bar.ts` | `C:\path\to\bar.ts` |
| `C:\path\to\foo/bar.ts` | `C:\path\to\foo\bar.ts` |

which will lead to

1. a rebuild will be triggered right after initial build
2. changes on these files will not trigger a rebuild

### cause of web-infra-dev/rsbuild#1704

when `artifactDirectory` in `relay.config.js` is set to `./foo`, the import statement for an operation will be `import Operation from "/path/to/./foo/Operation.graphql.ts"`.

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
