### PR TITLE
test: make CopyPlugin.test faster and more stable

### DIFF
--- a/packages/rspack/tests/helpers/AsyncEventIterator.js
+++ b/packages/rspack/tests/helpers/AsyncEventIterator.js
@@ -1,0 +1,47 @@
+/**
+ * @template {unknown} T
+ * @extends {AsyncIterableIterator<T>}
+ * @extends {AsyncIterator<T>}
+ */
+class AsyncEventIterator {
+	constructor() {
+		/**
+		 * @member {(data: T) => any} resolve
+		 */
+		this.resolve = data => {};
+		/**
+		 * @member {(err: unknown) => any} reject
+		 */
+		this.reject = err => {};
+		const self = this;
+
+		this._iter = (async function* createChangesIterator() {
+			try {
+				while (true) {
+					yield await new Promise((resolve, reject) => {
+						self.resolve = resolve;
+						self.reject = reject;
+					});
+				}
+			} finally {
+				self.resolve();
+				self.resolve = () => {};
+				self.reject = () => {};
+			}
+		})();
+	}
+	[Symbol.asyncIterator]() {
+		return this;
+	}
+	next(...args) {
+		return this._iter.next(...args);
+	}
+	return(...args) {
+		return this._iter.return(...args);
+	}
+	throw(...args) {
+		return this._iter.throw(...args);
+	}
+}
+
+module.exports = AsyncEventIterator;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

related: #6084

### failing CI samples:
- https://github.com/web-infra-dev/rspack/actions/runs/8505294188/job/23293849274#step:9:65
- https://github.com/web-infra-dev/rspack/actions/runs/8507670127/job/23300468307#step:8:66

```log
packages/rspack test: FAIL tests/copyPlugin/CopyPlugin.test.js (66.335 s, 34 MB heap size)
packages/rspack test:   ● CopyPlugin › watch mode › should include all files when multiple patterns used
packages/rspack test:     TypeError: Cannot read properties of undefined (reading 'compilation')
packages/rspack test:        9 | 	const assets = {};
packages/rspack test:       10 |
packages/rspack test:     > 11 | 	Reflect.ownKeys(stats.compilation.assets)
packages/rspack test:          | 	                      ^
packages/rspack test:       12 | 		.filter(a => a !== "main.js")
packages/rspack test:       13 | 		.forEach(asset => {
packages/rspack test:       14 | 			assets[transformWindowPath(asset)] = readAsset(asset, compiler, stats);
packages/rspack test:       at readAssets (tests/copyPlugin/helpers/readAssets.js:11:24)
packages/rspack test:       at tests/copyPlugin/helpers/run.js:191:25
packages/rspack test:       at shutdown (dist/Watching.js:99:21)
packages/rspack test:       at Watching.finalCallback [as _done] (dist/Watching.js:116:13)
packages/rspack test:       at onCompile (dist/Watching.js:2[61](https://github.com/web-infra-dev/rspack/actions/runs/8505294188/job/23293849274#step:9:62):18)
packages/rspack test:       at dist/Compiler.js:424:28
packages/rspack test:       at Hook.eval [as callAsync] (eval at create (../../node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
packages/rspack test:       at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (../../node_modules/tapable/lib/Hook.js:18:14)
packages/rspack test:       at dist/Compiler.js:420:41
packages/rspack test:       at dist/Compiler.js:747:[65](https://github.com/web-infra-dev/rspack/actions/runs/8505294188/job/23293849274#step:9:66)
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required). - no need
- [x] Documentation updated (or not required). - no need
