### PR TITLE
fix(minimizer): resolve error in minimizing esm asset file

### DIFF
--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -226,11 +226,15 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         let input_source_map = original_source.map(&MapOptions::default());
 
         let is_module = if let Some(module) = self.options.module {
-          module
+          Some(module)
         } else if let Some(module) = original.info.javascript_module {
-          module
+          Some(module)
+        } else if filename.ends_with(".mjs") {
+          Some(true)
+        } else if filename.ends_with(".cjs") {
+          Some(false)
         } else {
-          filename.ends_with(".mjs")
+          None
         };
 
         let js_minify_options = JsMinifyOptions {
@@ -362,7 +366,7 @@ pub struct JsMinifyOptions {
   pub ecma: TerserEcmaVersion,
   pub keep_class_names: bool,
   pub keep_fn_names: bool,
-  pub module: bool,
+  pub module: Option<bool>,
   pub safari10: bool,
   pub toplevel: bool,
   pub source_map: BoolOrDataConfig<TerserSourceMapKind>,

--- a/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
@@ -151,7 +151,7 @@ pub fn minify(
           // top_level defaults to true if module is true
 
           // https://github.com/swc-project/swc/issues/2254
-          if opts.module {
+          if opts.module.unwrap_or(false) {
             if let Some(opts) = &mut min_opts.compress {
               if opts.top_level.is_none() {
                 opts.top_level = Some(TopLevelOptions { functions: true });
@@ -174,7 +174,9 @@ pub fn minify(
               decorators_before_export: true,
               ..Default::default()
             }),
-            IsModule::Bool(opts.module),
+            opts
+              .module
+              .map_or_else(|| IsModule::Unknown, |v| IsModule::Bool(v)),
             Some(&comments),
           )
           .map_err(|errs| {

--- a/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/minify.rs
@@ -176,7 +176,7 @@ pub fn minify(
             }),
             opts
               .module
-              .map_or_else(|| IsModule::Unknown, |v| IsModule::Bool(v)),
+              .map_or_else(|| IsModule::Unknown, IsModule::Bool),
             Some(&comments),
           )
           .map_err(|errs| {

--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -313,6 +313,8 @@ div {
 "
 `;
 
+exports[`config config/optimization/minimizer-esm-asset exported tests minimizing an asset file of esm type should success 1`] = `"console.log(import.meta.url);export const a=1;"`;
+
 exports[`config config/optimization/minimizer-swc-extract-comments exported tests should keep the extracted license file stable 1`] = `
 "/**
  * bar

--- a/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/index.js
+++ b/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/index.js
@@ -1,0 +1,8 @@
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+
+it("minimizing an asset file of esm type should success", () => {
+	const worker = new URL("./pkg/pkg.js", import.meta.url);
+	const minifiedContent = readFileSync(fileURLToPath(worker), "utf-8");
+	expect(minifiedContent).toMatchSnapshot();
+});

--- a/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/pkg/package.json
+++ b/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/pkg/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/pkg/pkg.js
+++ b/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/pkg/pkg.js
@@ -1,0 +1,3 @@
+console.log(import.meta.url);
+
+export const a = 1;

--- a/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/webpack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/optimization/minimizer-esm-asset/webpack.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import("@rspack/core").Configuration}
+ */
+module.exports = {
+	optimization: {
+		minimize: true
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

let swc minimizer determine the module type if it is unknown - align with webpack and terser-webpack-plugin.

Fixes: #6513 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required) - No need.
