### PR TITLE
docs: rename Node.js API to JavaScript API

### DIFF
--- a/website/docs/en/api/_meta.json
+++ b/website/docs/en/api/_meta.json
@@ -6,7 +6,7 @@
     "name": "modules",
     "label": "Modules"
   },
-  "node-api",
+  "javascript-api",
   "hmr",
   {
     "type": "dir",

--- a/website/docs/en/api/index.mdx
+++ b/website/docs/en/api/index.mdx
@@ -14,11 +14,11 @@ When processing modules with rspack, it is important to understand the different
 
 [Learn more about the modules!](/api/modules/module-methods)
 
-## Node
+## JavaScript API
 
 While most users can get away with using the CLI along with a configuration file, more fine-grained control of the compilation can be achieved via the Node interface. This includes passing multiple configurations, programmatically running or watching, and collecting stats.
 
-[Learn more about the Node API!](/api/node-api)
+[Learn more about the JavaScript API!](/api/javascript-api)
 
 ## Hot Module Replacement
 

--- a/website/docs/en/api/javascript-api.mdx
+++ b/website/docs/en/api/javascript-api.mdx
@@ -3,27 +3,27 @@ import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
 
 <WebpackLicense from="https://webpack.js.org/api/node/" />
 
-# Node.js API
+# JavaScript API
 
-Rspack provides a Node.js API which can be used directly in Node.js runtime.
+Rspack provides a set of JavaScript APIs to be used in JavaScript runtimes like Node.js or Bun.
 
-The Node.js API is useful in scenarios in which you need to customize the build or development process since all the reporting and error handling must be done manually and webpack only does the compiling part. For this reason the [`stats`](/config/stats) configuration options will not have any effect in the `rspack()` call.
+The JavaScript API is useful in scenarios in which you need to customize the build or development process since all the reporting and error handling must be done manually and webpack only does the compiling part. For this reason the [`stats`](/config/stats) configuration options will not have any effect in the `rspack()` call.
 
 :::tip
-`@rspack/core` is designed based on Webpack's Node.js API to ensure functional consistency and a similar user experience.
+`@rspack/core` is designed based on Webpack's JavaScript API to ensure functional consistency and a similar user experience.
 :::
 
 ## Installation
 
-To start using the Rspack Node.js API, first install `@rspack/core` if you haven’t yet:
+To start using the Rspack JavaScript API, first install `@rspack/core` if you haven’t yet:
 
 ```bash
 npm install --save-dev @rspack/core
 ```
 
-Then require the `@rspack/core` module in your Node.js script:
+Then require the `@rspack/core` module in your JavaScript file:
 
-```bash
+```js title="build.js"
 import rspack from '@rspack/core';
 ```
 
@@ -43,11 +43,11 @@ rspack({}, (err, stats) => {
 ```
 
 :::tip
-The `err` object will not include compilation errors. Those must be handled separately using `stats.hasErrors()`, which will be covered in detail in the [Error Handling](/api/node-api#error-handling) section of this guide. The `err` object will only contain rspack-related issues, such as misconfiguration, etc.
+The `err` object will not include compilation errors. Those must be handled separately using `stats.hasErrors()`, which will be covered in detail in the [Error Handling](/api/javascript-api#error-handling) section of this guide. The `err` object will only contain rspack-related issues, such as misconfiguration, etc.
 :::
 
 :::tip
-You can provide the `rspack` function with an array of configurations. See the [MultiCompiler](/api/node-api#multicompiler) section below for more information.
+You can provide the `rspack` function with an array of configurations. See the [MultiCompiler](/api/javascript-api#multicompiler) section below for more information.
 :::
 
 ## Compiler Instance
@@ -149,7 +149,7 @@ watching.invalidate();
 
 ## Stats Object
 
-The `stats` object that is passed as a second argument of the [`rspack()`](/api/node-api#rspack) callback, is a good source of information about the code compilation process. It includes:
+The `stats` object that is passed as a second argument of the [`rspack()`](/api/javascript-api#rspack) callback, is a good source of information about the code compilation process. It includes:
 
 - Errors and Warnings (if any)
 - Timings
@@ -228,7 +228,7 @@ rspack(
 
 ## MultiCompiler
 
-The `MultiCompiler` module allows Rspack to run multiple configurations in separate compilers. If the `options` parameter in the Rspack's NodeJS api is an array of options, Rspack applies separate compilers and calls the callback after all compilers have been executed.
+The `MultiCompiler` module allows Rspack to run multiple configurations in separate compilers. If the `options` parameter in the Rspack's JavaScript API is an array of options, Rspack applies separate compilers and calls the callback after all compilers have been executed.
 
 ```js
 import rspack from '@rspack/core';

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -10,7 +10,7 @@ Generate packaging information that can be used to analyze module dependencies a
 :::info Output JSON file of stats
 
 - Using `@rspack/cli`, `rspack build --json stats.json`.
-- Using rspack's Node.js API, `stats.toJson(options)`、`stats.toString(options)`.
+- Using Rspack's JavaScript API, `stats.toJson(options)`、`stats.toString(options)`.
 
 :::
 

--- a/website/docs/zh/api/_meta.json
+++ b/website/docs/zh/api/_meta.json
@@ -6,7 +6,7 @@
     "name": "modules",
     "label": "模块"
   },
-  "node-api",
+  "javascript-api",
   "hmr",
   {
     "type": "dir",

--- a/website/docs/zh/api/index.mdx
+++ b/website/docs/zh/api/index.mdx
@@ -14,11 +14,11 @@ Rspack 提供了多种界面来自定义编译过程。一些功能在不同的�
 
 [了解更多关于模块的信息！](/api/modules/module-methods)
 
-## Node
+## JavaScript API
 
-虽然大多数用户可以通过命令行界面（CLI）和配置文件来进行操作，但通过 Node 接口可以实现对编译过程更为细致的控制。这包括传递多个配置、以编程方式运行或监控，以及收集统计信息。
+虽然大多数用户可以通过命令行界面（CLI）和配置文件来进行操作，但通过 JavaScript API 可以实现对编译过程更为细致的控制。这包括传递多个配置、以编程方式运行或监控，以及收集统计信息。
 
-[了解更多关于 Node API 的信息！](/api/node-api)
+[了解更多关于 JavaScript API 的信息！](/api/javascript-api)
 
 ## Hot Module Replacement
 

--- a/website/docs/zh/api/javascript-api.mdx
+++ b/website/docs/zh/api/javascript-api.mdx
@@ -3,27 +3,27 @@ import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
 
 <WebpackLicense from="https://webpack.docschina.org/api/node/" />
 
-# Node.js API
+# JavaScript API
 
-Rspack 提供了 Node.js API，可以在 Node.js 运行时下直接使用。
+Rspack 提供了一组 JavaScript API，可在 Node.js 或 Bun 等 JavaScript 运行时中使用。
 
-当你需要自定义构建或开发流程时，Node.js API 非常有用，因为此时所有的报告和错误处理都必须自行实现，Rspack 仅仅负责编译的部分。所以 [`stats`](/config/stats) 配置选项不会在 `rspack()` 调用中生效。
+当你需要自定义构建或开发流程时，JavaScript API 非常有用，因为此时所有的报告和错误处理都必须自行实现，Rspack 仅仅负责编译的部分。所以 [`stats`](/config/stats) 配置选项不会在 `rspack()` 调用中生效。
 
 :::tip 提示
-`@rspack/core` 是基于 Webpack Node.js API 设计的，旨在提供一致的功能和相似的使用体验。
+`@rspack/core` 是基于 Webpack JavaScript API 设计的，旨在提供一致的功能和相似的使用体验。
 :::
 
 ## 安装
 
-开始使用 Rspack 的 Node.js API 之前，首先你需要安装 `@rspack/core`：
+开始使用 Rspack 的 JavaScript API 之前，首先你需要安装 `@rspack/core`：
 
 ```bash
 npm install --save-dev @rspack/core
 ```
 
-在 Node.js 文件中，引入 `@rspack/core` 模块：
+在 JavaScript 文件中，引入 `@rspack/core` 模块：
 
-```bash
+```js title="build.js"
 import rspack from '@rspack/core';
 ```
 
@@ -43,11 +43,11 @@ rspack({}, (err, stats) => {
 ```
 
 :::tip 提示
-`err` 对象**不包含**编译错误，必须使用 `stats.hasErrors()` 单独处理，文档的[错误处理](/api/node-api#错误处理)将对这部分进行详细介绍。`err` 对象只包含 Rspack 相关的问题，例如配置错误等。
+`err` 对象**不包含**编译错误，必须使用 `stats.hasErrors()` 单独处理，文档的[错误处理](/api/javascript-api#错误处理)将对这部分进行详细介绍。`err` 对象只包含 Rspack 相关的问题，例如配置错误等。
 :::
 
 :::tip 提示
-你也可以为 rspack() 函数提供一个配置数组。更多详细信息，请查看 [MultiCompiler](/api/node-api#multicompiler) 章节。
+你也可以为 rspack() 函数提供一个配置数组。更多详细信息，请查看 [MultiCompiler](/api/javascript-api#multicompiler) 章节。
 :::
 
 ## Compiler 实例
@@ -149,7 +149,7 @@ watching.invalidate();
 
 ## Stats 对象
 
-`stats` 对象会被作为 [`rspack()`](/api/node-api#rspack) 回调函数的第二个参数传递，可以通过它获取到代码编译过程中的有用信息，包括：
+`stats` 对象会被作为 [`rspack()`](/api/javascript-api#rspack) 回调函数的第二个参数传递，可以通过它获取到代码编译过程中的有用信息，包括：
 
 - 错误和警告（如果有的话）
 - 计时信息
@@ -228,7 +228,7 @@ rspack(
 
 ## MultiCompiler
 
-`MultiCompiler` 模块可以让 Rspack 同时执行多个配置。如果传给 Rspack 的 Node.js API 的 `options` 参数，该参数由是由多个配置对象构成的数组，Rspack 会相应地创建多个 compiler 实例，并且在所有 compiler 执行完毕后调用 `callback` 方法。
+`MultiCompiler` 模块可以让 Rspack 同时执行多个配置。如果传给 Rspack 的 JavaScript API 的 `options` 参数，该参数由是由多个配置对象构成的数组，Rspack 会相应地创建多个 compiler 实例，并且在所有 compiler 执行完毕后调用 `callback` 方法。
 
 ```js
 import rspack from '@rspack/core';

--- a/website/docs/zh/config/stats.mdx
+++ b/website/docs/zh/config/stats.mdx
@@ -10,7 +10,7 @@ import WebpackLicense from '@components/webpack-license';
 :::info 输出打包信息的 JSON 文件
 
 - 使用 `@rspack/cli`，`rspack build --json stats.json`。
-- 通过 Rspack 的 Node.js API，`stats.toJson(options)`、`stats.toString(options)`。
+- 通过 Rspack 的 JavaScript API，`stats.toJson(options)`、`stats.toString(options)`。
 
 :::
 

--- a/website/theme/components/HomeFooter/index.tsx
+++ b/website/theme/components/HomeFooter/index.tsx
@@ -46,7 +46,7 @@ function useFooterData() {
         },
         {
           title: 'JavaScript API',
-          link: getLink('/api/node-api'),
+          link: getLink('/api/javascript-api'),
         },
       ],
     },


### PR DESCRIPTION
## Summary

Rename Node.js API to JavaScript API, because Rspack also supports JavaScript runtimes other than Node.js, such as Bun.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
