### PR TITLE
fix: when comparing, cache group index should consider before modules

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -110,7 +110,13 @@ pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
     return diff_size_reduce;
   }
 
-  // 4. by number of modules (to be able to compare by identifier)
+  // 4. by cache group index
+  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
+  if index_diff != 0f64 {
+    return index_diff;
+  }
+
+  // 5. by number of modules (to be able to compare by identifier)
   let modules_a_len = a.modules.len();
   let modules_b_len = b.modules.len();
   let diff = modules_a_len as f64 - modules_b_len as f64;
@@ -125,7 +131,7 @@ pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
 
   loop {
     match (modules_a.pop(), modules_b.pop()) {
-      (None, None) => break,
+      (None, None) => return 0f64,
       (Some(a), Some(b)) => {
         let res = a.cmp(b);
         if !res.is_eq() {
@@ -135,9 +141,6 @@ pub(crate) fn compare_entries(a: &ModuleGroup, b: &ModuleGroup) -> f64 {
       _ => unreachable!(),
     }
   }
-
-  // 5. by cache group index
-  b.cache_group_index as f64 - a.cache_group_index as f64
 }
 
 fn total_size(sizes: &SplitChunkSizes) -> f64 {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In #6508, we change the `compare_entires` in `SplitChunksPlugin`, at that time I thought cache group index should not be considered before modules, however some users do need the cache group index to make some modules hit certain cache group.

For example, we have 2 cache groups with the same index, and the same test. But we want the first one to be the right cache group.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
