### PR TITLE
docs: remove deprecated html and node-polyfill plugin

### DIFF
--- a/website/components/i18n/en.json
+++ b/website/components/i18n/en.json
@@ -4,7 +4,7 @@
   "included": "included",
   "babel-loader-description": "SWC has been used internally to implement babel-loader with most of its conversion capabilities",
   "babel-loader-remark": "Be cautious of the performance impact of babel-loader",
-  "html-webpack-plugin-desc": "Support for this plugin was implemented in v0.3.3, before v0.3.3 you could use @rspack/plugin-html or builtins.html instead.",
+  "html-webpack-plugin-desc": "Support for this plugin was implemented in v0.3.3, please upgrade the version to use.",
   "sentry_webpack-plugin-desc": "Support for the plugin version v1.20.1 and above has been implemented in v0.3.3",
   "define-plugin-desc": "Support for this plugin was implemented in v0.3.3, before v0.3.3 you could use builtins.define instead.",
   "copy-plugin-desc": "Use builtins.copy or rspack.CopyRspackPlugin instead.",

--- a/website/components/i18n/en.json
+++ b/website/components/i18n/en.json
@@ -4,7 +4,7 @@
   "included": "included",
   "babel-loader-description": "SWC has been used internally to implement babel-loader with most of its conversion capabilities",
   "babel-loader-remark": "Be cautious of the performance impact of babel-loader",
-  "html-webpack-plugin-desc": "Support for this plugin was implemented in v0.3.3, please upgrade the version to use.",
+  "html-webpack-plugin-desc": "Support for this plugin was implemented in v0.3.3, please upgrade the Rspack version to use it.",
   "sentry_webpack-plugin-desc": "Support for the plugin version v1.20.1 and above has been implemented in v0.3.3",
   "define-plugin-desc": "Support for this plugin was implemented in v0.3.3, before v0.3.3 you could use builtins.define instead.",
   "copy-plugin-desc": "Use builtins.copy or rspack.CopyRspackPlugin instead.",

--- a/website/components/i18n/zh.json
+++ b/website/components/i18n/zh.json
@@ -4,7 +4,7 @@
   "included": "已内置",
   "babel-loader-description": "内部使用 SWC 实现了 babel-loader 的大部分转换功能",
   "babel-loader-remark": "babel-loader 对性能影响较大，请谨慎使用",
-  "html-webpack-plugin-desc": "在 v0.3.3 已实现对该插件的支持，请升级版本来使用",
+  "html-webpack-plugin-desc": "在 v0.3.3 已实现对该插件的支持，请升级 Rspack 版本来使用",
   "sentry_webpack-plugin-desc": "在 v0.3.3 已实现对该插件 v1.20.1 以上版本的支持",
   "define-plugin-desc": "在 v0.3.3 已实现对该插件的支持，v0.3.3 之前可使用 builtins.define 替代",
   "copy-plugin-desc": "使用 builtins.copy 或 rspack.CopyRspackPlugin 替代",

--- a/website/components/i18n/zh.json
+++ b/website/components/i18n/zh.json
@@ -4,7 +4,7 @@
   "included": "已内置",
   "babel-loader-description": "内部使用 SWC 实现了 babel-loader 的大部分转换功能",
   "babel-loader-remark": "babel-loader 对性能影响较大，请谨慎使用",
-  "html-webpack-plugin-desc": "在 v0.3.3 已实现对该插件的支持，v0.3.3 之前可使用 @rspack/plugin-html 或 builtins.html 代替",
+  "html-webpack-plugin-desc": "在 v0.3.3 已实现对该插件的支持，请升级版本来使用",
   "sentry_webpack-plugin-desc": "在 v0.3.3 已实现对该插件 v1.20.1 以上版本的支持",
   "define-plugin-desc": "在 v0.3.3 已实现对该插件的支持，v0.3.3 之前可使用 builtins.define 替代",
   "copy-plugin-desc": "使用 builtins.copy 或 rspack.CopyRspackPlugin 替代",

--- a/website/docs/en/config/builtins.mdx
+++ b/website/docs/en/config/builtins.mdx
@@ -281,10 +281,8 @@ type BuiltinsHtml = Array<{
 | `favicon`            | `string\|undefined`                              | undefined    | Adds the given favicon path to the output HTML.                                                                                                                                                                                   |
 | `meta`               | `Record<string, string\|Record<string, string>>` | \{\}         | Allows to inject meta-tags.                                                                                                                                                                                                       |
 
-:::info
-
-For complex HTML configuration requirements, you can use [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) (after v0.3.3) or [@rspack/plugin-html](https://www.npmjs.com/package/@rspack/plugin-html) (before v0.3.3).
-
+:::tip
+If the configuration options provided by `rspack.HtmlRspackPlugin` cannot meet your needs, you can also directly use the community's [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) plugin.
 :::
 
 ## builtins.minifyOptions

--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -646,7 +646,7 @@ These plugins are Rspack's unique internal plugin and follow the XxxRspackPlugin
 
 <ApiMeta addedVersion={'0.3.3'} />
 
-This plugin can be used to create html files that are associated with Rspack assets.
+This plugin can be used to create HTML files that are associated with Rspack assets.
 
 ```js
 new rspack.HtmlRspackPlugin(options);
@@ -787,8 +787,8 @@ new rspack.HtmlRspackPlugin(options);
     ]}
   />
 
-:::info
-For complex HTML configuration requirements, you can use [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) (after v0.3.3) or [@rspack/plugin-html](https://www.npmjs.com/package/@rspack/plugin-html) (before v0.3.3).
+:::tip
+If the configuration options provided by `rspack.HtmlRspackPlugin` cannot meet your needs, you can also directly use the community's [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) plugin.
 :::
 
 #### SwcJsMinimizerRspackPlugin

--- a/website/docs/en/guide/language-support.mdx
+++ b/website/docs/en/guide/language-support.mdx
@@ -44,13 +44,13 @@ See [resolve.tsConfigPath](/config/resolve#resolvetsconfigpath) for details.
 
 ### Node polyfills
 
-Rspack does not automatically inject polyfills for Node. If you need to use the corresponding functionality, add the `node-polyfill-webpack-plugin` plugin and corresponding configuration in `rspack.config.js`:
+Rspack does not automatically inject polyfills for Node. If you need to use the corresponding functionality, add the [node-polyfill-webpack-plugin](https://www.npmjs.com/package/node-polyfill-webpack-plugin) plugin and corresponding configuration in `rspack.config.js`:
 
 ```ts title="rspack.config.js"
-const NodePolyfill = require('node-polyfill-webpack-plugin');
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 module.exports = {
-  plugins: [new NodePolyfill()],
+  plugins: [new NodePolyfillPlugin()],
 };
 ```
 

--- a/website/docs/en/misc/branding.mdx
+++ b/website/docs/en/misc/branding.mdx
@@ -6,7 +6,7 @@ Here you can find the branding guideline, assets and license for the project.
 
 ## The Name
 
-When used standalone, Rspack should always be written as Rspack, not rspack or RSPACK or RSPack. However, lowercase letters can be used in command lines or package names, such as `@rspack/plugin-html`.
+When used standalone, Rspack should always be written as Rspack, not rspack or RSPACK or RSPack. However, lowercase letters can be used in command lines or package names, such as `@rspack/cli`.
 
 ## Logo
 

--- a/website/docs/zh/config/builtins.mdx
+++ b/website/docs/zh/config/builtins.mdx
@@ -336,7 +336,7 @@ module.exports = {
 请迁移至 [`HtmlRspackPlugin`](/config/plugins.html#htmlrspackplugin)。
 :::
 
-该配置可以快速创建与 Rspack 产物关联的 html 文件。
+该配置可以快速创建与 Rspack 产物关联的 HTML 文件。
 
 - **类型：**
 
@@ -385,7 +385,7 @@ type BuiltinsHtml = Array<{
       name: '`title`',
       type: '`string|undefined`',
       default: 'undefined',
-      description: '构建 html 的标题',
+      description: '构建 HTML 的标题',
     },
     {
       name: '`filename`',
@@ -458,21 +458,19 @@ type BuiltinsHtml = Array<{
       name: '`favicon`',
       type: '`string|undefined`',
       default: 'undefined',
-      description: '配置 html 图标',
+      description: '配置 HTML 图标',
     },
     {
       name: '`meta`',
       type: '`Record<string, string|Record<string, string>>` ',
       default: '{}',
-      description: '配置需要注入 html 的 meta',
+      description: '配置需要注入 HTML 的 meta',
     },
   ]}
 />
 
-:::info
-
-对于复杂的 HTML 配置需求，可使用 [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) 或 [@rspack/plugin-html](https://www.npmjs.com/package/@rspack/plugin-html)。
-
+:::tip
+如果 `rspack.HtmlRspackPlugin` 提供的配置项无法满足需求，你也可以直接使用社区的 [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) 插件。
 :::
 
 ## builtins.minifyOptions

--- a/website/docs/zh/config/plugins.mdx
+++ b/website/docs/zh/config/plugins.mdx
@@ -645,7 +645,7 @@ new rspack.electron.ElectronTargetPlugin();
 
 <ApiMeta addedVersion={'0.3.3'} />
 
-此插件可以创建与 Rspack 产物关联的 html 文件。
+此插件可以创建与 Rspack 产物关联的 HTML 文件。
 
 ```js
 new rspack.HtmlRspackPlugin(options);
@@ -700,7 +700,7 @@ new rspack.HtmlRspackPlugin(options);
         name: '`title`',
         type: '`string|undefined`',
         default: 'undefined',
-        description: '构建 html 的标题',
+        description: '构建 HTML 的标题',
       },
       {
         name: '`filename`',
@@ -773,19 +773,19 @@ new rspack.HtmlRspackPlugin(options);
         name: '`favicon`',
         type: '`string|undefined`',
         default: 'undefined',
-        description: '配置 html 图标',
+        description: '配置 HTML 图标',
       },
       {
         name: '`meta`',
         type: '`Record<string, string|Record<string, string>>` ',
         default: '{}',
-        description: '配置需要注入 html 的 meta',
+        description: '配置需要注入 HTML 的 meta',
       },
     ]}
   />
 
-:::info
-对于复杂的 HTML 配置需求，可使用 [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) 或 [@rspack/plugin-html](https://www.npmjs.com/package/@rspack/plugin-html)。
+:::tip
+如果 `rspack.HtmlRspackPlugin` 提供的配置项无法满足需求，你也可以直接使用社区的 [html-webpack-plugin](https://www.npmjs.com/package/html-webpack-plugin) 插件。
 :::
 
 #### SwcJsMinimizerRspackPlugin

--- a/website/docs/zh/guide/language-support.mdx
+++ b/website/docs/zh/guide/language-support.mdx
@@ -45,13 +45,13 @@
 
 ### Node Polyfill
 
-Rspack 不会自动引入 Node Polyfill，如果你需要使用相应功能，你可以选择使用 `@rspack/plugin-node-polyfill` 插件，并在 `rspack.config.js` 完成配置：
+Rspack 不会自动引入 Node Polyfill，如果你需要使用相应功能，你可以选择使用 [node-polyfill-webpack-plugin](https://www.npmjs.com/package/node-polyfill-webpack-plugin) 插件，并在 `rspack.config.js` 完成配置：
 
 ```ts title="rspack.config.js"
-const NodePolyfill = require('@rspack/plugin-node-polyfill');
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 
 module.exports = {
-  plugins: [new NodePolyfill()],
+  plugins: [new NodePolyfillPlugin()],
 };
 ```
 

--- a/website/docs/zh/misc/branding.mdx
+++ b/website/docs/zh/misc/branding.mdx
@@ -6,7 +6,7 @@ import Logo from '../../public/logo.png';
 
 ## 名称
 
-Rspack 在独立使用的情况下都应该写作 Rspack，而不是 rspack 或者 RSPACK，但在命令行或者包名中可以使用小写，如 `@rspack/plugin-html`。
+Rspack 在独立使用的情况下都应该写作 Rspack，而不是 rspack 或者 RSPACK，但在命令行或者包名中可以使用小写，如 `@rspack/cli`。
 
 ## Logo
 


### PR DESCRIPTION


## Summary

Remove the deprecated rspack-html-plugin & rspack-plugin-node-polyfill from the website.

See: https://github.com/web-infra-dev/rspack/pull/5988

## Require Documentation?

<!-- Does this PR require documentation? -->

- [ ] No
- [ ] Yes, the corresponding rspack-website PR is \_\_
