### PR TITLE
perf: use set as queue for flag_dependency_usage_plugin

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,5 +1,4 @@
 use std::collections::hash_map::Entry;
-use std::collections::VecDeque;
 
 use itertools::Itertools;
 use rspack_core::{
@@ -13,34 +12,7 @@ use rspack_hook::{plugin, plugin_hook, AsyncSeries};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_core::ecma::atoms::Atom;
 
-struct Queue {
-  q: VecDeque<ModuleIdentifier>,
-  set: HashSet<ModuleIdentifier>,
-}
-
-impl Queue {
-  fn new() -> Self {
-    Self {
-      q: VecDeque::default(),
-      set: HashSet::default(),
-    }
-  }
-
-  fn enqueue(&mut self, id: ModuleIdentifier) {
-    if !self.set.contains(&id) {
-      self.q.push_back(id);
-      self.set.insert(id);
-    }
-  }
-
-  fn dequeue(&mut self) -> Option<ModuleIdentifier> {
-    if let Some(module_id) = self.q.pop_front() {
-      self.set.remove(&module_id);
-      return Some(module_id);
-    }
-    None
-  }
-}
+use crate::utils::queue::Queue;
 
 struct FlagDependencyExportsProxy<'a> {
   mg: &'a mut ModuleGraph<'a>,
@@ -122,7 +94,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
     }
   }
 
-  pub fn notify_dependencies(&mut self, q: &mut Queue) {
+  pub fn notify_dependencies(&mut self, q: &mut Queue<ModuleIdentifier>) {
     if let Some(set) = self.dependencies.get(&self.current_module_id) {
       for mi in set.iter() {
         q.enqueue(*mi);

--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod eval;
 mod get_prop_from_obj;
 pub mod mangle_exports;
+pub(crate) mod queue;
 
 use rspack_core::{ErrorSpan, ModuleType};
 use rspack_error::{DiagnosticKind, TraceableError};

--- a/crates/rspack_plugin_javascript/src/utils/queue.rs
+++ b/crates/rspack_plugin_javascript/src/utils/queue.rs
@@ -1,0 +1,32 @@
+use std::{collections::VecDeque, hash::Hash};
+
+use rustc_hash::FxHashSet as HashSet;
+
+pub(crate) struct Queue<T> {
+  q: VecDeque<T>,
+  set: HashSet<T>,
+}
+
+impl<T: Hash + PartialEq + Eq + Copy + Clone> Queue<T> {
+  pub(crate) fn new() -> Self {
+    Self {
+      q: VecDeque::default(),
+      set: HashSet::default(),
+    }
+  }
+
+  pub(crate) fn enqueue(&mut self, item: T) {
+    if !self.set.contains(&item) {
+      self.q.push_back(item);
+      self.set.insert(item);
+    }
+  }
+
+  pub(crate) fn dequeue(&mut self) -> Option<T> {
+    if let Some(item) = self.q.pop_front() {
+      self.set.remove(&item);
+      return Some(item);
+    }
+    None
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Webpack uses SetQueue under the hood, thus can reduce many duplication computations

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
