### PR TITLE
fix: module_executor keep make_failed_module

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -67,10 +67,10 @@ impl MakeTaskContext {
       //      factorize_timer: logger.time_aggregate("module factorize task"),
       //      build_timer: logger.time_aggregate("module build task"),
       module_graph_partial: artifact.module_graph_partial,
-      // ignore make_failed_xxx and diagnostics
-      make_failed_dependencies: Default::default(),
-      make_failed_module: Default::default(),
-      diagnostics: Default::default(),
+
+      make_failed_dependencies: artifact.make_failed_dependencies,
+      make_failed_module: artifact.make_failed_module,
+      diagnostics: artifact.diagnostics,
 
       entry_dependencies: artifact.entry_dependencies,
       entry_module_identifiers: artifact.entry_module_identifiers,

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -52,6 +52,7 @@ impl ModuleExecutor {
       let modules = std::mem::take(&mut make_artifact.make_failed_module);
       params.push(MakeParam::ForceBuildModules(modules));
     }
+    make_artifact.diagnostics = Default::default();
 
     make_artifact =
       if let Ok(artifact) = update_module_graph_with_artifact(compilation, make_artifact, params) {

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/0.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case recovery: Step 0
+
+## Changed Files
+- index.css
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+		
+## Update

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -1,0 +1,46 @@
+# Case recovery: Step 2
+
+## Changed Files
+- index.css
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: main.LAST_HASH.hot-update.js, size: 201
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+		
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+self["webpackHotUpdate"]('main', {
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+!function() {
+__webpack_require__.h = function () {
+	return "CURRENT_HASH";
+};
+
+}();
+
+}
+);
+```

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/changed-file.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/changed-file.js
@@ -1,0 +1,6 @@
+// TODO: remove this file after cache.
+const path = require('path');
+
+module.exports = [
+  path.resolve(__dirname, './index.css')
+]

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/index.css
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/index.css
@@ -1,0 +1,9 @@
+body {
+    background-color: red;
+}
+---
+body {} {} {@}
+---
+body {
+    background-color: yellow;
+}

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/index.js
@@ -1,0 +1,10 @@
+import "./index.css";
+
+it("css recovery", done => {
+	NEXT(
+		require("../../update")(err => {
+			expect(String(err)).toContain("Module build failed");
+			NEXT(require("../../update")(done, true, () => done()));
+		})
+	);
+});

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/index.js
@@ -2,9 +2,13 @@ import "./index.css";
 
 it("css recovery", done => {
 	NEXT(
-		require("../../update")(err => {
-			expect(String(err)).toContain("Module build failed");
-			NEXT(require("../../update")(done, true, () => done()));
-		})
+		require("../../update")(
+			err => {
+				expect(String(err)).toContain("Module build failed");
+				NEXT(require("../../update")(done, true, () => done()));
+			},
+			true,
+			() => done()
+		)
 	);
 });

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/rspack.config.js
@@ -1,0 +1,29 @@
+const { CssExtractRspackPlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	mode: "development",
+	devtool: false,
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: CssExtractRspackPlugin.loader
+					},
+					"css-loader"
+				]
+			}
+		]
+	},
+	experiments: {
+		css: false
+	},
+	plugins: [
+		new CssExtractRspackPlugin({
+			filename: "[name].css"
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The MakeTaskContext should retain all of artifact data.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
