### PR TITLE
feat(swc_plugin_import): legacy kebab/snake case for legacy babel-plugin-import compatibility

### DIFF
--- a/crates/swc_plugin_import/src/legacy_case.rs
+++ b/crates/swc_plugin_import/src/legacy_case.rs
@@ -1,0 +1,82 @@
+use core::fmt;
+
+// for compatibility with babel_plugin_import versions before 1.13.7 which is its widely used versions.
+// [<1.13.7]{@link https://github.com/umijs/babel-plugin-import/blob/8efa0aa1472f0e6c1d574eb04bf2b9100fccf5a7/src/Plugin.js#L4-L6}
+//     only transform uppercase characters to a hyphen followed by its lowercase
+// [1.13.8]{@link https://github.com/umijs/babel-plugin-import/blob/8cc97c8e394891a684d7300d26cbe2b86f20d076/src/Plugin.js#L4-L10}
+//     transform like `kebabCase`
+fn transform_like_babel_plugin_import(s: &str, sym: &str, f: &mut fmt::Formatter) -> fmt::Result {
+  let char_indices = s.char_indices().peekable();
+  let mut is_first = true;
+  for (_, c) in char_indices {
+    if c.is_uppercase() {
+      if is_first {
+        write!(f, "{}", c.to_lowercase())?;
+      } else {
+        write!(f, "{}{}", sym, c.to_lowercase())?;
+      }
+    } else {
+      write!(f, "{}", c)?;
+    }
+    is_first = false
+  }
+  Ok(())
+}
+
+pub struct AsLegacyKebabCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsLegacyKebabCase<T> {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    transform_like_babel_plugin_import(self.0.as_ref(), "-", f)
+  }
+}
+
+pub struct AsLegacySnakeCase<T: AsRef<str>>(pub T);
+
+impl<T: AsRef<str>> fmt::Display for AsLegacySnakeCase<T> {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    transform_like_babel_plugin_import(self.0.as_ref(), "_", f)
+  }
+}
+
+// transform an identifier like babel_plugin_import@<1.13.7 did.
+// it's like `kebabCase` but differs, e.g.,
+// ```rust
+// assert_eq!(
+//   identifier_to_legacy_kebab_case("HTTPRequest"),
+//   "h-t-t-p-request"
+// );
+// ```
+// it won't be `impl` for `str` as it's not strict name convention
+pub fn identifier_to_legacy_kebab_case(s: &str) -> String {
+  AsLegacyKebabCase(s).to_string()
+}
+
+// transform an identifier like babel_plugin_import@<1.13.7 did with `camel2UnderlineComponentName`.
+// it's like `kebabCase` but differs, e.g.,
+// ```rust
+// assert_eq!(
+//   identifier_to_legacy_snake_case("HTTPRequest"),
+//   "h_t_t_p_request"
+// );
+// ```
+// it won't be `impl` for `str` as it's not strict name convention
+pub fn identifier_to_legacy_snake_case(s: &str) -> String {
+  AsLegacySnakeCase(s).to_string()
+}
+
+#[test]
+fn test_legacy_case() {
+  let cases = [
+    ("XIPObject", "x-i-p-object", "x_i_p_object"),
+    ("XMLHttpRequest", "x-m-l-http-request", "x_m_l_http_request"),
+    ("PascalCase", "pascal-case", "pascal_case"),
+    ("snake_case", "snake_case", "snake_case"),
+    ("WithNumber3d", "with-number3d", "with_number3d"),
+  ];
+
+  for (src, legacy_kebab, legacy_snake) in cases {
+    assert_eq!(identifier_to_legacy_kebab_case(src), legacy_kebab);
+    assert_eq!(identifier_to_legacy_snake_case(src), legacy_snake);
+  }
+}

--- a/crates/swc_plugin_import/src/lib.rs
+++ b/crates/swc_plugin_import/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::unwrap_used)]
 
+mod legacy_case;
 mod visit;
+
 use std::fmt::Debug;
 
 use handlebars::{Context, Helper, HelperResult, Output, RenderContext, Template};
@@ -19,6 +21,7 @@ use swc_core::{
   },
 };
 
+use crate::legacy_case::{identifier_to_legacy_kebab_case, identifier_to_legacy_snake_case};
 use crate::visit::IdentComponent;
 
 #[derive(Debug, Deserialize, Clone)]
@@ -103,6 +106,25 @@ pub fn plugin_import(config: &Vec<PluginImportConfig>) -> impl Fold + '_ {
   );
 
   renderer.register_helper(
+    "legacyKebabCase",
+    Box::new(
+      |helper: &Helper<'_>,
+       _: &'_ handlebars::Handlebars<'_>,
+       _: &'_ Context,
+       _: &mut RenderContext<'_, '_>,
+       out: &mut dyn Output|
+       -> HelperResult {
+        let param = helper
+          .param(0)
+          .and_then(|v| v.value().as_str())
+          .unwrap_or("");
+        out.write(identifier_to_legacy_kebab_case(param).as_ref())?;
+        Ok(())
+      },
+    ),
+  );
+
+  renderer.register_helper(
     "camelCase",
     Box::new(
       |helper: &Helper<'_>,
@@ -135,6 +157,25 @@ pub fn plugin_import(config: &Vec<PluginImportConfig>) -> impl Fold + '_ {
           .and_then(|v| v.value().as_str())
           .unwrap_or("");
         out.write(param.to_snake_case().as_ref())?;
+        Ok(())
+      },
+    ),
+  );
+
+  renderer.register_helper(
+    "legacySnakeCase",
+    Box::new(
+      |helper: &Helper<'_>,
+       _: &'_ handlebars::Handlebars<'_>,
+       _: &'_ Context,
+       _: &mut RenderContext<'_, '_>,
+       out: &mut dyn Output|
+       -> HelperResult {
+        let param = helper
+          .param(0)
+          .and_then(|v| v.value().as_str())
+          .unwrap_or("");
+        out.write(identifier_to_legacy_snake_case(param).as_ref())?;
         Ok(())
       },
     ),

--- a/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/index.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/index.js
@@ -6,3 +6,4 @@ import "./style-css";
 import "./style-library";
 import "./style-tpl";
 import "./style-true";
+import "./legacy-babel-plugin-import";

--- a/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/legacy-babel-plugin-import.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/legacy-babel-plugin-import.js
@@ -1,0 +1,5 @@
+import { XIPObject } from "./src/legacy-babel-plugin-import";
+
+it("legacy-babel-plugin-import", () => {
+    expect(XIPObject).toBe("XIPObject");
+});

--- a/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/src/legacy-babel-plugin-import/index.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/src/legacy-babel-plugin-import/index.js
@@ -1,0 +1,1 @@
+export const XIPObject = "this shouldn't be included";

--- a/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/src/legacy-babel-plugin-import/lib/x-i-p-object/x_i_p_object.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/src/legacy-babel-plugin-import/lib/x-i-p-object/x_i_p_object.js
@@ -1,0 +1,1 @@
+export default "XIPObject";

--- a/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/plugin-import/webpack.config.js
@@ -68,6 +68,11 @@ module.exports = {
 							{
 								libraryName: "./src/style-true",
 								style: true
+							},
+							{
+								libraryName: './src/legacy-babel-plugin-import',
+								customName: './src/legacy-babel-plugin-import/lib/{{ legacyKebabCase member }}/{{ legacySnakeCase member }}',
+								style: false
 							}
 						]
 					}

--- a/website/docs/en/guide/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/builtin-swc-loader.mdx
@@ -197,7 +197,9 @@ Transformed to:
 import Btn from 'foo/es/my-button';
 ```
 
-In addition to `kebabCase`, there are `camelCase`, `snakeCase`, `upperCase` and `lowerCase` can be used as well.
+In addition to `kebabCase`, there are `camelCase`, `snakeCase`, `upperCase`, `lowerCase` and `legacyKebabCase`/`legacySnakeCase` can be used as well.
+
+The `legacyKebabCase`/`legacySnakeCase` works as babel-plugin-import versions before 1.13.7.
 
 You can check the document of [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import) for other configurations.
 

--- a/website/docs/zh/guide/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/builtin-swc-loader.mdx
@@ -189,7 +189,9 @@ module.exports = {
 import Btn from 'foo/es/my-button';
 ```
 
-除了 `kebabCase` 以外还有 `camelCase`、`snakeCase`、`upperCase` 和 `lowerCase` 可以使用。
+除了 `kebabCase` 以外还有 `camelCase`、`snakeCase`、`upperCase`、 `lowerCase` 和 `legacyKebabCase`、`legacySnakeCase` 可以使用。
+
+其中 `legacyKebabCase`/`legacySnakeCase` 使用跟 babel-plugin-import@1.13.7 之前的版本相同的转换逻辑。
 
 其他配置可以直接查看 [babel-plugin-import](https://www.npmjs.com/package/babel-plugin-import)。
 


### PR DESCRIPTION
## Summary

fixes: #6060

- Add `legacyKebabCase` for compatibility with babel-plugin-import versions [before 1.13.7](https://github.com/umijs/babel-plugin-import/blob/8efa0aa1472f0e6c1d574eb04bf2b9100fccf5a7/src/Plugin.js#L4-L6)
- Add `legacySnakeCase` for compatibility with babel-plugin-import versions [before 1.13.7](https://github.com/umijs/babel-plugin-import/blob/8efa0aa1472f0e6c1d574eb04bf2b9100fccf5a7/src/Plugin.js#L4-L6) using [camel2UnderlineComponentName](https://github.com/umijs/babel-plugin-import/blob/8cc97c8e394891a684d7300d26cbe2b86f20d076/src/Plugin.js#L68-L69)

(yes babel-plugin-import breaks its core naming convention behavior in a patch update

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
