### PR TITLE
feat: align `AssetInfo` type with webpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2884,6 +2884,7 @@ dependencies = [
  "rspack_regex",
  "rustc-hash",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -237,6 +237,13 @@ export interface JsAssetInfo {
   javascriptModule?: boolean
   /** related object to other assets, keyed by type of relation (only points from parent to child) */
   related: JsAssetInfoRelated
+  /**
+   * Webpack: AssetInfo = KnownAssetInfo & Record<string, any>
+   * But Napi.rs does not support Intersectiont types. This is a hack to store the additional fields
+   * in the rust struct and have the Js side to reshape and align with webpack
+   * Related: packages/rspack/src/Compilation.ts
+   */
+  extras: Record<string, any>
 }
 
 export interface JsAssetInfoRelated {

--- a/crates/rspack_binding_values/Cargo.toml
+++ b/crates/rspack_binding_values/Cargo.toml
@@ -17,3 +17,4 @@ rspack_napi  = { path = "../rspack_napi" }
 rspack_regex = { path = "../rspack_regex" }
 rustc-hash   = { workspace = true }
 serde        = { workspace = true }
+serde_json   = { workspace = true }

--- a/crates/rspack_binding_values/src/asset.rs
+++ b/crates/rspack_binding_values/src/asset.rs
@@ -12,6 +12,7 @@ impl From<JsAssetInfoRelated> for rspack_core::AssetInfoRelated {
     }
   }
 }
+
 #[napi(object)]
 pub struct JsAssetInfo {
   /// if the asset can be long term cached forever (contains a hash)
@@ -38,6 +39,11 @@ pub struct JsAssetInfo {
   pub javascript_module: Option<bool>,
   /// related object to other assets, keyed by type of relation (only points from parent to child)
   pub related: JsAssetInfoRelated,
+  /// Webpack: AssetInfo = KnownAssetInfo & Record<string, any>
+  /// But Napi.rs does not support Intersectiont types. This is a hack to store the additional fields
+  /// in the rust struct and have the Js side to reshape and align with webpack
+  /// Related: packages/rspack/src/Compilation.ts
+  pub extras: serde_json::Map<String, serde_json::Value>,
 }
 
 impl From<JsAssetInfo> for rspack_core::AssetInfo {
@@ -53,6 +59,7 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
       version: String::from(""),
       source_filename: i.source_filename,
       javascript_module: i.javascript_module,
+      extras: i.extras,
     }
   }
 }
@@ -83,6 +90,7 @@ impl From<rspack_core::AssetInfo> for JsAssetInfo {
       content_hash: info.content_hash.into_iter().collect(),
       source_filename: info.source_filename,
       javascript_module: info.javascript_module,
+      extras: info.extras,
     }
   }
 }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1716,6 +1716,11 @@ pub struct AssetInfo {
   /// An empty string means no version, it will always emit
   pub version: String,
   pub source_filename: Option<String>,
+  /// Webpack: AssetInfo = KnownAssetInfo & Record<string, any>
+  /// But Napi.rs does not support Intersectiont types. This is a hack to store the additional fields
+  /// in the rust struct and have the Js side to reshape and align with webpack.
+  /// Related: packages/rspack/src/Compilation.ts
+  pub extras: serde_json::Map<String, serde_json::Value>,
 }
 
 impl AssetInfo {

--- a/packages/rspack-cli/tests/build/basic/public/main.js.map
+++ b/packages/rspack-cli/tests/build/basic/public/main.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"main.js","sources":["webpack:///./src/entry.js"],"sourcesContent":["console.log(\"CONFIG\");\n"],"names":[],"mappings":";;AAAA,QAAQ,GAAG,CAAC"}
+{"version":3,"file":"main.js","sources":["webpack:///./src/entry.js"],"sourcesContent":["console.log(\"CONFIG\");\n"],"names":[],"mappings":";;AAAA"}

--- a/packages/rspack-test-tools/tests/compilerCases/assets-update-info.js
+++ b/packages/rspack-test-tools/tests/compilerCases/assets-update-info.js
@@ -2,34 +2,40 @@ class MyPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap("Plugin", compilation => {
 			compilation.hooks.processAssets.tap(
-				{ name: "Plugin", stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE - 1 },
-				() => compilation
-					.getAssets()
-					.forEach(a => {
-						const new_info = {...a.info, unminified_name: a.name ?? "non_empty_str"};
+				{
+					name: "Plugin",
+					stage:
+						compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE - 1
+				},
+				() => {
+					compilation.getAssets().forEach(a => {
+						const new_info = {
+							...a.info,
+							unminified_name: a.name ?? "non_empty_str"
+						};
 						compilation.updateAsset(a.name, a.source, new_info);
-					})
+					});
+				}
 			);
+		});
 
-			compiler.hooks.done.tapPromise("Plugin", async (stats) => {
-				stats.compilation
-					.getAssets()
-					.forEach(a => {
-						expect(a.info.unminified_name).toBeTruthy();
-					})
-			})
+		compiler.hooks.done.tapPromise("Plugin", async stats => {
+			stats.compilation.getAssets().forEach(a => {
+				expect(a.info.unminified_name).toBeTruthy();
+			});
 		});
 	}
 }
 
 /** @type {import('../..').TCompilerCaseConfig} */
 module.exports = {
-	description: "compilation.updateAsset should preserve fields in addition to KnownAssetInfo",
+	description:
+		"compilation.updateAsset should preserve fields in addition to KnownAssetInfo",
 	options(context) {
 		return {
 			context: context.getSource(),
 			entry: "./d",
 			plugins: [new MyPlugin()]
 		};
-	},
+	}
 };

--- a/packages/rspack-test-tools/tests/compilerCases/assets-update-info.js
+++ b/packages/rspack-test-tools/tests/compilerCases/assets-update-info.js
@@ -1,0 +1,35 @@
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Plugin", compilation => {
+			compilation.hooks.processAssets.tap(
+				{ name: "Plugin", stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE - 1 },
+				() => compilation
+					.getAssets()
+					.forEach(a => {
+						const new_info = {...a.info, unminified_name: a.name ?? "non_empty_str"};
+						compilation.updateAsset(a.name, a.source, new_info);
+					})
+			);
+
+			compiler.hooks.done.tapPromise("Plugin", async (stats) => {
+				stats.compilation
+					.getAssets()
+					.forEach(a => {
+						expect(a.info.unminified_name).toBeTruthy();
+					})
+			})
+		});
+	}
+}
+
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+	description: "compilation.updateAsset should preserve fields in addition to KnownAssetInfo",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./d",
+			plugins: [new MyPlugin()]
+		};
+	},
+};

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -126,7 +126,7 @@ const asRegExp: (test: string | RegExp) => RegExp;
 // @public (undocumented)
 export interface Asset {
     // (undocumented)
-    info: JsAssetInfo;
+    info: AssetInfo;
     // (undocumented)
     name: string;
     // (undocumented)
@@ -253,7 +253,7 @@ const assetGeneratorOptions: z.ZodObject<{
 }>;
 
 // @public (undocumented)
-export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
+export type AssetInfo = Partial<Omit<JsAssetInfo_2, "extras">> & Record<string, any>;
 
 // @public (undocumented)
 export type AssetInlineGeneratorOptions = z.infer<typeof assetInlineGeneratorOptions>;
@@ -4168,6 +4168,14 @@ const javascriptParserOptions: z.ZodObject<{
     reexportExportsPresence?: false | "error" | "warn" | "auto" | undefined;
     strictExportPresence?: boolean | undefined;
 }>;
+
+// @public (undocumented)
+class JsAssetInfo_2 {
+    // (undocumented)
+    static __from_binding(jsAssetInfo: JsAssetInfo): AssetInfo;
+    // (undocumented)
+    static __to_binding(assetInfo?: AssetInfo): JsAssetInfo;
+}
 
 // @public (undocumented)
 type JscTarget = "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext";

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -253,7 +253,7 @@ const assetGeneratorOptions: z.ZodObject<{
 }>;
 
 // @public (undocumented)
-export type AssetInfo = Partial<Omit<JsAssetInfo_2, "extras">> & Record<string, any>;
+export type AssetInfo = Partial<Omit<JsAssetInfo, "extras">> & Record<string, any>;
 
 // @public (undocumented)
 export type AssetInlineGeneratorOptions = z.infer<typeof assetInlineGeneratorOptions>;
@@ -4168,14 +4168,6 @@ const javascriptParserOptions: z.ZodObject<{
     reexportExportsPresence?: false | "error" | "warn" | "auto" | undefined;
     strictExportPresence?: boolean | undefined;
 }>;
-
-// @public (undocumented)
-class JsAssetInfo_2 {
-    // (undocumented)
-    static __from_binding(jsAssetInfo: JsAssetInfo): AssetInfo;
-    // (undocumented)
-    static __to_binding(assetInfo?: AssetInfo): JsAssetInfo;
-}
 
 // @public (undocumented)
 type JscTarget = "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext";

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -581,7 +581,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		return assets.map(asset => {
 			return Object.defineProperties(asset, {
 				info: {
-					get: () => JsAssetInfo.__from_binding(asset.info)
+					value: JsAssetInfo.__from_binding(asset.info)
 				},
 				source: {
 					get: () => this.__internal__getAssetSource(asset.name)
@@ -597,7 +597,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		}
 		return Object.defineProperties(asset, {
 			info: {
-				get: () => JsAssetInfo.__from_binding(asset.info)
+				value: JsAssetInfo.__from_binding(asset.info)
 			},
 			source: {
 				get: () => this.__internal__getAssetSource(asset.name)

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -9,7 +9,6 @@
  */
 import type {
 	ExternalObject,
-	JsAssetInfo,
 	JsCompatSource,
 	JsCompilation,
 	JsDiagnostic,
@@ -50,18 +49,19 @@ import {
 } from "./Stats";
 import { StatsFactory } from "./stats/StatsFactory";
 import { StatsPrinter } from "./stats/StatsPrinter";
-import { concatErrorMsgAndStack, toJsAssetInfo } from "./util";
+import { concatErrorMsgAndStack } from "./util";
+import { type AssetInfo, JsAssetInfo } from "./util/AssetInfo";
 import { createFakeCompilationDependencies } from "./util/fake";
 import { memoizeValue } from "./util/memoize";
 import MergeCaller from "./util/MergeCaller";
 import { JsSource } from "./util/source";
+export { type AssetInfo } from "./util/AssetInfo";
 
-export type AssetInfo = Partial<JsAssetInfo> & Record<string, any>;
 export type Assets = Record<string, Source>;
 export interface Asset {
 	name: string;
 	source: Source;
-	info: JsAssetInfo;
+	info: AssetInfo;
 }
 
 export type PathData = JsPathData;
@@ -543,8 +543,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			assetInfoUpdateOrFunction === undefined
 				? assetInfoUpdateOrFunction
 				: typeof assetInfoUpdateOrFunction === "function"
-					? jsAssetInfo => toJsAssetInfo(assetInfoUpdateOrFunction(jsAssetInfo))
-					: toJsAssetInfo(assetInfoUpdateOrFunction)
+					? jsAssetInfo =>
+							JsAssetInfo.__to_binding(assetInfoUpdateOrFunction(jsAssetInfo))
+					: JsAssetInfo.__to_binding(assetInfoUpdateOrFunction)
 		);
 	}
 
@@ -559,7 +560,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		this.#inner.emitAsset(
 			filename,
 			JsSource.__to_binding(source),
-			toJsAssetInfo(assetInfo)
+			JsAssetInfo.__to_binding(assetInfo)
 		);
 	}
 
@@ -578,9 +579,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		const assets = this.#inner.getAssets();
 
 		return assets.map(asset => {
-			return Object.defineProperty(asset, "source", {
-				get: () => this.__internal__getAssetSource(asset.name)
-			}) as Asset;
+			return Object.defineProperties(asset, {
+				info: {
+					get: () => JsAssetInfo.__from_binding(asset.info)
+				},
+				source: {
+					get: () => this.__internal__getAssetSource(asset.name)
+				}
+			}) as unknown as Asset;
 		});
 	}
 
@@ -589,9 +595,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		if (!asset) {
 			return;
 		}
-		return Object.defineProperty(asset, "source", {
-			get: () => this.__internal__getAssetSource(asset.name)
-		}) as Asset;
+		return Object.defineProperties(asset, {
+			info: {
+				get: () => JsAssetInfo.__from_binding(asset.info)
+			},
+			source: {
+				get: () => this.__internal__getAssetSource(asset.name)
+			}
+		}) as unknown as Asset;
 	}
 
 	/**

--- a/packages/rspack/src/util/AssetInfo.ts
+++ b/packages/rspack/src/util/AssetInfo.ts
@@ -1,6 +1,6 @@
 import type { JsAssetInfo as JsAssetInfoBinding } from "@rspack/binding";
 
-export type AssetInfo = Partial<Omit<JsAssetInfo, "extras">> &
+export type AssetInfo = Partial<Omit<JsAssetInfoBinding, "extras">> &
 	Record<string, any>;
 
 class JsAssetInfo {

--- a/packages/rspack/src/util/AssetInfo.ts
+++ b/packages/rspack/src/util/AssetInfo.ts
@@ -1,0 +1,61 @@
+import type { JsAssetInfo as JsAssetInfoBinding } from "@rspack/binding";
+
+export type AssetInfo = Partial<Omit<JsAssetInfo, "extras">> &
+	Record<string, any>;
+
+class JsAssetInfo {
+	static __from_binding(jsAssetInfo: JsAssetInfoBinding): AssetInfo {
+		const {
+			immutable,
+			minimized,
+			development,
+			hotModuleReplacement,
+			related,
+			chunkHash,
+			contentHash,
+			javascriptModule,
+			sourceFilename,
+			extras
+		} = jsAssetInfo;
+		return {
+			...extras, // extras should not overwrite any KnownAssetFields
+			immutable,
+			minimized,
+			development,
+			hotModuleReplacement,
+			related,
+			chunkHash,
+			contentHash,
+			javascriptModule,
+			sourceFilename
+		};
+	}
+
+	static __to_binding(assetInfo: AssetInfo = {}): JsAssetInfoBinding {
+		let {
+			immutable = false,
+			minimized = false,
+			development = false,
+			hotModuleReplacement = false,
+			related = {},
+			chunkHash = [],
+			contentHash = [],
+			javascriptModule,
+			sourceFilename,
+			...extras
+		} = assetInfo;
+		extras = extras ?? {};
+		return {
+			immutable,
+			minimized,
+			development,
+			hotModuleReplacement,
+			related,
+			chunkHash,
+			contentHash,
+			extras
+		};
+	}
+}
+
+export { JsAssetInfo };

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -1,6 +1,5 @@
 import type { JsAssetInfo, JsStatsError } from "@rspack/binding";
 
-import { AssetInfo } from "../Compilation";
 import { LoaderObject } from "../config/adapterRuleUse";
 
 export function mapValues(
@@ -98,18 +97,6 @@ export function asArray<T>(item: T | T[]): T[] {
 	return Array.isArray(item) ? item : [item];
 }
 
-export function toJsAssetInfo(info?: AssetInfo): JsAssetInfo {
-	return {
-		immutable: false,
-		minimized: false,
-		development: false,
-		hotModuleReplacement: false,
-		related: {},
-		chunkHash: [],
-		contentHash: [],
-		...info
-	};
-}
 const getDeprecationStatus = () => {
 	const defaultEnableDeprecatedWarning = true;
 	if (
@@ -123,6 +110,7 @@ const getDeprecationStatus = () => {
 		"false"
 	);
 };
+
 const yellow = (content: string) =>
 	`\u001b[1m\u001b[33m${content}\u001b[39m\u001b[22m`;
 


### PR DESCRIPTION
## Summary
- compilation.updateAsset does not add additional fields to AssetInfo in Rspack. This PR aims to resolve this/

Type definition of AssetInfo in webpack:
```typescript
type AssetInfo = KnownAssetInfo & Record<string, any>;
declare interface KnownAssetInfo {
  /**
   * true, if the asset can be long term cached forever (contains a hash)
   */
  immutable?: boolean;
  /**
   * whether the asset is minimized
   */
  minimized?: boolean;
  /**
   * the value(s) of the full hash used for this asset
   */
  fullhash?: string | string[];
  /**
   * the value(s) of the chunk hash used for this asset
   */
  chunkhash?: string | string[];
  /**
   * the value(s) of the module hash used for this asset
   */
  modulehash?: string | string[];
  /**
   * the value(s) of the content hash used for this asset
   */
  contenthash?: string | string[];
  /**
   * when asset was created from a source file (potentially transformed), the original filename relative to compilation context
   */
  sourceFilename?: string;
  /**
   * size in bytes, only set after asset has been emitted
   */
  size?: number;
  /**
   * true, when asset is only used for development and doesn't count towards user-facing assets
   */
  development?: boolean;
  /**
   * true, when asset ships data for updating an existing application (HMR)
   */
  hotModuleReplacement?: boolean;
  /**
   * true, when asset is javascript and an ESM
   */
  javascriptModule?: boolean;
  /**
   * object of pointers to other assets, keyed by type of relation (only points from parent to child)
   */
  related?: Record<string, string | string[]>;
}
```

Type definition of AssetInfo in Rspack:
```rust
#[derive(Debug, Default, Clone)]
pub struct AssetInfo {
  /// if the asset can be long term cached forever (contains a hash)
  pub immutable: bool,
  /// whether the asset is minimized
  pub minimized: bool,
  /// the value(s) of the full hash used for this asset
  // pub full_hash:
  /// the value(s) of the chunk hash used for this asset
  pub chunk_hash: HashSet<String>,
  /// the value(s) of the module hash used for this asset
  // pub module_hash:
  /// the value(s) of the content hash used for this asset
  pub content_hash: HashSet<String>,
  /// when asset was created from a source file (potentially transformed), the original filename relative to compilation context
  // pub source_filename:
  /// size in bytes, only set after asset has been emitted
  // pub size: f64,
  /// when asset is only used for development and doesn't count towards user-facing assets
  pub development: bool,
  /// when asset ships data for updating an existing application (HMR)
  pub hot_module_replacement: bool,
  /// when asset is javascript and an ESM
  pub javascript_module: Option<bool>,
  /// related object to other assets, keyed by type of relation (only points from parent to child)
  pub related: AssetInfoRelated,
  /// the asset version, emit can be skipped when both filename and version are the same
  /// An empty string means no version, it will always emit
  pub version: String,
  pub source_filename: Option<String>,
}
```

So, the type definition of AssetInto in Rspack is strictly `KnownAssetInfo`, but not `KnownAssetInfo & Record<string, any>`;

This PR aligns the behavior to webpack

## Checklist

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
