### PR TITLE
fix: installedCssChunks unicode error on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,6 +3314,7 @@ dependencies = [
  "rspack_plugin_runtime",
  "rspack_util",
  "rustc-hash",
+ "serde_json",
  "ustr-fxhash",
 ]
 

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -100,7 +100,13 @@ pub fn stringify_map<T: Display>(map: &HashMap<String, T>) -> String {
       .keys()
       .sorted_unstable()
       .fold(String::new(), |prev, cur| {
-        prev + format!(r#""{}": {},"#, cur, map.get(cur).expect("get key from map")).as_str()
+        prev
+          + format!(
+            r#"{}: {},"#,
+            serde_json::to_string(cur).expect("json stringify failed"),
+            map.get(cur).expect("get key from map")
+          )
+          .as_str()
       })
   )
 }

--- a/crates/rspack_plugin_extract_css/Cargo.toml
+++ b/crates/rspack_plugin_extract_css/Cargo.toml
@@ -18,4 +18,5 @@ rspack_plugin_css     = { path = "../rspack_plugin_css" }
 rspack_plugin_runtime = { path = "../rspack_plugin_runtime" }
 rspack_util           = { path = "../rspack_util" }
 rustc-hash            = { workspace = true }
+serde_json            = { workspace = true }
 ustr                  = { workspace = true }

--- a/crates/rspack_plugin_extract_css/src/runtime.rs
+++ b/crates/rspack_plugin_extract_css/src/runtime.rs
@@ -136,9 +136,15 @@ impl RuntimeModule for CssLoadingRuntimeModule {
         let chunk = compilation.chunk_by_ukey.expect_get(&self.chunk);
         let with_loading = WITH_LOADING.replace(
           "__INSTALLED_CHUNKS__",
-          &chunk.ids.iter().fold(String::default(), |output, id| {
-            format!("{output}\"{id}\": 0,\n")
-          }),
+          &chunk
+            .ids
+            .iter()
+            .fold(String::default(), |output, id: &String| {
+              format!(
+                "{output}{}: 0,\n",
+                serde_json::to_string(id).expect("json stringify failed")
+              )
+            }),
         );
 
         let with_loading = with_loading.replace(
@@ -155,7 +161,12 @@ impl RuntimeModule for CssLoadingRuntimeModule {
               .filter_map(|id| {
                 let chunk = compilation.chunk_by_ukey.expect_get(id);
 
-                chunk.id.as_ref().map(|id| format!("\"{}\": 1,\n", id))
+                chunk.id.as_ref().map(|id| {
+                  format!(
+                    "{}: 1,\n",
+                    serde_json::to_string(id).expect("json stringify failed")
+                  )
+                })
               })
               .collect::<String>()
           ),

--- a/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
+++ b/crates/rspack_plugin_runtime/src/array_push_callback_chunk_format.rs
@@ -82,12 +82,12 @@ impl JavascriptModulesPluginPlugin for ArrayPushCallbackChunkFormatJavascriptMod
       let chunk_loading_global = &args.compilation.options.output.chunk_loading_global;
 
       source.add(RawSource::from(format!(
-        r#"({}['{}'] = {}['{}'] || []).push([["{}"], "#,
+        r#"({}['{}'] = {}['{}'] || []).push([[{}], "#,
         global_object,
         chunk_loading_global,
         global_object,
         chunk_loading_global,
-        chunk.expect_id(),
+        serde_json::to_string(chunk.expect_id()).expect("json stringify failed"),
       )));
       source.add(args.module_source.clone());
       let has_entry = chunk.has_entry_module(&args.compilation.chunk_graph);

--- a/plugin-test/css-extract/cases/issue-6649/expected/main.js
+++ b/plugin-test/css-extract/cases/issue-6649/expected/main.js
@@ -1,0 +1,426 @@
+(() => { // webpackBootstrap
+var __webpack_modules__ = ({});
+/************************************************************************/
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+// expose the modules object (__webpack_modules__)
+__webpack_require__.m = __webpack_modules__;
+
+/************************************************************************/
+// webpack/runtime/create_fake_namespace_object
+(() => {
+var getProto = Object.getPrototypeOf ? function(obj) { return Object.getPrototypeOf(obj); } : function(obj) { return obj.__proto__ };
+var leafPrototypes;
+// create a fake namespace object
+// mode & 1: value is a module id, require it
+// mode & 2: merge all properties of value into the ns
+// mode & 4: return value when already ns object
+// mode & 16: return value when it's Promise-like
+// mode & 8|1: behave like require
+__webpack_require__.t = function(value, mode) {
+	if(mode & 1) value = this(value);
+	if(mode & 8) return value;
+	if(typeof value === 'object' && value) {
+		if((mode & 4) && value.__esModule) return value;
+		if((mode & 16) && typeof value.then === 'function') return value;
+	}
+	var ns = Object.create(null);
+	__webpack_require__.r(ns);
+	var def = {};
+	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
+	for(var current = mode & 2 && value; typeof current == 'object' && !~leafPrototypes.indexOf(current); current = getProto(current)) {
+		Object.getOwnPropertyNames(current).forEach(function(key) { def[key] = function() { return  value[key]; } });
+	}
+	def['default'] = function() { return value };
+	__webpack_require__.d(ns, def);
+	return ns;
+};
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = function(exports, definition) {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/ensure_chunk
+(() => {
+__webpack_require__.f = {};
+// This file contains only the entry chunk.
+// The chunk loading function for additional chunks
+__webpack_require__.e = function (chunkId) {
+	return Promise.all(
+		Object.keys(__webpack_require__.f).reduce(function (promises, key) {
+			__webpack_require__.f[key](chunkId, promises);
+			return promises;
+		}, [])
+	);
+};
+
+})();
+// webpack/runtime/get javascript chunk filename
+(() => {
+// This function allow to reference chunks
+        __webpack_require__.u = function (chunkId) {
+          // return url for filenames not based on template
+          
+          // return url for filenames based on template
+          return "" + chunkId + ".$" + {"\\css\\chunk": "b88d395b0e288c1b8cfe","\\js\\chunk": "5dc72ab590cca7957d71",}[chunkId] + "$.js";
+        };
+      
+})();
+// webpack/runtime/get mini-css chunk filename
+(() => {
+// This function allow to reference chunks
+        __webpack_require__.miniCssF = function (chunkId) {
+          // return url for filenames not based on template
+          
+          // return url for filenames based on template
+          return "" + chunkId + ".$" + "fcf981e297c26c279077" + "$.css";
+        };
+      
+})();
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = function () {
+	return "a0870bd6e64301212efb";
+};
+
+})();
+// webpack/runtime/global
+(() => {
+__webpack_require__.g = (function () {
+	if (typeof globalThis === 'object') return globalThis;
+	try {
+		return this || new Function('return this')();
+	} catch (e) {
+		if (typeof window === 'object') return window;
+	}
+})();
+
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = function (obj, prop) {
+	return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+})();
+// webpack/runtime/load_script
+(() => {
+var inProgress = {};
+
+
+// loadScript function to load a script via script tag
+__webpack_require__.l = function (url, done, key, chunkId) {
+	if (inProgress[url]) {
+		inProgress[url].push(done);
+		return;
+	}
+	var script, needAttach;
+	if (key !== undefined) {
+		var scripts = document.getElementsByTagName("script");
+		for (var i = 0; i < scripts.length; i++) {
+			var s = scripts[i];
+			if (s.getAttribute("src") == url) {
+				script = s;
+				break;
+			}
+		}
+	}
+	if (!script) {
+		needAttach = true;
+		script = document.createElement('script');
+		
+		script.charset = 'utf-8';
+		script.timeout = 120;
+		if (__webpack_require__.nc) {
+			script.setAttribute("nonce", __webpack_require__.nc);
+		}
+		
+		script.src = url;
+
+		
+	}
+	inProgress[url] = [done];
+	var onScriptComplete = function (prev, event) {
+		script.onerror = script.onload = null;
+		clearTimeout(timeout);
+		var doneFns = inProgress[url];
+		delete inProgress[url];
+		script.parentNode && script.parentNode.removeChild(script);
+		doneFns &&
+			doneFns.forEach(function (fn) {
+				return fn(event);
+			});
+		if (prev) return prev(event);
+	};
+	var timeout = setTimeout(
+		onScriptComplete.bind(null, undefined, {
+			type: 'timeout',
+			target: script
+		}),
+		120000
+	);
+	script.onerror = onScriptComplete.bind(null, script.onerror);
+	script.onload = onScriptComplete.bind(null, script.onload);
+	needAttach && document.head.appendChild(script);
+};
+
+})();
+// webpack/runtime/make_namespace_object
+(() => {
+// define __esModule on exports
+__webpack_require__.r = function(exports) {
+	if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+		Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+	}
+	Object.defineProperty(exports, '__esModule', { value: true });
+};
+
+})();
+// webpack/runtime/auto_public_path
+(() => {
+
+    var scriptUrl;
+    if (__webpack_require__.g.importScripts) scriptUrl = __webpack_require__.g.location + "";
+    var document = __webpack_require__.g.document;
+    if (!scriptUrl && document) {
+      if (document.currentScript) scriptUrl = document.currentScript.src;
+        if (!scriptUrl) {
+          var scripts = document.getElementsByTagName("script");
+              if (scripts.length) {
+                var i = scripts.length - 1;
+                while (i > -1 && !scriptUrl) scriptUrl = scripts[i--].src;
+              }
+        }
+      }
+    
+    // When supporting browsers where an automatic publicPath is not supported you must specify an output.publicPath manually via configuration",
+    // or pass an empty string ("") and set the __webpack_public_path__ variable from your code to use your own logic.',
+    if (!scriptUrl) throw new Error("Automatic publicPath is not supported in this browser");
+    scriptUrl = scriptUrl.replace(/#.*$/, "").replace(/\?.*$/, "").replace(/\/[^\/]+$/, "/");
+    __webpack_require__.p = scriptUrl
+    
+})();
+// webpack/runtime/css loading
+(() => {
+if (typeof document === "undefined") return;
+var createStylesheet = function (
+	chunkId, fullhref, oldTag, resolve, reject
+) {
+	var linkTag = document.createElement("link");
+	
+	linkTag.rel = "stylesheet";
+	linkTag.type="text/css";
+	var onLinkComplete = function (event) {
+		// avoid mem leaks.
+		linkTag.onerror = linkTag.onload = null;
+		if (event.type === 'load') {
+			resolve();
+		} else {
+			var errorType = event && (event.type === 'load' ? 'missing' : event.type);
+			var realHref = event && event.target && event.target.href || fullhref;
+			var err = new Error("Loading CSS chunk " + chunkId + " failed.\\n(" + realHref + ")");
+			err.code = "CSS_CHUNK_LOAD_FAILED";
+			err.type = errorType;
+			err.request = realHref;
+			if (linkTag.parentNode) linkTag.parentNode.removeChild(linkTag)
+			reject(err);
+		}
+	}
+
+	linkTag.onerror = linkTag.onload = onLinkComplete;
+	linkTag.href = fullhref;
+	
+	if (oldTag) {
+  oldTag.parentNode.insertBefore(linkTag, oldTag.nextSibling);
+} else {
+  document.head.appendChild(linkTag);
+}
+	return linkTag;
+}
+var findStylesheet = function (href, fullhref) {
+	var existingLinkTags = document.getElementsByTagName("link");
+	for(var i = 0; i < existingLinkTags.length; i++) {
+		var tag = existingLinkTags[i];
+		var dataHref = tag.getAttribute("data-href") || tag.getAttribute("href");
+		if(tag.rel === "stylesheet" && (dataHref === href || dataHref === fullhref)) return tag;
+	}
+
+	var existingStyleTags = document.getElementsByTagName("style");
+	for(var i = 0; i < existingStyleTags.length; i++) {
+		var tag = existingStyleTags[i];
+		var dataHref = tag.getAttribute("data-href");
+		if(dataHref === href || dataHref === fullhref) return tag;
+	}
+}
+
+var loadStylesheet = function (chunkId) {
+	return new Promise(function (resolve, reject) {
+		var href = __webpack_require__.miniCssF(chunkId);
+		var fullhref = __webpack_require__.p + href;
+		if(findStylesheet(href, fullhref)) return resolve();
+		createStylesheet(chunkId, fullhref, null, resolve, reject);
+	})
+}
+
+// object to store loaded CSS chunks
+var installedCssChunks = {
+	"\\entry\\name": 0,
+
+};
+
+__webpack_require__.f.miniCss = function(chunkId, promises) {
+	var cssChunks = {
+"\\css\\chunk": 1,
+
+};
+	if(installedCssChunks[chunkId]) promises.push(installedCssChunks[chunkId])
+	else if(installedCssChunks[chunkId] !== 0 && cssChunks[chunkId])
+		promises.push(
+			installedCssChunks[chunkId] = loadStylesheet(chunkId).then(
+				function() {
+					installedCssChunks[chunkId] = 0;
+				},
+				function(e) {
+					delete installedCssChunks[chunkId];
+					throw e;
+				}
+			)
+		)
+}
+
+// no hmr
+
+})();
+// webpack/runtime/jsonp_chunk_loading
+(() => {
+
+      // object to store loaded and loading chunks
+      // undefined = chunk not loaded, null = chunk preloaded/prefetched
+      // [resolve, reject, Promise] = chunk loading, 0 = chunk loaded
+      var installedChunks = {"\\entry\\name": 0,};
+      
+        __webpack_require__.f.j = function (chunkId, promises) {
+          // JSONP chunk loading for javascript
+var installedChunkData = __webpack_require__.o(installedChunks, chunkId)
+	? installedChunks[chunkId]
+	: undefined;
+if (installedChunkData !== 0) {
+	// 0 means "already installed".
+
+	// a Promise means "currently loading".
+	if (installedChunkData) {
+		promises.push(installedChunkData[2]);
+	} else {
+		if (true) {
+			// setup Promise in chunk cache
+			var promise = new Promise(function (resolve, reject) {
+				installedChunkData = installedChunks[chunkId] = [resolve, reject];
+			});
+			promises.push((installedChunkData[2] = promise));
+
+			// start chunk loading
+			var url = __webpack_require__.p + __webpack_require__.u(chunkId);
+			// create error before stack unwound to get useful stacktrace later
+			var error = new Error();
+			var loadingEnded = function (event) {
+				if (__webpack_require__.o(installedChunks, chunkId)) {
+					installedChunkData = installedChunks[chunkId];
+					if (installedChunkData !== 0) installedChunks[chunkId] = undefined;
+					if (installedChunkData) {
+						var errorType =
+							event && (event.type === 'load' ? 'missing' : event.type);
+						var realSrc = event && event.target && event.target.src;
+						error.message =
+							'Loading chunk ' +
+							chunkId +
+							' failed.\n(' +
+							errorType +
+							': ' +
+							realSrc +
+							')';
+						error.name = 'ChunkLoadError';
+						error.type = errorType;
+						error.request = realSrc;
+						installedChunkData[1](error);
+					}
+				}
+			};
+			__webpack_require__.l(url, loadingEnded, "chunk-" + chunkId, chunkId);
+		} 
+	}
+}
+
+        }
+        // install a JSONP callback for chunk loading
+var webpackJsonpCallback = function (parentChunkLoadingFunction, data) {
+	var chunkIds = data[0];
+	var moreModules = data[1];
+	var runtime = data[2];
+	// add "moreModules" to the modules object,
+	// then flag all "chunkIds" as loaded and fire callback
+	var moduleId,
+		chunkId,
+		i = 0;
+	if (chunkIds.some(function (id) { return installedChunks[id] !== 0 })) {
+		for (moduleId in moreModules) {
+			if (__webpack_require__.o(moreModules, moduleId)) {
+				__webpack_require__.m[moduleId] = moreModules[moduleId];
+			}
+		}
+		if (runtime) var result = runtime(__webpack_require__);
+	}
+	if (parentChunkLoadingFunction) parentChunkLoadingFunction(data);
+	for (; i < chunkIds.length; i++) {
+		chunkId = chunkIds[i];
+		if (
+			__webpack_require__.o(installedChunks, chunkId) &&
+			installedChunks[chunkId]
+		) {
+			installedChunks[chunkId][0]();
+		}
+		installedChunks[chunkId] = 0;
+	}
+	
+};
+
+var chunkLoadingGlobal = self["webpackChunk"] = self["webpackChunk"] || [];
+chunkLoadingGlobal.forEach(webpackJsonpCallback.bind(null, 0));
+chunkLoadingGlobal.push = webpackJsonpCallback.bind(
+	null,
+	chunkLoadingGlobal.push.bind(chunkLoadingGlobal)
+);
+
+})();
+/************************************************************************/
+var __webpack_exports__ = {};
+__webpack_require__.e(/* import() | \js\chunk */ "\\js\\chunk").then(__webpack_require__.t.bind(__webpack_require__, "./src/chunk.js", 23));
+
+})()
+;

--- a/plugin-test/css-extract/cases/issue-6649/src/chunk.js
+++ b/plugin-test/css-extract/cases/issue-6649/src/chunk.js
@@ -1,0 +1,1 @@
+import(/* webpackChunkName: "\css\chunk" */"./inject.css");

--- a/plugin-test/css-extract/cases/issue-6649/src/index.js
+++ b/plugin-test/css-extract/cases/issue-6649/src/index.js
@@ -1,0 +1,1 @@
+import(/* webpackChunkName: "\js\chunk" */"./chunk.js");

--- a/plugin-test/css-extract/cases/issue-6649/src/inject.css
+++ b/plugin-test/css-extract/cases/issue-6649/src/inject.css
@@ -1,0 +1,3 @@
+body {
+  background: red;
+}

--- a/plugin-test/css-extract/cases/issue-6649/webpack.config.js
+++ b/plugin-test/css-extract/cases/issue-6649/webpack.config.js
@@ -1,0 +1,37 @@
+/* global document */
+
+const { CssExtractRspackPlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		"\\entry\\name": "./src/index.js"
+	},
+	optimization: {
+		chunkIds: "named"
+	},
+	output: {
+		chunkFilename: "[name].$[contenthash]$.js",
+		filename: "main.js"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [
+					{
+						loader: CssExtractRspackPlugin.loader
+					},
+					{
+						loader: "css-loader"
+					}
+				]
+			}
+		]
+	},
+	plugins: [
+		new CssExtractRspackPlugin({
+			filename: "[name].$[contenthash]$.css",
+		})
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #6649

- wrap chunk id with `"{}"` will encouter the unicode issue
- chunk id should render with `serde_json::to_string`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
