### PR TITLE
refactor: support new tsfn (stage 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,8 +2104,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 [[package]]
 name = "napi"
 version = "2.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a63d0570e4c3e0daf7a8d380563610e159f538e20448d6c911337246f40e84"
+source = "git+https://github.com/h-a-n-a/napi-rs?branch=rspack#459372f20ec4d069d1e909a3508900012cf9e477"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -2121,14 +2120,12 @@ dependencies = [
 [[package]]
 name = "napi-build"
 version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9130fccc5f763cf2069b34a089a18f0d0883c66aceb81f2fad541a3d823c43"
+source = "git+https://github.com/h-a-n-a/napi-rs?branch=rspack#459372f20ec4d069d1e909a3508900012cf9e477"
 
 [[package]]
 name = "napi-derive"
 version = "2.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05bb7c37e3c1dda9312fdbe4a9fc7507fca72288ba154ec093e2d49114e727ce"
+source = "git+https://github.com/h-a-n-a/napi-rs?branch=rspack#459372f20ec4d069d1e909a3508900012cf9e477"
 dependencies = [
  "cfg-if",
  "convert_case",
@@ -2141,8 +2138,7 @@ dependencies = [
 [[package]]
 name = "napi-derive-backend"
 version = "1.0.62"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f785a8b8d7b83e925f5aa6d2ae3c159d17fe137ac368dc185bef410e7acdaeb4"
+source = "git+https://github.com/h-a-n-a/napi-rs?branch=rspack#459372f20ec4d069d1e909a3508900012cf9e477"
 dependencies = [
  "convert_case",
  "once_cell",
@@ -2156,8 +2152,7 @@ dependencies = [
 [[package]]
 name = "napi-sys"
 version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
+source = "git+https://github.com/h-a-n-a/napi-rs?branch=rspack#459372f20ec4d069d1e909a3508900012cf9e477"
 dependencies = [
  "libloading",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,10 @@ ustr               = { package = "ustr-fxhash", version = "1.0.0" }
 xxhash-rust        = { version = "0.8.10" }
 
 # Pinned
-napi              = { version = "=2.16.0" }
-napi-build        = { version = "=2.1.2" }
-napi-derive       = { version = "=2.16.0" }
-napi-sys          = { version = "=2.3.0" }
+napi              = { git = "https://github.com/h-a-n-a/napi-rs", branch = "rspack" }
+napi-build        = { git = "https://github.com/h-a-n-a/napi-rs", branch = "rspack" }
+napi-derive       = { git = "https://github.com/h-a-n-a/napi-rs", branch = "rspack" }
+napi-sys          = { git = "https://github.com/h-a-n-a/napi-rs", branch = "rspack" }
 tikv-jemallocator = { version = "=0.5.4", features = ["disable_initial_exec_tls"] }
 
 # Must be pinned with the same swc versions

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1281,9 +1281,9 @@ export interface RawTrustedTypes {
 export function registerGlobalTrace(filter: string, layer: "chrome" | "logger", output: string): void
 
 export interface RegisterJsTaps {
-  registerCompilerCompilationTaps: (...args: any[]) => any
-  registerCompilerMakeTaps: (...args: any[]) => any
-  registerCompilationProcessAssetsTaps: (...args: any[]) => any
+  registerCompilerCompilationTaps: (arg: Array<number>) => any
+  registerCompilerMakeTaps: (arg: Array<number>) => any
+  registerCompilationProcessAssetsTaps: (arg: Array<number>) => any
 }
 
 /** Builtin loader runner */

--- a/crates/node_binding/src/plugins/mod.rs
+++ b/crates/node_binding/src/plugins/mod.rs
@@ -29,7 +29,6 @@ use rspack_core::{PluginNormalModuleFactoryResolveForSchemeOutput, PluginShouldE
 use rspack_napi_shared::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use rspack_napi_shared::NapiResultExt;
 
-use self::interceptor::ThreadsafeRegisterJsTaps;
 pub use self::loader::JsLoaderResolver;
 use crate::{DisabledHooks, Hook, JsCompilation, JsHooks};
 
@@ -67,7 +66,7 @@ pub struct JsHooksAdapterInner {
 #[derive(Clone)]
 pub struct JsHooksAdapterPlugin {
   inner: Arc<JsHooksAdapterInner>,
-  interceptor: Box<ThreadsafeRegisterJsTaps>,
+  interceptor: Box<RegisterJsTaps>,
 }
 
 impl fmt::Debug for JsHooksAdapterPlugin {
@@ -726,7 +725,7 @@ impl JsHooksAdapterPlugin {
       js_fn_into_threadsafe_fn!(runtime_module, env);
 
     Ok(JsHooksAdapterPlugin {
-      interceptor: Box::new(ThreadsafeRegisterJsTaps::from_js_taps(interceptor, env)?),
+      interceptor: Box::new(interceptor),
       inner: Arc::new(JsHooksAdapterInner {
         disabled_hooks,
         after_process_assets_tsfn,

--- a/crates/rspack_napi_shared/src/callback.rs
+++ b/crates/rspack_napi_shared/src/callback.rs
@@ -1,0 +1,147 @@
+use std::marker::PhantomData;
+use std::os::raw::c_void;
+use std::ptr;
+use std::sync::Arc;
+use std::{ffi::CStr, sync::RwLock};
+
+use napi::{check_status, sys, Env, Result};
+
+struct DeferredData<Resolver: FnOnce(Env)> {
+  resolver: Resolver,
+}
+
+pub struct JsCallback<Resolver: FnOnce(Env)> {
+  tsfn: sys::napi_threadsafe_function,
+  aborted: Arc<RwLock<bool>>,
+  _resolver: PhantomData<Resolver>,
+}
+
+unsafe impl<Resolver: FnOnce(Env)> Send for JsCallback<Resolver> {}
+
+impl<Resolver: FnOnce(Env)> JsCallback<Resolver> {
+  pub(crate) fn new(env: sys::napi_env) -> Result<Self> {
+    let mut async_resource_name = ptr::null_mut();
+    let s = unsafe { CStr::from_bytes_with_nul_unchecked(b"napi_js_callback\0") };
+    check_status!(
+      unsafe { sys::napi_create_string_utf8(env, s.as_ptr(), 16, &mut async_resource_name) },
+      "Create async resource name in JsCallback failed"
+    )?;
+
+    let mut tsfn = ptr::null_mut();
+    let aborted: Arc<RwLock<bool>> = Arc::new(Default::default());
+    check_status!(
+      unsafe {
+        sys::napi_create_threadsafe_function(
+          env,
+          ptr::null_mut(),
+          ptr::null_mut(),
+          async_resource_name,
+          0,
+          1,
+          Arc::into_raw(aborted.clone()) as _,
+          Some(napi_js_finalize),
+          ptr::null_mut(),
+          Some(napi_js_callback::<Resolver>),
+          &mut tsfn,
+        )
+      },
+      "Create threadsafe function in JsCallback failed"
+    )?;
+
+    check_status!(unsafe { sys::napi_unref_threadsafe_function(env, tsfn) })?;
+
+    let deferred = Self {
+      tsfn,
+      aborted,
+      _resolver: PhantomData,
+    };
+
+    Ok(deferred)
+  }
+
+  /// The provided function will be called from the JavaScript thread
+  pub fn call(&self, resolver: Resolver) {
+    self.call_tsfn(resolver)
+  }
+
+  fn call_tsfn(&self, result: Resolver) {
+    let data = DeferredData { resolver: result };
+
+    // Call back into the JS thread via a threadsafe function. This results in napi_js_callback being called.
+    let status = unsafe {
+      sys::napi_call_threadsafe_function(
+        self.tsfn,
+        Box::into_raw(Box::from(data)).cast(),
+        sys::ThreadsafeFunctionCallMode::blocking,
+      )
+    };
+    debug_assert!(
+      status == sys::Status::napi_ok,
+      "Call threadsafe function in JsCallback failed"
+    );
+  }
+
+  fn with_aborted_read<T>(&self, f: impl FnOnce(bool) -> T) -> T {
+    let aborted = self.aborted.read().expect("failed to lock aborted");
+    f(*aborted)
+  }
+}
+
+impl<Resolver: FnOnce(Env)> Clone for JsCallback<Resolver> {
+  fn clone(&self) -> Self {
+    self.with_aborted_read(|aborted| {
+      if aborted {
+        panic!("JsCallback was aborted, can not clone it");
+      }
+      Self {
+        tsfn: self.tsfn,
+        aborted: self.aborted.clone(),
+        _resolver: self._resolver,
+      }
+    })
+  }
+}
+
+impl<Resolver: FnOnce(Env)> Drop for JsCallback<Resolver> {
+  fn drop(&mut self) {
+    self.with_aborted_read(|aborted| {
+      if !aborted {
+        let status = unsafe {
+          sys::napi_release_threadsafe_function(
+            self.tsfn,
+            sys::ThreadsafeFunctionReleaseMode::release,
+          )
+        };
+        debug_assert!(
+          status == sys::Status::napi_ok,
+          "Release threadsafe function in JsCallback failed"
+        );
+      }
+    })
+  }
+}
+
+extern "C" fn napi_js_finalize(
+  _env: sys::napi_env,
+  finalize_data: *mut c_void,
+  _finalize_hint: *mut c_void,
+) {
+  let aborted = unsafe { Arc::<RwLock<bool>>::from_raw(finalize_data.cast()) };
+  let mut aborted = aborted.write().expect("failed to lock aborted");
+  if !*aborted {
+    *aborted = true;
+  }
+}
+
+extern "C" fn napi_js_callback<Resolver: FnOnce(Env)>(
+  env: sys::napi_env,
+  _js_callback: sys::napi_value,
+  _context: *mut c_void,
+  data: *mut c_void,
+) {
+  if env.is_null() {
+    return;
+  }
+  let deferred_data = unsafe { Box::<DeferredData<Resolver>>::from_raw(data.cast()) };
+  (deferred_data.resolver)(unsafe { Env::from_raw(env) });
+}

--- a/crates/rspack_napi_shared/src/lib.rs
+++ b/crates/rspack_napi_shared/src/lib.rs
@@ -1,12 +1,16 @@
 #![feature(try_blocks)]
 #![forbid(unsafe_op_in_unsafe_fn)]
 
+mod callback;
+pub(crate) use callback::JsCallback;
+
 mod errors;
 mod ext;
 mod js_values;
 mod utils;
 pub use errors::{NapiErrorExt, NapiResultExt};
 
+pub mod new_tsfn;
 pub mod threadsafe_function;
 
 thread_local! {

--- a/crates/rspack_napi_shared/src/new_tsfn.rs
+++ b/crates/rspack_napi_shared/src/new_tsfn.rs
@@ -1,0 +1,340 @@
+use std::marker::PhantomData;
+
+use napi::{
+  bindgen_prelude::{
+    check_status, Either3, Either4, FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName,
+    ValidateNapiValue,
+  },
+  sys::{self, napi_env},
+  threadsafe_function::{
+    ErrorStrategy, ThreadsafeFunction as RawThreadsafeFunction, ThreadsafeFunctionCallMode,
+  },
+  Either, Env, JsUnknown, NapiRaw,
+};
+use rspack_error::{miette::IntoDiagnostic, Error, Result};
+
+use crate::{JsCallback, NapiErrorExt};
+
+type ErrorResolver = dyn FnOnce(Env);
+
+pub struct ThreadsafeFunction<T: 'static, R> {
+  inner: RawThreadsafeFunction<T, ErrorStrategy::Fatal>,
+  env: napi_env,
+  resolver: JsCallback<Box<ErrorResolver>>,
+  _data: PhantomData<R>,
+}
+
+impl<T: 'static, R> Clone for ThreadsafeFunction<T, R> {
+  fn clone(&self) -> Self {
+    Self {
+      inner: self.inner.clone(),
+      env: self.env,
+      resolver: self.resolver.clone(),
+      _data: self._data,
+    }
+  }
+}
+
+unsafe impl<T: 'static, R> Sync for ThreadsafeFunction<T, R> {}
+unsafe impl<T: 'static, R> Send for ThreadsafeFunction<T, R> {}
+
+impl<T: 'static + JsValuesTupleIntoVec, R> FromNapiValue for ThreadsafeFunction<T, R> {
+  unsafe fn from_napi_value(env: sys::napi_env, napi_val: sys::napi_value) -> napi::Result<Self> {
+    let inner = unsafe {
+      <RawThreadsafeFunction<T, ErrorStrategy::Fatal> as FromNapiValue>::from_napi_value(
+        env, napi_val,
+      )
+    }?;
+    check_status!(unsafe { sys::napi_unref_threadsafe_function(env, inner.raw()) })?;
+    Ok(Self {
+      inner,
+      env,
+      resolver: JsCallback::new(env)?,
+      _data: PhantomData,
+    })
+  }
+}
+
+impl<T: 'static, R> ThreadsafeFunction<T, R> {
+  async fn resolve_error(&self, err: napi::Error) -> Error {
+    let (tx, rx) = tokio::sync::oneshot::channel::<rspack_error::Error>();
+    self.resolver.call(Box::new(move |env| {
+      let err = err.into_rspack_error_with_detail(&env);
+      tx.send(err).expect("failed to resolve js error");
+    }));
+    rx.await.expect("failed to resolve js error")
+  }
+
+  async fn call_async<D: 'static + FromNapiValue>(&self, value: T) -> Result<D> {
+    let (tx, rx) = tokio::sync::oneshot::channel::<Result<D>>();
+    let env = self.env;
+    self
+      .inner
+      .call_with_return_value_raw(value, ThreadsafeFunctionCallMode::NonBlocking, {
+        move |r: napi::Result<JsUnknown>| {
+          let r = match r {
+            Err(err) => Err(err.into_rspack_error_with_detail(&unsafe { Env::from_raw(env) })),
+            Ok(o) => unsafe { D::from_napi_value(env, o.raw()) }.into_diagnostic(),
+          };
+          tx.send(r)
+            .unwrap_or_else(|_| panic!("failed to send tsfn value"));
+          Ok(())
+        }
+      });
+    rx.await.expect("failed to receive tsfn value")
+  }
+}
+
+impl<T: 'static, R: 'static + FromNapiValue> ThreadsafeFunction<T, R> {
+  /// Call the JS function.
+  pub async fn call_with_sync(&self, value: T) -> Result<R> {
+    match self.call_async::<R>(value).await {
+      Ok(r) => Ok(r),
+      Err(err) => Err(err),
+    }
+  }
+}
+
+impl<T: 'static, R: 'static + FromNapiValue + ValidateNapiValue> ThreadsafeFunction<T, R> {
+  /// Call the JS function.
+  /// This method expects the returned value of JS function to be a `Promise<R>` or `R`.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  ///
+  /// ## Warning
+  /// This method is *NOT* recommended to be used in most cases. It makes return value ambiguous.
+  pub async fn call(&self, value: T) -> Result<R> {
+    match self.call_async::<Either<Promise<R>, R>>(value).await {
+      Ok(Either::A(r)) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Ok(Either::B(r)) => Ok(r),
+      Err(err) => Err(err),
+    }
+  }
+}
+
+impl<T: 'static, R: 'static + FromNapiValue> ThreadsafeFunction<T, Promise<R>> {
+  /// Call the JS function.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  pub async fn call_with_promise(&self, value: T) -> Result<R> {
+    match self.call_async::<Promise<R>>(value).await {
+      Ok(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Err(err) => Err(err),
+    }
+  }
+}
+
+impl<T: 'static, R: 'static + FromNapiValue + ValidateNapiValue + TypeName>
+  ThreadsafeFunction<T, Either<Promise<R>, R>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<R> {
+    match self.call_async::<Either<Promise<R>, R>>(value).await? {
+      Either::A(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Either::B(r) => Ok(r),
+    }
+  }
+}
+
+impl<T: 'static, R: 'static + FromNapiValue + ValidateNapiValue + TypeName>
+  ThreadsafeFunction<T, Either<R, Promise<R>>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<R> {
+    match self.call_async::<Either<R, Promise<R>>>(value).await? {
+      Either::A(r) => Ok(r),
+      Either::B(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either3<T0, T1, Promise<Either<T0, T1>>>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either<T0, T1>> {
+    match self
+      .call_async::<Either3<T0, T1, Promise<Either<T0, T1>>>>(value)
+      .await?
+    {
+      Either3::A(r) => Ok(Either::A(r)),
+      Either3::B(r) => Ok(Either::B(r)),
+      Either3::C(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either3<T0, Promise<Either<T0, T1>>, T1>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either<T0, T1>> {
+    match self
+      .call_async::<Either3<T0, Promise<Either<T0, T1>>, T1>>(value)
+      .await?
+    {
+      Either3::A(r) => Ok(Either::A(r)),
+      Either3::B(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Either3::C(r) => Ok(Either::B(r)),
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either3<Promise<Either<T0, T1>>, T0, T1>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either<T0, T1>> {
+    match self
+      .call_async::<Either3<Promise<Either<T0, T1>>, T0, T1>>(value)
+      .await?
+    {
+      Either3::A(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Either3::B(r) => Ok(Either::A(r)),
+      Either3::C(r) => Ok(Either::B(r)),
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either4<T0, T1, T2, Promise<Either3<T0, T1, T2>>>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
+    match self
+      .call_async::<Either4<T0, T1, T2, Promise<Either3<T0, T1, T2>>>>(value)
+      .await?
+    {
+      Either4::A(r) => Ok(Either3::A(r)),
+      Either4::B(r) => Ok(Either3::B(r)),
+      Either4::C(r) => Ok(Either3::C(r)),
+      Either4::D(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either4<T0, T1, Promise<Either3<T0, T1, T2>>, T2>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
+    match self
+      .call_async::<Either4<T0, T1, Promise<Either3<T0, T1, T2>>, T2>>(value)
+      .await?
+    {
+      Either4::A(r) => Ok(Either3::A(r)),
+      Either4::B(r) => Ok(Either3::B(r)),
+      Either4::C(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Either4::D(r) => Ok(Either3::C(r)),
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either4<T0, Promise<Either3<T0, T1, T2>>, T1, T2>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
+    match self
+      .call_async::<Either4<T0, Promise<Either3<T0, T1, T2>>, T1, T2>>(value)
+      .await?
+    {
+      Either4::A(r) => Ok(Either3::A(r)),
+      Either4::B(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Either4::C(r) => Ok(Either3::B(r)),
+      Either4::D(r) => Ok(Either3::C(r)),
+    }
+  }
+}
+
+impl<
+    T: 'static,
+    T0: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T1: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+    T2: 'static + FromNapiValue + ValidateNapiValue + TypeName,
+  > ThreadsafeFunction<T, Either4<Promise<Either3<T0, T1, T2>>, T0, T1, T2>>
+{
+  /// Call the JS function and resolve the returned value depending on its type.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, if `T` is returned, it will be returned as-is.
+  pub async fn call_with_auto(&self, value: T) -> Result<Either3<T0, T1, T2>> {
+    match self
+      .call_async::<Either4<Promise<Either3<T0, T1, T2>>, T0, T1, T2>>(value)
+      .await?
+    {
+      Either4::A(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Either4::B(r) => Ok(Either3::A(r)),
+      Either4::C(r) => Ok(Either3::B(r)),
+      Either4::D(r) => Ok(Either3::C(r)),
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR refactored the old tsfn impl. The original impl has a few problems as follows:

- **Type definition** It's hard to read whether the original JS function returned `Promise<T>` or `T`. This is originally designed for loader, since JS Loaders can be called both synchronously and asynchronously. This usage has been spread to most of JS functions and each signature should be defined explicitly.
- **Type conversion** The original tsfn locates in the NAPI-RS crate, it's hard for us to extract implementation like https://github.com/napi-rs/napi-rs/pull/1475 because of the orphan rule especially paired with generics which trait constraint is defined in NAPI-RS.

In this new tsfn impl, the improvements are as follows:

- **Type definition** Type should be explicitly defined, such as `ThreadsafeFunction<(A, B), Either<A, Promise<T>>>`.
- **Tuple type auto conversion** `ThreadsafeFunction<(A, B), ...>` would be converted to the two parameters for JS functions. In this example: it's `(a: A, b: B) => ...`
- **Auto `FromNapiValue`** It's not necessary to convert `JSFunction` to `ThreadsafeFunction` on your own, just apply derive`#[napi(object, object_to_js = false)]` and replace `JSFunction` with `ThreadsafeFunction<T, R>`
- **Builtin sync and async call** For threadsafe functions returning `Promise<T>`, it's up to your choice to either call with `call_with_promise` to resolve to it's original value with error being carefully converted to JS and `call_with_sync` with the original `Promise<T>` being returned. If `Either<T, Promise<T>>` is returned, you may also `call_with_auto` to extract the value `T`.
- **Escape hatch** For old functions that haven't been migrated to the new implementation,  method `call` is still provided for you to extract the value behind `Promise<T> | T` by calling method `call`, you may keep the threadsafe function's type signature as-is, such as `ThreadsafeFunction<(A, B), T>`. This is highly NOT recommended tho.

NAPI Refs:
- https://github.com/napi-rs/napi-rs/pull/1991
- https://github.com/napi-rs/napi-rs/pull/1993

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
