### PR TITLE
docs: update minification guides

### DIFF
--- a/website/components/i18n/en.json
+++ b/website/components/i18n/en.json
@@ -11,7 +11,7 @@
   "banner-plugin-desc": "Support for this plugin was implemented in v0.3.3, before v0.3.3 you could use builtins.banner instead.",
   "ignore-plugin-desc": "Recommend using rspack.IgnorePlugin instead.",
   "mini-css-extract-plugin-desc": "use experiments.css or rspack.CssExtractRspackPlugin instead",
-  "terser-webpack-plugin-desc": "Use rspack.SwcJsMinimizerRspackPlugin or builtins.minifyOptions instead.",
+  "terser-webpack-plugin-desc": "Use rspack.SwcJsMinimizerRspackPlugin instead.",
   "progress-plugin-desc": "use builtins.progress instead",
   "tsconfig-paths-webpack-plugin-desc": "use resolve.tsconfigPath instead"
 }

--- a/website/components/i18n/zh.json
+++ b/website/components/i18n/zh.json
@@ -11,7 +11,7 @@
   "banner-plugin-desc": "在 v0.3.3 已实现对该插件的支持，v0.3.3 之前可使用 builtins.banner 替代",
   "ignore-plugin-desc": "推荐使用 rspack.IgnorePlugin 替代",
   "mini-css-extract-plugin-desc": "使用 experiments.css 或 rspack.CssExtractRspackPlugin 替代",
-  "terser-webpack-plugin-desc": "使用 rspack.SwcJsMinimizerRspackPlugin 或 builtins.minifyOptions 替代",
+  "terser-webpack-plugin-desc": "使用 rspack.SwcJsMinimizerRspackPlugin 替代",
   "progress-plugin-desc": "使用 builtins.progress 替代",
   "tsconfig-paths-webpack-plugin-desc": "使用 resolve.tsconfigPath 替代"
 }

--- a/website/docs/en/guide/production.mdx
+++ b/website/docs/en/guide/production.mdx
@@ -6,4 +6,21 @@ It is recommended to enable SourceMap for production environments to facilitate 
 
 ## Minification
 
-Rspack uses the built-in minimizer to compress JavaScript and CSS code by default, which can be configured by [builtins.minifyOptions](config/builtins#builtinsminifyoptions). If the built-in minimizer cannot meet your needs, you can use [optimization.minimizer](config/optimization#optimizationminimizer) to set a custom minimizer.
+During the production build, Rspack uses the built-in minimizer to minify JavaScript and CSS code by default. You can use [SwcJsMinimizerRspackPlugin](plugins/rspack/swc-js-minimizer-rspack-plugin) for configuration.
+
+```js title=rspack.config.js
+const rspack = require('@rspack/core');
+
+module.exports = {
+  optimization: {
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        // JS minimizer configuration
+      }),
+      new rspack.SwcCssMinimizerRspackPlugin(),
+    ],
+  },
+};
+```
+
+If the built-in minimizer cannot meet your needs, you can also use [optimization.minimizer](/config/optimization#optimizationminimizer) to set custom minimizers.

--- a/website/docs/en/guide/production.mdx
+++ b/website/docs/en/guide/production.mdx
@@ -6,7 +6,7 @@ It is recommended to enable SourceMap for production environments to facilitate 
 
 ## Minification
 
-During the production build, Rspack uses the built-in minimizer to minify JavaScript and CSS code by default. You can use [SwcJsMinimizerRspackPlugin](plugins/rspack/swc-js-minimizer-rspack-plugin) for configuration.
+During the production build, Rspack uses the built-in minimizer to minify JavaScript and CSS code by default. You can use [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) for configuration.
 
 ```js title=rspack.config.js
 const rspack = require('@rspack/core');

--- a/website/docs/zh/guide/production.mdx
+++ b/website/docs/zh/guide/production.mdx
@@ -6,7 +6,7 @@
 
 ## 代码压缩
 
-在执行生产构建时，Rspack 默认使用内置的压缩器对 JavaScript 和 CSS 代码进行压缩，你可以使用 [SwcJsMinimizerRspackPlugin](plugins/rspack/swc-js-minimizer-rspack-plugin) 来进行配置。
+在执行生产构建时，Rspack 默认使用内置的压缩器对 JavaScript 和 CSS 代码进行压缩，你可以使用 [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) 来进行配置。
 
 ```js title=rspack.config.js
 const rspack = require('@rspack/core');

--- a/website/docs/zh/guide/production.mdx
+++ b/website/docs/zh/guide/production.mdx
@@ -6,4 +6,21 @@
 
 ## 代码压缩
 
-Rspack 默认使用内置的压缩器对 JavaScript 和 CSS 代码进行压缩，你可以使用 [builtins.minifyOptions](config/builtins#builtinsminifyoptions) 来进行配置。若内置压缩器无法满足需求，可以使用 [optimization.minimizer](config/optimization#optimizationminimizer) 设置自定义压缩器。
+在执行生产构建时，Rspack 默认使用内置的压缩器对 JavaScript 和 CSS 代码进行压缩，你可以使用 [SwcJsMinimizerRspackPlugin](plugins/rspack/swc-js-minimizer-rspack-plugin) 来进行配置。
+
+```js title=rspack.config.js
+const rspack = require('@rspack/core');
+
+module.exports = {
+  optimization: {
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        // JS minimizer 配置
+      }),
+      new rspack.SwcCssMinimizerRspackPlugin(),
+    ],
+  },
+};
+```
+
+如果内置压缩器无法满足需求，你也可以使用 [optimization.minimizer](/config/optimization#optimizationminimizer) 设置自定义压缩器。


### PR DESCRIPTION
## Summary

`builtins.minifyOptions` has been removed since v0.5.0. This PR updates the minification guides to use `SwcJsMinimizerRspackPlugin`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
