### PR TITLE
fix: should insert semi after variable decl

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
@@ -78,7 +78,12 @@ impl<'a> InsertedSemicolons<'a> {
 impl<'a> Visit for InsertedSemicolons<'a> {
   fn visit_expr_stmt(&mut self, n: &swc_core::ecma::ast::ExprStmt) {
     self.post_semi(&n.span);
-    n.visit_children_with(self);
+    n.visit_children_with(self)
+  }
+
+  fn visit_var_decl(&mut self, n: &swc_core::ecma::ast::VarDecl) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
   }
 
   fn visit_update_expr(&mut self, n: &swc_core::ecma::ast::UpdateExpr) {

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-javascript/builtins-define/__snapshots__/output.snap.txt
@@ -11,30 +11,30 @@ __webpack_require__.r(__webpack_exports__);
 const lib = __webpack_require__("./lib.js");
 const { DO_NOT_CONVERTED9 } = __webpack_require__("./lib.js");
 
-equal(true, true);
+equal((true), true);
 // require("assert").deepStrictEqual(FALSE, false);
-assert.deepStrictEqual(3 + 2, 5);
-assert.deepStrictEqual(null, null);
-assert.deepStrictEqual(undefined, undefined);
+assert.deepStrictEqual((3 + 2), 5);
+assert.deepStrictEqual((null), null);
+assert.deepStrictEqual((undefined), undefined);
 // assert.equal(FUNCTION(5), 6);
 // assert.equal(typeof FUNCTION, "function");
-assert.deepStrictEqual(100.05, 100.05);
-assert.deepStrictEqual(0, 0);
+assert.deepStrictEqual((100.05), 100.05);
+assert.deepStrictEqual((0), 0);
 let ZERO_OBJ = { ZERO: 0 };
 assert.deepStrictEqual(ZERO_OBJ.ZERO, 0);
-assert.deepStrictEqual(ZERO_OBJ[0], undefined);
+assert.deepStrictEqual(ZERO_OBJ[(0)], undefined);
 assert.deepStrictEqual(ZERO_OBJ[0], undefined);
 assert.deepStrictEqual(ZERO_OBJ["ZERO"], 0);
-assert.deepStrictEqual(BigInt(10000), 10000n);
-assert.deepStrictEqual(100000000000n, 100000000000n);
-assert.deepStrictEqual(+0, 0);
-assert.deepStrictEqual(-0, -0);
-assert.deepStrictEqual(+100.25, 100.25);
-assert.deepStrictEqual(-100.25, -100.25);
-assert.deepStrictEqual("string", "string");
-assert.deepStrictEqual("", "");
-assert.deepStrictEqual(/abc/i, /abc/i);
-assert.deepStrictEqual(0.ABC, undefined);
+assert.deepStrictEqual((BigInt(10000)), 10000n);
+assert.deepStrictEqual((100000000000n), 100000000000n);
+assert.deepStrictEqual((+0), 0);
+assert.deepStrictEqual((-0), -0);
+assert.deepStrictEqual((+100.25), 100.25);
+assert.deepStrictEqual((-100.25), -100.25);
+assert.deepStrictEqual(("string"), "string");
+assert.deepStrictEqual((""), "");
+assert.deepStrictEqual((/abc/i), /abc/i);
+assert.deepStrictEqual((0).ABC, undefined);
 
 let error_count = 0;
 try {
@@ -51,34 +51,34 @@ try {
 } catch (err) {}
 assert.deepStrictEqual(error_count, 2);
 
-assert.deepStrictEqual([300, ["six"]], [300, ["six"]]);
-assert.deepStrictEqual([300, ["six"]][0], 300);
-assert.deepStrictEqual([300, ["six"]][0][1], undefined);
-assert.deepStrictEqual([300, ["six"]][1], ["six"]);
-assert.deepStrictEqual([300, ["six"]][1][0], "six");
-assert.deepStrictEqual([300, ["six"]][1][0][0], "s");
-assert.deepStrictEqual([300, ["six"]][1], ["six"]);
-assert.deepStrictEqual([300, ["six"]][[300, ["six"]]], undefined);
+assert.deepStrictEqual(([300, ["six"]]), [300, ["six"]]);
+assert.deepStrictEqual(([300, ["six"]])[0], 300);
+assert.deepStrictEqual(([300, ["six"]])[0][1], undefined);
+assert.deepStrictEqual(([300, ["six"]])[1], ["six"]);
+assert.deepStrictEqual(([300, ["six"]])[1][0], "six");
+assert.deepStrictEqual(([300, ["six"]])[1][0][0], "s");
+assert.deepStrictEqual(([300, ["six"]])[(1)], ["six"]);
+assert.deepStrictEqual(([300, ["six"]])[([300, ["six"]])], undefined);
 
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}, {
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}), {
 	UNDEFINED: undefined,
 	REGEXP: /def/i,
 	STR: "string",
 	OBJ: { NUM: 1 }
 });
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}.OBJ, { NUM: 1 });
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}.OBJ.NUM, 1);
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}.UNDEFINED, undefined);
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}.REGEXP, /def/i);
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}.STR, "string");
-assert.deepStrictEqual({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}.AAA, undefined);
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}).OBJ, { NUM: 1 });
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}).OBJ.NUM, 1);
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}).UNDEFINED, undefined);
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}).REGEXP, /def/i);
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}).STR, "string");
+assert.deepStrictEqual(({UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}).AAA, undefined);
 
-assert.deepStrictEqual(301, 301);
-assert.deepStrictEqual("302", "302");
-assert.deepStrictEqual(303, 303);
-assert.deepStrictEqual(304, 304);
+assert.deepStrictEqual((301), 301);
+assert.deepStrictEqual(("302"), "302");
+assert.deepStrictEqual((303), 303);
+assert.deepStrictEqual((304), 304);
 
-assert.deepStrictEqual(303.P4, undefined); // "303.P4"
+assert.deepStrictEqual((303).P4, undefined); // "303.P4"
 
 try {
 	error_count += 1;
@@ -87,9 +87,9 @@ try {
 } catch (err) {}
 assert.deepStrictEqual(error_count, 3);
 
-assert.deepStrictEqual("302".P1, undefined);
-assert.deepStrictEqual("302".P3, undefined);
-assert.deepStrictEqual("302".P4, undefined);
+assert.deepStrictEqual(("302").P1, undefined);
+assert.deepStrictEqual(("302").P3, undefined);
+assert.deepStrictEqual(("302").P4, undefined);
 
 const DO_NOT_CONVERTED = 201;
 assert.deepStrictEqual(DO_NOT_CONVERTED, 201);
@@ -115,7 +115,7 @@ const USELESS = {
 	const DO_NOT_CONVERTED3 = 205;
 	assert.deepStrictEqual(DO_NOT_CONVERTED3, 205);
 
-	const B = 0;
+	const B = (0);
 	assert.deepStrictEqual(B, 0);
 
 	let IN_BLOCK = 2;
@@ -124,7 +124,7 @@ const USELESS = {
 	{
 		{
 			{
-				assert.deepStrictEqual(205, 205);
+				assert.deepStrictEqual((205), 205);
 			}
 		}
 	}
@@ -132,14 +132,14 @@ const USELESS = {
 
 try {
 	error_count += 1;
-	SHOULD_BE_CONVERTED_IN_UNDEFINED_BLOCK;
+	(SHOULD_BE_CONVERTED_IN_UNDEFINED_BLOCK);
 	error_count += 1;
 } catch (err) {}
 assert.deepStrictEqual(error_count, 5);
 
 assert.deepStrictEqual(USELESS, { ZERO: 0 });
 assert.deepStrictEqual({}.DO_NOT_CONVERTED5, undefined);
-assert.deepStrictEqual({}.DO_NOT_CONVERTED6, undefined);
+assert.deepStrictEqual(({}).DO_NOT_CONVERTED6, undefined);
 assert.deepStrictEqual(_lib__WEBPACK_IMPORTED_MODULE_0__.DO_NOT_CONVERTED7, 402);
 assert.deepStrictEqual(_lib__WEBPACK_IMPORTED_MODULE_0__["default"], 401);
 assert.deepStrictEqual(DO_NOT_CONVERTED9, 403);
@@ -169,17 +169,17 @@ assert.deepStrictEqual(error_count, 6);
 // deepStrictEqual(error_count, 7);
 try {
 	error_count += 1;
-	aa = 205;
+	aa = (205);
 	error_count += 1;
 } catch (err) {}
 assert.deepStrictEqual(error_count, 7);
 
-assert.deepStrictEqual(205 == 205, true);
-assert.deepStrictEqual(207 == 205, false);
+assert.deepStrictEqual((205) == 205, true);
+assert.deepStrictEqual(207 == (205), false);
 
 try {
 	error_count += 1;
-	A1.A2.A3;
+	(A1.A2.A3);
 	error_count += 1;
 } catch (err) {}
 assert.deepStrictEqual(error_count, 8);

--- a/packages/rspack-test-tools/tests/configCases/builtins/define/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/define/index.js
@@ -65,6 +65,10 @@ it("should builtins define works", () => {
 	expect(OBJECT.STR).toBe("string");
 	expect(OBJECT.AAA).toBe(undefined);
 
+	OBJECT2.FN();
+	expect(typeof OBJECT2.FN).toBe("function");
+	expect(OBJECT2).not.toBeUndefined();
+
 	expect(P1.P2.P3).toBe(301);
 	expect(P1.P2.P4).toBe("302");
 	expect(P1).toBe(303);

--- a/packages/rspack-test-tools/tests/configCases/builtins/define/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/define/rspack.config.js
@@ -30,6 +30,7 @@ module.exports = {
 			REGEXP: "/abc/i",
 			OBJECT:
 				'{UNDEFINED: undefined, REGEXP: /def/i, STR: "string", OBJ: { NUM: 1}}',
+			OBJECT2: '{ FN: function() {} }',
 			"P1.P2.P3": "301",
 			"P1.P2.P4": '"302"',
 			P1: "303",

--- a/packages/rspack-test-tools/tests/normalCases/parsing/asi/a.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/asi/a.js
@@ -1,0 +1,1 @@
+export const foo = function() {}

--- a/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
@@ -1,0 +1,7 @@
+import { foo } from "./a"
+var a = {
+	a: 1
+}
+foo()
+const b = (function() { throw new Error("do not callme") })
+foo()

--- a/plugin-test/css-extract/cases/issue-6649/expected/main.js
+++ b/plugin-test/css-extract/cases/issue-6649/expected/main.js
@@ -89,7 +89,7 @@ __webpack_require__.e = function (chunkId) {
           // return url for filenames not based on template
           
           // return url for filenames based on template
-          return "" + chunkId + ".$" + {"\\css\\chunk": "b88d395b0e288c1b8cfe","\\js\\chunk": "5dc72ab590cca7957d71",}[chunkId] + "$.js";
+          return "" + chunkId + ".$" + {"\\css\\chunk": "a6681fb0036ba5fc970a","\\js\\chunk": "fed3c082f6312f1983aa",}[chunkId] + "$.js";
         };
       
 })();
@@ -107,7 +107,7 @@ __webpack_require__.e = function (chunkId) {
 // webpack/runtime/get_full_hash
 (() => {
 __webpack_require__.h = function () {
-	return "a0870bd6e64301212efb";
+	return "fefca101f5f5eed780fa";
 };
 
 })();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Fixed a case where semicolon is not inserted after a variable declaration
- Fixed a case of define plugin using with object

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
