### PR TITLE
fix: Move @import to top of concatenated CSS output (#6000)

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
-static EXTERNAL_MODULE_CSS_SOURCE_TYPES: &[SourceType] = &[SourceType::Css];
+static EXTERNAL_MODULE_CSS_SOURCE_TYPES: &[SourceType] = &[SourceType::CssImport];
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -114,6 +114,7 @@ pub enum SourceType {
   ConsumeShared,
   #[default]
   Unknown,
+  CssImport,
 }
 
 impl std::fmt::Display for SourceType {
@@ -128,6 +129,7 @@ impl std::fmt::Display for SourceType {
       SourceType::ShareInit => write!(f, "share-init"),
       SourceType::ConsumeShared => write!(f, "consume-shared"),
       SourceType::Unknown => write!(f, "unknown"),
+      SourceType::CssImport => write!(f, "css-import"),
     }
   }
 }
@@ -146,6 +148,7 @@ impl TryFrom<&str> for SourceType {
       "share-init" => Ok(Self::ShareInit),
       "consume-shared" => Ok(Self::ConsumeShared),
       "unknown" => Ok(Self::Unknown),
+      "css-import" => Ok(Self::CssImport),
 
       _ => {
         use rspack_error::error;

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -13,8 +13,8 @@ use rspack_core::{
 };
 use rspack_core::{
   ChunkLoading, ChunkLoadingType, Compilation, CompilationParams, CompilerOptions, DependencyType,
-  LibIdentOptions, PluginContext, PluginRuntimeRequirementsInTreeOutput, PublicPath,
-  RuntimeGlobals, RuntimeRequirementsInTreeArgs,
+  ExternalModule, LibIdentOptions, PluginContext, PluginRuntimeRequirementsInTreeOutput,
+  PublicPath, RuntimeGlobals, RuntimeRequirementsInTreeArgs,
 };
 use rspack_error::{IntoTWithDiagnosticArray, Result};
 use rspack_hash::RspackHash;
@@ -36,39 +36,53 @@ impl CssPlugin {
     chunk: &Chunk,
     ordered_css_modules: &[&dyn Module],
   ) -> rspack_error::Result<ConcatSource> {
-    let module_sources = ordered_css_modules
-      .iter()
-      .map(|module| {
-        let module_id = &module.identifier();
-        let code_gen_result = compilation
-          .code_generation_results
-          .get(module_id, Some(&chunk.runtime));
+    // Prepare data for parallel processing, instead of collecting them immediately
+    let mut sources_to_process = Vec::new();
 
-        Ok(
-          code_gen_result
-            .get(&SourceType::Css)
-            .map(|source| (CssModuleDebugInfo { module: *module }, source)),
-        )
-      })
-      .collect::<Result<Vec<_>>>()?;
+    for &module in ordered_css_modules {
+      let module_id = module.identifier();
+      let code_gen_result = compilation
+        .code_generation_results
+        .get(&module_id, Some(&chunk.runtime));
 
-    let source = module_sources
+      if let Some(code) = code_gen_result.get(&SourceType::Css) {
+        // Determine the order of the modules by whether it is 'css-import'
+        let priority =
+          if let Some(external_module) = module.as_any().downcast_ref::<ExternalModule>() {
+            // If the module is an external module and its type is 'css-import', give it a higher priority (0)
+            if external_module.get_external_type() == "css-import" {
+              0
+            } else {
+              1
+            }
+          } else {
+            // If the module is not an external module, give it a lower priority (1)
+            1
+          };
+
+        // Push the module into the list for processing, along with its priority and code
+        sources_to_process.push((priority, CssModuleDebugInfo { module }, code.clone()));
+      }
+    }
+
+    // Sort all modules in order according to their priority attribute
+    sources_to_process.sort_by_key(|&(priority, _, _)| priority);
+
+    // Use a parallel iterator to process the sorted list of source codes
+    let source = sources_to_process
       .into_par_iter()
-      // TODO(hyf0): I couldn't think of a situation where a module doesn't have `Source`.
-      // Should we return a Error if there is a `None` in `module_sources`?
-      // Webpack doesn't throw. It just do a best-effort checking https://github.com/webpack/webpack/blob/5e3c4d0ddf8ae6a6e45fea42be4e8950fe49c0bb/lib/css/CssModulesPlugin.js#L565-L568
-      .flatten()
-      .fold(
-        ConcatSource::default,
-        |mut acc, (debug_info, cur_source)| {
-          let (start, end) = Self::render_module_debug_info(compilation, &debug_info);
-          acc.add(start);
-          acc.add(cur_source.clone());
-          acc.add(RawSource::from("\n"));
-          acc.add(end);
-          acc
-        },
-      )
+      .map(|(_, debug_info, cur_source)| {
+        let mut acc = ConcatSource::default();
+        // Render the debug info for the module
+        let (start, end) = Self::render_module_debug_info(compilation, &debug_info);
+        // Add the start marker, the source code, a newline, and the end marker to the accumulator
+        acc.add(start);
+        acc.add(cur_source);
+        acc.add(RawSource::from("\n"));
+        acc.add(end);
+        acc
+      })
+      // Reduce the list of sources into a single ConcatSource
       .reduce(ConcatSource::default, |mut acc, cur| {
         acc.add(cur);
         acc

--- a/crates/rspack_plugin_css/src/plugin/mod.rs
+++ b/crates/rspack_plugin_css/src/plugin/mod.rs
@@ -120,9 +120,37 @@ impl CssPlugin {
     module_graph: &'chunk_graph ModuleGraph,
     compilation: &Compilation,
   ) -> Vec<&'chunk_graph dyn Module> {
+    let mut external_css_modules = Self::get_ordered_chunk_css_modules_by_type(
+      chunk,
+      chunk_graph,
+      module_graph,
+      compilation,
+      SourceType::CssImport,
+    );
+
+    let mut css_modules = Self::get_ordered_chunk_css_modules_by_type(
+      chunk,
+      chunk_graph,
+      module_graph,
+      compilation,
+      SourceType::Css,
+    );
+
+    external_css_modules.append(&mut css_modules);
+
+    external_css_modules
+  }
+
+  fn get_ordered_chunk_css_modules_by_type<'chunk_graph>(
+    chunk: &Chunk,
+    chunk_graph: &'chunk_graph ChunkGraph,
+    module_graph: &'chunk_graph ModuleGraph,
+    compilation: &Compilation,
+    source_type: SourceType,
+  ) -> Vec<&'chunk_graph dyn Module> {
     // Align with https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/css/CssModulesPlugin.js#L368
     let mut css_modules = chunk_graph
-      .get_chunk_modules_iterable_by_source_type(&chunk.ukey, SourceType::Css, module_graph)
+      .get_chunk_modules_iterable_by_source_type(&chunk.ukey, source_type, module_graph)
       .collect::<Vec<_>>();
     css_modules.sort_unstable_by_key(|module| module.identifier());
 

--- a/crates/rspack_plugin_css/tests/fixtures/webpack/at-import-in-the-middle/expected/main.css
+++ b/crates/rspack_plugin_css/tests/fixtures/webpack/at-import-in-the-middle/expected/main.css
@@ -1,8 +1,9 @@
+@import url("https://some/other/external/css");
+@import url("https://some/external/css");
 body {
   background: red;
 }
 
-@import url("https://some/other/external/css");
 .c {
   background: red;
 }
@@ -13,7 +14,6 @@ body {
   color: yellow;
 }
 
-@import url("https://some/external/css");
 .b {
   background: red;
 }

--- a/crates/rspack_plugin_css/tests/fixtures/webpack/at-import-in-the-middle/snapshot/output.snap
+++ b/crates/rspack_plugin_css/tests/fixtures/webpack/at-import-in-the-middle/snapshot/output.snap
@@ -2,11 +2,12 @@
 source: crates/rspack_testing/src/run_fixture.rs
 ---
 ```css title=main.css
+@import url("https://some/other/external/css");
+@import url("https://some/external/css");
 body {
   background: red;
 }
 
-@import url("https://some/other/external/css");
 .c {
   background: red;
 }
@@ -17,7 +18,6 @@ body {
   color: yellow;
 }
 
-@import url("https://some/external/css");
 .b {
   background: red;
 }

--- a/packages/rspack/tests/__snapshots__/ConfigTestCases.basictest.js.snap
+++ b/packages/rspack/tests/__snapshots__/ConfigTestCases.basictest.js.snap
@@ -209,6 +209,29 @@ exports[`ConfigTestCases chunk-index available-modules-order-index exported test
 "
 `;
 
+exports[`ConfigTestCases css at-import-in-the-top exported tests at-import-in-the-top 1`] = `
+"@import url(\\"https://fonts.googleapis.com/css2?family=Roboto\\");
+@import url(\\"https://fonts.googleapis.com/css2?family=Inter\\");
+.c {
+	color: pink;
+}
+
+
+
+
+.a {
+	color: blue;
+}
+
+
+
+.b {
+	color: red;
+}
+
+"
+`;
+
 exports[`ConfigTestCases css rewrite-url exported tests should rewrite the css url() 1`] = `"eb587e4780c414fe3a22.png"`;
 
 exports[`ConfigTestCases css rewrite-url exported tests should rewrite the css url() 2`] = `"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAwAAAAOCAYAAAAbvf3sAAAACXBIWXMAABYlAAAWJQFJUiTwAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAEWSURBVHgBjZFRSsNAEIb/3fQAOUK9gfpe6YIovjU3UE+gJ2g8gTcw3sC+itUFrW+BeAN7ATFSKAjbHWcSC+mSlszLDrvfzvzzj0LHmNpZBtBQd4Gf7fuYgHPPueoCe1DK1UsHd7Dzw+P0daQj/SC5h09OzdGktw221vZXUBlVMN0ILPd6O9yzBBXX8CBdv6kWOGa4YLivQJNjM0ia73oTLsBwJjCB5gu4i7CgbsIey5ThEcOfKziTGFOGHypJeZ7jZ/Gbst4x2/fN9h2eGTNvgk92VrDEWLNmfJXLpIYrRy5b4Fs+9v2/pL0oUncI7FuHLI6PK5lJZGoe8qXNvrry27DesoRLpLPmNkTw9yEcxPWJMR+S/AFbfpAZqxwUNQAAAABJRU5ErkJggg=="`;

--- a/packages/rspack/tests/configCases/css/at-import-in-the-top/a.css
+++ b/packages/rspack/tests/configCases/css/at-import-in-the-top/a.css
@@ -1,0 +1,6 @@
+@import url("https://fonts.googleapis.com/css2?family=Roboto");
+@import url("./c.css");
+
+.a {
+	color: blue;
+}

--- a/packages/rspack/tests/configCases/css/at-import-in-the-top/b.css
+++ b/packages/rspack/tests/configCases/css/at-import-in-the-top/b.css
@@ -1,0 +1,5 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter");
+
+.b {
+	color: red;
+}

--- a/packages/rspack/tests/configCases/css/at-import-in-the-top/c.css
+++ b/packages/rspack/tests/configCases/css/at-import-in-the-top/c.css
@@ -1,0 +1,3 @@
+.c {
+	color: pink;
+}

--- a/packages/rspack/tests/configCases/css/at-import-in-the-top/index.js
+++ b/packages/rspack/tests/configCases/css/at-import-in-the-top/index.js
@@ -1,0 +1,13 @@
+require("./a.css");
+require("./b.css");
+const fs = require("fs");
+const path = require("path");
+
+it("at-import-in-the-top", async () => {
+	const css = await fs.promises.readFile(
+		path.resolve(__dirname, "bundle0.css"),
+		"utf-8"
+	);
+
+	expect(css).toMatchSnapshot();
+});

--- a/packages/rspack/tests/configCases/css/at-import-in-the-top/webpack.config.js
+++ b/packages/rspack/tests/configCases/css/at-import-in-the-top/webpack.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+	entry: {
+		main: "./index.js"
+	},
+	experiments: {
+		css: true
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix issue [6000](https://github.com/web-infra-dev/rspack/issues/6000)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
