### PR TITLE
refactor: make hooks remove make_param

### DIFF
--- a/crates/node_binding/src/plugins/interceptor.rs
+++ b/crates/node_binding/src/plugins/interceptor.rs
@@ -33,7 +33,7 @@ use rspack_core::{
   CompilerShouldEmitHook, CompilerThisCompilation, CompilerThisCompilationHook,
   ContextModuleFactoryAfterResolve, ContextModuleFactoryAfterResolveHook,
   ContextModuleFactoryBeforeResolve, ContextModuleFactoryBeforeResolveHook, ExecuteModuleId,
-  MakeParam, ModuleFactoryCreateData, ModuleIdentifier, NormalModuleCreateData,
+  ModuleFactoryCreateData, ModuleIdentifier, NormalModuleCreateData,
   NormalModuleFactoryAfterResolve, NormalModuleFactoryAfterResolveHook,
   NormalModuleFactoryBeforeResolve, NormalModuleFactoryBeforeResolveHook,
   NormalModuleFactoryCreateModule, NormalModuleFactoryCreateModuleHook,
@@ -719,11 +719,7 @@ impl CompilerCompilation for CompilerCompilationTap {
 
 #[async_trait]
 impl CompilerMake for CompilerMakeTap {
-  async fn run(
-    &self,
-    compilation: &mut Compilation,
-    _: &mut Vec<MakeParam>,
-  ) -> rspack_error::Result<()> {
+  async fn run(&self, compilation: &mut Compilation) -> rspack_error::Result<()> {
     // SAFETY:
     // 1. `Compiler` is stored on the heap and pinned in binding crate.
     // 2. `Compilation` outlives `JsCompilation` and `Compiler` outlives `Compilation`.

--- a/crates/rspack_core/src/cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/cache/local/code_splitting_cache.rs
@@ -33,7 +33,7 @@ where
     return Ok(());
   }
 
-  if !compilation.has_module_import_export_change {
+  if !compilation.has_module_import_export_change() {
     let cache = &mut compilation.code_splitting_cache;
     rayon::scope(|s| {
       s.spawn(|_| compilation.chunk_by_ukey = cache.chunk_by_ukey.clone());

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -143,7 +143,6 @@ pub struct Compilation {
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub make_failed_dependencies: HashSet<BuildDependency>,
   pub make_failed_module: HashSet<ModuleIdentifier>,
-  pub has_module_import_export_change: bool,
   pub runtime_modules: IdentifierMap<Box<dyn RuntimeModule>>,
   pub runtime_module_code_generation_results: IdentifierMap<(RspackHashDigest, BoxSource)>,
   pub chunk_graph: ChunkGraph,
@@ -231,7 +230,6 @@ impl Compilation {
       dependency_factories: Default::default(),
       make_failed_dependencies: HashSet::default(),
       make_failed_module: HashSet::default(),
-      has_module_import_export_change: true,
       runtime_modules: Default::default(),
       runtime_module_code_generation_results: Default::default(),
       chunk_by_ukey: Default::default(),
@@ -623,6 +621,7 @@ impl Compilation {
 
     params.push(make_failed_module);
     params.push(make_failed_dependencies);
+    self.make_artifact.has_module_graph_change = false;
     update_module_graph(self, params).await
   }
 
@@ -1572,6 +1571,11 @@ impl Compilation {
         )
       })
       .clone()
+  }
+
+  // TODO remove it after code splitting support incremental rebuild
+  pub fn has_module_import_export_change(&self) -> bool {
+    self.make_artifact.has_module_graph_change
   }
 }
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -164,7 +164,6 @@ pub struct Compilation {
   pub used_symbol_ref: HashSet<SymbolRef>,
   /// Collecting all module that need to skip in tree-shaking ast modification phase
   pub bailout_module_identifiers: IdentifierMap<BailoutFlag>,
-  pub optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
 
   pub code_generation_results: CodeGenerationResults,
   pub code_generated_modules: IdentifierSet,
@@ -250,7 +249,6 @@ impl Compilation {
       named_chunk_groups: Default::default(),
       entry_module_identifiers: IdentifierSet::default(),
       used_symbol_ref: HashSet::default(),
-      optimize_analyze_result_map: IdentifierMap::default(),
       bailout_module_identifiers: IdentifierMap::default(),
 
       code_generation_results: Default::default(),
@@ -1576,6 +1574,15 @@ impl Compilation {
   // TODO remove it after code splitting support incremental rebuild
   pub fn has_module_import_export_change(&self) -> bool {
     self.make_artifact.has_module_graph_change
+  }
+
+  // TODO remove it after remove old treeshaking
+  pub fn optimize_analyze_result_map(&self) -> &IdentifierMap<OptimizeAnalyzeResult> {
+    &self.make_artifact.optimize_analyze_result_map
+  }
+  // TODO remove it after remove old treeshaking
+  pub fn optimize_analyze_result_map_mut(&mut self) -> &mut IdentifierMap<OptimizeAnalyzeResult> {
+    &mut self.make_artifact.optimize_analyze_result_map
   }
 }
 

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -107,8 +107,6 @@ where
         new_compilation.build_dependencies =
           std::mem::take(&mut self.compilation.build_dependencies);
         // tree shaking usage start
-        new_compilation.optimize_analyze_result_map =
-          std::mem::take(&mut self.compilation.optimize_analyze_result_map);
         new_compilation.entry_module_identifiers =
           std::mem::take(&mut self.compilation.entry_module_identifiers);
         new_compilation.bailout_module_identifiers =

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -121,8 +121,6 @@ where
 
         // reuse module executor
         new_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);
-
-        new_compilation.has_module_import_export_change = false;
       }
 
       let setup_make_params = if is_incremental_rebuild_make {

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -8,7 +8,6 @@ use rspack_identifier::{Identifier, IdentifierMap};
 use rspack_sources::Source;
 use rustc_hash::FxHashSet as HashSet;
 
-use super::MakeParam;
 use crate::{
   fast_set, get_chunk_from_ukey, ChunkKind, Compilation, Compiler, ModuleExecutor, RuntimeSpec,
 };
@@ -20,7 +19,7 @@ where
   pub async fn rebuild(
     &mut self,
     changed_files: std::collections::HashSet<String>,
-    removed_files: std::collections::HashSet<String>,
+    deleted_files: std::collections::HashSet<String>,
   ) -> Result<()> {
     let old = self.compilation.get_stats();
     let old_hash = self.compilation.hash.clone();
@@ -56,11 +55,11 @@ where
     {
       let mut modified_files = HashSet::default();
       modified_files.extend(changed_files.iter().map(PathBuf::from));
-      let mut deleted_files = HashSet::default();
-      deleted_files.extend(removed_files.iter().map(PathBuf::from));
+      let mut removed_files = HashSet::default();
+      removed_files.extend(deleted_files.iter().map(PathBuf::from));
 
       let mut all_files = modified_files.clone();
-      all_files.extend(deleted_files.clone());
+      all_files.extend(removed_files.clone());
 
       self.cache.end_idle();
       self
@@ -76,6 +75,8 @@ where
         Some(records),
         self.cache.clone(),
         Some(ModuleExecutor::default()),
+        modified_files,
+        removed_files,
       );
 
       if let Some(state) = self.options.get_incremental_rebuild_make_state() {
@@ -91,10 +92,6 @@ where
         self
           .compilation
           .swap_make_artifact_with_compilation(&mut new_compilation);
-        new_compilation.make_failed_dependencies =
-          std::mem::take(&mut self.compilation.make_failed_dependencies);
-        new_compilation.make_failed_module =
-          std::mem::take(&mut self.compilation.make_failed_module);
         new_compilation.entries = std::mem::take(&mut self.compilation.entries);
         new_compilation.global_entry = std::mem::take(&mut self.compilation.global_entry);
         new_compilation.lazy_visit_modules =
@@ -121,22 +118,13 @@ where
         new_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);
       }
 
-      let setup_make_params = if is_incremental_rebuild_make {
-        vec![
-          MakeParam::ModifiedFiles(modified_files),
-          MakeParam::DeletedFiles(deleted_files),
-        ]
-      } else {
-        vec![MakeParam::ForceBuildDeps(Default::default())]
-      };
-
       new_compilation.lazy_visit_modules = changed_files.clone();
 
       // FOR BINDING SAFETY:
       // Update `compilation` for each rebuild.
       // Make sure `thisCompilation` hook was called before any other hooks that leverage `JsCompilation`.
       fast_set(&mut self.compilation, new_compilation);
-      self.compile(setup_make_params).await?;
+      self.compile().await?;
 
       self.cache.begin_idle();
     }

--- a/crates/rspack_core/src/compiler/make/cutout/clean_isolated_module.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/clean_isolated_module.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::super::MakeArtifact;
-use crate::ModuleIdentifier;
+use crate::{DependencyId, ModuleIdentifier};
 
 #[derive(Debug, Default)]
 pub struct CleanIsolatedModule {
@@ -22,6 +22,16 @@ impl CleanIsolatedModule {
         .need_check_isolated_module_ids
         .insert(*connection.module_identifier());
     }
+  }
+
+  pub fn analyze_removed_deps(&mut self, artifact: &MakeArtifact, dep_id: &DependencyId) {
+    let module_graph = artifact.get_module_graph();
+    let connection = module_graph
+      .connection_by_dependency(dep_id)
+      .expect("should have connection");
+    self
+      .need_check_isolated_module_ids
+      .insert(*connection.module_identifier());
   }
 
   pub fn fix_artifact(self, artifact: &mut MakeArtifact) {

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -18,11 +18,12 @@ use crate::{
 
 #[derive(Debug, Default)]
 pub struct MakeArtifact {
-  module_graph_partial: ModuleGraphPartial,
+  pub module_graph_partial: ModuleGraphPartial,
   pub make_failed_dependencies: HashSet<BuildDependency>,
   pub make_failed_module: HashSet<ModuleIdentifier>,
   pub diagnostics: Vec<Diagnostic>,
 
+  entry_dependencies: HashSet<DependencyId>,
   entry_module_identifiers: IdentifierSet,
   pub optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
   pub file_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
@@ -67,25 +68,65 @@ impl MakeArtifact {
     compilation.build_dependencies = std::mem::take(&mut self.build_dependencies);
 
     compilation.push_batch_diagnostic(std::mem::take(&mut self.diagnostics));
-    compilation.make_failed_module = std::mem::take(&mut self.make_failed_module);
-    compilation.make_failed_dependencies = std::mem::take(&mut self.make_failed_dependencies);
   }
 }
 
 #[derive(Debug, Clone)]
 pub enum MakeParam {
+  Entry(HashSet<DependencyId>),
   ModifiedFiles(HashSet<PathBuf>),
-  DeletedFiles(HashSet<PathBuf>),
+  RemovedFiles(HashSet<PathBuf>),
   ForceBuildDeps(HashSet<BuildDependency>),
   ForceBuildModules(HashSet<ModuleIdentifier>),
 }
 
-impl MakeParam {
-  pub fn new_force_build_dep_param(dep: DependencyId, module: Option<ModuleIdentifier>) -> Self {
-    let mut data = HashSet::default();
-    data.insert((dep, module));
-    Self::ForceBuildDeps(data)
+pub fn make_module_graph(
+  compilation: &mut Compilation,
+  mut artifact: MakeArtifact,
+) -> Result<MakeArtifact> {
+  let mut params = Vec::with_capacity(5);
+
+  if !compilation.entries.is_empty() {
+    params.push(MakeParam::Entry(
+      compilation
+        .entries
+        .values()
+        .flat_map(|item| &item.dependencies)
+        .chain(&compilation.global_entry.dependencies)
+        .cloned()
+        .collect(),
+    ));
   }
+  // no modified files but rebuild means force build
+  // some module which cacheable is false will need to be rebuilt even if modified files is empty
+  params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
+  if !compilation.removed_files.is_empty() {
+    params.push(MakeParam::RemovedFiles(compilation.removed_files.clone()));
+  }
+  if !artifact.make_failed_module.is_empty() {
+    let make_failed_module = std::mem::take(&mut artifact.make_failed_module);
+    params.push(MakeParam::ForceBuildModules(make_failed_module));
+  }
+  if !artifact.make_failed_dependencies.is_empty() {
+    let make_failed_dependencies = std::mem::take(&mut artifact.make_failed_dependencies);
+    params.push(MakeParam::ForceBuildDeps(make_failed_dependencies));
+  }
+
+  // reset diagnostics
+  artifact.diagnostics = Default::default();
+  artifact.has_module_graph_change = false;
+
+  artifact.move_data_from_compilation(compilation);
+
+  artifact = update_module_graph_with_artifact(compilation, artifact, params)?;
+
+  if compilation.options.builtins.tree_shaking.enable() {
+    let module_graph = artifact.get_module_graph();
+    compilation.bailout_module_identifiers = calc_bailout_module_identifiers(&module_graph);
+  }
+
+  artifact.move_data_to_compilation(compilation);
+  Ok(artifact)
 }
 
 pub async fn update_module_graph(
@@ -96,47 +137,11 @@ pub async fn update_module_graph(
   compilation.swap_make_artifact(&mut artifact);
   artifact.move_data_from_compilation(compilation);
 
-  artifact = update_module_graph_with_artifact(compilation, artifact, params).await?;
+  artifact = update_module_graph_with_artifact(compilation, artifact, params)?;
 
-  // Avoid to introduce too much overhead,
-  // until we find a better way to align with webpack hmr behavior
-
-  // add context module and context element module to bailout_module_identifiers
   if compilation.options.builtins.tree_shaking.enable() {
     let module_graph = artifact.get_module_graph();
-    compilation.bailout_module_identifiers = module_graph
-      .dependencies()
-      .values()
-      .par_bridge()
-      .filter_map(|dep| {
-        if dep.as_context_dependency().is_some()
-          && let Some(module) = module_graph.get_module_by_dependency_id(dep.id())
-        {
-          let mut values = vec![(module.identifier(), BailoutFlag::CONTEXT_MODULE)];
-          if let Some(dependencies) = module_graph.get_module_all_dependencies(&module.identifier())
-          {
-            for dependency in dependencies {
-              if let Some(dependency_module) =
-                module_graph.module_identifier_by_dependency_id(dependency)
-              {
-                values.push((*dependency_module, BailoutFlag::CONTEXT_MODULE));
-              }
-            }
-          }
-
-          Some(values)
-        } else if matches!(
-          dep.dependency_type(),
-          DependencyType::ContainerExposed | DependencyType::ProvideModuleForShared
-        ) && let Some(module) = module_graph.get_module_by_dependency_id(dep.id())
-        {
-          Some(vec![(module.identifier(), BailoutFlag::CONTAINER_EXPOSED)])
-        } else {
-          None
-        }
-      })
-      .flatten()
-      .collect();
+    compilation.bailout_module_identifiers = calc_bailout_module_identifiers(&module_graph);
   }
 
   artifact.move_data_to_compilation(compilation);
@@ -144,7 +149,7 @@ pub async fn update_module_graph(
   Ok(())
 }
 
-pub async fn update_module_graph_with_artifact(
+pub fn update_module_graph_with_artifact(
   compilation: &Compilation,
   mut artifact: MakeArtifact,
   params: Vec<MakeParam>,
@@ -155,4 +160,43 @@ pub async fn update_module_graph_with_artifact(
   cutout.fix_artifact(&mut artifact);
 
   Ok(artifact)
+}
+
+fn calc_bailout_module_identifiers(module_graph: &ModuleGraph) -> IdentifierMap<BailoutFlag> {
+  // Avoid to introduce too much overhead,
+  // until we find a better way to align with webpack hmr behavior
+
+  // add context module and context element module to bailout_module_identifiers
+  module_graph
+    .dependencies()
+    .values()
+    .par_bridge()
+    .filter_map(|dep| {
+      if dep.as_context_dependency().is_some()
+        && let Some(module) = module_graph.get_module_by_dependency_id(dep.id())
+      {
+        let mut values = vec![(module.identifier(), BailoutFlag::CONTEXT_MODULE)];
+        if let Some(dependencies) = module_graph.get_module_all_dependencies(&module.identifier()) {
+          for dependency in dependencies {
+            if let Some(dependency_module) =
+              module_graph.module_identifier_by_dependency_id(dependency)
+            {
+              values.push((*dependency_module, BailoutFlag::CONTEXT_MODULE));
+            }
+          }
+        }
+
+        Some(values)
+      } else if matches!(
+        dep.dependency_type(),
+        DependencyType::ContainerExposed | DependencyType::ProvideModuleForShared
+      ) && let Some(module) = module_graph.get_module_by_dependency_id(dep.id())
+      {
+        Some(vec![(module.identifier(), BailoutFlag::CONTAINER_EXPOSED)])
+      } else {
+        None
+      }
+    })
+    .flatten()
+    .collect()
 }

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -24,7 +24,7 @@ pub struct MakeArtifact {
   pub diagnostics: Vec<Diagnostic>,
 
   entry_module_identifiers: IdentifierSet,
-  optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
+  pub optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
   pub file_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
   pub context_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
   pub missing_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
@@ -52,7 +52,6 @@ impl MakeArtifact {
   // TODO remove it
   fn move_data_from_compilation(&mut self, compilation: &mut Compilation) {
     self.entry_module_identifiers = std::mem::take(&mut compilation.entry_module_identifiers);
-    self.optimize_analyze_result_map = std::mem::take(&mut compilation.optimize_analyze_result_map);
     self.file_dependencies = std::mem::take(&mut compilation.file_dependencies);
     self.context_dependencies = std::mem::take(&mut compilation.context_dependencies);
     self.missing_dependencies = std::mem::take(&mut compilation.missing_dependencies);
@@ -62,7 +61,6 @@ impl MakeArtifact {
   // TODO remove it
   fn move_data_to_compilation(&mut self, compilation: &mut Compilation) {
     compilation.entry_module_identifiers = std::mem::take(&mut self.entry_module_identifiers);
-    compilation.optimize_analyze_result_map = std::mem::take(&mut self.optimize_analyze_result_map);
     compilation.file_dependencies = std::mem::take(&mut self.file_dependencies);
     compilation.context_dependencies = std::mem::take(&mut self.context_dependencies);
     compilation.missing_dependencies = std::mem::take(&mut self.missing_dependencies);

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -30,7 +30,7 @@ pub struct MakeArtifact {
   pub missing_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
   pub build_dependencies: IndexSet<PathBuf, BuildHasherDefault<FxHasher>>,
 
-  has_module_graph_change: bool,
+  pub has_module_graph_change: bool,
 }
 
 impl MakeArtifact {
@@ -57,7 +57,6 @@ impl MakeArtifact {
     self.context_dependencies = std::mem::take(&mut compilation.context_dependencies);
     self.missing_dependencies = std::mem::take(&mut compilation.missing_dependencies);
     self.build_dependencies = std::mem::take(&mut compilation.build_dependencies);
-    self.has_module_graph_change = compilation.has_module_import_export_change;
   }
 
   // TODO remove it
@@ -68,7 +67,6 @@ impl MakeArtifact {
     compilation.context_dependencies = std::mem::take(&mut self.context_dependencies);
     compilation.missing_dependencies = std::mem::take(&mut self.missing_dependencies);
     compilation.build_dependencies = std::mem::take(&mut self.build_dependencies);
-    compilation.has_module_import_export_change = self.has_module_graph_change;
 
     compilation.push_batch_diagnostic(std::mem::take(&mut self.diagnostics));
     compilation.make_failed_module = std::mem::take(&mut self.make_failed_module);

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -17,7 +17,7 @@ use crate::{
   tree_shaking::visitor::OptimizeAnalyzeResult,
   utils::task_loop::{run_task_loop, Task},
   BuildDependency, CacheCount, CacheOptions, Compilation, CompilationLogger, CompilerOptions,
-  DependencyType, Logger, Module, ModuleFactory, ModuleIdentifier, ModuleProfile,
+  DependencyId, DependencyType, Logger, Module, ModuleFactory, ModuleIdentifier, ModuleProfile,
   NormalModuleSource, ResolverFactory, SharedPluginDriver,
 };
 
@@ -45,6 +45,7 @@ pub struct MakeTaskContext {
   make_failed_dependencies: HashSet<BuildDependency>,
   make_failed_module: HashSet<ModuleIdentifier>,
 
+  entry_dependencies: HashSet<DependencyId>,
   entry_module_identifiers: IdentifierSet,
   diagnostics: Vec<Diagnostic>,
   optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
@@ -87,6 +88,7 @@ impl MakeTaskContext {
       make_failed_module: Default::default(),
       diagnostics: Default::default(),
 
+      entry_dependencies: artifact.entry_dependencies,
       entry_module_identifiers: artifact.entry_module_identifiers,
       optimize_analyze_result_map: artifact.optimize_analyze_result_map,
       file_dependencies: artifact.file_dependencies,
@@ -112,6 +114,7 @@ impl MakeTaskContext {
       has_module_graph_change,
       build_cache_counter,
       factorize_cache_counter,
+      entry_dependencies,
       logger,
       ..
     } = self;
@@ -126,6 +129,7 @@ impl MakeTaskContext {
       make_failed_dependencies,
       make_failed_module,
       diagnostics,
+      entry_dependencies,
       entry_module_identifiers,
       optimize_analyze_result_map,
       file_dependencies,
@@ -151,6 +155,8 @@ impl MakeTaskContext {
       None,
       self.cache.clone(),
       None,
+      Default::default(),
+      Default::default(),
     );
     compilation.dependency_factories = self.dependency_factories.clone();
     let mut make_artifact = MakeArtifact {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -215,7 +215,7 @@ where
         })
         .unwrap_or(false)
     {
-      let (analyze_result, diagnostics) = self
+      let (mut analyze_result, diagnostics) = self
         .compilation
         .optimize_dependency()
         .await?
@@ -280,7 +280,10 @@ where
       {
         self.compilation.include_module_ids = analyze_result.include_module_ids;
       }
-      self.compilation.optimize_analyze_result_map = analyze_result.analyze_results;
+      std::mem::swap(
+        self.compilation.optimize_analyze_result_map_mut(),
+        &mut analyze_result.analyze_results,
+      );
     }
     let start = logger.time("seal compilation");
     self.compilation.seal(self.plugin_driver.clone()).await?;

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -20,7 +20,6 @@ use tracing::instrument;
 
 pub use self::compilation::*;
 pub use self::hmr::{collect_changed_modules, CompilationRecords};
-pub use self::make::MakeParam;
 pub use self::module_executor::{ExecuteModuleId, ModuleExecutor};
 use crate::cache::Cache;
 use crate::tree_shaking::symbol::{IndirectType, StarSymbolKind, DEFAULT_JS_WORD};
@@ -33,8 +32,8 @@ use crate::{ContextModuleFactory, NormalModuleFactory};
 define_hook!(CompilerThisCompilation: AsyncSeries(compilation: &mut Compilation, params: &mut CompilationParams));
 // should be SyncHook, but rspack need call js hook
 define_hook!(CompilerCompilation: AsyncSeries(compilation: &mut Compilation, params: &mut CompilationParams));
-// should be AsyncParallelHook, but rspack need add MakeParam to incremental rebuild
-define_hook!(CompilerMake: AsyncSeries(compilation: &mut Compilation, params: &mut Vec<MakeParam>));
+// should be AsyncParallelHook
+define_hook!(CompilerMake: AsyncSeries(compilation: &mut Compilation));
 define_hook!(CompilerFinishMake: AsyncSeries(compilation: &mut Compilation));
 // should be SyncBailHook, but rspack need call js hook
 define_hook!(CompilerShouldEmit: AsyncSeriesBail(compilation: &mut Compilation) -> bool);
@@ -99,6 +98,8 @@ where
         None,
         cache.clone(),
         Some(module_executor),
+        Default::default(),
+        Default::default(),
       ),
       output_filesystem,
       plugin_driver,
@@ -132,19 +133,19 @@ where
         None,
         self.cache.clone(),
         Some(module_executor),
+        Default::default(),
+        Default::default(),
       ),
     );
 
-    self
-      .compile(vec![MakeParam::ForceBuildDeps(Default::default())])
-      .await?;
+    self.compile().await?;
     self.cache.begin_idle();
     self.compile_done().await?;
     Ok(())
   }
 
   #[instrument(name = "compile", skip_all)]
-  async fn compile(&mut self, mut params: Vec<MakeParam>) -> Result<()> {
+  async fn compile(&mut self) -> Result<()> {
     let mut compilation_params = self.new_compilation_params();
     // FOR BINDING SAFETY:
     // Make sure `thisCompilation` hook was called for each `JsCompilation` update before any access to it.
@@ -172,14 +173,14 @@ where
       .plugin_driver
       .compiler_hooks
       .make
-      .call(&mut self.compilation, &mut params)
+      .call(&mut self.compilation)
       .await
       .err()
     {
       self.compilation.push_batch_diagnostic(vec![e.into()]);
     }
     logger.time_end(make_hook_start);
-    self.compilation.make(params).await?;
+    self.compilation.make().await?;
     logger.time_end(make_start);
 
     let start = logger.time("finish make hook");

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -268,7 +268,7 @@ impl<'a> ModuleGraph<'a> {
   /// Remove a connection and return connection origin module identifier and dependency
   ///
   /// force will completely remove dependency, and you will not regenerate it from dependency_id
-  fn revoke_connection(
+  pub fn revoke_connection(
     &mut self,
     connection_id: &ConnectionId,
     force: bool,

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -106,7 +106,7 @@ impl<'a> CodeSizeOptimizer<'a> {
     //   analyze_result_map
     // };
     let mut optimize_analyze_result_map =
-      std::mem::take(&mut self.compilation.optimize_analyze_result_map);
+      std::mem::take(self.compilation.optimize_analyze_result_map_mut());
     let module_graph = self.compilation.get_module_graph();
     optimize_analyze_result_map.iter_mut().for_each(
       |(module_identifier, optimize_analyze_result)| {
@@ -118,10 +118,13 @@ impl<'a> CodeSizeOptimizer<'a> {
         }
       },
     );
-    self.compilation.optimize_analyze_result_map = optimize_analyze_result_map;
+    std::mem::swap(
+      &mut optimize_analyze_result_map,
+      self.compilation.optimize_analyze_result_map_mut(),
+    );
     // We will set it back and return the analyze result, take is safe here.
     let mut finalized_result_map =
-      std::mem::take(&mut self.compilation.optimize_analyze_result_map);
+      std::mem::take(self.compilation.optimize_analyze_result_map_mut());
     let mut evaluated_used_symbol_ref: HashSet<SymbolRef> = HashSet::default();
     let mut evaluated_module_identifiers = IdentifierSet::default();
     let side_effects_options = self

--- a/crates/rspack_plugin_dynamic_entry/src/lib.rs
+++ b/crates/rspack_plugin_dynamic_entry/src/lib.rs
@@ -3,8 +3,7 @@ use derivative::Derivative;
 use futures::future::BoxFuture;
 use rspack_core::{
   ApplyContext, BoxDependency, Compilation, CompilationParams, CompilerCompilation, CompilerMake,
-  CompilerOptions, Context, DependencyType, EntryDependency, EntryOptions, MakeParam, Plugin,
-  PluginContext,
+  CompilerOptions, Context, DependencyType, EntryDependency, EntryOptions, Plugin, PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -48,16 +47,13 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilerMake for DynamicEntryPlugin)]
-async fn make(&self, compilation: &mut Compilation, params: &mut Vec<MakeParam>) -> Result<()> {
+async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   let entry_fn = &self.entry;
   let decs = entry_fn().await?;
   for EntryDynamicResult { import, options } in decs {
     for entry in import {
       let dependency: BoxDependency = Box::new(EntryDependency::new(entry, self.context.clone()));
-      let dependency_id = *dependency.id();
       compilation.add_entry(dependency, options.clone()).await?;
-
-      params.push(MakeParam::new_force_build_dep_param(dependency_id, None));
     }
   }
   Ok(())

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -3,8 +3,7 @@
 use async_trait::async_trait;
 use rspack_core::{
   ApplyContext, BoxDependency, Compilation, CompilationParams, CompilerCompilation, CompilerMake,
-  CompilerOptions, Context, DependencyType, EntryDependency, EntryOptions, MakeParam, Plugin,
-  PluginContext,
+  CompilerOptions, Context, DependencyType, EntryDependency, EntryOptions, Plugin, PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -12,14 +11,14 @@ use rspack_hook::{plugin, plugin_hook};
 #[plugin]
 #[derive(Debug)]
 pub struct EntryPlugin {
+  dependency: BoxDependency,
   options: EntryOptions,
-  entry_request: String,
-  context: Context,
 }
 
 impl EntryPlugin {
   pub fn new(context: Context, entry_request: String, options: EntryOptions) -> Self {
-    Self::new_inner(options, entry_request, context)
+    let dependency: BoxDependency = Box::new(EntryDependency::new(entry_request, context));
+    Self::new_inner(dependency, options)
   }
 }
 
@@ -34,23 +33,11 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilerMake for EntryPlugin)]
-async fn make(&self, compilation: &mut Compilation, params: &mut Vec<MakeParam>) -> Result<()> {
-  if let Some(state) = compilation.options.get_incremental_rebuild_make_state()
-    && !state.is_first()
-  {
-    return Ok(());
-  }
+async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   let this = &self.inner;
-  let dependency: BoxDependency = Box::new(EntryDependency::new(
-    this.entry_request.clone(),
-    this.context.clone(),
-  ));
-  let dependency_id = *dependency.id();
   compilation
-    .add_entry(dependency, this.options.clone())
+    .add_entry(this.dependency.clone(), this.options.clone())
     .await?;
-
-  params.push(MakeParam::new_force_build_dep_param(dependency_id, None));
   Ok(())
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -90,7 +90,7 @@ impl HarmonyImportSpecifierDependency {
     let module_graph = compilation.get_module_graph();
     let related_symbol = module_graph
       .get_parent_module(&self.id)
-      .and_then(|parent_module| compilation.optimize_analyze_result_map.get(parent_module))
+      .and_then(|parent_module| compilation.optimize_analyze_result_map().get(parent_module))
       .and_then(|analyze_res| {
         analyze_res
           .harmony_import_specifier_dependency_alias_map

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -206,7 +206,7 @@ impl JavascriptModulesPluginPlugin for AssignLibraryJavascriptModulesPluginPlugi
       let export_target = access_with_init(&full_name_resolved, self.options.prefix.len(), true);
       if let Some(analyze_results) = args
         .compilation
-        .optimize_analyze_result_map
+        .optimize_analyze_result_map()
         .get(&args.module)
       {
         for info in analyze_results.ordered_exports() {

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -70,7 +70,7 @@ impl JavascriptModulesPluginPlugin for ModuleLibraryJavascriptModulesPluginPlugi
       }
     } else if let Some(analyze_results) = args
       .compilation
-      .optimize_analyze_result_map
+      .optimize_analyze_result_map()
       .get(&args.module)
     {
       use rspack_core::tree_shaking::webpack_ext::ExportInfoExt;

--- a/crates/rspack_plugin_mf/src/container/container_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_plugin.rs
@@ -6,8 +6,8 @@ use rspack_core::{
   CompilerOptions,
 };
 use rspack_core::{
-  Compilation, CompilationParams, Dependency, DependencyType, EntryOptions, EntryRuntime,
-  FilenameTemplate, LibraryOptions, MakeParam, Plugin, PluginContext, RuntimeGlobals,
+  Compilation, CompilationParams, DependencyType, EntryOptions, EntryRuntime, FilenameTemplate,
+  LibraryOptions, Plugin, PluginContext, RuntimeGlobals,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -66,14 +66,13 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilerMake for ContainerPlugin)]
-async fn make(&self, compilation: &mut Compilation, params: &mut Vec<MakeParam>) -> Result<()> {
+async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   let dep = ContainerEntryDependency::new(
     self.options.name.clone(),
     self.options.exposes.clone(),
     self.options.share_scope.clone(),
     self.options.enhanced,
   );
-  let dependency_id = *dep.id();
   compilation
     .add_entry(
       Box::new(dep),
@@ -86,8 +85,6 @@ async fn make(&self, compilation: &mut Compilation, params: &mut Vec<MakeParam>)
       },
     )
     .await?;
-
-  params.push(MakeParam::new_force_build_dep_param(dependency_id, None));
   Ok(())
 }
 

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -14,8 +14,8 @@ use rspack_core::{
   CompilationOptimizeChunks, CompilationOptimizeDependencies, CompilationOptimizeModules,
   CompilationOptimizeTree, CompilationParams, CompilationProcessAssets, CompilationSeal,
   CompilationSucceedModule, CompilerAfterEmit, CompilerCompilation, CompilerEmit,
-  CompilerFinishMake, CompilerMake, CompilerOptions, CompilerThisCompilation, MakeParam,
-  ModuleIdentifier, Plugin, PluginContext,
+  CompilerFinishMake, CompilerMake, CompilerOptions, CompilerThisCompilation, ModuleIdentifier,
+  Plugin, PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -230,7 +230,7 @@ async fn compilation(
 }
 
 #[plugin_hook(CompilerMake for ProgressPlugin)]
-async fn make(&self, _compilation: &mut Compilation, _params: &mut Vec<MakeParam>) -> Result<()> {
+async fn make(&self, _compilation: &mut Compilation) -> Result<()> {
   if !self.options.profile {
     self.progress_bar.reset();
     self.progress_bar.set_prefix(self.options.prefix.clone());

--- a/packages/rspack-test-tools/tests/hotCases/chunk/ensure-chunk-change-to-promise-all/snapshot/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/chunk/ensure-chunk-change-to-promise-all/snapshot/web/1.snap.txt
@@ -9,7 +9,7 @@
 - Bundle: vendors-node_modules_vue_js.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 94
 - Update: file_js.LAST_HASH.hot-update.js, size: 450
-- Update: main.LAST_HASH.hot-update.js, size: 709
+- Update: main.LAST_HASH.hot-update.js, size: 726
 
 ## Manifest
 
@@ -60,7 +60,7 @@ __webpack_require__.d(__webpack_exports__, {
 #### Changed Content
 ```js
 self["webpackHotUpdate"]('main', {
-"./chunk.js": (function (module, __webpack_exports__, __webpack_require__) {
+"./chunk.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {

--- a/packages/rspack-test-tools/tests/hotCases/harmony/cjs-analyze-changed/snapshot/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/harmony/cjs-analyze-changed/snapshot/web/1.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 721
+- Update: main.LAST_HASH.hot-update.js, size: 738
 
 ## Manifest
 
@@ -38,7 +38,7 @@ Object.defineProperty(exports, "__esModule", ({
 }));
 exports["default"] = 1;
 }),
-"./reexport.js": (function (module, __webpack_exports__, __webpack_require__) {
+"./reexport.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */var _file__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./file */ "./file.js");


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

* remove some useless fields in compilation, include compilation.has_module_import_export_change and compilation.optimize_analyze_result_map
* make hooks align with webpack and remove make_param

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
