### PR TITLE
docs(website): change "get started" button to primary and "intro" button to secondary

### DIFF
--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -13,11 +13,11 @@ hero:
     alt: logo
   actions:
     - theme: brand
-      text: Introduction
-      link: /guide/introduction
-    - theme: alt
-      text: Quick Start
+      text: Get Started
       link: /guide/quick-start
+    - theme: alt
+      text: Learn More
+      link: /guide/introduction
 
 features:
   - title: Fast Startup

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -13,11 +13,11 @@ hero:
     alt: logo
   actions:
     - theme: brand
-      text: 介绍
-      link: /zh/guide/introduction
-    - theme: alt
       text: 快速开始
       link: /zh/guide/quick-start
+    - theme: alt
+      text: 深入了解
+      link: /zh/guide/introduction
 
 features:
   - title: 启动速度极快


### PR DESCRIPTION
Most landing pages put "get started" as the primary button.