### PR TITLE
refactor: make `make_artifact` as raw data

### DIFF
--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -279,8 +279,7 @@ impl JsCompilation {
   pub fn get_file_dependencies(&self) -> Vec<String> {
     self
       .0
-      .file_dependencies
-      .iter()
+      .file_dependencies()
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
@@ -289,8 +288,7 @@ impl JsCompilation {
   pub fn get_context_dependencies(&self) -> Vec<String> {
     self
       .0
-      .context_dependencies
-      .iter()
+      .context_dependencies()
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
@@ -299,8 +297,7 @@ impl JsCompilation {
   pub fn get_missing_dependencies(&self) -> Vec<String> {
     self
       .0
-      .missing_dependencies
-      .iter()
+      .missing_dependencies()
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }
@@ -309,8 +306,7 @@ impl JsCompilation {
   pub fn get_build_dependencies(&self) -> Vec<String> {
     self
       .0
-      .build_dependencies
-      .iter()
+      .build_dependencies()
       .map(|i| i.to_string_lossy().to_string())
       .collect()
   }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -157,7 +157,6 @@ pub struct Compilation {
   pub loader_resolver_factory: Arc<ResolverFactory>,
   pub named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) named_chunk_groups: HashMap<String, ChunkGroupUkey>,
-  pub entry_module_identifiers: IdentifierSet,
   /// Collecting all used export symbol
   pub used_symbol_ref: HashSet<SymbolRef>,
   /// Collecting all module that need to skip in tree-shaking ast modification phase
@@ -247,7 +246,6 @@ impl Compilation {
       loader_resolver_factory,
       named_chunks: Default::default(),
       named_chunk_groups: Default::default(),
-      entry_module_identifiers: IdentifierSet::default(),
       used_symbol_ref: HashSet::default(),
       bailout_module_identifiers: IdentifierMap::default(),
 
@@ -898,8 +896,8 @@ impl Compilation {
     result
   }
 
-  pub fn entry_modules(&self) -> impl Iterator<Item = ModuleIdentifier> {
-    self.entry_module_identifiers.clone().into_iter()
+  pub fn entry_modules(&self) -> IdentifierSet {
+    self.make_artifact.entry_module_identifiers.clone()
   }
 
   pub fn entrypoint_by_name(&self, name: &str) -> &Entrypoint {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -314,6 +314,74 @@ impl Compilation {
     }
   }
 
+  pub fn file_dependencies(&self) -> impl Iterator<Item = &PathBuf> {
+    self
+      .make_artifact
+      .file_dependencies
+      .files()
+      .chain(
+        self
+          .module_executor
+          .as_ref()
+          .expect("should have module_executor")
+          .make_artifact
+          .file_dependencies
+          .files(),
+      )
+      .chain(&self.file_dependencies)
+  }
+
+  pub fn context_dependencies(&self) -> impl Iterator<Item = &PathBuf> {
+    self
+      .make_artifact
+      .context_dependencies
+      .files()
+      .chain(
+        self
+          .module_executor
+          .as_ref()
+          .expect("should have module_executor")
+          .make_artifact
+          .context_dependencies
+          .files(),
+      )
+      .chain(&self.context_dependencies)
+  }
+
+  pub fn missing_dependencies(&self) -> impl Iterator<Item = &PathBuf> {
+    self
+      .make_artifact
+      .missing_dependencies
+      .files()
+      .chain(
+        self
+          .module_executor
+          .as_ref()
+          .expect("should have module_executor")
+          .make_artifact
+          .missing_dependencies
+          .files(),
+      )
+      .chain(&self.missing_dependencies)
+  }
+
+  pub fn build_dependencies(&self) -> impl Iterator<Item = &PathBuf> {
+    self
+      .make_artifact
+      .build_dependencies
+      .files()
+      .chain(
+        self
+          .module_executor
+          .as_ref()
+          .expect("should have module_executor")
+          .make_artifact
+          .build_dependencies
+          .files(),
+      )
+      .chain(&self.build_dependencies)
+  }
+
   // TODO move out from compilation
   pub fn get_import_var(&self, dep_id: &DependencyId) -> String {
     let module_graph = self.get_module_graph();

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -96,13 +96,6 @@ where
         new_compilation.global_entry = std::mem::take(&mut self.compilation.global_entry);
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
-        new_compilation.file_dependencies = std::mem::take(&mut self.compilation.file_dependencies);
-        new_compilation.context_dependencies =
-          std::mem::take(&mut self.compilation.context_dependencies);
-        new_compilation.missing_dependencies =
-          std::mem::take(&mut self.compilation.missing_dependencies);
-        new_compilation.build_dependencies =
-          std::mem::take(&mut self.compilation.build_dependencies);
 
         // seal stage used
         new_compilation.code_splitting_cache =

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -103,12 +103,6 @@ where
           std::mem::take(&mut self.compilation.missing_dependencies);
         new_compilation.build_dependencies =
           std::mem::take(&mut self.compilation.build_dependencies);
-        // tree shaking usage start
-        new_compilation.entry_module_identifiers =
-          std::mem::take(&mut self.compilation.entry_module_identifiers);
-        new_compilation.bailout_module_identifiers =
-          std::mem::take(&mut self.compilation.bailout_module_identifiers);
-        // tree shaking usage end
 
         // seal stage used
         new_compilation.code_splitting_cache =

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -24,7 +24,7 @@ pub struct MakeArtifact {
   pub diagnostics: Vec<Diagnostic>,
 
   entry_dependencies: HashSet<DependencyId>,
-  entry_module_identifiers: IdentifierSet,
+  pub entry_module_identifiers: IdentifierSet,
   pub optimize_analyze_result_map: IdentifierMap<OptimizeAnalyzeResult>,
   pub file_dependencies: FileCounter,
   pub context_dependencies: FileCounter,
@@ -51,17 +51,7 @@ impl MakeArtifact {
   }
 
   // TODO remove it
-  fn move_data_from_compilation(&mut self, compilation: &mut Compilation) {
-    self.entry_module_identifiers = std::mem::take(&mut compilation.entry_module_identifiers);
-    //    self.file_dependencies = std::mem::take(&mut compilation.file_dependencies);
-    //    self.context_dependencies = std::mem::take(&mut compilation.context_dependencies);
-    //    self.missing_dependencies = std::mem::take(&mut compilation.missing_dependencies);
-    //    self.build_dependencies = std::mem::take(&mut compilation.build_dependencies);
-  }
-
-  // TODO remove it
   fn move_data_to_compilation(&mut self, compilation: &mut Compilation) {
-    compilation.entry_module_identifiers = std::mem::take(&mut self.entry_module_identifiers);
     compilation
       .file_dependencies
       .extend(self.file_dependencies.files().cloned());
@@ -150,8 +140,6 @@ pub fn make_module_graph(
   artifact.diagnostics = Default::default();
   artifact.has_module_graph_change = false;
 
-  artifact.move_data_from_compilation(compilation);
-
   artifact = update_module_graph_with_artifact(compilation, artifact, params)?;
 
   if compilation.options.builtins.tree_shaking.enable() {
@@ -169,7 +157,6 @@ pub async fn update_module_graph(
 ) -> Result<()> {
   let mut artifact = MakeArtifact::default();
   compilation.swap_make_artifact(&mut artifact);
-  artifact.move_data_from_compilation(compilation);
 
   artifact = update_module_graph_with_artifact(compilation, artifact, params)?;
 

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct ModuleExecutor {
   request_dep_map: DashMap<String, DependencyId>,
-  make_artifact: MakeArtifact,
+  pub make_artifact: MakeArtifact,
 
   event_sender: Option<UnboundedSender<Event>>,
   stop_receiver: Option<oneshot::Receiver<MakeArtifact>>,
@@ -40,9 +40,7 @@ impl ModuleExecutor {
   pub async fn hook_before_make(&mut self, compilation: &Compilation) {
     let mut make_artifact = std::mem::take(&mut self.make_artifact);
     let mut params = vec![];
-    if !compilation.modified_files.is_empty() {
-      params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
-    }
+    params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
     if !compilation.removed_files.is_empty() {
       params.push(MakeParam::RemovedFiles(compilation.removed_files.clone()));
     }
@@ -107,19 +105,6 @@ impl ModuleExecutor {
 
     let diagnostics = std::mem::take(&mut self.make_artifact.diagnostics);
     compilation.push_batch_diagnostic(diagnostics);
-
-    compilation
-      .file_dependencies
-      .extend(self.make_artifact.file_dependencies.files().cloned());
-    compilation
-      .context_dependencies
-      .extend(self.make_artifact.context_dependencies.files().cloned());
-    compilation
-      .missing_dependencies
-      .extend(self.make_artifact.missing_dependencies.files().cloned());
-    compilation
-      .build_dependencies
-      .extend(self.make_artifact.build_dependencies.files().cloned());
   }
 
   #[allow(clippy::too_many_arguments)]

--- a/crates/rspack_core/src/tree_shaking/optimizer.rs
+++ b/crates/rspack_core/src/tree_shaking/optimizer.rs
@@ -143,7 +143,7 @@ impl<'a> CodeSizeOptimizer<'a> {
       let forced_side_effects = !side_effects_options
         || self
           .compilation
-          .entry_module_identifiers
+          .entry_modules()
           .contains(&analyze_result.module_identifier);
       // side_effects: true
       if forced_side_effects
@@ -430,7 +430,7 @@ impl<'a> CodeSizeOptimizer<'a> {
           side_effects_free: self.side_effects_free_modules.contains(&module_identifier),
           is_entry: self
             .compilation
-            .entry_module_identifiers
+            .entry_modules()
             .contains(&module_identifier),
           module_identifier,
         };
@@ -590,9 +590,9 @@ impl<'a> CodeSizeOptimizer<'a> {
     mut side_effect_map: IdentifierMap<SideEffectType>,
   ) -> IdentifierSet {
     // normalize side_effects, there are two kinds of `side_effects` one from configuration and another from analyze ast
-    for entry_module_ident in self.compilation.entry_module_identifiers.iter() {
+    for entry_module_ident in self.compilation.entry_modules() {
       Self::normalize_side_effects(
-        *entry_module_ident,
+        entry_module_ident,
         &self.compilation.get_module_graph(),
         &mut IdentifierSet::default(),
         &mut side_effect_map,

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -549,7 +549,7 @@ async fn nmf_module(
 
 #[plugin_hook(CompilationOptimizeDependencies for SideEffectsFlagPlugin)]
 fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
-  let entries = compilation.entry_modules().collect::<Vec<_>>();
+  let entries = compilation.entry_modules();
   let level_order_module_identifier =
     get_level_order_module_ids(&compilation.get_module_graph(), entries);
   for module_identifier in level_order_module_identifier {
@@ -693,10 +693,7 @@ impl Plugin for SideEffectsFlagPlugin {
   }
 }
 
-fn get_level_order_module_ids(
-  mg: &ModuleGraph,
-  entries: Vec<ModuleIdentifier>,
-) -> Vec<ModuleIdentifier> {
+fn get_level_order_module_ids(mg: &ModuleGraph, entries: IdentifierSet) -> Vec<ModuleIdentifier> {
   let mut res = vec![];
   let mut visited = IdentifierSet::default();
   for entry in entries {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will remove the behavior that move some data from make_artifact to compilation. it will make make_artifact save all of make data and compilation proxy the data access only.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
