### PR TITLE
fix: export star missing module panic

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -467,9 +467,6 @@ impl HarmonyExportImportedSpecifierDependency {
     } = ctxt;
     let mut fragments = vec![];
     let mg = &compilation.get_module_graph();
-    let imported_module = mg
-      .module_identifier_by_dependency_id(&self.id)
-      .expect("should have imported module identifier");
     let module_identifier = module.identifier();
     let import_var = mg.get_import_var(&self.id);
     match mode.ty {
@@ -584,6 +581,9 @@ impl HarmonyExportImportedSpecifierDependency {
         fragments.push(init_fragment);
       }
       ExportModeType::NormalReexport => {
+        let imported_module = mg
+          .module_identifier_by_dependency_id(&self.id)
+          .expect("should have imported module identifier");
         for item in mode.items.into_iter().flatten() {
           let NormalReexportItem {
             name,

--- a/packages/rspack/tests/TestCases.template.js
+++ b/packages/rspack/tests/TestCases.template.js
@@ -101,7 +101,6 @@ const describeCases = config => {
 								parallel: false
 							});
 							let options = {
-								...testConfig,
 								context: casesPath,
 								entry: "./" + category.name + "/" + testName + "/",
 								target: config.target || "async-node",
@@ -112,7 +111,7 @@ const describeCases = config => {
 											emitOnErrors: true,
 											minimizer: [terserForTesting],
 											...testConfig.optimization
-									  }
+										}
 									: {
 											removeAvailableModules: true,
 											removeEmptyChunks: true,
@@ -135,7 +134,7 @@ const describeCases = config => {
 											chunkIds: "named",
 											minimizer: [terserForTesting],
 											...config.optimization
-									  },
+										},
 								// CHANGE: rspack does not support `performance` yet.
 								// performance: {
 								// 	hints: false

--- a/packages/rspack/tests/cases/esm/export-star-missing/errors.js
+++ b/packages/rspack/tests/cases/esm/export-star-missing/errors.js
@@ -1,0 +1,3 @@
+module.exports = [
+  [/Can't resolve '\.\/missing'/]
+]

--- a/packages/rspack/tests/cases/esm/export-star-missing/index.js
+++ b/packages/rspack/tests/cases/esm/export-star-missing/index.js
@@ -1,0 +1,9 @@
+it("should work well when export namespace with missing module", function () {
+	let lib;
+	try {
+		lib = require("./lib")
+	} catch (e) {
+		expect(e.message).toBe("Cannot find module './missing'")
+	}
+	expect(lib).toBe(undefined)
+});

--- a/packages/rspack/tests/cases/esm/export-star-missing/lib.js
+++ b/packages/rspack/tests/cases/esm/export-star-missing/lib.js
@@ -1,0 +1,1 @@
+export * from "./missing"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix panic when export star a missing module

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
