### PR TITLE
fix: pattern with wildcard and globstar can't match correctly when using `glob_match`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fast-glob"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048c62105db2ac2d651145c1e828d14f726998c3041d24104ec0c34a44b7b899"
+checksum = "239ce881ea1fc42c19951979aa7fc75d740f6cd553101922b4d1f48d68429234"
 
 [[package]]
 name = "fastrand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fast-glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "048c62105db2ac2d651145c1e828d14f726998c3041d24104ec0c34a44b7b899"
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,12 +1354,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "glob-match"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "half"
@@ -3582,7 +3582,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.5.0",
  "dashmap 5.5.3",
- "glob-match",
+ "fast-glob",
  "indexmap 2.2.6",
  "indoc",
  "itertools 0.12.1",

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -10,7 +10,7 @@ anymap = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }
-fast-glob = "0.3.0"
+fast-glob = "0.3.1"
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -10,7 +10,7 @@ anymap = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }
-glob-match = "0.2.1"
+fast-glob = "0.3.0"
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -10,7 +10,7 @@ anymap = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }
-fast-glob = "0.3.1"
+fast-glob = "0.3.2"
 indexmap = { workspace = true }
 indoc = { workspace = true }
 itertools = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -77,7 +77,7 @@ fn glob_match_with_normalized_pattern(pattern: &str, string: &str) -> bool {
   } else {
     String::from("**/") + trim_start
   };
-  glob_match::glob_match(&normalized_glob, string.trim_start_matches("./"))
+  fast_glob::glob_match_with_brace(&normalized_glob, string.trim_start_matches("./"))
 }
 
 pub struct SideEffectsFlagPluginVisitor<'a> {
@@ -933,6 +933,10 @@ mod test_side_effects {
     assert!(!get_side_effects_from_package_json_helper(
       vec!["./src/**/*.js", "./dirty.js"],
       "./clean.js"
+    ));
+    assert!(get_side_effects_from_package_json_helper(
+      vec!["./src/**/*/z.js"],
+      "./src/x/y/z.js"
     ));
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Fixed #6245 and #6613 

To solve this problem, I have invested a lot of effort in understanding the [`glob_match`](https://crates.io/crates/glob-match). Due to the original author not maintaining it for a long time, I have republished the [`fast_glob`](https://crates.io/crates/fast-glob).

Using `fast_glob`, you can get:

- Faster problem response
- Nearly 60% performance improvement

The original intention of `fast_glob` is only to promptly fix the first issue mentioned above.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
