### PR TITLE
refactor: make_module_graph use immutable compilation

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -963,7 +963,7 @@ impl Compilation {
     self.extend_diagnostics(diagnostics);
     logger.time_end(start);
     let diagnostics = self.make_artifact.take_diagnostics();
-    self.push_batch_diagnostic(diagnostics);
+    self.extend_diagnostics(diagnostics);
 
     // sync assets to compilation from module_executor
     if let Some(module_executor) = &mut self.module_executor {

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -438,13 +438,16 @@ impl Compilation {
     } else {
       self.global_entry.include_dependencies.push(entry_id);
     }
-    update_module_graph(
+
+    let artifact = std::mem::take(&mut self.make_artifact);
+    self.make_artifact = update_module_graph(
       self,
+      artifact,
       vec![MakeParam::ForceBuildDeps(HashSet::from_iter([(
         entry_id, None,
       )]))],
-    )
-    .await
+    )?;
+    Ok(())
   }
 
   pub fn update_asset(
@@ -671,16 +674,12 @@ impl Compilation {
     module_identifiers: HashSet<ModuleIdentifier>,
     f: impl Fn(Vec<&BoxModule>) -> T,
   ) -> Result<T> {
-    update_module_graph(
+    let artifact = std::mem::take(&mut self.make_artifact);
+    self.make_artifact = update_module_graph(
       self,
+      artifact,
       vec![MakeParam::ForceBuildModules(module_identifiers.clone())],
-    )
-    .await?;
-
-    let logger = self.get_logger("rspack.Compilation");
-    let start = logger.time("finish module");
-    self.finish(self.plugin_driver.clone()).await?;
-    logger.time_end(start);
+    )?;
 
     let module_graph = self.get_module_graph();
     Ok(f(module_identifiers
@@ -963,7 +962,8 @@ impl Compilation {
     }
     self.extend_diagnostics(diagnostics);
     logger.time_end(start);
-
+    let diagnostics = self.make_artifact.take_diagnostics();
+    self.push_batch_diagnostic(diagnostics);
     Ok(())
   }
 

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -15,7 +15,8 @@ use crate::{
 
 #[derive(Debug, Default)]
 pub struct MakeArtifact {
-  // temporary data, should be reset when rebuild
+  // temporary data, used by subsequent steps of make
+  // should be reset when rebuild
   pub diagnostics: Vec<Diagnostic>,
   pub has_module_graph_change: bool,
 

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -15,12 +15,13 @@ use crate::{
 
 #[derive(Debug, Default)]
 pub struct MakeArtifact {
-  // should be reset when make
-  pub make_failed_dependencies: HashSet<BuildDependency>,
-  pub make_failed_module: HashSet<ModuleIdentifier>,
+  // temporary data, should be reset when rebuild
   pub diagnostics: Vec<Diagnostic>,
   pub has_module_graph_change: bool,
 
+  // data
+  pub make_failed_dependencies: HashSet<BuildDependency>,
+  pub make_failed_module: HashSet<ModuleIdentifier>,
   pub module_graph_partial: ModuleGraphPartial,
   entry_dependencies: HashSet<DependencyId>,
   pub entry_module_identifiers: IdentifierSet,
@@ -44,6 +45,10 @@ impl MakeArtifact {
   // TODO remove it
   pub fn get_module_graph_partial_mut(&mut self) -> &mut ModuleGraphPartial {
     &mut self.module_graph_partial
+  }
+
+  pub fn take_diagnostics(&mut self) -> Vec<Diagnostic> {
+    std::mem::take(&mut self.diagnostics)
   }
 
   fn revoke_modules(&mut self, ids: HashSet<ModuleIdentifier>) -> Vec<BuildDependency> {
@@ -83,7 +88,7 @@ pub enum MakeParam {
 }
 
 pub fn make_module_graph(
-  compilation: &mut Compilation,
+  compilation: &Compilation,
   mut artifact: MakeArtifact,
 ) -> Result<MakeArtifact> {
   let mut params = Vec::with_capacity(5);
@@ -117,28 +122,11 @@ pub fn make_module_graph(
   // reset diagnostics
   artifact.diagnostics = Default::default();
   artifact.has_module_graph_change = false;
-
-  artifact = update_module_graph_with_artifact(compilation, artifact, params)?;
-
-  compilation.extend_diagnostics(std::mem::take(&mut artifact.diagnostics));
+  artifact = update_module_graph(compilation, artifact, params)?;
   Ok(artifact)
 }
 
-pub async fn update_module_graph(
-  compilation: &mut Compilation,
-  params: Vec<MakeParam>,
-) -> Result<()> {
-  let mut artifact = MakeArtifact::default();
-  compilation.swap_make_artifact(&mut artifact);
-
-  artifact = update_module_graph_with_artifact(compilation, artifact, params)?;
-
-  compilation.extend_diagnostics(std::mem::take(&mut artifact.diagnostics));
-  compilation.swap_make_artifact(&mut artifact);
-  Ok(())
-}
-
-pub fn update_module_graph_with_artifact(
+pub fn update_module_graph(
   compilation: &Compilation,
   mut artifact: MakeArtifact,
   params: Vec<MakeParam>,

--- a/crates/rspack_core/src/compiler/make/repair/add.rs
+++ b/crates/rspack_core/src/compiler/make/repair/add.rs
@@ -27,8 +27,9 @@ impl Task<MakeTaskContext> for AddTask {
     }
 
     let module_identifier = self.module.identifier();
+    let artifact = &mut context.artifact;
     let module_graph =
-      &mut MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+      &mut MakeTaskContext::get_module_graph_mut(&mut artifact.module_graph_partial);
 
     if self.module.as_self_module().is_some() {
       let issuer = self
@@ -73,7 +74,7 @@ impl Task<MakeTaskContext> for AddTask {
     )?;
 
     if self.is_entry {
-      context.entry_module_identifiers.insert(module_identifier);
+      artifact.entry_module_identifiers.insert(module_identifier);
     }
 
     if let Some(current_profile) = &self.current_profile {

--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -110,28 +110,29 @@ impl Task<MakeTaskContext> for BuildResultTask {
       current_profile,
     } = *self;
 
+    let artifact = &mut context.artifact;
     let module_graph =
-      &mut MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+      &mut MakeTaskContext::get_module_graph_mut(&mut artifact.module_graph_partial);
 
     if !diagnostics.is_empty() {
-      context.make_failed_module.insert(module.identifier());
+      artifact.make_failed_module.insert(module.identifier());
     }
 
     tracing::trace!("Module built: {}", module.identifier());
-    context.diagnostics.extend(diagnostics);
+    artifact.diagnostics.extend(diagnostics);
     module_graph
       .get_optimization_bailout_mut(&module.identifier())
       .extend(build_result.optimization_bailouts);
-    context
+    artifact
       .file_dependencies
       .add_batch_file(&build_result.build_info.file_dependencies);
-    context
+    artifact
       .context_dependencies
       .add_batch_file(&build_result.build_info.context_dependencies);
-    context
+    artifact
       .missing_dependencies
       .add_batch_file(&build_result.build_info.missing_dependencies);
-    context
+    artifact
       .build_dependencies
       .add_batch_file(&build_result.build_info.build_dependencies);
 

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -11,7 +11,7 @@ use crate::{
   utils::task_loop::{Task, TaskResult, TaskType},
   BoxDependency, CompilerOptions, Context, DependencyId, ExportInfo, ExportsInfo, ModuleFactory,
   ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleProfile, Resolve,
-  ResolverFactory, SharedPluginDriver, UsageState,
+  UsageState,
 };
 
 #[derive(Debug)]
@@ -25,10 +25,7 @@ pub struct FactorizeTask {
   pub dependencies: Vec<DependencyId>,
   pub is_entry: bool,
   pub resolve_options: Option<Box<Resolve>>,
-  pub resolver_factory: Arc<ResolverFactory>,
-  pub loader_resolver_factory: Arc<ResolverFactory>,
   pub options: Arc<CompilerOptions>,
-  pub plugin_driver: SharedPluginDriver,
   pub current_profile: Option<Box<ModuleProfile>>,
 }
 

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -203,31 +203,34 @@ impl Task<MakeTaskContext> for FactorizeResultTask {
       diagnostics,
       ..
     } = *self;
+    let artifact = &mut context.artifact;
     if !diagnostics.is_empty() {
       if let Some(id) = original_module_identifier {
-        context.make_failed_module.insert(id);
+        artifact.make_failed_module.insert(id);
       } else {
-        context
+        artifact
           .make_failed_dependencies
           .insert((dependencies[0], None));
       }
     }
 
-    context.diagnostics.extend(
+    artifact.diagnostics.extend(
       diagnostics
         .into_iter()
         .map(|d| d.with_module_identifier(original_module_identifier)),
     );
 
-    context.file_dependencies.add_batch_file(&file_dependencies);
-    context
+    artifact
+      .file_dependencies
+      .add_batch_file(&file_dependencies);
+    artifact
       .context_dependencies
       .add_batch_file(&context_dependencies);
-    context
+    artifact
       .missing_dependencies
       .add_batch_file(&missing_dependencies);
     let module_graph =
-      &mut MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+      &mut MakeTaskContext::get_module_graph_mut(&mut artifact.module_graph_partial);
     let Some(factory_result) = factory_result else {
       let dep = module_graph
         .dependency_by_id(&dependencies[0])

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -5,18 +5,16 @@ pub mod process_dependencies;
 
 use std::sync::Arc;
 
-use rspack_error::{Diagnostic, Result};
-use rspack_identifier::IdentifierSet;
+use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::{file_counter::FileCounter, MakeArtifact};
+use super::MakeArtifact;
 use crate::{
   module_graph::{ModuleGraph, ModuleGraphPartial},
   old_cache::Cache as OldCache,
   utils::task_loop::{run_task_loop, Task},
-  BuildDependency, Compilation, CompilerOptions, DependencyId, DependencyType, Module,
-  ModuleFactory, ModuleIdentifier, ModuleProfile, NormalModuleSource, ResolverFactory,
-  SharedPluginDriver,
+  BuildDependency, Compilation, CompilerOptions, DependencyType, Module, ModuleFactory,
+  ModuleProfile, NormalModuleSource, ResolverFactory, SharedPluginDriver,
 };
 
 pub struct MakeTaskContext {
@@ -28,25 +26,7 @@ pub struct MakeTaskContext {
   pub old_cache: Arc<OldCache>,
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
 
-  //  add_timer: StartTimeAggregate,
-  //  process_deps_timer: StartTimeAggregate,
-  //  factorize_timer: StartTimeAggregate,
-  //  build_timer: StartTimeAggregate,
-  /// Collecting all module that need to skip in tree-shaking ast modification phase
-  //  bailout_module_identifiers: IdentifierMap<BailoutFlag>,
-  // TODO change to artifact
-  pub module_graph_partial: ModuleGraphPartial,
-  make_failed_dependencies: HashSet<BuildDependency>,
-  make_failed_module: HashSet<ModuleIdentifier>,
-
-  entry_dependencies: HashSet<DependencyId>,
-  entry_module_identifiers: IdentifierSet,
-  diagnostics: Vec<Diagnostic>,
-  file_dependencies: FileCounter,
-  context_dependencies: FileCounter,
-  missing_dependencies: FileCounter,
-  build_dependencies: FileCounter,
-  has_module_graph_change: bool,
+  pub artifact: MakeArtifact,
 }
 
 impl MakeTaskContext {
@@ -58,56 +38,13 @@ impl MakeTaskContext {
       loader_resolver_factory: compilation.loader_resolver_factory.clone(),
       old_cache: compilation.old_cache.clone(),
       dependency_factories: compilation.dependency_factories.clone(),
-
-      // TODO use timer in tasks
-      //      add_timer: logger.time_aggregate("module add task"),
-      //      process_deps_timer: logger.time_aggregate("module process dependencies task"),
-      //      factorize_timer: logger.time_aggregate("module factorize task"),
-      //      build_timer: logger.time_aggregate("module build task"),
-      module_graph_partial: artifact.module_graph_partial,
-
-      make_failed_dependencies: artifact.make_failed_dependencies,
-      make_failed_module: artifact.make_failed_module,
-      diagnostics: artifact.diagnostics,
-
-      entry_dependencies: artifact.entry_dependencies,
-      entry_module_identifiers: artifact.entry_module_identifiers,
-      file_dependencies: artifact.file_dependencies,
-      context_dependencies: artifact.context_dependencies,
-      missing_dependencies: artifact.missing_dependencies,
-      build_dependencies: artifact.build_dependencies,
-      has_module_graph_change: artifact.has_module_graph_change,
+      artifact,
     }
   }
 
   pub fn transform_to_make_artifact(self) -> MakeArtifact {
-    let Self {
-      module_graph_partial,
-      make_failed_dependencies,
-      make_failed_module,
-      diagnostics,
-      entry_module_identifiers,
-      file_dependencies,
-      context_dependencies,
-      missing_dependencies,
-      build_dependencies,
-      has_module_graph_change,
-      entry_dependencies,
-      ..
-    } = self;
-    MakeArtifact {
-      module_graph_partial,
-      make_failed_dependencies,
-      make_failed_module,
-      diagnostics,
-      entry_dependencies,
-      entry_module_identifiers,
-      file_dependencies,
-      context_dependencies,
-      missing_dependencies,
-      build_dependencies,
-      has_module_graph_change,
-    }
+    let Self { artifact, .. } = self;
+    artifact
   }
 
   // TODO use module graph with make artifact
@@ -129,26 +66,12 @@ impl MakeTaskContext {
       Default::default(),
     );
     compilation.dependency_factories = self.dependency_factories.clone();
-    let mut make_artifact = MakeArtifact {
-      module_graph_partial: std::mem::take(&mut self.module_graph_partial),
-      file_dependencies: std::mem::take(&mut self.file_dependencies),
-      context_dependencies: std::mem::take(&mut self.context_dependencies),
-      missing_dependencies: std::mem::take(&mut self.missing_dependencies),
-      build_dependencies: std::mem::take(&mut self.build_dependencies),
-      ..Default::default()
-    };
-    compilation.swap_make_artifact(&mut make_artifact);
+    compilation.swap_make_artifact(&mut self.artifact);
     compilation
   }
 
   pub fn recovery_from_temp_compilation(&mut self, mut compilation: Compilation) {
-    let mut make_artifact = Default::default();
-    compilation.swap_make_artifact(&mut make_artifact);
-    self.module_graph_partial = make_artifact.module_graph_partial;
-    self.file_dependencies = make_artifact.file_dependencies;
-    self.context_dependencies = make_artifact.context_dependencies;
-    self.missing_dependencies = make_artifact.missing_dependencies;
-    self.build_dependencies = make_artifact.build_dependencies;
+    compilation.swap_make_artifact(&mut self.artifact);
   }
 }
 

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -204,10 +204,7 @@ pub fn repair(
         dependencies: vec![id],
         is_entry: parent_module_identifier.is_none(),
         resolve_options: parent_module.and_then(|module| module.get_resolve_options()),
-        resolver_factory: compilation.resolver_factory.clone(),
-        loader_resolver_factory: compilation.loader_resolver_factory.clone(),
         options: compilation.options.clone(),
-        plugin_driver: compilation.plugin_driver.clone(),
         current_profile,
       }))
     })

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -25,7 +25,7 @@ impl Task<MakeTaskContext> for ProcessDependenciesTask {
     } = *self;
     let mut sorted_dependencies = HashMap::default();
     let module_graph =
-      &mut MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+      &mut MakeTaskContext::get_module_graph_mut(&mut context.artifact.module_graph_partial);
 
     dependencies.into_iter().for_each(|dependency_id| {
       let dependency = module_graph

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -113,10 +113,7 @@ impl Task<MakeTaskContext> for ProcessDependenciesTask {
         dependencies,
         is_entry: false,
         resolve_options: module.get_resolve_options(),
-        resolver_factory: context.resolver_factory.clone(),
-        loader_resolver_factory: context.loader_resolver_factory.clone(),
         options: context.compiler_options.clone(),
-        plugin_driver: context.plugin_driver.clone(),
         current_profile,
       }));
     }

--- a/crates/rspack_core/src/compiler/module_executor/ctrl.rs
+++ b/crates/rspack_core/src/compiler/module_executor/ctrl.rs
@@ -171,7 +171,8 @@ impl Task<MakeTaskContext> for FinishModuleTask {
       module_identifier,
     } = *self;
     let mut res: Vec<Box<dyn Task<MakeTaskContext>>> = vec![];
-    let module_graph = MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+    let module_graph =
+      MakeTaskContext::get_module_graph_mut(&mut context.artifact.module_graph_partial);
     let mut queue = VecDeque::new();
     queue.push_back(module_identifier);
 

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -55,10 +55,7 @@ impl Task<MakeTaskContext> for EntryTask {
           dependencies: vec![dep_id],
           is_entry: true,
           resolve_options: None,
-          resolver_factory: context.resolver_factory.clone(),
-          loader_resolver_factory: context.loader_resolver_factory.clone(),
           options: context.compiler_options.clone(),
-          plugin_driver: context.plugin_driver.clone(),
           current_profile: context
             .compiler_options
             .profile

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -25,7 +25,8 @@ impl Task<MakeTaskContext> for EntryTask {
 
   fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let Self { param } = *self;
-    let mut module_graph = MakeTaskContext::get_module_graph_mut(&mut context.module_graph_partial);
+    let mut module_graph =
+      MakeTaskContext::get_module_graph_mut(&mut context.artifact.module_graph_partial);
 
     match param {
       EntryParam::DependencyId(dep_id, sender) => {

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -82,7 +82,7 @@ impl ModuleExecutor {
     });
   }
 
-  pub async fn hook_before_process_assets(&mut self, compilation: &mut Compilation) {
+  pub async fn hook_after_finish_modules(&mut self, compilation: &mut Compilation) {
     let sender = std::mem::take(&mut self.event_sender);
     sender
       .expect("should have sender")

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -18,9 +18,7 @@ use self::{
   execute::{ExecuteModuleResult, ExecuteTask},
   overwrite::OverwriteTask,
 };
-use super::make::{
-  repair::MakeTaskContext, update_module_graph_with_artifact, MakeArtifact, MakeParam,
-};
+use super::make::{repair::MakeTaskContext, update_module_graph, MakeArtifact, MakeParam};
 use crate::{
   task_loop::run_task_loop_with_event, Compilation, CompilationAsset, Context, Dependency,
   DependencyId, EntryDependency,
@@ -54,12 +52,11 @@ impl ModuleExecutor {
     }
     make_artifact.diagnostics = Default::default();
 
-    make_artifact =
-      if let Ok(artifact) = update_module_graph_with_artifact(compilation, make_artifact, params) {
-        artifact
-      } else {
-        MakeArtifact::default()
-      };
+    make_artifact = if let Ok(artifact) = update_module_graph(compilation, make_artifact, params) {
+      artifact
+    } else {
+      MakeArtifact::default()
+    };
 
     let mut ctx = MakeTaskContext::new(compilation, make_artifact);
     let (event_sender, event_receiver) = unbounded_channel();
@@ -104,7 +101,7 @@ impl ModuleExecutor {
       compilation.emit_asset(filename, asset);
     }
 
-    let diagnostics = std::mem::take(&mut self.make_artifact.diagnostics);
+    let diagnostics = self.make_artifact.take_diagnostics();
     compilation.extend_diagnostics(diagnostics);
   }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR makes it clearer and easier to modify the module graph.
* `make_module_graph` will collect make_params and call `update_module_graph` to regenerate module_graph, and it will only use immutable compilation
* `update_module_graph` will regenerate module_graph by make_params, and it will only use immutable compilation


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
