### PR TITLE
fix: empty resource query and fragment

### DIFF
--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -179,8 +179,8 @@ impl ContextModuleFactory {
         ContextModuleOptions {
           addon: loader_request.to_string(),
           resource: resource.path.to_string_lossy().to_string(),
-          resource_query: resource.query,
-          resource_fragment: resource.fragment,
+          resource_query: Some(resource.query),
+          resource_fragment: Some(resource.fragment),
           resolve_options: data.resolve_options.clone(),
           context_options: dependency.options().clone(),
         },

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -336,8 +336,8 @@ impl NormalModuleFactory {
             let uri = resource.full_path().display().to_string();
             (
               ResourceData::new(uri, resource.path)
-                .query_optional(resource.query)
-                .fragment_optional(resource.fragment)
+                .query(resource.query)
+                .fragment(resource.fragment)
                 .description_optional(resource.description_data),
               from_cache,
             )

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -36,8 +36,8 @@ pub enum ResolveResult {
 #[derive(Clone)]
 pub struct Resource {
   pub path: PathBuf,
-  pub query: Option<String>,
-  pub fragment: Option<String>,
+  pub query: String,
+  pub fragment: String,
   pub description_data: Option<DescriptionData>,
 }
 
@@ -58,12 +58,8 @@ impl Resource {
   /// Get the full path with query and fragment attached.
   pub fn full_path(&self) -> PathBuf {
     let mut buf = format!("{}", self.path.display());
-    if let Some(query) = self.query.as_ref() {
-      buf.push_str(query);
-    }
-    if let Some(fragment) = self.fragment.as_ref() {
-      buf.push_str(fragment);
-    }
+    buf.push_str(&self.query);
+    buf.push_str(&self.fragment);
     PathBuf::from(buf)
   }
 }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -130,8 +130,8 @@ impl Resolver {
       Self::OxcResolver(resolver) => match resolver.resolve(path, request) {
         Ok(r) => Ok(ResolveResult::Resource(Resource {
           path: r.path().to_path_buf(),
-          query: r.query().map(ToString::to_string),
-          fragment: r.fragment().map(ToString::to_string),
+          query: r.query().unwrap_or_default().to_string(),
+          fragment: r.fragment().unwrap_or_default().to_string(),
           description_data: r
             .package_json()
             .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(d.raw_json()))),
@@ -162,8 +162,8 @@ impl Resolver {
         match result {
           Ok(r) => Ok(ResolveResult::Resource(Resource {
             path: r.path().to_path_buf(),
-            query: r.query().map(ToString::to_string),
-            fragment: r.fragment().map(ToString::to_string),
+            query: r.query().unwrap_or_default().to_string(),
+            fragment: r.fragment().unwrap_or_default().to_string(),
             description_data: r
               .package_json()
               .map(|d| DescriptionData::new(d.directory().to_path_buf(), Arc::clone(d.raw_json()))),

--- a/packages/rspack/tests/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/packages/rspack/tests/__snapshots__/StatsTestCases.basictest.js.snap
@@ -94,7 +94,7 @@ exports[`StatsTestCases should print correct stats for ignore-plugin 1`] = `
 "runtime modules 1 module
 ./index.js
 ./locals/en.js
-Xdir/ignore-plugin/locals|None|None|ContextOptions|Sync|true|Some(RspackRegex(\\"^\\\\\\\\.\\\\\\\\/.*$\\"))|\\"^\\\\\\\\.\\\\\\\\/.*$\\"|None|None|CommonJS|\\"./locals\\"|Unset|None"
+Xdir/ignore-plugin/locals|Some(\\"\\")|Some(\\"\\")|ContextOptions|Sync|true|Some(RspackRegex(\\"^\\\\\\\\.\\\\\\\\/.*$\\"))|\\"^\\\\\\\\.\\\\\\\\/.*$\\"|None|None|CommonJS|\\"./locals\\"|Unset|None"
 `;
 
 exports[`StatsTestCases should print correct stats for ignore-warning 1`] = `"Rspack compiled successfully"`;

--- a/packages/rspack/tests/configCases/loader/rspack-issue-4297/fragmentloader.js
+++ b/packages/rspack/tests/configCases/loader/rspack-issue-4297/fragmentloader.js
@@ -1,0 +1,5 @@
+function loader(content) {
+	this.callback(null, content + ' + "fragmentloader"');
+}
+
+module.exports = loader;

--- a/packages/rspack/tests/configCases/loader/rspack-issue-4297/index.js
+++ b/packages/rspack/tests/configCases/loader/rspack-issue-4297/index.js
@@ -1,0 +1,9 @@
+import lib1 from "./lib?source";
+import lib2 from "./lib#source";
+import lib3 from "./lib";
+
+it("should have empty resourceQuery and resourceFragment when resource without ends with ?xx or #xx", () => {
+	expect(lib1).toBe("afragmentloader");
+	expect(lib2).toBe("aqueryloader");
+	expect(lib3).toBe("afragmentloaderqueryloader");
+});

--- a/packages/rspack/tests/configCases/loader/rspack-issue-4297/lib.js
+++ b/packages/rspack/tests/configCases/loader/rspack-issue-4297/lib.js
@@ -1,0 +1,1 @@
+module.exports = "a"

--- a/packages/rspack/tests/configCases/loader/rspack-issue-4297/queryloader.js
+++ b/packages/rspack/tests/configCases/loader/rspack-issue-4297/queryloader.js
@@ -1,0 +1,5 @@
+function loader(content) {
+	this.callback(null, content + ' + "queryloader"');
+}
+
+module.exports = loader;

--- a/packages/rspack/tests/configCases/loader/rspack-issue-4297/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/rspack-issue-4297/webpack.config.js
@@ -1,0 +1,25 @@
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: /lib\.js$/,
+				resourceQuery: /source/,
+			},
+			{
+				test: /lib\.js$/,
+				resourceQuery: { not: [/source/] },
+				loader: "./queryloader.js"
+			},
+			{
+				test: /lib\.js$/,
+				resourceFragment: /source/,
+			},
+			{
+				test: /lib\.js$/,
+				resourceFragment: { not: [/source/] },
+				loader: "./fragmentloader.js"
+			},
+		]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #4297

resolved resource without ? and #, its resourceQuery and resourceFragment should be empty string instead of None

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
