### PR TITLE
docs: use Open Sans as the default font

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -39,6 +39,7 @@
     "nano-staged": "^0.8.0",
     "prettier": "^2.8.3",
     "rspress": "1.11.0",
+    "rspress-plugin-font-open-sans": "1.0.0",
     "typescript": "^5.0.4"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       rspress:
         specifier: 1.11.0
         version: 1.11.0(typescript@5.4.3)(webpack@5.91.0)
+      rspress-plugin-font-open-sans:
+        specifier: 1.0.0
+        version: 1.0.0
       typescript:
         specifier: ^5.0.4
         version: 5.4.3
@@ -4137,6 +4140,10 @@ packages:
     resolution: {integrity: sha512-qyBM9XsP7oxBQSms2cr715XOeoDi6p5hUYXtlNDfst0jha8vfWVPNeC7j5+j5dG+yt//1OCmLaOY2rWqPSVXDg==}
     dependencies:
       fs-extra: 11.2.0
+    dev: true
+
+  /rspress-plugin-font-open-sans@1.0.0:
+    resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
     dev: true
 
   /rspress@1.11.0(typescript@5.4.3)(webpack@5.91.0):

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { defineConfig } from 'rspress/config';
 import type { NavItem, Sidebar } from '@rspress/shared';
 import { pluginRss, type PluginRssOption } from './rspress/plugin-rss';
+import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 import { toArray } from './rspress/plugin-rss/utils';
 
 const PUBLISH_URL = 'https://rspack.dev';
@@ -426,6 +427,7 @@ export default defineConfig({
 			},
 			toFeedItem,
 		}),
+		pluginFontOpenSans(),
 	],
 	themeConfig: {
 		footer: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR adds Open Sans as the default font for Rspack website, uses https://github.com/rspack-contrib/rspress-plugin-font-open-sans.

The Node.js new website is using Open Sans and looks good. see http://nodejs.org/

## Preview

![image](https://github.com/web-infra-dev/rspack/assets/7237365/7a5d5014-2a76-4582-932b-5146093936cb)

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
