### PR TITLE
perf(core): remove events dependency

### DIFF
--- a/packages/rspack/hot/emitter.js
+++ b/packages/rspack/hot/emitter.js
@@ -1,2 +1,21 @@
-var EventEmitter = require("events");
+function EventEmitter() {
+	this.events = {};
+}
+
+EventEmitter.prototype.on = function (eventName, callback) {
+	if (!this.events[eventName]) {
+		this.events[eventName] = [];
+	}
+	this.events[eventName].push(callback);
+};
+
+EventEmitter.prototype.emit = function (eventName) {
+	var args = Array.prototype.slice.call(arguments, 1);
+	if (this.events[eventName]) {
+		this.events[eventName].forEach(function (callback) {
+			callback.apply(null, args);
+		});
+	}
+};
+
 module.exports = new EventEmitter();

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -75,7 +75,6 @@
     "@rspack/binding": "workspace:*",
     "browserslist": "^4.21.3",
     "enhanced-resolve": "5.12.0",
-    "events": "^3.3.0",
     "graceful-fs": "4.2.10",
     "json-parse-even-better-errors": "^3.0.0",
     "neo-async": "2.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -432,9 +432,6 @@ importers:
       enhanced-resolve:
         specifier: 5.12.0
         version: 5.12.0
-      events:
-        specifier: ^3.3.0
-        version: 3.3.0
       graceful-fs:
         specifier: 4.2.10
         version: 4.2.10


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Remove the `events` dependency of `@rspack/core`, it is only used by hot client code and can be replaced with a simple handwritten event emitter:

![image](https://github.com/web-infra-dev/rspack/assets/7237365/53393566-7939-4fe2-a98c-26f2e155fbc6)

see: https://github.com/web-infra-dev/rspack/issues/5097

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
