### PR TITLE
chore: make format compatible with windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build:viewer": "pnpm --filter \"@rspack/*\" build:viewer",
     "test:js": "pnpm -r run test",
     "format:rs": "pnpm --filter @rspack/core... build",
-    "format:js": "./node_modules/prettier/bin/prettier.cjs 'packages/**/src/**/*.{ts,js}' 'crates/rspack_plugin_runtime/**/*.{ts,js}' 'x.mjs' --check --write",
+    "format:js": "prettier \"packages/**/src/**/*.{ts,js}\" \"crates/rspack_plugin_runtime/**/*.{ts,js}\" \"x.mjs\" --check --write",
     "format-ci:toml": "npx @taplo/cli format --check '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "format:toml": "npx @taplo/cli format '.cargo/*.toml' './crates/**/Cargo.toml' './Cargo.toml'",
     "lint:js": "oxlint --deny-warnings -c .eslintrc.json",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Modify the format:js script command to make it compatible with the Windows environment.

### before
![image](https://github.com/web-infra-dev/rspack/assets/22117876/fb0aeb1c-663b-4fe4-9448-f3cc79dcea32)

### now
![image](https://github.com/web-infra-dev/rspack/assets/22117876/277fa97e-845a-43eb-a476-b361c54a2c05)


## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
