### PR TITLE
docs: bump Rspress v1.18.2 and remove dividers

### DIFF
--- a/website/docs/en/guide/quick-start.mdx
+++ b/website/docs/en/guide/quick-start.mdx
@@ -4,8 +4,6 @@ import { Tabs, Tab, PackageManagerTabs } from '@theme';
 
 Get up to speed quickly with a new Rspack based project.
 
----
-
 ## Creating project using scaffolding
 
 ### Using Rsbuild
@@ -28,8 +26,6 @@ Run the following command to create an Rspack CLI project:
 
 Then follow the prompts in your terminal.
 
----
-
 ## Migrating from existing projects
 
 If you need to migrate from an existing project to Rspack or Rsbuild, you can refer to the following guides:
@@ -39,8 +35,6 @@ If you need to migrate from an existing project to Rspack or Rsbuild, you can re
 - [Migrating from Vue CLI to Rsbuild](https://rsbuild.dev/guide/migration/vue-cli)
 - [Migrating from Create React App to Rsbuild](https://rsbuild.dev/guide/migration/cra)
 - [Migrating from Storybook](/guide/migrate-storybook)
-
----
 
 ## Community toolchain
 

--- a/website/docs/zh/guide/quick-start.mdx
+++ b/website/docs/zh/guide/quick-start.mdx
@@ -4,8 +4,6 @@ import { Tabs, Tab, PackageManagerTabs } from '@theme';
 
 通过本章节来了解如何快速上手并使用 Rspack。
 
----
-
 ## 使用脚手架快速创建
 
 ### 使用 Rsbuild
@@ -28,8 +26,6 @@ Rspack CLI 是对标 Webpack CLI 的工具，提供基础的 `serve` 和 `build`
 
 然后按照提示操作。
 
----
-
 ## 从现有项目迁移
 
 如果你需要从一个现有项目迁移迁移到 Rspack 或 Rsbuild，可以参考以下指南：
@@ -39,8 +35,6 @@ Rspack CLI 是对标 Webpack CLI 的工具，提供基础的 `serve` 和 `build`
 - [从 Vue CLI 迁移到 Rsbuild](https://rsbuild.dev/zh/guide/migration/vue-cli)
 - [从 Create React App 迁移到 Rsbuild](https://rsbuild.dev/zh/guide/migration/cra)
 - [从 Storybook 迁移](/guide/migrate-storybook)
-
----
 
 ## 社区工具链
 

--- a/website/package.json
+++ b/website/package.json
@@ -29,8 +29,8 @@
   },
   "devDependencies": {
     "@modern-js/tsconfig": "^2.46.1",
-    "@rspress/plugin-rss": "^1.17.1",
-    "@rspress/shared": "^1.17.1",
+    "@rspress/plugin-rss": "^1.18.2",
+    "@rspress/shared": "^1.18.2",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@types/semver": "^7.5.2",
@@ -41,7 +41,7 @@
     "prettier": "3.2.5",
     "rsbuild-plugin-google-analytics": "1.0.0",
     "rsbuild-plugin-open-graph": "1.0.0",
-    "rspress": "^1.17.1",
+    "rspress": "^1.18.2",
     "rspress-plugin-font-open-sans": "1.0.0",
     "typescript": "^5.0.4"
   }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -43,11 +43,11 @@ importers:
         specifier: ^2.46.1
         version: 2.48.4
       '@rspress/plugin-rss':
-        specifier: ^1.17.1
-        version: 1.17.1(react@18.2.0)(rspress@1.17.1)
+        specifier: ^1.18.2
+        version: 1.18.2(react@18.2.0)(rspress@1.18.2)
       '@rspress/shared':
-        specifier: ^1.17.1
-        version: 1.17.1
+        specifier: ^1.18.2
+        version: 1.18.2
       '@types/node':
         specifier: ^18.11.18
         version: 18.19.31
@@ -74,13 +74,13 @@ importers:
         version: 3.2.5
       rsbuild-plugin-google-analytics:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@0.5.1)
+        version: 1.0.0(@rsbuild/core@0.6.1)
       rsbuild-plugin-open-graph:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@0.5.1)
+        version: 1.0.0(@rsbuild/core@0.6.1)
       rspress:
-        specifier: ^1.17.1
-        version: 1.17.1(webpack@5.91.0)
+        specifier: ^1.18.2
+        version: 1.18.2(webpack@5.91.0)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -529,8 +529,8 @@ packages:
     resolution: {integrity: sha512-9XESp5lHMVYdZE+BcBN2LhDaQxZ4FWhDZlX4HdBTHHvlosf4lwYoDPc5VlIYXAsXIpdI6xwzKWEHeEKcdcbz9A==}
     dev: true
 
-  /@modern-js/utils@2.48.4:
-    resolution: {integrity: sha512-ummxga/VKrQjh8TdWtxckx9hefMKfe6cxY1fpDmn5wOkJbNpLS2GIlEFPDhlN451JyeMDD9kbxRedq4ETE+NqQ==}
+  /@modern-js/utils@2.49.0:
+    resolution: {integrity: sha512-WatsnUK7mp8PwkQKjApfoKTGJSzN66GKPJ9CujKrL8sJDSPHAWDKoDgmXvVZ09OWs7Vgcf8lq4bHL1NQ75Bh1g==}
     dependencies:
       '@swc/helpers': 0.5.3
       caniuse-lite: 1.0.30001599
@@ -592,134 +592,130 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: true
 
-  /@rsbuild/core@0.5.1:
-    resolution: {integrity: sha512-xpWRETHgRUmEgmKhK03PloiiYZ455myyGkc0VTionCLUSpdT+jyTtDUW0T+rNvHkgukH20fVvjpwMbQnT19vXw==}
+  /@rsbuild/core@0.6.1:
+    resolution: {integrity: sha512-I/AE7AbRu7hEytRlxKptSGkd2ZXAgowUjH86dspkinoBlGcGjRhYGAYaDR4svfq3MmTTuU0lA/w4JAHHR0E59A==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
-      '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
-      '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
+      '@rsbuild/shared': 0.6.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.6.1(@swc/helpers@0.5.3)
       '@swc/helpers': 0.5.3
       core-js: 3.36.1
-      html-webpack-plugin: /html-rspack-plugin@5.6.2(@rspack/core@0.5.8)
+      html-webpack-plugin: /html-rspack-plugin@5.6.2(@rspack/core@0.6.1)
       postcss: 8.4.38
     dev: true
 
-  /@rsbuild/plugin-react@0.5.1(@rsbuild/core@0.5.1):
-    resolution: {integrity: sha512-5GkLJj/Ht+6HUOGMSXK3v3lfe4ldkaPBtKLd11XUrvGkgPrOAYHZvzF6vLSZaM2yJRr0irLTMYYTBrK+D2Iypw==}
+  /@rsbuild/plugin-react@0.6.1(@rsbuild/core@0.6.1):
+    resolution: {integrity: sha512-U/ZeuXDbT0lqUmIBWZOuZlaR036eGvsPaXUCugDQWWYRo0dM894dQd2q3EPh6KJv55VQ9eMxNMvKgVYA+7fhug==}
     peerDependencies:
-      '@rsbuild/core': ^0.5.1
+      '@rsbuild/core': ^0.6.1
     dependencies:
-      '@rsbuild/core': 0.5.1
-      '@rsbuild/shared': 0.5.1(@swc/helpers@0.5.3)
-      '@rspack/plugin-react-refresh': 0.5.8(react-refresh@0.14.0)
+      '@rsbuild/core': 0.6.1
+      '@rsbuild/shared': 0.6.1(@swc/helpers@0.5.3)
+      '@rspack/plugin-react-refresh': 0.6.1(react-refresh@0.14.0)
       react-refresh: 0.14.0
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@rsbuild/shared@0.5.1(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-jBa4Cm91s/1KBcDs1MgGqYbaGRtmSjJK9BQeFV1dKvQoxpXViwOO457EBmOb+T28Dy6hNJK/1f9Uza5qQ4/7Tg==}
+  /@rsbuild/shared@0.6.1(@swc/helpers@0.5.3):
+    resolution: {integrity: sha512-AEjdkhgc1FHPPEPWua3k6i/UOgxw9xvIGjl7IEyC4jJgYAKDqr2LcL6hhP+dS3BAVDUsJrQJ0FN3zWLkaYICDQ==}
     dependencies:
-      '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
-      caniuse-lite: 1.0.30001599
+      '@rspack/core': 0.6.1(@swc/helpers@0.5.3)
+      caniuse-lite: 1.0.30001611
       postcss: 8.4.38
     transitivePeerDependencies:
       - '@swc/helpers'
     dev: true
 
-  /@rspack/binding-darwin-arm64@0.5.8:
-    resolution: {integrity: sha512-kvz2f9bMoFOEuXJ/fyJzOWuNXq5EvQhA19cqgwrDRQgfc5sQ0qv2vW3qI5v2oVOHccQBwKHkVTHHDn5vWlnRsQ==}
+  /@rspack/binding-darwin-arm64@0.6.1:
+    resolution: {integrity: sha512-VbNGprAwNDrddEzGUuy6c+Q9DVlLj8jbtKsBK8maw0ERH7csX+RiH8iK+mUUf3TVMB7egRPODCBgzluyh4smYw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-darwin-x64@0.5.8:
-    resolution: {integrity: sha512-TgVtKntzOGcIczogZXMWqqXrvK07XjRnz1ES56RYfsOVvzTEmldvX5S+pQIwYzCt7fNddIMl9muHa9qYswzFbQ==}
+  /@rspack/binding-darwin-x64@0.6.1:
+    resolution: {integrity: sha512-JPRSVUEHxPPNaD8H1e5dCinu/ST5UKF0PTfxL4yElbwWnujWRYhoXZAqEEImDTFIHl8pzf5asUEUt01UGpLuqw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu@0.5.8:
-    resolution: {integrity: sha512-g+4ddgEpK+R50mqKs6jPr7IiPGpukabbSBSYGGezErHMMAfgSxuRQ1IGP/pOOHQXXmHJbrbqk4Ow56vE0fKZnQ==}
+  /@rspack/binding-linux-arm64-gnu@0.6.1:
+    resolution: {integrity: sha512-XM3qcxuoH3cETolV1xE8ig169K8hJ5xUcll3bJ0xAmDOdqzXIjnlcKiXWEJbgDY5VFwOqh27SoB3xxXQQv6KPQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-linux-arm64-musl@0.5.8:
-    resolution: {integrity: sha512-MistQCUYkcwb4u3XTnmwGimxD161LlRZqP/7PPrInaBNCpYQYnXI4RX6RhMgusnjaW406N0XBS94Q9QNwujyxg==}
+  /@rspack/binding-linux-arm64-musl@0.6.1:
+    resolution: {integrity: sha512-WHDZew5i/Vts5MOyFwwjkfZrPehx9d6Zx/dGSsUriyu+bFmJGNnvSPpcpJejL9t0GNsjs1EL7K5fjwXro3qABA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-linux-x64-gnu@0.5.8:
-    resolution: {integrity: sha512-DlsCXeSZKKOh7T8uwIcUgbOXLcsoUVCHkWx04GDBi09OYHjrT+dc1Iqpy5uHcIScRWjtVgGnOb6M9EsyABNoAw==}
+  /@rspack/binding-linux-x64-gnu@0.6.1:
+    resolution: {integrity: sha512-bvexuC7ad2hbIDWRURAdwvMHoJmDLL+W2iaQp2xe7x1WKaGt5fT6ZePAth+f0xro+PuAbnfJ5H3J++xvqvAUHA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-linux-x64-musl@0.5.8:
-    resolution: {integrity: sha512-B4V5wFGig+WCNbeOwU6O8rvxzu9sONUML6YEe/NiR+e9NLsYemEQG8volZVQ4WM/SDii6G4h9z/2jEoGXcfRsQ==}
+  /@rspack/binding-linux-x64-musl@0.6.1:
+    resolution: {integrity: sha512-o4P54sUVaHVYyCd6KAUgBNOkBVD39xOyjpK3Ob8+lmrunDAzw6hbE2tMORMm9BfaCeKh+F17VthPjTlFgQsRRg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc@0.5.8:
-    resolution: {integrity: sha512-ubWsFoJkUQNOt1w1WDQCk5UvFPOII/dNj/orpEe+NPveEn6i+im2euK+6fKucmDrXAyC1ZhEzjJeFMjcvyS9Dg==}
+  /@rspack/binding-win32-arm64-msvc@0.6.1:
+    resolution: {integrity: sha512-6OoPlxZH2j+k1JyzO0khbtodJmXgpscx7sa6i2HvUsSWJVxAAjMf2ZdRsDGwMxATp9S9HIDklqV7h2X9/nfIvg==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc@0.5.8:
-    resolution: {integrity: sha512-NPwkNbEe/IY/I93E07q3p7AM4rLDLkpgTzBPFhi6jgNzK8k/eGAUIdaEDJhEkWzsI8o8m7I5XlJyxrmK5/SWFw==}
+  /@rspack/binding-win32-ia32-msvc@0.6.1:
+    resolution: {integrity: sha512-eJ+WNrEymxFBAB187fFobCS3MUc1afCv0EzAs9LAVPgj2Z3fE8l2XCDUPsRkGtQyh8ftTdyyY9JNqYEIOrx4RQ==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@0.5.8:
-    resolution: {integrity: sha512-ox+PdrWh5VjI3G2GCLoXJ0eZ/lLgxPQsmGkyjikJyaIuetWtMun8khvaoAspnSw3FzHCEbA62vs0ot8YV3DggQ==}
+  /@rspack/binding-win32-x64-msvc@0.6.1:
+    resolution: {integrity: sha512-Wk/p1jwcjICKOGLmUkrbUZTZ5yQuYJEjNhMyAZDBQtQMOqkycOsijw8c/KYEfJTzSK0TuE+5rK5WDqQkGaYFoQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@rspack/binding@0.5.8:
-    resolution: {integrity: sha512-RDiiBDeIwCPtqQ/CYMXoFqstaJVGZu3KoUKeuJoiN+TO77OAC0fRs7J/BvV+KLoF35SFpe/XnSLCkv+Nkk9/ow==}
+  /@rspack/binding@0.6.1:
+    resolution: {integrity: sha512-Kh81wjmT7r0JiFrqyMOkuve5Pwm4Mq44m6+tywE15bDTpahDIDQ3x18fZqeSTWG4t3P0fhvljsiWWAlPvwyjOg==}
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.5.8
-      '@rspack/binding-darwin-x64': 0.5.8
-      '@rspack/binding-linux-arm64-gnu': 0.5.8
-      '@rspack/binding-linux-arm64-musl': 0.5.8
-      '@rspack/binding-linux-x64-gnu': 0.5.8
-      '@rspack/binding-linux-x64-musl': 0.5.8
-      '@rspack/binding-win32-arm64-msvc': 0.5.8
-      '@rspack/binding-win32-ia32-msvc': 0.5.8
-      '@rspack/binding-win32-x64-msvc': 0.5.8
+      '@rspack/binding-darwin-arm64': 0.6.1
+      '@rspack/binding-darwin-x64': 0.6.1
+      '@rspack/binding-linux-arm64-gnu': 0.6.1
+      '@rspack/binding-linux-arm64-musl': 0.6.1
+      '@rspack/binding-linux-x64-gnu': 0.6.1
+      '@rspack/binding-linux-x64-musl': 0.6.1
+      '@rspack/binding-win32-arm64-msvc': 0.6.1
+      '@rspack/binding-win32-ia32-msvc': 0.6.1
+      '@rspack/binding-win32-x64-msvc': 0.6.1
     dev: true
 
-  /@rspack/core@0.5.8(@swc/helpers@0.5.3):
-    resolution: {integrity: sha512-F7NiiLCE//5JXsEmS36DcIUiSyi5sylZZ5MKw9ABSGrtqVDB23oOjUxP1kt/Wo6npf0V2eVuAHpoudwJ1lUmhQ==}
+  /@rspack/core@0.6.1(@swc/helpers@0.5.3):
+    resolution: {integrity: sha512-DBlyxm0cyxJ0WiYLeirdJghLhKovLXDhZiQZovZPTFljd1ZX1lCDvTj11KApmW8eJDoiBi0QDYWRLXeZetGllg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -728,7 +724,7 @@ packages:
         optional: true
     dependencies:
       '@module-federation/runtime-tools': 0.0.8
-      '@rspack/binding': 0.5.8
+      '@rspack/binding': 0.6.1
       '@swc/helpers': 0.5.3
       browserslist: 4.23.0
       enhanced-resolve: 5.12.0
@@ -743,8 +739,8 @@ packages:
       zod-validation-error: 1.3.1(zod@3.22.4)
     dev: true
 
-  /@rspack/plugin-react-refresh@0.5.8(react-refresh@0.14.0):
-    resolution: {integrity: sha512-y6wp0r4u+QxReP5DmKI2MTG5VfOATHIsFmbujhrM/C1Afon7azGZL7by7Rn+pc6A2ul2jigTph7Mlp7vVC3tbQ==}
+  /@rspack/plugin-react-refresh@0.6.1(react-refresh@0.14.0):
+    resolution: {integrity: sha512-yTxsm/tiso3YQRt7kHQbk/b+QZWpBNutWjLBAb7571Wu53p98Jlv9rhYKpuXgQQWGKxCPXQcR1fAd5zbvU0UMQ==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -754,28 +750,28 @@ packages:
       react-refresh: 0.14.0
     dev: true
 
-  /@rspress/core@1.17.1(webpack@5.91.0):
-    resolution: {integrity: sha512-pGdgEG8QqGxvNzh1NerYdExJ+Gl1ZE5+APkPHO4NniDS5nCUe5STEgbXANVXV1xTlrzuG7qXzqAArjx98AY4kw==}
+  /@rspress/core@1.18.2(webpack@5.91.0):
+    resolution: {integrity: sha512-9y/mRFXk6gEszTJxV89yJ7awxaL2AgtbWa2eJUDd3uB1X4xiN8eilWJoj5qg7S8u/BumGv1uR/HkNupS3ohqNg==}
     engines: {node: '>=14.17.6'}
     dependencies:
       '@loadable/component': 5.15.2(react@18.2.0)
       '@mdx-js/loader': 2.3.0(webpack@5.91.0)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.2.0)
-      '@modern-js/utils': 2.48.4
-      '@rsbuild/core': 0.5.1
-      '@rsbuild/plugin-react': 0.5.1(@rsbuild/core@0.5.1)
+      '@modern-js/utils': 2.49.0
+      '@rsbuild/core': 0.6.1
+      '@rsbuild/plugin-react': 0.6.1(@rsbuild/core@0.6.1)
       '@rspress/mdx-rs': 0.5.1
-      '@rspress/plugin-auto-nav-sidebar': 1.17.1
-      '@rspress/plugin-container-syntax': 1.17.1
-      '@rspress/plugin-last-updated': 1.17.1
-      '@rspress/plugin-medium-zoom': 1.17.1(@rspress/runtime@1.17.1)
-      '@rspress/runtime': 1.17.1
-      '@rspress/shared': 1.17.1
-      '@rspress/theme-default': 1.17.1
+      '@rspress/plugin-auto-nav-sidebar': 1.18.2
+      '@rspress/plugin-container-syntax': 1.18.2
+      '@rspress/plugin-last-updated': 1.18.2
+      '@rspress/plugin-medium-zoom': 1.18.2(@rspress/runtime@1.18.2)
+      '@rspress/runtime': 1.18.2
+      '@rspress/shared': 1.18.2
+      '@rspress/theme-default': 1.18.2
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
-      enhanced-resolve: 5.12.0
+      enhanced-resolve: 5.16.0
       flexsearch: 0.6.32
       fs-extra: 10.1.0
       github-slugger: 2.0.0
@@ -899,65 +895,65 @@ packages:
       '@rspress/mdx-rs-win32-x64-msvc': 0.5.1
     dev: true
 
-  /@rspress/plugin-auto-nav-sidebar@1.17.1:
-    resolution: {integrity: sha512-TBR1U50n0FpxZRTw1mVmKh6Pmc4JcFSFZVAIZ4b00SMW2vMHEFvsqZyrO/C8+yICG7+9SO+7lHn61W+b/Ls30A==}
+  /@rspress/plugin-auto-nav-sidebar@1.18.2:
+    resolution: {integrity: sha512-DwpA3rSXUDVvI6+ruaGlwDgVDP5yB5j8KgihOfyzo469L8XJDIYxuagSMkY1n+3KA9cMjIuSimNRJoKQ5PFOEQ==}
     engines: {node: '>=14.17.6'}
     dependencies:
-      '@rspress/shared': 1.17.1
+      '@rspress/shared': 1.18.2
     dev: true
 
-  /@rspress/plugin-container-syntax@1.17.1:
-    resolution: {integrity: sha512-3VIaauYQaIF987GSXU6M7fI/5RpXcdsD7Qz3BdddWZ+serwjcFmHLlkvdxI6rm3voFcPI33b4YZIRnqxQYDAiw==}
+  /@rspress/plugin-container-syntax@1.18.2:
+    resolution: {integrity: sha512-8FQJLk1dNFQuoYyYWPxKYjs2hLxe5LI4WBPn1t3OFyCaVGgJaA7cisAhcPA9jW4swIie4BfGoqccKI33GYNgCw==}
     engines: {node: '>=14.17.6'}
     dependencies:
-      '@rspress/shared': 1.17.1
+      '@rspress/shared': 1.18.2
     dev: true
 
-  /@rspress/plugin-last-updated@1.17.1:
-    resolution: {integrity: sha512-//shdj5PPy9KGW9esOXW4ULKs4XccRkXZTJyKNQX6ZKlYOzSXLGAGYQBCgEzjoXBCW4XbVx3ttu8kX/Z78cUOw==}
+  /@rspress/plugin-last-updated@1.18.2:
+    resolution: {integrity: sha512-KyCzUWmxOw8b58myFzl9TkOcWy0mbvMJ7zGxUPxJNl0r9PkbXb7qNsjDIqHsiObLgnLmGFLFLB9lHaN88cTtuw==}
     engines: {node: '>=14.17.6'}
     dependencies:
-      '@rspress/shared': 1.17.1
+      '@rspress/shared': 1.18.2
     dev: true
 
-  /@rspress/plugin-medium-zoom@1.17.1(@rspress/runtime@1.17.1):
-    resolution: {integrity: sha512-vFo0/yFh9n3TOqg/Odnr9IxDIkcG5zG+WWtCv/vpj5NKkc358F+ZSMnOhYuOpd8ygT3v+paXcphNLkd1LFAkWA==}
+  /@rspress/plugin-medium-zoom@1.18.2(@rspress/runtime@1.18.2):
+    resolution: {integrity: sha512-t8IEXGJgT7SbiPje3bewbC3Pg5tb+ozltFMhGNeoLMy1A5ECHqBs5YpzuAstmoeUubg8/LZ49NkEIu2H3Mti4w==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       '@rspress/runtime': ^1.0.2
     dependencies:
-      '@rspress/runtime': 1.17.1
+      '@rspress/runtime': 1.18.2
       medium-zoom: 1.0.8
     dev: true
 
-  /@rspress/plugin-rss@1.17.1(react@18.2.0)(rspress@1.17.1):
-    resolution: {integrity: sha512-wYklDM1kvjE3Ql7pQLQ9D9wJcPt/9M6+S61TxSEN6Z7IKGtSzXkgV3SbPgOg7c9NaYlpsS9EozOIoMbq+P1L2Q==}
+  /@rspress/plugin-rss@1.18.2(react@18.2.0)(rspress@1.18.2):
+    resolution: {integrity: sha512-DgyU9dRIh1CuHAAC6jrwvJqJqIZSuDaKk+qp2jm1VW952n1bTJLWJemfh4tM9r6i1C2+YhuP4h0MPw17hC6Ffw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
       rspress: ^1.17.0
     dependencies:
-      '@rspress/shared': 1.17.1
+      '@rspress/shared': 1.18.2
       feed: 4.2.2
       react: 18.2.0
-      rspress: 1.17.1(webpack@5.91.0)
+      rspress: 1.18.2(webpack@5.91.0)
     dev: true
 
-  /@rspress/runtime@1.17.1:
-    resolution: {integrity: sha512-BwT9UgkgBdyxXsh9fgRMCQtarfv70M2ULj1a9ztfqJsVZ5T6X6OjTS7O/gspeS215373nxHvIKmFmM254ySU2w==}
+  /@rspress/runtime@1.18.2:
+    resolution: {integrity: sha512-2lAG7i1AEe+uClTxrJKG079ZjCa6jSAEimLRvSZO3t4G9BbY71j9ODl8XwC4rTc8JzHONdX1UYv4sKN3BQYRvw==}
     engines: {node: '>=14.17.6'}
     dependencies:
-      '@rspress/shared': 1.17.1
+      '@rspress/shared': 1.18.2
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-helmet-async: 1.3.0(react-dom@18.2.0)(react@18.2.0)
       react-router-dom: 6.22.3(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
-  /@rspress/shared@1.17.1:
-    resolution: {integrity: sha512-cHH58P3S+CWqu1/Qr3Uo+nkGMDlbB8hiokwqAl/4N+DNR+qFcaE7tJqbt9IU6ud+v5SJWg/sv099CzRq5U2/kw==}
+  /@rspress/shared@1.18.2:
+    resolution: {integrity: sha512-/siTFxmA5Aj9x6dXpZSrY7lAqd3aAvI5gZiQZ+HnfDuLBJDPndf073jRFJcAILLupWrSUnrIDUsuGIqDUAZu+w==}
     dependencies:
-      '@rsbuild/core': 0.5.1
+      '@rsbuild/core': 0.6.1
       chalk: 4.1.2
       execa: 5.1.1
       fs-extra: 11.2.0
@@ -965,13 +961,13 @@ packages:
       unified: 10.1.2
     dev: true
 
-  /@rspress/theme-default@1.17.1:
-    resolution: {integrity: sha512-6APJufBgazaDE06h/JEggOyEdST9TAv1jjkZv7nudiyEgmGkCENW4ANY1cXgr5eXsUxwg4ms7i0s4P3kz3Cwfg==}
+  /@rspress/theme-default@1.18.2:
+    resolution: {integrity: sha512-CEPqkWqASLpxUevhf89aqgK0u++EItWIDGMHO8aYquxFbv9iMPVEnjd9xUKiUwBlpueELyRmrHxH1GTz+nTctQ==}
     engines: {node: '>=14.17.6'}
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.2.0)
-      '@rspress/runtime': 1.17.1
-      '@rspress/shared': 1.17.1
+      '@rspress/runtime': 1.18.2
+      '@rspress/shared': 1.18.2
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.6.32
@@ -1385,6 +1381,10 @@ packages:
 
   /caniuse-lite@1.0.30001599:
     resolution: {integrity: sha512-LRAQHZ4yT1+f9LemSMeqdMpMxZcc4RMWdj4tiFe3G8tNkWK+E58g+/tzotb5cU6TbcVJLr4fySiAW7XmxQvZQA==}
+    dev: true
+
+  /caniuse-lite@1.0.30001611:
+    resolution: {integrity: sha512-19NuN1/3PjA3QI8Eki55N8my4LzfkMCRLgCVfrl/slbSAchQfV0+GwjPrK3rq37As4UCLlM/DHajbKkAqbv92Q==}
     dev: true
 
   /case-police@0.6.1:
@@ -2403,7 +2403,7 @@ packages:
     resolution: {integrity: sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==}
     dev: true
 
-  /html-rspack-plugin@5.6.2(@rspack/core@0.5.8):
+  /html-rspack-plugin@5.6.2(@rspack/core@0.6.1):
     resolution: {integrity: sha512-cPGwV3odvKJ7DBAG/DxF5e0nMMvBl1zGfyDciT2xMETRrIwajwC7LtEB3cf7auoGMK6xJOOLjWJgaKHLu/FzkQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -2412,7 +2412,7 @@ packages:
       '@rspack/core':
         optional: true
     dependencies:
-      '@rspack/core': 0.5.8(@swc/helpers@0.5.3)
+      '@rspack/core': 0.6.1(@swc/helpers@0.5.3)
       lodash: 4.17.21
       tapable: 2.2.1
     dev: true
@@ -3911,7 +3911,7 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  /rsbuild-plugin-google-analytics@1.0.0(@rsbuild/core@0.5.1):
+  /rsbuild-plugin-google-analytics@1.0.0(@rsbuild/core@0.6.1):
     resolution: {integrity: sha512-Z2hVetWq48QT+X/HMmtp+YTxzPw+ujt/KUrbQXn98LmUDYqJyGSCBAjit8atAoRiThUSKlkG+NU3+zkFvKoLdA==}
     peerDependencies:
       '@rsbuild/core': 0.x
@@ -3919,10 +3919,10 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 0.5.1
+      '@rsbuild/core': 0.6.1
     dev: true
 
-  /rsbuild-plugin-open-graph@1.0.0(@rsbuild/core@0.5.1):
+  /rsbuild-plugin-open-graph@1.0.0(@rsbuild/core@0.6.1):
     resolution: {integrity: sha512-SuN9w2FH2v9Mp9/jBowH/RvR74i5A1KzM8+3JrCwCpsuny2HQ3iZqVETgDJ0VIcXqLHUxPnI0aGMgbAcqmlzcg==}
     peerDependencies:
       '@rsbuild/core': 0.x
@@ -3930,7 +3930,7 @@ packages:
       '@rsbuild/core':
         optional: true
     dependencies:
-      '@rsbuild/core': 0.5.1
+      '@rsbuild/core': 0.6.1
     dev: true
 
   /rsfamily-nav-icon@1.0.2:
@@ -3952,13 +3952,13 @@ packages:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
     dev: true
 
-  /rspress@1.17.1(webpack@5.91.0):
-    resolution: {integrity: sha512-/Gi0oMFfgXXChudL37cEsujxPrtsgWvka0oLoVV6k03kKpNQDynzpMwbVB+iqqVafD4W2mHjYF6mqPjRaZqHFw==}
+  /rspress@1.18.2(webpack@5.91.0):
+    resolution: {integrity: sha512-fzAR0m8A1n7D3pPRblGEsws7J9XSgzDf6PXUH5CRKr0sVgGF80SxMF79V1AEiI3cgCzumqqBoXDzHWpQQU3AKg==}
     hasBin: true
     dependencies:
-      '@rsbuild/core': 0.5.1
-      '@rspress/core': 1.17.1(webpack@5.91.0)
-      '@rspress/shared': 1.17.1
+      '@rsbuild/core': 0.6.1
+      '@rspress/core': 1.18.2(webpack@5.91.0)
+      '@rspress/shared': 1.18.2
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.6.0

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -3,17 +3,17 @@ import { HomeLayout } from './pages';
 import { RsfamilyNavIcon } from 'rsfamily-nav-icon';
 import 'rsfamily-nav-icon/dist/index.css';
 // enable this when we need a new announcement
-import { Announcement } from './components/Announcement';
-import { NoSSR } from 'rspress/runtime';
+// import { Announcement } from './components/Announcement';
+// import { NoSSR } from 'rspress/runtime';
 
 const Layout = () => (
   <Theme.Layout
     beforeNavTitle={<RsfamilyNavIcon />}
-    beforeNav={
-      <NoSSR>
-        <Announcement />
-      </NoSSR>
-    }
+    // beforeNav={
+    //   <NoSSR>
+    //     <Announcement />
+    //   </NoSSR>
+    // }
   />
 );
 


### PR DESCRIPTION
## Summary

Bump Rspress v1.18.2 and remove dividers. Rspress now provides a default divider for h2 title.

Also removed the hiring announcement in the homepage.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v1.18.2

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
