### PR TITLE
feat(css-extract): add defaultExport and namedExport support

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -1571,6 +1571,8 @@ const cssChunkFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.Zod
 // @public (undocumented)
 export interface CssExtractRspackLoaderOptions {
     // (undocumented)
+    defaultExport?: boolean;
+    // (undocumented)
     emit?: boolean;
     // (undocumented)
     esModule?: boolean;

--- a/packages/rspack/src/builtin-plugin/css-extract/loader-options.json
+++ b/packages/rspack/src/builtin-plugin/css-extract/loader-options.json
@@ -27,6 +27,11 @@
     },
     "layer": {
       "type": "string"
+    },
+    "defaultExport": {
+      "type": "boolean",
+      "description": "Duplicate the named export with CSS modules locals to the default export (only when `esModules: true` for css-loader).",
+      "link": "https://github.com/webpack-contrib/mini-css-extract-plugin#defaultexports"
     }
   }
 }

--- a/plugin-test/css-extract/cases/custom-loader-with-functional-exports/expected/main.js
+++ b/plugin-test/css-extract/cases/custom-loader-with-functional-exports/expected/main.js
@@ -4,12 +4,13 @@ var __webpack_modules__ = ({
 "./style.css?3e20": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  cnA: function() { return cnA; },
-  cnB: function() { return cnB; }
+  cnA: function() { return _1; },
+  cnB: function() { return _2; }
 });
 // extracted by css-extract-rspack-plugin
-var cnA = ()=>"class-name-a";
-var cnB = ()=>"class-name-b";
+var _1 = ()=>"class-name-a";
+var _2 = ()=>"class-name-b";
+
 }),
 
 });

--- a/plugin-test/css-extract/cases/es-named-export-as-is-output-module/expected/main.css
+++ b/plugin-test/css-extract/cases/es-named-export-as-is-output-module/expected/main.css
@@ -1,0 +1,12 @@
+.Xh041yLR4iCP4RGjge50 {
+  background: red;
+}
+
+.NMuRsxoDwvW8BhSXhFAY {
+  color: green;
+}
+
+.ayWIv09rPsAqE2JznIsI {
+  color: blue;
+}
+

--- a/plugin-test/css-extract/cases/es-named-export-as-is-output-module/expected/main.mjs
+++ b/plugin-test/css-extract/cases/es-named-export-as-is-output-module/expected/main.mjs
@@ -1,5 +1,3 @@
-(() => { // webpackBootstrap
-"use strict";
 var __webpack_modules__ = ({
 "./style.css?eccb": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
@@ -9,9 +7,9 @@ __webpack_require__.d(__webpack_exports__, {
   cClass: function() { return _3; }
 });
 // extracted by css-extract-rspack-plugin
-var _1 = "foo__style__a-class";
-var _2 = "foo__style__b__class";
-var _3 = "foo__style__cClass";
+var _1 = "Xh041yLR4iCP4RGjge50";
+var _2 = "NMuRsxoDwvW8BhSXhFAY";
+var _3 = "ayWIv09rPsAqE2JznIsI";
 
 }),
 
@@ -79,12 +77,10 @@ __webpack_require__.r(__webpack_exports__);
 // eslint-disable-next-line no-console
 console.log({
     css: _style_css__WEBPACK_IMPORTED_MODULE_0__["default"],
-    aClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.aClass,
-    bClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.bClass,
+    aClass: _style_css__WEBPACK_IMPORTED_MODULE_0__["a-class"],
+    bClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.b__class,
     cClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.cClass
 });
 
 })();
 
-})()
-;

--- a/plugin-test/css-extract/cases/es-named-export-as-is-output-module/index.js
+++ b/plugin-test/css-extract/cases/es-named-export-as-is-output-module/index.js
@@ -1,0 +1,8 @@
+import css, {
+  "a-class" as aClass,
+  "b__class" as bClass,
+  cClass,
+} from "./style.css";
+
+// eslint-disable-next-line no-console
+console.log({ css, aClass, bClass, cClass });

--- a/plugin-test/css-extract/cases/es-named-export-as-is-output-module/style.css
+++ b/plugin-test/css-extract/cases/es-named-export-as-is-output-module/style.css
@@ -1,0 +1,11 @@
+.a-class {
+  background: red;
+}
+
+.b__class {
+  color: green;
+}
+
+.cClass {
+  color: blue;
+}

--- a/plugin-test/css-extract/cases/es-named-export-as-is-output-module/webpack.config.js
+++ b/plugin-test/css-extract/cases/es-named-export-as-is-output-module/webpack.config.js
@@ -1,0 +1,38 @@
+const Self = require("@rspack/core").CssExtractRspackPlugin;
+
+module.exports = {
+  entry: "./index.js",
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: Self.loader,
+          },
+          {
+            loader: "css-loader",
+            options: {
+              esModule: true,
+              modules: {
+                namedExport: true,
+                exportLocalsConvention: "asIs",
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  output: {
+    module: true,
+  },
+  experiments: {
+    outputModule: true,
+  },
+  plugins: [
+    new Self({
+      filename: "[name].css",
+    }),
+  ],
+};

--- a/plugin-test/css-extract/cases/es-named-export-as-is/expected/main.css
+++ b/plugin-test/css-extract/cases/es-named-export-as-is/expected/main.css
@@ -1,0 +1,12 @@
+.Xh041yLR4iCP4RGjge50 {
+  background: red;
+}
+
+.NMuRsxoDwvW8BhSXhFAY {
+  color: green;
+}
+
+.ayWIv09rPsAqE2JznIsI {
+  color: blue;
+}
+

--- a/plugin-test/css-extract/cases/es-named-export-as-is/expected/main.js
+++ b/plugin-test/css-extract/cases/es-named-export-as-is/expected/main.js
@@ -9,9 +9,9 @@ __webpack_require__.d(__webpack_exports__, {
   cClass: function() { return _3; }
 });
 // extracted by css-extract-rspack-plugin
-var _1 = "foo__style__a-class";
-var _2 = "foo__style__b__class";
-var _3 = "foo__style__cClass";
+var _1 = "Xh041yLR4iCP4RGjge50";
+var _2 = "NMuRsxoDwvW8BhSXhFAY";
+var _3 = "ayWIv09rPsAqE2JznIsI";
 
 }),
 
@@ -79,8 +79,8 @@ __webpack_require__.r(__webpack_exports__);
 // eslint-disable-next-line no-console
 console.log({
     css: _style_css__WEBPACK_IMPORTED_MODULE_0__["default"],
-    aClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.aClass,
-    bClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.bClass,
+    aClass: _style_css__WEBPACK_IMPORTED_MODULE_0__["a-class"],
+    bClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.b__class,
     cClass: _style_css__WEBPACK_IMPORTED_MODULE_0__.cClass
 });
 

--- a/plugin-test/css-extract/cases/es-named-export-as-is/index.js
+++ b/plugin-test/css-extract/cases/es-named-export-as-is/index.js
@@ -1,0 +1,8 @@
+import css, {
+  "a-class" as aClass,
+  "b__class" as bClass,
+  cClass,
+} from "./style.css";
+
+// eslint-disable-next-line no-console
+console.log({ css, aClass, bClass, cClass });

--- a/plugin-test/css-extract/cases/es-named-export-as-is/style.css
+++ b/plugin-test/css-extract/cases/es-named-export-as-is/style.css
@@ -1,0 +1,11 @@
+.a-class {
+  background: red;
+}
+
+.b__class {
+  color: green;
+}
+
+.cClass {
+  color: blue;
+}

--- a/plugin-test/css-extract/cases/es-named-export-as-is/webpack.config.js
+++ b/plugin-test/css-extract/cases/es-named-export-as-is/webpack.config.js
@@ -1,0 +1,32 @@
+const Self = require("@rspack/core").CssExtractRspackPlugin;
+
+module.exports = {
+  entry: "./index.js",
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: Self.loader,
+          },
+          {
+            loader: "css-loader",
+            options: {
+              esModule: true,
+              modules: {
+                namedExport: true,
+                exportLocalsConvention: "asIs",
+              },
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new Self({
+      filename: "[name].css",
+    }),
+  ],
+};

--- a/plugin-test/css-extract/cases/es-named-export-output-module/expected/main.mjs
+++ b/plugin-test/css-extract/cases/es-named-export-output-module/expected/main.mjs
@@ -2,14 +2,15 @@ var __webpack_modules__ = ({
 "./style.css?eccb": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  aClass: function() { return aClass; },
-  bClass: function() { return bClass; },
-  cClass: function() { return cClass; }
+  aClass: function() { return _1; },
+  bClass: function() { return _2; },
+  cClass: function() { return _3; }
 });
 // extracted by css-extract-rspack-plugin
-var aClass = "foo__style__a-class";
-var bClass = "foo__style__b__class";
-var cClass = "foo__style__cClass";
+var _1 = "foo__style__a-class";
+var _2 = "foo__style__b__class";
+var _3 = "foo__style__cClass";
+
 }),
 
 });

--- a/plugin-test/css-extract/cases/es-named-export/webpack.config.js
+++ b/plugin-test/css-extract/cases/es-named-export/webpack.config.js
@@ -16,6 +16,7 @@ module.exports = {
 							esModule: true,
 							modules: {
 								namedExport: true,
+                exportLocalsConvention: "asIs",
 								localIdentName: "foo__[name]__[local]"
 							}
 						}

--- a/plugin-test/css-extract/cases/export-only-locals-and-es-named-export/expected/main.js
+++ b/plugin-test/css-extract/cases/export-only-locals-and-es-named-export/expected/main.js
@@ -4,14 +4,15 @@ var __webpack_modules__ = ({
 "./style.css": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  aClass: function() { return aClass; },
-  bClass: function() { return bClass; },
-  cClass: function() { return cClass; }
+  aClass: function() { return _1; },
+  bClass: function() { return _2; },
+  cClass: function() { return _3; }
 });
 // extracted by css-extract-rspack-plugin
-var aClass = "foo__style__a-class";
-var bClass = "foo__style__b__class";
-var cClass = "foo__style__cClass";
+var _1 = "foo__style__a-class";
+var _2 = "foo__style__b__class";
+var _3 = "foo__style__cClass";
+
 }),
 
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #6614

Copied from https://github.com/webpack-contrib/mini-css-extract-plugin/pull/1078 and https://github.com/webpack-contrib/mini-css-extract-plugin/pull/1084

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
