### PR TITLE
docs: recommend using sass-embedded for performance

### DIFF
--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -118,7 +118,7 @@ module.exports = {
 };
 ```
 
-The above configuration runs all `*.sass` files through the [sass-loader](https://github.com/webpack-contrib/sass-loader) and passes the resulting results to Rspack for CSS post-processing.
+The above configuration runs all `*.sass` and `*.scss` files through the [sass-loader](https://github.com/webpack-contrib/sass-loader) and passes the resulting results to Rspack for CSS post-processing.
 
 ## Less
 

--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -57,7 +57,9 @@ For more on CSS Modules configuration, please refer to [module.parser.css](/conf
 
 ## PostCSS
 
-Rspack is compatible with [postcss-loader](https://github.com/webpack-contrib/postcss-loader), which you can configure like this:
+Rspack supports [postcss-loader](https://github.com/webpack-contrib/postcss-loader), which you can configure like this:
+
+<PackageManagerTabs command="add postcss postcss-loader -D" />
 
 ```ts title="rspack.config.js"
 module.exports = {
@@ -75,7 +77,8 @@ module.exports = {
             },
           },
         ],
-        type: 'css/auto', // set to 'css/auto' if you want to support '*.module.css' as CSS Module, otherwise set type to 'css'
+        // set to 'css/auto' if you want to support '*.module.css' as CSS Module, otherwise set type to 'css'
+        type: 'css/auto',
       },
     ],
   },
@@ -84,9 +87,44 @@ module.exports = {
 
 The above configuration will have all `*.css` files processed by [postcss-loader](https://github.com/webpack-contrib/postcss-loader). The output will be passed to Rspack for CSS post-processing.
 
+## Sass
+
+Rspack supports [sass-loader](https://github.com/webpack-contrib/sass-loader), which you can configure like this:
+
+<PackageManagerTabs command="add sass-embedded sass-loader -D" />
+
+```ts title="rspack.config.js"
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(sass|scss)$/,
+        use: [
+          {
+            loader: 'sass-loader',
+            options: {
+              // 同时使用 `modern-compiler` 和 `sass-embedded` 可以显著提升构建性能
+              // 需要 `sass-loader >= 14.2.1`
+              api: 'modern-compiler',
+              implementation: require.resolve('sass-embedded'),
+            },
+          },
+        ],
+        // set to 'css/auto' if you want to support '*.module.(scss|sass)' as CSS Module, otherwise set type to 'css'
+        type: 'css/auto',
+      },
+    ],
+  },
+};
+```
+
+The above configuration runs all `*.sass` files through the [sass-loader](https://github.com/webpack-contrib/sass-loader) and passes the resulting results to Rspack for CSS post-processing.
+
 ## Less
 
-Rspack is compatible with [less-loader](https://github.com/webpack-contrib/less-loader), which you can configure like this:
+Rspack supports [less-loader](https://github.com/webpack-contrib/less-loader), which you can configure like this:
+
+<PackageManagerTabs command="add less less-loader -D" />
 
 ```ts title="rspack.config.js"
 module.exports = {
@@ -102,7 +140,8 @@ module.exports = {
             },
           },
         ],
-        type: 'css/auto', // set to 'css/auto' if you want to support '*.module.less' as CSS Module, otherwise set type to 'css'
+        // set to 'css/auto' if you want to support '*.module.less' as CSS Module, otherwise set type to 'css'
+        type: 'css/auto',
       },
     ],
   },
@@ -110,33 +149,6 @@ module.exports = {
 ```
 
 The above configuration runs all `*.less` files through the [less-loader](https://github.com/webpack-contrib/less-loader) and passes the generated results to Rspack for CSS post-processing.
-
-## Sass
-
-Rspack is compatible with [sass-loader](https://github.com/webpack-contrib/sass-loader), which you can configure like this:
-
-```ts title="rspack.config.js"
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.(sass|scss)$/,
-        use: [
-          {
-            loader: 'sass-loader',
-            options: {
-              // ...
-            },
-          },
-        ],
-        type: 'css/auto', // set to 'css/auto' if you want to support '*.module.(scss|sass)' as CSS Module, otherwise set type to 'css'
-      },
-    ],
-  },
-};
-```
-
-The above configuration runs all `*.sass` files through the [sass-loader](https://github.com/webpack-contrib/sass-loader) and passes the resulting results to Rspack for CSS post-processing.
 
 ## Tailwind CSS
 

--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -103,8 +103,8 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
-              // 同时使用 `modern-compiler` 和 `sass-embedded` 可以显著提升构建性能
-              // 需要 `sass-loader >= 14.2.1`
+              // using `modern-compiler` and `sass-embedded` together significantly improve build performance,
+              // requires `sass-loader >= 14.2.1`
               api: 'modern-compiler',
               implementation: require.resolve('sass-embedded'),
             },

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -57,7 +57,9 @@ document.getElementById('element').className = styles.red;
 
 ## PostCSS
 
-Rspack 已经完成了对 [postcss-loader](https://github.com/webpack-contrib/postcss-loader) 的兼容，你可以这样配置：
+Rspack 支持使用 [postcss-loader](https://github.com/webpack-contrib/postcss-loader)，你可以这样配置：
+
+<PackageManagerTabs command="add postcss postcss-loader -D" />
 
 ```ts title="rspack.config.js"
 module.exports = {
@@ -75,7 +77,8 @@ module.exports = {
             },
           },
         ],
-        type: 'css/auto', // 如果你需要将 '*.module.css' 视为 CSS Module 那么将 'type' 设置为 'css/auto' 否则设置为 'css'
+        // 如果你需要将 '*.module.css' 视为 CSS Module 那么将 'type' 设置为 'css/auto' 否则设置为 'css'
+        type: 'css/auto',
       },
     ],
   },
@@ -84,9 +87,44 @@ module.exports = {
 
 上述配置会将所有 `*.css` 文件经过 [postcss-loader](https://github.com/webpack-contrib/postcss-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
 
+## Sass
+
+Rspack 支持使用 [sass-loader](https://github.com/webpack-contrib/sass-loader)，你可以这样配置：
+
+<PackageManagerTabs command="add sass-embedded sass-loader -D" />
+
+```ts title="rspack.config.js"
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(sass|scss)$/,
+        use: [
+          {
+            loader: 'sass-loader',
+            options: {
+              // using `modern-compiler` and `sass-embedded` together significantly improve build performance,
+              // requires `sass-loader >= 14.2.1`
+              api: 'modern-compiler',
+              implementation: require.resolve('sass-embedded'),
+            },
+          },
+        ],
+        // 如果你需要将 '*.module.(sass|scss)' 视为 CSS Module 那么将 'type' 设置为 'css/auto' 否则设置为 'css'
+        type: 'css/auto',
+      },
+    ],
+  },
+};
+```
+
+上述配置会将所有 `*.sass` 文件经过 [sass-loader](https://github.com/webpack-contrib/sass-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
+
 ## Less
 
-Rspack 已经完成了对 [less-loader](https://github.com/webpack-contrib/less-loader) 的兼容，你可以这样配置：
+Rspack 支持使用 [less-loader](https://github.com/webpack-contrib/less-loader)，你可以这样配置：
+
+<PackageManagerTabs command="add less less-loader -D" />
 
 ```ts title="rspack.config.js"
 module.exports = {
@@ -102,7 +140,8 @@ module.exports = {
             },
           },
         ],
-        type: 'css/auto', // 如果你需要将 '*.module.less' 视为 CSS Module 那么将 'type' 设置为 'css/auto' 否则设置为 'css'
+        // 如果你需要将 '*.module.less' 视为 CSS Module 那么将 'type' 设置为 'css/auto' 否则设置为 'css'
+        type: 'css/auto',
       },
     ],
   },
@@ -110,33 +149,6 @@ module.exports = {
 ```
 
 上述配置会将所有 `*.less` 文件经过 [less-loader](https://github.com/webpack-contrib/less-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
-
-## Sass
-
-Rspack 已经完成了对 [sass-loader](https://github.com/webpack-contrib/sass-loader) 的兼容，你可以这样配置：
-
-```ts title="rspack.config.js"
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.sass$/,
-        use: [
-          {
-            loader: 'sass-loader',
-            options: {
-              // ...
-            },
-          },
-        ],
-        type: 'css/auto', // 如果你需要将 '*.module.(sass|scss)' 视为 CSS Module 那么将 'type' 设置为 'css/auto' 否则设置为 'css'
-      },
-    ],
-  },
-};
-```
-
-上述配置会将所有 `*.sass` 文件经过 [sass-loader](https://github.com/webpack-contrib/sass-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
 
 ## Tailwind CSS
 

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -103,8 +103,8 @@ module.exports = {
           {
             loader: 'sass-loader',
             options: {
-              // using `modern-compiler` and `sass-embedded` together significantly improve build performance,
-              // requires `sass-loader >= 14.2.1`
+              // 同时使用 `modern-compiler` 和 `sass-embedded` 可以显著提升构建性能
+              // 需要 `sass-loader >= 14.2.1`
               api: 'modern-compiler',
               implementation: require.resolve('sass-embedded'),
             },

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -118,7 +118,7 @@ module.exports = {
 };
 ```
 
-上述配置会将所有 `*.sass` 文件经过 [sass-loader](https://github.com/webpack-contrib/sass-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
+上述配置会将所有 `*.sass` 和 `*.scss` 文件经过 [sass-loader](https://github.com/webpack-contrib/sass-loader) 处理，并将生成的结果交给 Rspack 完成 CSS 后续流程的处理。
 
 ## Less
 


### PR DESCRIPTION
## Summary

Recommend using sass-embedded to improve the Sass compilation performance.

![image](https://github.com/web-infra-dev/rspack/assets/7237365/2bafdfc8-fbbf-4bcb-939c-df1c36f0f2c5)

See: 

- https://x.com/rspack_dev/status/1793830951832944676
- https://github.com/webpack-contrib/sass-loader/releases/tag/v14.2.0
- https://github.com/chenjiahan/rsbuild-sass-perf

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
