### PR TITLE
docs: add import.meta.webpackContext

### DIFF
--- a/website/docs/en/api/modules/module-methods.mdx
+++ b/website/docs/en/api/modules/module-methods.mdx
@@ -141,9 +141,13 @@ Aside from the module syntaxes described above, Rspack also support some webpack
 
 ### require.context
 
-`require.context` is a special function in webpack that allows you to dynamically require a set of modules.
+`require.context` is a function specific to webpack that allows you to dynamically require a set of modules.
 
-Rspack parses for `require.context()` in the code while building.
+You can use `require.context` in your code, and Rspack will parse and reference the matching modules during the build process.
+
+:::tip
+The return value of `require.context` is the same as [import.meta.webpackContext](/api/modules/module-variables#importmetawebpackcontext). We recommend using `import.meta.webpackContext`, which is more powerful.
+:::
 
 - **Type:**
 
@@ -191,40 +195,3 @@ const context = require.context('./locales', true, /\.json$/, 'lazy');
 ```
 
 > The arguments passed to `require.context()` must be literals.
-
-#### context API
-
-The context returned by `require.context()` is a function that takes a `request` argument (module path).
-
-This function has three properties: `resolve`, `keys`, and `id`.
-
-- `resolve` is a function and returns the module id of the parsed request.
-- `keys` is a function that returns an array of all possible requests that the context module can handle.
-- `id` is the module id of the context module. This may be useful for `module.hot.accept`.
-
-This can be useful if you want to require all files in a directory or matching a pattern.
-
-Consider a scenario where you have a folder structure like this:
-
-```
-src
-├── components
-│   ├── Button.js
-│   ├── Header.js
-│   └── Footer.js
-```
-
-You can use `require.context()` to dynamically import all component files in the folder:
-
-```js
-const componentsContext = require.context('./components', false, /\.js$/);
-
-componentsContext.keys().forEach(fileName => {
-  const componentModule = componentsContext(fileName);
-
-  // Here you can use your module, for example console.log
-  console.log(componentModule);
-});
-```
-
-`require.context()` streamlines the process of module importation especially when you have a lot of files to manage. When using it, please avoid matching unnecessary files, as this might lead to significantly increased build time and output size.

--- a/website/docs/en/api/modules/module-variables.mdx
+++ b/website/docs/en/api/modules/module-variables.mdx
@@ -11,6 +11,121 @@ This section covers all **variables** available in code compiled with webpack. M
 
 Indicates whether or not Hot Module Replacement is enabled and provides an interface to the process. See the [HMR API page](/api/hmr) for details.
 
+### import.meta.webpackContext
+
+`import.meta.webpackContext` is a function specific to webpack that allows you to dynamically import a set of modules.
+
+You can use `import.meta.webpackContext` in your code, and Rspack will parse and reference the matching modules during the build process.
+
+:::tip
+The return value of `import.meta.webpackContext` is the same as [import.meta.webpackContext](/api/modules/module-variables#importmetawebpackcontext). We recommend using `import.meta.webpackContext`, which is more powerful.
+:::
+
+- **Type:**
+
+```ts
+function webpackContext(
+  /**
+   * A directory to search.
+   */
+  request: string,
+  options?: {
+    /**
+     * Whether subdirectories should be searched.
+     * @default true
+     */
+    recursive?: boolean;
+    /**
+     * A regular expression to match files.
+     * @default /^\.\/.*$/ (any file)
+     */
+    regExp?: RegExp;
+    /**
+     * Module loading mode.
+     * @default 'sync'
+     */
+    mode?: 'sync' | 'eager' | 'weak' | 'lazy' | 'lazy-once';
+    include?: RegExp;
+    exclude?: RegExp;
+    preload?: boolean | number;
+    prefetch?: boolean | number;
+    chunkName?: string;
+    exports?: string | string[][];
+  },
+): Context;
+```
+
+- **Example:**
+
+```js
+// Create a context, with files from the test directory that
+// can be required with a request ending with `.test.js`.
+const context = import.meta.webpackContext('./test', {
+  recursive: false,
+  regExp: /\.test\.js$/,
+});
+```
+
+```js
+// Create a context with all files in the parent folder and
+// descending folders ending with `.stories.js`.
+const context = import.meta.webpackContext('../', {
+  recursive: true,
+  regExp: /\.stories\.js$/,
+});
+```
+
+```js
+// If mode is set to 'lazy', the underlying modules will be loaded asynchronously
+const context = import.meta.webpackContext('./locales', {
+  recursive: true,
+  regExp: /\.json$/,
+  mode: 'lazy',
+});
+```
+
+> The first arguments passed to `import.meta.webpackContext()` must be literals.
+
+### context API
+
+The context returned by `import.meta.webpackContext()` is a function that takes a `request` argument (module path).
+
+This function has three properties: `resolve`, `keys`, and `id`.
+
+- `resolve` is a function and returns the module id of the parsed request.
+- `keys` is a function that returns an array of all possible requests that the context module can handle.
+- `id` is the module id of the context module. This may be useful for `module.hot.accept`.
+
+This can be useful if you want to require all files in a directory or matching a pattern.
+
+Consider a scenario where you have a folder structure like this:
+
+```
+src
+├── components
+│   ├── Button.js
+│   ├── Header.js
+│   └── Footer.js
+```
+
+You can use `import.meta.webpackContext()` to dynamically import all component files in the folder:
+
+```js
+const componentsContext = import.meta.webpackContext('./components', {
+  recursive: false,
+  regExp: /\.js$/,
+});
+
+componentsContext.keys().forEach(fileName => {
+  const componentModule = componentsContext(fileName);
+
+  // Here you can use your module, for example console.log
+  console.log(componentModule);
+});
+```
+
+`import.meta.webpackContext()` streamlines the process of module importation especially when you have a lot of files to manage. When using it, please avoid matching unnecessary files, as this might lead to significantly increased build time and output size.
+
 ### import.meta.webpackHot (webpack-specific)
 
 An alias for `module.hot`, however `import.meta.webpackHot` can be used in strict ESM while `module.hot` can't.

--- a/website/docs/zh/api/modules/module-methods.mdx
+++ b/website/docs/zh/api/modules/module-methods.mdx
@@ -141,9 +141,13 @@ Data URI 模块可以被用作虚拟模块（Virtual Modules）的实现方式�
 
 ### require.context
 
-`require.context` 是 webpack 中的一个特殊函数，它允许你动态地 context 一组模块。
+`require.context` 是 webpack 特有的一个函数，它允许你动态地 require 一组模块。
 
-Rspack 会在构建过程中解析代码里的 `require.context()`。
+你可以在代码中使用 `require.context`，Rspack 将在构建时进行解析并引用匹配的模块。
+
+:::tip
+`require.context` 的返回值与 [import.meta.webpackContext](/api/modules/module-variables#importmetawebpackcontext) 相同，我们推荐使用 `import.meta.webpackContext`，它的功能更加强大。
+:::
 
 - **类型：**
 
@@ -191,40 +195,3 @@ const context = require.context('./locales', true, /\.json$/, 'lazy');
 ```
 
 > 传递给 `require.context()` 的参数必须是字面量。
-
-#### context API
-
-`require.context()` 返回的 context 是一个函数，它接收一个 `request` 参数（模块路径）。
-
-这个函数有三个属性：`resolve`，`keys` 与 `id`。
-
-- `resolve` 是一个函数，它返回 request 被解析后得到的模块 id。
-- `keys` 也是一个函数，它返回一个数组，由所有可能被此上下文模块处理的请求组成。
-- `id` 是上下文模块的模块 id. 它可能在使用 `module.hot.accept` 时会用到。
-
-如果你想引入一个文件夹下面的所有文件，或者引入能匹配一个正则表达式的所有文件，这个功能就会很有帮助。
-
-考虑一种情况，你有一个这样的文件夹结构：
-
-```
-src
-├── components
-│   ├── Button.js
-│   ├── Header.js
-│   └── Footer.js
-```
-
-你可以使用 `require.context()` 动态导入文件夹中的所有组件：
-
-```js
-const componentsContext = require.context('./components', false, /\.js$/);
-
-componentsContext.keys().forEach(fileName => {
-  const componentModule = componentsContext(fileName);
-
-  // 在这里你可以使用你的模块，例如使用 console.log 输出
-  console.log(componentModule);
-});
-```
-
-`require.context()` 简化了模块导入过程，尤其是当你有大量模块需要管理时。在使用时，请避免匹配到不需要的文件，否则可能导致构建时间和产物体积明显增加。

--- a/website/docs/zh/api/modules/module-variables.mdx
+++ b/website/docs/zh/api/modules/module-variables.mdx
@@ -11,6 +11,117 @@ import { ApiMeta } from '../../../../components/ApiMeta';
 
 是否启用了热模块替换，并提供了一些方法来处理该过程。有关详细信息，请参阅 [HMR API](/api/hmr) 页面。
 
+## import.meta.webpackContext
+
+`import.meta.webpackContext` 是 webpack 特有的一个函数，它允许你动态地 import 一组模块。
+
+你可以在代码中使用 `import.meta.webpackContext`，Rspack 将在构建时进行解析并引用匹配的模块。
+
+- **类型：**
+
+```ts
+function webpackContext(
+  /**
+   * 要搜索的目录
+   */
+  request: string,
+  options?: {
+    /**
+     * 是否还搜索其子目录
+     * @default true
+     */
+    recursive?: boolean;
+    /**
+     * 匹配文件的正则表达式
+     * @default /^\.\/.*$/（匹配任意文件）
+     */
+    regExp?: RegExp;
+    /**
+     * 模块加载模式
+     * @default 'sync'
+     */
+    mode?: 'sync' | 'eager' | 'weak' | 'lazy' | 'lazy-once';
+    include?: RegExp;
+    exclude?: RegExp;
+    preload?: boolean | number;
+    prefetch?: boolean | number;
+    chunkName?: string;
+    exports?: string | string[][];
+  },
+): Context;
+```
+
+- **示例：**
+
+```js
+// 创建一个上下文，
+// 文件直接来自 test 目录，匹配的文件名以 `.test.js` 结尾。
+const context = import.meta.webpackContext('./test', {
+  recursive: false,
+  regExp: /\.test\.js$/,
+});
+```
+
+```js
+// 创建一个上下文，
+// 文件来自父文件夹及其所有子级文件夹，匹配的文件名以 `.stories.js` 结尾。
+const context = import.meta.webpackContext('../', {
+  recursive: true,
+  regExp: /\.stories\.js$/,
+});
+```
+
+```js
+// 如果 `mode` 被设置为 `lazy`，模块将会被异步加载
+const context = import.meta.webpackContext('./locales', {
+  recursive: true,
+  regExp: /\.json$/,
+  mode: 'lazy',
+});
+```
+
+> 传递给 `import.meta.webpackContext()` 的第一个参数必须是字面量。
+
+### context API
+
+`import.meta.webpackContext()` 返回的 context 是一个函数，它接收一个 `request` 参数（模块路径）。
+
+这个函数有三个属性：`resolve`，`keys` 与 `id`。
+
+- `resolve` 是一个函数，它返回 request 被解析后得到的模块 id。
+- `keys` 也是一个函数，它返回一个数组，由所有可能被此上下文模块处理的请求组成。
+- `id` 是上下文模块的模块 id. 它可能在使用 `module.hot.accept` 时会用到。
+
+如果你想引入一个文件夹下面的所有文件，或者引入能匹配一个正则表达式的所有文件，这个功能就会很有帮助。
+
+考虑一种情况，你有一个这样的文件夹结构：
+
+```
+src
+├── components
+│   ├── Button.js
+│   ├── Header.js
+│   └── Footer.js
+```
+
+你可以使用 `import.meta.webpackContext()` 动态导入文件夹中的所有组件：
+
+```js
+const componentsContext = import.meta.webpackContext('./components', {
+  recursive: false,
+  regExp: /\.js$/,
+});
+
+componentsContext.keys().forEach(fileName => {
+  const componentModule = componentsContext(fileName);
+
+  // 在这里你可以使用你的模块，例如使用 console.log 输出
+  console.log(componentModule);
+});
+```
+
+`import.meta.webpackContext()` 简化了模块导入过程，尤其是当你有大量模块需要管理时。在使用时，请避免匹配到不需要的文件，否则可能导致构建时间和产物体积明显增加。
+
 ## import.meta.webpackHot（webpack 专用）
 
 `module.hot` 的别名，`import.meta.webpackHot` 可以在严格的 ESM 中使用，而 module.hot 不能。


### PR DESCRIPTION
## Summary

Add `import.meta.webpackContext` to document.

Compared to `require.context`, `import.meta.webpackContext` is more recommended to use.

- https://github.com/web-infra-dev/rspack/issues/4986
- https://github.com/web-infra-dev/rspack/issues/4305

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
