### PR TITLE
chore: enable pub_use lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,8 @@ swc_html_minifier   = { version = "=0.132.20" }
 swc_node_comments   = { version = "=0.20.12" }
 tikv-jemallocator   = { version = "=0.5.4", features = ["disable_initial_exec_tls"] }
 
+[workspace.lints.clippy]
+pub_use = "warn"
 [profile.dev]
 codegen-units = 16      # debug build will cause runtime panic if codegen-unints is default
 debug         = 2

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -78,3 +78,6 @@ ustr = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { version = "1.4.0" }
+
+[lints]
+workspace = true


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
not allow 
```rs
pub use code_splitting::*;
```
allow
```rs
pub mod code_splitting;
```
see https://rust-lang.github.io/rust-clippy/master/index.html#:~:text=%E2%88%92-,What%20it%20does,-Restricts%20the%20usage
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
