### PR TITLE
chore(test): force colorize Jest output

### DIFF
--- a/webpack-test/package.json
+++ b/webpack-test/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.d.ts",
   "scripts": {
     "test": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest",
-    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --json | node scripts/test-metric.js",
+    "test:metric": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --json --colors | node scripts/test-metric.js",
     "test:metric:json": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --max-old-space-size=4096 --trace-deprecation\" jest --logHeapUsage --json"
   },
   "files": [


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Force render color output when running `test:webpack`.

https://jestjs.io/docs/cli#--colors
<img width="1115" alt="image" src="https://github.com/web-infra-dev/rspack/assets/12322740/0147d48b-af51-453a-9dfa-f1990997b933">


before:

<img width="1368" alt="image" src="https://github.com/web-infra-dev/rspack/assets/12322740/4cf83f49-f64e-49c8-a62c-a7314be3fee4">

after:

<img width="1362" alt="image" src="https://github.com/web-infra-dev/rspack/assets/12322740/dff524c8-ead3-455e-a398-5da280f92a91">


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
