### PR TITLE
fix: module-decorator-dep should be module dependency

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -139,10 +139,6 @@ mod t {
       &crate::DependencyType::EsmImportSpecifier
     }
 
-    fn dependency_debug_name(&self) -> &'static str {
-      "test dep"
-    }
-
     fn id(&self) -> &DependencyId {
       &self.id
     }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -37,11 +37,11 @@ use crate::{
   BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, BuildResult,
   ChunkInitFragments, CodeGenerationDataTopLevelDeclarations, CodeGenerationResult, Compilation,
   ConcatenatedModuleIdent, ConcatenationScope, ConnectionId, ConnectionState, Context,
-  DependenciesBlock, DependencyId, DependencyTemplate, ErrorSpan, ExportInfoId, ExportInfoProvided,
-  ExportsArgument, ExportsType, FactoryMeta, IdentCollector, LibIdentOptions, Module,
-  ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleType, Resolve,
-  RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template, UsageState,
-  UsedName, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
+  DependenciesBlock, DependencyId, DependencyTemplate, DependencyType, ErrorSpan, ExportInfoId,
+  ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector, LibIdentOptions,
+  Module, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, ModuleType,
+  Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType, SpanExt, Template,
+  UsageState, UsedName, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
 };
 
 #[derive(Debug)]
@@ -2247,12 +2247,13 @@ impl Hash for ConcatenatedModule {
 }
 
 pub fn is_harmony_dep_like(dep: &BoxDependency) -> bool {
-  [
-    "HarmonyExportImportedSpecifierDependency",
-    "HarmonyImportSideEffectDependency",
-    "HarmonyImportSpecifierDependency",
-  ]
-  .contains(&dep.dependency_debug_name())
+  matches!(
+    dep.dependency_type(),
+    DependencyType::EsmImportSpecifier
+      | DependencyType::EsmExportImportedSpecifier
+      | DependencyType::EsmImport(_)
+      | DependencyType::EsmExport(_)
+  )
 }
 
 /// Mark boxed errors as [crate::diagnostics::ModuleParseError],

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -21,10 +21,6 @@ pub struct ContextElementDependency {
 }
 
 impl Dependency for ContextElementDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ContextElementDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -23,9 +23,6 @@ pub trait Dependency:
   + Sync
   + Debug
 {
-  /// name of the original struct or enum
-  fn dependency_debug_name(&self) -> &'static str;
-
   fn id(&self) -> &DependencyId;
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_core/src/dependency/dependency_type.rs
+++ b/crates/rspack_core/src/dependency/dependency_type.rs
@@ -95,6 +95,7 @@ pub enum DependencyType {
   WebpackIsIncluded,
   LoaderImport,
   LazyImport,
+  ModuleDecorator,
   Custom(Box<str>), // TODO it will increase large layout size
 }
 
@@ -156,6 +157,7 @@ impl DependencyType {
       DependencyType::ConsumeSharedFallback => Cow::Borrowed("consume shared fallback"),
       DependencyType::WebpackIsIncluded => Cow::Borrowed("__webpack_is_included__"),
       DependencyType::LazyImport => Cow::Borrowed("lazy import()"),
+      DependencyType::ModuleDecorator => Cow::Borrowed("module decorator"),
     }
   }
 }

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -27,10 +27,6 @@ impl EntryDependency {
 }
 
 impl Dependency for EntryDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "EntryDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_core/src/dependency/static_exports_dependency.rs
+++ b/crates/rspack_core/src/dependency/static_exports_dependency.rs
@@ -37,10 +37,6 @@ impl Dependency for StaticExportsDependency {
     &DependencyType::StaticExports
   }
 
-  fn dependency_debug_name(&self) -> &'static str {
-    "StaticExportsDependency"
-  }
-
   fn get_exports(&self, _mg: &ModuleGraph) -> Option<ExportsSpec> {
     Some(ExportsSpec {
       exports: match &self.exports {

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -36,10 +36,6 @@ impl Dependency for CssComposeDependency {
   fn span(&self) -> Option<ErrorSpan> {
     Some(self.span)
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "CssComposeDependency"
-  }
 }
 
 impl ModuleDependency for CssComposeDependency {

--- a/crates/rspack_plugin_css/src/dependency/export.rs
+++ b/crates/rspack_plugin_css/src/dependency/export.rs
@@ -23,10 +23,6 @@ impl CssExportDependency {
 }
 
 impl Dependency for CssExportDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "CssExportDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -25,10 +25,6 @@ impl CssImportDependency {
 }
 
 impl Dependency for CssImportDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "CssImportDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -27,10 +27,6 @@ impl CssLocalIdentDependency {
 }
 
 impl Dependency for CssLocalIdentDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "CssLocalIdentDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -76,10 +76,6 @@ impl Dependency for CssUrlDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "CssUrlDependency"
-  }
 }
 
 impl ModuleDependency for CssUrlDependency {

--- a/crates/rspack_plugin_extract_css/src/css_dependency.rs
+++ b/crates/rspack_plugin_extract_css/src/css_dependency.rs
@@ -74,10 +74,6 @@ impl AsDependencyTemplate for CssDependency {}
 impl AsContextDependency for CssDependency {}
 
 impl Dependency for CssDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "mini-extract-css-dependency"
-  }
-
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -170,10 +170,6 @@ impl CommonJsExportRequireDependency {
 }
 
 impl Dependency for CommonJsExportRequireDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "CommonJsExportRequireDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -72,10 +72,6 @@ impl CommonJsExportsDependency {
 }
 
 impl Dependency for CommonJsExportsDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "CommonJsExportsDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -59,10 +59,6 @@ impl Dependency for CommonJsFullRequireDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "CommonJsFullRequireDependency"
-  }
 }
 
 impl ModuleDependency for CommonJsFullRequireDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -48,10 +48,6 @@ impl Dependency for CommonJsRequireDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "CommonJsRequireDependency"
-  }
 }
 
 impl ModuleDependency for CommonJsRequireDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -29,10 +29,6 @@ impl CommonJsSelfReferenceDependency {
 }
 
 impl Dependency for CommonJsSelfReferenceDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "CommonJsSelfReferenceDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -1,16 +1,41 @@
 use rspack_core::{
-  AsDependency, DependencyTemplate, InitFragmentKey, InitFragmentStage, NormalInitFragment,
-  RuntimeGlobals, TemplateContext, TemplateReplaceSource,
+  create_exports_object_referenced, create_no_exports_referenced, AsContextDependency, Dependency,
+  DependencyId, DependencyTemplate, DependencyType, InitFragmentKey, InitFragmentStage,
+  ModuleDependency, NormalInitFragment, RuntimeGlobals, TemplateContext, TemplateReplaceSource,
 };
 
 #[derive(Debug, Clone)]
 pub struct ModuleDecoratorDependency {
   decorator: RuntimeGlobals,
+  allow_exports_access: bool,
+  id: DependencyId,
 }
 
 impl ModuleDecoratorDependency {
-  pub fn new(decorator: RuntimeGlobals) -> Self {
-    Self { decorator }
+  pub fn new(decorator: RuntimeGlobals, allow_exports_access: bool) -> Self {
+    Self {
+      decorator,
+      allow_exports_access,
+      id: DependencyId::new(),
+    }
+  }
+}
+
+impl ModuleDependency for ModuleDecoratorDependency {
+  fn request(&self) -> &str {
+    "self"
+  }
+
+  fn get_referenced_exports(
+    &self,
+    _module_graph: &rspack_core::ModuleGraph,
+    _runtime: Option<&rspack_core::RuntimeSpec>,
+  ) -> Vec<rspack_core::ExtendedReferencedExport> {
+    if self.allow_exports_access {
+      create_exports_object_referenced()
+    } else {
+      create_no_exports_referenced()
+    }
   }
 }
 
@@ -64,4 +89,19 @@ impl DependencyTemplate for ModuleDecoratorDependency {
     None
   }
 }
-impl AsDependency for ModuleDecoratorDependency {}
+
+impl AsContextDependency for ModuleDecoratorDependency {}
+
+impl Dependency for ModuleDecoratorDependency {
+  fn id(&self) -> &DependencyId {
+    &self.id
+  }
+
+  fn resource_identifier(&self) -> Option<&str> {
+    Some("self")
+  }
+
+  fn dependency_type(&self) -> &DependencyType {
+    &DependencyType::ModuleDecorator
+  }
+}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -19,10 +19,6 @@ impl RequireHeaderDependency {
 }
 
 impl Dependency for RequireHeaderDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "RequireHeaderDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -52,10 +52,6 @@ impl Dependency for RequireResolveDependency {
   fn span(&self) -> Option<ErrorSpan> {
     Some(self.span)
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "RequireResolveDependency"
-  }
 }
 
 impl ModuleDependency for RequireResolveDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -58,10 +58,6 @@ impl Dependency for CommonJsRequireContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "CommonJsRequireContextDependency"
-  }
 }
 
 impl ContextDependency for CommonJsRequireContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -58,10 +58,6 @@ impl Dependency for ImportContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ImportContextDependency"
-  }
 }
 
 impl ContextDependency for ImportContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -53,10 +53,6 @@ impl Dependency for ImportMetaContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ImportMetaContextDependency"
-  }
 }
 
 impl ContextDependency for ImportMetaContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -53,10 +53,6 @@ impl Dependency for RequireContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "RequireContextDependency"
-  }
 }
 
 impl ContextDependency for RequireContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
@@ -50,9 +50,7 @@ impl Dependency for HarmonyExportExpressionDependency {
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::EsmExportExpression
   }
-  fn dependency_debug_name(&self) -> &'static str {
-    "HarmonyExportExpressionDependency"
-  }
+
   fn id(&self) -> &rspack_core::DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_header_dependency.rs
@@ -30,9 +30,6 @@ impl Dependency for HarmonyExportHeaderDependency {
   fn id(&self) -> &rspack_core::DependencyId {
     &self.id
   }
-  fn dependency_debug_name(&self) -> &'static str {
-    "HarmonyExportHeaderDependency"
-  }
 }
 
 impl DependencyTemplate for HarmonyExportHeaderDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -1217,10 +1217,6 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
       })
   }
 
-  fn dependency_debug_name(&self) -> &'static str {
-    "HarmonyExportImportedSpecifierDependency"
-  }
-
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -24,10 +24,6 @@ impl HarmonyExportSpecifierDependency {
 }
 
 impl Dependency for HarmonyExportSpecifierDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "HarmonyExportSpecifierDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -391,10 +391,6 @@ pub fn harmony_import_dependency_get_linking_error<T: ModuleDependency>(
 }
 
 impl Dependency for HarmonyImportSideEffectDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "HarmonyImportSideEffectDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -258,10 +258,6 @@ impl Dependency for HarmonyImportSpecifierDependency {
       .unwrap_or_else(|| self.ids.clone())
   }
 
-  fn dependency_debug_name(&self) -> &'static str {
-    "HarmonyImportSpecifierDependency"
-  }
-
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -49,10 +49,6 @@ impl Dependency for ImportDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ImportDependency"
-  }
 }
 
 impl ModuleDependency for ImportDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -51,10 +51,6 @@ impl Dependency for ImportEagerDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ImportEagerDependency"
-  }
 }
 
 impl ModuleDependency for ImportEagerDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -45,10 +45,6 @@ impl Dependency for ProvideDependency {
   fn span(&self) -> Option<ErrorSpan> {
     None
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ProvideDependency"
-  }
 }
 
 impl ModuleDependency for ProvideDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -41,10 +41,6 @@ impl Dependency for ImportMetaHotAcceptDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ImportMetaHotAcceptDependency"
-  }
 }
 
 impl ModuleDependency for ImportMetaHotAcceptDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -26,10 +26,6 @@ impl ImportMetaHotDeclineDependency {
 }
 
 impl Dependency for ImportMetaHotDeclineDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ImportMetaHotDeclineDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -41,10 +41,6 @@ impl Dependency for ModuleHotAcceptDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ModuleHotAcceptDependency"
-  }
 }
 
 impl ModuleDependency for ModuleHotAcceptDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -41,10 +41,6 @@ impl Dependency for ModuleHotDeclineDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "ModuleHotDeclineDependency"
-  }
 }
 
 impl ModuleDependency for ModuleHotDeclineDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -26,10 +26,6 @@ impl WebpackIsIncludedDependency {
 impl AsContextDependency for WebpackIsIncludedDependency {}
 
 impl Dependency for WebpackIsIncludedDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "WebpackIsIncludedDependency"
-  }
-
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::WebpackIsIncluded
   }

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -34,9 +34,6 @@ impl Dependency for PureExpressionDependency {
     self.used_by_exports = used_by_exports;
   }
 
-  fn dependency_debug_name(&self) -> &'static str {
-    "PureExpressionDependency"
-  }
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &ModuleGraph,

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -44,10 +44,6 @@ impl URLDependency {
 }
 
 impl Dependency for URLDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "URLDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -49,10 +49,6 @@ impl Dependency for WorkerDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "WorkerDependency"
-  }
 }
 
 impl ModuleDependency for WorkerDependency {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -273,8 +273,11 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
       };
       parser.bailout();
       parser
-        .presentational_dependencies
-        .push(Box::new(ModuleDecoratorDependency::new(decorator)));
+        .dependencies
+        .push(Box::new(ModuleDecoratorDependency::new(
+          decorator,
+          !parser.is_esm,
+        )));
       Some(true)
     } else if !parser.is_esm && parser.is_exports_ident(ident) {
       parser.bailout();

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -156,16 +156,6 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
         };
         let active_state = connection.get_active_state(&module_graph, runtime.as_ref());
 
-        // dbg!(
-        //   &connection,
-        //   self
-        //     .compilation
-        //     .get_module_graph()
-        //     .dependency_by_id(&dep_id)
-        //     .expect("should have dependency")
-        //     .dependency_debug_name(),
-        //   active_state
-        // );
         match active_state {
           ConnectionState::Bool(false) => {
             continue;
@@ -193,12 +183,6 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
         } else {
           continue;
         };
-        // dbg!(
-        //   &connection,
-        //   dep.dependency_debug_name(),
-        //   &referenced_exports,
-        //   &old_referenced_exports
-        // );
 
         if old_referenced_exports.is_none()
           || matches!(old_referenced_exports, Some(ProcessModuleReferencedExports::ExtendRef(ref v)) if is_no_exports_referenced(v))

--- a/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs
@@ -112,10 +112,10 @@ async fn compilation(
       normal_module_factory: params.normal_module_factory.clone(),
     }),
   );
-  compilation.set_dependency_factory(
-    DependencyType::CjsSelfReference,
-    Arc::new(SelfModuleFactory {}),
-  );
+
+  let self_factory = Arc::new(SelfModuleFactory {});
+  compilation.set_dependency_factory(DependencyType::CjsSelfReference, self_factory.clone());
+  compilation.set_dependency_factory(DependencyType::ModuleDecorator, self_factory);
   Ok(())
 }
 

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -24,10 +24,6 @@ impl Dependency for JsonExportsDependency {
     &self.id
   }
 
-  fn dependency_debug_name(&self) -> &'static str {
-    "JsonExportsDependency"
-  }
-
   fn get_exports(&self, _mg: &ModuleGraph) -> Option<ExportsSpec> {
     Some(ExportsSpec {
       exports: get_exports_from_data(&self.data).unwrap_or(ExportsOfExportsSpec::Null),

--- a/crates/rspack_plugin_lazy_compilation/expand.rs
+++ b/crates/rspack_plugin_lazy_compilation/expand.rs
@@ -169,9 +169,6 @@ mod dependency {
   impl AsDependencyTemplate for LazyCompilationDependency {}
   impl AsContextDependency for LazyCompilationDependency {}
   impl Dependency for LazyCompilationDependency {
-    fn dependency_debug_name(&self) -> &'static str {
-      "lazy compilation dependency"
-    }
     fn id(&self) -> &rspack_core::DependencyId {
       &self.id
     }

--- a/crates/rspack_plugin_lazy_compilation/src/dependency.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/dependency.rs
@@ -36,10 +36,6 @@ impl AsDependencyTemplate for LazyCompilationDependency {}
 impl AsContextDependency for LazyCompilationDependency {}
 
 impl Dependency for LazyCompilationDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "lazy compilation dependency"
-  }
-
   fn id(&self) -> &rspack_core::DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/container/container_entry_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_dependency.rs
@@ -35,10 +35,6 @@ impl ContainerEntryDependency {
 }
 
 impl Dependency for ContainerEntryDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ContainerEntryDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/container/container_exposed_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/container_exposed_dependency.rs
@@ -24,10 +24,6 @@ impl ContainerExposedDependency {
 }
 
 impl Dependency for ContainerExposedDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ContainerExposedDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/container/fallback_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_dependency.rs
@@ -22,10 +22,6 @@ impl FallbackDependency {
 }
 
 impl Dependency for FallbackDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "FallbackDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/container/fallback_item_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_item_dependency.rs
@@ -19,10 +19,6 @@ impl FallbackItemDependency {
 }
 
 impl Dependency for FallbackItemDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "FallbackItemDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/container/remote_to_external_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_to_external_dependency.rs
@@ -19,10 +19,6 @@ impl RemoteToExternalDependency {
 }
 
 impl Dependency for RemoteToExternalDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "RemoteToExternalDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_fallback_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_fallback_dependency.rs
@@ -19,10 +19,6 @@ impl ConsumeSharedFallbackDependency {
 }
 
 impl Dependency for ConsumeSharedFallbackDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ConsumeSharedFallbackDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_for_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_for_shared_dependency.rs
@@ -19,10 +19,6 @@ impl ProvideForSharedDependency {
 }
 
 impl Dependency for ProvideForSharedDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ProvideForSharedDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
@@ -45,10 +45,6 @@ impl ProvideSharedDependency {
 }
 
 impl Dependency for ProvideSharedDependency {
-  fn dependency_debug_name(&self) -> &'static str {
-    "ProvideSharedDependency"
-  }
-
   fn id(&self) -> &DependencyId {
     &self.id
   }

--- a/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
@@ -50,10 +50,6 @@ impl Dependency for WasmImportDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
-
-  fn dependency_debug_name(&self) -> &'static str {
-    "WasmImportDependency"
-  }
 }
 
 impl ModuleDependency for WasmImportDependency {

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		main: "./src/index.js"
+	},
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/src/foo.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/src/foo.js
@@ -1,0 +1,4 @@
+// access module
+module;
+
+export const foo = 1;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/src/index.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/src/index.js
@@ -1,0 +1,2 @@
+import {foo} from './foo'
+foo;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/test.config.js
@@ -1,0 +1,4 @@
+/** @type {import("../../../").TDiffCaseConfig} */
+module.exports = {
+	modules: true
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/scope-hoisting/module-decorator-bailout/webpack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("webpack").Configuration} */
+module.exports = {
+	entry: {
+		main: "./src/index.js"
+	},
+	optimization: {
+		concatenateModules: true
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #6718

ModuleDecorator accesses `module` and `exports` object, so it should not be concatenated.

Align with webpack, ModuleDecoratorDependency should be a self dependency instead of presentational dependency

Remove useless `dependency_debug_name` method

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
