### PR TITLE
docs: integrate Rsbuild plugins for website

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -24,7 +24,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-intersection-observer": "^9.4.3",
-    "rsfamily-nav-icon": "^1.0.1",
+    "rsfamily-nav-icon": "^1.0.2",
     "semver": "^7.5.4",
     "tailwindcss": "^3.2.7"
   },
@@ -38,6 +38,8 @@
     "husky": "^8.0.3",
     "nano-staged": "^0.8.0",
     "prettier": "^2.8.3",
+    "rsbuild-plugin-google-analytics": "1.0.0",
+    "rsbuild-plugin-open-graph": "1.0.0",
     "rspress": "1.11.0",
     "rspress-plugin-font-open-sans": "1.0.0",
     "typescript": "^5.0.4"

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^9.4.3
         version: 9.8.1(react-dom@18.2.0)(react@18.2.0)
       rsfamily-nav-icon:
-        specifier: ^1.0.1
-        version: 1.0.1
+        specifier: ^1.0.2
+        version: 1.0.2
       semver:
         specifier: ^7.5.4
         version: 7.6.0
@@ -69,6 +69,12 @@ importers:
       prettier:
         specifier: ^2.8.3
         version: 2.8.8
+      rsbuild-plugin-google-analytics:
+        specifier: 1.0.0
+        version: 1.0.0
+      rsbuild-plugin-open-graph:
+        specifier: 1.0.0
+        version: 1.0.0
       rspress:
         specifier: 1.11.0
         version: 1.11.0(typescript@5.4.3)(webpack@5.91.0)
@@ -4127,8 +4133,26 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rsfamily-nav-icon@1.0.1:
-    resolution: {integrity: sha512-TJdyzLpFfmEGfJiPAwZqn1TdXwoR7j/Y0j9ejovNk3zABzJ1FRQ6WZl7DVQQTHoJnABlRgXphMuxnAZ2UMePdQ==}
+  /rsbuild-plugin-google-analytics@1.0.0:
+    resolution: {integrity: sha512-Z2hVetWq48QT+X/HMmtp+YTxzPw+ujt/KUrbQXn98LmUDYqJyGSCBAjit8atAoRiThUSKlkG+NU3+zkFvKoLdA==}
+    peerDependencies:
+      '@rsbuild/core': 0.x
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+    dev: true
+
+  /rsbuild-plugin-open-graph@1.0.0:
+    resolution: {integrity: sha512-SuN9w2FH2v9Mp9/jBowH/RvR74i5A1KzM8+3JrCwCpsuny2HQ3iZqVETgDJ0VIcXqLHUxPnI0aGMgbAcqmlzcg==}
+    peerDependencies:
+      '@rsbuild/core': 0.x
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+    dev: true
+
+  /rsfamily-nav-icon@1.0.2:
+    resolution: {integrity: sha512-gbvJ3wxy1iV6g6T1m/+UIM09t1Sr1ISEBMLUVwPITW+Ckhjuca1xyDh2gbMpYnYX+jXhOSSqA9qtlXpchUOH9Q==}
     dev: false
 
   /rslog@1.2.1:

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -3,19 +3,12 @@ import { defineConfig } from 'rspress/config';
 import type { NavItem, Sidebar } from '@rspress/shared';
 import { pluginRss, type PluginRssOption } from './rspress/plugin-rss';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
+import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
+import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { toArray } from './rspress/plugin-rss/utils';
 
 const PUBLISH_URL = 'https://rspack.dev';
 const COPYRIGHT = '© 2022-present ByteDance Inc. All Rights Reserved.';
-
-function getMeta(name: string, value: string) {
-	return {
-		[name]: {
-			property: name,
-			content: value,
-		},
-	};
-}
 
 function getI18nHelper(lang: 'zh' | 'en') {
 	const isZh = lang === 'zh';
@@ -103,7 +96,7 @@ function getNavConfig(lang: 'zh' | 'en'): NavItem[] {
 				{
 					text: getText(
 						'未来默认行为与功能废弃',
-						'Future behavior & Deprecation',
+						'Future behavior & Deprecation'
 					),
 					link: getLink('/misc/future'),
 				},
@@ -353,7 +346,7 @@ function getSidebarConfig(lang: 'zh' | 'en'): Sidebar {
 			{
 				text: getText(
 					'Rspack 支持模块联邦',
-					'Module Federation added to Rspack',
+					'Module Federation added to Rspack'
 				),
 				link: getLink('/blog/module-federation-added-to-rspack'),
 			},
@@ -476,6 +469,21 @@ export default defineConfig({
 		],
 	},
 	builderConfig: {
+		plugins: [
+			pluginGoogleAnalytics({ id: 'G-XKKCNZZNJD' }),
+			pluginOpenGraph({
+				title: 'Rspack',
+				type: 'website',
+				url: PUBLISH_URL,
+				image:
+					'https://sf16-sg.tiktokcdn.com/obj/eden-sg/geh7plsnuhog/rspack/rspack-banner.png',
+				description: 'Fast Rust-based Web Bundler',
+				twitter: {
+					site: '@rspack_dev',
+					card: 'summary_large_image',
+				},
+			}),
+		],
 		source: {
 			alias: {
 				'@builtIns': path.join(__dirname, 'components', 'builtIns'),
@@ -485,39 +493,6 @@ export default defineConfig({
 		},
 		dev: {
 			startUrl: true,
-		},
-		html: {
-			meta: {
-				...getMeta('og:title', 'Rspack'),
-				...getMeta('og:type', 'website'),
-				...getMeta('og:url', PUBLISH_URL),
-				...getMeta(
-					'og:image',
-					'https://sf16-sg.tiktokcdn.com/obj/eden-sg/geh7plsnuhog/rspack/rspack-banner.png',
-				),
-				...getMeta('og:description', 'Fast Rust-based Web Bundler'),
-				...getMeta('twitter:site', '@rspack_dev'),
-				...getMeta('twitter:card', 'summary_large_image'),
-			},
-			tags: [
-				// Configure Google Analytics
-				{
-					tag: 'script',
-					attrs: {
-						async: true,
-						src: 'https://www.googletagmanager.com/gtag/js?id=G-XKKCNZZNJD',
-					},
-				},
-				{
-					tag: 'script',
-					children: `
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-XKKCNZZNJD');`,
-				},
-			],
 		},
 		output: {
 			copy: {


### PR DESCRIPTION
## Summary

Integrate Rsbuild plugins for website:

- Use `rsbuild-plugin-google-analytics` to use google analytics. 
- Use `rsbuild-plugin-open-graph` to generate open graph meta tags.
- Bump `rsfamily-nav-icon` v1.0.2 to improve bundle size.

See:

- https://github.com/rspack-contrib/rsbuild-plugin-google-analytics
- https://github.com/rspack-contrib/rsbuild-plugin-open-graph
- https://github.com/rspack-contrib/rsfamily-nav-icon/commits/main/

## Require Documentation?

<!-- Does this PR require documentation? -->

- [x] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
