### PR TITLE
fix: align get_nested_exports_info with webpack

### DIFF
--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -276,6 +276,8 @@ impl ExportsInfoId {
       let info = self.get_read_only_export_info(&name[0], mg);
       if let Some(exports_info) = info.exports_info {
         return exports_info.get_nested_exports_info(Some(name[1..].to_vec()), mg);
+      } else {
+        return None;
       }
     }
     Some(*self)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align with webpack, [code](https://github.com/webpack/webpack/blob/b630e21e10f1dbee311dc07b218b49cea4df54a4/lib/ExportsInfo.js#L275)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
