### PR TITLE
fix: make entry add include dependencies

### DIFF
--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -92,8 +92,6 @@ where
         self
           .compilation
           .swap_make_artifact_with_compilation(&mut new_compilation);
-        new_compilation.entries = std::mem::take(&mut self.compilation.entries);
-        new_compilation.global_entry = std::mem::take(&mut self.compilation.global_entry);
         new_compilation.lazy_visit_modules =
           std::mem::take(&mut self.compilation.lazy_visit_modules);
 

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -97,8 +97,8 @@ pub fn make_module_graph(
       compilation
         .entries
         .values()
-        .flat_map(|item| &item.dependencies)
-        .chain(&compilation.global_entry.dependencies)
+        .flat_map(|item| item.all_dependencies())
+        .chain(compilation.global_entry.all_dependencies())
         .cloned()
         .collect(),
     ));

--- a/crates/rspack_core/src/options/entry.rs
+++ b/crates/rspack_core/src/options/entry.rs
@@ -23,3 +23,12 @@ pub struct EntryData {
   pub include_dependencies: Vec<DependencyId>,
   pub options: EntryOptions,
 }
+
+impl EntryData {
+  pub fn all_dependencies(&self) -> impl Iterator<Item = &DependencyId> {
+    self
+      .dependencies
+      .iter()
+      .chain(self.include_dependencies.iter())
+  }
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The entry dependencies of compilation should include both `dependencies` and `include_dependencies`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
