### PR TITLE
fix: apply js rule on module federation runtime

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/index.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/index.js
@@ -1,4 +1,4 @@
-it("should not have es5 upper syntax", async () => {
+it("should not have es6 upper syntax", async () => {
 	await __webpack_init_sharing__("default");
 	const container = __non_webpack_require__("./container.js");
 	container.init(__webpack_share_scopes__.default);

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/index.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/index.js
@@ -1,0 +1,7 @@
+it("should not have es5 upper syntax", async () => {
+	await __webpack_init_sharing__("default");
+	const container = __non_webpack_require__("./container.js");
+	container.init(__webpack_share_scopes__.default);
+	const moduleFactory = await container.get("./module");
+	expect(moduleFactory().ok).toBe(true);
+});

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/module.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/module.js
@@ -1,0 +1,1 @@
+export const ok = true;

--- a/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/container-1-5/lowing-syntax-with-loader/rspack.config.js
@@ -1,0 +1,41 @@
+const { rspack } = require("@rspack/core");
+const { ModuleFederationPlugin } = rspack.container;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								target: "es6"
+							}
+						}
+					}
+				]
+			}
+		]
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin({
+				format: {
+					ecma: 6
+				}
+			})
+		]
+	},
+	plugins: [
+		new ModuleFederationPlugin({
+			name: "container",
+			filename: "container.js",
+			library: { type: "commonjs-module" },
+			exposes: ["./module"]
+		})
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/get-source.js
+++ b/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/get-source.js
@@ -1,0 +1,3 @@
+module.exports = function (source) {
+  return `module.exports = ${JSON.stringify(source)}`
+}

--- a/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/index.js
+++ b/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/index.js
@@ -1,0 +1,7 @@
+import source from "./a.js!=!data:javascript,var b, c;export const a = (b ?? (c ??= 2 ** 2))";
+
+it("should transformed to es3 snytax", () => {
+	expect(source.includes("??")).toBe(false)
+	expect(source.includes("??=")).toBe(false)
+	expect(source.includes("**")).toBe(false)
+});

--- a/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/match-resource-mimetype/rspack.config.js
@@ -1,0 +1,25 @@
+const path = require("path");
+
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	module: {
+		rules: [
+			{
+				include: path.resolve(__dirname, 'a.js'),
+				use: [
+					'./get-source.js',
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							jsc: {
+								target: "es3",
+							}
+						}
+					}
+				]
+			},
+		]
+	}
+};

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -8,8 +8,6 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
-import assert from "assert";
-
 import type { Compilation } from "../Compilation";
 import type {
 	AssetModuleFilename,

--- a/packages/rspack/src/container/ModuleFederationPlugin.ts
+++ b/packages/rspack/src/container/ModuleFederationPlugin.ts
@@ -186,6 +186,5 @@ function getDefaultEntryRuntime(
 		)}`,
 		compiler.webpack.Template.getFunctionContent(require("./default.runtime"))
 	].join("\n");
-	// use "data:text/javascript" to use moduleType "javascript/auto"
-	return `data:text/javascript,${content}`;
+	return `@module-federation/runtime/rspack.js!=!data:text/javascript,${content}`;
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #6666 
fix #5969

Apply js rule for module federation runtime, if user have babel-loader/swc-loader to transform js code, then the module federation runtime will also transformed by it now

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
