### PR TITLE
fix(config): support snapshot config {timestamp: true} and {hash: true}

### DIFF
--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -191,14 +191,26 @@ const applySnapshotDefaults = (
 	snapshot: SnapshotOptions,
 	{ production }: { production: boolean }
 ) => {
-	D(snapshot, "module", {});
-	assertNotNill(snapshot.module);
-	D(snapshot.module, "timestamp", true);
-	D(snapshot.module, "hash", production);
-	D(snapshot, "resolve", {});
-	assertNotNill(snapshot.resolve);
-	D(snapshot.resolve, "timestamp", true);
-	D(snapshot.resolve, "hash", production);
+	if (typeof snapshot.module === "object") {
+		D(snapshot.module, "timestamp", false);
+		D(snapshot.module, "hash", false);
+	} else {
+		F(snapshot, "module", () =>
+			production
+				? { timestamp: true, hash: true }
+				: { timestamp: true, hash: false }
+		);
+	}
+	if (typeof snapshot.resolve === "object") {
+		D(snapshot.resolve, "timestamp", false);
+		D(snapshot.resolve, "hash", false);
+	} else {
+		F(snapshot, "resolve", () =>
+			production
+				? { timestamp: true, hash: true }
+				: { timestamp: true, hash: false }
+		);
+	}
 };
 
 const applyJavascriptParserOptionsDefaults = (


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

#6381  #6387 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
`{ hash: true }` `{ timestamp: true }` and `{ timestamp: true, hash: true }`  should be three different behaviors.
I think this is a very misleading configuration.

https://webpack.js.org/configuration/other-options/#builddependencies

<img width="400" alt="image" src="https://github.com/web-infra-dev/rspack/assets/79413249/b4b72644-46ab-47b3-8b5d-e1859f0fb074">


cases

`{}` and `{ timestamp: false, hash: false }` ->  `{ timestamp: false, hash: false }`
`{ hash: true }` -> `{ timestamp: false, hash: true }`
`{ timestamp: true }` -> `{ timestamp: true, hash: false }`
`{ timestamp: true, hash: true }`

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
