### PR TITLE
test: fix random ci failure

### DIFF
--- a/packages/rspack-test-tools/src/helper/legacy/copyDiff.js
+++ b/packages/rspack-test-tools/src/helper/legacy/copyDiff.js
@@ -4,7 +4,7 @@ const path = require("path");
 const rimraf = require("rimraf");
 
 module.exports = function copyDiff(src, dest, initial) {
-	if (!fs.existsSync(dest)) fs.mkdirSync(dest);
+	fs.mkdirSync(dest, { recursive: true });
 	const files = fs.readdirSync(src);
 	files.forEach(filename => {
 		const srcFile = path.join(src, filename);

--- a/packages/rspack/tests/WatchTestCases.template.js
+++ b/packages/rspack/tests/WatchTestCases.template.js
@@ -14,7 +14,7 @@ const deprecationTracking = require("./helpers/deprecationTracking");
 const FakeDocument = require("./helpers/FakeDocument");
 
 function copyDiff(src, dest, initial) {
-	if (!fs.existsSync(dest)) fs.mkdirSync(dest);
+	fs.mkdirSync(dest, { recursive: true });
 	const files = fs.readdirSync(src);
 	files.forEach(filename => {
 		const srcFile = path.join(src, filename);
@@ -73,9 +73,9 @@ const describeCases = config => {
 		});
 		beforeAll(() => {
 			let dest = path.join(__dirname, "js");
-			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
+			fs.mkdirSync(dest, { recursive: true });
 			dest = path.join(__dirname, "js", config.name + "-src");
-			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
+			fs.mkdirSync(dest, { recursive: true });
 		});
 		categories.forEach(category => {
 			beforeAll(() => {
@@ -85,7 +85,7 @@ const describeCases = config => {
 					config.name + "-src",
 					category.name
 				);
-				if (!fs.existsSync(dest)) fs.mkdirSync(dest);
+				fs.mkdirSync(dest, { recursive: true });
 			});
 			describe(category.name, () => {
 				category.tests.forEach(testName => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

related #6084  

### failing CI samples
- https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:198
- https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:53

```log
packages/rspack test: FAIL tests/WatchTestCases.longtest.js (32 MB heap size)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › multiply-compiler should compile
packages/rspack test:     EEXIST: file already exists, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js'
packages/rspack test:       74 | 		beforeAll(() => {
packages/rspack test:       75 | 			let dest = path.join(__dirname, "js");
packages/rspack test:     > 76 | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 			                             ^
packages/rspack test:       77 | 			dest = path.join(__dirname, "js", config.name + "-src");
packages/rspack test:       78 | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:       79 | 		});
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:76:33)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › multiply-compiler should compile
packages/rspack test:     ENOENT: no such file or directory, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js/WatchTestCases-src/compiler'
packages/rspack test:       86 | 					category.name
packages/rspack test:       87 | 				);
packages/rspack test:     > 88 | 				if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 				                             ^
packages/rspack test:       89 | 			});
packages/rspack test:       90 | 			describe(category.name, () => {
packages/rspack test:       91 | 				category.tests.forEach(testName => {
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:88:34)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › multiply-compiler should compile
packages/rspack test:     ENOENT: no such file or directory, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js/WatchTestCases-src/context'
packages/rspack test:       86 | 					category.name
packages/rspack test:       87 | 				);
packages/rspack test:     > 88 | 				if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 				                             ^
packages/rspack test:       89 | 			});
packages/rspack test:       90 | 			describe(category.name, () => {
packages/rspack test:       91 | 				category.tests.forEach(testName => {
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:88:34)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › exported tests 0 › should run the exported tests
packages/rspack test:     EEXIST: file already exists, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js'
packages/rspack test:       [74](https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:75) | 		beforeAll(() => {
packages/rspack test:       75 | 			let dest = path.join(__dirname, "js");
packages/rspack test:     > 76 | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 			                             ^
packages/rspack test:       77 | 			dest = path.join(__dirname, "js", config.name + "-src");
packages/rspack test:       78 | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:       79 | 		});
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:76:33)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › exported tests 0 › should run the exported tests
packages/rspack test:     ENOENT: no such file or directory, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js/WatchTestCases-src/compiler'
packages/rspack test:       86 | 					category.name
packages/rspack test:       87 | 				);
packages/rspack test:     > 88 | 				if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 				                             ^
packages/rspack test:       89 | 			});
packages/rspack test:       90 | 			describe(category.name, () => {
packages/rspack test:       91 | 				category.tests.forEach(testName => {
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:88:34)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › exported tests 0 › should run the exported tests
packages/rspack test:     ENOENT: no such file or directory, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js/WatchTestCases-src/context'
packages/rspack test:       86 | 					category.name
packages/rspack test:       87 | 				);
packages/rspack test:     > 88 | 				if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 				                             ^
packages/rspack test:       89 | 			});
packages/rspack test:       90 | 			describe(category.name, () => {
packages/rspack test:       91 | 				category.tests.forEach(testName => {
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:88:34)
packages/rspack test:   ● WatchTestCases › compiler › multiply-compiler › 0 should allow to read stats
packages/rspack test:     EEXIST: file already exists, mkdir '/home/webinfra/ec2-linux-ci-3/_work/rspack/rspack/packages/rspack/tests/js'
packages/rspack test:       74 | 		beforeAll(() => {
packages/rspack test:       [75](https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:76) | 			let dest = path.join(__dirname, "js");
packages/rspack test:     > [76](https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:77) | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:          | 			                             ^
packages/rspack test:       [77](https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:78) | 			dest = path.join(__dirname, "js", config.name + "-src");
packages/rspack test:       [78](https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:79) | 			if (!fs.existsSync(dest)) fs.mkdirSync(dest);
packages/rspack test:       [79](https://github.com/web-infra-dev/rspack/actions/runs/8507289799/job/23299027187#step:6:80) | 		});
packages/rspack test:       at Object.<anonymous> (tests/WatchTestCases.template.js:76:33)
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required). - no need
- [x] Documentation updated (or not required). - no need
