### PR TITLE
chore(rust/dep): update `sugar_path` to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,12 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "sugar_path"
-version = "0.0.12"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c23ada2c5165fc936136721f5f69c8dac6eceb5407de40262f32934510bd7b9"
-dependencies = [
- "once_cell",
-]
+checksum = "8230d5b8a65a6d4d4a7e5ee8dbdd9312ba447a8b8329689a390a0945d69b57ce"
 
 [[package]]
 name = "supports-color"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ schemars           = { version = "0.8.16" }
 serde              = { version = "1.0.197" }
 serde_json         = { version = "1.0.115" }
 similar            = { version = "2.5.0" }
-sugar_path         = { version = "0.0.12" }
+sugar_path         = { version = "1.2.0", features = ["cached_current_dir"] }
 syn                = { version = "2.0.58" }
 testing_macros     = { version = "0.2.12" }
 tokio              = { version = "1.37.0" }

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -2,7 +2,7 @@ use std::{fmt::Debug, path::PathBuf};
 
 use rspack_error::{Diagnostic, Result};
 use rustc_hash::FxHashSet as HashSet;
-use sugar_path::SugarPathBuf;
+use sugar_path::SugarPath;
 
 use crate::{BoxDependency, BoxModule, Context, FactoryMeta, ModuleIdentifier, Resolve};
 
@@ -23,34 +23,34 @@ pub struct ModuleFactoryCreateData {
 impl ModuleFactoryCreateData {
   pub fn add_file_dependency(&mut self, file: PathBuf) {
     if file.is_absolute() {
-      self.file_dependencies.insert(file.into_normalize());
+      self.file_dependencies.insert(file.normalize());
     }
   }
 
   pub fn add_file_dependencies(&mut self, files: impl IntoIterator<Item = PathBuf>) {
     self
       .file_dependencies
-      .extend(files.into_iter().map(|x| x.into_normalize()));
+      .extend(files.into_iter().map(|x| x.normalize()));
   }
 
   pub fn add_context_dependency(&mut self, context: PathBuf) {
-    self.context_dependencies.insert(context.into_normalize());
+    self.context_dependencies.insert(context.normalize());
   }
 
   pub fn add_context_dependencies(&mut self, contexts: impl IntoIterator<Item = PathBuf>) {
     self
       .context_dependencies
-      .extend(contexts.into_iter().map(|x| x.into_normalize()));
+      .extend(contexts.into_iter().map(|x| x.normalize()));
   }
 
   pub fn add_missing_dependency(&mut self, missing: PathBuf) {
-    self.missing_dependencies.insert(missing.into_normalize());
+    self.missing_dependencies.insert(missing.normalize());
   }
 
   pub fn add_missing_dependencies(&mut self, missing: impl IntoIterator<Item = PathBuf>) {
     self
       .missing_dependencies
-      .extend(missing.into_iter().map(|x| x.into_normalize()));
+      .extend(missing.into_iter().map(|x| x.normalize()));
   }
 }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -8,7 +8,7 @@ use rspack_hook::{
 };
 use rspack_loader_runner::{get_scheme, Loader, Scheme};
 use rspack_util::MergeFrom;
-use sugar_path::{AsPath, SugarPath};
+use sugar_path::SugarPath;
 use swc_core::common::Span;
 
 use crate::{

--- a/crates/rspack_core/src/options/context.rs
+++ b/crates/rspack_core/src/options/context.rs
@@ -1,5 +1,6 @@
 use std::{
   fmt,
+  ops::Deref,
   path::{Path, PathBuf},
 };
 
@@ -30,6 +31,14 @@ impl AsRef<Path> for Context {
 
 impl AsRef<str> for Context {
   fn as_ref(&self) -> &str {
+    &self.inner
+  }
+}
+
+impl Deref for Context {
+  type Target = str;
+
+  fn deref(&self) -> &Self::Target {
     &self.inner
   }
 }

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -8,7 +8,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use rspack_error::{Error, MietteExt};
 use rspack_loader_runner::DescriptionData;
-use sugar_path::{AsPath, SugarPath};
+use sugar_path::SugarPath;
 
 pub use self::factory::{ResolveOptionsWithDependencyType, ResolverFactory};
 pub use self::resolver_impl::{ResolveInnerOptions, Resolver};
@@ -99,7 +99,7 @@ pub fn resolve_for_error_hints(
     let resolver = plugin_driver.resolver_factory.get(dep);
     match resolver.resolve(base_dir, args.specifier) {
       Ok(ResolveResult::Resource(resource)) => {
-        let relative_path = resource.path.relative(args.context.as_path());
+        let relative_path = resource.path.relative(args.context);
         let suggestion = if let Some((_, [prefix])) = CURRENT_DIR_REGEX
           .captures_iter(args.specifier)
           .next()
@@ -219,7 +219,7 @@ which tries to resolve these kind of requests in the current directory too.",
               file.ok().and_then(|file| {
                 file.path().file_stem().and_then(|file_stem| {
                   if requested_names.contains(&file_stem.to_string_lossy().to_string()) {
-                    let mut suggestion = file.path().relative(args.context.as_path());
+                    let mut suggestion = file.path().relative(&args.context);
 
                     if !suggestion.to_string_lossy().starts_with('.') {
                       suggestion = PathBuf::from(format!("./{}", suggestion.to_string_lossy()));

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -18,7 +18,7 @@ use rspack_error::{Diagnostic, DiagnosticError, Error, ErrorExt, Result};
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest};
 use rspack_hook::{plugin, plugin_hook, AsyncSeries};
 use rspack_util::infallible::ResultInfallibleExt as _;
-use sugar_path::{AsPath, SugarPath};
+use sugar_path::SugarPath;
 
 #[derive(Debug, Clone)]
 pub struct CopyRspackPluginOptions {

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -6,7 +6,7 @@ use std::{
 use concat_string::concat_string;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use sugar_path::{AsPath, SugarPath};
+use sugar_path::SugarPath;
 
 static SEGMENTS_SPLIT_REGEXP: Lazy<Regex> = Lazy::new(|| Regex::new(r"([|!])").expect("TODO:"));
 static WINDOWS_ABS_PATH_REGEXP: Lazy<Regex> =


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- update `sugar_path` to 1.2.0
- There are no changes on internal logic.
- This update only removes some dropped API

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
