### PR TITLE
docs(react): add guide for React Compiler

### DIFF
--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -155,7 +155,7 @@ The steps to use React Compiler in Rspack:
 - [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
 - [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
 
-3. Register babel-loader in your Rspack config file:
+3. Register `babel-loader` in your Rspack config file:
 
 ```ts title="rspack.config.js"
 module.exports = {

--- a/website/docs/en/guide/tech/react.mdx
+++ b/website/docs/en/guide/tech/react.mdx
@@ -133,6 +133,87 @@ Compared to the previous approach, this method decouples the React Fast Refresh 
 - For usage with `builtin:swc-loader`, you can refer to the example at [examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh/rspack.config.js), When using with `swc-loader`, simply replace `builtin:swc-loader` with `swc-loader`.
 - For usage with `babel-loader`, you can refer to the example at [examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader/rspack.config.js)
 
+## React Compiler
+
+React Compiler is an experimental compiler introduced in React 19 that can automatically optimize your React code.
+
+Before you start using React Compiler, it's recommended to read the [React Compiler documentation](https://react.dev/learn/react-compiler) to understand the functionality, current state, and usage of the React Compiler.
+
+:::tip
+At present, React Compiler only supports Babel compilation, which may slow down the build time.
+:::
+
+### How to use
+
+The steps to use React Compiler in Rspack:
+
+1. Upgrade versions of `react` and `react-dom` to 19.
+2. React Compiler currently only provides a Babel plugin, you need to install:
+
+- [@babel/core](https://www.npmjs.com/package/@babel/core)
+- [babel-loader](https://www.npmjs.com/package/babel-loader)
+- [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
+- [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
+
+3. Register babel-loader in your Rspack config file:
+
+```ts title="rspack.config.js"
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'builtin:swc-loader',
+            options: {
+              // SWC options for JS
+            },
+          },
+        ],
+      },
+      {
+        test: /\.jsx$/,
+        use: [
+          {
+            loader: 'builtin:swc-loader',
+            options: {
+              // SWC options for JSX
+            },
+          },
+          { loader: 'babel-loader' },
+        ],
+      },
+    ],
+  },
+};
+```
+
+4. Create a `babel.config.js` and configure the plugins:
+
+```js title="babel.config.js"
+// babel.config.js
+const ReactCompilerConfig = {
+  /* ... */
+};
+
+module.exports = function () {
+  return {
+    plugins: [
+      ['babel-plugin-react-compiler', ReactCompilerConfig], // must run first!
+      '@babel/plugin-syntax-jsx',
+    ],
+  };
+};
+```
+
+### Examples
+
+You can refer to the following example projects:
+
+- [Rspack + React Compiler](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel)
+- [Rspack + React Compiler + TypeScript](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel-ts)
+
 ## Integrating SVGR
 
 [SVGR](https://react-svgr.com/) is an universal tool for transforming [Scalable Vector Graphics (SVG)](https://en.wikipedia.org/wiki/SVG) files into React components.

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -133,6 +133,87 @@ module.exports = {
 - 配合 `builtin:swc-loader` 使用方式可参考：[examples/react-refresh](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh/rspack.config.js)，使用 `swc-loader` 只需将 `builtin:swc-loader` 换为 `swc-loader` 即可。
 - 配合 `babel-loader` 的使用方式可参考：[examples/react-refresh-babel-loader](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-refresh-babel-loader/rspack.config.js)
 
+## React Compiler
+
+React Compiler 是 React 19 引入的一个实验性编译器，它可以自动优化你的 React 代码。
+
+在开始使用 React Compiler 之前，建议阅读 [React Compiler 文档](https://react.dev/learn/react-compiler)，以了解 React Compiler 的功能、当前状态和使用方法。
+
+:::tip
+React Compiler 目前仅支持 Babel 编译，这会导致构建时间变慢。
+:::
+
+### 如何使用
+
+在 Rspack 中使用 React Compiler 的步骤如下：
+
+1. 升级 `react` 和 `react-dom` 版本到 19。
+2. 目前 React Compiler 仅提供了 Babel 插件，你需要安装：
+
+- [@babel/core](https://www.npmjs.com/package/@babel/core)
+- [babel-loader](https://www.npmjs.com/package/babel-loader)
+- [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
+- [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
+
+3. 在你的 Rspack 配置文件中注册 babel-loader：
+
+```ts title="rspack.config.js"
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'builtin:swc-loader',
+            options: {
+              // SWC options for JS
+            },
+          },
+        ],
+      },
+      {
+        test: /\.jsx$/,
+        use: [
+          {
+            loader: 'builtin:swc-loader',
+            options: {
+              // SWC options for JSX
+            },
+          },
+          { loader: 'babel-loader' },
+        ],
+      },
+    ],
+  },
+};
+```
+
+4. 创建 `babel.config.js` 并配置插件：
+
+```js title="babel.config.js"
+// babel.config.js
+const ReactCompilerConfig = {
+  /* ... */
+};
+
+module.exports = function () {
+  return {
+    plugins: [
+      ['babel-plugin-react-compiler', ReactCompilerConfig], // must run first!
+      '@babel/plugin-syntax-jsx',
+    ],
+  };
+};
+```
+
+### 示例
+
+你可以参考以下示例项目：
+
+- [Rspack + React Compiler](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel)
+- [Rspack + React Compiler + TypeScript](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/react-compiler-babel-ts)
+
 ## 集成 SVGR
 
 [SVGR](https://react-svgr.com/) 是一个用于将 SVG 转换为 React 组件的工具，

--- a/website/docs/zh/guide/tech/react.mdx
+++ b/website/docs/zh/guide/tech/react.mdx
@@ -155,7 +155,7 @@ React Compiler 目前仅支持 Babel 编译，这会导致构建时间变慢。
 - [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)
 - [@babel/plugin-syntax-jsx](https://www.npmjs.com/package/@babel/plugin-syntax-jsx)
 
-3. 在你的 Rspack 配置文件中注册 babel-loader：
+3. 在你的 Rspack 配置文件中注册 `babel-loader`：
 
 ```ts title="rspack.config.js"
 module.exports = {


### PR DESCRIPTION
## Summary

Add guide for using React Compiler in Rspack:

- https://react.dev/learn/react-compiler
- https://rsbuild.dev/guide/framework/react#react-compiler

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
