### PR TITLE
fix: make code-splitting deterministic

### DIFF
--- a/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/build_chunk_graph/code_splitter.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::hash::BuildHasherDefault;
+use std::hash::{BuildHasherDefault, Hash};
 use std::sync::Arc;
 
 use indexmap::{IndexMap, IndexSet};
@@ -28,15 +28,15 @@ pub struct ChunkGroupInfo {
   pub min_available_modules_init: bool,
   pub available_modules_to_be_merged: Vec<BigUint>,
 
-  pub skipped_items: HashSet<ModuleIdentifier>,
+  pub skipped_items: IndexSet<ModuleIdentifier>,
   pub skipped_module_connections:
     IndexSet<(ModuleIdentifier, Vec<ConnectionId>), BuildHasherDefault<FxHasher>>,
   // set of children chunk groups, that will be revisited when available_modules shrink
-  pub children: HashSet<CgiUkey>,
+  pub children: IndexSet<CgiUkey>,
   // set of chunk groups that are the source for min_available_modules
-  pub available_sources: HashSet<CgiUkey>,
+  pub available_sources: IndexSet<CgiUkey>,
   // set of chunk groups which depend on the this chunk group as available_source
-  pub available_children: HashSet<CgiUkey>,
+  pub available_children: IndexSet<CgiUkey>,
 
   // set of modules available including modules from this chunk group
   // A derived attribute, therefore utilizing interior mutability to manage updates
@@ -114,10 +114,77 @@ impl From<Option<RuntimeSpec>> for OptionalRuntimeSpec {
 
 type CgiUkey = Ukey<ChunkGroupInfo>;
 
-type BlockModulesRuntimeMap = HashMap<
+type BlockModulesRuntimeMap = IndexMap<
   OptionalRuntimeSpec,
-  HashMap<DependenciesBlockIdentifier, Vec<(ModuleIdentifier, ConnectionState, Vec<ConnectionId>)>>,
+  IndexMap<
+    DependenciesBlockIdentifier,
+    Vec<(ModuleIdentifier, ConnectionState, Vec<ConnectionId>)>,
+  >,
 >;
+
+// Queue is used to debug code-splitting,
+// we store every op.
+// #[derive(Default)]
+// struct Queue {
+//   inner: Vec<QueueAction>,
+//   records: Vec<String>,
+// }
+
+// impl Queue {
+//   fn push(&mut self, item: QueueAction) {
+//     self.inner.push(item);
+//   }
+
+//   fn len(&self) -> usize {
+//     self.inner.len()
+//   }
+
+//   fn reverse(&mut self) {
+//     self.inner.reverse();
+//   }
+
+//   fn is_empty(&self) -> bool {
+//     self.inner.is_empty()
+//   }
+
+//   fn pop(&mut self) -> Option<QueueAction> {
+//     let item = self.inner.pop();
+//     if let Some(item) = &item {
+//       let res = match item {
+//         QueueAction::AddAndEnterEntryModule(item) => {
+//           format!("add_enter_entry: {}", item.module)
+//         }
+//         QueueAction::AddAndEnterModule(item) => {
+//           format!("add_enter: {}|{:?}", item.module, item.orig)
+//         }
+//         QueueAction::_EnterModule(_) => todo!(),
+//         QueueAction::ProcessBlock(item) => {
+//           format!("process_block: {:?}", item.block)
+//         }
+//         QueueAction::ProcessEntryBlock(item) => {
+//           format!("process_entry_block: {:?}", item.block,)
+//         }
+//         QueueAction::LeaveModule(item) => {
+//           format!("leave: {}", item.module,)
+//         }
+//       };
+
+//       let cwd = std::env::current_dir()
+//         .unwrap()
+//         .parent()
+//         .unwrap()
+//         .parent()
+//         .unwrap()
+//         .to_string_lossy()
+//         .to_string();
+//       self
+//         .records
+//         .push(LOC_RE.replace(&res, "").replace(&cwd, "").to_string());
+//     }
+
+//     item
+//   }
+// }
 
 pub(super) struct CodeSplitter<'me> {
   chunk_group_info_map: HashMap<ChunkGroupUkey, CgiUkey>,
@@ -130,10 +197,10 @@ pub(super) struct CodeSplitter<'me> {
   next_chunk_group_index: u32,
   queue: Vec<QueueAction>,
   queue_delayed: Vec<QueueAction>,
-  queue_connect: HashMap<CgiUkey, HashSet<CgiUkey>>,
-  chunk_groups_for_combining: HashSet<CgiUkey>,
-  outdated_chunk_group_info: HashSet<CgiUkey>,
-  chunk_groups_for_merging: HashSet<CgiUkey>,
+  queue_connect: IndexMap<CgiUkey, IndexSet<CgiUkey>>,
+  chunk_groups_for_combining: IndexSet<CgiUkey>,
+  outdated_chunk_group_info: IndexSet<CgiUkey>,
+  chunk_groups_for_merging: IndexSet<CgiUkey>,
   block_chunk_groups: HashMap<AsyncDependenciesBlockIdentifier, CgiUkey>,
   named_chunk_groups: HashMap<String, CgiUkey>,
   named_async_entrypoints: HashMap<String, CgiUkey>,
@@ -239,10 +306,14 @@ impl<'me> CodeSplitter<'me> {
 
   fn prepare_input_entrypoints_and_modules(
     &mut self,
-  ) -> Result<HashMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
-    let mut input_entrypoints_and_modules: HashMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
-      HashMap::default();
-    let mut assign_depths_map = HashMap::default();
+  ) -> Result<IndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>>> {
+    let mut input_entrypoints_and_modules: IndexMap<ChunkGroupUkey, Vec<ModuleIdentifier>> =
+      IndexMap::default();
+    let mut assign_depths_map: std::collections::HashMap<
+      rspack_identifier::Identifier,
+      usize,
+      BuildHasherDefault<FxHasher>,
+    > = HashMap::default();
 
     let entries = self.compilation.entries.clone();
     for (name, entry_data) in entries {
@@ -389,7 +460,7 @@ impl<'me> CodeSplitter<'me> {
       self.compilation.get_module_graph_mut().set_depth(k, v);
     }
 
-    let mut runtime_chunks = HashSet::default();
+    let mut runtime_chunks = IndexSet::<ChunkUkey>::default();
     let mut runtime_errors = vec![];
     for (name, entry_data) in &self.compilation.entries {
       let options = &entry_data.options;
@@ -545,7 +616,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         // This means no module is added until other sets are merged into
         // this min_available_modules (by the parent entrypoints)
         let chunk_group_info = self.chunk_group_infos.expect_get_mut(cgi);
-        chunk_group_info.skipped_items = HashSet::from_iter(modules);
+        chunk_group_info.skipped_items = IndexSet::from_iter(modules);
         self.chunk_groups_for_combining.insert(*cgi);
       } else {
         // The application may start here: We start with an empty list of available modules
@@ -666,7 +737,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         .copied()
         .collect::<Vec<_>>();
 
-      let mut visited = HashSet::default();
+      let mut visited = IndexSet::default();
 
       for root in blocks {
         let mut ctx = (0, 0, Default::default());
@@ -702,8 +773,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     &mut self,
     module_identifier: ModuleIdentifier,
     runtime: &RuntimeSpec,
-    visited: &mut HashSet<ModuleIdentifier>,
-    ctx: &mut (usize, usize, HashMap<ModuleIdentifier, (usize, usize)>),
+    visited: &mut IndexSet<ModuleIdentifier>,
+    ctx: &mut (usize, usize, IndexMap<ModuleIdentifier, (usize, usize)>),
   ) {
     let block_modules = self.get_block_modules(module_identifier.into(), Some(runtime));
     if visited.contains(&module_identifier) {
@@ -1230,7 +1301,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
   ) -> Vec<(ModuleIdentifier, ConnectionState, Vec<ConnectionId>)> {
     if let Some(modules) = self
       .block_modules_runtime_map
-      .get(&runtime.cloned().into())
+      .get::<OptionalRuntimeSpec>(&runtime.cloned().into())
       .and_then(|map| map.get(&module))
     {
       return modules.clone();
@@ -1238,7 +1309,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     self.extract_block_modules(module.get_root_block(self.compilation), runtime);
     self
       .block_modules_runtime_map
-      .get(&runtime.cloned().into())
+      .get::<OptionalRuntimeSpec>(&runtime.cloned().into())
       .and_then(|map| map.get(&module))
       .unwrap_or_else(|| {
         panic!("block_modules_map.get({module:?}) must not empty after extract_block_modules")
@@ -1321,7 +1392,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
   }
 
   fn process_connect_queue(&mut self) {
-    for (chunk_group_info_ukey, targets) in self.queue_connect.drain() {
+    for (chunk_group_info_ukey, targets) in self.queue_connect.drain(..) {
       let chunk_group_info = self
         .chunk_group_infos
         .expect_get_mut(&chunk_group_info_ukey);
@@ -1374,7 +1445,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
 
   fn process_outdated_chunk_group_info(&mut self) {
     // Revisit skipped elements
-    for chunk_group_info_ukey in self.outdated_chunk_group_info.drain() {
+    for chunk_group_info_ukey in self.outdated_chunk_group_info.drain(..) {
       let cgi = self
         .chunk_group_infos
         .expect_get_mut(&chunk_group_info_ukey);
@@ -1399,7 +1470,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       }
 
       for m in &enter_modules {
-        cgi.skipped_items.remove(m);
+        cgi.skipped_items.shift_remove(m);
 
         self
           .queue
@@ -1482,7 +1553,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       })
     });
 
-    let mut min_available_modules_mappings = HashMap::default();
+    let mut min_available_modules_mappings = IndexMap::<CgiUkey, BigUint>::default();
     for info_ukey in &self.chunk_groups_for_combining {
       let info = self.chunk_group_infos.expect_get(info_ukey);
       let mut available_modules = BigUint::from(0u32);
@@ -1506,7 +1577,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
   }
 
   fn process_chunk_groups_for_merging(&mut self) {
-    for info_ukey in self.chunk_groups_for_merging.drain() {
+    for info_ukey in self.chunk_groups_for_merging.drain(..) {
       let cgi = self.chunk_group_infos.expect_get_mut(&info_ukey);
 
       let mut changed = false;

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -92,8 +92,6 @@ where
         self
           .compilation
           .swap_make_artifact_with_compilation(&mut new_compilation);
-        new_compilation.entries = std::mem::take(&mut self.compilation.entries);
-        new_compilation.global_entry = std::mem::take(&mut self.compilation.global_entry);
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
         new_compilation.file_dependencies = std::mem::take(&mut self.compilation.file_dependencies);

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1771,7 +1771,7 @@ impl ExportInfo {
         key,
         ExportInfoTargetValue {
           connection: connection_inner_dep_id,
-          export: Some(export_name.cloned().unwrap_or_default()),
+          export: export_name.cloned(),
           priority: normalized_priority,
         },
       );

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::Entry;
 
+use indexmap::IndexMap;
 use itertools::Itertools;
 use rspack_core::{
   ApplyContext, BuildMetaExportsType, Compilation, CompilationFinishModules, CompilerOptions,
@@ -81,8 +82,8 @@ impl<'a> FlagDependencyExportsProxy<'a> {
     while let Some(module_id) = q.dequeue() {
       self.changed = false;
       self.current_module_id = module_id;
-      let mut exports_specs_from_dependencies: HashMap<DependencyId, ExportsSpec> =
-        HashMap::default();
+      let mut exports_specs_from_dependencies: IndexMap<DependencyId, ExportsSpec> =
+        IndexMap::default();
       self.process_dependencies_block(&module_id, &mut exports_specs_from_dependencies);
       let exports_info_id = self.mg.get_exports_info(&module_id).id;
       for (dep_id, exports_spec) in exports_specs_from_dependencies.into_iter() {
@@ -105,7 +106,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
   pub fn process_dependencies_block(
     &self,
     module_identifier: &ModuleIdentifier,
-    exports_specs_from_dependencies: &mut HashMap<DependencyId, ExportsSpec>,
+    exports_specs_from_dependencies: &mut IndexMap<DependencyId, ExportsSpec>,
   ) -> Option<()> {
     let block = &**self.mg.module_by_identifier(module_identifier)?;
     self.process_dependencies_block_inner(block, exports_specs_from_dependencies)
@@ -114,7 +115,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
   fn process_dependencies_block_inner<B: DependenciesBlock + ?Sized>(
     &self,
     block: &B,
-    exports_specs_from_dependencies: &mut HashMap<DependencyId, ExportsSpec>,
+    exports_specs_from_dependencies: &mut IndexMap<DependencyId, ExportsSpec>,
   ) -> Option<()> {
     for dep_id in block.get_dependencies().iter() {
       let dep = self
@@ -150,7 +151,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
     &self,
     dep_id: DependencyId,
     exports_specs: Option<ExportsSpec>,
-    exports_specs_from_dependencies: &mut HashMap<DependencyId, ExportsSpec>,
+    exports_specs_from_dependencies: &mut IndexMap<DependencyId, ExportsSpec>,
   ) -> Option<()> {
     // this is why we can bubble here. https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/FlagDependencyExportsPlugin.js#L140
     let exports_specs = exports_specs?;

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -102,20 +102,15 @@ pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
     return diff_count;
   }
 
-  // // 3. by size reduction
-  // let a_size_reduce = total_size(&a.sizes) * (a.chunks.len() - 1) as f64;
-  // let b_size_reduce = total_size(&b.sizes) * (b.chunks.len() - 1) as f64;
-  // let diff_size_reduce = a_size_reduce - b_size_reduce;
-  // if diff_size_reduce != 0f64 {
-  //   return diff_size_reduce;
-  // }
-  // 4. by cache group index
-  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
-  if index_diff != 0f64 {
-    return index_diff;
+  // 3. by size reduction
+  let a_size_reduce = total_size(&a.sizes) * (a.chunks.len() - 1) as f64;
+  let b_size_reduce = total_size(&b.sizes) * (b.chunks.len() - 1) as f64;
+  let diff_size_reduce = a_size_reduce - b_size_reduce;
+  if diff_size_reduce != 0f64 {
+    return diff_size_reduce;
   }
 
-  // 5. by number of modules (to be able to compare by identifier)
+  // 4. by number of modules (to be able to compare by identifier)
   let modules_a_len = a.modules.len();
   let modules_b_len = b.modules.len();
   let diff = modules_a_len as f64 - modules_b_len as f64;
@@ -130,7 +125,7 @@ pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
 
   loop {
     match (modules_a.pop(), modules_b.pop()) {
-      (None, None) => return 0f64,
+      (None, None) => break,
       (Some(a), Some(b)) => {
         let res = a.cmp(b);
         if !res.is_eq() {
@@ -140,4 +135,15 @@ pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
       _ => unreachable!(),
     }
   }
+
+  // 5. by cache group index
+  b.cache_group_index as f64 - a.cache_group_index as f64
+}
+
+fn total_size(sizes: &SplitChunkSizes) -> f64 {
+  let mut size = 0f64;
+  for ty_size in sizes.0.values() {
+    size += ty_size;
+  }
+  size
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Rspack offers 2 approaches for handling hot module replacement (HMR):
1. Fast path: Only modifies content without changing dependencies, allowing for the reuse of the chunk graph.
2. Slow path: Module dependencies or blocks have changed, requiring regeneration of the chunk graph.

Currently, we encounter issues with both scenarios:

1. Users may trigger the slow path even when not altering dependencies (e.g., adding a div in a React app). This occurs because we detect changes in dependencies; for instance, adding a new ImportSpecifierDependency triggers the slow path.

2. When encountering the slow path, the generated chunk graph differs from the original one.

In certain instances, the chunk graph may vary between builds even if there are no modifications to the module graph.
## What does this PR fix

make code-splitting deterministic, use IndexMap to preserve the iter order

fix `has_module_graph_change`, currently it cannot detect the change when dependencies' order changes

Align exports_info.set_unknown_target with webpack

Use IndexMap to make order of iterating exports deterministic

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
