### PR TITLE
fix: change the data URI type in ModuleFederationPlugin

### DIFF
--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -186,6 +186,6 @@ function getDefaultEntryRuntime(
 		)}`,
 		compiler.webpack.Template.getFunctionContent(require("./default.runtime"))
 	].join("\n");
-	// use "application/node" to use moduleType "javascript/auto"
-	return `data:application/node,${content}`;
+	// use "data:text/javascript" to use moduleType "javascript/auto"
+	return `data:text/javascript,${content}`;
 }


### PR DESCRIPTION
## Summary

Change the data URI type in ModuleFederationPlugin, from `data:application/node` to `data:text/javascript`.

Because `data:text/javascript` is commonly used and can be matched by the builtin JS transform rules of Rsbuild.

See https://github.com/web-infra-dev/rsbuild/issues/2360 for background.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
