### PR TITLE
fix: fix module type export name

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/index.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/index.js
@@ -1,0 +1,4 @@
+it("should have valid export", async () => {
+	const exports = await import('./lib')
+	expect(exports).toContain('hello')
+});

--- a/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/lib.js
@@ -1,0 +1,3 @@
+export function hello() {
+  console.log('hello world');
+}

--- a/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/rspack-issue-6572/rspack.config.js
@@ -1,0 +1,16 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		minimize: false,
+	},
+	output: {
+    library: {
+      type: "module",
+    },
+		filename: "[name].mjs",
+    module: true,
+    chunkFormat: "module",
+    chunkLoading: "import",
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #6572

`usedName` is the name in exports, which could be mangled.
`infoName` is the real name of export.

We should keep the real name in export.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
