### PR TITLE
fix(typing): fix partial ts-expect-error in  packages/rspack 

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -67,7 +67,7 @@ export interface Asset {
 }
 export interface LogEntry {
 	type: string;
-	args: any[];
+	args?: any[];
 	time?: number;
 	trace?: string[];
 }
@@ -662,7 +662,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 						);
 					}
 				}
-				let trace: string[];
+				let trace: string[] | undefined;
 				switch (type) {
 					case LogType.warn:
 					case LogType.error:
@@ -675,14 +675,12 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				const logEntry: LogEntry = {
 					time: Date.now(),
 					type,
-					// @ts-expect-error
 					args,
-					// @ts-expect-error
 					trace
 				};
 				if (this.hooks.log.call(name, logEntry) === undefined) {
 					if (logEntry.type === LogType.profileEnd) {
-						if (typeof console.profileEnd === "function") {
+						if (typeof console.profileEnd === "function" && logEntry.args) {
 							console.profileEnd(`[${name}] ${logEntry.args[0]}`);
 						}
 					}
@@ -695,7 +693,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 					}
 					logEntries.push(logEntry);
 					if (logEntry.type === LogType.profile) {
-						if (typeof console.profile === "function") {
+						if (typeof console.profile === "function" && logEntry.args) {
 							console.profile(`[${name}] ${logEntry.args[0]}`);
 						}
 					}

--- a/packages/rspack/src/MultiCompiler.ts
+++ b/packages/rspack/src/MultiCompiler.ts
@@ -524,7 +524,7 @@ export class MultiCompiler {
 				},
 				(compiler, watching, _done) => {
 					if (compiler.watching !== watching) return;
-					if (!watching.running) watching.invalidate();
+					if (!watching?.running) watching?.invalidate();
 				},
 				handler
 			);

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1129,6 +1129,7 @@ const watchOptions = z.strictObject({
 		.array()
 		.or(z.instanceof(RegExp))
 		.or(z.string())
+		.or(z.function(z.tuple([z.string()])).returns(z.boolean()))
 		.optional(),
 	poll: z.number().or(z.boolean()).optional(),
 	stdin: z.boolean().optional()

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -9,7 +9,8 @@
  */
 
 import util from "util";
-import Watchpack, { WatchOptions } from "watchpack";
+import Watchpack from "watchpack";
+import { WatchOptions } from "../config";
 import { FileSystemInfoEntry, Watcher, WatchFileSystem } from "../util/fs";
 
 export default class NodeWatchFileSystem implements WatchFileSystem {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->
part of [#4640](https://github.com/web-infra-dev/rspack/issues/4640)

## Summary
This pr fixes all ts-expect-error in packages/rspack/src/Compiler.ts and packages/rspack/src/Compilation.ts. Errors are most related to
* Align two type `WatchOptions` present in rspack
* Solve the type problems caused by optional `args` in type `LogFunction`
* Solve some type problems concerning optional or required attributes
  

## Test Plan
```
cd packages/rspack
pnpm build
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
