### PR TITLE
docs: add missing `module` option of swc minimizer plugin

### DIFF
--- a/website/docs/en/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
@@ -49,6 +49,7 @@ new rspack.SwcJsMinimizerRspackPlugin(options);
     extractComments?: boolean | RegExp;
     compress?: TerserCompressOptions | boolean;
     mangle?: TerserMangleOptions | boolean;
+    module?: boolean;
     format?: JsFormatOptions & ToSnakeCaseProperties<JsFormatOptions>;
 
     test?: MinifyConditions;

--- a/website/docs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/swc-js-minimizer-rspack-plugin.mdx
@@ -49,6 +49,7 @@ new rspack.SwcJsMinimizerRspackPlugin(options);
     extractComments?: boolean | RegExp;
     compress?: TerserCompressOptions | boolean;
     mangle?: TerserMangleOptions | boolean;
+    module?: boolean;
     format?: JsFormatOptions & ToSnakeCaseProperties<JsFormatOptions>;
 
     test?: MinifyConditions;


### PR DESCRIPTION
## Summary

This option is in the source code but not in official website dcos.

https://github.com/web-infra-dev/rspack/blob/7e15f6816c0ff5f440d2f7eb07235a03b51686e8/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_js_minimizer.rs#L82

Here's the docs on the official website:

![img_v3_02ao_f6732243-7781-40eb-aeca-3a9d54ad791g](https://github.com/web-infra-dev/rspack/assets/31957758/0420755e-580f-463c-8ca6-21abe754a038)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
