### PR TITLE
docs: announcing 0.6

### DIFF
--- a/website/docs/en/blog/announcing-0.6.mdx
+++ b/website/docs/en/blog/announcing-0.6.mdx
@@ -1,0 +1,40 @@
+---
+date: 2024-04-10 16:00:00
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rspack 0.6 Release Announcement
+
+> April 10, 2024
+
+## Major Feature Updates
+
+### Built-in support for mini-css-extract-plugin
+
+## Breaking Changes
+
+### Enable new tree shaking by default
+
+The new tree shaking uses the same algorithm as webpack, which can generate more efficient and smaller code.
+
+This feature was introduced in `0.4.2` and can be enabled through `experiments.rspackFuture.newTreeshaking`, and has been enabled by default in `0.6.0`.
+
+### Remove experiments.rspackFuture.disableApplyEntryLazily
+
+### Remove compiler.build and compiler.rebuild
+
+### Remove builtins.css
+
+### Upgrade swc to 0.90.x
+
+## Migration Guide
+
+### Apply rspack.CssExtractRspackPlugin
+
+### Migrate builtins.css
+
+### Migrate to compiler.run
+
+### Upgrade the swc plugins
+

--- a/website/docs/zh/blog/announcing-0.6.mdx
+++ b/website/docs/zh/blog/announcing-0.6.mdx
@@ -1,0 +1,39 @@
+---
+date: 2024-04-10 12:00:00
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Rspack 0.6 发布公告
+
+> 2024 年 4 月 10 日
+
+## 主要功能更新
+
+### 内置支持 mini-css-extract-plugin
+
+## 破坏性更新
+
+### 默认启用新版本 tree shaking
+
+新版本 tree shaking 采用了与 webpack 相同的算法，可以生成更高效和更小的代码。
+
+该功能在 `0.4.2` 版本引入并可通过 `experiments.rspackFuture.newTreeshaking` 开启，在 `0.6.0` 版本中已默认启用。
+
+### 移除 experiments.rspackFuture.disableApplyEntryLazily
+
+### 移除 compiler.build 和 compiler.rebuild
+
+### 移除 builtins.css
+
+### 升级 swc 到 0.90.x
+
+## 迁移指南
+
+### 使用 rspack.CssExtractRspackPlugin
+
+### 迁移 builtins.css 配置
+
+### 调用 compiler.run 执行构建
+
+### 升级 swc 插件


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Major Feature Updates:
- [ ] Built-in support for mini-css-extract-plugin @JSerFeng 

Breaking Changes:
- [x] Enable new tree shaking by default @LingyuCoder 
- [ ] Remove experiments.rspackFuture.disableApplyEntryLazily @ahabhgk 
- [ ] Remove compiler.build and compiler.rebuild @h-a-n-a 
- [ ] Remove builtins.css @ahabhgk 

Migration Guide:
- [ ] Apply rspack.CssExtractRspackPlugin @JSerFeng 
- [ ] Migrate builtins.css @ahabhgk 
- [ ] Migrate to compiler.run @h-a-n-a 
- [ ] Upgrade the swc plugins @h-a-n-a 

Overview: @hardfist 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
