### PR TITLE
perf(core): prebundle enhanced-resolve to reduce dependencies

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -7720,7 +7720,7 @@ export type ResolveOptions = z.infer<typeof baseResolveOptions> & {
 };
 
 // @public (undocumented)
-type ResolveRequest BaseResolveRequest & Partial<ParsedIdentifier>;
+type ResolveRequest = BaseResolveRequest & Partial<ParsedIdentifier>;
 
 // @public (undocumented)
 export type ResolveTsconfig = z.infer<typeof resolveTsconfig>;

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -61,7 +61,6 @@ import type { RawRelayConfig } from '@rspack/binding';
 import { RawRuntimeChunkOptions } from '@rspack/binding';
 import { RawSourceMapDevToolPluginOptions } from '@rspack/binding';
 import { RawSwcJsMinimizerRspackPluginOptions } from '@rspack/binding';
-import { ResolveRequest } from 'enhanced-resolve';
 import ResolverFactory = require('./ResolverFactory');
 import { RspackOptionsNormalized as RspackOptionsNormalized_2 } from '.';
 import { Source } from 'webpack-sources';
@@ -645,6 +644,24 @@ const baseResolveOptions: z.ZodObject<{
     restrictions?: string[] | undefined;
     roots?: string[] | undefined;
 }>;
+
+// @public (undocumented)
+interface BaseResolveRequest {
+    	// (undocumented)
+    descriptionFileData?: object;
+    	// (undocumented)
+    descriptionFilePath?: string;
+    	// (undocumented)
+    descriptionFileRoot?: string;
+    	// (undocumented)
+    fullySpecified?: boolean;
+    	// (undocumented)
+    ignoreSymlinks?: boolean;
+    	// (undocumented)
+    path: string | false;
+    	// (undocumented)
+    relativePath?: string;
+}
 
 // @public (undocumented)
 const baseRuleSetCondition: z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>;
@@ -6975,6 +6992,24 @@ export interface OutputNormalized {
 }
 
 // @public (undocumented)
+interface ParsedIdentifier {
+    	// (undocumented)
+    directory: boolean;
+    	// (undocumented)
+    file: boolean;
+    	// (undocumented)
+    fragment: string;
+    	// (undocumented)
+    internal: boolean;
+    	// (undocumented)
+    module: boolean;
+    	// (undocumented)
+    query: string;
+    	// (undocumented)
+    request: string;
+}
+
+// @public (undocumented)
 export type ParserOptionsByModuleType = z.infer<typeof parserOptionsByModuleType>;
 
 // @public (undocumented)
@@ -7683,6 +7718,9 @@ type ResolveData = {
 export type ResolveOptions = z.infer<typeof baseResolveOptions> & {
     byDependency?: Record<string, ResolveOptions>;
 };
+
+// @public (undocumented)
+type ResolveRequest BaseResolveRequest & Partial<ParsedIdentifier>;
 
 // @public (undocumented)
 export type ResolveTsconfig = z.infer<typeof resolveTsconfig>;

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -51,6 +51,7 @@
     "copy-webpack-plugin": "5.1.2",
     "cross-env": "^7.0.3",
     "del": "^6.0.0",
+    "enhanced-resolve": "5.12.0",
     "file-loader": "^6.2.0",
     "glob": "^10.3.10",
     "graceful-fs": "4.2.10",
@@ -86,7 +87,6 @@
     "@module-federation/runtime-tools": "0.1.6",
     "@rspack/binding": "workspace:*",
     "caniuse-lite": "^1.0.30001616",
-    "enhanced-resolve": "5.12.0",
     "tapable": "2.2.1",
     "webpack-sources": "3.2.3"
   },

--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -1,4 +1,6 @@
 // @ts-check
+import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 
 /** @type {import('prebundle').Config} */
 export default {
@@ -11,7 +13,7 @@ export default {
 		{
 			name: "watchpack",
 			externals: {
-				"graceful-fs": "../graceful-fs"
+				"graceful-fs": "../graceful-fs/index.js"
 			}
 		},
 		{
@@ -20,6 +22,30 @@ export default {
 			externals: {
 				"caniuse-lite": "caniuse-lite",
 				"/^caniuse-lite(/.*)/": "caniuse-lite$1"
+			}
+		},
+		{
+			name: "enhanced-resolve",
+			externals: {
+				tapable: "tapable",
+				"graceful-fs": "../graceful-fs/index.js"
+			},
+			afterBundle({ depPath, distPath }) {
+				copyFileSync(
+					join(depPath, "lib/CachedInputFileSystem.js"),
+					join(distPath, "CachedInputFileSystem.js")
+				);
+
+				// ResolveRequest type is used by Rspack but not exported
+				const dtsFile = join(distPath, "index.d.ts");
+				const content = readFileSync(dtsFile, "utf-8");
+				writeFileSync(
+					dtsFile,
+					content.replace(
+						"type ResolveRequest =",
+						"export type ResolveRequest ="
+					)
+				);
 			}
 		}
 	]

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -10,6 +10,10 @@
       "watchpack": ["../compiled/watchpack"],
       "graceful-fs": ["../compiled/graceful-fs"],
       "browserslist": ["../compiled/browserslist"],
+      "enhanced-resolve": ["../compiled/enhanced-resolve"],
+      "enhanced-resolve/lib/CachedInputFileSystem": [
+        "../compiled/enhanced-resolve/CachedInputFileSystem"
+      ],
       "zod-validation-error": ["../compiled/zod-validation-error"],
       "json-parse-even-better-errors": [
         "../compiled/json-parse-even-better-errors"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -466,9 +466,6 @@ importers:
       caniuse-lite:
         specifier: ^1.0.30001616
         version: 1.0.30001616
-      enhanced-resolve:
-        specifier: 5.12.0
-        version: 5.12.0
       tapable:
         specifier: 2.2.1
         version: 2.2.1
@@ -515,6 +512,9 @@ importers:
       del:
         specifier: ^6.0.0
         version: 6.1.1
+      enhanced-resolve:
+        specifier: 5.12.0
+        version: 5.12.0
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.90.1)
@@ -9258,7 +9258,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.10
       tapable: 2.2.1
-    dev: false
 
   /enhanced-resolve@5.16.0:
     resolution: {integrity: sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==}


### PR DESCRIPTION
## Summary

Prebundle enhanced-resolve to reduce dependencies,  the motivation is the same as https://github.com/web-infra-dev/rspack/pull/6462

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
