### PR TITLE
fix: napi value convert error in css-loader

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -33,10 +33,10 @@ export class JsCompilation {
   pushDiagnostic(severity: "error" | "warning", title: string, message: string): void
   pushNativeDiagnostics(diagnostics: ExternalObject<'Diagnostic[]'>): void
   getStats(): JsStats
-  getAssetPath(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: PathData): string
-  getAssetPathWithInfo(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: PathData): PathWithInfo
-  getPath(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: PathData): string
-  getPathWithInfo(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: PathData): PathWithInfo
+  getAssetPath(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: JsPathData): string
+  getAssetPathWithInfo(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: JsPathData): PathWithInfo
+  getPath(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: JsPathData): string
+  getPathWithInfo(filename: string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string), data: JsPathData): PathWithInfo
   addFileDependencies(deps: Array<string>): void
   addContextDependencies(deps: Array<string>): void
   addMissingDependencies(deps: Array<string>): void
@@ -260,7 +260,7 @@ export interface JsChunkPathData {
   id?: string
   name?: string
   hash?: string
-  contentHash?: Record<string, string>
+  contentHash?: string | Record<string, string>
 }
 
 export interface JsCodegenerationResult {
@@ -378,6 +378,16 @@ export interface JsNormalModuleFactoryCreateModuleArgs {
   resourceResolveData: JsResourceData
   context: string
   matchResource?: string
+}
+
+export interface JsPathData {
+  filename?: string
+  hash?: string
+  contentHash?: string
+  runtime?: string
+  url?: string
+  id?: string
+  chunk?: JsChunkPathData
 }
 
 export interface JsResolveForSchemeArgs {
@@ -547,16 +557,6 @@ export interface NodeFS {
   removeFile: (...args: any[]) => any
   mkdir: (...args: any[]) => any
   mkdirp: (...args: any[]) => any
-}
-
-export interface PathData {
-  filename?: string
-  hash?: string
-  contentHash?: string
-  runtime?: string
-  url?: string
-  id?: string
-  chunk?: JsChunkPathData
 }
 
 export interface PathWithInfo {

--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -20,7 +20,7 @@ use crate::JsStatsOptimizationBailout;
 use crate::LocalJsFilename;
 use crate::{
   chunk::JsChunk, module::JsModule, CompatSource, JsAsset, JsAssetInfo, JsChunkGroup,
-  JsCompatSource, JsStats, PathData, ToJsCompatSource,
+  JsCompatSource, JsPathData, JsStats, ToJsCompatSource,
 };
 
 #[napi(object_from_js = false)]
@@ -335,7 +335,7 @@ impl JsCompilation {
     &self,
     #[napi(ts_arg_type = "string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string)")]
     filename: LocalJsFilename,
-    data: PathData,
+    data: JsPathData,
   ) -> napi::Result<String> {
     self
       .0
@@ -347,7 +347,7 @@ impl JsCompilation {
     &self,
     #[napi(ts_arg_type = "string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string)")]
     filename: LocalJsFilename,
-    data: PathData,
+    data: JsPathData,
   ) -> napi::Result<PathWithInfo> {
     let path_and_asset_info = self
       .0
@@ -360,7 +360,7 @@ impl JsCompilation {
     &self,
     #[napi(ts_arg_type = "string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string)")]
     filename: LocalJsFilename,
-    data: PathData,
+    data: JsPathData,
   ) -> napi::Result<String> {
     self.0.get_path(&filename.into(), data.as_core_path_data())
   }
@@ -370,7 +370,7 @@ impl JsCompilation {
     &self,
     #[napi(ts_arg_type = "string | ((pathData: PathData, assetInfo?: JsAssetInfo) => string)")]
     filename: LocalJsFilename,
-    data: PathData,
+    data: JsPathData,
   ) -> napi::Result<PathWithInfo> {
     let path_and_asset_info = self
       .0

--- a/crates/rspack_binding_values/src/filename.rs
+++ b/crates/rspack_binding_values/src/filename.rs
@@ -100,7 +100,7 @@ impl LocalFilenameFn for LocalJsFilenameFn {
     path_data: &PathData,
     asset_info: Option<&AssetInfo>,
   ) -> Result<String, Self::Error> {
-    let js_path_data = JsPathData::try_from(*path_data)?;
+    let js_path_data = JsPathData::from(*path_data);
     let js_asset_info = asset_info.cloned().map(JsAssetInfo::from);
     self.0.call2(js_path_data, js_asset_info)
   }

--- a/crates/rspack_binding_values/src/filename.rs
+++ b/crates/rspack_binding_values/src/filename.rs
@@ -7,10 +7,10 @@ use napi::{
 };
 use rspack_core::{AssetInfo, LocalFilenameFn, PathData};
 use rspack_core::{Filename, FilenameFn};
-use rspack_napi::{threadsafe_function::ThreadsafeFunction, NapiResultExt};
+use rspack_napi::threadsafe_function::ThreadsafeFunction;
 use serde::Deserialize;
 
-use crate::{JsAssetInfo, PathData as JsPathData};
+use crate::{JsAssetInfo, JsPathData};
 
 /// A js filename value. Either a string or a function
 ///
@@ -82,7 +82,7 @@ impl LocalFilenameFn for ThreadSafeFilenameFn {
     asset_info: Option<&AssetInfo>,
   ) -> rspack_error::Result<String> {
     self.0.blocking_call_with_sync((
-      JsPathData::try_from(*path_data).into_rspack_result()?,
+      JsPathData::from(*path_data),
       asset_info.cloned().map(JsAssetInfo::from),
     ))
   }

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -32,6 +32,7 @@ import { JsCreateData } from '@rspack/binding';
 import { JsLoaderContext } from '@rspack/binding';
 import { JsLoaderResult } from '@rspack/binding';
 import { JsModule } from '@rspack/binding';
+import { JsPathData } from '@rspack/binding';
 import type { JsRuntimeModule } from '@rspack/binding';
 import { JsStats } from '@rspack/binding';
 import type { JsStatsChunk } from '@rspack/binding';
@@ -41,7 +42,6 @@ import { libCacheFacade } from './lib/CacheFacade';
 import { LoaderContext as LoaderContext_2 } from './config';
 import { Logger as Logger_2 } from './logging/Logger';
 import { MultiHook } from 'tapable';
-import { PathData } from '@rspack/binding';
 import { PathWithInfo } from '@rspack/binding';
 import { RawBannerPluginOptions } from '@rspack/binding';
 import { RawBuiltins } from '@rspack/binding';
@@ -382,6 +382,8 @@ export class Compilation {
     //
     // (undocumented)
     getLogger(name: string | (() => string)): Logger;
+    // Warning: (ae-forgotten-export) The symbol "PathData" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     getPath(filename: Filename, data?: PathData): string;
     // (undocumented)
@@ -2278,11 +2280,11 @@ export const rspackOptions: z.ZodObject<{
         path: z.ZodOptional<z.ZodString>;
         clean: z.ZodOptional<z.ZodBoolean>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
-        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-        chunkFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
+        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
+        chunkFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         crossOriginLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["anonymous", "use-credentials"]>]>>;
-        cssFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-        cssChunkFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
+        cssFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
+        cssChunkFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         hotUpdateMainFilename: z.ZodOptional<z.ZodString>;
         hotUpdateChunkFilename: z.ZodOptional<z.ZodString>;
         hotUpdateGlobal: z.ZodOptional<z.ZodString>;
@@ -2425,11 +2427,11 @@ export const rspackOptions: z.ZodObject<{
         path?: string | undefined;
         clean?: boolean | undefined;
         publicPath?: string | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
@@ -2500,11 +2502,11 @@ export const rspackOptions: z.ZodObject<{
         path?: string | undefined;
         clean?: boolean | undefined;
         publicPath?: string | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
@@ -3739,11 +3741,11 @@ export const rspackOptions: z.ZodObject<{
         path?: string | undefined;
         clean?: boolean | undefined;
         publicPath?: string | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
@@ -4124,11 +4126,11 @@ export const rspackOptions: z.ZodObject<{
         path?: string | undefined;
         clean?: boolean | undefined;
         publicPath?: string | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
@@ -4968,13 +4970,13 @@ export type WorkerPublicPath = z.infer<typeof workerPublicPath>;
 
 // Warnings were encountered during analysis:
 //
-// dist/Compilation.d.ts:65:9 - (ae-forgotten-export) The symbol "liteTapable" needs to be exported by the entry point index.d.ts
-// dist/Compilation.d.ts:70:9 - (ae-forgotten-export) The symbol "Module" needs to be exported by the entry point index.d.ts
-// dist/Compilation.d.ts:72:9 - (ae-forgotten-export) The symbol "Chunk" needs to be exported by the entry point index.d.ts
-// dist/Compilation.d.ts:85:9 - (ae-forgotten-export) The symbol "StatsFactory" needs to be exported by the entry point index.d.ts
-// dist/Compilation.d.ts:86:9 - (ae-forgotten-export) The symbol "StatsPrinter" needs to be exported by the entry point index.d.ts
-// dist/Compilation.d.ts:88:9 - (ae-forgotten-export) The symbol "ExecuteModuleArgument" needs to be exported by the entry point index.d.ts
-// dist/Compilation.d.ts:88:9 - (ae-forgotten-export) The symbol "ExecuteModuleContext" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:66:9 - (ae-forgotten-export) The symbol "liteTapable" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:71:9 - (ae-forgotten-export) The symbol "Module" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:73:9 - (ae-forgotten-export) The symbol "Chunk" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:86:9 - (ae-forgotten-export) The symbol "StatsFactory" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:87:9 - (ae-forgotten-export) The symbol "StatsPrinter" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:89:9 - (ae-forgotten-export) The symbol "ExecuteModuleArgument" needs to be exported by the entry point index.d.ts
+// dist/Compilation.d.ts:89:9 - (ae-forgotten-export) The symbol "ExecuteModuleContext" needs to be exported by the entry point index.d.ts
 // dist/Compiler.d.ts:82:9 - (ae-forgotten-export) The symbol "AssetEmittedInfo" needs to be exported by the entry point index.d.ts
 // dist/MultiCompiler.d.ts:35:9 - (ae-forgotten-export) The symbol "Any" needs to be exported by the entry point index.d.ts
 // dist/NormalModuleFactory.d.ts:9:9 - (ae-forgotten-export) The symbol "ResourceDataWithData" needs to be exported by the entry point index.d.ts

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -20,7 +20,7 @@ import type {
 	JsRuntimeModule,
 	JsStatsChunk,
 	JsStatsError,
-	PathData
+	JsPathData
 } from "@rspack/binding";
 
 import {
@@ -65,6 +65,9 @@ export interface Asset {
 	source: Source;
 	info: JsAssetInfo;
 }
+
+export type PathData = JsPathData;
+
 export interface LogEntry {
 	type: string;
 	args: any[];

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1,4 +1,4 @@
-import { RawFuncUseCtx, PathData, JsAssetInfo } from "@rspack/binding";
+import { RawFuncUseCtx, JsAssetInfo } from "@rspack/binding";
 import { z } from "zod";
 import { Compilation, Compiler } from "..";
 import type * as oldBuiltins from "../builtin-plugin";
@@ -6,6 +6,7 @@ import type * as webpackDevServer from "webpack-dev-server";
 import { deprecatedWarn } from "../util";
 import { Module } from "../Module";
 import { Chunk } from "../Chunk";
+import { PathData } from "../Compilation";
 
 //#region Name
 const name = z.string();

--- a/packages/rspack/tests/configCases/hooks/compat-path-data-chunk-contenthash/test.config.js
+++ b/packages/rspack/tests/configCases/hooks/compat-path-data-chunk-contenthash/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  noTests: true,
+}

--- a/packages/rspack/tests/configCases/hooks/compat-path-data-chunk-contenthash/webpack.config.js
+++ b/packages/rspack/tests/configCases/hooks/compat-path-data-chunk-contenthash/webpack.config.js
@@ -1,0 +1,28 @@
+const pluginName = "plugin";
+
+class Plugin {
+	apply(compiler) {
+		let called = false;
+		compiler.hooks.compilation.tap(pluginName, compilation => {
+			const p = compilation.getPath("[contenthash]", {
+				contentHash: "xxx1",
+				chunk: {
+					contentHash: "xxx2"
+				}
+			});
+			called = true;
+			expect(p).toBe("xxx1")
+		});
+		compiler.hooks.done.tap(pluginName, stats => {
+			let json = stats.toJson();
+			expect(json.errors.length === 0);
+			expect(called).toBe(true);
+		});
+	}
+}
+
+/**@type {import('@rspack/cli').Configuration}*/
+module.exports = {
+	context: __dirname,
+	plugins: [new Plugin()]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

before `pathdata.chunk.contentHash` is only `HashMap<String, String>`, but in practice (css-loader) it can be a `String`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
