### PR TITLE
docs: update Module Federation guide

### DIFF
--- a/website/docs/en/guide/features/module-federation.mdx
+++ b/website/docs/en/guide/features/module-federation.mdx
@@ -39,7 +39,7 @@ Module Federation v1.0 is no longer being iterated. We recommend using Module Fe
 
 ### Module Federation v1.5
 
-This version is natively supported in Rspack, providing features such as module export, module loading, dependency sharing.
+This version is natively supported in Rspack. In addition to supporting module export, module loading, and dependency sharing capabilities of Module Federation v1.0, it also adds runtime plugin functionality, allowing users to extend the behavior and functionality of module federation.
 
 You can use it with Rspack's [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin), no need to install any plugins.
 
@@ -63,7 +63,7 @@ module.exports = {
 
 ### Module Federation v2.0
 
-This is the enhanced version of Module Federation. It provides additional features based on Module Federation v1.5, such as dynamic type hinting, manifest, federation runtime, runtime plugin system, etc. These features make Module Federation more suitable for supporting micro-front-end architecture of large web applications.
+This is the enhanced version of Module Federation. Based on Module Federation v1.5, it provides some additional features out of the box, such as dynamic type hints and manifest, etc. These features make Module Federation more suitable for supporting micro-front-end architecture of large web applications.
 
 You need to install the additional `@module-federation/enhanced` plugin to use Module Federation v2.0.
 

--- a/website/docs/en/guide/features/module-federation.mdx
+++ b/website/docs/en/guide/features/module-federation.mdx
@@ -4,19 +4,81 @@ import { ApiMeta, Stability } from '@components/ApiMeta';
 
 <ApiMeta addedVersion={'0.5.0'} stability={Stability.Experimental} />
 
-Module Federation allows JavaScript applications to dynamically load code from other builds at runtime.
-This feature has several use cases, including:
+Module Federation is an architectural pattern for the decentralization of JavaScript applications (similar to microservices on the server-side). It allows you to share code and resources among multiple JavaScript applications (or micro-frontends).
 
-- Independent applications (known as "microfrontends" in microfrontend architecture) to share modules without the need to recompile the entire application.
+The Rspack team worked closely with the Module Federation development team, and provides first-class support for the Module Federation.
+
+## Use case
+
+Module Federation has some typical use cases, including:
+
+- Allow independent applications (known as "microfrontends" in microfrontend architecture) to share modules without the need to recompile the entire application.
 - Distributed teams to work on different parts of the same application without the need to recompile the entire application.
 - Dynamic code loading and sharing between applications during runtime
 
-Rspack supports two versions of Module Federation: Module Federation 1.0 and Module Federation 1.5.
+Module Federation can help you:
 
-- Module Federation 1.0 is the current implementation of ModuleFederationPlugin in Webpack.
-- Module Federation 1.5, among other things, adds runtime plugin functionality to 1.0, allowing for the extension of Module Federation's behavior, functionality, and providing control inversion to users.
+- Reduce code duplication
+- Improve code maintainability
+- Lower the overall size of your applications
+- Enhance the performance of your applications
 
-Detailed configuration can be found in:
+## How to use
 
-- [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin)
-- [ModuleFederationPluginV1](/plugins/webpack/module-federation-plugin-v1)
+There are currently several versions of Module Federation, you can choose one to use:
+
+### Module Federation v1.0
+
+This version was implemented for compatibility with the [webpack.container.ModuleFederationPlugin](https://webpack.js.org/plugins/module-federation-plugin/).
+
+You can use it through Rspack's [ModuleFederationPluginV1](/plugins/webpack/module-federation-plugin-v1).
+
+:::tip
+Module Federation v1.0 is no longer being iterated. We recommend using Module Federation v1.5 or v2.0.
+:::
+
+### Module Federation v1.5
+
+This version is natively supported in Rspack, providing features such as module export, module loading, dependency sharing.
+
+You can use it with Rspack's [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin), no need to install any plugins.
+
+```js title="rspack.config.js"
+const rspack = require('@rspack/core');
+
+module.exports = {
+  output: {
+    // set uniqueName explicitly to make HMR work
+    uniqueName: 'app',
+  },
+  plugins: [
+    new rspack.container.ModuleFederationPlugin({
+      // options
+    }),
+  ],
+};
+```
+
+> Refer to: [Module Federation v1.5 Example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/module-federation-v1.5).
+
+### Module Federation v2.0
+
+This is the enhanced version of Module Federation. It provides additional features based on Module Federation v1.5, such as dynamic type hinting, manifest, federation runtime, runtime plugin system, etc. These features make Module Federation more suitable for supporting micro-front-end architecture of large web applications.
+
+You need to install the additional `@module-federation/enhanced` plugin to use Module Federation v2.0.
+
+```js title="rspack.config.js"
+const {
+  ModuleFederationPlugin,
+} = require('@module-federation/enhanced/rspack');
+
+module.exports = {
+  plugins: [
+    new ModuleFederationPlugin({
+      // options
+    }),
+  ],
+};
+```
+
+Please refer to the [Module Federation v2.0 documentation](https://module-federation.io/) for detailed usage.

--- a/website/docs/en/plugins/webpack/module-federation-plugin-v1.mdx
+++ b/website/docs/en/plugins/webpack/module-federation-plugin-v1.mdx
@@ -1,13 +1,31 @@
-import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
+import { ApiMeta, Stability } from '@components/ApiMeta';
 
 # ModuleFederationPluginV1
 
 <ApiMeta addedVersion={'0.4.5'} stability={Stability.Experimental} />
 
-This plugin corresponds to Module Federation 1.0, which is [the ModuleFederationPlugin in Webpack](https://webpack.js.org/plugins/module-federation-plugin/).
+This plugin corresponds to Module Federation v1.0, which is the [ModuleFederationPlugin in webpack](https://webpack.js.org/plugins/module-federation-plugin/).
 
 The configuration is consistent with the ModuleFederationPlugin above, except for the two fields `implementation` and `runtimePlugins`.
 
 ```js
 new rspack.container.ModuleFederationPluginV1();
+```
+
+:::tip
+Module Federation v1.0 is no longer being iterated. We recommend using Module Federation v1.5 or v2.0. See [Module Federation](/guide/features/module-federation)。
+:::
+
+## Example
+
+```js title="rspack.config.js"
+const rspack = require('@rspack/core');
+
+module.exports = {
+  plugins: [
+    new rspack.container.ModuleFederationPluginV1({
+      // options
+    }),
+  ],
+};
 ```

--- a/website/docs/en/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/en/plugins/webpack/module-federation-plugin.mdx
@@ -1,10 +1,28 @@
-import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
+import { ApiMeta, Stability } from '@components/ApiMeta';
 
 # ModuleFederationPlugin
 
 <ApiMeta addedVersion={'0.5.0'} stability={Stability.Experimental} />
 
 This plugin implements [Module Federation 1.5](https://github.com/module-federation/universe/tree/main/packages/enhanced).
+
+## Example
+
+```js
+const rspack = require('@rspack/core');
+
+module.exports = {
+  output: {
+    // set uniqueName explicitly to make HMR works
+    uniqueName: 'app',
+  },
+  plugins: [
+    new rspack.container.ModuleFederationPlugin({
+      // options
+    }),
+  ],
+};
+```
 
 ## Options
 

--- a/website/docs/zh/guide/features/module-federation.mdx
+++ b/website/docs/zh/guide/features/module-federation.mdx
@@ -39,7 +39,7 @@ Module Federation v1.0 已经不再迭代，我们推荐使用 Module Federation
 
 ### Module Federation v1.5
 
-这是 Rspack 内置支持的版本，提供模块导出、模块加载、依赖共享等能力。
+这是 Rspack 内置支持的版本，除了支持 Module Federation v1.0 的模块导出、模块加载、依赖共享等能力之外，还添加了运行时插件功能，允许用户扩展模块联邦的行为、功能。
 
 你可以通过 Rspack 的 [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin) 来使用它，无须安装任何插件。
 
@@ -63,7 +63,7 @@ module.exports = {
 
 ### Module Federation v2.0
 
-这是 Module Federation 的增强版本。它在 Module Federation v1.5 的基础上，提供了额外的功能，比如动态类型提示、manifest、federation runtime、runtime plugin system 等，这些功能让 Module Federation 更适用于支持大型 Web 应用的微前端架构。
+这是 Module Federation 的增强版本。它基于 Module Federation v1.5，并在其基础上，开箱即用的提供了一些额外的功能，比如动态类型提示、manifest 等，这些功能让 Module Federation 更适用于支持大型 Web 应用的微前端架构。
 
 你需要安装额外的 `@module-federation/enhanced` 插件，才能使用 Module Federation v2.0。
 

--- a/website/docs/zh/guide/features/module-federation.mdx
+++ b/website/docs/zh/guide/features/module-federation.mdx
@@ -4,20 +4,81 @@ import { ApiMeta, Stability } from '@components/ApiMeta';
 
 <ApiMeta addedVersion={'0.5.0'} stability={Stability.Experimental} />
 
-模块联邦（Module Federation）允许 JavaScript 应用在运行时从其他构建中动态加载代码。
+Module Federation 是一种 JavaScript 应用分治的架构模式（类似于服务端的微服务），它允许你在多个 JavaScript 应用程序（或微前端）之间共享代码和资源。
 
-此功能有几个用例，包括：
+Rspack 团队与 Module Federation 的开发团队密切合作，并为 Module Federation 提供一流的支持。
 
-- 独立应用（在微前端架构中称为“微前端”）之间共享模块，无需重新编译整个应用。
+## 使用场景
+
+模块联邦有一些典型的使用场景，包括：
+
+- 允许独立应用（在微前端架构中称为"微前端"）之间共享模块，无需重新编译整个应用。
 - 不同的团队在不需要重新编译整个应用的情况下处理同一应用的不同部分。
 - 应用之间在运行时进行动态代码加载和共享。
 
-Rspack 支持两个版本的模块联邦：模块联邦 1.0 和模块联邦 1.5。
+模块联邦可以帮助你：
 
-- 模块联邦 1.0（Module Federation 1.0）是 Webpack 中 ModuleFederationPlugin 的当前实现。
-- 模块联邦 1.5（Module Federation 1.5）除其他功能外，还为 1.0 添加了运行时插件功能，允许扩展模块联邦的行为、功能，并向用户提供控制反转的能力。
+- 减少代码重复
+- 提高代码可维护性
+- 降低应用程序的整体大小
+- 提高应用程序的性能
 
-详细配置可参考：
+## 如何使用
 
-- [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin)
-- [ModuleFederationPluginV1](/plugins/webpack/module-federation-plugin-v1)
+Module Federation 目前有多个主要版本，你可以选择其中一个使用。
+
+### Module Federation v1.0
+
+这是为了兼容 [webpack.container.ModuleFederationPlugin](https://webpack.js.org/plugins/module-federation-plugin/) 实现的版本。
+
+你可以通过 Rspack 的 [ModuleFederationPluginV1](/plugins/webpack/module-federation-plugin-v1) 来使用它。
+
+:::tip
+Module Federation v1.0 已经不再迭代，我们推荐使用 Module Federation v1.5 或 v2.0 版本。
+:::
+
+### Module Federation v1.5
+
+这是 Rspack 内置支持的版本，提供模块导出、模块加载、依赖共享等能力。
+
+你可以通过 Rspack 的 [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin) 来使用它，无须安装任何插件。
+
+```js title="rspack.config.js"
+const rspack = require('@rspack/core');
+
+module.exports = {
+  output: {
+    // set uniqueName explicitly to make HMR works
+    uniqueName: 'app',
+  },
+  plugins: [
+    new rspack.container.ModuleFederationPlugin({
+      // options
+    }),
+  ],
+};
+```
+
+> 参考：[Module Federation v1.5 示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/module-federation-v1.5)。
+
+### Module Federation v2.0
+
+这是 Module Federation 的增强版本。它在 Module Federation v1.5 的基础上，提供了额外的功能，比如动态类型提示、manifest、federation runtime、runtime plugin system 等，这些功能让 Module Federation 更适用于支持大型 Web 应用的微前端架构。
+
+你需要安装额外的 `@module-federation/enhanced` 插件，才能使用 Module Federation v2.0。
+
+```js title="rspack.config.js"
+const {
+  ModuleFederationPlugin,
+} = require('@module-federation/enhanced/rspack');
+
+module.exports = {
+  plugins: [
+    new ModuleFederationPlugin({
+      // options
+    }),
+  ],
+};
+```
+
+请参考 [Module Federation v2.0 官方文档](https://module-federation.io/zh/) 来了解具体的用法。

--- a/website/docs/zh/plugins/webpack/module-federation-plugin-v1.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin-v1.mdx
@@ -1,13 +1,31 @@
-import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
+import { ApiMeta, Stability } from '@components/ApiMeta';
 
 # ModuleFederationPluginV1
 
 <ApiMeta addedVersion={'0.4.5'} stability={Stability.Experimental} />
 
-该插件对应 Module Federation 1.0，即 [Webpack 中的 ModuleFederationPlugin](https://webpack.js.org/plugins/module-federation-plugin/)。
-
-配置与上面 ModuleFederationPlugin 配置一致，除了没有 `implementation` 和 `runtimePlugins` 两个字段。
+该插件对应 Module Federation v1.0，即 [webpack 中的 ModuleFederationPlugin](https://webpack.js.org/plugins/module-federation-plugin/)。
 
 ```js
 new rspack.container.ModuleFederationPluginV1();
 ```
+
+:::tip
+Module Federation v1.0 已经不再迭代，我们推荐使用 Module Federation v1.5 或 v2.0 版本，详见 [模块联邦](/guide/features/module-federation)。
+:::
+
+## 示例
+
+```js title="rspack.config.js"
+const rspack = require('@rspack/core');
+
+module.exports = {
+  plugins: [
+    new rspack.container.ModuleFederationPluginV1({
+      // options
+    }),
+  ],
+};
+```
+
+The options for ModuleFederationPluginV1 are basically the same as those for [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin), but it does not support the `implementation` and `runtimePlugins` fields.

--- a/website/docs/zh/plugins/webpack/module-federation-plugin-v1.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin-v1.mdx
@@ -28,4 +28,4 @@ module.exports = {
 };
 ```
 
-The options for ModuleFederationPluginV1 are basically the same as those for [ModuleFederationPlugin](/plugins/webpack/module-federation-plugin), but it does not support the `implementation` and `runtimePlugins` fields.
+ModuleFederationPluginV1 的配置基本与 [ModuleFederationPlugin](https://github.com/plugins/webpack/module-federation-plugin) 相同，但不支持 `implementation` 和 `runtimePlugins` 字段。

--- a/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
@@ -1,10 +1,28 @@
-import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
+import { ApiMeta, Stability } from '@components/ApiMeta';
 
 # ModuleFederationPlugin
 
 <ApiMeta addedVersion={'0.5.0'} stability={Stability.Experimental} />
 
 该插件实现了 [Module Federation 1.5](https://github.com/module-federation/universe/tree/main/packages/enhanced)。
+
+## 示例
+
+```js
+const rspack = require('@rspack/core');
+
+module.exports = {
+  output: {
+    // set uniqueName explicitly to make HMR works
+    uniqueName: 'app',
+  },
+  plugins: [
+    new rspack.container.ModuleFederationPlugin({
+      // options
+    }),
+  ],
+};
+```
 
 ## 选项
 


### PR DESCRIPTION
## Summary

Update Module Federation guide:

- Add Module Federation v2
- Add some comparisons
- Add some basic examples
- No longer recommend to use Module Federation v1.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
