### PR TITLE
refactor: set compilation.module_graph as private

### DIFF
--- a/crates/rspack_binding_values/src/chunk_graph.rs
+++ b/crates/rspack_binding_values/src/chunk_graph.rs
@@ -9,7 +9,7 @@ pub fn get_chunk_modules(js_chunk_ukey: u32, compilation: &JsCompilation) -> Vec
   let compilation = &compilation.inner;
   let modules = compilation.chunk_graph.get_chunk_modules(
     &ChunkUkey::from(js_chunk_ukey as usize),
-    &compilation.get_module_graph(),
+    compilation.get_module_graph(),
   );
 
   return modules
@@ -66,7 +66,7 @@ pub fn get_chunk_modules_iterable_by_source_type(
         &ChunkUkey::from(js_chunk_ukey as usize),
         SourceType::try_from(source_type.as_str())
           .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
       )
       .filter_map(|module| module.to_js_module().ok())
       .collect(),

--- a/crates/rspack_binding_values/src/chunk_graph.rs
+++ b/crates/rspack_binding_values/src/chunk_graph.rs
@@ -9,7 +9,7 @@ pub fn get_chunk_modules(js_chunk_ukey: u32, compilation: &JsCompilation) -> Vec
   let compilation = &compilation.inner;
   let modules = compilation.chunk_graph.get_chunk_modules(
     &ChunkUkey::from(js_chunk_ukey as usize),
-    &compilation.module_graph,
+    &compilation.get_module_graph(),
   );
 
   return modules
@@ -27,7 +27,7 @@ pub fn get_chunk_entry_modules(js_chunk_ukey: u32, compilation: &JsCompilation) 
 
   return modules
     .iter()
-    .filter_map(|module| compilation.module_graph.module_by_identifier(module))
+    .filter_map(|module| compilation.get_module_graph().module_by_identifier(module))
     .filter_map(|module| module.to_js_module().ok())
     .collect::<Vec<_>>();
 }
@@ -66,7 +66,7 @@ pub fn get_chunk_modules_iterable_by_source_type(
         &ChunkUkey::from(js_chunk_ukey as usize),
         SourceType::try_from(source_type.as_str())
           .map_err(|e| napi::Error::from_reason(e.to_string()))?,
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
       )
       .filter_map(|module| module.to_js_module().ok())
       .collect(),

--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -134,7 +134,7 @@ impl JsCompilation {
   pub fn get_modules(&self) -> Vec<JsModule> {
     self
       .inner
-      .module_graph
+      .get_module_graph()
       .modules()
       .values()
       .filter_map(|module| module.to_js_module().ok())
@@ -145,7 +145,7 @@ impl JsCompilation {
   pub fn get_optimization_bailout(&self) -> Vec<JsStatsOptimizationBailout> {
     self
       .inner
-      .module_graph
+      .get_module_graph()
       .module_graph_modules()
       .values()
       .flat_map(|item| item.optimization_bailout.clone())
@@ -182,7 +182,7 @@ impl JsCompilation {
   ) -> bool {
     match self
       .inner
-      .module_graph
+      .get_module_graph_mut()
       .module_by_identifier_mut(&Identifier::from(module_identifier.as_str()))
     {
       Some(module) => match module.as_normal_module_mut() {

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -152,7 +152,7 @@ impl<'me> CodeSplitter<'me> {
 
     // This optimization is inspired from  https://github.com/webpack/webpack/pull/18090 by https://github.com/dmichon-msft
     // Thanks!
-    for m in compilation.module_graph.modules().keys() {
+    for m in compilation.get_module_graph().modules().keys() {
       module_ids.insert(*m, current.clone());
 
       current <<= 1;
@@ -186,40 +186,41 @@ impl<'me> CodeSplitter<'me> {
   fn prepare_input_entrypoints_and_modules(
     &mut self,
   ) -> Result<HashMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
-    let compilation = &mut self.compilation;
-
     let mut input_entrypoints_and_modules: HashMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
       HashMap::default();
     let mut assign_depths_map = HashMap::default();
 
-    for (name, entry_data) in &compilation.entries {
+    let entries = self.compilation.entries.clone();
+    for (name, entry_data) in entries {
       let options = &entry_data.options;
       let dependencies = [
-        compilation.global_entry.dependencies.clone(),
+        self.compilation.global_entry.dependencies.clone(),
         entry_data.dependencies.clone(),
       ]
       .concat();
       let module_identifiers = dependencies
         .iter()
         .filter_map(|dep| {
-          compilation
-            .module_graph
+          self
+            .compilation
+            .get_module_graph()
             .module_identifier_by_dependency_id(dep)
+            .cloned()
         })
         .collect::<Vec<_>>();
 
       let chunk_ukey = Compilation::add_named_chunk(
         name.to_string(),
-        &mut compilation.chunk_by_ukey,
-        &mut compilation.named_chunks,
+        &mut self.compilation.chunk_by_ukey,
+        &mut self.compilation.named_chunks,
       );
-      let chunk = compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
+      let chunk = self.compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
       if let Some(filename) = &entry_data.options.filename {
         chunk.filename_template = Some(filename.clone());
       }
       chunk.chunk_reasons.push(format!("Entrypoint({name})",));
 
-      compilation.chunk_graph.add_chunk(chunk.ukey);
+      self.compilation.chunk_graph.add_chunk(chunk.ukey);
 
       let mut entrypoint = ChunkGroup::new(ChunkGroupKind::new_entrypoint(
         true,
@@ -229,17 +230,17 @@ impl<'me> CodeSplitter<'me> {
       let chunk_group_info = {
         let mut cgi = ChunkGroupInfo::new(
           entrypoint.ukey,
-          get_entry_runtime(name, options),
+          get_entry_runtime(&name, options),
           !matches!(
             options
               .chunk_loading
               .as_ref()
-              .unwrap_or(&compilation.options.output.chunk_loading),
+              .unwrap_or(&self.compilation.options.output.chunk_loading),
             ChunkLoading::Disable
           ),
           options
             .async_chunks
-            .unwrap_or(compilation.options.output.async_chunks),
+            .unwrap_or(self.compilation.options.output.async_chunks),
         );
         cgi.min_available_modules_init = true;
         cgi
@@ -251,29 +252,31 @@ impl<'me> CodeSplitter<'me> {
       entrypoint.set_entry_point_chunk(chunk.ukey);
       entrypoint.connect_chunk(chunk);
 
-      compilation
+      self
+        .compilation
         .named_chunk_groups
         .insert(name.to_string(), entrypoint.ukey);
 
-      compilation
+      self
+        .compilation
         .entrypoints
         .insert(name.to_string(), entrypoint.ukey);
 
       let entrypoint = {
         let ukey = entrypoint.ukey;
-        compilation.chunk_group_by_ukey.add(entrypoint);
-        compilation.chunk_group_by_ukey.expect_get(&ukey)
+        self.compilation.chunk_group_by_ukey.add(entrypoint);
+        self.compilation.chunk_group_by_ukey.expect_get(&ukey)
       };
 
-      for &module_identifier in module_identifiers.iter() {
-        compilation.chunk_graph.add_module(*module_identifier);
+      for module_identifier in module_identifiers.iter() {
+        self.compilation.chunk_graph.add_module(*module_identifier);
 
         input_entrypoints_and_modules
           .entry(entrypoint.ukey)
           .or_default()
           .push(*module_identifier);
 
-        compilation.chunk_graph.connect_chunk_and_entry_module(
+        self.compilation.chunk_graph.connect_chunk_and_entry_module(
           chunk.ukey,
           *module_identifier,
           entrypoint.ukey,
@@ -281,17 +284,19 @@ impl<'me> CodeSplitter<'me> {
       }
       assign_depths(
         &mut assign_depths_map,
-        &compilation.module_graph,
-        module_identifiers,
+        self.compilation.get_module_graph(),
+        module_identifiers.iter().collect_vec(),
       );
 
-      let global_included_modules = compilation
+      let global_included_modules = self
+        .compilation
         .global_entry
         .include_dependencies
         .iter()
         .filter_map(|dep| {
-          compilation
-            .module_graph
+          self
+            .compilation
+            .get_module_graph()
             .module_identifier_by_dependency_id(dep)
         })
         .copied()
@@ -300,8 +305,9 @@ impl<'me> CodeSplitter<'me> {
         .include_dependencies
         .iter()
         .filter_map(|dep| {
-          compilation
-            .module_graph
+          self
+            .compilation
+            .get_module_graph()
             .module_identifier_by_dependency_id(dep)
         })
         .copied()
@@ -310,7 +316,7 @@ impl<'me> CodeSplitter<'me> {
       for included_module in included_modules.clone() {
         assign_depth(
           &mut assign_depths_map,
-          &compilation.module_graph,
+          self.compilation.get_module_graph(),
           included_module,
         );
       }
@@ -333,23 +339,24 @@ impl<'me> CodeSplitter<'me> {
 
     // Using this defer insertion strategies to workaround rustc borrow rules
     for (k, v) in assign_depths_map {
-      compilation.module_graph.set_depth(k, v);
+      self.compilation.get_module_graph_mut().set_depth(k, v);
     }
 
     let mut runtime_chunks = HashSet::default();
     let mut runtime_error = None;
-    for (name, entry_data) in &compilation.entries {
+    for (name, entry_data) in &self.compilation.entries {
       let options = &entry_data.options;
 
       if let Some(runtime) = &options.runtime {
-        let ukey = compilation
+        let ukey = self
+          .compilation
           .entrypoints
           .get(name)
           .ok_or_else(|| error!("no entrypoints found"))?;
 
-        let entry_point = compilation.chunk_group_by_ukey.expect_get_mut(ukey);
+        let entry_point = self.compilation.chunk_group_by_ukey.expect_get_mut(ukey);
 
-        let chunk = match compilation.named_chunks.get(runtime) {
+        let chunk = match self.compilation.named_chunks.get(runtime) {
           Some(ukey) => {
             if !runtime_chunks.contains(ukey) {
               // TODO: add dependOn error message once we implement dependeOn
@@ -363,18 +370,18 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
               entry_point.set_runtime_chunk(entry_chunk);
               continue;
             }
-            compilation.chunk_by_ukey.expect_get_mut(ukey)
+            self.compilation.chunk_by_ukey.expect_get_mut(ukey)
           }
           None => {
             let chunk_ukey = Compilation::add_named_chunk(
               runtime.to_string(),
-              &mut compilation.chunk_by_ukey,
-              &mut compilation.named_chunks,
+              &mut self.compilation.chunk_by_ukey,
+              &mut self.compilation.named_chunks,
             );
-            let chunk = compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
+            let chunk = self.compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
             chunk.prevent_integration = true;
             chunk.chunk_reasons.push(format!("RuntimeChunk({name})",));
-            compilation.chunk_graph.add_chunk(chunk.ukey);
+            self.compilation.chunk_graph.add_chunk(chunk.ukey);
             runtime_chunks.insert(chunk.ukey);
             chunk
           }
@@ -387,7 +394,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
 
     if let Some(err) = runtime_error {
-      compilation.push_diagnostic(err.into());
+      self.compilation.push_diagnostic(err.into());
     }
     Ok(input_entrypoints_and_modules)
   }
@@ -485,7 +492,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .filter_map(|dep| {
           self
             .compilation
-            .module_graph
+            .get_module_graph()
             .module_identifier_by_dependency_id(dep)
         })
         .copied()
@@ -509,8 +516,15 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     }
 
     // make sure all module (weak dependency particularly) has a mgm
-    for module_identifier in self.compilation.module_graph.modules().keys() {
-      self.compilation.chunk_graph.add_module(*module_identifier)
+    let ids = self
+      .compilation
+      .get_module_graph()
+      .modules()
+      .keys()
+      .cloned()
+      .collect::<Vec<_>>();
+    for module_identifier in ids {
+      self.compilation.chunk_graph.add_module(module_identifier)
     }
 
     Ok(())
@@ -656,7 +670,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     {
       let module = self
         .compilation
-        .module_graph
+        .get_module_graph_mut()
         .module_graph_module_by_identifier_mut(&item.module)
         .unwrap_or_else(|| panic!("No module found {:?}", &item.module));
 
@@ -699,7 +713,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
     let module = self
       .compilation
-      .module_graph
+      .get_module_graph_mut()
       .module_graph_module_by_identifier_mut(&item.module)
       .unwrap_or_else(|| panic!("no module found: {:?}", &item.module));
 
@@ -809,13 +823,14 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let mut entrypoint: Option<ChunkGroupUkey> = None;
     let mut c: Option<ChunkGroupUkey> = None;
 
-    let block = self
+    let chunk_ukey = if let Some(chunk_name) = self
       .compilation
-      .module_graph
+      .get_module_graph()
       .block_by_id(&block_id)
-      .expect("should have block");
-
-    let chunk_ukey = if let Some(chunk_name) = block.get_group_options().and_then(|x| x.name()) {
+      .expect("should have block")
+      .get_group_options()
+      .and_then(|x| x.name())
+    {
       Compilation::add_named_chunk(
         chunk_name.to_string(),
         &mut self.compilation.chunk_by_ukey,
@@ -826,6 +841,11 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     };
     self.compilation.chunk_graph.add_chunk(chunk_ukey);
 
+    let block = self
+      .compilation
+      .get_module_graph()
+      .block_by_id(&block_id)
+      .expect("should have block");
     let entry_options = block.get_group_options().and_then(|o| o.entry_options());
     let cgi = if let Some(cgi) = cgi {
       let cgi = self.chunk_group_infos.expect_get(cgi);
@@ -848,6 +868,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
               .connect_block_and_chunk_group(block_id, cgi.chunk_group);
             cgi.ukey
           } else {
+            let entry_options = entry_options.clone();
             let chunk = self.compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
             if let Some(filename) = &entry_options.filename {
               chunk.filename_template = Some(filename.clone());
@@ -949,12 +970,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             .connect_block_and_chunk_group(block_id, cgi.chunk_group);
           cgi
         } else {
+          let mut chunk_group = add_chunk_in_group(block.get_group_options());
           let chunk = self.compilation.chunk_by_ukey.expect_get_mut(&chunk_ukey);
           chunk
             .chunk_reasons
             .push(format!("DynamicImport({:?})", block_id));
 
-          let mut chunk_group = add_chunk_in_group(block.get_group_options());
           let info = ChunkGroupInfo::new(
             chunk_group.ukey,
             item_chunk_group_info.runtime.clone(),
@@ -1050,7 +1071,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
   }
 
   fn extract_block_modules(&mut self, module: ModuleIdentifier, runtime: Option<&RuntimeSpec>) {
-    let module_graph = &self.compilation.module_graph;
+    let module_graph = &self.compilation.get_module_graph();
     let map = self
       .block_modules_runtime_map
       .entry(runtime.cloned().into())
@@ -1096,16 +1117,17 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       // This could happen when module factorization is failed, but `options.bail` set to `false`
       let Some(module_identifier) = self
         .compilation
-        .module_graph
+        .get_module_graph()
         .module_identifier_by_dependency_id(dep_id)
       else {
         continue;
       };
-      let block_id = if let Some(block) = self.compilation.module_graph.get_parent_block(dep_id) {
-        (*block).into()
-      } else {
-        module.into()
-      };
+      let block_id =
+        if let Some(block) = self.compilation.get_module_graph().get_parent_block(dep_id) {
+          (*block).into()
+        } else {
+          module.into()
+        };
       connection_map
         .entry((block_id, *module_identifier))
         .and_modify(|e| e.push(*connection_id))
@@ -1117,7 +1139,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .get_mut(&block_id)
         .expect("should have modules in block_modules_runtime_map");
       let active_state = if self.compilation.options.is_new_tree_shaking() {
-        get_active_state_of_connections(&connections, runtime, &self.compilation.module_graph)
+        get_active_state_of_connections(&connections, runtime, self.compilation.get_module_graph())
       } else {
         ConnectionState::Bool(true)
       };
@@ -1135,7 +1157,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       let chunk_group = self
         .compilation
         .chunk_group_by_ukey
-        .expect_get_mut(&chunk_group_ukey);
+        .expect_get(&chunk_group_ukey);
       let runtime = chunk_group_info.runtime.clone();
 
       // calculate minAvailableModules
@@ -1145,7 +1167,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         for m in self
           .compilation
           .chunk_graph
-          .get_chunk_modules(chunk, &self.compilation.module_graph)
+          .get_chunk_modules(chunk, self.compilation.get_module_graph())
         {
           let m_id = self
             .module_ids
@@ -1171,7 +1193,12 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         cgi.chunk_group
       });
 
-      chunk_group.children.extend(target_groups.clone());
+      self
+        .compilation
+        .chunk_group_by_ukey
+        .expect_get_mut(&chunk_group_ukey)
+        .children
+        .extend(target_groups.clone());
 
       for target_ukey in targets {
         let target_cgi = self.chunk_group_infos.expect_get_mut(&target_ukey);
@@ -1252,7 +1279,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             let active_state = get_active_state_of_connections(
               connections,
               Some(&cgi.runtime),
-              &self.compilation.module_graph,
+              &self.compilation.get_module_graph(),
             );
             if active_state.is_false() {
               continue;
@@ -1366,13 +1393,13 @@ impl DependenciesBlockIdentifier {
   pub fn get_blocks(&self, compilation: &Compilation) -> Vec<AsyncDependenciesBlockIdentifier> {
     match self {
       DependenciesBlockIdentifier::Module(m) => compilation
-        .module_graph
+        .get_module_graph()
         .module_by_identifier(m)
         .expect("should have module")
         .get_blocks()
         .to_vec(),
       DependenciesBlockIdentifier::AsyncDependenciesBlock(a) => compilation
-        .module_graph
+        .get_module_graph()
         .block_by_id(a)
         .expect("should have block")
         .get_blocks()

--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -1279,7 +1279,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
             let active_state = get_active_state_of_connections(
               connections,
               Some(&cgi.runtime),
-              &self.compilation.get_module_graph(),
+              self.compilation.get_module_graph(),
             );
             if active_state.is_false() {
               continue;

--- a/crates/rspack_core/src/cache/occasion/create_chunk_assets.rs
+++ b/crates/rspack_core/src/cache/occasion/create_chunk_assets.rs
@@ -40,7 +40,7 @@ impl CreateChunkAssetsOccasion {
     let is_cache_valid = modules.iter().all(|module_id| {
       matches!(
         compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(module_id)
           .and_then(|m| m.as_normal_module())
           .map(|m| matches!(m.source(), NormalModuleSource::Unbuild)),

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -420,7 +420,7 @@ impl Chunk {
     self.ids.hash(hasher);
     for module in compilation
       .chunk_graph
-      .get_ordered_chunk_modules(&self.ukey, &compilation.get_module_graph())
+      .get_ordered_chunk_modules(&self.ukey, compilation.get_module_graph())
     {
       if let Some(hash) = compilation
         .code_generation_results

--- a/crates/rspack_core/src/chunk.rs
+++ b/crates/rspack_core/src/chunk.rs
@@ -420,7 +420,7 @@ impl Chunk {
     self.ids.hash(hasher);
     for module in compilation
       .chunk_graph
-      .get_ordered_chunk_modules(&self.ukey, &compilation.module_graph)
+      .get_ordered_chunk_modules(&self.ukey, &compilation.get_module_graph())
     {
       if let Some(hash) = compilation
         .code_generation_results

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -175,7 +175,7 @@ impl ChunkGraph {
   ) -> String {
     let mut hasher = DefaultHasher::new();
     let mut connection_hash_cache: HashMap<Identifier, u64> = HashMap::new();
-    let module_graph = &compilation.module_graph;
+    let module_graph = &compilation.get_module_graph();
 
     let process_module_graph_module = |module: &BoxModule, strict: Option<bool>| -> u64 {
       let mut hasher = DefaultHasher::new();

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -661,7 +661,7 @@ impl Compilation {
             .get_module_chunks(*module_identifier)
             .iter()
           {
-            temp.push((chunk.clone(), asset.clone()))
+            temp.push((*chunk, asset.clone()))
           }
           // already emitted asset by loader, so no need to re emit here
         }
@@ -1014,7 +1014,7 @@ impl Compilation {
       let mut set = RuntimeGlobals::default();
       for module in self
         .chunk_graph
-        .get_chunk_modules(&chunk_ukey, &self.get_module_graph())
+        .get_chunk_modules(&chunk_ukey, self.get_module_graph())
       {
         let chunk = self.chunk_by_ukey.expect_get(&chunk_ukey);
         if let Some(runtime_requirements) = self

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -66,7 +66,7 @@ pub struct Compilation {
   pub options: Arc<CompilerOptions>,
   pub entries: Entry,
   pub global_entry: EntryData,
-  pub module_graph: ModuleGraph,
+  module_graph: ModuleGraph,
   dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub make_failed_dependencies: HashSet<BuildDependency>,
   pub make_failed_module: HashSet<ModuleIdentifier>,
@@ -146,6 +146,7 @@ impl Compilation {
     hooks: Arc<CompilationHooks>,
     cache: Arc<Cache>,
   ) -> Self {
+    let module_graph = module_graph.with_treeshaking(options.is_new_tree_shaking());
     Self {
       hot_index: 0,
       hooks,
@@ -203,6 +204,14 @@ impl Compilation {
     }
   }
 
+  pub fn get_module_graph(&self) -> &ModuleGraph {
+    &self.module_graph
+  }
+
+  pub fn get_module_graph_mut(&mut self) -> &mut ModuleGraph {
+    &mut self.module_graph
+  }
+
   pub fn get_entry_runtime(&self, name: &String, options: Option<&EntryOptions>) -> RuntimeSpec {
     let (_, runtime) = if let Some(options) = options {
       ((), options.runtime.as_ref())
@@ -221,7 +230,7 @@ impl Compilation {
 
   pub fn add_entry(&mut self, entry: BoxDependency, options: EntryOptions) -> Result<()> {
     let entry_id = *entry.id();
-    self.module_graph.add_dependency(entry);
+    self.get_module_graph_mut().add_dependency(entry);
     if let Some(name) = options.name.clone() {
       if let Some(data) = self.entries.get_mut(&name) {
         data.dependencies.push(entry_id);
@@ -242,7 +251,7 @@ impl Compilation {
 
   pub async fn add_include(&mut self, entry: BoxDependency, options: EntryOptions) -> Result<()> {
     let entry_id = *entry.id();
-    self.module_graph.add_dependency(entry);
+    self.get_module_graph_mut().add_dependency(entry);
     if let Some(name) = options.name.clone() {
       if let Some(data) = self.entries.get_mut(&name) {
         data.include_dependencies.push(entry_id);
@@ -496,10 +505,11 @@ impl Compilation {
       logger.time_end(start);
     }
 
+    let module_graph = self.get_module_graph();
     Ok(
       module_identifiers
         .into_iter()
-        .filter_map(|id| self.module_graph.module_by_identifier(&id))
+        .filter_map(|id| module_graph.module_by_identifier(&id))
         .collect::<Vec<_>>(),
     )
   }
@@ -525,7 +535,7 @@ impl Compilation {
         codegen_cache_counter,
         used_exports_optimization,
         compilation
-          .module_graph
+          .get_module_graph()
           .modules()
           .iter()
           .filter(filter_op)
@@ -548,7 +558,7 @@ impl Compilation {
     // and it is widely called after compilation.finish()
     // so add this method to trigger moduleGraph modification and
     // then make sure that moduleGraph is immutable
-    prepare_get_exports_type(&mut self.module_graph);
+    prepare_get_exports_type(self.get_module_graph_mut());
 
     run_iteration(self, &mut codegen_cache_counter, |(_, module)| {
       module.get_code_generation_dependencies().is_none()
@@ -581,7 +591,7 @@ impl Compilation {
         }
 
         let module = self
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(&module_identifier)
           .expect("module should exist");
         let res = self
@@ -642,7 +652,8 @@ impl Compilation {
 
   #[instrument(name = "compilation::create_module_assets", skip_all)]
   async fn create_module_assets(&mut self, _plugin_driver: SharedPluginDriver) {
-    for (module_identifier, module) in self.module_graph.modules() {
+    let mut temp = vec![];
+    for (module_identifier, module) in self.get_module_graph().modules() {
       if let Some(build_info) = module.build_info() {
         for asset in build_info.asset_filenames.iter() {
           for chunk in self
@@ -650,12 +661,16 @@ impl Compilation {
             .get_module_chunks(*module_identifier)
             .iter()
           {
-            let chunk = self.chunk_by_ukey.expect_get_mut(chunk);
-            chunk.auxiliary_files.insert(asset.clone());
+            temp.push((chunk.clone(), asset.clone()))
           }
           // already emitted asset by loader, so no need to re emit here
         }
       }
+    }
+
+    for (chunk, asset) in temp {
+      let chunk = self.chunk_by_ukey.expect_get_mut(&chunk);
+      chunk.auxiliary_files.insert(asset);
     }
   }
 
@@ -799,7 +814,7 @@ impl Compilation {
     logger.time_end(start);
 
     // if self.options.is_new_tree_shaking() {
-    //   debug_all_exports_info!(&self.module_graph);
+    //   debug_all_exports_info!(&self.get_module_graph());
     // }
     let start = logger.time("create chunks");
     use_code_splitting_cache(self, |compilation| async {
@@ -835,14 +850,14 @@ impl Compilation {
     self.code_generation()?;
     logger.time_end(start);
     // if self.options.is_new_tree_shaking() {
-    //   debug_all_exports_info!(&self.module_graph);
+    //   debug_all_exports_info!(&self.get_module_graph());
     // }
 
     let start = logger.time("runtime requirements");
     self
       .process_runtime_requirements(
         self
-          .module_graph
+          .get_module_graph()
           .modules()
           .keys()
           .copied()
@@ -999,7 +1014,7 @@ impl Compilation {
       let mut set = RuntimeGlobals::default();
       for module in self
         .chunk_graph
-        .get_chunk_modules(&chunk_ukey, &self.module_graph)
+        .get_chunk_modules(&chunk_ukey, &self.get_module_graph())
       {
         let chunk = self.chunk_by_ukey.expect_get(&chunk_ukey);
         if let Some(runtime_requirements) = self
@@ -1228,7 +1243,7 @@ impl Compilation {
   // #[instrument(name = "compilation:create_module_hash", skip_all)]
   // pub fn create_module_hash(&mut self) {
   //   let module_hash_map: HashMap<ModuleIdentifier, u64> = self
-  //     .module_graph
+  //     .get_module_graph()
   //     .module_identifier_to_module
   //     .par_iter()
   //     .map(|(identifier, module)| {

--- a/crates/rspack_core/src/compiler/execute_module.rs
+++ b/crates/rspack_core/src/compiler/execute_module.rs
@@ -45,10 +45,10 @@ impl Compilation {
     while let Some(m) = queue.pop() {
       modules.insert(m);
       let m = self
-        .module_graph
+        .get_module_graph()
         .module_by_identifier(&m)
         .expect("should have module");
-      for m in self.module_graph.get_outgoing_connections(m) {
+      for m in self.get_module_graph().get_outgoing_connections(m) {
         // TODO: handle circle
         if !modules.contains(&m.module_identifier) {
           queue.push(m.module_identifier);
@@ -107,7 +107,7 @@ impl Compilation {
     // Assign ids to modules and modules to the chunk
     for m in &modules {
       let module = self
-        .module_graph
+        .get_module_graph()
         .module_by_identifier(m)
         .expect("should have module");
 
@@ -188,7 +188,7 @@ impl Compilation {
           .iter()
           .fold(ExecuteModuleResult::default(), |mut res, m| {
             let module = self
-              .module_graph
+              .get_module_graph()
               .module_by_identifier(m)
               .expect("unreachable");
 
@@ -365,7 +365,7 @@ impl Compilation {
             module,
             Box::new(move |module, compilation| {
               let m = compilation
-                .module_graph
+                .get_module_graph()
                 .module_by_identifier(&module)
                 .expect("todo");
 
@@ -374,7 +374,7 @@ impl Compilation {
                   module,
                   Some(
                     compilation
-                      .module_graph
+                      .get_module_graph()
                       .get_outgoing_connections(m)
                       .into_iter()
                       .map(|conn| conn.module_identifier)

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -70,7 +70,7 @@ where
 
       let mut new_compilation = Compilation::new(
         self.options.clone(),
-        ModuleGraph::default().with_treeshaking(self.options.is_new_tree_shaking()),
+        ModuleGraph::default(),
         self.plugin_driver.clone(),
         self.resolver_factory.clone(),
         self.loader_resolver_factory.clone(),
@@ -89,7 +89,10 @@ where
       if is_incremental_rebuild_make {
         // copy field from old compilation
         // make stage used
-        new_compilation.module_graph = std::mem::take(&mut self.compilation.module_graph);
+        std::mem::swap(
+          self.compilation.get_module_graph_mut(),
+          new_compilation.get_module_graph_mut(),
+        );
         new_compilation.make_failed_dependencies =
           std::mem::take(&mut self.compilation.make_failed_dependencies);
         new_compilation.make_failed_module =

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -117,7 +117,7 @@ impl UpdateModuleGraph {
     compilation: &mut Compilation,
     params: Vec<MakeParam>,
   ) -> Result<HashSet<BuildDependency>> {
-    let deps_builder = RebuildDepsBuilder::new(params, &compilation.get_module_graph());
+    let deps_builder = RebuildDepsBuilder::new(params, compilation.get_module_graph());
 
     self.origin_module_deps = HashMap::from_iter(
       deps_builder
@@ -287,7 +287,7 @@ impl UpdateModuleGraph {
         let mut sorted_dependencies = HashMap::default();
 
         task.dependencies.into_iter().for_each(|dependency_id| {
-          let dependency = dependency_id.get_dependency(&compilation.get_module_graph());
+          let dependency = dependency_id.get_dependency(compilation.get_module_graph());
           // FIXME: now only module/context dependency can put into resolve queue.
           // FIXME: should align webpack
           let resource_identifier =
@@ -875,7 +875,7 @@ impl UpdateModuleGraph {
       .profile
       .then(Box::<ModuleProfile>::default);
     let dependency = dependencies[0]
-      .get_dependency(&compilation.get_module_graph())
+      .get_dependency(compilation.get_module_graph())
       .clone();
     let original_module_source = original_module_identifier
       .and_then(|i| compilation.get_module_graph().module_by_identifier(&i))

--- a/crates/rspack_core/src/compiler/make/queue.rs
+++ b/crates/rspack_core/src/compiler/make/queue.rs
@@ -265,7 +265,7 @@ impl AddTask {
         .expect("self module should have issuer");
 
       set_resolved_module(
-        &mut compilation.module_graph,
+        compilation.get_module_graph_mut(),
         self.original_module_identifier,
         self.dependencies,
         *issuer,
@@ -280,12 +280,12 @@ impl AddTask {
 
     if self.connect_origin
       && compilation
-        .module_graph
+        .get_module_graph()
         .module_graph_module_by_identifier(&module_identifier)
         .is_some()
     {
       set_resolved_module(
-        &mut compilation.module_graph,
+        compilation.get_module_graph_mut(),
         self.original_module_identifier,
         self.dependencies,
         module_identifier,
@@ -301,12 +301,12 @@ impl AddTask {
     }
 
     compilation
-      .module_graph
+      .get_module_graph_mut()
       .add_module_graph_module(*self.module_graph_module);
 
     if self.connect_origin {
       set_resolved_module(
-        &mut compilation.module_graph,
+        compilation.get_module_graph_mut(),
         self.original_module_identifier,
         self.dependencies,
         module_identifier,
@@ -500,7 +500,7 @@ impl CleanTask {
   pub fn run(self, compilation: &mut Compilation) -> CleanTaskResult {
     let module_identifier = self.module_identifier;
     let mgm = match compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_identifier(&module_identifier)
     {
       Some(mgm) => mgm,
@@ -517,13 +517,15 @@ impl CleanTask {
     }
 
     let dependent_module_identifiers: Vec<ModuleIdentifier> = compilation
-      .module_graph
+      .get_module_graph()
       .get_module_all_depended_modules(&module_identifier)
       .expect("should have module")
       .into_iter()
       .copied()
       .collect();
-    compilation.module_graph.revoke_module(&module_identifier);
+    compilation
+      .get_module_graph_mut()
+      .revoke_module(&module_identifier);
     CleanTaskResult::ModuleIsCleaned {
       module_identifier,
       dependent_module_identifiers,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -559,7 +559,7 @@ impl Module for ConcatenatedModule {
 
       // populate dependencies
       for dep_id in module.get_dependencies() {
-        let dep = dep_id.get_dependency(&compilation.get_module_graph());
+        let dep = dep_id.get_dependency(compilation.get_module_graph());
         let module_id_of_dep = compilation
           .get_module_graph()
           .module_identifier_by_dependency_id(dep_id);
@@ -608,7 +608,7 @@ impl Module for ConcatenatedModule {
     let context = compilation.options.context.clone();
 
     let (modules_with_info, module_to_info_map) =
-      self.get_modules_with_info(&compilation.get_module_graph(), runtime);
+      self.get_modules_with_info(compilation.get_module_graph(), runtime);
 
     // Set with modules that need a generated namespace object
     let mut needed_namespace_objects: IndexSet<ModuleIdentifier> = IndexSet::default();
@@ -850,7 +850,7 @@ impl Module for ConcatenatedModule {
       ) in info_params_list
       {
         let final_name = Self::get_final_name(
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
           &referenced_info_id,
           export_name,
           &mut module_to_info_map,
@@ -899,7 +899,7 @@ impl Module for ConcatenatedModule {
       .get_exports_info(&root_module_id);
 
     for (_, export_info_id) in exports_info.exports.iter() {
-      let export_info = export_info_id.get_export_info(&compilation.get_module_graph());
+      let export_info = export_info_id.get_export_info(compilation.get_module_graph());
       let name = export_info.name.clone().unwrap_or("".into());
       if matches!(export_info.provided, Some(ExportInfoProvided::False)) {
         continue;
@@ -912,7 +912,7 @@ impl Module for ConcatenatedModule {
       };
       exports_map.insert(used_name, {
         let final_name = Self::get_final_name(
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
           &root_module_id,
           [name.clone()].to_vec(),
           &mut module_to_info_map,
@@ -943,7 +943,7 @@ impl Module for ConcatenatedModule {
       .get_module_graph()
       .get_exports_info(&self.id())
       .other_exports_info
-      .get_used(&compilation.get_module_graph(), runtime)
+      .get_used(compilation.get_module_graph(), runtime)
       != UsageState::Unused
     {
       result.add(RawSource::from("// ESM COMPAT FLAG\n"));
@@ -1031,14 +1031,14 @@ impl Module for ConcatenatedModule {
           .get_module_graph()
           .get_exports_info(module_info_id);
         for (_name, export_info_id) in exports_info.exports.iter() {
-          let export_info = export_info_id.get_export_info(&compilation.get_module_graph());
+          let export_info = export_info_id.get_export_info(compilation.get_module_graph());
           if matches!(export_info.provided, Some(ExportInfoProvided::False)) {
             continue;
           }
 
           if let Some(used_name) = export_info.get_used_name(None, runtime) {
             let final_name = Self::get_final_name(
-              &compilation.get_module_graph(),
+              compilation.get_module_graph(),
               module_info_id,
               vec![export_info.name.clone().unwrap_or("".into())],
               &mut module_to_info_map,

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -265,7 +265,7 @@ impl ContextModule {
     let sorted_modules = dependencies
       .filter_map(|dep_id| {
         compilation
-          .module_graph
+          .get_module_graph()
           .module_identifier_by_dependency_id(dep_id)
           .map(|m| (m, dep_id))
       })
@@ -279,7 +279,7 @@ impl ContextModule {
       .sorted_unstable_by_key(|(module_id, _)| module_id.to_string());
     for (module_id, dep) in sorted_modules {
       let exports_type = get_exports_type_with_strict(
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
         dep,
         matches!(
           self.options.context_options.namespace_object,
@@ -347,10 +347,10 @@ impl ContextModule {
     let mut map = HashMap::default();
     for dependency in dependencies {
       if let Some(module_identifier) = compilation
-        .module_graph
+        .get_module_graph()
         .module_identifier_by_dependency_id(dependency)
       {
-        if let Some(dependency) = compilation.module_graph.dependency_by_id(dependency) {
+        if let Some(dependency) = compilation.get_module_graph().dependency_by_id(dependency) {
           let request = if let Some(d) = dependency.as_module_dependency() {
             Some(d.user_request().to_string())
           } else {
@@ -386,7 +386,7 @@ impl ContextModule {
     let mut map = HashMap::default();
     for (block, dep_id) in blocks {
       if let Some(dependency) = compilation
-        .module_graph
+        .get_module_graph()
         .dependency_by_id(dep_id)
         .and_then(|d| d.as_module_dependency())
       {
@@ -414,7 +414,7 @@ impl ContextModule {
           .first()
           .expect("LazyOnce ContextModule should have first block");
         let block = compilation
-          .module_graph
+          .get_module_graph()
           .block_by_id(block)
           .expect("should have block");
         self.generate_source(block.get_dependencies(), compilation)
@@ -431,7 +431,7 @@ impl ContextModule {
     let blocks = self
       .get_blocks()
       .iter()
-      .filter_map(|b| compilation.module_graph.block_by_id(b));
+      .filter_map(|b| compilation.get_module_graph().block_by_id(b));
     let block_map = self.get_block_promise_map(blocks.clone(), compilation, runtime_requirements);
     let dependencies = blocks.filter_map(|b| b.get_dependencies().first());
     let fake_map = self.get_fake_map(dependencies.clone(), compilation);
@@ -686,7 +686,7 @@ impl Module for ContextModule {
     let mut all_deps = self.get_dependencies().to_vec();
     for block in self.get_blocks() {
       let block = compilation
-        .module_graph
+        .get_module_graph()
         .block_by_id(block)
         .expect("should have block in ContextModule code_generation");
       all_deps.extend(block.get_dependencies());

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -279,7 +279,7 @@ impl ContextModule {
       .sorted_unstable_by_key(|(module_id, _)| module_id.to_string());
     for (module_id, dep) in sorted_modules {
       let exports_type = get_exports_type_with_strict(
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
         dep,
         matches!(
           self.options.context_options.namespace_object,

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -67,12 +67,12 @@ impl From<String> for AsyncDependenciesBlockIdentifier {
 
 impl AsyncDependenciesBlockIdentifier {
   pub fn get<'c>(&self, compilation: &'c Compilation) -> Option<&'c AsyncDependenciesBlock> {
-    compilation.module_graph.block_by_id(self)
+    compilation.get_module_graph().block_by_id(self)
   }
 
   pub fn expect_get<'c>(&self, compilation: &'c Compilation) -> &'c AsyncDependenciesBlock {
     compilation
-      .module_graph
+      .get_module_graph()
       .block_by_id(self)
       .expect("should have block")
   }

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -113,7 +113,7 @@ pub fn export_from_import(
     ..
   } = code_generatable_context;
   let Some(module_identifier) = compilation
-    .module_graph
+    .get_module_graph()
     .module_identifier_by_dependency_id(id)
     .copied()
   else {
@@ -121,7 +121,7 @@ pub fn export_from_import(
   };
   let is_new_treeshaking = compilation.options.is_new_tree_shaking();
 
-  let exports_type = get_exports_type(&compilation.module_graph, id, &module.identifier());
+  let exports_type = get_exports_type(&compilation.get_module_graph(), id, &module.identifier());
 
   if default_interop {
     if !export_name.is_empty()
@@ -180,11 +180,11 @@ pub fn export_from_import(
   if !export_name.is_empty() {
     let used_name = if is_new_treeshaking {
       let exports_info_id = compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&module_identifier)
         .id;
       let used = exports_info_id.get_used_name(
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
         *runtime,
         crate::UsedName::Vec(export_name.clone()),
       );
@@ -266,7 +266,7 @@ pub fn module_id(
   weak: bool,
 ) -> String {
   if let Some(module_identifier) = compilation
-    .module_graph
+    .get_module_graph()
     .module_identifier_by_dependency_id(id)
     && let Some(module_id) = compilation.chunk_graph.get_module_id(*module_identifier)
   {
@@ -287,7 +287,7 @@ pub fn import_statement(
   update: bool, // whether a new variable should be created or the existing one updated
 ) -> (String, String) {
   if compilation
-    .module_graph
+    .get_module_graph()
     .module_identifier_by_dependency_id(id)
     .is_none()
   {
@@ -298,7 +298,7 @@ pub fn import_statement(
 
   runtime_requirements.insert(RuntimeGlobals::REQUIRE);
 
-  let import_var = get_import_var(&compilation.module_graph, *id);
+  let import_var = get_import_var(&compilation.get_module_graph(), *id);
 
   let opt_declaration = if update { "" } else { "var " };
 
@@ -307,7 +307,7 @@ pub fn import_statement(
     RuntimeGlobals::REQUIRE
   );
 
-  let exports_type = get_exports_type(&compilation.module_graph, id, &module.identifier());
+  let exports_type = get_exports_type(&compilation.get_module_graph(), id, &module.identifier());
   if matches!(exports_type, ExportsType::Dynamic) {
     runtime_requirements.insert(RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT);
     return (
@@ -336,7 +336,7 @@ pub fn module_namespace_promise(
     ..
   } = code_generatable_context;
   if compilation
-    .module_graph
+    .get_module_graph()
     .module_identifier_by_dependency_id(dep_id)
     .is_none()
   {
@@ -344,7 +344,11 @@ pub fn module_namespace_promise(
   };
 
   let promise = block_promise(block, runtime_requirements, compilation);
-  let exports_type = get_exports_type(&compilation.module_graph, dep_id, &module.identifier());
+  let exports_type = get_exports_type(
+    &compilation.get_module_graph(),
+    dep_id,
+    &module.identifier(),
+  );
   let module_id_expr = module_id(compilation, dep_id, request, weak);
 
   let header = if weak {
@@ -387,9 +391,9 @@ pub fn module_namespace_promise(
       }
       runtime_requirements.insert(RuntimeGlobals::CREATE_FAKE_NAMESPACE_OBJECT);
       if matches!(
-        compilation.module_graph.is_async(
+        compilation.get_module_graph().is_async(
           compilation
-            .module_graph
+            .get_module_graph()
             .module_identifier_by_dependency_id(dep_id)
             .expect("should have module")
         ),
@@ -495,7 +499,7 @@ pub fn module_raw(
   weak: bool,
 ) -> String {
   if let Some(module_identifier) = compilation
-    .module_graph
+    .get_module_graph()
     .module_identifier_by_dependency_id(id)
     && let Some(module_id) = compilation.chunk_graph.get_module_id(*module_identifier)
   {

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -121,7 +121,7 @@ pub fn export_from_import(
   };
   let is_new_treeshaking = compilation.options.is_new_tree_shaking();
 
-  let exports_type = get_exports_type(&compilation.get_module_graph(), id, &module.identifier());
+  let exports_type = get_exports_type(compilation.get_module_graph(), id, &module.identifier());
 
   if default_interop {
     if !export_name.is_empty()
@@ -184,7 +184,7 @@ pub fn export_from_import(
         .get_exports_info(&module_identifier)
         .id;
       let used = exports_info_id.get_used_name(
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
         *runtime,
         crate::UsedName::Vec(export_name.clone()),
       );
@@ -298,7 +298,7 @@ pub fn import_statement(
 
   runtime_requirements.insert(RuntimeGlobals::REQUIRE);
 
-  let import_var = get_import_var(&compilation.get_module_graph(), *id);
+  let import_var = get_import_var(compilation.get_module_graph(), *id);
 
   let opt_declaration = if update { "" } else { "var " };
 
@@ -307,7 +307,7 @@ pub fn import_statement(
     RuntimeGlobals::REQUIRE
   );
 
-  let exports_type = get_exports_type(&compilation.get_module_graph(), id, &module.identifier());
+  let exports_type = get_exports_type(compilation.get_module_graph(), id, &module.identifier());
   if matches!(exports_type, ExportsType::Dynamic) {
     runtime_requirements.insert(RuntimeGlobals::COMPAT_GET_DEFAULT_EXPORT);
     return (
@@ -344,11 +344,7 @@ pub fn module_namespace_promise(
   };
 
   let promise = block_promise(block, runtime_requirements, compilation);
-  let exports_type = get_exports_type(
-    &compilation.get_module_graph(),
-    dep_id,
-    &module.identifier(),
-  );
+  let exports_type = get_exports_type(compilation.get_module_graph(), dep_id, &module.identifier());
   let module_id_expr = module_id(compilation, dep_id, request, weak);
 
   let header = if weak {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -224,7 +224,7 @@ module.exports = new Promise(function(resolve, reject) {{
       }
       "amd" | "amd-require" | "umd" | "umd2" | "system" | "jsonp" => {
         let id = compilation
-          .module_graph
+          .get_module_graph()
           .module_graph_module_by_identifier(&self.identifier())
           .map(|m| m.id(&compilation.chunk_graph))
           .unwrap_or_default();
@@ -243,7 +243,7 @@ module.exports = new Promise(function(resolve, reject) {{
       "module" if let Some(request) = request => {
         if compilation.options.output.module {
           let id = compilation
-            .module_graph
+            .get_module_graph()
             .module_graph_module_by_identifier(&self.identifier())
             .map(|m| m.id(&compilation.chunk_graph))
             .unwrap_or_default();

--- a/crates/rspack_core/src/module_profile.rs
+++ b/crates/rspack_core/src/module_profile.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use once_cell::sync::OnceCell;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct TimeRange {
   start: OnceCell<Instant>,
   end: OnceCell<Instant>,
@@ -27,7 +27,7 @@ impl TimeRange {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ModulePhaseProfile {
   range: TimeRange,
   parallelism_factor: OnceCell<u16>,
@@ -46,7 +46,7 @@ impl ModulePhaseProfile {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ModuleProfile {
   pub factory: ModulePhaseProfile,
   // pub restoring: ModulePhaseProfile,

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -17,7 +17,7 @@ pub struct EntryDescription {
   pub filename: Option<Filename>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct EntryData {
   pub dependencies: Vec<DependencyId>,
   pub include_dependencies: Vec<DependencyId>,

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -191,7 +191,7 @@ impl Stats<'_> {
           let chunk_modules = self
             .compilation
             .chunk_graph
-            .get_chunk_modules(&c.ukey, &self.compilation.get_module_graph());
+            .get_chunk_modules(&c.ukey, self.compilation.get_module_graph());
           let mut chunk_modules = chunk_modules
             .into_iter()
             .map(|m| {
@@ -229,7 +229,7 @@ impl Stats<'_> {
           size: self
             .compilation
             .chunk_graph
-            .get_chunk_modules_size(&c.ukey, &self.compilation.get_module_graph()),
+            .get_chunk_modules_size(&c.ukey, self.compilation.get_module_graph()),
           modules: chunk_modules,
           parents,
           children,
@@ -434,7 +434,7 @@ impl Stats<'_> {
     let reasons = reasons
       .then(|| -> Result<_> {
         let mut reasons: Vec<StatsModuleReason> = mgm
-          .get_incoming_connections_unordered(&self.compilation.get_module_graph())?
+          .get_incoming_connections_unordered(self.compilation.get_module_graph())?
           .map(|connection| {
             let (module_name, module_id) = connection
               .original_module_identifier

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -136,7 +136,7 @@ impl Stats<'_> {
   ) -> Result<Vec<StatsModule>> {
     let mut modules: Vec<StatsModule> = self
       .compilation
-      .module_graph
+      .get_module_graph()
       .modules()
       .values()
       .map(|module| {
@@ -191,7 +191,7 @@ impl Stats<'_> {
           let chunk_modules = self
             .compilation
             .chunk_graph
-            .get_chunk_modules(&c.ukey, &self.compilation.module_graph);
+            .get_chunk_modules(&c.ukey, &self.compilation.get_module_graph());
           let mut chunk_modules = chunk_modules
             .into_iter()
             .map(|m| {
@@ -229,7 +229,7 @@ impl Stats<'_> {
           size: self
             .compilation
             .chunk_graph
-            .get_chunk_modules_size(&c.ukey, &self.compilation.module_graph),
+            .get_chunk_modules_size(&c.ukey, &self.compilation.get_module_graph()),
           modules: chunk_modules,
           parents,
           children,
@@ -314,7 +314,7 @@ impl Stats<'_> {
           .and_then(|identifier| {
             let module = self
               .compilation
-              .module_graph
+              .get_module_graph()
               .module_by_identifier(&identifier)?;
             Some(get_stats_module_name_and_id(module, self.compilation))
           })
@@ -346,7 +346,7 @@ impl Stats<'_> {
           .and_then(|identifier| {
             let module = self
               .compilation
-              .module_graph
+              .get_module_graph()
               .module_by_identifier(&identifier)?;
             Some(get_stats_module_name_and_id(module, self.compilation))
           })
@@ -410,11 +410,11 @@ impl Stats<'_> {
     let identifier = module.identifier();
     let mgm = self
       .compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_identifier(&identifier)
       .unwrap_or_else(|| panic!("Could not find ModuleGraphModule by identifier: {identifier:?}"));
 
-    let issuer = self.compilation.module_graph.get_issuer(module);
+    let issuer = self.compilation.get_module_graph().get_issuer(module);
     let (issuer_name, issuer_id) = issuer
       .map(|i| get_stats_module_name_and_id(i, self.compilation))
       .unzip();
@@ -427,23 +427,23 @@ impl Stats<'_> {
         name,
         id,
       });
-      current_issuer = self.compilation.module_graph.get_issuer(i);
+      current_issuer = self.compilation.get_module_graph().get_issuer(i);
     }
     issuer_path.reverse();
 
     let reasons = reasons
       .then(|| -> Result<_> {
         let mut reasons: Vec<StatsModuleReason> = mgm
-          .get_incoming_connections_unordered(&self.compilation.module_graph)?
+          .get_incoming_connections_unordered(&self.compilation.get_module_graph())?
           .map(|connection| {
             let (module_name, module_id) = connection
               .original_module_identifier
-              .and_then(|i| self.compilation.module_graph.module_by_identifier(&i))
+              .and_then(|i| self.compilation.get_module_graph().module_by_identifier(&i))
               .map(|m| get_stats_module_name_and_id(m, self.compilation))
               .unzip();
             let dependency = self
               .compilation
-              .module_graph
+              .get_module_graph()
               .dependency_by_id(&connection.dependency_id);
             let (r#type, user_request) =
               if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
@@ -513,7 +513,7 @@ impl Stats<'_> {
       if provided_exports && self.compilation.options.optimization.provided_exports {
         match self
           .compilation
-          .module_graph
+          .get_module_graph()
           .get_provided_exports(module.identifier())
         {
           ProvidedExports::Vec(v) => Some(v.iter().map(|i| i.to_string()).collect_vec()),
@@ -533,7 +533,7 @@ impl Stats<'_> {
     {
       match self
         .compilation
-        .module_graph
+        .get_module_graph()
         .get_used_exports(module.identifier(), None)
       {
         UsedExports::Null => Some(StatsUsedExports::Null),

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -163,7 +163,7 @@ impl<'a> CodeSizeOptimizer<'a> {
 
     let inherit_export_ref_graph = get_inherit_export_ref_graph(
       &mut finalized_result_map,
-      &self.compilation.get_module_graph(),
+      self.compilation.get_module_graph(),
     );
     let mut errors = vec![];
     let mut used_symbol_ref = HashSet::default();
@@ -314,8 +314,7 @@ impl<'a> CodeSizeOptimizer<'a> {
             let normalized_symbols = p
               .into_iter()
               .map(|symbol| {
-                symbol
-                  .convert_module_identifier_to_module_path(&self.compilation.get_module_graph())
+                symbol.convert_module_identifier_to_module_path(self.compilation.get_module_graph())
               })
               .collect::<Vec<_>>();
             println!("{normalized_symbols:#?}",);
@@ -603,7 +602,7 @@ impl<'a> CodeSizeOptimizer<'a> {
     for entry_module_ident in self.compilation.entry_module_identifiers.iter() {
       Self::normalize_side_effects(
         *entry_module_ident,
-        &self.compilation.get_module_graph(),
+        self.compilation.get_module_graph(),
         &mut IdentifierSet::default(),
         &mut side_effect_map,
       );
@@ -745,7 +744,7 @@ impl<'a> CodeSizeOptimizer<'a> {
   ) {
     current_symbol_ref_with_member_chain.0 = current_symbol_ref_with_member_chain
       .0
-      .update_src_from_dep_id(&self.compilation.get_module_graph());
+      .update_src_from_dep_id(self.compilation.get_module_graph());
     if visited_symbol_ref.contains(&current_symbol_ref_with_member_chain) {
       return;
     } else {

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -105,21 +105,20 @@ impl<'a> CodeSizeOptimizer<'a> {
     // } else {
     //   analyze_result_map
     // };
-
-    self
-      .compilation
-      .optimize_analyze_result_map
-      .iter_mut()
-      .for_each(|(module_identifier, optimize_analyze_result)| {
-        if let Some(factory_meta_side_effects) = self
-          .compilation
-          .module_graph
+    let mut optimize_analyze_result_map =
+      std::mem::take(&mut self.compilation.optimize_analyze_result_map);
+    let module_graph = self.compilation.get_module_graph();
+    optimize_analyze_result_map.iter_mut().for_each(
+      |(module_identifier, optimize_analyze_result)| {
+        if let Some(factory_meta_side_effects) = module_graph
           .module_graph_module_by_identifier(module_identifier)
           .and_then(|mgm| ModuleRefAnalyze::get_side_effects_from_config(&mgm.factory_meta))
         {
           optimize_analyze_result.side_effects = factory_meta_side_effects;
         }
-      });
+      },
+    );
+    self.compilation.optimize_analyze_result_map = optimize_analyze_result_map;
     // We will set it back and return the analyze result, take is safe here.
     let mut finalized_result_map =
       std::mem::take(&mut self.compilation.optimize_analyze_result_map);
@@ -162,8 +161,10 @@ impl<'a> CodeSizeOptimizer<'a> {
 
     self.side_effects_free_modules = self.get_side_effects_free_modules(side_effect_map);
 
-    let inherit_export_ref_graph =
-      get_inherit_export_ref_graph(&mut finalized_result_map, &self.compilation.module_graph);
+    let inherit_export_ref_graph = get_inherit_export_ref_graph(
+      &mut finalized_result_map,
+      &self.compilation.get_module_graph(),
+    );
     let mut errors = vec![];
     let mut used_symbol_ref = HashSet::default();
     let mut used_export_module_identifiers: IdentifierMap<ModuleUsedType> =
@@ -213,7 +214,7 @@ impl<'a> CodeSizeOptimizer<'a> {
     );
     // let debug_graph = generate_debug_symbol_graph(
     //   &self.symbol_graph,
-    //   &self.compilation.module_graph,
+    //   &self.compilation.get_module_graph(),
     //   &self.compilation.options.context.as_str().to_owned(),
     // );
     // let res = serde_json::to_string(&debug_graph).unwrap();
@@ -242,7 +243,7 @@ impl<'a> CodeSizeOptimizer<'a> {
   }
 
   fn merge_bailout_modules_reason(&mut self, k: &ModuleIdOrDepId, v: BailoutFlag) {
-    let mg = &self.compilation.module_graph;
+    let mg = &self.compilation.get_module_graph();
     let normalized_module_id = match k {
       ModuleIdOrDepId::ModuleId(module_id) => *module_id,
       ModuleIdOrDepId::DepId(dep_id) => {
@@ -313,7 +314,8 @@ impl<'a> CodeSizeOptimizer<'a> {
             let normalized_symbols = p
               .into_iter()
               .map(|symbol| {
-                symbol.convert_module_identifier_to_module_path(&self.compilation.module_graph)
+                symbol
+                  .convert_module_identifier_to_module_path(&self.compilation.get_module_graph())
               })
               .collect::<Vec<_>>();
             println!("{normalized_symbols:#?}",);
@@ -438,7 +440,7 @@ impl<'a> CodeSizeOptimizer<'a> {
 
         let mgm = self
           .compilation
-          .module_graph
+          .get_module_graph_mut()
           .module_graph_module_by_identifier_mut(&module_identifier)
           .unwrap_or_else(|| panic!("Failed to get mgm by module identifier {module_identifier}"));
         include_module_ids.insert(mgm.module_identifier);
@@ -464,7 +466,7 @@ impl<'a> CodeSizeOptimizer<'a> {
         // reachable_dependency_identifier.extend(analyze_result.inherit_export_maps.keys());
         for dependency_id in self
           .compilation
-          .module_graph
+          .get_module_graph()
           .get_module_all_dependencies(&module_identifier)
           .unwrap_or_else(|| {
             panic!("Failed to get ModuleGraphModule by module identifier {module_identifier}")
@@ -473,7 +475,7 @@ impl<'a> CodeSizeOptimizer<'a> {
         {
           let dep = self
             .compilation
-            .module_graph
+            .get_module_graph()
             .dependency_by_id(dependency_id)
             .expect("should have dependency");
 
@@ -482,14 +484,14 @@ impl<'a> CodeSizeOptimizer<'a> {
           }
           let module_id_by_dep_id = match self
             .compilation
-            .module_graph
+            .get_module_graph()
             .module_identifier_by_dependency_id(dependency_id)
           {
             Some(module_identifier) => module_identifier,
             None => {
               let module = self
                 .compilation
-                .module_graph
+                .get_module_graph()
                 .module_by_identifier(&module_identifier);
 
               if module
@@ -519,7 +521,7 @@ impl<'a> CodeSizeOptimizer<'a> {
           };
           let dependency = match self
             .compilation
-            .module_graph
+            .get_module_graph()
             .dependency_by_id(dependency_id)
           {
             Some(dep) => dep,
@@ -557,7 +559,7 @@ impl<'a> CodeSizeOptimizer<'a> {
           ) {
             let deps_module_id_of_context_module = self
               .compilation
-              .module_graph
+              .get_module_graph()
               .get_module_all_dependencies(module_id_by_dep_id)
               .map(|deps| {
                 deps
@@ -565,7 +567,7 @@ impl<'a> CodeSizeOptimizer<'a> {
                   .filter_map(|dep| {
                     self
                       .compilation
-                      .module_graph
+                      .get_module_graph()
                       .module_identifier_by_dependency_id(dep)
                       .cloned()
                   })
@@ -601,7 +603,7 @@ impl<'a> CodeSizeOptimizer<'a> {
     for entry_module_ident in self.compilation.entry_module_identifiers.iter() {
       Self::normalize_side_effects(
         *entry_module_ident,
-        &self.compilation.module_graph,
+        &self.compilation.get_module_graph(),
         &mut IdentifierSet::default(),
         &mut side_effect_map,
       );
@@ -743,7 +745,7 @@ impl<'a> CodeSizeOptimizer<'a> {
   ) {
     current_symbol_ref_with_member_chain.0 = current_symbol_ref_with_member_chain
       .0
-      .update_src_from_dep_id(&self.compilation.module_graph);
+      .update_src_from_dep_id(&self.compilation.get_module_graph());
     if visited_symbol_ref.contains(&current_symbol_ref_with_member_chain) {
       return;
     } else {
@@ -1072,11 +1074,11 @@ impl<'a> CodeSizeOptimizer<'a> {
                 // if should_diagnostic {
                 //   let module_path = self
                 //     .compilation
-                //     .module_graph
+                //     .get_module_graph()
                 //     .normal_module_source_path_by_identifier(&module_result.module_identifier);
                 //   let importer_module_path = self
                 //     .compilation
-                //     .module_graph
+                //     .get_module_graph()
                 //     .normal_module_source_path_by_identifier(&indirect_symbol.importer());
                 //   if let (Some(module_path), Some(importer_module_path)) =
                 //     (module_path, importer_module_path)
@@ -1114,7 +1116,7 @@ impl<'a> CodeSizeOptimizer<'a> {
                   .filter_map(|(module_identifier, _)| {
                     self
                       .compilation
-                      .module_graph
+                      .get_module_graph()
                       .normal_module_source_path_by_identifier(module_identifier)
                   })
                   .map(|identifier| {
@@ -1149,7 +1151,7 @@ impl<'a> CodeSizeOptimizer<'a> {
             if is_js_like_uri(&src_module_identifier) {
               let module_path = self
                 .compilation
-                .module_graph
+                .get_module_graph()
                 .normal_module_source_path_by_identifier(&star_symbol.src());
               if let Some(module_path) = module_path {
                 let error_message = format!("Can't get analyze result of {module_path}");
@@ -1499,13 +1501,13 @@ fn get_inherit_export_ref_graph(
 // async fn par_analyze_module(compilation: &mut Compilation) -> IdentifierMap<OptimizeAnalyzeResult> {
 //   let analyze_results = {
 //     compilation
-//       .module_graph
-//       .module_graph_modules()
+//       .get_module_graph()
+//       .get_module_graph()_modules()
 //       .par_iter()
 //       .filter_map(|(module_identifier, mgm)| {
 //         let optimize_analyze_result = if mgm.module_type.is_js_like() {
 //           match compilation
-//             .module_graph
+//             .get_module_graph()
 //             .module_by_identifier(&mgm.module_identifier)
 //             .and_then(|module| module.as_normal_module().and_then(|m| m.ast()))
 //             // A module can missing its AST if the module is failed to build
@@ -1516,7 +1518,7 @@ fn get_inherit_export_ref_graph(
 //               &mgm
 //                 .dependencies
 //                 .iter()
-//                 .filter_map(|id| compilation.module_graph.dependency_by_id(id).cloned())
+//                 .filter_map(|id| compilation.get_module_graph().dependency_by_id(id).cloned())
 //                 .collect::<Vec<_>>(),
 //               *module_identifier,
 //               &compilation.options,

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -137,7 +137,7 @@ pub fn compare_chunk_group(
     Ordering::Greater => Ordering::Less,
     Ordering::Equal => compare_chunks_iterables(
       &compilation.chunk_graph,
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
       chunks_a,
       chunks_b,
     ),

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -137,7 +137,7 @@ pub fn compare_chunk_group(
     Ordering::Greater => Ordering::Less,
     Ordering::Equal => compare_chunks_iterables(
       &compilation.chunk_graph,
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
       chunks_a,
       chunks_b,
     ),

--- a/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_chunk_ids_plugin.rs
@@ -26,8 +26,8 @@ impl Plugin for DeterministicChunkIdsPlugin {
     let mut used_ids = get_used_chunk_ids(compilation);
     let used_ids_len = used_ids.len();
 
-    let chunk_graph = &mut compilation.chunk_graph;
-    let module_graph = &compilation.module_graph;
+    let chunk_graph = &compilation.chunk_graph;
+    let module_graph = compilation.get_module_graph();
     let context = self
       .context
       .clone()

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -40,7 +40,7 @@ pub fn get_used_module_ids_and_modules(
   //   }
 
   compilation
-    .module_graph
+    .get_module_graph()
     .modules()
     .values()
     .for_each(|module| {

--- a/crates/rspack_ids/src/named_chunk_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_chunk_ids_plugin.rs
@@ -28,24 +28,24 @@ impl Plugin for NamedChunkIdsPlugin {
   }
 
   fn chunk_ids(&self, compilation: &mut rspack_core::Compilation) -> rspack_error::Result<()> {
+    // set default value
+    for chunk in compilation.chunk_by_ukey.values_mut() {
+      if let Some(name) = &chunk.name {
+        chunk.id = Some(name.clone());
+        chunk.ids = vec![name.clone()];
+      }
+    }
+
     let mut used_ids = get_used_chunk_ids(compilation);
     let chunk_graph = &compilation.chunk_graph;
-    let module_graph = &compilation.module_graph;
+    let module_graph = compilation.get_module_graph();
     let context = self
       .context
       .clone()
       .unwrap_or_else(|| compilation.options.context.to_string());
-
     let chunks = compilation
       .chunk_by_ukey
-      .values_mut()
-      .map(|chunk| {
-        if let Some(name) = &chunk.name {
-          chunk.id = Some(name.clone());
-          chunk.ids = vec![name.clone()];
-        }
-        chunk
-      })
+      .values()
       .filter(|chunk| chunk.id.is_none())
       .map(|chunk| chunk as &Chunk)
       .collect::<Vec<_>>();

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -501,7 +501,7 @@ impl Plugin for AssetPlugin {
   ) -> PluginRenderManifestHookOutput {
     let compilation = args.compilation;
     let chunk = args.chunk();
-    let module_graph = &compilation.module_graph;
+    let module_graph = &compilation.get_module_graph();
 
     let ordered_modules = compilation
       .chunk_graph
@@ -511,7 +511,7 @@ impl Plugin for AssetPlugin {
       .par_iter()
       .filter(|m| {
         let module = compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(&m.identifier())
           // FIXME: use result
           .expect("Failed to get module");

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -98,7 +98,7 @@ impl DependencyTemplate for CssUrlDependency {
   ) {
     let TemplateContext { compilation, .. } = code_generatable_context;
     if let Some(mgm) = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(self.id())
       && let Some(target_url) = self.get_target_url(&mgm.module_identifier, compilation)
     {

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -284,7 +284,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
 
         module.get_dependencies().iter().for_each(|id| {
           if let Some(dependency) = compilation
-            .module_graph
+            .get_module_graph()
             .dependency_by_id(id)
             .expect("should have dependency")
             .as_dependency_template()

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -180,7 +180,7 @@ impl Plugin for CssPlugin {
     let ordered_modules = Self::get_ordered_chunk_css_modules(
       chunk,
       &compilation.chunk_graph,
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
       compilation,
     );
     let mut hasher = RspackHash::from(&compilation.options.output);
@@ -222,7 +222,7 @@ impl Plugin for CssPlugin {
     let ordered_css_modules = Self::get_ordered_chunk_css_modules(
       chunk,
       &compilation.chunk_graph,
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
       compilation,
     );
 

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -180,7 +180,7 @@ impl Plugin for CssPlugin {
     let ordered_modules = Self::get_ordered_chunk_css_modules(
       chunk,
       &compilation.chunk_graph,
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
       compilation,
     );
     let mut hasher = RspackHash::from(&compilation.options.output);
@@ -222,7 +222,7 @@ impl Plugin for CssPlugin {
     let ordered_css_modules = Self::get_ordered_chunk_css_modules(
       chunk,
       &compilation.chunk_graph,
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
       compilation,
     );
 

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -135,7 +135,7 @@ pub fn css_modules_exports_to_string(
             .get_dependencies()
             .iter()
             .find_map(|id| {
-              let dependency = compilation.module_graph.dependency_by_id(id);
+              let dependency = compilation.get_module_graph().dependency_by_id(id);
               let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
                 Some(d.request())
               } else {
@@ -147,7 +147,7 @@ pub fn css_modules_exports_to_string(
                 && request == from_name
               {
                 return compilation
-                  .module_graph
+                  .get_module_graph()
                   .module_graph_module_by_dependency_id(id);
               }
               None
@@ -194,7 +194,7 @@ pub fn css_modules_exports_to_concatenate_module_string(
             .get_dependencies()
             .iter()
             .find_map(|id| {
-              let dependency = compilation.module_graph.dependency_by_id(id);
+              let dependency = compilation.get_module_graph().dependency_by_id(id);
               let request = if let Some(d) = dependency.and_then(|d| d.as_module_dependency()) {
                 Some(d.request())
               } else {
@@ -206,7 +206,7 @@ pub fn css_modules_exports_to_concatenate_module_string(
                 && request == from_name
               {
                 return compilation
-                  .module_graph
+                  .get_module_graph()
                   .module_graph_module_by_dependency_id(id);
               }
               None

--- a/crates/rspack_plugin_devtool/src/lib.rs
+++ b/crates/rspack_plugin_devtool/src/lib.rs
@@ -253,7 +253,10 @@ impl SourceMapDevToolPluginInner {
           let module_or_source = if let Some(stripped) = source.strip_prefix("webpack://") {
             let source = make_paths_absolute(compilation.options.context.as_str(), stripped);
             let identifier = ModuleIdentifier::from(source.clone());
-            match compilation.module_graph.module_by_identifier(&identifier) {
+            match compilation
+              .get_module_graph()
+              .module_by_identifier(&identifier)
+            {
               Some(module) => ModuleOrSource::Module(module.identifier()),
               None => ModuleOrSource::Source(source),
             }
@@ -281,7 +284,10 @@ impl SourceMapDevToolPluginInner {
             let module_or_source = if let Some(stripped) = source.strip_prefix("webpack://") {
               let source = make_paths_absolute(compilation.options.context.as_str(), stripped);
               let identifier = ModuleIdentifier::from(source.clone());
-              match compilation.module_graph.module_by_identifier(&identifier) {
+              match compilation
+                .get_module_graph()
+                .module_by_identifier(&identifier)
+              {
                 Some(module) => ModuleOrSource::Module(module.identifier()),
                 None => ModuleOrSource::Source(source),
               }
@@ -611,7 +617,6 @@ impl ModuleFilenameHelpers {
   ) -> ModuleFilenameTemplateFnCtx {
     let Compilation {
       chunk_graph,
-      module_graph,
       options,
       ..
     } = compilation;
@@ -619,7 +624,8 @@ impl ModuleFilenameHelpers {
 
     match module_or_source {
       ModuleOrSource::Module(module_identifier) => {
-        let module = module_graph
+        let module = compilation
+          .get_module_graph()
           .module_by_identifier(module_identifier)
           .expect("failed to find a module for the given identifier");
 

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -67,7 +67,7 @@ impl Plugin for EnsureChunkConditionsPlugin {
                   .module_by_identifier(module_id)
                 {
                   if matches!(module.chunk_condition(chunk, compilation), Some(true)) {
-                    target_chunks.insert(chunk.clone());
+                    target_chunks.insert(*chunk);
                     continue 'out;
                   }
                 }

--- a/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
+++ b/crates/rspack_plugin_ensure_chunk_conditions/src/lib.rs
@@ -25,7 +25,7 @@ impl Plugin for EnsureChunkConditionsPlugin {
 
     let mut source_module_chunks = HashMap::new();
     compilation
-      .module_graph
+      .get_module_graph()
       .modules()
       .iter()
       .for_each(|(module_id, module)| {
@@ -41,7 +41,7 @@ impl Plugin for EnsureChunkConditionsPlugin {
           })
           .collect::<Vec<_>>();
         if !source_chunks.is_empty() {
-          source_module_chunks.insert(module_id, source_chunks);
+          source_module_chunks.insert(*module_id, source_chunks);
         }
       });
 
@@ -62,9 +62,12 @@ impl Plugin for EnsureChunkConditionsPlugin {
               get_chunk_group_from_ukey(chunk_group_key, &compilation.chunk_group_by_ukey)
             {
               for chunk in &chunk_group.chunks {
-                if let Some(module) = compilation.module_graph.module_by_identifier(module_id) {
+                if let Some(module) = compilation
+                  .get_module_graph()
+                  .module_by_identifier(module_id)
+                {
                   if matches!(module.chunk_condition(chunk, compilation), Some(true)) {
-                    target_chunks.insert(chunk);
+                    target_chunks.insert(chunk.clone());
                     continue 'out;
                   }
                 }
@@ -87,21 +90,21 @@ impl Plugin for EnsureChunkConditionsPlugin {
       }
       target_module_chunks.insert(*module_id, target_chunks);
     }
+
+    let mut chunk_graph = std::mem::take(&mut compilation.chunk_graph);
     for (module_id, chunks) in source_module_chunks {
       for chunk in chunks {
-        compilation
-          .chunk_graph
-          .disconnect_chunk_and_module(&chunk, module_id.to_owned());
+        chunk_graph.disconnect_chunk_and_module(&chunk, module_id.to_owned());
       }
     }
 
     for (module_id, chunks) in target_module_chunks {
       for chunk in chunks {
-        compilation
-          .chunk_graph
-          .connect_chunk_and_module(chunk.to_owned(), module_id.to_owned());
+        chunk_graph.connect_chunk_and_module(chunk, module_id);
       }
     }
+    compilation.chunk_graph = chunk_graph;
+
     logger.time_end(start);
 
     Ok(())

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -198,7 +198,7 @@ impl AsyncSeries<Compilation> for HotModuleReplacementPluginProcessAssetsHook {
 
         for module_identifier in new_modules.iter() {
           if let Some(module) = compilation
-            .module_graph
+            .get_module_graph()
             .module_by_identifier(module_identifier)
           {
             module.hash(&mut chunk_hash);

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -286,10 +286,10 @@ impl DependencyTemplate for CommonJsExportRequireDependency {
       ..
     } = code_generatable_context;
 
-    let mg = &compilation.module_graph;
+    let mg = &compilation.get_module_graph();
 
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -119,16 +119,16 @@ impl DependencyTemplate for CommonJsExportsDependency {
     } = code_generatable_context;
 
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
     let used = compilation
-      .module_graph
+      .get_module_graph()
       .get_exports_info(&module.identifier())
       .id
       .get_used_name(
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
         *runtime,
         UsedName::Vec(self.names.clone()),
       );

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -128,7 +128,7 @@ impl DependencyTemplate for CommonJsExportsDependency {
       .get_exports_info(&module.identifier())
       .id
       .get_used_name(
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
         *runtime,
         UsedName::Vec(self.names.clone()),
       );

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -125,15 +125,15 @@ impl DependencyTemplate for CommonJsFullRequireDependency {
     );
 
     if let Some(imported_module) = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(&self.id)
     {
       let used = compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&imported_module.module_identifier)
         .id
         .get_used_name(
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
           *runtime,
           UsedName::Vec(self.names.clone()),
         );

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -133,7 +133,7 @@ impl DependencyTemplate for CommonJsFullRequireDependency {
         .get_exports_info(&imported_module.module_identifier)
         .id
         .get_used_name(
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
           *runtime,
           UsedName::Vec(self.names.clone()),
         );

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -87,17 +87,17 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
     } = code_generatable_context;
 
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
 
     let used = if self.names.is_empty() {
       compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&module.identifier())
         .id
         .get_used_name(
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
           *runtime,
           UsedName::Vec(self.names.clone()),
         )

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -97,7 +97,7 @@ impl DependencyTemplate for CommonJsSelfReferenceDependency {
         .get_exports_info(&module.identifier())
         .id
         .get_used_name(
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
           *runtime,
           UsedName::Vec(self.names.clone()),
         )

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -34,7 +34,7 @@ impl DependencyTemplate for ModuleDecoratorDependency {
     runtime_requirements.insert(self.decorator);
 
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
     let module_argument = module.get_module_argument();

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -102,7 +102,7 @@ impl DependencyTemplate for CommonJsRequireContextDependency {
     );
 
     if compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(&self.id)
       .is_none()
     {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -102,7 +102,7 @@ impl DependencyTemplate for ImportContextDependency {
     );
 
     if compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(&self.id)
       .is_none()
     {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -86,7 +86,7 @@ impl DependencyTemplate for ImportMetaContextDependency {
     } = code_generatable_context;
 
     let module_id = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(&self.id)
       .map(|m| m.id(&compilation.chunk_graph))
       .expect("should have dependency id");

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -86,7 +86,7 @@ impl DependencyTemplate for RequireContextDependency {
     } = code_generatable_context;
 
     let module_id = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(&self.id)
       .map(|m| m.id(&compilation.chunk_graph))
       .expect("should have dependency id");

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
@@ -37,7 +37,7 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
     if !matches!(
       exports_info
         .id
-        .get_read_only_export_info(&Atom::from("__esModule"), &compilation.get_module_graph())
+        .get_read_only_export_info(&Atom::from("__esModule"), compilation.get_module_graph())
         .get_used(*runtime),
       UsageState::Unused
     ) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_compatibility_dependency.rs
@@ -28,16 +28,16 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
       return;
     }
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
     let exports_info = compilation
-      .module_graph
+      .get_module_graph()
       .get_exports_info(&module.identifier());
     if !matches!(
       exports_info
         .id
-        .get_read_only_export_info(&Atom::from("__esModule"), &compilation.module_graph)
+        .get_read_only_export_info(&Atom::from("__esModule"), &compilation.get_module_graph())
         .get_used(*runtime),
       UsageState::Unused
     ) {
@@ -57,7 +57,9 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
     }
 
     if matches!(
-      compilation.module_graph.is_async(&module.identifier()),
+      compilation
+        .get_module_graph()
+        .is_async(&module.identifier()),
       Some(true)
     ) {
       runtime_requirements.insert(RuntimeGlobals::MODULE);
@@ -67,7 +69,7 @@ impl DependencyTemplate for HarmonyCompatibilityDependency {
           "{}({}, async function (__webpack_handle_async_dependencies__, __webpack_async_result__) {{ try {{\n",
           RuntimeGlobals::ASYNC_MODULE,
           compilation
-            .module_graph
+            .get_module_graph()
             .module_by_identifier(&module.identifier())
             .expect("should have mgm")
             .get_module_argument()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
@@ -108,7 +108,7 @@ impl DependencyTemplate for HarmonyExportExpressionDependency {
           .get_exports_info(module_identifier)
           .id
           .get_used_name(
-            &compilation.get_module_graph(),
+            compilation.get_module_graph(),
             *runtime,
             UsedName::Str(name.into()),
           )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
@@ -104,17 +104,17 @@ impl DependencyTemplate for HarmonyExportExpressionDependency {
     ) -> Option<UsedName> {
       if compilation.options.is_new_tree_shaking() {
         compilation
-          .module_graph
+          .get_module_graph()
           .get_exports_info(module_identifier)
           .id
           .get_used_name(
-            &compilation.module_graph,
+            &compilation.get_module_graph(),
             *runtime,
             UsedName::Str(name.into()),
           )
       } else if compilation.options.builtins.tree_shaking.is_true() {
         compilation
-          .module_graph
+          .get_module_graph()
           .get_exports_info(module_identifier)
           .old_get_used_exports()
           .contains(&name.into())

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -857,7 +857,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
 
     let mode = self.get_mode(
       self.name.clone(),
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
       &self.id,
       *runtime,
     );
@@ -877,7 +877,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
       .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
 
-    let import_var = get_import_var(&compilation.get_module_graph(), self.id);
+    let import_var = get_import_var(compilation.get_module_graph(), self.id);
     let is_new_treeshaking = compilation.options.is_new_tree_shaking();
 
     let mut used_exports = if is_new_treeshaking {
@@ -891,7 +891,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
         .filter_map(|(local, _)| {
           exports_info_id
             .get_used_name(
-              &compilation.get_module_graph(),
+              compilation.get_module_graph(),
               *runtime,
               UsedName::Str(local.clone()),
             )

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -466,7 +466,7 @@ impl HarmonyExportImportedSpecifierDependency {
       ..
     } = ctxt;
     let mut fragments = vec![];
-    let mg = &compilation.module_graph;
+    let mg = &compilation.get_module_graph();
     let imported_module = mg
       .module_identifier_by_dependency_id(&self.id)
       .expect("should have imported module identifier");
@@ -675,12 +675,12 @@ impl HarmonyExportImportedSpecifierDependency {
         runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
 
         let module = compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(&module.identifier())
           .expect("should have module graph module");
         let exports_name = module.get_exports_argument();
         let is_async = compilation
-          .module_graph
+          .get_module_graph()
           .is_async(&module.identifier())
           .unwrap_or_default();
         fragments.push(
@@ -729,7 +729,7 @@ impl HarmonyExportImportedSpecifierDependency {
       format!("/* {} */ {}", comment, return_value).into(),
     ));
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
     HarmonyExportInitFragment::new(module.get_exports_argument(), export_map)
@@ -750,7 +750,7 @@ impl HarmonyExportImportedSpecifierDependency {
     } = ctxt;
 
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
     runtime_requirements.insert(RuntimeGlobals::EXPORTS);
@@ -813,7 +813,7 @@ impl HarmonyExportImportedSpecifierDependency {
     } = ctxt;
     let return_value = Self::get_return_value(name.to_string(), value_key);
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm");
     let exports_name = module.get_exports_argument();
@@ -857,7 +857,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
 
     let mode = self.get_mode(
       self.name.clone(),
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
       &self.id,
       *runtime,
     );
@@ -873,16 +873,16 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
     }
 
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
 
-    let import_var = get_import_var(&compilation.module_graph, self.id);
+    let import_var = get_import_var(&compilation.get_module_graph(), self.id);
     let is_new_treeshaking = compilation.options.is_new_tree_shaking();
 
     let mut used_exports = if is_new_treeshaking {
       let exports_info_id = compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&module.identifier())
         .id;
       let res = self
@@ -891,7 +891,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
         .filter_map(|(local, _)| {
           exports_info_id
             .get_used_name(
-              &compilation.module_graph,
+              &compilation.get_module_graph(),
               *runtime,
               UsedName::Str(local.clone()),
             )
@@ -905,7 +905,7 @@ impl DependencyTemplate for HarmonyExportImportedSpecifierDependency {
     } else if compilation.options.builtins.tree_shaking.is_true() {
       Some(
         compilation
-          .module_graph
+          .get_module_graph()
           .get_exports_info(&module.identifier())
           .old_get_used_exports()
           .into_iter()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -83,17 +83,17 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
       return;
     }
     let module = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have module graph module");
 
     let used_name = if compilation.options.is_new_tree_shaking() {
       let exports_info_id = compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&module.identifier())
         .id;
       let used_name = exports_info_id.get_used_name(
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
         *runtime,
         UsedName::Str(self.name.clone()),
       );
@@ -107,7 +107,7 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
       })
     } else if compilation.options.builtins.tree_shaking.is_true() {
       compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&module.identifier())
         .old_get_used_exports()
         .contains(&self.name)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -93,7 +93,7 @@ impl DependencyTemplate for HarmonyExportSpecifierDependency {
         .get_exports_info(&module.identifier())
         .id;
       let used_name = exports_info_id.get_used_name(
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
         *runtime,
         UsedName::Str(self.name.clone()),
       );

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -107,7 +107,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
       .get_module_graph()
       .connection_by_dependency(module_dependency.id());
     if let Some(con) = connection {
-      Some(con.is_target_active(&compilation.get_module_graph(), *runtime))
+      Some(con.is_target_active(compilation.get_module_graph(), *runtime))
     } else {
       Some(true)
     }
@@ -195,7 +195,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
     .connection_by_dependency(module_dependency.id())
   {
     filter_runtime(*runtime, |r| {
-      connection.is_target_active(&compilation.get_module_graph(), r)
+      connection.is_target_active(compilation.get_module_graph(), r)
     })
   } else {
     RuntimeCondition::Boolean(true)
@@ -219,7 +219,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
   let ref_module = compilation
     .get_module_graph()
     .module_identifier_by_dependency_id(module_dependency.id());
-  let import_var = get_import_var(&compilation.get_module_graph(), *module_dependency.id());
+  let import_var = get_import_var(compilation.get_module_graph(), *module_dependency.id());
   //
   // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/dependencies/HarmonyImportDependency.js#L282-L285
   let module_key = ref_module

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -100,14 +100,14 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
   } = code_generatable_context;
   // Only available when module factorization is successful.
   let ref_mgm = compilation
-    .module_graph
+    .get_module_graph()
     .module_graph_module_by_dependency_id(module_dependency.id());
   let is_target_active = if compilation.options.is_new_tree_shaking() {
     let connection = compilation
-      .module_graph
+      .get_module_graph()
       .connection_by_dependency(module_dependency.id());
     if let Some(con) = connection {
-      Some(con.is_target_active(&compilation.module_graph, *runtime))
+      Some(con.is_target_active(&compilation.get_module_graph(), *runtime))
     } else {
       Some(true)
     }
@@ -191,11 +191,11 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
   }
 
   let runtime_condition = if let Some(connection) = compilation
-    .module_graph
+    .get_module_graph()
     .connection_by_dependency(module_dependency.id())
   {
     filter_runtime(*runtime, |r| {
-      connection.is_target_active(&compilation.module_graph, r)
+      connection.is_target_active(&compilation.get_module_graph(), r)
     })
   } else {
     RuntimeCondition::Boolean(true)
@@ -217,9 +217,9 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
     ..
   } = code_generatable_context;
   let ref_module = compilation
-    .module_graph
+    .get_module_graph()
     .module_identifier_by_dependency_id(module_dependency.id());
-  let import_var = get_import_var(&compilation.module_graph, *module_dependency.id());
+  let import_var = get_import_var(&compilation.get_module_graph(), *module_dependency.id());
   //
   // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/dependencies/HarmonyImportDependency.js#L282-L285
   let module_key = ref_module
@@ -257,7 +257,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
     }
   }
 
-  let is_async_module = matches!(ref_module, Some(ref_module) if compilation.module_graph.is_async(ref_module) == Some(true));
+  let is_async_module = matches!(ref_module, Some(ref_module) if compilation.get_module_graph().is_async(ref_module) == Some(true));
   if is_async_module {
     init_fragments.push(Box::new(ConditionalInitFragment::new(
       content.0,
@@ -292,7 +292,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
     runtime_requirements.insert(RuntimeGlobals::EXPORT_STAR);
     runtime_requirements.insert(RuntimeGlobals::REQUIRE);
     let exports_argument = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm")
       .get_exports_argument();
@@ -418,7 +418,7 @@ impl DependencyTemplate for HarmonyImportSideEffectDependency {
     } = code_generatable_context;
     if let Some(scope) = concatenation_scope {
       let module = compilation
-        .module_graph
+        .get_module_graph()
         .get_module(&self.id)
         .expect("should have module");
       if scope.is_module_in_scope(&module.identifier()) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -166,7 +166,7 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
         .get_module_graph()
         .connection_by_dependency(&self.id);
       let is_target_active = if let Some(con) = connection {
-        con.is_target_active(&compilation.get_module_graph(), *runtime)
+        con.is_target_active(compilation.get_module_graph(), *runtime)
       } else {
         true
       };
@@ -189,8 +189,8 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
       return;
     }
 
-    let ids = self.get_ids(&compilation.get_module_graph());
-    let import_var = get_import_var(&compilation.get_module_graph(), self.id);
+    let ids = self.get_ids(compilation.get_module_graph());
+    let import_var = get_import_var(compilation.get_module_graph(), self.id);
 
     let export_expr = if let Some(scope) = concatenation_scope
       && let Some(con) = compilation

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -88,7 +88,7 @@ impl HarmonyImportSpecifierDependency {
       return true;
     }
     let related_symbol = compilation
-      .module_graph
+      .get_module_graph()
       .get_parent_module(&self.id)
       .and_then(|parent_module| compilation.optimize_analyze_result_map.get(parent_module))
       .and_then(|analyze_res| {
@@ -105,12 +105,12 @@ impl HarmonyImportSpecifierDependency {
     match &self.specifier {
       Specifier::Namespace(_) => true,
       Specifier::Default(_) => compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&reference_mgm.module_identifier)
         .old_get_used_exports()
         .contains(&DEFAULT_JS_WORD),
       Specifier::Named(local, imported) => compilation
-        .module_graph
+        .get_module_graph()
         .get_exports_info(&reference_mgm.module_identifier)
         .old_get_used_exports()
         .contains(imported.as_ref().unwrap_or(local)),
@@ -158,13 +158,15 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
 
     // Only available when module factorization is successful.
     let reference_mgm = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_dependency_id(&self.id);
     let is_new_treeshaking = compilation.options.is_new_tree_shaking();
     if is_new_treeshaking {
-      let connection = compilation.module_graph.connection_by_dependency(&self.id);
+      let connection = compilation
+        .get_module_graph()
+        .connection_by_dependency(&self.id);
       let is_target_active = if let Some(con) = connection {
-        con.is_target_active(&compilation.module_graph, *runtime)
+        con.is_target_active(&compilation.get_module_graph(), *runtime)
       } else {
         true
       };
@@ -187,11 +189,13 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
       return;
     }
 
-    let ids = self.get_ids(&compilation.module_graph);
-    let import_var = get_import_var(&compilation.module_graph, self.id);
+    let ids = self.get_ids(&compilation.get_module_graph());
+    let import_var = get_import_var(&compilation.get_module_graph(), self.id);
 
     let export_expr = if let Some(scope) = concatenation_scope
-      && let Some(con) = compilation.module_graph.connection_by_dependency(&self.id)
+      && let Some(con) = compilation
+        .get_module_graph()
+        .connection_by_dependency(&self.id)
       && scope.is_module_in_scope(&con.module_identifier)
     {
       if ids.is_empty() {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -83,7 +83,7 @@ impl DependencyTemplate for ImportDependency {
   ) {
     let block = code_generatable_context
       .compilation
-      .module_graph
+      .get_module_graph()
       .get_parent_block(&self.id);
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -97,7 +97,7 @@ impl DependencyTemplate for ImportEagerDependency {
   ) {
     let block = code_generatable_context
       .compilation
-      .module_graph
+      .get_module_graph()
       .get_parent_block(&self.id);
     source.replace(
       self.start,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -78,14 +78,17 @@ impl DependencyTemplate for ProvideDependency {
       init_fragments,
       ..
     } = code_generatable_context;
-    let Some(con) = compilation.module_graph.connection_by_dependency(&self.id) else {
+    let Some(con) = compilation
+      .get_module_graph()
+      .connection_by_dependency(&self.id)
+    else {
       unreachable!();
     };
     let exports_info = compilation
-      .module_graph
+      .get_module_graph()
       .get_exports_info(&con.module_identifier);
     let used_name = exports_info.id.get_used_name(
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
       *runtime,
       UsedName::Vec(self.ids.clone()),
     );

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -88,7 +88,7 @@ impl DependencyTemplate for ProvideDependency {
       .get_module_graph()
       .get_exports_info(&con.module_identifier);
     let used_name = exports_info.id.get_used_name(
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
       *runtime,
       UsedName::Vec(self.ids.clone()),
     );

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_api_dep.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_api_dep.rs
@@ -74,7 +74,7 @@ impl ExportInfoApiDependency {
             Some(exports_info.get_used(
               rspack_core::UsedName::Str(export_name.clone()),
               *runtime,
-              &compilation.get_module_graph(),
+              compilation.get_module_graph(),
             ))
           } else {
             Some(export_info.usage_state)

--- a/crates/rspack_plugin_javascript/src/dependency/export_info_api_dep.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/export_info_api_dep.rs
@@ -60,21 +60,21 @@ impl ExportInfoApiDependency {
         "used" => {
           let id = module.identifier();
           let mgm = compilation
-            .module_graph
+            .get_module_graph()
             .module_graph_module_by_identifier(&id)?;
           let exports_info = compilation
-            .module_graph
+            .get_module_graph()
             .get_exports_info_by_id(&mgm.exports);
           let info_id = exports_info.exports.get(export_name)?;
           let export_info = compilation
-            .module_graph
+            .get_module_graph()
             .export_info_map
             .try_get(**info_id as usize)?;
           if compilation.options.is_new_tree_shaking() {
             Some(exports_info.get_used(
               rspack_core::UsedName::Str(export_name.clone()),
               *runtime,
-              &compilation.module_graph,
+              &compilation.get_module_graph(),
             ))
           } else {
             Some(export_info.usage_state)

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/harmony_accept_dependency.rs
@@ -41,9 +41,9 @@ impl DependencyTemplate for HarmonyAcceptDependency {
     let mut content = String::default();
 
     self.dependency_ids.iter().for_each(|id| {
-      let dependency = compilation.module_graph.dependency_by_id(id);
+      let dependency = compilation.get_module_graph().dependency_by_id(id);
       let runtime_condition =
-        match dependency.and_then(|dep| compilation.module_graph.get_module(dep.id())) {
+        match dependency.and_then(|dep| compilation.get_module_graph().get_module(dep.id())) {
           Some(ref_module) => {
             get_import_emitted_runtime(&module.identifier(), &ref_module.identifier())
           }

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -66,7 +66,7 @@ impl DependencyTemplate for WebpackIsIncludedDependency {
     let TemplateContext { compilation, .. } = code_generatable_context;
 
     let included = compilation
-      .module_graph
+      .get_module_graph()
       .connection_by_dependency(&self.id)
       .map(|connection| {
         compilation

--- a/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/module_argument_dependency.rs
@@ -31,7 +31,7 @@ impl DependencyTemplate for ModuleArgumentDependency {
     runtime_requirements.insert(RuntimeGlobals::MODULE);
 
     let module_argument = compilation
-      .module_graph
+      .get_module_graph()
       .module_by_identifier(&module.identifier())
       .expect("should have mgm")
       .get_module_argument();

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -66,7 +66,7 @@ impl DependencyTemplate for PureExpressionDependency {
             exports_info.get_used(
               UsedName::Str(id.clone()),
               cur_runtime,
-              &ctx.compilation.get_module_graph(),
+              ctx.compilation.get_module_graph(),
             ) != UsageState::Unused
           })
         });

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -58,7 +58,7 @@ impl DependencyTemplate for PureExpressionDependency {
       Some(UsedByExports::Set(ref set)) => {
         let exports_info = ctx
           .compilation
-          .module_graph
+          .get_module_graph()
           .get_exports_info(&self.module_identifier);
         let runtime = ctx.runtime;
         let runtime_condition = filter_runtime(runtime, |cur_runtime| {
@@ -66,7 +66,7 @@ impl DependencyTemplate for PureExpressionDependency {
             exports_info.get_used(
               UsedName::Str(id.clone()),
               cur_runtime,
-              &ctx.compilation.module_graph,
+              &ctx.compilation.get_module_graph(),
             ) != UsageState::Unused
           })
         });

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -89,7 +89,7 @@ impl DependencyTemplate for WorkerDependency {
       ..
     } = code_generatable_context;
     let chunk_id = compilation
-      .module_graph
+      .get_module_graph()
       .get_parent_block(&self.id)
       .and_then(|block| {
         compilation

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -55,7 +55,7 @@ impl JavaScriptParserAndGenerator {
     context: &mut TemplateContext,
   ) {
     if let Some(dependency) = compilation
-      .module_graph
+      .get_module_graph()
       .dependency_by_id(dependency_id)
       .expect("should have dependency")
       .as_dependency_template()

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -369,7 +369,7 @@ impl Plugin for FlagDependencyExportsPlugin {
   }
 
   async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
-    let mut proxy = FlagDependencyExportsProxy::new(&mut compilation.module_graph);
+    let mut proxy = FlagDependencyExportsProxy::new(compilation.get_module_graph_mut());
     proxy.apply();
     Ok(())
   }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -168,7 +168,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           continue;
         };
         let active_state =
-          connection.get_active_state(&self.compilation.get_module_graph(), runtime.as_ref());
+          connection.get_active_state(self.compilation.get_module_graph(), runtime.as_ref());
 
         // dbg!(
         //   &connection,
@@ -200,7 +200,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           .expect("should have dep");
 
         let referenced_exports = if let Some(md) = dep.as_module_dependency() {
-          md.get_referenced_exports(&self.compilation.get_module_graph(), runtime.as_ref())
+          md.get_referenced_exports(self.compilation.get_module_graph(), runtime.as_ref())
         } else if dep.as_context_dependency().is_some() {
           vec![ExtendedReferencedExport::Array(vec![])]
         } else {
@@ -378,7 +378,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             let last_one = i == len - 1;
             if !last_one {
               let nested_info =
-                export_info_id.get_nested_exports_info(&self.compilation.get_module_graph());
+                export_info_id.get_nested_exports_info(self.compilation.get_module_graph());
               // dbg!(&nested_info);
               if let Some(nested_info) = nested_info {
                 let changed_flag = export_info_id.set_used_conditionally(

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -193,7 +193,7 @@ impl Plugin for JsPlugin {
     let mut ordered_modules = compilation.chunk_graph.get_chunk_modules_by_source_type(
       &args.chunk_ukey,
       SourceType::JavaScript,
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
     );
     // SAFETY: module identifier is unique
     ordered_modules.sort_unstable_by_key(|m| m.identifier().as_str());
@@ -248,7 +248,7 @@ impl Plugin for JsPlugin {
       if !chunk_has_js(
         &args.chunk_ukey,
         &compilation.chunk_graph,
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
       ) {
         return Ok(vec![].with_empty_diagnostic());
       }

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -193,7 +193,7 @@ impl Plugin for JsPlugin {
     let mut ordered_modules = compilation.chunk_graph.get_chunk_modules_by_source_type(
       &args.chunk_ukey,
       SourceType::JavaScript,
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
     );
     // SAFETY: module identifier is unique
     ordered_modules.sort_unstable_by_key(|m| m.identifier().as_str());
@@ -248,7 +248,7 @@ impl Plugin for JsPlugin {
       if !chunk_has_js(
         &args.chunk_ukey,
         &compilation.chunk_graph,
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
       ) {
         return Ok(vec![].with_empty_diagnostic());
       }

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -20,7 +20,7 @@ impl Plugin for InferAsyncModulesPlugin {
     let mut uniques = HashSet::new();
 
     let mut modules: Vec<Identifier> = compilation
-      .module_graph
+      .get_module_graph()
       .modules()
       .values()
       .filter(|m| {
@@ -35,7 +35,7 @@ impl Plugin for InferAsyncModulesPlugin {
 
     modules.retain(|m| queue.insert(*m));
 
-    let module_graph = &mut compilation.module_graph;
+    let module_graph = compilation.get_module_graph_mut();
 
     while let Some(module) = queue.pop_front() {
       module_graph.set_async(&module);

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -49,7 +49,7 @@ impl Plugin for MangleExportsPlugin {
   async fn optimize_code_generation(&self, compilation: &mut Compilation) -> Result<Option<()>> {
     // TODO: should bailout if compilation.moduleMemCache is enable, https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/MangleExportsPlugin.js#L160-L164
     // We don't do that cause we don't have this option
-    let mg = &mut compilation.module_graph;
+    let mg = compilation.get_module_graph_mut();
     let module_id_list = mg
       .module_identifier_to_module
       .keys()

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -203,7 +203,7 @@ impl JsPlugin {
             })
             .collect::<Vec<_>>();
           let module_id = compilation
-            .module_graph
+            .get_module_graph()
             .module_graph_module_by_identifier(module)
             .map(|module| module.id(&compilation.chunk_graph))
             .expect("should have module id");

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -196,12 +196,12 @@ impl ModuleConcatenationPlugin {
     statistics: &mut Statistics,
   ) -> Option<Warning> {
     let Compilation {
-      module_graph,
       chunk_graph,
       options,
       chunk_by_ukey,
       ..
     } = compilation;
+    let module_graph = compilation.get_module_graph();
     if let Some(cache_entry) = failure_cache.get(module_id) {
       statistics.cached += 1;
       return Some(cache_entry.clone());
@@ -265,7 +265,7 @@ impl ModuleConcatenationPlugin {
     if let Some(incoming_connections_from_non_modules) = incoming_connections.get(&None) {
       let active_non_modules_connections = incoming_connections_from_non_modules
         .iter()
-        .filter(|&connection| connection.is_active(&compilation.module_graph, runtime))
+        .filter(|&connection| connection.is_active(&compilation.get_module_graph(), runtime))
         .collect::<Vec<_>>();
 
       // TODO: ADD module connection explanations
@@ -321,7 +321,7 @@ impl ModuleConcatenationPlugin {
 
         let active_connections: Vec<_> = connections
           .iter()
-          .filter(|&connection| connection.is_active(&compilation.module_graph, runtime))
+          .filter(|&connection| connection.is_active(&compilation.get_module_graph(), runtime))
           .cloned()
           .collect();
 
@@ -350,7 +350,7 @@ impl ModuleConcatenationPlugin {
           .iter()
           .map(|&mid| {
             let m = compilation
-              .module_graph
+              .get_module_graph()
               .module_by_identifier(mid)
               .expect("should have module");
             m.readable_identifier(&compilation.options.context)
@@ -377,7 +377,7 @@ impl ModuleConcatenationPlugin {
         .iter()
         .filter(|&connection| {
           if let Some(dep) = compilation
-            .module_graph
+            .get_module_graph()
             .dependency_by_id(&connection.dependency_id)
           {
             !is_harmony_dep_like(dep)
@@ -399,7 +399,7 @@ impl ModuleConcatenationPlugin {
           .iter()
           .map(|(origin_module, connections)| {
             let module = compilation
-              .module_graph
+              .get_module_graph()
               .module_by_identifier(origin_module)
               .expect("should have module");
             let readable_identifier = module.readable_identifier(&compilation.options.context);
@@ -407,7 +407,7 @@ impl ModuleConcatenationPlugin {
               .iter()
               .filter_map(|item| {
                 let dep = compilation
-                  .module_graph
+                  .get_module_graph()
                   .dependency_by_id(&item.dependency_id)?;
                 Some(dep.dependency_type().to_string())
               })
@@ -442,7 +442,7 @@ impl ModuleConcatenationPlugin {
         let mut current_runtime_condition = RuntimeCondition::Boolean(false);
         for connection in connections {
           let runtime_condition = filter_runtime(Some(runtime), |runtime| {
-            connection.is_target_active(&compilation.module_graph, runtime)
+            connection.is_target_active(&compilation.get_module_graph(), runtime)
           });
 
           if runtime_condition == RuntimeCondition::Boolean(false) {
@@ -478,7 +478,7 @@ impl ModuleConcatenationPlugin {
               .iter()
               .map(|(origin_module, runtime_condition)| {
                 let module = compilation
-                  .module_graph
+                  .get_module_graph()
                   .module_by_identifier(origin_module)
                   .expect("should have module");
                 let readable_identifier = module.readable_identifier(&compilation.options.context);
@@ -531,7 +531,7 @@ impl ModuleConcatenationPlugin {
         return Some(problem);
       }
     }
-    for imp in Self::get_imports(&compilation.module_graph, *module_id, runtime) {
+    for imp in Self::get_imports(&compilation.get_module_graph(), *module_id, runtime) {
       candidates.insert(imp);
     }
     statistics.added += 1;
@@ -548,7 +548,7 @@ impl Plugin for ModuleConcatenationPlugin {
     let mut possible_inners = HashSet::default();
     let start = logger.time("select relevant modules");
     let module_id_list = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_modules()
       .keys()
       .copied()
@@ -556,18 +556,20 @@ impl Plugin for ModuleConcatenationPlugin {
     for module_id in module_id_list {
       let mut can_be_root = true;
       let mut can_be_inner = true;
-      let m = compilation.module_graph.module_by_identifier(&module_id);
+      let m = compilation
+        .get_module_graph()
+        .module_by_identifier(&module_id);
       // If the result is `None`, that means we have some differences with webpack,
       // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ModuleConcatenationPlugin.js#L168-L171
       if compilation
-        .module_graph
+        .get_module_graph()
         .is_async(&module_id)
         .expect("should have async result")
       {
         self.set_bailout_reason(
           &module_id,
           "Module is async".to_string(),
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
         );
         continue;
       }
@@ -580,7 +582,7 @@ impl Plugin for ModuleConcatenationPlugin {
         self.set_bailout_reason(
           &module_id,
           "Module is not in strict mode".to_string(),
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
         );
         continue;
       }
@@ -592,19 +594,20 @@ impl Plugin for ModuleConcatenationPlugin {
         self.set_bailout_reason(
           &module_id,
           "Module is not in any chunk".to_string(),
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
         );
         continue;
       }
-      let exports_info = compilation.module_graph.get_exports_info(&module_id);
-      let relevnat_epxorts = exports_info.get_relevant_exports(None, &compilation.module_graph);
+      let exports_info = compilation.get_module_graph().get_exports_info(&module_id);
+      let relevnat_epxorts =
+        exports_info.get_relevant_exports(None, &compilation.get_module_graph());
       let unknown_exports = relevnat_epxorts
         .iter()
         .filter(|id| {
           let export_info = id
-            .get_export_info_mut(&mut compilation.module_graph)
+            .get_export_info_mut(compilation.get_module_graph_mut())
             .clone();
-          MutexModuleGraph::new(&mut compilation.module_graph).with_lock(|mut mga| {
+          MutexModuleGraph::new(compilation.get_module_graph_mut()).with_lock(|mut mga| {
             export_info.is_reexport() && export_info.id.get_target(&mut mga, None).is_none()
           })
         })
@@ -614,7 +617,7 @@ impl Plugin for ModuleConcatenationPlugin {
         let bailout_reason = unknown_exports
           .into_iter()
           .map(|id| {
-            let export_info = id.get_export_info(&compilation.module_graph);
+            let export_info = id.get_export_info(&compilation.get_module_graph());
             let name = export_info
               .name
               .as_ref()
@@ -623,7 +626,9 @@ impl Plugin for ModuleConcatenationPlugin {
             format!(
               "{} : {}",
               name,
-              export_info.id.get_used_info(&compilation.module_graph)
+              export_info
+                .id
+                .get_used_info(&compilation.get_module_graph())
             )
           })
           .collect::<Vec<String>>()
@@ -631,7 +636,7 @@ impl Plugin for ModuleConcatenationPlugin {
         self.set_bailout_reason(
           &module_id,
           format!("Reexports in this module do not have a static target ({bailout_reason})"),
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
         );
 
         continue;
@@ -639,7 +644,7 @@ impl Plugin for ModuleConcatenationPlugin {
       let unknown_provided_exports = relevnat_epxorts
         .iter()
         .filter(|id| {
-          let export_info = id.get_export_info(&compilation.module_graph);
+          let export_info = id.get_export_info(&compilation.get_module_graph());
           !matches!(export_info.provided, Some(ExportInfoProvided::True))
         })
         .copied()
@@ -649,7 +654,7 @@ impl Plugin for ModuleConcatenationPlugin {
         let bailout_reason = unknown_provided_exports
           .into_iter()
           .map(|id| {
-            let export_info = id.get_export_info(&compilation.module_graph);
+            let export_info = id.get_export_info(&compilation.get_module_graph());
             let name = export_info
               .name
               .as_ref()
@@ -658,8 +663,12 @@ impl Plugin for ModuleConcatenationPlugin {
             format!(
               "{} : {} and {}",
               name,
-              export_info.id.get_provided_info(&compilation.module_graph),
-              export_info.id.get_used_info(&compilation.module_graph)
+              export_info
+                .id
+                .get_provided_info(&compilation.get_module_graph()),
+              export_info
+                .id
+                .get_used_info(&compilation.get_module_graph())
             )
           })
           .collect::<Vec<String>>()
@@ -667,7 +676,7 @@ impl Plugin for ModuleConcatenationPlugin {
         self.set_bailout_reason(
           &module_id,
           format!("List of module exports is dynamic ({bailout_reason})"),
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
         );
         can_be_root = false;
       }
@@ -676,7 +685,7 @@ impl Plugin for ModuleConcatenationPlugin {
         self.set_bailout_reason(
           &module_id,
           "Module is an entry point".to_string(),
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
         );
         can_be_inner = false;
       }
@@ -697,8 +706,8 @@ impl Plugin for ModuleConcatenationPlugin {
 
     let start = logger.time("sort relevant modules");
     relevant_modules.sort_by(|a, b| {
-      let ad = compilation.module_graph.get_depth(a);
-      let bd = compilation.module_graph.get_depth(b);
+      let ad = compilation.get_module_graph().get_depth(a);
+      let bd = compilation.get_module_graph().get_depth(b);
       ad.cmp(&bd)
     });
 
@@ -724,9 +733,12 @@ impl Plugin for ModuleConcatenationPlugin {
       {
         chunk_runtime = merge_runtime(&chunk_runtime, &r);
       }
-      let exports_info_id = compilation.module_graph.get_exports_info(current_root).id;
+      let exports_info_id = compilation
+        .get_module_graph()
+        .get_exports_info(current_root)
+        .id;
       let filtered_runtime = filter_runtime(Some(&chunk_runtime), |r| {
-        exports_info_id.is_module_used(&compilation.module_graph, r)
+        exports_info_id.is_module_used(&compilation.get_module_graph(), r)
       });
       let active_runtime = match filtered_runtime {
         RuntimeCondition::Boolean(true) => Some(chunk_runtime.clone()),
@@ -742,7 +754,7 @@ impl Plugin for ModuleConcatenationPlugin {
       let mut candidates = VecDeque::new();
 
       let imports = Self::get_imports(
-        &compilation.module_graph,
+        &compilation.get_module_graph(),
         *current_root,
         active_runtime.as_ref(),
       );
@@ -795,7 +807,7 @@ impl Plugin for ModuleConcatenationPlugin {
       } else {
         stats_empty_configurations += 1;
         let optimization_bailouts = compilation
-          .module_graph
+          .get_module_graph_mut()
           .get_optimization_bailout_mut(*current_root);
         for warning in current_configuration.get_warnings_sorted() {
           optimization_bailouts.push(self.format_bailout_warning(warning.0, &warning.1));
@@ -848,7 +860,7 @@ impl Plugin for ModuleConcatenationPlugin {
         used_modules.insert(*m);
       }
       let box_module = compilation
-        .module_graph
+        .get_module_graph()
         .module_by_identifier(&root_module_id)
         .expect("should have module");
       let root_module_ctxt = RootModuleContext {
@@ -870,15 +882,17 @@ impl Plugin for ModuleConcatenationPlugin {
           .get_presentational_dependencies()
           .map(|deps| deps.to_vec()),
         context: Some(compilation.options.context.clone()),
-        side_effect_connection_state: box_module
-          .get_side_effects_connection_state(&compilation.module_graph, &mut HashSet::default()),
+        side_effect_connection_state: box_module.get_side_effects_connection_state(
+          &compilation.get_module_graph(),
+          &mut HashSet::default(),
+        ),
         build_meta: box_module.build_meta().cloned(),
       };
       let modules = modules_set
         .iter()
         .map(|id| {
           let module = compilation
-            .module_graph
+            .get_module_graph()
             .module_by_identifier(id)
             .unwrap_or_else(|| panic!("should have module {}", id));
           let inner_module = ConcatenatedInnerModule {
@@ -927,64 +941,54 @@ impl Plugin for ModuleConcatenationPlugin {
         .await?;
       new_module.set_module_build_info_and_meta(build_result.build_info, build_result.build_meta);
       let root_mgm_epxorts = compilation
-        .module_graph
+        .get_module_graph()
         .module_graph_module_by_identifier(&root_module_id)
         .expect("should have mgm")
         .exports;
       let module_graph_module =
         ModuleGraphModule::new(new_module.id(), *new_module.module_type(), root_mgm_epxorts);
       compilation
-        .module_graph
+        .get_module_graph_mut()
         .add_module_graph_module(module_graph_module);
       compilation
-        .module_graph
+        .get_module_graph_mut()
         .clone_module_attributes(&root_module_id, &new_module.id());
       // integrate
+      let mut chunk_graph = std::mem::take(&mut compilation.chunk_graph);
       for m in modules_set {
         if m == &root_module_id {
           continue;
         }
         compilation
-          .module_graph
+          .get_module_graph_mut()
           .copy_outgoing_module_connections(m, &new_module.id(), |c, mg| {
             let dep = c.dependency_id.get_dependency(mg);
             c.original_module_identifier.as_ref() == Some(m)
               && !(is_harmony_dep_like(dep) && modules_set.contains(&c.module_identifier))
           });
         // TODO: optimize asset module https://github.com/webpack/webpack/pull/15515/files
-        for chunk_ukey in compilation
-          .chunk_graph
-          .get_module_chunks(root_module_id)
-          .clone()
-        {
+        for chunk_ukey in chunk_graph.get_module_chunks(root_module_id).clone() {
           let module = compilation
-            .module_graph
+            .get_module_graph_mut()
             .module_by_identifier_mut(m)
             .expect("should exist module");
 
-          let source_types = compilation
-            .chunk_graph
-            .get_chunk_module_source_types(&chunk_ukey, module);
+          let source_types = chunk_graph.get_chunk_module_source_types(&chunk_ukey, module);
 
           if source_types.len() == 1 {
-            compilation
-              .chunk_graph
-              .disconnect_chunk_and_module(&chunk_ukey, *m);
+            chunk_graph.disconnect_chunk_and_module(&chunk_ukey, *m);
           } else {
             let new_source_types = source_types
               .into_iter()
               .filter(|source_type| !matches!(source_type, SourceType::JavaScript))
               .collect();
-            compilation.chunk_graph.set_chunk_modules_source_types(
-              &chunk_ukey,
-              *m,
-              new_source_types,
-            )
+            chunk_graph.set_chunk_modules_source_types(&chunk_ukey, *m, new_source_types)
           }
         }
       }
+      compilation.chunk_graph = chunk_graph;
       // compilation
-      //   .module_graph
+      //   .get_module_graph()
       //   .module_identifier_to_module
       //   .remove(&root_module_id);
       // compilation.chunk_graph.clear
@@ -993,7 +997,7 @@ impl Plugin for ModuleConcatenationPlugin {
         .chunk_graph
         .replace_module(&root_module_id, &new_module.id());
 
-      compilation.module_graph.move_module_connections(
+      compilation.get_module_graph_mut().move_module_connections(
         &root_module_id,
         &new_module.id(),
         |c, mg| {
@@ -1012,7 +1016,9 @@ impl Plugin for ModuleConcatenationPlugin {
           !inner_connection
         },
       );
-      compilation.module_graph.add_module(new_module.boxed());
+      compilation
+        .get_module_graph_mut()
+        .add_module(new_module.boxed());
     }
     Ok(())
   }

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -265,7 +265,7 @@ impl ModuleConcatenationPlugin {
     if let Some(incoming_connections_from_non_modules) = incoming_connections.get(&None) {
       let active_non_modules_connections = incoming_connections_from_non_modules
         .iter()
-        .filter(|&connection| connection.is_active(&compilation.get_module_graph(), runtime))
+        .filter(|&connection| connection.is_active(compilation.get_module_graph(), runtime))
         .collect::<Vec<_>>();
 
       // TODO: ADD module connection explanations
@@ -321,7 +321,7 @@ impl ModuleConcatenationPlugin {
 
         let active_connections: Vec<_> = connections
           .iter()
-          .filter(|&connection| connection.is_active(&compilation.get_module_graph(), runtime))
+          .filter(|&connection| connection.is_active(compilation.get_module_graph(), runtime))
           .cloned()
           .collect();
 
@@ -442,7 +442,7 @@ impl ModuleConcatenationPlugin {
         let mut current_runtime_condition = RuntimeCondition::Boolean(false);
         for connection in connections {
           let runtime_condition = filter_runtime(Some(runtime), |runtime| {
-            connection.is_target_active(&compilation.get_module_graph(), runtime)
+            connection.is_target_active(compilation.get_module_graph(), runtime)
           });
 
           if runtime_condition == RuntimeCondition::Boolean(false) {
@@ -531,7 +531,7 @@ impl ModuleConcatenationPlugin {
         return Some(problem);
       }
     }
-    for imp in Self::get_imports(&compilation.get_module_graph(), *module_id, runtime) {
+    for imp in Self::get_imports(compilation.get_module_graph(), *module_id, runtime) {
       candidates.insert(imp);
     }
     statistics.added += 1;
@@ -600,7 +600,7 @@ impl Plugin for ModuleConcatenationPlugin {
       }
       let exports_info = compilation.get_module_graph().get_exports_info(&module_id);
       let relevnat_epxorts =
-        exports_info.get_relevant_exports(None, &compilation.get_module_graph());
+        exports_info.get_relevant_exports(None, compilation.get_module_graph());
       let unknown_exports = relevnat_epxorts
         .iter()
         .filter(|id| {
@@ -617,7 +617,7 @@ impl Plugin for ModuleConcatenationPlugin {
         let bailout_reason = unknown_exports
           .into_iter()
           .map(|id| {
-            let export_info = id.get_export_info(&compilation.get_module_graph());
+            let export_info = id.get_export_info(compilation.get_module_graph());
             let name = export_info
               .name
               .as_ref()
@@ -626,9 +626,7 @@ impl Plugin for ModuleConcatenationPlugin {
             format!(
               "{} : {}",
               name,
-              export_info
-                .id
-                .get_used_info(&compilation.get_module_graph())
+              export_info.id.get_used_info(compilation.get_module_graph())
             )
           })
           .collect::<Vec<String>>()
@@ -644,7 +642,7 @@ impl Plugin for ModuleConcatenationPlugin {
       let unknown_provided_exports = relevnat_epxorts
         .iter()
         .filter(|id| {
-          let export_info = id.get_export_info(&compilation.get_module_graph());
+          let export_info = id.get_export_info(compilation.get_module_graph());
           !matches!(export_info.provided, Some(ExportInfoProvided::True))
         })
         .copied()
@@ -654,7 +652,7 @@ impl Plugin for ModuleConcatenationPlugin {
         let bailout_reason = unknown_provided_exports
           .into_iter()
           .map(|id| {
-            let export_info = id.get_export_info(&compilation.get_module_graph());
+            let export_info = id.get_export_info(compilation.get_module_graph());
             let name = export_info
               .name
               .as_ref()
@@ -665,10 +663,8 @@ impl Plugin for ModuleConcatenationPlugin {
               name,
               export_info
                 .id
-                .get_provided_info(&compilation.get_module_graph()),
-              export_info
-                .id
-                .get_used_info(&compilation.get_module_graph())
+                .get_provided_info(compilation.get_module_graph()),
+              export_info.id.get_used_info(compilation.get_module_graph())
             )
           })
           .collect::<Vec<String>>()
@@ -738,7 +734,7 @@ impl Plugin for ModuleConcatenationPlugin {
         .get_exports_info(current_root)
         .id;
       let filtered_runtime = filter_runtime(Some(&chunk_runtime), |r| {
-        exports_info_id.is_module_used(&compilation.get_module_graph(), r)
+        exports_info_id.is_module_used(compilation.get_module_graph(), r)
       });
       let active_runtime = match filtered_runtime {
         RuntimeCondition::Boolean(true) => Some(chunk_runtime.clone()),
@@ -754,7 +750,7 @@ impl Plugin for ModuleConcatenationPlugin {
       let mut candidates = VecDeque::new();
 
       let imports = Self::get_imports(
-        &compilation.get_module_graph(),
+        compilation.get_module_graph(),
         *current_root,
         active_runtime.as_ref(),
       );
@@ -883,7 +879,7 @@ impl Plugin for ModuleConcatenationPlugin {
           .map(|deps| deps.to_vec()),
         context: Some(compilation.options.context.clone()),
         side_effect_connection_state: box_module.get_side_effects_connection_state(
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
           &mut HashSet::default(),
         ),
         build_meta: box_module.build_meta().cloned(),

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -518,7 +518,7 @@ impl Plugin for SideEffectsFlagPlugin {
 
   async fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<()>> {
     let entries = compilation.entry_modules().collect::<Vec<_>>();
-    let mg = &mut compilation.module_graph;
+    let mg = compilation.get_module_graph_mut();
     let level_order_module_identifier = get_level_order_module_ids(mg, entries);
     for module_identifier in level_order_module_identifier {
       let mut module_chain = HashSet::default();

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -13,7 +13,7 @@ pub fn render_chunk_modules(
   compilation: &Compilation,
   chunk_ukey: &ChunkUkey,
 ) -> Result<(BoxSource, ChunkInitFragments)> {
-  let module_graph = &compilation.module_graph;
+  let module_graph = &compilation.get_module_graph();
   let ordered_modules = compilation.chunk_graph.get_chunk_modules_by_source_type(
     chunk_ukey,
     SourceType::JavaScript,
@@ -28,7 +28,7 @@ pub fn render_chunk_modules(
   let mut module_code_array = ordered_modules
     .par_iter()
     .filter(|module| {
-      compilation.module_graph.is_new_treeshaking
+      compilation.get_module_graph().is_new_treeshaking
         || include_module_ids.contains(&module.identifier())
     })
     .filter_map(|module| {

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -162,7 +162,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
             if exports_info
               .other_exports_info
-              .get_export_info(&compilation.get_module_graph())
+              .get_export_info(compilation.get_module_graph())
               .get_used(*runtime)
               == UsageState::Unused =>
           {
@@ -170,7 +170,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
               json_data.clone(),
               exports_info,
               *runtime,
-              &compilation.get_module_graph(),
+              compilation.get_module_graph(),
             )
           }
           _ => json_data.clone(),

--- a/crates/rspack_plugin_json/src/lib.rs
+++ b/crates/rspack_plugin_json/src/lib.rs
@@ -146,7 +146,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .runtime_requirements
           .insert(RuntimeGlobals::MODULE);
         let module = compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(&module.identifier())
           .expect("should have module identifier");
         let json_data = module
@@ -155,14 +155,14 @@ impl ParserAndGenerator for JsonParserAndGenerator {
           .and_then(|info| info.json_data.as_ref())
           .expect("should have json data");
         let exports_info = compilation
-          .module_graph
+          .get_module_graph()
           .get_exports_info(&module.identifier());
 
         let final_json = match json_data {
           json::JsonValue::Object(_) | json::JsonValue::Array(_)
             if exports_info
               .other_exports_info
-              .get_export_info(&compilation.module_graph)
+              .get_export_info(&compilation.get_module_graph())
               .get_used(*runtime)
               == UsageState::Unused =>
           {
@@ -170,7 +170,7 @@ impl ParserAndGenerator for JsonParserAndGenerator {
               json_data.clone(),
               exports_info,
               *runtime,
-              &compilation.module_graph,
+              &compilation.get_module_graph(),
             )
           }
           _ => json_data.clone(),

--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -104,7 +104,7 @@ impl Plugin for AmdLibraryPlugin {
       .iter()
       .filter_map(|identifier| {
         compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(identifier)
           .and_then(|module| module.as_external_module())
           .and_then(|m| {

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -190,6 +190,7 @@ impl Plugin for AssignLibraryPlugin {
   }
 
   async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
+    let mut runtime_info = Vec::with_capacity(compilation.entries.len());
     for (entry_name, entry) in compilation.entries.iter() {
       let EntryData {
         dependencies,
@@ -203,7 +204,7 @@ impl Plugin for AssignLibraryPlugin {
         .or_else(|| compilation.options.output.library.as_ref());
       let module_of_last_dep = dependencies
         .last()
-        .and_then(|dep| compilation.module_graph.get_module(dep));
+        .and_then(|dep| compilation.get_module_graph().get_module(dep));
       let Some(module_of_last_dep) = module_of_last_dep else {
         continue;
       };
@@ -215,20 +216,32 @@ impl Plugin for AssignLibraryPlugin {
         .as_ref()
         .and_then(|item| item.first())
       {
+        runtime_info.push((
+          runtime,
+          Some(export.clone()),
+          module_of_last_dep.identifier(),
+        ));
+      } else {
+        runtime_info.push((runtime, None, module_of_last_dep.identifier()));
+      }
+    }
+
+    for (runtime, export, module_identifier) in runtime_info {
+      if let Some(export) = export {
         let exports_info = compilation
-          .module_graph
-          .get_export_info(module_of_last_dep.identifier(), &(export.as_str()).into());
+          .get_module_graph_mut()
+          .get_export_info(module_identifier, &(export.as_str()).into());
         exports_info.set_used(
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
           UsageState::Used,
           Some(&runtime),
         );
       } else {
         let exports_info_id = compilation
-          .module_graph
-          .get_exports_info(&module_of_last_dep.identifier())
+          .get_module_graph()
+          .get_exports_info(&module_identifier)
           .id;
-        exports_info_id.set_used_in_unknown_way(&mut compilation.module_graph, Some(&runtime));
+        exports_info_id.set_used_in_unknown_way(compilation.get_module_graph_mut(), Some(&runtime));
       }
     }
     Ok(())

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -84,7 +84,7 @@ impl Plugin for ExportPropertyLibraryPlugin {
         options,
         ..
       } = entry;
-      let runtime = compilation.get_entry_runtime(&entry_name, Some(&options));
+      let runtime = compilation.get_entry_runtime(entry_name, Some(options));
       let library_options = options
         .library
         .as_ref()

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -77,20 +77,21 @@ impl Plugin for ExportPropertyLibraryPlugin {
   }
 
   async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
+    let mut runtime_info = Vec::with_capacity(compilation.entries.len());
     for (entry_name, entry) in compilation.entries.iter() {
       let EntryData {
         dependencies,
         options,
         ..
       } = entry;
-      let runtime = compilation.get_entry_runtime(entry_name, Some(options));
+      let runtime = compilation.get_entry_runtime(&entry_name, Some(&options));
       let library_options = options
         .library
         .as_ref()
         .or_else(|| compilation.options.output.library.as_ref());
       let module_of_last_dep = dependencies
         .last()
-        .and_then(|dep| compilation.module_graph.get_module(dep));
+        .and_then(|dep| compilation.get_module_graph().get_module(dep));
       let Some(module_of_last_dep) = module_of_last_dep else {
         continue;
       };
@@ -102,29 +103,44 @@ impl Plugin for ExportPropertyLibraryPlugin {
         .as_ref()
         .and_then(|item| item.first())
       {
+        runtime_info.push((
+          runtime,
+          Some(export.clone()),
+          module_of_last_dep.identifier(),
+        ));
+      } else {
+        runtime_info.push((runtime, None, module_of_last_dep.identifier()));
+      }
+    }
+
+    for (runtime, export, module_identifier) in runtime_info {
+      if let Some(export) = export {
         let export_info_id = compilation
-          .module_graph
-          .get_export_info(module_of_last_dep.identifier(), &(export.as_str()).into());
+          .get_module_graph_mut()
+          .get_export_info(module_identifier, &(export.as_str()).into());
         export_info_id.set_used(
-          &mut compilation.module_graph,
+          compilation.get_module_graph_mut(),
           UsageState::Used,
           Some(&runtime),
         );
         export_info_id
-          .get_export_info_mut(&mut compilation.module_graph)
+          .get_export_info_mut(compilation.get_module_graph_mut())
           .can_mangle_use = Some(false);
       } else {
         let exports_info_id = compilation
-          .module_graph
-          .get_exports_info(&module_of_last_dep.identifier())
+          .get_module_graph()
+          .get_exports_info(&module_identifier)
           .id;
         if self.ns_object_used {
-          exports_info_id.set_used_in_unknown_way(&mut compilation.module_graph, Some(&runtime));
+          exports_info_id
+            .set_used_in_unknown_way(compilation.get_module_graph_mut(), Some(&runtime));
         } else {
-          exports_info_id.set_all_known_exports_used(&mut compilation.module_graph, Some(&runtime));
+          exports_info_id
+            .set_all_known_exports_used(compilation.get_module_graph_mut(), Some(&runtime));
         }
       }
     }
+
     Ok(())
   }
   fn js_chunk_hash(

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -54,7 +54,7 @@ impl Plugin for ModuleLibraryPlugin {
         .get_module_graph()
         .get_exports_info(&args.module);
       for id in exports_info.get_ordered_exports() {
-        let info = id.get_export_info(&args.compilation.get_module_graph());
+        let info = id.get_export_info(args.compilation.get_module_graph());
         let info_name = info.name.as_ref().expect("name can't be empty").as_str();
         let name = to_identifier(info_name);
         let var_name = format!("__webpack_exports__{name}");

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -49,9 +49,12 @@ impl Plugin for ModuleLibraryPlugin {
     source.add(args.source.clone());
     let mut exports = vec![];
     if args.compilation.options.is_new_tree_shaking() {
-      let exports_info = args.compilation.module_graph.get_exports_info(&args.module);
+      let exports_info = args
+        .compilation
+        .get_module_graph()
+        .get_exports_info(&args.module);
       for id in exports_info.get_ordered_exports() {
-        let info = id.get_export_info(&args.compilation.module_graph);
+        let info = id.get_export_info(&args.compilation.get_module_graph());
         let info_name = info.name.as_ref().expect("name can't be empty").as_str();
         let name = to_identifier(info_name);
         let var_name = format!("__webpack_exports__{name}");

--- a/crates/rspack_plugin_library/src/system_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/system_library_plugin.rs
@@ -94,7 +94,7 @@ impl Plugin for SystemLibraryPlugin {
       .iter()
       .filter_map(|identifier| {
         compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(identifier)
           .and_then(|module| module.as_external_module())
           .and_then(|m| (m.get_external_type() == "system").then_some(m))

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -106,7 +106,7 @@ impl Plugin for UmdLibraryPlugin {
       .iter()
       .filter_map(|identifier| {
         compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(identifier)
           .and_then(|module| module.as_external_module())
           .and_then(|m| {

--- a/crates/rspack_plugin_library/src/utils.rs
+++ b/crates/rspack_plugin_library/src/utils.rs
@@ -25,7 +25,7 @@ fn inner_external_arguments(modules: &[&ExternalModule], compilation: &Compilati
         "__WEBPACK_EXTERNAL_MODULE_{}__",
         to_identifier(
           compilation
-            .module_graph
+            .get_module_graph()
             .module_graph_module_by_identifier(&m.identifier())
             .expect("Module not found")
             .id(&compilation.chunk_graph)

--- a/crates/rspack_plugin_limit_chunk_count/src/lib.rs
+++ b/crates/rspack_plugin_limit_chunk_count/src/lib.rs
@@ -109,7 +109,7 @@ impl Plugin for LimitChunkCountPlugin {
 
     for (b_idx, b) in chunks_ukeys.iter().enumerate() {
       for (a_idx, a) in chunks_ukeys.iter().enumerate().take(b_idx) {
-        if !chunk_graph.can_chunks_be_integrated(a, b, &chunk_by_ukey, &chunk_group_by_ukey) {
+        if !chunk_graph.can_chunks_be_integrated(a, b, chunk_by_ukey, chunk_group_by_ukey) {
           continue;
         }
 
@@ -117,22 +117,22 @@ impl Plugin for LimitChunkCountPlugin {
           a,
           b,
           &chunk_size_option,
-          &chunk_by_ukey,
-          &chunk_group_by_ukey,
+          chunk_by_ukey,
+          chunk_group_by_ukey,
           module_graph,
         );
         let a_size = chunk_graph.get_chunk_size(
           a,
           &chunk_size_option,
-          &chunk_by_ukey,
-          &chunk_group_by_ukey,
+          chunk_by_ukey,
+          chunk_group_by_ukey,
           module_graph,
         );
         let b_size = chunk_graph.get_chunk_size(
           b,
           &chunk_size_option,
-          &chunk_by_ukey,
-          &chunk_group_by_ukey,
+          chunk_by_ukey,
+          chunk_group_by_ukey,
           module_graph,
         );
 
@@ -178,7 +178,7 @@ impl Plugin for LimitChunkCountPlugin {
         }
         for group_ukey in queue.clone() {
           for modified_chunk_ukey in modified_chunks.clone() {
-            if let Some(m_chunk) = get_chunk_from_ukey(&modified_chunk_ukey, &chunk_by_ukey) {
+            if let Some(m_chunk) = get_chunk_from_ukey(&modified_chunk_ukey, chunk_by_ukey) {
               if modified_chunk_ukey != a
                 && modified_chunk_ukey != b
                 && m_chunk.is_in_group(&group_ukey)
@@ -193,7 +193,7 @@ impl Plugin for LimitChunkCountPlugin {
               }
             }
           }
-          if let Some(group) = get_chunk_group_from_ukey(&group_ukey, &chunk_group_by_ukey) {
+          if let Some(group) = get_chunk_group_from_ukey(&group_ukey, chunk_group_by_ukey) {
             for parent in group.parents_iterable() {
               queue.insert(*parent);
             }
@@ -201,7 +201,7 @@ impl Plugin for LimitChunkCountPlugin {
         }
       }
 
-      if chunk_graph.can_chunks_be_integrated(&a, &b, &chunk_by_ukey, &chunk_group_by_ukey) {
+      if chunk_graph.can_chunks_be_integrated(&a, &b, chunk_by_ukey, chunk_group_by_ukey) {
         new_chunk_graph.integrate_chunks(
           &a,
           &b,
@@ -243,8 +243,7 @@ impl Plugin for LimitChunkCountPlugin {
               continue;
             }
             if combination.a == b {
-              if !chunk_graph.can_chunks_be_integrated(&a, &b, &chunk_by_ukey, &chunk_group_by_ukey)
-              {
+              if !chunk_graph.can_chunks_be_integrated(&a, &b, chunk_by_ukey, chunk_group_by_ukey) {
                 combination.deleted = true;
                 combinations.delete(ukey);
                 continue;
@@ -254,8 +253,8 @@ impl Plugin for LimitChunkCountPlugin {
                 &a,
                 &combination.b,
                 &chunk_size_option,
-                &chunk_by_ukey,
-                &chunk_group_by_ukey,
+                chunk_by_ukey,
+                chunk_group_by_ukey,
                 module_graph,
               );
               combination.a = a;
@@ -264,8 +263,7 @@ impl Plugin for LimitChunkCountPlugin {
               combination.size_diff = combination.b_size + integrated_size - new_integrated_size;
               combinations.update();
             } else if combination.b == b {
-              if !chunk_graph.can_chunks_be_integrated(&b, &a, &chunk_by_ukey, &chunk_group_by_ukey)
-              {
+              if !chunk_graph.can_chunks_be_integrated(&b, &a, chunk_by_ukey, chunk_group_by_ukey) {
                 combination.deleted = true;
                 combinations.delete(ukey);
                 continue;
@@ -275,8 +273,8 @@ impl Plugin for LimitChunkCountPlugin {
                 &combination.a,
                 &a,
                 &chunk_size_option,
-                &chunk_by_ukey,
-                &chunk_group_by_ukey,
+                chunk_by_ukey,
+                chunk_group_by_ukey,
                 module_graph,
               );
               combination.b = a;

--- a/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
+++ b/crates/rspack_plugin_merge_duplicate_chunks/src/lib.rs
@@ -42,7 +42,7 @@ impl Plugin for MergeDuplicateChunksPlugin {
       let mut possible_duplicates: Option<HashSet<ChunkUkey>> = None;
       for module in compilation
         .chunk_graph
-        .get_chunk_modules(&chunk_ukey, &compilation.get_module_graph())
+        .get_chunk_modules(&chunk_ukey, compilation.get_module_graph())
       {
         if let Some(ref mut possible_duplicates) = possible_duplicates {
           possible_duplicates.retain(|dup| {
@@ -102,7 +102,7 @@ impl Plugin for MergeDuplicateChunksPlugin {
           if !is_runtime_equal(&chunk.runtime, &other_chunk.runtime) {
             for module in compilation
               .chunk_graph
-              .get_chunk_modules(&chunk_ukey, &compilation.get_module_graph())
+              .get_chunk_modules(&chunk_ukey, compilation.get_module_graph())
             {
               let exports_info = compilation
                 .get_module_graph()
@@ -110,7 +110,7 @@ impl Plugin for MergeDuplicateChunksPlugin {
               if !exports_info.is_equally_used(
                 &chunk.runtime,
                 &other_chunk.runtime,
-                &compilation.get_module_graph(),
+                compilation.get_module_graph(),
               ) {
                 continue 'outer;
               }
@@ -130,7 +130,7 @@ impl Plugin for MergeDuplicateChunksPlugin {
               &other_chunk_ukey,
               &mut chunk_by_ukey,
               &mut chunk_group_by_ukey,
-              &compilation.get_module_graph(),
+              compilation.get_module_graph(),
             );
             chunk_by_ukey.remove(&other_chunk_ukey);
             compilation.chunk_graph = chunk_graph;

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -188,14 +188,14 @@ impl Module for ContainerEntryModule {
       let block = block_id.expect_get(compilation);
       let modules_iter = block.get_dependencies().iter().map(|dependency_id| {
         let dep = compilation
-          .module_graph
+          .get_module_graph()
           .dependency_by_id(dependency_id)
           .expect("should have dependency");
         let dep = dep
           .downcast_ref::<ContainerExposedDependency>()
           .expect("dependencies of ContainerEntryModule should be ContainerExposedDependency");
         let name = dep.exposed_name.as_str();
-        let module = compilation.module_graph.get_module(dependency_id);
+        let module = compilation.get_module_graph().get_module(dependency_id);
         let user_request = dep.user_request();
         (name, module, user_request, dependency_id)
       });

--- a/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
@@ -42,7 +42,7 @@ impl ExposeRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &c,
           SourceType::Expose,
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
         );
       for m in modules {
         let code_gen = compilation

--- a/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/expose_runtime_module.rs
@@ -42,7 +42,7 @@ impl ExposeRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &c,
           SourceType::Expose,
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
         );
       for m in modules {
         let code_gen = compilation

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -157,7 +157,7 @@ impl Module for FallbackModule {
     let ids: Vec<_> = self
       .get_dependencies()
       .iter()
-      .filter_map(|dep| compilation.module_graph.get_module(dep))
+      .filter_map(|dep| compilation.get_module_graph().get_module(dep))
       .filter_map(|module| {
         compilation
           .chunk_graph

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -173,7 +173,9 @@ impl Module for RemoteModule {
     _: Option<ConcatenationScope>,
   ) -> Result<CodeGenerationResult> {
     let mut codegen = CodeGenerationResult::default();
-    let module = compilation.module_graph.get_module(&self.dependencies[0]);
+    let module = compilation
+      .get_module_graph()
+      .get_module(&self.dependencies[0]);
     let id = module.and_then(|m| {
       compilation
         .chunk_graph

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -53,7 +53,7 @@ impl RuntimeModule for RemoteRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &chunk,
           SourceType::Remote,
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
         );
       let mut remotes = Vec::new();
       for m in modules {

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -53,7 +53,7 @@ impl RuntimeModule for RemoteRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &chunk,
           SourceType::Remote,
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
         );
       let mut remotes = Vec::new();
       for m in modules {
@@ -69,7 +69,7 @@ impl RuntimeModule for RemoteRuntimeModule {
         let share_scope = m.share_scope.as_str();
         let dep = m.get_dependencies()[0];
         let external_module = compilation
-          .module_graph
+          .get_module_graph()
           .get_module(&dep)
           .expect("should have module");
         let external_module_id = compilation

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -78,7 +78,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &chunk,
           SourceType::ConsumeShared,
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
         );
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
       let mut ids = vec![];
@@ -99,7 +99,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &chunk,
           SourceType::ConsumeShared,
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
         );
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
       for module in modules {

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_runtime_module.rs
@@ -78,7 +78,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &chunk,
           SourceType::ConsumeShared,
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
         );
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
       let mut ids = vec![];
@@ -99,7 +99,7 @@ impl RuntimeModule for ConsumeSharedRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &chunk,
           SourceType::ConsumeShared,
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
         );
       let chunk = compilation.chunk_by_ukey.expect_get(&chunk);
       for module in modules {

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -53,7 +53,7 @@ impl RuntimeModule for ShareRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &c,
           SourceType::ShareInit,
-          &compilation.module_graph,
+          &compilation.get_module_graph(),
         )
         .sorted_unstable_by_key(|m| m.identifier());
       for m in modules {

--- a/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/share_runtime_module.rs
@@ -53,7 +53,7 @@ impl RuntimeModule for ShareRuntimeModule {
         .get_chunk_modules_iterable_by_source_type(
           &c,
           SourceType::ShareInit,
-          &compilation.get_module_graph(),
+          compilation.get_module_graph(),
         )
         .sorted_unstable_by_key(|m| m.identifier());
       for m in modules {

--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -20,7 +20,7 @@ pub fn update_hash_for_entry_startup(
 ) {
   for (module, entry) in entries {
     if let Some(module_id) = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_identifier(module)
       .map(|module| module.id(&compilation.chunk_graph))
     {
@@ -144,7 +144,7 @@ pub fn generate_entry_startup(
 
   for (module, entry) in entries {
     if let Some(module_id) = compilation
-      .module_graph
+      .get_module_graph()
       .module_graph_module_by_identifier(module)
       .map(|module| module.id(&compilation.chunk_graph))
     {

--- a/crates/rspack_plugin_runtime/src/module_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/module_chunk_format.rs
@@ -129,7 +129,7 @@ impl Plugin for ModuleChunkFormatPlugin {
       let mut loaded_chunks = HashSet::default();
       for (i, (module, entry)) in entries.iter().enumerate() {
         let module_id = compilation
-          .module_graph
+          .get_module_graph()
           .module_graph_module_by_identifier(module)
           .map(|module| module.id(&compilation.chunk_graph))
           .expect("should have module id");

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -63,7 +63,7 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
     .get_chunk_modules_by_source_type(
       chunk_ukey,
       SourceType::JavaScript,
-      &compilation.get_module_graph(),
+      compilation.get_module_graph(),
     )
     .is_empty()
 }
@@ -71,7 +71,7 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
 pub fn chunk_has_css(chunk: &ChunkUkey, compilation: &Compilation) -> bool {
   !compilation
     .chunk_graph
-    .get_chunk_modules_by_source_type(chunk, SourceType::Css, &compilation.get_module_graph())
+    .get_chunk_modules_by_source_type(chunk, SourceType::Css, compilation.get_module_graph())
     .is_empty()
 }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/utils.rs
@@ -63,7 +63,7 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
     .get_chunk_modules_by_source_type(
       chunk_ukey,
       SourceType::JavaScript,
-      &compilation.module_graph,
+      &compilation.get_module_graph(),
     )
     .is_empty()
 }
@@ -71,7 +71,7 @@ pub fn chunk_has_js(chunk_ukey: &ChunkUkey, compilation: &Compilation) -> bool {
 pub fn chunk_has_css(chunk: &ChunkUkey, compilation: &Compilation) -> bool {
   !compilation
     .chunk_graph
-    .get_chunk_modules_by_source_type(chunk, SourceType::Css, &compilation.module_graph)
+    .get_chunk_modules_by_source_type(chunk, SourceType::Css, &compilation.get_module_graph())
     .is_empty()
 }
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -83,7 +83,7 @@ fn deterministic_grouping_for_modules(
 
   let items = compilation
     .chunk_graph
-    .get_chunk_modules(chunk, &compilation.get_module_graph());
+    .get_chunk_modules(chunk, compilation.get_module_graph());
 
   let context = compilation.options.context.as_ref();
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -83,7 +83,7 @@ fn deterministic_grouping_for_modules(
 
   let items = compilation
     .chunk_graph
-    .get_chunk_modules(chunk, &compilation.module_graph);
+    .get_chunk_modules(chunk, &compilation.get_module_graph());
 
   let context = compilation.options.context.as_ref();
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -45,7 +45,7 @@ impl SplitChunksPlugin {
       .par_iter()
       .filter_map(|module_id| {
         let module = &**compilation
-          .module_graph
+          .get_module_graph()
           .module_by_identifier(module_id)
           .expect("Should have a module");
         let having_violating_source_type = violating_source_types

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -62,7 +62,7 @@ impl SplitChunksPlugin {
     // single_chunk_sets: chunkset of module that belongs to only one chunk
     // chunk_sets_by_count: use chunkset len as key
     let (chunk_sets_in_graph, chunk_sets_by_count) =
-      { Self::prepare_combination_maps(&compilation.get_module_graph(), &compilation.chunk_graph) };
+      { Self::prepare_combination_maps(compilation.get_module_graph(), &compilation.chunk_graph) };
 
     let combinations_cache = DashMap::<ChunksKey, Vec<FxHashSet<ChunkUkey>>>::default();
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -62,7 +62,7 @@ impl SplitChunksPlugin {
     // single_chunk_sets: chunkset of module that belongs to only one chunk
     // chunk_sets_by_count: use chunkset len as key
     let (chunk_sets_in_graph, chunk_sets_by_count) =
-      { Self::prepare_combination_maps(&compilation.module_graph, &compilation.chunk_graph) };
+      { Self::prepare_combination_maps(&compilation.get_module_graph(), &compilation.chunk_graph) };
 
     let combinations_cache = DashMap::<ChunksKey, Vec<FxHashSet<ChunkUkey>>>::default();
 
@@ -89,7 +89,7 @@ impl SplitChunksPlugin {
       result
     };
 
-    compilation.module_graph.modules().values().par_bridge().for_each(|module| {
+    compilation.get_module_graph().modules().values().par_bridge().for_each(|module| {
       let module = &**module;
 
       let belong_to_chunks = compilation
@@ -282,7 +282,7 @@ impl SplitChunksPlugin {
           if other_module_group.modules.contains(module) {
             tracing::trace!("remove module({module}) from {key}");
             let module = compilation
-              .module_graph
+              .get_module_graph()
               .module_by_identifier(module)
               .unwrap_or_else(|| panic!("Module({module}) not found"));
             other_module_group.remove_module(&**module);

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -54,7 +54,7 @@ impl Plugin for WarnCaseSensitiveModulesPlugin {
     let start = logger.time("check case sensitive modules");
     let mut diagnostics: Vec<Diagnostic> = vec![];
     let modules = compilation
-      .module_graph
+      .get_module_graph()
       .modules()
       .values()
       .collect::<Vec<_>>();
@@ -89,7 +89,7 @@ impl Plugin for WarnCaseSensitiveModulesPlugin {
         case_modules.sort_by_key(|m| m.identifier());
         diagnostics.push(Diagnostic::warn(
           "Sensitive Modules Warn".to_string(),
-          self.create_sensitive_modules_warning(&case_modules, &compilation.module_graph),
+          self.create_sensitive_modules_warning(&case_modules, &compilation.get_module_graph()),
         ));
       }
     }

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -89,7 +89,7 @@ impl Plugin for WarnCaseSensitiveModulesPlugin {
         case_modules.sort_by_key(|m| m.identifier());
         diagnostics.push(Diagnostic::warn(
           "Sensitive Modules Warn".to_string(),
-          self.create_sensitive_modules_warning(&case_modules, &compilation.get_module_graph()),
+          self.create_sensitive_modules_warning(&case_modules, compilation.get_module_graph()),
         ));
       }
     }

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -149,7 +149,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
         let mut wasm_deps_by_request = IndexMap::<&str, Vec<(Identifier, String, String)>>::new();
         let mut promises: Vec<String> = vec![];
 
-        let module_graph = &compilation.module_graph;
+        let module_graph = &compilation.get_module_graph();
         let chunk_graph = &compilation.chunk_graph;
 
         module

--- a/crates/rspack_plugin_wasm/src/wasm_plugin.rs
+++ b/crates/rspack_plugin_wasm/src/wasm_plugin.rs
@@ -89,7 +89,7 @@ impl Plugin for AsyncWasmPlugin {
   ) -> PluginRenderManifestHookOutput {
     let compilation = args.compilation;
     let chunk = args.chunk();
-    let module_graph = &compilation.module_graph;
+    let module_graph = &compilation.get_module_graph();
 
     let ordered_modules = compilation
       .chunk_graph


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. remove pub in compilation.module_graph
2. add get_module_graph() and get_module_graph_mut() in compilation
3. change all of code which use compilation.module_graph to get_module_graph() and get_module_graph_mut()

https://github.com/web-infra-dev/rspack/issues/5887

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
