### PR TITLE
docs(website): fix broken right nav in join-us page

### DIFF
--- a/website/docs/en/misc/join-us.mdx
+++ b/website/docs/en/misc/join-us.mdx
@@ -36,7 +36,7 @@ The Web Infra - Web Solutions team advocates for an **open-source, technology-dr
 - Value-Oriented:
   - Combine technological development with business growth, transform technological outcomes into business value, and provide input for the development and iteration of technology.
 
-## 🙋 Who We Are
+## 🙋 Who's on the team
 
 - [@Zack Jackson](https://github.com/ScriptedAlchemy): webpack core member, author of Module Federation.
 - [@hardfist](https://github.com/hardfist): Senior configuration engineer, pitfall troubleshooter, responsible for Rspack.


### PR DESCRIPTION
There are two "who we are" titles in the page, causing this:

![img_v3_029v_d9cb7e83-4570-45cd-b716-c0420bc4ec7g](https://github.com/web-infra-dev/rspack/assets/1430279/d19049ba-964f-412e-94ad-49a3f27109e0)
