### PR TITLE
fix: panic when update entry dependency

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/clean_isolated_module.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/clean_isolated_module.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use rustc_hash::FxHashSet as HashSet;
 
 use super::super::MakeArtifact;
-use crate::{DependencyId, ModuleIdentifier};
+use crate::ModuleIdentifier;
 
 #[derive(Debug, Default)]
 pub struct CleanIsolatedModule {
@@ -24,14 +24,10 @@ impl CleanIsolatedModule {
     }
   }
 
-  pub fn analyze_removed_deps(&mut self, artifact: &MakeArtifact, dep_id: &DependencyId) {
-    let module_graph = artifact.get_module_graph();
-    let connection = module_graph
-      .connection_by_dependency(dep_id)
-      .expect("should have connection");
+  pub fn add_need_check_module(&mut self, module_identifier: ModuleIdentifier) {
     self
       .need_check_isolated_module_ids
-      .insert(*connection.module_identifier());
+      .insert(module_identifier);
   }
 
   pub fn fix_artifact(self, artifact: &mut MakeArtifact) {

--- a/crates/rspack_core/src/compiler/make/cutout/mod.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/mod.rs
@@ -100,24 +100,26 @@ impl Cutout {
     force_build_deps.extend(artifact.revoke_modules(force_build_modules));
 
     if !next_entry_deps.is_empty() {
-      let mut old_entry_deps = std::mem::take(&mut artifact.entry_dependencies);
+      let mut remove_entry_deps = std::mem::take(&mut artifact.entry_dependencies);
       for dep_id in &next_entry_deps {
-        if old_entry_deps.contains(dep_id) {
-          old_entry_deps.remove(dep_id);
+        if remove_entry_deps.contains(dep_id) {
+          remove_entry_deps.remove(dep_id);
         } else {
           force_build_deps.insert((*dep_id, None));
         }
       }
+
       artifact.entry_dependencies = next_entry_deps;
-      for dep_id in old_entry_deps {
-        self
-          .clean_isolated_module
-          .analyze_removed_deps(artifact, &dep_id);
+      for dep_id in remove_entry_deps {
         let mut module_graph = artifact.get_module_graph_mut();
-        let con_id = *module_graph
-          .connection_id_by_dependency_id(&dep_id)
-          .expect("should have connection");
-        module_graph.revoke_connection(&con_id, true);
+        // connection may have been deleted by revoke module
+        if let Some(con) = module_graph.connection_by_dependency(&dep_id) {
+          self
+            .clean_isolated_module
+            .add_need_check_module(*con.module_identifier());
+          let con_id = con.id;
+          module_graph.revoke_connection(&con_id, true);
+        }
         force_build_deps.remove(&(dep_id, None));
       }
     }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The connection maybe has been deleted by revoke_module when update entries.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
