### PR TITLE
fix: browserslist resolve is broken by prebundle

### DIFF
--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -22,6 +22,18 @@ export default {
 			externals: {
 				"caniuse-lite": "caniuse-lite",
 				"/^caniuse-lite(/.*)/": "caniuse-lite$1"
+			},
+			// preserve the `require(require.resolve())`
+			beforeBundle(task) {
+				const nodeFile = join(task.depPath, "node.js");
+				const content = readFileSync(nodeFile, "utf-8");
+				writeFileSync(
+					nodeFile,
+					content.replaceAll(
+						"require(require.resolve",
+						'eval("require")(require.resolve'
+					)
+				);
 			}
 		},
 		{


### PR DESCRIPTION
## Summary

Fix browserslist resolve is broken by prebundle.

This PR is part of fixes to support `extends` in browserslist config, see https://github.com/web-infra-dev/rsbuild/issues/2443

The same as https://github.com/web-infra-dev/rsbuild/pull/2446

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
