### PR TITLE
fix(create-rspack): remove useless sourceMap option in templates

### DIFF
--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -36,7 +36,7 @@ const config = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: false,
+					sourceMaps: false,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -53,7 +53,7 @@ const config = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: false,
+					sourceMaps: false,
 					jsc: {
 						parser: {
 							syntax: "typescript",

--- a/diffcases/arco-pro/webpack.config.js
+++ b/diffcases/arco-pro/webpack.config.js
@@ -3,7 +3,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 
 /** @type {import('webpack').Configuration} */
 const config = {
-	mode: 'production',
+	mode: "production",
 	context: __dirname,
 	entry: "./src/index.tsx",
 	target: ["web", "es5"],
@@ -13,7 +13,7 @@ const config = {
 				test: /\.less$/,
 				use: "less-loader",
 				parser: {
-					namedExports: false,
+					namedExports: false
 				},
 				generator: {
 					exportsOnly: true
@@ -40,7 +40,7 @@ const config = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "swc-loader",
 				options: {
-					sourceMap: false,
+					sourceMaps: false,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -57,7 +57,7 @@ const config = {
 				loader: "swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: false,
+					sourceMaps: false,
 					jsc: {
 						parser: {
 							syntax: "typescript",
@@ -90,7 +90,7 @@ const config = {
 			// expression, which causes stack overflow for swc parser in debug mode.
 			// Alias to the unminified version mitigates this problem.
 			// See also <https://github.com/search?q=repo%3Aswc-project%2Fswc+parser+stack+overflow&type=issues>
-			mockjs: require.resolve("./patches/mock.js"),
+			mockjs: require.resolve("./patches/mock.js")
 		},
 		extensions: [".js", ".jsx", ".ts", ".tsx", ".css", ".less"]
 	},
@@ -127,10 +127,10 @@ const config = {
 			title: "Arco Pro App",
 			template: path.join(__dirname, "index.html"),
 			favicon: path.join(__dirname, "public", "favicon.ico")
-		}),
+		})
 	],
 	infrastructureLogging: {
 		debug: false
-	},
+	}
 };
 module.exports = config;

--- a/packages/create-rspack/template-react-ts/rspack.config.js
+++ b/packages/create-rspack/template-react-ts/rspack.config.js
@@ -24,7 +24,6 @@ module.exports = {
 					{
 						loader: "builtin:swc-loader",
 						options: {
-							sourceMap: true,
 							jsc: {
 								parser: {
 									syntax: "typescript",

--- a/packages/create-rspack/template-react/rspack.config.js
+++ b/packages/create-rspack/template-react/rspack.config.js
@@ -24,7 +24,6 @@ module.exports = {
 					{
 						loader: "builtin:swc-loader",
 						options: {
-							sourceMap: true,
 							jsc: {
 								parser: {
 									syntax: "typescript",

--- a/packages/create-rspack/template-vue/rspack.config.js
+++ b/packages/create-rspack/template-vue/rspack.config.js
@@ -31,7 +31,6 @@ const config = {
 					{
 						loader: "builtin:swc-loader",
 						options: {
-							sourceMap: true,
 							jsc: {
 								parser: {
 									syntax: "typescript",

--- a/packages/rspack-test-tools/rspack.config.js
+++ b/packages/rspack-test-tools/rspack.config.js
@@ -25,7 +25,7 @@ module.exports = {
 				exclude: [/[\\/]node_modules[\\/]/],
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: false,
+					sourceMaps: false,
 					jsc: {
 						parser: {
 							syntax: "typescript"
@@ -42,7 +42,7 @@ module.exports = {
 				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
 				options: {
-					sourceMap: false,
+					sourceMaps: false,
 					jsc: {
 						parser: {
 							syntax: "typescript",

--- a/packages/rspack/tests/configCases/builtin-swc-loader/inline-pitching/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/inline-pitching/webpack.config.js
@@ -10,8 +10,6 @@ module.exports = {
 					{
 						loader: "builtin:swc-loader",
 						options: {
-							// Enable source map
-							sourceMap: true,
 							jsc: {
 								parser: {
 									syntax: "typescript",

--- a/packages/rspack/tests/configCases/builtin-swc-loader/react-runtime-automic/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/react-runtime-automic/webpack.config.js
@@ -9,7 +9,6 @@ module.exports = {
 				test: /\.jsx$/,
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "ecmascript",

--- a/packages/rspack/tests/configCases/builtin-swc-loader/react-runtime-classic/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/react-runtime-classic/webpack.config.js
@@ -9,7 +9,6 @@ module.exports = {
 				test: /\.jsx$/,
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "ecmascript",

--- a/packages/rspack/tests/configCases/builtin-swc-loader/swc-plugin/webpack.config.js
+++ b/packages/rspack/tests/configCases/builtin-swc-loader/swc-plugin/webpack.config.js
@@ -7,7 +7,6 @@ module.exports = {
 				use: {
 					loader: "builtin:swc-loader",
 					options: {
-						sourceMap: true,
 						jsc: {
 							parser: {
 								syntax: "typescript",

--- a/packages/rspack/tests/configCases/loader/loader-builtin-swc/webpack.config.js
+++ b/packages/rspack/tests/configCases/loader/loader-builtin-swc/webpack.config.js
@@ -7,8 +7,6 @@ module.exports = {
 				use: {
 					loader: "builtin:swc-loader",
 					options: {
-						// Enable source map
-						sourceMap: true,
 						jsc: {
 							parser: {
 								syntax: "typescript",

--- a/packages/rspack/tests/configCases/source-map/source-map/webpack.config.js
+++ b/packages/rspack/tests/configCases/source-map/source-map/webpack.config.js
@@ -12,7 +12,6 @@ module.exports = {
 				test: /\.jsx$/,
 				loader: "builtin:swc-loader",
 				options: {
-					sourceMap: true,
 					jsc: {
 						parser: {
 							syntax: "ecmascript",

--- a/website/docs/en/blog/announcing-0.3.mdx
+++ b/website/docs/en/blog/announcing-0.3.mdx
@@ -133,8 +133,6 @@ const config = {
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            // Enable source map
-            sourceMap: true,
             jsc: {
               parser: {
                 syntax: 'ecmascript',

--- a/website/docs/en/blog/announcing-0.5.mdx
+++ b/website/docs/en/blog/announcing-0.5.mdx
@@ -45,7 +45,6 @@ module.exports = {
         exclude: /[\\/]node_modules[\\/]/,
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'ecmascript',
@@ -70,7 +69,6 @@ module.exports = {
         exclude: /[\\/]node_modules[\\/]/,
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -95,7 +93,6 @@ module.exports = {
         exclude: /[\\/]node_modules[\\/]/,
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',

--- a/website/docs/en/guide/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/builtin-swc-loader.mdx
@@ -21,7 +21,6 @@ module.exports = {
         exclude: [/node_modules/],
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -46,7 +45,6 @@ module.exports = {
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            sourceMaps: true,
             jsc: {
               parser: {
                 syntax: 'ecmascript',

--- a/website/docs/en/guide/migrate-from-webpack.mdx
+++ b/website/docs/en/guide/migrate-from-webpack.mdx
@@ -43,7 +43,6 @@ module.exports = {
 +        exclude: [/[\\/]node_modules[\\/]/],
 +        loader: 'builtin:swc-loader',
 +        options: {
-+          sourceMap: true,
 +          jsc: {
 +            parser: {
 +              syntax: 'typescript',
@@ -67,7 +66,6 @@ module.exports = {
 +        loader: 'builtin:swc-loader',
 +        exclude: [/[\\/]node_modules[\\/]/],
 +        options: {
-+          sourceMap: true,
 +          jsc: {
 +            parser: {
 +              syntax: 'typescript',

--- a/website/docs/en/guide/vue.mdx
+++ b/website/docs/en/guide/vue.mdx
@@ -109,7 +109,6 @@ module.exports = {
         test: /\.ts$/, // add this rule when you use typescript in Vue SFC
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',

--- a/website/docs/zh/blog/announcing-0.3.mdx
+++ b/website/docs/zh/blog/announcing-0.3.mdx
@@ -134,8 +134,6 @@ const config = {
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            // Enable source map
-            sourceMap: true,
             jsc: {
               parser: {
                 syntax: 'ecmascript',

--- a/website/docs/zh/blog/announcing-0.5.mdx
+++ b/website/docs/zh/blog/announcing-0.5.mdx
@@ -45,7 +45,6 @@ module.exports = {
         exclude: /[\\/]node_modules[\\/]/,
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'ecmascript',
@@ -70,7 +69,6 @@ module.exports = {
         exclude: /[\\/]node_modules[\\/]/,
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -95,7 +93,6 @@ module.exports = {
         exclude: /[\\/]node_modules[\\/]/,
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',

--- a/website/docs/zh/guide/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/builtin-swc-loader.mdx
@@ -21,7 +21,6 @@ module.exports = {
         exclude: [/node_modules/],
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',
@@ -46,7 +45,6 @@ module.exports = {
         use: {
           loader: 'builtin:swc-loader',
           options: {
-            sourceMaps: true,
             jsc: {
               parser: {
                 syntax: 'ecmascript',

--- a/website/docs/zh/guide/migrate-from-webpack.mdx
+++ b/website/docs/zh/guide/migrate-from-webpack.mdx
@@ -43,7 +43,6 @@ module.exports = {
 +        exclude: [/[\\/]node_modules[\\/]/],
 +        loader: 'builtin:swc-loader',
 +        options: {
-+          sourceMap: true,
 +          jsc: {
 +            parser: {
 +              syntax: 'typescript',
@@ -67,7 +66,6 @@ module.exports = {
 +        loader: 'builtin:swc-loader',
 +        exclude: [/[\\/]node_modules[\\/]/],
 +        options: {
-+          sourceMap: true,
 +          jsc: {
 +            parser: {
 +              syntax: 'typescript',

--- a/website/docs/zh/guide/vue.mdx
+++ b/website/docs/zh/guide/vue.mdx
@@ -109,7 +109,6 @@ module.exports = {
         test: /\.ts$/, // 如果需要在 Vue SFC 里使用 TypeScript, 请添加该规则
         loader: 'builtin:swc-loader',
         options: {
-          sourceMaps: true,
           jsc: {
             parser: {
               syntax: 'typescript',


### PR DESCRIPTION
## Summary

Two changes in our templates and documentations:

- Remove `sourceMap: true` of swc-loader, because swc-loader will read the `devtool` option of Rspack and set source map automatically, see: https://github.com/web-infra-dev/rspack/blob/599ce4693c8d184a056a0ba90d64008cf6b564ad/crates/rspack_loader_swc/src/lib.rs#L83-L86

- Rename `sourceMap: false` to `sourceMaps: false`, the `sourceMap` is a legacy name and we should use `sourceMaps`. see: https://github.com/web-infra-dev/rspack/blob/599ce4693c8d184a056a0ba90d64008cf6b564ad/crates/rspack_loader_swc/src/options.rs#L117-L119

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
