### PR TITLE
docs: modify treeshaking sideEffects docs and remove removeAvaModules config

### DIFF
--- a/website/docs/en/config/optimization.mdx
+++ b/website/docs/en/config/optimization.mdx
@@ -8,28 +8,6 @@ import WebpackLicense from '../../../components/webpack-license';
 
 Rspack will select appropriate optimization configuration based on the [`mode`](/config/mode). You can also customize the configuration via [`optimization`](/config/optimization).
 
-## optimization.removeAvailableModules
-
-<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
-
-A module can be removed from a Chunk if the module have been included in all of its parent Chunks.
-
-```
-EntryChunk(index.js, a.js, b.js)
-                                  \
-                                  ChunkFoo(b.js, c.js)
-                                  /
-EntryChunk2(index.js, a.js, b.js)
-```
-
-In the above example, `b.js` has already been included in `EntryChunk` and `EntryChunk2`, so `b.js` can be removed from `ChunkFoo`.
-
-:::info Inconsistent behaviors with Webpack
-
-- [Webpack](https://webpack.js.org/configuration/optimization/#optimizationremoveavailablemodules) only enable this optimization in `production` mode.
-
-:::
-
 ## optimization.moduleIds
 
 <PropertyType type="'named' | 'deterministic'" />
@@ -267,13 +245,10 @@ module.exports = {
 
 ## optimization.providedExports
 
-<PropertyType
-  type="boolean"
-  defaultValueList={[
-    { defaultValue: 'true'},
-  ]}
-/>
-Tells rspack to figure out which exports are provided by modules to generate more efficient code for `export * from ....` By default `optimization.providedExports` is enabled.
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+After enabling, Rspack will analyze which exports the module provides, including re-exported modules. A warning or error will be issued when importing members that reference non-existent exports. By default, `optimization.providedExports` is enabled. This analysis will increase build time. You may consider disabling this configuration in development mode. Disabling it may lead to errors related to runtime circular dependencies as mentioned in the [SideEffects section](/guide/tree-shaking#reexports-optimization).
+
 ```js title=rspack.config.js
 module.exports = {
   //...

--- a/website/docs/en/guide/tree-shaking.mdx
+++ b/website/docs/en/guide/tree-shaking.mdx
@@ -255,7 +255,7 @@ var __webpack_modules__ = {
 // ...
 ```
 
-## module.rule.sideEffects
+### module.rule.sideEffects
 
 You could override some modules sideEffects by using `module.rule.sideEffects`.
 Why do we need such feature?
@@ -344,3 +344,51 @@ module.exports = config;
 ```
 
 Rebuilding the project, we could got the same result as before, the whole **math/add.js** module got dropped.
+
+### Reexports optimization
+
+After enabling SideEffects optimization, Rspack tries to optimize re-exports modules.
+
+```js title=sdk.js
+export { a } from './a.js';
+export { b } from './b.js';
+export { c } from './c.js';
+// ...
+```
+
+```js title=index.js
+import { a } from './sdk.js';
+console.log(a);
+```
+
+If Rspack knows that module `sdk.js` has no side effects, Rspack will try to import `a` directly from `a.js` rather than imports the whole `sdk.js`.
+
+In some non-standard libraries, there may be circular dependencies, for example, `a.js` imports members from `b.js` via `sdk.js`.
+
+```js title=a.js
+import { b } from './sdk.js';
+export const a = b;
+```
+
+```js title=index.js
+import { a } from './sdk.js';
+console.log(a);
+```
+
+At this time, there is a circular dependency between `a.js` and `sdk.js`, which is not recommended to intentionally use circular dependencies like this. However, it can still be built successfully and run successfully. This is because Rspack will attempt to transform the above imports into:
+
+```diff title=a.js
+- import { b } from './sdk.js';
++ import { b } from './a.js';
+export const a = b;
+```
+
+```diff title=index.js
+- import { a } from './sdk.js'
++ import { a } from './a.js'
+console.log(a);
+```
+
+After the transformation, the circular dependency is gone. However, if you try to turn off `optimization.providedExports` or `optimization.sideEffects`, the build will be successful, but errors due to circular dependencies will occur at runtime.
+
+You can find above example [here](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/rspack/treeshaking-transform-imports).

--- a/website/docs/zh/config/optimization.mdx
+++ b/website/docs/zh/config/optimization.mdx
@@ -8,28 +8,6 @@ import WebpackLicense from '../../../components/webpack-license';
 
 优化：该选项用于自定义优化配置。你可以通过 [optimization](/config/optimization) 来自定义优化配置。默认情况下，Rspack 会根据 [mode](/config/mode) 来选择合适的优化配置。
 
-## optimization.removeAvailableModules
-
-<PropertyType.CN type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
-
-如果一个 Chunk 的模块都已经被包含在其所有的父 Chunk 中，那么这个模块就可以被移除。
-
-```
-EntryChunk(index.js, a.js, b.js)
-                                  \
-                                  ChunkFoo(b.js, c.js)
-                                  /
-EntryChunk2(index.js, a.js, b.js)
-```
-
-在上面的例子中，`b.js` 都已经被包含在 `EntryChunk` 和 `EntryChunk2`，所以 `b.js` 可以从 `ChunkFoo` 中移除。
-
-:::info Webpack 的差异点
-
-- [Webpack](https://webpack.js.org/configuration/optimization/#optimizationremoveavailablemodules) 只在 `production` 模式下开启这个优化。
-
-:::
-
 ## optimization.moduleIds
 
 <PropertyType.CN type="'named' | 'deterministic'" />
@@ -259,13 +237,10 @@ module.exports = {
 
 ## optimization.providedExports
 
-<PropertyType
-  type="boolean"
-  defaultValueList={[
-    { defaultValue: 'true'},
-  ]}
-/>
-告诉 rspack 弄清楚模块提供哪些导出，以为 `export * from ....` 生成更有效的代码。默认情况下，`optimization.providedExports` 已启用。
+<PropertyType type="boolean" defaultValueList={[{ defaultValue: 'true' }]} />
+
+开启后 Rspack 将会分析模块提供哪些导出，包括重导出模块，引用模块不存在的导出时会发出提示。默认情况下，`optimization.providedExports` 已启用，该分析会增加构建时间，你可以考虑在 development 模式中关闭该配置，关闭后有可能会遇到[SideEffects 章节](/guide/tree-shaking#reexports-optimization)运行时循环依赖的错误。
+
 ```js title=rspack.config.js
 module.exports = {
   //...

--- a/website/docs/zh/guide/tree-shaking.mdx
+++ b/website/docs/zh/guide/tree-shaking.mdx
@@ -250,7 +250,7 @@ var __webpack_modules__ = {
 // ...
 ```
 
-## module.rule.sideEffects
+### module.rule.sideEffects
 
 你可以使用 `module.rule.sideEffects` 覆盖某些模块的 sideEffects 选项。
 
@@ -338,3 +338,51 @@ module.exports = config;
 ```
 
 重新构建项目，我们得到和之前相同的结果，整个 **math/add.js** 模块都被删除了。
+
+### Reexports optimization
+
+开启 SideEffects 优化后，Rspack 还会尝试对重导出模块进行优化。
+
+```js title=sdk.js
+export { a } from './a.js';
+export { b } from './b.js';
+export { c } from './c.js';
+// ...
+```
+
+```js title=index.js
+import { a } from './sdk.js';
+console.log(a);
+```
+
+当 `sdk.js` 无副作用时，Rspack 会尝试直接从 `a.js` 中引入 `a`，而不引入 `sdk.js` 中重导出的其他模块。
+
+在某些不规范的库中可能存在循环依赖，例如 `a.js` 从 `sdk.js` 中引入 `b.js` 中的成员。
+
+```js title=a.js
+import { b } from './sdk.js';
+export const a = b;
+```
+
+```js title=index.js
+import { a } from './sdk.js';
+console.log(a);
+```
+
+此时 `a.js` 和 `sdk.js` 之间存在循环依赖，很不推荐有意这样利用循环依赖，但仍然可以构建成功，并且成功运行。这是因为 Rspack 会尝试将上述的引用转换成：
+
+```diff title=a.js
+- import { b } from './sdk.js';
++ import { b } from './a.js';
+export const a = b;
+```
+
+```diff title=index.js
+- import { a } from './sdk.js'
++ import { a } from './a.js'
+console.log(a);
+```
+
+转换后循环依赖没有了。但是如果你尝试关掉 `optimization.providedExports` 或 `optimization.sideEffects`，构建会成功，但运行时会因为循环依赖而遇到错误。
+
+上述循环依赖的例子可以在[这里](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/rspack/treeshaking-transform-imports)找到。


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Add docs about transform imports in sideEffects
- Remove useless `removeAvailableModules` option

Need https://github.com/rspack-contrib/rspack-examples/pull/49

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
