### PR TITLE
feat: support more intuitive css diagnostic

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -180,6 +180,8 @@ impl ParserAndGenerator for CssParserAndGenerator {
       &new_stylesheet_ast,
       code_generation_dependencies,
       &mut diagnostic_vec,
+      &source_code,
+      module_user_request,
     );
     for (k, v) in exports_pairs {
       dependencies.push(Box::new(CssModuleExportDependency::new(

--- a/packages/rspack/tests/diagnostics/factorize/css-module-request-prefix/stats.err
+++ b/packages/rspack/tests/diagnostics/factorize/css-module-request-prefix/stats.err
@@ -1,4 +1,10 @@
 WARNING in ./index.css
   ⚠ Module parse warning:
-  ╰─▶   ⚠ css: Deprecated '~'
-        │ '@import' or 'url()' with a request starts with '~' is deprecated.
+  ╰─▶   ⚠ css: Deprecated '~': '@import' or 'url()' with a request starts with '~' is deprecated.
+         ╭─[1:1]
+       1 │ @import "~normalize.css";
+         ·          ─
+       2 │
+       3 │ .class {
+         ╰────
+        help: Remove '~' from the request.


### PR DESCRIPTION
Closed: #5986
Before: 
<img width="897" alt="image" src="https://github.com/web-infra-dev/rspack/assets/44047106/053e17e6-ae9c-4346-a62b-51b0a1702adc">

After:
<img width="788" alt="image" src="https://github.com/web-infra-dev/rspack/assets/44047106/46036336-3467-450a-a2de-822c8ab1ac54">


## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
