### PR TITLE
perf: improve determine_export_assignments

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -307,11 +307,13 @@ impl HarmonyExportImportedSpecifierDependency {
     let hidden_exports = self
       .discover_active_exports_from_other_star_exports(module_graph)
       .map(|other_star_exports| {
-        other_star_exports.names.into_iter()
-            .take(other_star_exports.names_slice)
-            .filter(|name| !ignored_exports.contains(name))
-            .cloned()
-            .collect::<HashSet<_>>()
+        other_star_exports
+          .names
+          .into_iter()
+          .take(other_star_exports.names_slice)
+          .filter(|name| !ignored_exports.contains(name))
+          .cloned()
+          .collect::<HashSet<_>>()
       });
     if !no_extra_exports && !no_extra_imports {
       return StarReexportsInfo {
@@ -1355,7 +1357,7 @@ fn determine_export_assignments<'a>(
   let mut names = Vec::new();
   let mut hints = HashSet::default();
   let mut dependency_indices =
-      Vec::with_capacity(dependencies.len() + additional_dependency.is_some() as usize);
+    Vec::with_capacity(dependencies.len() + additional_dependency.is_some() as usize);
 
   for dependency in dependencies.iter().chain(additional_dependency.iter()) {
     if let Some(module_identifier) = module_graph.module_identifier_by_dependency_id(dependency) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -1358,7 +1358,7 @@ fn determine_export_assignments<'a>(
   // js `Set` keep the insertion order, use `IndexSet` to align there behavior
   let mut names: IndexSet<&Atom, BuildHasherDefault<FxHasher>> = IndexSet::default();
   let mut dependency_indices =
-    Vec::with_capacity(dependencies.len() + additional_dependency.is_some() as usize);
+    Vec::with_capacity(dependencies.len() + usize::from(additional_dependency.is_some()));
 
   for dependency in dependencies.iter().chain(additional_dependency.iter()) {
     if let Some(module_identifier) = module_graph.module_identifier_by_dependency_id(dependency) {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -430,7 +430,7 @@ impl HarmonyExportImportedSpecifierDependency {
     let all_star_exports = self.all_star_exports(module_graph);
     if !all_star_exports.is_empty() {
       let (names, dependency_indices) =
-        determine_export_assignments(module_graph, &all_star_exports, None);
+        determine_export_assignments(module_graph, all_star_exports, None);
 
       return Some(DiscoverActiveExportsFromOtherStarExportsRet {
         names,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

This is an optimization for `TypeScript` repo build hotspot. I did some performance tests before the 5-1, but now the results have been destroyed along with harddisk.

* Use .chain instead of .clone + .push
* eliminate Atom drop by avoiding redundant Atom clone
* eliminate Atom clone
* rewrite collect hidden_exports

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
