### PR TITLE
perf(core): Use unicase for compare_ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ dependencies = [
  "rustc-hash",
  "sugar_path",
  "swc_core",
+ "unicase",
 ]
 
 [[package]]
@@ -6252,9 +6253,9 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicase"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
 dependencies = [
  "version_check",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ testing_macros     = { version = "0.2.12" }
 tokio              = { version = "1.36.0" }
 tracing            = { version = "0.1.40" }
 tracing-subscriber = { version = "0.3.18" }
+unicase            = { version = "2.7.0" }
 url                = { version = "2.5.0" }
 urlencoding        = { version = "2.1.3" }
 ustr               = { package = "ustr-fxhash", version = "1.0.0" }

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -14,5 +14,6 @@ once_cell     = { workspace = true }
 regex         = { workspace = true }
 rustc-hash    = { workspace = true }
 sugar_path    = { workspace = true }
+unicase       = { workspace = true }
 
 swc_core = { workspace = true, features = ["ecma_ast"] }

--- a/crates/rspack_util/src/comparators.rs
+++ b/crates/rspack_util/src/comparators.rs
@@ -1,26 +1,11 @@
 use std::cmp::Ordering;
 
-#[allow(clippy::comparison_chain)]
 pub fn compare_ids(a: &str, b: &str) -> Ordering {
-  let a = a.to_lowercase();
-  let b = b.to_lowercase();
-  if a < b {
-    Ordering::Less
-  } else if a > b {
-    Ordering::Greater
-  } else {
-    Ordering::Equal
-  }
+  unicase::UniCase::new(a).cmp(&unicase::UniCase::new(b))
 }
-#[allow(clippy::comparison_chain)]
+
 pub fn compare_numbers(a: u32, b: u32) -> Ordering {
-  if a < b {
-    Ordering::Less
-  } else if a > b {
-    Ordering::Greater
-  } else {
-    Ordering::Equal
-  }
+  a.cmp(&b)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

The current implement of `compare_ids` always alloc memory for `a`, `b` unnecessarily. we can use `unicase` to implement 0-allocation compare. this is expected to be good for performance.
The `unicase` crate is already in our dependency tree, so it's not a new dependency.

This PR also modifies `compare_numbers` to Rusty implementation.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
