### PR TITLE
revert: revert swc comment preserver (#6389)

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/mod.rs
@@ -12,7 +12,7 @@ use swc_core::ecma::transforms::base::pass::Optional;
 use swc_core::ecma::visit::Fold;
 
 pub use self::dependency::*;
-use self::swc_visitor::dropped_comments_preserver;
+// use self::swc_visitor::dropped_comments_preserver;
 pub use self::JavascriptParser;
 
 /// Webpack builtin plugins
@@ -71,7 +71,7 @@ pub fn run_before_pass(
       let comments = program.comments.take();
       {
         let mut pass = chain!(
-          dropped_comments_preserver(comments.clone()),
+          // dropped_comments_preserver(comments.clone()),
           swc_visitor::resolver(unresolved_mark, top_level_mark, false),
           builtins_webpack_plugin(options, unresolved_mark, diagnostics),
           swc_visitor::hygiene(false, top_level_mark),

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
@@ -157,8 +157,7 @@ assert.deepStrictEqual(301, 301);
 assert.deepStrictEqual("302", "302");
 assert.deepStrictEqual(303, 303);
 assert.deepStrictEqual(304, 304);
-assert.deepStrictEqual(303..P4, undefined);
-// "303.P4"
+assert.deepStrictEqual(303..P4, undefined); // "303.P4"
 try {
     error_count += 1;
     P4.P1;
@@ -260,8 +259,7 @@ __webpack_require__.d(__webpack_exports__, {
 });
 const DO_NOT_CONVERTED7 = 402;
 const DO_NOT_CONVERTED9 = 403;
-/* harmony default export */ __webpack_exports__["default"] = (401);
-// DO_NOT_CONVERTED8
+/* harmony default export */ __webpack_exports__["default"] = (401); // DO_NOT_CONVERTED8
 
 }),
 

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/provide/__snapshots__/output.snap.txt
@@ -170,8 +170,7 @@ process.title = "browser";
 process.browser = true;
 process.env = {};
 process.argv = [];
-process.version = "";
-// empty string to avoid regexp issues
+process.version = ""; // empty string to avoid regexp issues
 process.versions = {};
 function noop() {}
 process.on = noop;

--- a/packages/rspack-test-tools/tests/configCases/parsing/preserve-all-comments/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/preserve-all-comments/index.js
@@ -1,7 +1,7 @@
 it("should preserve all comments", () => {
 	require("./a");
-	const fs = require("fs");
-	let file = fs.readFileSync(__filename, "utf8");
-	expect(file).toContain("c" + " outer");
-	expect(file).toContain("c" + " inner");
+	// const fs = require("fs");
+	// let file = fs.readFileSync(__filename, "utf8");
+	// expect(file).toContain("c" + " outer");
+	// expect(file).toContain("c" + " inner");
 })

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/duplicate/output.snap.txt
@@ -80,8 +80,7 @@ var __webpack_exports__ = {};
 /* harmony import */var fs__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__("fs");
 /* harmony import */var fs__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(fs__WEBPACK_IMPORTED_MODULE_2__);
 
-
-// b.js will be transform to c.js
+ // b.js will be transform to c.js
 
 
 it("should remove duplicate request modules generate by after resolve hook", ()=>{

--- a/packages/rspack-test-tools/tests/treeShakingCases/webpack-innergraph-try-globals/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/webpack-innergraph-try-globals/__snapshots__/treeshaking.snap.txt
@@ -32,9 +32,8 @@ try {
     var c = b;
     const a = 42;
     var ok2 = false;
-    eval("");
-} // TODO terser has a bug and incorrectly remove this code, eval opts out
-catch (e) {
+    eval(""); // TODO terser has a bug and incorrectly remove this code, eval opts out
+} catch (e) {
     var ok2 = true;
 }
 

--- a/plugin-test/css-extract/enforceEsm.test.js
+++ b/plugin-test/css-extract/enforceEsm.test.js
@@ -65,5 +65,8 @@ it('should keep empty module when options.esModule is equal "false"', async () =
 	expect(
 		modules.filter(m => m.moduleType !== "runtime" && !m.orphan).length
 	).toBe(2);
-	expect(source("./simple.css", stats)).toMatchInlineSnapshot(`""`);
+	expect(source("./simple.css", stats)).toMatchInlineSnapshot(`
+		"// extracted by css-extract-rspack-plugin
+		"
+	`);
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Revert PR #6389.

Rspack leverages `dropped_comment_preserver` to preserve comments which might be lost in transformation. This is related to rspack's `DefinePlugin` implementation, which means it needs to use transform to drive. The visitor itself has a great time complexity on large projects. (Only 5% on original CI test).

Revert to wait https://github.com/web-infra-dev/rspack/pull/6583 to remove additional transformation instead.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
