### PR TITLE
docs: duplicated ignoreOrder option in CssExtractPlugin

### DIFF
--- a/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -71,18 +71,11 @@ If your project does not depend on css-loader, it is recommended to use the buil
           'The name of the asynchronous loading CSS artifact. If not set, it will use filename; please see output.chunkFilename',
       },
       {
-        name: "'ignoreOrder'",
-        type: "'boolean'",
-        default: 'false',
-        description:
-          'Whether to issue a warning if there are conflicts in the order of some CSS in different chunks. For example, entryA introduces a.css b.css, entryB introduces b.css a.css, and the order of a.css and b.css cannot be determined',
-      },
-      {
         name: '`ignoreOrder`',
         type: '`boolean`',
         default: 'false',
         description:
-          'If there are conflicts in the order of certain CSS files in different chunks, should a warning be issued? For example, entryA imports a.css and b.css, while entryB imports b.css and a.css. The order of a.css and b.css cannot be determined.',
+          'Whether to issue a warning if there are conflicts in the order of some CSS in different chunks. For example, entryA introduces a.css b.css, entryB introduces b.css a.css, and the order of a.css and b.css cannot be determined',
       },
       {
         name: '`insert`',


### PR DESCRIPTION
## Summary

Fix duplicated ignoreOrder option in document:

![image](https://github.com/web-infra-dev/rspack/assets/7237365/4b115323-4baa-4c78-97b3-51c4fe360ba4)

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
