### PR TITLE
refactor: entry_modules calculate by entry_deps

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -922,7 +922,20 @@ impl Compilation {
   }
 
   pub fn entry_modules(&self) -> IdentifierSet {
-    self.make_artifact.entry_module_identifiers.clone()
+    let module_graph = self.get_module_graph();
+    self
+      .entries
+      .values()
+      .flat_map(|item| item.all_dependencies())
+      .chain(self.global_entry.all_dependencies())
+      .filter_map(|dep_id| {
+        // some entry dependencies may not find module because of resolve failed
+        // so use filter_map to ignore them
+        module_graph
+          .module_identifier_by_dependency_id(dep_id)
+          .cloned()
+      })
+      .collect()
   }
 
   pub fn entrypoint_by_name(&self, name: &str) -> &Entrypoint {

--- a/crates/rspack_core/src/compiler/make/mod.rs
+++ b/crates/rspack_core/src/compiler/make/mod.rs
@@ -5,7 +5,6 @@ pub mod repair;
 use std::path::PathBuf;
 
 use rspack_error::{Diagnostic, Result};
-use rspack_identifier::IdentifierSet;
 use rustc_hash::FxHashSet as HashSet;
 
 use self::{cutout::Cutout, file_counter::FileCounter, repair::repair};
@@ -25,7 +24,6 @@ pub struct MakeArtifact {
   pub make_failed_module: HashSet<ModuleIdentifier>,
   pub module_graph_partial: ModuleGraphPartial,
   entry_dependencies: HashSet<DependencyId>,
-  pub entry_module_identifiers: IdentifierSet,
   pub file_dependencies: FileCounter,
   pub context_dependencies: FileCounter,
   pub missing_dependencies: FileCounter,

--- a/crates/rspack_core/src/compiler/make/repair/add.rs
+++ b/crates/rspack_core/src/compiler/make/repair/add.rs
@@ -13,7 +13,6 @@ pub struct AddTask {
   pub module: Box<dyn Module>,
   pub module_graph_module: Box<ModuleGraphModule>,
   pub dependencies: Vec<DependencyId>,
-  pub is_entry: bool,
   pub current_profile: Option<Box<ModuleProfile>>,
 }
 
@@ -72,10 +71,6 @@ impl Task<MakeTaskContext> for AddTask {
       self.dependencies,
       module_identifier,
     )?;
-
-    if self.is_entry {
-      artifact.entry_module_identifiers.insert(module_identifier);
-    }
 
     if let Some(current_profile) = &self.current_profile {
       current_profile.mark_integration_end();

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -23,7 +23,6 @@ pub struct FactorizeTask {
   pub issuer: Option<Box<str>>,
   pub dependency: BoxDependency,
   pub dependencies: Vec<DependencyId>,
-  pub is_entry: bool,
   pub resolve_options: Option<Box<Resolve>>,
   pub options: Arc<CompilerOptions>,
   pub current_profile: Option<Box<ModuleProfile>>,
@@ -62,7 +61,6 @@ impl Task<MakeTaskContext> for FactorizeTask {
       original_module_identifier: self.original_module_identifier,
       factory_result: None,
       dependencies: self.dependencies,
-      is_entry: self.is_entry,
       current_profile: self.current_profile,
       exports_info_related: ExportsInfoRelated {
         exports_info,
@@ -148,7 +146,6 @@ pub struct FactorizeResultTask {
   /// Result will be available if [crate::ModuleFactory::create] returns `Ok`.
   pub factory_result: Option<ModuleFactoryResult>,
   pub dependencies: Vec<DependencyId>,
-  pub is_entry: bool,
   pub current_profile: Option<Box<ModuleProfile>>,
   pub exports_info_related: ExportsInfoRelated,
 
@@ -194,7 +191,6 @@ impl Task<MakeTaskContext> for FactorizeResultTask {
       original_module_identifier,
       factory_result,
       dependencies,
-      is_entry,
       current_profile,
       exports_info_related,
       file_dependencies,
@@ -269,7 +265,6 @@ impl Task<MakeTaskContext> for FactorizeResultTask {
       module,
       module_graph_module: Box::new(mgm),
       dependencies,
-      is_entry,
       current_profile,
     })])
   }

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -125,7 +125,6 @@ pub fn repair(
         original_module_context: parent_module.and_then(|m| m.get_context()),
         dependency: dependency.clone(),
         dependencies: vec![id],
-        is_entry: parent_module_identifier.is_none(),
         resolve_options: parent_module.and_then(|module| module.get_resolve_options()),
         options: compilation.options.clone(),
         current_profile,

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -111,7 +111,6 @@ impl Task<MakeTaskContext> for ProcessDependenciesTask {
           .and_then(|module| module.name_for_condition()),
         dependency,
         dependencies,
-        is_entry: false,
         resolve_options: module.get_resolve_options(),
         options: context.compiler_options.clone(),
         current_profile,

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -54,7 +54,6 @@ impl Task<MakeTaskContext> for EntryTask {
           original_module_context: None,
           dependency: dep,
           dependencies: vec![dep_id],
-          is_entry: true,
           resolve_options: None,
           options: context.compiler_options.clone(),
           current_profile: context


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

We collect entry_modules in make addTask, which needs to pass is_entry in multiple tasks. This PR will calculate entry_modules via entry_deps.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
