### PR TITLE
fix: allow all characters for webpackChunkName

### DIFF
--- a/crates/rspack_plugin_javascript/src/webpack_comment.rs
+++ b/crates/rspack_plugin_javascript/src/webpack_comment.rs
@@ -88,7 +88,7 @@ fn add_magic_comment_warning(
 // _5 for true/false
 // TODO: regexp/array
 static WEBPACK_MAGIC_COMMENT_REGEXP: Lazy<regex::Regex> = Lazy::new(|| {
-  regex::Regex::new(r#"(?P<_0>webpack[a-zA-Z\d_-]+)\s*:\s*("(?P<_1>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)"|'(?P<_2>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)'|`(?P<_3>(\./)?([\w0-9_\-\[\]\(\)]+/)*?[\w0-9_\-\[\]\(\)]+)`|(?P<_4>[\d.-]+)|(?P<_5>true|false))"#)
+  regex::Regex::new(r#"(?P<_0>webpack[a-zA-Z\d_-]+)\s*:\s*("(?P<_1>[^"]+)"|'(?P<_2>[^']+)'|`(?P<_3>[^`]+)`|(?P<_4>[\d.-]+)|(?P<_5>true|false))"#)
     .expect("invalid regex")
 });
 

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/magic_comment/index.js
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/magic_comment/index.js
@@ -1,4 +1,5 @@
 import(/* webpackChunkName: "normal" */ "./normal");
+import(/* webpackChunkName: "with.dot" */ "./with_dot");
 import(/* webpackChunkName: "./sub/fold" */ "./sub_fold");
 import(/* webpackChunkName: './sub/single' */ "./single_quote");
 

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/magic_comment/snapshot/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/magic_comment/snapshot/output.snap.txt
@@ -47,6 +47,7 @@ console.log("123");
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./index.js": (function (__unused_webpack_module, __unused_webpack_exports, __webpack_require__) {
 __webpack_require__.e(/* import() | normal */ "normal").then(__webpack_require__.t.bind(__webpack_require__, "./normal.js", 23));
+__webpack_require__.e(/* import() | with.dot */ "with.dot").then(__webpack_require__.t.bind(__webpack_require__, "./with_dot.js", 23));
 __webpack_require__.e(/* import() | ./sub/fold */ "./sub/fold").then(__webpack_require__.t.bind(__webpack_require__, "./sub_fold.js", 23));
 __webpack_require__.e(/* import() | ./sub/single */ "./sub/single").then(__webpack_require__.t.bind(__webpack_require__, "./single_quote.js", 23));
 __webpack_require__.e(/* import() | ./sub/other */ "./sub/other").then(__webpack_require__.t.bind(__webpack_require__, "./other.js", 23));
@@ -86,6 +87,15 @@ console.log("user (id)/page3");
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["user/[id]/page"], {
 "./user/page/2.js": (function () {
 console.log("user [id]/page2");
+}),
+
+}]);
+```
+
+```js title=with.dot.js
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["with.dot"], {
+"./with_dot.js": (function () {
+console.log("123");
 }),
 
 }]);

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/magic_comment/with_dot.js
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/magic_comment/with_dot.js
@@ -1,0 +1,1 @@
+console.log("123");


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Webpack allows any string for webpackChunkName: https://github.com/webpack/webpack/blob/c586c7b1e027e1d252d68b4372f08a9bce40d96c/lib/javascript/JavascriptParser.js#L4584-L4587

fixes #6358

Just a quick fix.

### Known issues (Edge cases)

- will not work with texts containing the character that is same as the quote character, e.g, `"a\\"b"` (rust's regex does not support backreference)
- still does not support all js expressions like `Boolean(1)` which seems to be allowed in webpack

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
