### PR TITLE
feat: lazy compilation ignore global entry

### DIFF
--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -125,6 +125,7 @@ impl ModuleExecutor {
         let dep = EntryDependency::new(
           request.clone(),
           original_module_context.unwrap_or(Context::from("")),
+          false,
         );
         let dep_id = *dep.id();
         v.insert(dep_id);

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -8,15 +8,21 @@ pub struct EntryDependency {
   id: DependencyId,
   request: String,
   context: Context,
+  is_global: bool,
 }
 
 impl EntryDependency {
-  pub fn new(request: String, context: Context) -> Self {
+  pub fn new(request: String, context: Context, is_global: bool) -> Self {
     Self {
       request,
       context,
       id: DependencyId::new(),
+      is_global,
     }
+  }
+
+  pub fn is_global(&self) -> bool {
+    self.is_global
   }
 }
 

--- a/crates/rspack_plugin_dynamic_entry/src/lib.rs
+++ b/crates/rspack_plugin_dynamic_entry/src/lib.rs
@@ -52,7 +52,8 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   let decs = entry_fn().await?;
   for EntryDynamicResult { import, options } in decs {
     for entry in import {
-      let dependency: BoxDependency = Box::new(EntryDependency::new(entry, self.context.clone()));
+      let dependency: BoxDependency =
+        Box::new(EntryDependency::new(entry, self.context.clone(), false));
       compilation.add_entry(dependency, options.clone()).await?;
     }
   }

--- a/crates/rspack_plugin_entry/src/lib.rs
+++ b/crates/rspack_plugin_entry/src/lib.rs
@@ -17,7 +17,11 @@ pub struct EntryPlugin {
 
 impl EntryPlugin {
   pub fn new(context: Context, entry_request: String, options: EntryOptions) -> Self {
-    let dependency: BoxDependency = Box::new(EntryDependency::new(entry_request, context));
+    let dependency: BoxDependency = Box::new(EntryDependency::new(
+      entry_request,
+      context,
+      options.name.is_none(),
+    ));
     Self::new_inner(dependency, options)
   }
 }

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -3,8 +3,8 @@ use std::{fmt::Debug, sync::Arc};
 use once_cell::sync::Lazy;
 use rspack_core::{
   ApplyContext, BoxModule, Compilation, CompilationParams, CompilerCompilation, CompilerOptions,
-  DependencyType, Module, ModuleFactory, ModuleFactoryCreateData, NormalModuleCreateData,
-  NormalModuleFactoryModule, Plugin, PluginContext,
+  DependencyType, EntryDependency, Module, ModuleFactory, ModuleFactoryCreateData,
+  NormalModuleCreateData, NormalModuleFactoryModule, Plugin, PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -139,9 +139,22 @@ async fn normal_module_factory_module(
     return Ok(());
   }
 
-  if !self.entries && is_entries {
-    return Ok(());
+  if is_entries {
+    if !self.entries {
+      return Ok(());
+    }
+
+    // ignore global entry
+    let entry: Option<&EntryDependency> = module_factory_create_data.dependency.downcast_ref();
+    let Some(entry) = entry else {
+      return Ok(());
+    };
+
+    if entry.is_global() {
+      return Ok(());
+    }
   }
+
   if !self.imports && is_imports {
     return Ok(());
   }

--- a/packages/playground/cases/lazy-compilation/ignore-entry/index.test.ts
+++ b/packages/playground/cases/lazy-compilation/ignore-entry/index.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "@/fixtures";
+
+test("should load success", async ({ page }) => {
+	await page.waitForTimeout(1000);
+	const body = await page.$("body");
+	expect(await body!.innerText()).toBe("hello world");
+});

--- a/packages/playground/cases/lazy-compilation/ignore-entry/rspack.config.js
+++ b/packages/playground/cases/lazy-compilation/ignore-entry/rspack.config.js
@@ -1,0 +1,18 @@
+const rspack = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	entry: "./src/index.js",
+	stats: "none",
+	mode: "development",
+	plugins: [new rspack.HtmlRspackPlugin()],
+	experiments: {
+		lazyCompilation: {
+			entries: true
+		}
+	},
+	devServer: {
+		hot: true
+	}
+};

--- a/packages/playground/cases/lazy-compilation/ignore-entry/src/index.js
+++ b/packages/playground/cases/lazy-compilation/ignore-entry/src/index.js
@@ -1,0 +1,1 @@
+document.body.innerText = "hello world";

--- a/packages/playground/playwright.config.ts
+++ b/packages/playground/playwright.config.ts
@@ -5,7 +5,7 @@ const TIMEOUT = 2 * 60 * 1000;
 
 export default defineConfig<RspackOptions>({
 	// Look for test files in the "fixtures" directory, relative to this configuration file.
-	testDir: "./cases",
+	testDir: "./cases/lazy-compilation",
 
 	//	globalSetup: require.resolve("./scripts/globalSetup"),
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

lazy compilation ignore global entry, so that react-refresh entry and hmr entry can be applied correctly

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
