### PR TITLE
docs: add image assets guide to website README

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -21,6 +21,12 @@ The source code of Rspress can be found in [this folder](https://github.com/web-
 
 If you have any problems using the Rspress, please create a new issue at [Rspress Issues](https://github.com/web-infra-dev/rspress/issues).
 
+## Image Assets
+
+For images you use in the document, it's better to upload them to the [rspack-contrib/rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) repository, so the size of the current repository doesn't get too big.
+
+After you upload the images there, they will be automatically deployed under the <https://assets.rspack.dev/>.
+
 ### Install dependencies
 
 Enable [pnpm](https://pnpm.io/) with corepack:

--- a/website/docs/en/guide/tree-shaking.mdx
+++ b/website/docs/en/guide/tree-shaking.mdx
@@ -395,4 +395,4 @@ After the transformation, the circular dependency is gone. However, if you try t
 
 This diagram demonstrates the process of re-exports optimization:
 
-![](https://rsfamily-design-resources.netlify.app/rspack/assets/rspack-reexports-optimization.png)
+![](https://assets.rspack.dev/rspack/assets/rspack-reexports-optimization.png)

--- a/website/docs/zh/guide/tree-shaking.mdx
+++ b/website/docs/zh/guide/tree-shaking.mdx
@@ -389,4 +389,4 @@ console.log(a);
 
 这张图演示了重导出优化的过程：
 
-![](https://rsfamily-design-resources.netlify.app/rspack/assets/rspack-reexports-optimization.png)
+![](https://assets.rspack.dev/rspack/assets/rspack-reexports-optimization.png)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Add image assets guide to website README.

We use `https://assets.rspack.dev/` to host assets. The `rsfamily-design-resources.netlify.app` is no longer used because it might be blocked in some areas.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
