### PR TITLE
feat: export Chunk and Module types from `@rspack/core`

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -970,7 +970,7 @@ type CallFn = (...args: any[]) => any;
 type CallFn_2<D> = (args: D[]) => void;
 
 // @public (undocumented)
-class Chunk {
+export class Chunk {
     constructor(chunk: JsChunk, compilation: JsCompilation);
     // (undocumented)
     static __from_binding(chunk: JsChunk, compilation: Compilation): Chunk;
@@ -4920,7 +4920,7 @@ export type Mode = z.infer<typeof mode>;
 const mode: z.ZodEnum<["development", "production", "none"]>;
 
 // @public (undocumented)
-class Module {
+export class Module {
     constructor(module: JsModule);
     // (undocumented)
     static __from_binding(module: JsModule): Module;
@@ -7875,8 +7875,10 @@ declare namespace rspackExports {
         StatsModule,
         StatsWarnings,
         MultiStats,
+        Chunk,
         ChunkGroup,
         NormalModuleFactory,
+        Module,
         NormalModule,
         ModuleFilenameHelpers,
         Template,

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -32,9 +32,12 @@ export type {
 
 export { MultiStats } from "./MultiStats";
 
+export type { Chunk } from "./Chunk";
 export type { ChunkGroup } from "./ChunkGroup";
 
 export type { NormalModuleFactory } from "./NormalModuleFactory";
+
+export type { Module } from "./Module";
 
 export { NormalModule } from "./NormalModule";
 


### PR DESCRIPTION
## Summary

I'm migrating [webpack-manifest-plugin](https://github.com/shellscape/webpack-manifest-plugin) to [rspack-manifest-plugin](https://github.com/rspack-contrib/rspack-manifest-plugin), and found that webpack exports the `Chunk` and `Module` types, but Rspack not.

This PR adds `Chunk` and `Module` exports for `@rspack/core`.

See: https://github.com/rspack-contrib/rspack-manifest-plugin/commit/2affdc9a1979d7f858b49250c9de6331bf7ea453

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
