### PR TITLE
fix: lazy compilation should escape data uri and should not rely on dependency request

### DIFF
--- a/crates/rspack_plugin_lazy_compilation/src/dependency.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/dependency.rs
@@ -16,7 +16,7 @@ impl LazyCompilationDependency {
       .dependency
       .as_module_dependency()
       .expect("LazyCompilation: should convert to module dependency");
-    let request = format!("{}?lazy-compilation-proxy-dep", dep.request());
+    let request = dep.request().to_string();
 
     Self {
       id: DependencyId::new(),

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -269,7 +269,8 @@ impl Module for LazyCompilationProxyModule {
         chunk_graph
           .get_module_id(*module)
           .as_ref()
-          .expect("should have module id"),
+          .expect("should have module id")
+          .replace('"', r#"\""#),
         keep_active,
       ))
     } else {

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -96,22 +96,11 @@ async fn normal_module_factory_module(
   create_data: &mut NormalModuleCreateData,
   module: &mut BoxModule,
 ) -> Result<()> {
-  if let Some(query) = &create_data.resource_resolve_data.resource_query
-    && query.contains("lazy-compilation-proxy-dep")
-  {
-    let remaining_query = query.clone().replace("lazy-compilation-proxy-dep", "");
-
-    create_data.resource_resolve_data.resource_query =
-      if remaining_query.is_empty() || remaining_query == "?" {
-        None
-      } else {
-        Some(remaining_query)
-      };
-
-    return Ok(());
-  }
-
   let dep_type = module_factory_create_data.dependency.dependency_type();
+
+  if matches!(dep_type, DependencyType::LazyImport) {
+    return Ok(());
+  };
 
   let is_imports = matches!(
     dep_type,

--- a/packages/playground/cases/lazy-compilation/ignore-entry/rspack.config.js
+++ b/packages/playground/cases/lazy-compilation/ignore-entry/rspack.config.js
@@ -3,7 +3,13 @@ const rspack = require("@rspack/core");
 /** @type { import('@rspack/core').RspackOptions } */
 module.exports = {
 	context: __dirname,
-	entry: "./src/index.js",
+	entry: {
+		main: [
+			// Will trigger the issue.
+			'data:text/javascript,import "core-js";',
+			"./src/index.js"
+		]
+	},
 	stats: "none",
 	mode: "development",
 	plugins: [new rspack.HtmlRspackPlugin()],

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -15,6 +15,7 @@
     "@babel/core": "^7.22.20",
     "@babel/preset-react": "^7.22.15",
     "@playwright/test": "1.35.0",
+    "core-js": "^3.37",
     "@rspack/core": "workspace:*",
     "@rspack/dev-server": "workspace:*",
     "@rspack/plugin-react-refresh": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       babel-loader:
         specifier: ^9.1.3
         version: 9.1.3(@babel/core@7.24.4)(webpack@5.90.1)
+      core-js:
+        specifier: ^3.37
+        version: 3.37.1
       fs-extra:
         specifier: 11.2.0
         version: 11.2.0
@@ -8299,6 +8302,11 @@ packages:
 
   /core-js@3.36.1:
     resolution: {integrity: sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==}
+    requiresBuild: true
+    dev: true
+
+  /core-js@3.37.1:
+    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
     requiresBuild: true
     dev: true
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close: #6701

LazyCompilation utilizes the nmf hook to enable normal module creation. Therefore, we must determine if a module has already undergone lazy compilation before utilizing dependency.request() with the string 'lazy-compilation-proxy-dep'. However, this method is not optimal; instead, we can identify the type of dependency. Additionally, the generated code should escape the quote character.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
