### PR TITLE
perf: use mimalloc for musl target

### DIFF
--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -11,5 +11,8 @@ version    = "0.1.0"
 [target.'cfg(not(target_os = "linux"))'.dependencies]
 mimalloc-rust = { workspace = true }
 
+[target.'cfg(all(target_os = "linux", target_env = "musl"))'.dependencies]
+mimalloc-rust = { workspace = true, features = ["local-dynamic-tls"] }
+
 [target.'cfg(all(target_os = "linux", target_env = "gnu", any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies]
 tikv-jemallocator = { workspace = true }

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -2,6 +2,10 @@
 #[global_allocator]
 static GLOBAL: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
 
+#[cfg(all(target_os = "linux", target_env = "musl"))]
+#[global_allocator]
+static GLOBAL: mimalloc_rust::GlobalMiMalloc = mimalloc_rust::GlobalMiMalloc;
+
 #[cfg(all(
   target_os = "linux",
   target_env = "gnu",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

closes: #6072

related: #6065

linux musl binding now performs ~3x times faster than before.

### [sample](https://github.com/xc2/rspack-stress/tree/f57da94d840d8ab9e728abbdeffba9b8b0157d4b/malloc-bench) of 0.5.9

```
Running case debian (GNU)
Rspack compiled successfully in 1.67 s

Running case alpine (musl)
Rspack compiled successfully in 6.39 s

Running case alpine-mimalloc-v1 (musl, redirecting malloc to mimalloc 1.8.2)
Rspack compiled successfully in 1.78 s

Running case alpine-mimalloc-v2 (musl, redirecting malloc to mimalloc 2.1.2)
Rspack compiled successfully in 1.70 s
```

### [sample](https://github.com/xc2/rspack-stress/commit/d6e439d3dcf275875613cc2549f4bf22b49250fc#diff-cce38c3e347877d4aca0aeb73acb7f524235fe6b58515bfdfe0dbf786fd657c7) of this change

```
Running case debian (GNU, nothing change in this pr)
Rspack compiled successfully in 1.86 s

Running case alpine (musl, with mimalloc rust binding)
Rspack compiled successfully in 1.97 s

Running case alpine-mimalloc-v1 (musl, with mimalloc rust binding, redirecting malloc to mimalloc 1.8.2)
Rspack compiled successfully in 1.89 s

Running case alpine-mimalloc-v2 (musl, with mimalloc rust binding, redirecting malloc to mimalloc 2.1.2)
Rspack compiled successfully in 1.81 s

```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required): no need
- [x] Documentation updated (or not required): no need
