### PR TITLE
feat: export types of CSS extract plugin

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -1565,18 +1565,50 @@ export type CssChunkFilename = z.infer<typeof cssChunkFilename>;
 const cssChunkFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
 
 // @public (undocumented)
+export interface CssExtractRspackLoaderOptions {
+    // (undocumented)
+    emit?: boolean;
+    // (undocumented)
+    esModule?: boolean;
+    // (undocumented)
+    layer?: boolean;
+    // (undocumented)
+    publicPath?: string | ((resourcePath: string, context: string) => string);
+}
+
+// @public (undocumented)
 export class CssExtractRspackPlugin {
-    constructor(options?: PluginOptions);
+    constructor(options?: CssExtractRspackPluginOptions);
     // (undocumented)
     apply(compiler: Compiler): void;
     // (undocumented)
     static loader: string;
     // (undocumented)
-    normalizeOptions(options: PluginOptions): RawCssExtractPluginOption;
+    normalizeOptions(options: CssExtractRspackPluginOptions): RawCssExtractPluginOption;
     // (undocumented)
-    options: PluginOptions;
+    options: CssExtractRspackPluginOptions;
     // (undocumented)
     static pluginName: string;
+}
+
+// @public (undocumented)
+export interface CssExtractRspackPluginOptions {
+    // (undocumented)
+    attributes?: Record<string, string>;
+    // (undocumented)
+    chunkFilename?: string;
+    // (undocumented)
+    filename?: string;
+    // (undocumented)
+    ignoreOrder?: boolean;
+    // (undocumented)
+    insert?: string | ((linkTag: HTMLLinkElement) => void);
+    // (undocumented)
+    linkType?: string | "text/css" | false;
+    // (undocumented)
+    pathinfo?: boolean;
+    // (undocumented)
+    runtime?: boolean;
 }
 
 // @public (undocumented)
@@ -7179,26 +7211,6 @@ type PluginImportConfig = {
 type PluginImportOptions = PluginImportConfig[] | undefined;
 
 // @public (undocumented)
-interface PluginOptions {
-    // (undocumented)
-    attributes?: Record<string, string>;
-    // (undocumented)
-    chunkFilename?: string;
-    // (undocumented)
-    filename?: string;
-    // (undocumented)
-    ignoreOrder?: boolean;
-    // (undocumented)
-    insert?: string | ((linkTag: HTMLLinkElement) => void);
-    // (undocumented)
-    linkType?: string | "text/css" | false;
-    // (undocumented)
-    pathinfo?: boolean;
-    // (undocumented)
-    runtime?: boolean;
-}
-
-// @public (undocumented)
 export type Plugins = z.infer<typeof plugins>;
 
 // @public (undocumented)
@@ -7565,6 +7577,8 @@ declare namespace rspackExports {
         EvalDevToolModulePlugin,
         EvalDevToolModulePluginOptions,
         CssExtractRspackPlugin,
+        CssExtractRspackPluginOptions,
+        CssExtractRspackLoaderOptions,
         SwcLoaderOptions,
         SwcLoaderEnvConfig,
         SwcLoaderJscConfig,

--- a/packages/rspack/src/builtin-plugin/css-extract/index.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/index.ts
@@ -7,7 +7,9 @@ export * from "./loader";
 const DEFAULT_FILENAME = "[name].css";
 const LOADER_PATH = require.resolve("./loader");
 
-export interface PluginOptions {
+export type { CssExtractRspackLoaderOptions } from './loader';
+
+export interface CssExtractRspackPluginOptions {
 	filename?: string;
 	chunkFilename?: string;
 	ignoreOrder?: boolean;
@@ -24,9 +26,9 @@ export class CssExtractRspackPlugin {
 	static pluginName: string = "css-extract-rspack-plugin";
 	static loader: string = LOADER_PATH;
 
-	options: PluginOptions;
+	options: CssExtractRspackPluginOptions;
 
-	constructor(options?: PluginOptions) {
+	constructor(options?: CssExtractRspackPluginOptions) {
 		this.options = options || {};
 	}
 
@@ -56,7 +58,9 @@ export class CssExtractRspackPlugin {
 		});
 	}
 
-	normalizeOptions(options: PluginOptions): RawCssExtractPluginOption {
+	normalizeOptions(
+		options: CssExtractRspackPluginOptions
+	): RawCssExtractPluginOption {
 		let chunkFilename = options.chunkFilename;
 
 		if (!chunkFilename) {

--- a/packages/rspack/src/builtin-plugin/css-extract/index.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/index.ts
@@ -7,7 +7,7 @@ export * from "./loader";
 const DEFAULT_FILENAME = "[name].css";
 const LOADER_PATH = require.resolve("./loader");
 
-export type { CssExtractRspackLoaderOptions } from './loader';
+export type { CssExtractRspackLoaderOptions } from "./loader";
 
 export interface CssExtractRspackPluginOptions {
 	filename?: string;

--- a/packages/rspack/src/builtin-plugin/css-extract/loader.ts
+++ b/packages/rspack/src/builtin-plugin/css-extract/loader.ts
@@ -26,7 +26,7 @@ interface DependencyDescription {
 	filepath: string;
 }
 
-export interface LoaderOptions {
+export interface CssExtractRspackLoaderOptions {
 	publicPath?: string | ((resourcePath: string, context: string) => string);
 	emit?: boolean;
 	esModule?: boolean;
@@ -39,7 +39,7 @@ function hotLoader(
 	content: string,
 	context: {
 		loaderContext: LoaderContext;
-		options: LoaderOptions;
+		options: CssExtractRspackLoaderOptions;
 		locals: Record<string, string>;
 	}
 ) {
@@ -102,7 +102,7 @@ export const pitch: LoaderDefinition["pitch"] = function (request, _, data) {
 		return;
 	}
 
-	const options = this.getOptions(schema) as LoaderOptions;
+	const options = this.getOptions(schema) as CssExtractRspackLoaderOptions;
 	const emit = typeof options.emit !== "undefined" ? options.emit : true;
 	const callback = this.async();
 	const filepath = this.resourcePath;

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -257,6 +257,10 @@ export { EvalDevToolModulePlugin } from "./builtin-plugin";
 export type { EvalDevToolModulePluginOptions } from "./builtin-plugin";
 
 export { CssExtractRspackPlugin } from "./builtin-plugin";
+export type {
+	CssExtractRspackPluginOptions,
+	CssExtractRspackLoaderOptions
+} from "./builtin-plugin";
 
 ///// Rspack Postfixed Internal Loaders /////
 export type {


### PR DESCRIPTION
## Summary

Export two types of CSS extract plugin because Rsbuild needs to use these types:

```ts
import type { CssExtractRspackPluginOptions, CssExtractRspackLoaderOptions } from '@rspack/core';
```

This is equivalent to `mini-css-extract-plugin`:

```ts
import type { PluginOptions, LoaderOptions } from 'mini-css-extract-plugin';
```

See: https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/types/index.d.ts#L94-L95

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
