### PR TITLE
fix: 🐛 should not mangle css module identifier

### DIFF
--- a/crates/rspack_plugin_css/src/dependency/css_module_export.rs
+++ b/crates/rspack_plugin_css/src/dependency/css_module_export.rs
@@ -43,7 +43,7 @@ impl Dependency for CssModuleExportDependency {
     Some(ExportsSpec {
       exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
         name: self.name.as_str().into(),
-        can_mangle: Some(true),
+        can_mangle: Some(false),
         ..Default::default()
       })]),
       ..Default::default()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
1. Closed https://github.com/web-infra-dev/rspack/issues/5869
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
