### PR TITLE
perf: optimize execute module

### DIFF
--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -463,13 +463,6 @@ impl JsCompilation {
     original_module_context: Option<String>,
     callback: JsFunction,
   ) -> Result<()> {
-    let options = self.0.options.clone();
-    let plugin_driver = self.0.plugin_driver.clone();
-    let resolver_factory = self.0.resolver_factory.clone();
-    let loader_resolver_factory = self.0.loader_resolver_factory.clone();
-    let cache = self.0.cache.clone();
-    let dependency_factories = self.0.dependency_factories.clone();
-
     callbackify(env, callback, async {
       let module_executor = self
         .0
@@ -478,12 +471,6 @@ impl JsCompilation {
         .expect("should have module executor");
       let result = module_executor
         .import_module(
-          options,
-          plugin_driver,
-          resolver_factory,
-          loader_resolver_factory,
-          cache,
-          dependency_factories,
           request,
           public_path,
           base_uri,

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -9,7 +9,9 @@ use rspack_sources::Source;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::MakeParam;
-use crate::{fast_set, get_chunk_from_ukey, ChunkKind, Compilation, Compiler, RuntimeSpec};
+use crate::{
+  fast_set, get_chunk_from_ukey, ChunkKind, Compilation, Compiler, ModuleExecutor, RuntimeSpec,
+};
 
 impl<T> Compiler<T>
 where
@@ -73,8 +75,7 @@ where
         self.loader_resolver_factory.clone(),
         Some(records),
         self.cache.clone(),
-        // reuse module executor
-        std::mem::take(&mut self.compilation.module_executor),
+        Some(ModuleExecutor::default()),
       );
 
       if let Some(state) = self.options.get_incremental_rebuild_make_state() {
@@ -118,7 +119,7 @@ where
         new_compilation.code_splitting_cache =
           std::mem::take(&mut self.compilation.code_splitting_cache);
 
-        // module executor
+        // reuse module executor
         new_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);
 
         new_compilation.has_module_import_export_change = false;

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -118,6 +118,9 @@ where
         new_compilation.code_splitting_cache =
           std::mem::take(&mut self.compilation.code_splitting_cache);
 
+        // module executor
+        new_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);
+
         new_compilation.has_module_import_export_change = false;
       }
 

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -147,7 +147,7 @@ pub struct ExportsInfoRelated {
 }
 
 #[derive(Debug)]
-struct FactorizeResultTask {
+pub struct FactorizeResultTask {
   //  pub dependency: DependencyId,
   pub original_module_identifier: Option<ModuleIdentifier>,
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.

--- a/crates/rspack_core/src/compiler/module_executor/ctrl.rs
+++ b/crates/rspack_core/src/compiler/module_executor/ctrl.rs
@@ -1,0 +1,218 @@
+use std::collections::VecDeque;
+
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use super::{
+  entry::{EntryParam, EntryTask},
+  execute::ExecuteTask,
+};
+use crate::{
+  compiler::make::repair::MakeTaskContext,
+  utils::task_loop::{Task, TaskResult, TaskType},
+  Dependency, DependencyId, ModuleIdentifier,
+};
+
+#[derive(Debug)]
+struct UnfinishCounter {
+  is_building: bool,
+  unfinished_child_module_count: usize,
+}
+
+impl UnfinishCounter {
+  fn new() -> Self {
+    UnfinishCounter {
+      is_building: true,
+      unfinished_child_module_count: 0,
+    }
+  }
+
+  fn set_unfinished_child_module_count(&mut self, count: usize) {
+    self.is_building = false;
+    self.unfinished_child_module_count = count;
+  }
+
+  fn minus_one(&mut self) {
+    if self.is_building || self.unfinished_child_module_count <= 0 {
+      panic!("UnfinishDepCount Error")
+    }
+    self.unfinished_child_module_count -= 1;
+  }
+
+  fn is_finished(&self) -> bool {
+    !self.is_building && self.unfinished_child_module_count == 0
+  }
+}
+
+pub enum Event {
+  StartBuild(ModuleIdentifier),
+  // origin_module_identifier and current dependency id and target_module_identifier
+  FinishDeps(
+    Option<ModuleIdentifier>,
+    DependencyId,
+    Option<ModuleIdentifier>,
+  ),
+  // current_module_identifier and sub dependency count
+  FinishModule(ModuleIdentifier, usize),
+  ExecuteModule(EntryParam, ExecuteTask),
+  Stop(),
+}
+
+#[derive(Debug)]
+pub struct CtrlTask {
+  pub event_receiver: UnboundedReceiver<Event>,
+  execute_task_map: HashMap<DependencyId, ExecuteTask>,
+  finish_module_map: HashMap<ModuleIdentifier, UnfinishCounter>,
+}
+
+impl CtrlTask {
+  pub fn new(event_receiver: UnboundedReceiver<Event>) -> Self {
+    Self {
+      event_receiver,
+      execute_task_map: Default::default(),
+      finish_module_map: Default::default(),
+    }
+  }
+}
+
+#[async_trait::async_trait]
+impl Task<MakeTaskContext> for CtrlTask {
+  fn get_task_type(&self) -> TaskType {
+    TaskType::Async
+  }
+
+  async fn async_run(mut self: Box<Self>) -> TaskResult<MakeTaskContext> {
+    while let Some(event) = self.event_receiver.recv().await {
+      match event {
+        Event::StartBuild(module_identifier) => {
+          self
+            .as_mut()
+            .finish_module_map
+            .insert(module_identifier, UnfinishCounter::new());
+        }
+        Event::FinishDeps(origin_module_identifier, dep_id, target_module_graph) => {
+          if let Some(target_module_graph) = target_module_graph {
+            if let Some(value) = self.as_ref().finish_module_map.get(&target_module_graph) {
+              if !value.is_finished() {
+                continue;
+              }
+            }
+          }
+
+          // target module finished
+          let Some(origin_module_identifier) = origin_module_identifier else {
+            // origin_module_identifier is none means entry dep
+            let execute_task = self
+              .as_mut()
+              .execute_task_map
+              .remove(&dep_id)
+              .expect("should have execute task");
+            return Ok(vec![Box::new(execute_task), self]);
+          };
+
+          let value = self
+            .as_mut()
+            .finish_module_map
+            .get_mut(&origin_module_identifier)
+            .expect("should have counter");
+          value.minus_one();
+          if value.is_finished() {
+            return Ok(vec![Box::new(FinishModuleTask {
+              ctrl_task: self,
+              module_identifier: origin_module_identifier,
+            })]);
+          }
+        }
+        Event::FinishModule(mid, size) => {
+          let value = self
+            .as_mut()
+            .finish_module_map
+            .get_mut(&mid)
+            .expect("should have counter");
+          value.set_unfinished_child_module_count(size);
+          if value.is_finished() {
+            return Ok(vec![Box::new(FinishModuleTask {
+              ctrl_task: self,
+              module_identifier: mid,
+            })]);
+          }
+        }
+        Event::ExecuteModule(param, execute_task) => {
+          let dep_id = match &param {
+            EntryParam::DependencyId(id, _) => *id,
+            EntryParam::EntryDependency(dep) => *dep.id(),
+          };
+          self.execute_task_map.insert(dep_id, execute_task);
+          return Ok(vec![Box::new(EntryTask { param }), self]);
+        }
+        Event::Stop() => {
+          return Ok(vec![]);
+        }
+      }
+    }
+    // if channel has been closed, finish this task
+    Ok(vec![])
+  }
+}
+
+#[derive(Debug)]
+struct FinishModuleTask {
+  ctrl_task: Box<CtrlTask>,
+  module_identifier: ModuleIdentifier,
+}
+
+impl Task<MakeTaskContext> for FinishModuleTask {
+  fn get_task_type(&self) -> TaskType {
+    TaskType::Sync
+  }
+
+  fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+    let Self {
+      mut ctrl_task,
+      module_identifier,
+    } = *self;
+    let mut res: Vec<Box<dyn Task<MakeTaskContext>>> = vec![];
+    let module_graph = MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+
+    let mut queue = VecDeque::new();
+    queue.push_back(module_identifier);
+    while let Some(module_identifier) = queue.pop_front() {
+      let mgm = module_graph
+        .module_graph_module_by_identifier(&module_identifier)
+        .expect("should have mgm");
+
+      let mut original_module_identifiers = HashSet::default();
+      for connection_id in mgm.incoming_connections() {
+        let connection = module_graph
+          .connection_by_connection_id(connection_id)
+          .expect("should have connection");
+        if let Some(original_module_identifier) = &connection.original_module_identifier {
+          original_module_identifiers.insert(original_module_identifier.clone());
+        } else {
+          // entry
+          let execute_task = ctrl_task
+            .as_mut()
+            .execute_task_map
+            .remove(&connection.dependency_id)
+            .expect("should have execute task");
+          res.push(Box::new(execute_task));
+        }
+      }
+
+      for id in original_module_identifiers {
+        let value = ctrl_task
+          .as_mut()
+          .finish_module_map
+          .get_mut(&id)
+          .expect("should have counter");
+        value.minus_one();
+        if value.is_finished() {
+          queue.push_back(id);
+        }
+      }
+    }
+
+    res.push(ctrl_task);
+    Ok(res)
+  }
+}

--- a/crates/rspack_core/src/compiler/module_executor/ctrl.rs
+++ b/crates/rspack_core/src/compiler/module_executor/ctrl.rs
@@ -33,7 +33,7 @@ impl UnfinishCounter {
   }
 
   fn minus_one(&mut self) {
-    if self.is_building || self.unfinished_child_module_count <= 0 {
+    if self.is_building || self.unfinished_child_module_count == 0 {
       panic!("UnfinishDepCount Error")
     }
     self.unfinished_child_module_count -= 1;
@@ -187,7 +187,7 @@ impl Task<MakeTaskContext> for FinishModuleTask {
           .connection_by_connection_id(connection_id)
           .expect("should have connection");
         if let Some(original_module_identifier) = &connection.original_module_identifier {
-          original_module_identifiers.insert(original_module_identifier.clone());
+          original_module_identifiers.insert(*original_module_identifier);
         } else {
           // entry
           let execute_task = ctrl_task

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -1,0 +1,75 @@
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::ctrl::Event;
+use crate::{
+  compiler::make::repair::{factorize::FactorizeTask, MakeTaskContext},
+  utils::task_loop::{Task, TaskResult, TaskType},
+  Dependency, DependencyId, EntryDependency, ModuleProfile,
+};
+
+#[derive(Debug)]
+pub enum EntryParam {
+  DependencyId(DependencyId, UnboundedSender<Event>),
+  EntryDependency(Box<EntryDependency>),
+}
+
+#[derive(Debug)]
+pub struct EntryTask {
+  pub param: EntryParam,
+}
+
+impl Task<MakeTaskContext> for EntryTask {
+  fn get_task_type(&self) -> TaskType {
+    TaskType::Sync
+  }
+
+  fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+    let Self { param } = *self;
+    let mut module_graph = MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+
+    match param {
+      EntryParam::DependencyId(dep_id, sender) => {
+        if let Some(module_identifier) = module_graph.module_identifier_by_dependency_id(&dep_id) {
+          sender
+            .send(Event::FinishDeps(
+              None,
+              dep_id,
+              Some(module_identifier.clone()),
+            ))
+            .expect("should success");
+        } else {
+          // no module_identifier means the factorize task not run, do nothing
+        }
+        Ok(vec![])
+      }
+      EntryParam::EntryDependency(dep) => {
+        let dep_id = *dep.id();
+        module_graph.add_dependency(dep.clone());
+        Ok(vec![Box::new(FactorizeTask {
+          module_factory: context
+            .dependency_factories
+            .get(dep.dependency_type())
+            .expect("should have dependency_factories")
+            .clone(),
+          original_module_identifier: None,
+          original_module_source: None,
+          issuer: None,
+          original_module_context: None,
+          dependency: dep,
+          dependencies: vec![dep_id],
+          is_entry: true,
+          resolve_options: None,
+          resolver_factory: context.resolver_factory.clone(),
+          loader_resolver_factory: context.loader_resolver_factory.clone(),
+          options: context.compiler_options.clone(),
+          plugin_driver: context.plugin_driver.clone(),
+          cache: context.cache.clone(),
+          current_profile: context
+            .compiler_options
+            .profile
+            .then(Box::<ModuleProfile>::default),
+        })])
+      }
+    }
+  }
+}

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -31,11 +31,7 @@ impl Task<MakeTaskContext> for EntryTask {
       EntryParam::DependencyId(dep_id, sender) => {
         if let Some(module_identifier) = module_graph.module_identifier_by_dependency_id(&dep_id) {
           sender
-            .send(Event::FinishDeps(
-              None,
-              dep_id,
-              Some(module_identifier.clone()),
-            ))
+            .send(Event::FinishDeps(None, dep_id, Some(*module_identifier)))
             .expect("should success");
         } else {
           // no module_identifier means the factorize task not run, do nothing

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -1,0 +1,181 @@
+mod ctrl;
+mod entry;
+mod execute;
+mod overwrite;
+
+use dashmap::mapref::entry::Entry;
+use dashmap::DashMap;
+pub use execute::ExecuteModuleId;
+use rspack_error::Result;
+use tokio::sync::{
+  mpsc::{unbounded_channel, UnboundedSender},
+  oneshot,
+};
+
+use self::{
+  ctrl::{CtrlTask, Event},
+  entry::EntryParam,
+  execute::{ExecuteModuleResult, ExecuteTask},
+  overwrite::OverwriteTask,
+};
+use super::make::{repair::MakeTaskContext, update_module_graph_with_artifact, MakeArtifact};
+use crate::{
+  task_loop::run_task_loop_with_event, Compilation, CompilationAsset, Context, Dependency,
+  DependencyId, EntryDependency, MakeParam,
+};
+
+#[derive(Debug, Default)]
+pub struct ModuleExecutor {
+  request_dep_map: DashMap<String, DependencyId>,
+  make_artifact: MakeArtifact,
+
+  event_sender: Option<UnboundedSender<Event>>,
+  stop_receiver: Option<oneshot::Receiver<MakeArtifact>>,
+  assets: DashMap<String, CompilationAsset>,
+}
+
+impl ModuleExecutor {
+  pub async fn hook_before_make(
+    &mut self,
+    compilation: &Compilation,
+    global_params: &Vec<MakeParam>,
+  ) {
+    let mut make_artifact = std::mem::take(&mut self.make_artifact);
+    let mut params = vec![];
+    for param in global_params {
+      if matches!(param, MakeParam::DeletedFiles(_)) {
+        params.push(param.clone());
+      }
+      if matches!(param, MakeParam::ModifiedFiles(_)) {
+        params.push(param.clone());
+      }
+    }
+    if !make_artifact.make_failed_dependencies.is_empty() {
+      let deps = std::mem::take(&mut make_artifact.make_failed_dependencies);
+      params.push(MakeParam::ForceBuildDeps(deps));
+    }
+    if !make_artifact.make_failed_module.is_empty() {
+      let modules = std::mem::take(&mut make_artifact.make_failed_module);
+      params.push(MakeParam::ForceBuildModules(modules));
+    }
+
+    make_artifact = if let Ok(artifact) =
+      update_module_graph_with_artifact(compilation, make_artifact, params).await
+    {
+      artifact
+    } else {
+      MakeArtifact::default()
+    };
+
+    let mut ctx = MakeTaskContext::new(compilation, make_artifact);
+    let (event_sender, event_receiver) = unbounded_channel();
+    let (stop_sender, stop_receiver) = oneshot::channel();
+    self.event_sender = Some(event_sender.clone());
+    self.stop_receiver = Some(stop_receiver);
+
+    tokio::spawn(async move {
+      let _ = run_task_loop_with_event(
+        &mut ctx,
+        vec![Box::new(CtrlTask::new(event_receiver))],
+        |_, task| {
+          Box::new(OverwriteTask {
+            origin_task: task,
+            event_sender: event_sender.clone(),
+          })
+        },
+      );
+
+      stop_sender
+        .send(ctx.transform_to_make_artifact())
+        .expect("should success");
+    });
+  }
+
+  pub async fn hook_before_process_assets(&mut self, compilation: &mut Compilation) {
+    let sender = std::mem::take(&mut self.event_sender);
+    sender
+      .expect("should have sender")
+      .send(Event::Stop())
+      .expect("should success");
+
+    let stop_receiver = std::mem::take(&mut self.stop_receiver);
+    if let Ok(make_artifact) = stop_receiver.expect("should have receiver").await {
+      self.make_artifact = make_artifact;
+    } else {
+      panic!("receive make artifact failed");
+    }
+
+    let assets = std::mem::take(&mut self.assets);
+    for (filename, asset) in assets {
+      compilation.emit_asset(filename, asset);
+    }
+
+    let diagnostics = std::mem::take(&mut self.make_artifact.diagnostics);
+    compilation.push_batch_diagnostic(diagnostics);
+
+    compilation
+      .file_dependencies
+      .extend(self.make_artifact.file_dependencies.iter().cloned());
+    compilation
+      .context_dependencies
+      .extend(self.make_artifact.context_dependencies.iter().cloned());
+    compilation
+      .missing_dependencies
+      .extend(self.make_artifact.missing_dependencies.iter().cloned());
+    compilation
+      .build_dependencies
+      .extend(self.make_artifact.build_dependencies.iter().cloned());
+  }
+
+  #[allow(clippy::too_many_arguments)]
+  pub async fn import_module(
+    &self,
+    request: String,
+    public_path: Option<String>,
+    base_uri: Option<String>,
+    original_module_context: Option<Context>,
+  ) -> Result<ExecuteModuleResult> {
+    let sender = self
+      .event_sender
+      .as_ref()
+      .expect("should have event sender");
+    let (param, dep_id) = match self.request_dep_map.entry(request.clone()) {
+      Entry::Vacant(v) => {
+        let dep = EntryDependency::new(
+          request.clone(),
+          original_module_context.unwrap_or(Context::from("")),
+        );
+        let dep_id = *dep.id();
+        v.insert(dep_id.clone());
+        (EntryParam::EntryDependency(Box::new(dep)), dep_id)
+      }
+      Entry::Occupied(v) => {
+        let dep_id = *v.get();
+        (
+          EntryParam::DependencyId(dep_id.clone(), sender.clone()),
+          dep_id,
+        )
+      }
+    };
+
+    let (tx, rx) = oneshot::channel();
+    sender
+      .send(Event::ExecuteModule(
+        param,
+        ExecuteTask {
+          entry_dep_id: dep_id,
+          public_path,
+          base_uri,
+          result_sender: tx,
+        },
+      ))
+      .expect("should success");
+    let (execute_result, assets) = rx.await.expect("should receiver success");
+
+    for (key, value) in assets {
+      self.assets.insert(key, value);
+    }
+
+    execute_result
+  }
+}

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -146,15 +146,12 @@ impl ModuleExecutor {
           original_module_context.unwrap_or(Context::from("")),
         );
         let dep_id = *dep.id();
-        v.insert(dep_id.clone());
+        v.insert(dep_id);
         (EntryParam::EntryDependency(Box::new(dep)), dep_id)
       }
       Entry::Occupied(v) => {
         let dep_id = *v.get();
-        (
-          EntryParam::DependencyId(dep_id.clone(), sender.clone()),
-          dep_id,
-        )
+        (EntryParam::DependencyId(dep_id, sender.clone()), dep_id)
       }
     };
 

--- a/crates/rspack_core/src/compiler/module_executor/overwrite.rs
+++ b/crates/rspack_core/src/compiler/module_executor/overwrite.rs
@@ -1,0 +1,92 @@
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::ctrl::Event;
+use crate::{
+  compiler::make::repair::{
+    add::AddTask, factorize::FactorizeResultTask, process_dependencies::ProcessDependenciesTask,
+    MakeTaskContext,
+  },
+  utils::task_loop::{Task, TaskResult, TaskType},
+};
+
+pub struct OverwriteTask {
+  pub origin_task: Box<dyn Task<MakeTaskContext>>,
+  pub event_sender: UnboundedSender<Event>,
+}
+
+#[async_trait::async_trait]
+impl Task<MakeTaskContext> for OverwriteTask {
+  fn get_task_type(&self) -> TaskType {
+    self.origin_task.get_task_type()
+  }
+
+  fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+    let Self {
+      origin_task,
+      event_sender,
+    } = *self;
+    // process dependencies
+    if let Some(process_dependencies_task) = origin_task
+      .as_any()
+      .downcast_ref::<ProcessDependenciesTask>()
+    {
+      let original_module_identifier = process_dependencies_task.original_module_identifier.clone();
+      let res = origin_task.sync_run(context)?;
+      event_sender
+        .send(Event::FinishModule(original_module_identifier, res.len()))
+        .expect("should success");
+      return Ok(res);
+    }
+
+    // factorize result task
+    if let Some(factorize_result_task) = origin_task.as_any().downcast_ref::<FactorizeResultTask>()
+    {
+      let dep_id = factorize_result_task
+        .dependencies
+        .get(0)
+        .cloned()
+        .expect("should have dep_id");
+      let original_module_identifier = factorize_result_task.original_module_identifier.clone();
+      let res = origin_task.sync_run(context)?;
+      if res.len() == 0 {
+        event_sender
+          .send(Event::FinishDeps(original_module_identifier, dep_id, None))
+          .expect("should success");
+      }
+      return Ok(res);
+    }
+    // add task
+    if let Some(add_task) = origin_task.as_any().downcast_ref::<AddTask>() {
+      let dep_id = add_task
+        .dependencies
+        .get(0)
+        .cloned()
+        .expect("should have dep_id");
+      let original_module_identifier = add_task.original_module_identifier.clone();
+      let target_module_identifier = add_task.module.identifier();
+
+      let res = origin_task.sync_run(context)?;
+      if res.len() == 0 {
+        event_sender
+          .send(Event::FinishDeps(
+            original_module_identifier,
+            dep_id,
+            Some(target_module_identifier),
+          ))
+          .expect("should success");
+      } else {
+        event_sender
+          .send(Event::StartBuild(target_module_identifier))
+          .expect("should success");
+      }
+      return Ok(res);
+    }
+
+    // other task
+    origin_task.sync_run(context)
+  }
+
+  async fn async_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
+    self.origin_task.async_run().await
+  }
+}

--- a/crates/rspack_core/src/compiler/module_executor/overwrite.rs
+++ b/crates/rspack_core/src/compiler/module_executor/overwrite.rs
@@ -30,7 +30,7 @@ impl Task<MakeTaskContext> for OverwriteTask {
       .as_any()
       .downcast_ref::<ProcessDependenciesTask>()
     {
-      let original_module_identifier = process_dependencies_task.original_module_identifier.clone();
+      let original_module_identifier = process_dependencies_task.original_module_identifier;
       let res = origin_task.sync_run(context)?;
       event_sender
         .send(Event::FinishModule(original_module_identifier, res.len()))
@@ -43,12 +43,12 @@ impl Task<MakeTaskContext> for OverwriteTask {
     {
       let dep_id = factorize_result_task
         .dependencies
-        .get(0)
+        .first()
         .cloned()
         .expect("should have dep_id");
-      let original_module_identifier = factorize_result_task.original_module_identifier.clone();
+      let original_module_identifier = factorize_result_task.original_module_identifier;
       let res = origin_task.sync_run(context)?;
-      if res.len() == 0 {
+      if res.is_empty() {
         event_sender
           .send(Event::FinishDeps(original_module_identifier, dep_id, None))
           .expect("should success");
@@ -59,14 +59,14 @@ impl Task<MakeTaskContext> for OverwriteTask {
     if let Some(add_task) = origin_task.as_any().downcast_ref::<AddTask>() {
       let dep_id = add_task
         .dependencies
-        .get(0)
+        .first()
         .cloned()
         .expect("should have dep_id");
-      let original_module_identifier = add_task.original_module_identifier.clone();
+      let original_module_identifier = add_task.original_module_identifier;
       let target_module_identifier = add_task.module.identifier();
 
       let res = origin_task.sync_run(context)?;
-      if res.len() == 0 {
+      if res.is_empty() {
         event_sender
           .send(Event::FinishDeps(
             original_module_identifier,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR refactor `execute module` by use make task loop, and it will improve the running speed of `execute module` by sharing module graph.

There are some task added by this PR.
* overwrite task - This task will analyze all tasks and send events to the ctrl task to collect module build status.
* entry task - This task is used to add a new entry for execute module entry dependency.
* execute task - This task is used to execute module.
* ctrl task - This task is used to collect all task status and start other task.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
