### PR TITLE
refactor: regenerate module_graph after finish make

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/mod.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/mod.rs
@@ -26,20 +26,47 @@ impl Cutout {
     artifact: &mut MakeArtifact,
     params: Vec<MakeParam>,
   ) -> HashSet<BuildDependency> {
+    let mut entry_dependencies = std::mem::take(&mut artifact.entry_dependencies);
     let mut force_build_modules = HashSet::default();
     let mut force_build_deps = HashSet::default();
-    let mut next_entry_deps = HashSet::default();
+    let mut remove_entry_deps = HashSet::default();
 
     let module_graph = artifact.get_module_graph();
+
     for item in params {
       match item {
-        MakeParam::Entry(deps) => {
-          next_entry_deps.extend(deps);
+        MakeParam::BuildEntry(deps) => {
+          for dep_id in deps {
+            if !entry_dependencies.contains(&dep_id) {
+              force_build_deps.insert((dep_id, None));
+              entry_dependencies.insert(dep_id);
+            }
+          }
+        }
+        MakeParam::BuildEntryAndClean(deps) => {
+          remove_entry_deps.extend(std::mem::take(&mut entry_dependencies));
+          entry_dependencies = deps;
+          for dep_id in &entry_dependencies {
+            if remove_entry_deps.contains(dep_id) {
+              remove_entry_deps.remove(dep_id);
+            } else {
+              force_build_deps.insert((*dep_id, None));
+            }
+          }
+        }
+        MakeParam::CheckNeedBuild => {
+          force_build_modules.extend(module_graph.modules().values().filter_map(|module| {
+            if module.need_build() {
+              Some(module.identifier())
+            } else {
+              None
+            }
+          }));
         }
         MakeParam::ModifiedFiles(files) => {
           force_build_modules.extend(module_graph.modules().values().filter_map(|module| {
             // check has dependencies modified
-            if !module.is_available(&files) {
+            if module.depends_on(&files) {
               Some(module.identifier())
             } else {
               None
@@ -51,7 +78,7 @@ impl Cutout {
             let mut res = vec![];
 
             // check has dependencies modified
-            if !module.is_available(&files) {
+            if module.depends_on(&files) {
               // add module id
               res.push(module.identifier());
               // add parent module id
@@ -99,30 +126,20 @@ impl Cutout {
     // do revoke module and collect deps
     force_build_deps.extend(artifact.revoke_modules(force_build_modules));
 
-    if !next_entry_deps.is_empty() {
-      let mut remove_entry_deps = std::mem::take(&mut artifact.entry_dependencies);
-      for dep_id in &next_entry_deps {
-        if remove_entry_deps.contains(dep_id) {
-          remove_entry_deps.remove(dep_id);
-        } else {
-          force_build_deps.insert((*dep_id, None));
-        }
+    let mut module_graph = artifact.get_module_graph_mut();
+    for dep_id in remove_entry_deps {
+      // connection may have been deleted by revoke module
+      if let Some(con) = module_graph.connection_by_dependency(&dep_id) {
+        self
+          .clean_isolated_module
+          .add_need_check_module(*con.module_identifier());
+        let con_id = con.id;
+        module_graph.revoke_connection(&con_id, true);
       }
-
-      artifact.entry_dependencies = next_entry_deps;
-      for dep_id in remove_entry_deps {
-        let mut module_graph = artifact.get_module_graph_mut();
-        // connection may have been deleted by revoke module
-        if let Some(con) = module_graph.connection_by_dependency(&dep_id) {
-          self
-            .clean_isolated_module
-            .add_need_check_module(*con.module_identifier());
-          let con_id = con.id;
-          module_graph.revoke_connection(&con_id, true);
-        }
-        force_build_deps.remove(&(dep_id, None));
-      }
+      force_build_deps.remove(&(dep_id, None));
     }
+
+    artifact.entry_dependencies = entry_dependencies;
 
     force_build_deps
   }

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -97,7 +97,7 @@ pub fn make_module_graph(
   let mut params = Vec::with_capacity(6);
 
   if !compilation.entries.is_empty() {
-    params.push(MakeParam::BuildEntryAndClean(
+    params.push(MakeParam::BuildEntry(
       compilation
         .entries
         .values()

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -81,7 +81,9 @@ impl MakeArtifact {
 
 #[derive(Debug, Clone)]
 pub enum MakeParam {
-  Entry(HashSet<DependencyId>),
+  BuildEntry(HashSet<DependencyId>),
+  BuildEntryAndClean(HashSet<DependencyId>),
+  CheckNeedBuild,
   ModifiedFiles(HashSet<PathBuf>),
   RemovedFiles(HashSet<PathBuf>),
   ForceBuildDeps(HashSet<BuildDependency>),
@@ -92,10 +94,10 @@ pub fn make_module_graph(
   compilation: &Compilation,
   mut artifact: MakeArtifact,
 ) -> Result<MakeArtifact> {
-  let mut params = Vec::with_capacity(5);
+  let mut params = Vec::with_capacity(6);
 
   if !compilation.entries.is_empty() {
-    params.push(MakeParam::Entry(
+    params.push(MakeParam::BuildEntryAndClean(
       compilation
         .entries
         .values()
@@ -105,9 +107,10 @@ pub fn make_module_graph(
         .collect(),
     ));
   }
-  // no modified files but rebuild means force build
-  // some module which cacheable is false will need to be rebuilt even if modified files is empty
-  params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
+  params.push(MakeParam::CheckNeedBuild);
+  if !compilation.modified_files.is_empty() {
+    params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
+  }
   if !compilation.removed_files.is_empty() {
     params.push(MakeParam::RemovedFiles(compilation.removed_files.clone()));
   }
@@ -120,9 +123,10 @@ pub fn make_module_graph(
     params.push(MakeParam::ForceBuildDeps(make_failed_dependencies));
   }
 
-  // reset diagnostics
+  // reset temporary data
   artifact.diagnostics = Default::default();
   artifact.has_module_graph_change = false;
+
   artifact = update_module_graph(compilation, artifact, params)?;
   Ok(artifact)
 }

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -37,8 +37,11 @@ pub struct ModuleExecutor {
 impl ModuleExecutor {
   pub async fn hook_before_make(&mut self, compilation: &Compilation) {
     let mut make_artifact = std::mem::take(&mut self.make_artifact);
-    let mut params = vec![];
-    params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
+    let mut params = Vec::with_capacity(5);
+    params.push(MakeParam::CheckNeedBuild);
+    if !compilation.modified_files.is_empty() {
+      params.push(MakeParam::ModifiedFiles(compilation.modified_files.clone()));
+    }
     if !compilation.removed_files.is_empty() {
       params.push(MakeParam::RemovedFiles(compilation.removed_files.clone()));
     }
@@ -51,6 +54,7 @@ impl ModuleExecutor {
       params.push(MakeParam::ForceBuildModules(modules));
     }
     make_artifact.diagnostics = Default::default();
+    make_artifact.has_module_graph_change = false;
 
     make_artifact = if let Ok(artifact) = update_module_graph(compilation, make_artifact, params) {
       artifact

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -344,24 +344,29 @@ pub trait Module:
     ConnectionState::Bool(true)
   }
 
-  fn is_available(&self, modified_file: &HashSet<PathBuf>) -> bool {
+  fn need_build(&self) -> bool {
     if let Some(build_info) = self.build_info() {
       if !build_info.cacheable {
-        return false;
+        return true;
       }
+    }
+    false
+  }
 
+  fn depends_on(&self, modified_file: &HashSet<PathBuf>) -> bool {
+    if let Some(build_info) = self.build_info() {
       for item in modified_file {
         if build_info.file_dependencies.contains(item)
           || build_info.build_dependencies.contains(item)
           || build_info.context_dependencies.contains(item)
           || build_info.missing_dependencies.contains(item)
         {
-          return false;
+          return true;
         }
       }
     }
 
-    true
+    false
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

* split module.is_available to module.need_build and module.depends_on
* add more MakeParams and regenerate module_graph after finish make

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
