### PR TITLE
fix: systemjs runtime extra semicolon

### DIFF
--- a/crates/rspack_plugin_library/src/amd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/amd_library_plugin.rs
@@ -132,7 +132,7 @@ impl JavascriptModulesPluginPlugin for AmdLibraryJavascriptModulesPluginPlugin {
       )));
     }
     source.add(args.source.clone());
-    source.add(RawSource::from("\n});"));
+    source.add(RawSource::from("\n})"));
     Ok(Some(source.boxed()))
   }
 

--- a/crates/rspack_plugin_library/src/umd_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/umd_library_plugin.rs
@@ -232,7 +232,7 @@ impl JavascriptModulesPluginPlugin for UmdLibraryJavascriptModulesPluginPlugin {
       external_arguments(&externals, compilation)
     )));
     source.add(args.source.clone());
-    source.add(RawSource::from("\n});"));
+    source.add(RawSource::from("\n})"));
     Ok(Some(source.boxed()))
   }
 

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -77,7 +77,7 @@ impl JavascriptModulesPluginPlugin for ArrayPushCallbackChunkFormatJavascriptMod
           args.chunk_ukey,
         )?);
       }
-      source.add(RawSource::Source(");".to_string()));
+      source.add(RawSource::Source(")".to_string()));
     } else {
       let chunk_loading_global = &args.compilation.options.output.chunk_loading_global;
 
@@ -129,7 +129,7 @@ impl JavascriptModulesPluginPlugin for ArrayPushCallbackChunkFormatJavascriptMod
         }
         source.add(RawSource::from("\n}\n"));
       }
-      source.add(RawSource::from("]);"));
+      source.add(RawSource::from("])"));
     }
 
     Ok(Some(source.boxed()))

--- a/packages/rspack-test-tools/tests/configCases/library/system-runtime/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/system-runtime/index.js
@@ -1,0 +1,3 @@
+it("should run", () => {
+  expect(true);
+});

--- a/packages/rspack-test-tools/tests/configCases/library/system-runtime/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/system-runtime/test.config.js
@@ -1,0 +1,17 @@
+const System = require("../../../../dist/helper/legacy/fakeSystem");
+
+module.exports = {
+  beforeExecute: () => {
+    System.init();
+  },
+  findBundle() {
+    return ["./main.js"];
+  },
+  moduleScope(scope) {
+    System.setRequire(scope.require);
+    scope.System = System;
+  },
+  afterExecute: () => {
+    System.execute("(anonym)");
+  }
+};

--- a/packages/rspack-test-tools/tests/configCases/library/system-runtime/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/system-runtime/webpack.config.js
@@ -1,0 +1,20 @@
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: "web",
+  mode: "development",
+  entry: {
+    main: "./index.js",
+  },
+  output: {
+    filename: "[name].js",
+    library: {
+      type: 'system',
+    },
+  },
+  optimization: {
+    runtimeChunk: {
+      name: "runtime"
+    },
+  },
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Compiling with `optimization.runtimeChunk=true` and `library.type="system"` may cause runtime error by an extra semicolon：

Before: 
```js
System.register([], function(__WEBPACK_DYNAMIC_EXPORT__, __system_context__) {
return {
execute: function() {
__WEBPACK_DYNAMIC_EXPORT__((self['webpackChunk'] = self['webpackChunk'] || []).push([["main"], {
"./index.js": (function () {
it("should run", ()=>{
    expect(true);
});
}),

},function(__webpack_require__) {
var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
var __webpack_exports__ = (__webpack_exec__("./index.js"));
return __webpack_exports__;

}
]);)} // error occur in runtime
}

})
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
