### PR TITLE
test: use `toMatchFileSnapshot`

### DIFF
--- a/packages/rspack-test-tools/etc/api.md
+++ b/packages/rspack-test-tools/etc/api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+/// <reference types="../jest.d.ts" />
 /// <reference types="jest" />
 /// <reference types="node" />
 

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -27,7 +27,8 @@
   "files": [
     "client",
     "dist",
-    "template"
+    "template",
+    "jest.d.ts"
   ],
   "publishConfig": {
     "access": "public"

--- a/packages/rspack-test-tools/src/processor/diagnostic.ts
+++ b/packages/rspack-test-tools/src/processor/diagnostic.ts
@@ -1,8 +1,7 @@
 import assert from "assert";
-import fs from "fs";
 import path from "path";
 
-import { escapeEOL, isUpdateSnapshot } from "../helper";
+import { escapeEOL } from "../helper";
 import {
 	ECompilerType,
 	ITestContext,
@@ -58,12 +57,7 @@ export class DiagnosticProcessor<
 		const errorOutputPath = path.resolve(
 			context.getSource(this._diagnosticOptions.snapshot)
 		);
-		if (!fs.existsSync(errorOutputPath) || isUpdateSnapshot()) {
-			fs.writeFileSync(errorOutputPath, escapeEOL(output));
-		} else {
-			const expectContent = fs.readFileSync(errorOutputPath, "utf-8");
-			env.expect(escapeEOL(output)).toBe(escapeEOL(expectContent));
-		}
+		env.expect(escapeEOL(output)).toMatchFileSnapshot(errorOutputPath);
 	}
 
 	static defaultOptions<T extends ECompilerType>(

--- a/packages/rspack-test-tools/src/processor/hook.ts
+++ b/packages/rspack-test-tools/src/processor/hook.ts
@@ -170,7 +170,6 @@ export class HookCasesContext extends TestContext {
 		}, "");
 		env
 			.expect(snapshots)
-			// @ts-ignore
 			.toMatchFileSnapshot(path.join(this.src, "hooks.snap.txt"), options);
 	}
 }

--- a/packages/rspack-test-tools/src/processor/hot-step.ts
+++ b/packages/rspack-test-tools/src/processor/hot-step.ts
@@ -1,8 +1,8 @@
-import { Chunk, StatsCompilation } from "@rspack/core";
+import { Chunk } from "@rspack/core";
 import fs from "fs-extra";
 import path from "path";
 
-import { escapeEOL, escapeSep, isUpdateSnapshot } from "../helper";
+import { escapeEOL, escapeSep } from "../helper";
 import { THotStepRuntimeData } from "../runner";
 import {
 	ECompilerType,
@@ -358,12 +358,6 @@ ${runtime.javascript.disposedModules.map(i => `- ${i}`).join("\n")}
 
 				`.trim();
 
-		if (!fs.existsSync(snapshotPath) || isUpdateSnapshot()) {
-			fs.ensureDirSync(path.dirname(snapshotPath));
-			fs.writeFileSync(snapshotPath, content, "utf-8");
-			return;
-		}
-		const snapshotContent = escapeEOL(fs.readFileSync(snapshotPath, "utf-8"));
-		env.expect(content).toBe(snapshotContent);
+		expect(escapeEOL(content)).toMatchFileSnapshot(snapshotPath);
 	}
 }

--- a/packages/rspack-test-tools/src/processor/snapshot.ts
+++ b/packages/rspack-test-tools/src/processor/snapshot.ts
@@ -1,12 +1,11 @@
 import { type Compiler as RspackCompiler } from "@rspack/core";
-import fs from "fs-extra";
 import path from "path";
 import {
 	type Compilation as WebpackCompilation,
 	type Compiler as WebpackCompiler
 } from "webpack";
 
-import { escapeEOL, isUpdateSnapshot } from "../helper";
+import { escapeEOL } from "../helper";
 import { ECompilerType, ITestContext, ITestEnv } from "../type";
 import { BasicProcessor, IBasicProcessorOptions } from "./basic";
 
@@ -70,12 +69,6 @@ export class SnapshotProcessor<
 					`./__snapshots__/${this._snapshotOptions.snapshot}`
 				);
 
-		if (!fs.existsSync(snapshotPath) || isUpdateSnapshot()) {
-			fs.ensureDirSync(path.dirname(snapshotPath));
-			fs.writeFileSync(snapshotPath, content, "utf-8");
-			return;
-		}
-		const snapshotContent = escapeEOL(fs.readFileSync(snapshotPath, "utf-8"));
-		env.expect(content).toBe(snapshotContent);
+		env.expect(content).toMatchFileSnapshot(snapshotPath);
 	}
 }

--- a/packages/rspack-test-tools/src/type.ts
+++ b/packages/rspack-test-tools/src/type.ts
@@ -1,3 +1,5 @@
+/// <reference types="../jest.d.ts" />
+
 import {
 	Compiler as RspackCompiler,
 	RspackOptions,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This is another `vitest` compatiblity patch like #6611.

- use `env.expect().toMatchFileSnapshot` just like vitest
- add typings for `toMatchFileSnapshot`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
