### PR TITLE
fix(SwcJsMinimizerRspackPlugin): allow filename in extractComments

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -846,6 +846,7 @@ export interface RawExternalsPresets {
 export interface RawExtractComments {
   banner?: string | boolean
   condition?: string
+  filename?: string
 }
 
 export interface RawFallbackCacheGroupOptions {

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_js_minimizer.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_js_minimizer.rs
@@ -19,6 +19,7 @@ struct RawSwcJsMinimizerRulesWrapper(RawSwcJsMinimizerRules);
 pub struct RawExtractComments {
   pub banner: Option<Either<String, bool>>,
   pub condition: Option<String>,
+  pub filename: Option<String>,
 }
 
 #[derive(Debug)]
@@ -53,6 +54,7 @@ fn into_condition(c: Option<RawSwcJsMinimizerRules>) -> Option<SwcJsMinimizerRul
 fn into_extract_comments(c: Option<RawExtractComments>) -> Option<ExtractComments> {
   let c = c?;
   let condition = c.condition?;
+  let filename = c.filename;
   let banner = match c.banner {
     Some(banner) => match banner {
       Either::A(s) => OptionWrapper::Custom(s),
@@ -67,7 +69,11 @@ fn into_extract_comments(c: Option<RawExtractComments>) -> Option<ExtractComment
     None => OptionWrapper::Default,
   };
 
-  Some(ExtractComments { condition, banner })
+  Some(ExtractComments {
+    condition,
+    banner,
+    filename,
+  })
 }
 
 impl TryFrom<RawSwcJsMinimizerRspackPluginOptions> for SwcJsMinimizerRspackPluginOptions {

--- a/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcJsMinimizerPlugin.ts
@@ -10,11 +10,11 @@ type MinifyConditions = MinifyCondition | MinifyCondition[];
 
 type ExtractCommentsCondition = boolean | RegExp;
 type ExtractCommentsBanner = string | boolean;
-// type ExtractFilename = string;
+type ExtractFilename = string;
 type ExtractCommentsObject = {
 	condition?: ExtractCommentsCondition | undefined;
 	banner?: ExtractCommentsBanner | undefined;
-	// filename?: ExtractFilename | undefined
+	filename?: ExtractFilename | undefined;
 };
 type ExtractCommentsOptions = ExtractCommentsCondition | ExtractCommentsObject;
 
@@ -368,7 +368,8 @@ function getRawExtractCommentsOptions(
 		} else {
 			const res = {
 				condition: conditionStr(extractComments.condition),
-				banner: extractComments.banner
+				banner: extractComments.banner,
+				filename: extractComments.filename
 			};
 			return res;
 		}

--- a/packages/rspack/tests/configCases/plugins/minify-extract-comments-filename/chunk.js
+++ b/packages/rspack/tests/configCases/plugins/minify-extract-comments-filename/chunk.js
@@ -1,0 +1,3 @@
+/**
+ * @preserve Some comment
+ */

--- a/packages/rspack/tests/configCases/plugins/minify-extract-comments-filename/index.js
+++ b/packages/rspack/tests/configCases/plugins/minify-extract-comments-filename/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+import(/* webpackChunkName: "chunk" */"./chunk");
+
+it("should minify and extract comments", () => {
+	const content = fs.readFileSync(
+		path.resolve(__dirname, "chunk.bundle0.js.chunk.bundle0.js.COMMENTS.txt"),
+		"utf-8"
+	);
+	expect(content).toBe("/**\n * @preserve Some comment\n */");
+});

--- a/packages/rspack/tests/configCases/plugins/minify-extract-comments-filename/webpack.config.js
+++ b/packages/rspack/tests/configCases/plugins/minify-extract-comments-filename/webpack.config.js
@@ -1,0 +1,19 @@
+const rspack = require("@rspack/core");
+
+/**
+ * @type {import("@rspack/core").Configuration}
+ */
+module.exports = {
+	optimization: {
+		minimize: true,
+		splitChunks: false,
+		chunkIds: "named"
+	},
+	plugins: [
+		new rspack.SwcJsMinimizerRspackPlugin({
+			extractComments: {
+				filename: "[file].[base].COMMENTS.txt[query]"
+			}
+		})
+	]
+};


### PR DESCRIPTION
Allow `filename` in `extractComments` options of `rspack.SwcJsMinimizerRspackPlugin`

In original `TerserPlugin` `[base]` and `[file]` are same and `[query]` is empty. I don't know a case where this should be different.

## Require Documentation?

- [X] No
