### PR TITLE
fix: swc-loader options.sourceMaps not work

### DIFF
--- a/crates/rspack_loader_swc/src/lib.rs
+++ b/crates/rspack_loader_swc/src/lib.rs
@@ -19,6 +19,7 @@ use rspack_plugin_javascript::ast::{self, SourceMapConfig};
 use rspack_plugin_javascript::TransformOutput;
 use rspack_util::source_map::SourceMapKind;
 use swc_config::{config_types::MergingOption, merge::Merge};
+use swc_core::base::config::SourceMapsConfig;
 use swc_core::base::config::{InputSourceMap, OutputCharset, TransformConfig};
 
 #[derive(Debug)]
@@ -79,7 +80,11 @@ impl Loader<LoaderRunnerContext> for SwcLoader {
       swc_options
     };
 
-    let source_map_kind = &loader_context.context.module_source_map_kind;
+    let source_map_kind: &SourceMapKind = match swc_options.config.source_maps {
+      Some(SourceMapsConfig::Bool(false)) => &SourceMapKind::None,
+      _ => &loader_context.context.module_source_map_kind,
+    };
+
     let source = content.try_into_string()?;
     let c = SwcCompiler::new(resource_path.clone(), source.clone(), swc_options)
       .map_err(AnyhowError::from)?;

--- a/website/docs/en/guide/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/builtin-swc-loader.mdx
@@ -4,7 +4,7 @@ import { ApiMeta, Stability } from '../../../components/ApiMeta';
 
 <ApiMeta addedVersion="0.3.0" />
 
-`builtin:swc-loader` is the Rust version of [`swc-loader`](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader), aiming to deliver better performance. The Loader's [configuration](https://swc.rs/docs/configuration/compilation) is aligned with the JS version of `swc-loader` (SWC plugins will be provided in future releases and are currently not supported).
+`builtin:swc-loader` is the Rust version of [`swc-loader`](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader), aiming to deliver better performance. The Loader's [configuration](https://swc.rs/docs/configuration/compilation) is aligned with the JS version of `swc-loader`.
 
 ## Example
 
@@ -46,7 +46,7 @@ module.exports = {
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            sourceMap: true,
+            sourceMaps: true,
             jsc: {
               parser: {
                 syntax: 'ecmascript',

--- a/website/docs/zh/guide/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/builtin-swc-loader.mdx
@@ -4,8 +4,7 @@ import { ApiMeta, Stability } from '../../../components/ApiMeta';
 
 <ApiMeta addedVersion="0.3.0" />
 
-`builtin:swc-loader` 是 [`swc-loader`](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader) 的 Rust 版本，旨在提供更优的性能，
-Loader 的[配置](https://swc.rs/docs/configuration/compilation)与 JS 版本的 `swc-loader` 保持对齐（SWC 插件将会在未来版本进行提供，暂不支持）。
+`builtin:swc-loader` 是 [`swc-loader`](https://github.com/swc-project/pkgs/tree/main/packages/swc-loader) 的 Rust 版本，旨在提供更优的性能，Loader 的[配置](https://swc.rs/docs/configuration/compilation)与 JS 版本的 `swc-loader` 保持对齐。
 
 ## 示例
 
@@ -36,7 +35,7 @@ module.exports = {
 };
 ```
 
-或是对 `js` 文件进行转译：
+或是对 `jsx` 文件进行转译：
 
 ```js
 module.exports = {
@@ -47,7 +46,7 @@ module.exports = {
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            sourceMap: true,
+            sourceMaps: true,
             jsc: {
               parser: {
                 syntax: 'ecmascript',


### PR DESCRIPTION
## Summary

Fix the swc-loader's `options.sourceMaps: false` not work.

- The option: https://swc.rs/docs/configuration/compilation#sourcemaps
- The usage: Set the default sourcemap behavior based on Rspack mapping flag, but allow users to override if they want.

See also: https://github.com/swc-project/pkgs/blob/f035da2969b45ab9b1810fc2b93be9798ccf8069/packages/swc-loader/src/index.js#L35-L40

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
