### PR TITLE
fix(config): snapshot.module accept `{ timestamp: true}`

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/cache/issues-6381/a/a.js
+++ b/packages/rspack-test-tools/tests/configCases/cache/issues-6381/a/a.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/rspack-test-tools/tests/configCases/cache/issues-6381/index.js
+++ b/packages/rspack-test-tools/tests/configCases/cache/issues-6381/index.js
@@ -1,0 +1,5 @@
+const a = "a";
+import(`./a/${a}.js`);
+it("should work when snapshot.module or snapshot.resolve only set { timestamp: true }", () => {
+	expect(require("./a/a").default).toBe(1);
+});

--- a/packages/rspack-test-tools/tests/configCases/cache/issues-6381/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/cache/issues-6381/webpack.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	cache: true,
+  snapshot: {
+		module: {
+			timestamp: true,
+		},
+		resolve: {
+			timestamp: true,
+		},
+  },
+};

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -191,26 +191,14 @@ const applySnapshotDefaults = (
 	snapshot: SnapshotOptions,
 	{ production }: { production: boolean }
 ) => {
-	if (typeof snapshot.module === "object") {
-		D(snapshot.module, "timestamp", false);
-		D(snapshot.module, "hash", false);
-	} else {
-		F(snapshot, "module", () =>
-			production
-				? { timestamp: true, hash: true }
-				: { timestamp: true, hash: false }
-		);
-	}
-	if (typeof snapshot.resolve === "object") {
-		D(snapshot.resolve, "timestamp", false);
-		D(snapshot.resolve, "hash", false);
-	} else {
-		F(snapshot, "resolve", () =>
-			production
-				? { timestamp: true, hash: true }
-				: { timestamp: true, hash: false }
-		);
-	}
+	D(snapshot, "module", {});
+	assertNotNill(snapshot.module);
+	D(snapshot.module, "timestamp", true);
+	D(snapshot.module, "hash", production);
+	D(snapshot, "resolve", {});
+	assertNotNill(snapshot.resolve);
+	D(snapshot.resolve, "timestamp", true);
+	D(snapshot.resolve, "hash", production);
 };
 
 const applyJavascriptParserOptionsDefaults = (

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -191,16 +191,26 @@ const applySnapshotDefaults = (
 	snapshot: SnapshotOptions,
 	{ production }: { production: boolean }
 ) => {
-	F(snapshot, "module", () =>
-		production
-			? { timestamp: true, hash: true }
-			: { timestamp: true, hash: false }
-	);
-	F(snapshot, "resolve", () =>
-		production
-			? { timestamp: true, hash: true }
-			: { timestamp: true, hash: false }
-	);
+	if (typeof snapshot.module === "object") {
+		D(snapshot.module, "timestamp", false);
+		D(snapshot.module, "hash", false);
+	} else {
+		F(snapshot, "module", () =>
+			production
+				? { timestamp: true, hash: true }
+				: { timestamp: true, hash: false }
+		);
+	}
+	if (typeof snapshot.resolve === "object") {
+		D(snapshot.resolve, "timestamp", false);
+		D(snapshot.resolve, "hash", false);
+	} else {
+		F(snapshot, "resolve", () =>
+			production
+				? { timestamp: true, hash: true }
+				: { timestamp: true, hash: false }
+		);
+	}
 };
 
 const applyJavascriptParserOptionsDefaults = (


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close https://github.com/web-infra-dev/rspack/issues/6381

`{ timestamp: true}` should has the same meaning of `{ timestamp: true, hash: false }`

We need to process this default value when we pass it to rust side.


<img width="774" alt="image" src="https://github.com/web-infra-dev/rspack/assets/79413249/2906e1dd-b6f7-4c16-94b4-b904c7531b3b">

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
