### PR TITLE
docs: fix example code casing typo in CSS plugin doc

### DIFF
--- a/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -160,7 +160,7 @@ module.exports = {
     rules:[
       {
         test: /\.css$/i,
-        use: [rspack.CssExtractRspacKplugin.loader,'Css-Loader']
+        use: [rspack.CssExtractRspackPlugin.loader,'Css-Loader']
       }
     ]
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Sorry, just had a small typo in the example code snippet in the CSS plugin docs

https://deploy-preview-6187--rspack.netlify.app/plugins/rspack/css-extract-rspack-plugin.html

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
