### PR TITLE
refactor: harmony import dependency parser plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3401,7 +3401,6 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash",
- "serde",
  "serde_json",
  "sugar_path",
  "swc_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,6 +3378,7 @@ dependencies = [
 name = "rspack_plugin_javascript"
 version = "0.1.0"
 dependencies = [
+ "anymap",
  "async-trait",
  "bitflags 2.5.0",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ resolver = "2"          # See https://doc.rust-lang.org/cargo/reference/resolver
 
 [workspace.dependencies]
 anyhow             = { version = "1.0.81", features = ["backtrace"] }
+anymap             = { version = "=1.0.0-beta.2" }
 async-recursion    = { version = "1.1.0" }
 async-scoped       = { version = "0.9.0" }
 async-trait        = { version = "0.1.79" }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/web-infra-dev/rspack"
 version    = "0.1.0"
 
 [dependencies]
-anymap = "1.0.0-beta.2"
+anymap = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -303,7 +303,6 @@ mod t {
     let module_deps_2 = ModuleDeps::from_module(&mg, &module1_id);
 
     assert_eq!(module_deps_1, module_deps_2);
-    dbg!(module_deps_1.clone());
 
     let dep2 = Box::new(TestDep::new(vec!["bar"]));
     let dep2_id = *dep2.id();
@@ -320,6 +319,5 @@ mod t {
 
     let module_deps_3 = ModuleDeps::from_module(&mg, &module_orig_id);
     assert_ne!(module_deps_3, module_deps_1);
-    dbg!(module_deps_3);
   }
 }

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/web-infra-dev/rspack"
 version    = "0.1.0"
 
 [dependencies]
-anymap          = "1.0.0-beta.2"
+anymap          = { workspace = true }
 async-recursion = { workspace = true }
 async-trait     = { workspace = true }
 bitflags        = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -6,6 +6,7 @@ repository = "https://github.com/web-infra-dev/rspack"
 version    = "0.1.0"
 
 [dependencies]
+anymap = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -29,7 +29,6 @@ rspack_ids = { path = "../rspack_ids/" }
 rspack_regex = { path = "../rspack_regex" }
 rspack_util = { path = "../rspack_util" }
 rustc-hash = { workspace = true }
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sugar_path = { workspace = true }
 swc_core = { workspace = true, features = [

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -66,7 +66,6 @@ pub struct HarmonyImportSideEffectDependency {
   pub id: DependencyId,
   pub span: Option<ErrorSpan>,
   pub source_span: Option<ErrorSpan>,
-  pub specifiers: Vec<Specifier>,
   pub dependency_type: DependencyType,
   pub export_all: bool,
   resource_identifier: String,
@@ -78,7 +77,6 @@ impl HarmonyImportSideEffectDependency {
     source_order: i32,
     span: Option<ErrorSpan>,
     source_span: Option<ErrorSpan>,
-    specifiers: Vec<Specifier>,
     dependency_type: DependencyType,
     export_all: bool,
   ) -> Self {
@@ -89,7 +87,6 @@ impl HarmonyImportSideEffectDependency {
       request,
       span,
       source_span,
-      specifiers,
       dependency_type,
       export_all,
       resource_identifier,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -187,7 +187,6 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
       }
     } else {
       harmony_import_dependency_apply(self, self.source_order, code_generatable_context);
-      // dbg!(&self.shorthand, self.asi_safe);
       export_from_import(
         code_generatable_context,
         true,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -124,21 +124,11 @@ impl JavascriptParserPlugin for CompatibilityPlugin {
     if name != RuntimeGlobals::REQUIRE.name() {
       return None;
     }
-    let Some(variable_info) = parser.get_mut_variable_info(name) else {
-      return None;
-    };
+    let tag_info = parser
+      .definitions_db
+      .expect_get_mut_tag_info(&parser.current_tag_info?);
 
-    // FIXME: should find the `tag_info` which tag equal `NESTED_WEBPACK_IDENTIFIER_TAG`;
-    let Some(tag_info) = &mut variable_info.tag_info else {
-      unreachable!();
-    };
-    if tag_info.tag != NESTED_WEBPACK_IDENTIFIER_TAG {
-      return None;
-    }
-    let Some(data) = tag_info.data.as_mut().map(std::mem::take) else {
-      unreachable!();
-    };
-    let mut nested_require_data = NestedRequireData::deserialize(data);
+    let mut nested_require_data = NestedRequireData::deserialize(tag_info.data.take()?);
     let mut deps = Vec::with_capacity(2);
     if !nested_require_data.update {
       deps.push(ConstDependency::new(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/harmony_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/harmony_export_dependency_parser_plugin.rs
@@ -74,15 +74,7 @@ fn handle_esm_export_harmony_import_side_effects_dep(
     });
   }
 
-  handle_harmony_import_side_effects_dep(
-    parser,
-    request,
-    span,
-    source_span,
-    specifiers,
-    dep_type,
-    export_all,
-  )
+  handle_harmony_import_side_effects_dep(parser, request, span, source_span, dep_type, export_all)
 }
 pub struct HarmonyExportDependencyParserPlugin;
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/harmony_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/harmony_import_dependency_parser_plugin.rs
@@ -73,7 +73,7 @@ pub struct HarmonyImportDependencyParserPlugin;
 
 const HARMONY_SPECIFIER_TAG: &str = "_identifier__harmony_specifier_tag__";
 
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone)]
 struct HarmonySpecifierData {
   name: Atom,
   source: Atom,
@@ -82,12 +82,14 @@ struct HarmonySpecifierData {
 }
 
 impl TagInfoData for HarmonySpecifierData {
-  fn serialize(data: &Self) -> serde_json::Value {
-    serde_json::to_value(data).expect("serialize failed for `HarmonySpecifierData`")
+  fn into_any(data: Self) -> Box<dyn anymap::CloneAny> {
+    Box::new(data)
   }
 
-  fn deserialize(value: serde_json::Value) -> Self {
-    serde_json::from_value(value).expect("deserialize failed for `HarmonySpecifierData`")
+  fn downcast(any: Box<dyn anymap::CloneAny>) -> Self {
+    *(any as Box<dyn std::any::Any>)
+      .downcast()
+      .expect("HarmonySpecifierData should be downcasted from correct tag info")
   }
 }
 
@@ -212,7 +214,7 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
     let tag_info = parser
       .definitions_db
       .expect_get_tag_info(&parser.current_tag_info?);
-    let settings = HarmonySpecifierData::deserialize(tag_info.data.clone()?);
+    let settings = HarmonySpecifierData::downcast(tag_info.data.clone()?);
 
     parser
       .rewrite_usage_span
@@ -255,7 +257,7 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
     let tag_info = parser
       .definitions_db
       .expect_get_tag_info(&parser.current_tag_info?);
-    let settings = HarmonySpecifierData::deserialize(tag_info.data.clone()?);
+    let settings = HarmonySpecifierData::downcast(tag_info.data.clone()?);
 
     let non_optional_members = get_non_optional_part(members, members_optionals);
     let (start, end) = if members.len() > non_optional_members.len() {
@@ -309,7 +311,7 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
     let tag_info = parser
       .definitions_db
       .expect_get_tag_info(&parser.current_tag_info?);
-    let settings = HarmonySpecifierData::deserialize(tag_info.data.clone()?);
+    let settings = HarmonySpecifierData::downcast(tag_info.data.clone()?);
 
     let non_optional_members = get_non_optional_part(members, members_optionals);
     let (start, end) = if members.len() > non_optional_members.len() {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/harmony_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/harmony_import_dependency_parser_plugin.rs
@@ -1,10 +1,9 @@
-use rspack_core::tree_shaking::symbol::DEFAULT_JS_WORD;
-use rspack_core::{extract_member_expression_chain, ConstDependency, DependencyType, SpanExt};
+use rspack_core::{ConstDependency, DependencyType, SpanExt};
 use swc_core::atoms::Atom;
 use swc_core::common::{Span, Spanned};
 use swc_core::ecma::ast::{
-  AssignExpr, AssignOp, AssignTarget, AssignTargetPat, Callee, ImportSpecifier, ModuleExportName,
-  OptChainExpr,
+  AssignExpr, AssignOp, AssignTarget, AssignTargetPat, Callee, ImportSpecifier, MemberExpr,
+  ModuleExportName, OptChainBase,
 };
 use swc_core::ecma::ast::{Expr, Ident, ImportDecl};
 
@@ -20,7 +19,6 @@ pub(super) fn handle_harmony_import_side_effects_dep(
   request: Atom,
   span: Span,
   source_span: Span,
-  specifiers: Vec<Specifier>,
   dep_type: DependencyType,
   exports_all: bool,
 ) {
@@ -29,27 +27,67 @@ pub(super) fn handle_harmony_import_side_effects_dep(
     parser.last_harmony_import_order,
     Some(span.into()),
     Some(source_span.into()),
-    specifiers,
     dep_type,
     exports_all,
   );
   parser.dependencies.push(Box::new(dependency));
 }
 
+fn get_non_optional_part<'a>(members: &'a [Atom], members_optionals: &[bool]) -> &'a [Atom] {
+  let mut i = 0;
+  while i < members.len() && matches!(members_optionals.get(i), Some(false)) {
+    i += 1;
+  }
+  if i != members.len() {
+    &members[0..i]
+  } else {
+    members
+  }
+}
+
+fn get_non_optional_member_chain_from_expr(mut expr: &Expr, mut count: i32) -> &Expr {
+  while count != 0 {
+    if let Expr::Member(member) = expr {
+      expr = &member.obj;
+      count -= 1;
+    } else if let Expr::OptChain(opt_chain) = expr {
+      expr = match &*opt_chain.base {
+        OptChainBase::Member(member) => &*member.obj,
+        OptChainBase::Call(call) if let Some(member) = call.callee.as_member() => &*member.obj,
+        _ => unreachable!(),
+      };
+      count -= 1;
+    } else {
+      unreachable!()
+    }
+  }
+  expr
+}
+
+fn get_non_optional_member_chain_from_member(member: &MemberExpr, mut count: i32) -> &Expr {
+  count -= 1;
+  get_non_optional_member_chain_from_expr(&member.obj, count)
+}
+
 pub struct HarmonyImportDependencyParserPlugin;
 
 const HARMONY_SPECIFIER_TAG: &str = "_identifier__harmony_specifier_tag__";
 
-#[derive(serde::Deserialize, serde::Serialize, Clone)]
-struct MockData;
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+struct HarmonySpecifierData {
+  name: Atom,
+  source: Atom,
+  ids: Vec<Atom>,
+  source_order: i32,
+}
 
-impl TagInfoData for MockData {
-  fn serialize(_: &Self) -> serde_json::Value {
-    serde_json::Value::Null
+impl TagInfoData for HarmonySpecifierData {
+  fn serialize(data: &Self) -> serde_json::Value {
+    serde_json::to_value(data).expect("serialize failed for `HarmonySpecifierData`")
   }
 
-  fn deserialize(_: serde_json::Value) -> Self {
-    MockData
+  fn deserialize(value: serde_json::Value) -> Self {
+    serde_json::from_value(value).expect("deserialize failed for `HarmonySpecifierData`")
   }
 }
 
@@ -95,7 +133,7 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
           ImporterReferenceInfo::new(
             import_decl.src.value.clone(),
             specifier.clone(),
-            Some(DEFAULT_JS_WORD.clone()),
+            Some("default".into()),
             parser.last_harmony_import_order,
           ),
         );
@@ -121,7 +159,6 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
       import_decl.src.value.clone(),
       import_decl.span,
       import_decl.src.span,
-      specifiers,
       DependencyType::EsmImport(import_decl.span.into()),
       false,
     );
@@ -146,12 +183,20 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     _statement: &ImportDecl,
-    _source: &Atom,
-    _export_name: Option<&str>,
-    identifier_name: &str,
+    source: &Atom,
+    id: Option<&Atom>,
+    name: &Atom,
   ) -> Option<bool> {
-    // TODO: fill data with `Some({name, source, ids, source_order, assertions })`
-    parser.tag_variable::<MockData>(identifier_name.to_string(), HARMONY_SPECIFIER_TAG, None);
+    parser.tag_variable::<HarmonySpecifierData>(
+      name.to_string(),
+      HARMONY_SPECIFIER_TAG,
+      Some(HarmonySpecifierData {
+        name: name.clone(),
+        source: source.clone(),
+        ids: id.map(|id| vec![id.clone()]).unwrap_or_default(),
+        source_order: parser.last_harmony_import_order,
+      }),
+    );
     Some(true)
   }
 
@@ -159,142 +204,146 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
     &self,
     parser: &mut JavascriptParser,
     ident: &Ident,
-    _for_name: &str,
+    for_name: &str,
   ) -> Option<bool> {
-    if let Some(reference) = parser.import_map.get(&ident.to_id()) {
-      parser
-        .rewrite_usage_span
-        .insert(ident.span, ExtraSpanInfo::ReWriteUsedByExports);
-      parser
-        .dependencies
-        .push(Box::new(HarmonyImportSpecifierDependency::new(
-          reference.request.clone(),
-          reference.specifier.name(),
-          reference.source_order,
-          parser.in_short_hand,
-          !parser.is_asi_position(ident.span_lo()),
-          ident.span.real_lo(),
-          ident.span.real_hi(),
-          reference.names.clone().map(|f| vec![f]).unwrap_or_default(),
-          parser.in_tagged_template_tag,
-          true,
-          HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-          parser.properties_in_destructuring.remove(&ident.sym),
-          ident.span,
-        )));
-      return Some(true);
+    if for_name != HARMONY_SPECIFIER_TAG {
+      return None;
     }
-    None
+    let tag_info = parser
+      .definitions_db
+      .expect_get_tag_info(&parser.current_tag_info?);
+    let settings = HarmonySpecifierData::deserialize(tag_info.data.clone()?);
+
+    parser
+      .rewrite_usage_span
+      .insert(ident.span, ExtraSpanInfo::ReWriteUsedByExports);
+    parser
+      .dependencies
+      .push(Box::new(HarmonyImportSpecifierDependency::new(
+        settings.source,
+        settings.name,
+        settings.source_order,
+        parser.in_short_hand,
+        !parser.is_asi_position(ident.span_lo()),
+        ident.span.real_lo(),
+        ident.span.real_hi(),
+        settings.ids,
+        parser.in_tagged_template_tag,
+        true,
+        HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+        parser.properties_in_destructuring.remove(&ident.sym),
+        ident.span,
+      )));
+    Some(true)
   }
 
   fn call_member_chain(
     &self,
     parser: &mut JavascriptParser,
-    _root_info: &crate::visitors::ExportedVariableInfo,
-    expr: &swc_core::ecma::ast::CallExpr,
-    // TODO: members: &Vec<String>,
-    // TODO: members_optionals: Vec<bool>,
-    // TODO: members_ranges: Vec<DependencyLoc>
+    call_expr: &swc_core::ecma::ast::CallExpr,
+    for_name: &str,
+    members: &[Atom],
+    members_optionals: &[bool],
+    _member_ranges: &[Span],
   ) -> Option<bool> {
-    let Callee::Expr(callee) = &expr.callee else {
+    let Callee::Expr(callee) = &call_expr.callee else {
       unreachable!()
     };
-    let expression_info = extract_member_expression_chain(&**callee);
-    let member_chain = expression_info.members();
-    assert!(
-      !member_chain.is_empty(),
-      "enter from call expression so the len of member must be not empty"
-    );
-    if let Some(reference) = parser.import_map.get(&member_chain[0]) {
-      let direct_import = member_chain.len() == 1;
-      let mut non_optional_members = expression_info.non_optional_part();
-      let start = callee.span().real_lo();
-      let end = if !non_optional_members.is_empty()
-        && let Some(span) = expression_info
-          .members_spans()
-          .get(non_optional_members.len() - 1)
-      {
-        span.real_hi()
-      } else {
-        callee.span().real_hi()
-      };
-      non_optional_members.pop_front();
-      let mut ids = reference.names.clone().map(|f| vec![f]).unwrap_or_default();
-      ids.extend(non_optional_members.into_iter().map(|item| item.0.clone()));
-      parser
-        .rewrite_usage_span
-        .insert(callee.span(), ExtraSpanInfo::ReWriteUsedByExports);
-      parser
-        .dependencies
-        .push(Box::new(HarmonyImportSpecifierDependency::new(
-          reference.request.clone(),
-          reference.specifier.name(),
-          reference.source_order,
-          false,
-          !parser.is_asi_position(expr.span_lo()),
-          start,
-          end,
-          ids,
-          true,
-          direct_import,
-          HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-          None,
-          callee.span(),
-        )));
-      parser.walk_expr_or_spread(&expr.args);
-      return Some(true);
+    if for_name != HARMONY_SPECIFIER_TAG {
+      return None;
     }
-    None
+    let tag_info = parser
+      .definitions_db
+      .expect_get_tag_info(&parser.current_tag_info?);
+    let settings = HarmonySpecifierData::deserialize(tag_info.data.clone()?);
+
+    let non_optional_members = get_non_optional_part(members, members_optionals);
+    let (start, end) = if members.len() > non_optional_members.len() {
+      let expr = get_non_optional_member_chain_from_expr(
+        callee,
+        (members.len() - non_optional_members.len()) as i32,
+      );
+      (expr.span().real_lo(), expr.span().real_hi())
+    } else {
+      (callee.span().real_lo(), callee.span().real_hi())
+    };
+    let mut ids = settings.ids;
+    ids.extend(non_optional_members.iter().cloned());
+    let direct_import = members.is_empty();
+    parser
+      .rewrite_usage_span
+      .insert(callee.span(), ExtraSpanInfo::ReWriteUsedByExports);
+    parser
+      .dependencies
+      .push(Box::new(HarmonyImportSpecifierDependency::new(
+        settings.source,
+        settings.name,
+        settings.source_order,
+        false,
+        !parser.is_asi_position(call_expr.span_lo()),
+        start,
+        end,
+        ids,
+        true,
+        direct_import,
+        HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+        None,
+        callee.span(),
+      )));
+    parser.walk_expr_or_spread(&call_expr.args);
+    Some(true)
   }
 
-  fn member(
+  fn member_chain(
     &self,
     parser: &mut JavascriptParser,
     member_expr: &swc_core::ecma::ast::MemberExpr,
-    _for_name: &str,
+    for_name: &str,
+    members: &[Atom],
+    members_optionals: &[bool],
+    _member_ranges: &[Span],
   ) -> Option<bool> {
-    let expression_info = extract_member_expression_chain(member_expr);
-    dbg!(&expression_info);
-    let member_chain = expression_info.members();
-    if let Some(reference) = parser.import_map.get(&member_chain[0]) {
-      let mut non_optional_members = expression_info.non_optional_part();
-      dbg!(&non_optional_members);
-      let start = member_expr.span().real_lo();
-      let end = if !non_optional_members.is_empty()
-        && let Some(span) = expression_info
-          .members_spans()
-          .get(non_optional_members.len() - 1)
-      {
-        span.real_hi()
-      } else {
-        member_expr.span().real_hi()
-      };
-      non_optional_members.pop_front();
-      let mut ids = reference.names.clone().map(|f| vec![f]).unwrap_or_default();
-      ids.extend(non_optional_members.into_iter().map(|item| item.0.clone()));
-      parser
-        .rewrite_usage_span
-        .insert(member_expr.span, ExtraSpanInfo::ReWriteUsedByExports);
-      parser
-        .dependencies
-        .push(Box::new(HarmonyImportSpecifierDependency::new(
-          reference.request.clone(),
-          reference.specifier.name(),
-          reference.source_order,
-          false,
-          !parser.is_asi_position(member_expr.span_lo()),
-          start,
-          end,
-          ids,
-          false,
-          false, // x.xx()
-          HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-          None,
-          member_expr.span,
-        )));
-      return Some(true);
+    if for_name != HARMONY_SPECIFIER_TAG {
+      return None;
     }
-    None
+    let tag_info = parser
+      .definitions_db
+      .expect_get_tag_info(&parser.current_tag_info?);
+    let settings = HarmonySpecifierData::deserialize(tag_info.data.clone()?);
+
+    let non_optional_members = get_non_optional_part(members, members_optionals);
+    let (start, end) = if members.len() > non_optional_members.len() {
+      let expr = get_non_optional_member_chain_from_member(
+        member_expr,
+        (members.len() - non_optional_members.len()) as i32,
+      );
+      (expr.span().real_lo(), expr.span().real_hi())
+    } else {
+      (member_expr.span.real_lo(), member_expr.span.real_hi())
+    };
+    let mut ids = settings.ids;
+    ids.extend(non_optional_members.iter().cloned());
+    parser
+      .rewrite_usage_span
+      .insert(member_expr.span, ExtraSpanInfo::ReWriteUsedByExports);
+    parser
+      .dependencies
+      .push(Box::new(HarmonyImportSpecifierDependency::new(
+        settings.source,
+        settings.name,
+        settings.source_order,
+        false,
+        !parser.is_asi_position(member_expr.span_lo()),
+        start,
+        end,
+        ids,
+        false,
+        false, // x.xx()
+        HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
+        None,
+        member_expr.span,
+      )));
+    Some(true)
   }
 
   // collect referenced properties in destructuring
@@ -317,60 +366,4 @@ impl JavascriptParserPlugin for HarmonyImportDependencyParserPlugin {
     }
     None
   }
-
-  // fn optional_chaining(
-  //   &self,
-  //   parser: &mut JavascriptParser,
-  //   opt_chain_expr: &OptChainExpr,
-  // ) -> Option<bool> {
-  //   let expression_info = extract_member_expression_chain(opt_chain_expr);
-  //   // dbg!(&expression_info);
-  //   let member_chain = expression_info.members();
-  //   if member_chain.len() > 1
-  //     && let Some(reference) = parser.import_map.get(&member_chain[0])
-  //   {
-  //     let mut non_optional_members = expression_info.non_optional_part();
-  //     // dbg!(&non_optional_members);
-  //     let start = opt_chain_expr.span.real_lo();
-  //     let end = if !non_optional_members.is_empty()
-  //       && let Some(span) = expression_info
-  //         .members_spans()
-  //         .get(non_optional_members.len() - 1)
-  //     {
-  //       span.real_hi()
-  //     } else {
-  //       opt_chain_expr.span.real_hi()
-  //     };
-  //     non_optional_members.pop_front();
-  //     let mut ids = reference.names.clone().map(|f| vec![f]).unwrap_or_default();
-  //     ids.extend_from_slice(
-  //       &non_optional_members
-  //         .into_iter()
-  //         .map(|item| item.0.clone())
-  //         .collect::<Vec<_>>(),
-  //     );
-  //     parser
-  //       .rewrite_usage_span
-  //       .insert(opt_chain_expr.span, ExtraSpanInfo::ReWriteUsedByExports);
-  //     parser
-  //       .dependencies
-  //       .push(Box::new(HarmonyImportSpecifierDependency::new(
-  //         reference.request.clone(),
-  //         reference.specifier.name(),
-  //         reference.source_order,
-  //         false,
-  //         !parser.is_asi_position(opt_chain_expr.span_lo()),
-  //         start,
-  //         end,
-  //         ids,
-  //         parser.enter_callee && !parser.enter_new_expr,
-  //         !parser.enter_callee, // x.xx()
-  //         HarmonyImportSpecifierDependency::create_export_presence_mode(parser.javascript_options),
-  //         None,
-  //         opt_chain_expr.span,
-  //       )));
-  //     return Some(true);
-  //   }
-  //   None
-  // }
 }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -94,11 +94,11 @@ pub trait JavascriptParserPlugin {
   fn call_member_chain(
     &self,
     _parser: &mut JavascriptParser,
-    _root_info: &ExportedVariableInfo,
     _expr: &CallExpr,
-    // TODO: members: &Vec<String>,
-    // TODO: members_optionals: Vec<bool>,
-    // TODO: members_ranges: Vec<DependencyLoc>
+    _for_name: &str,
+    _members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[Span],
   ) -> Option<bool> {
     None
   }
@@ -108,6 +108,18 @@ pub trait JavascriptParserPlugin {
     _parser: &mut JavascriptParser,
     _expr: &MemberExpr,
     _for_name: &str,
+  ) -> Option<bool> {
+    None
+  }
+
+  fn member_chain(
+    &self,
+    _parser: &mut JavascriptParser,
+    _expr: &MemberExpr,
+    _for_name: &str,
+    _members: &[Atom],
+    _members_optionals: &[bool],
+    _member_ranges: &[Span],
   ) -> Option<bool> {
     None
   }
@@ -236,8 +248,8 @@ pub trait JavascriptParserPlugin {
     _parser: &mut JavascriptParser,
     _statement: &ImportDecl,
     _source: &Atom,
-    _export_name: Option<&str>,
-    _identifier_name: &str,
+    _export_name: Option<&Atom>,
+    _identifier_name: &Atom,
   ) -> Option<bool> {
     None
   }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -1,0 +1,42 @@
+use rspack_core::SpanExt;
+use swc_core::ecma::ast::MemberExpr;
+
+use super::BasicEvaluatedExpression;
+use crate::parser_plugin::JavascriptParserPlugin;
+use crate::visitors::{AllowedMemberTypes, JavascriptParser, MemberExpressionInfo};
+
+pub fn eval_member_expression(
+  parser: &mut JavascriptParser,
+  member: &MemberExpr,
+) -> Option<BasicEvaluatedExpression> {
+  let ret = if let Some(MemberExpressionInfo::Expression(info)) =
+    parser.get_member_expression_info(member, AllowedMemberTypes::Expression)
+  {
+    parser
+      .plugin_drive
+      .clone()
+      .evaluate_identifier(
+        parser,
+        &info.name,
+        member.span.real_lo(),
+        member.span.hi().0,
+      )
+      .or_else(|| {
+        // TODO: fallback with `evaluateDefinedIdentifier`
+        let mut eval =
+          BasicEvaluatedExpression::with_range(member.span.real_lo(), member.span.hi().0);
+        eval.set_identifier(
+          info.name,
+          info.root_info,
+          Some(info.members),
+          Some(info.members_optionals),
+          Some(info.member_ranges),
+        );
+        Some(eval)
+      })
+  } else {
+    None
+  };
+  parser.member_expr_in_optional_chain = false;
+  ret
+}

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -3,6 +3,7 @@ mod eval_binary_expr;
 mod eval_call_expr;
 mod eval_cond_expr;
 mod eval_lit_expr;
+mod eval_member_expr;
 mod eval_new_expr;
 mod eval_source;
 mod eval_tpl_expr;
@@ -11,12 +12,15 @@ mod eval_unary_expr;
 use bitflags::bitflags;
 use num_bigint::BigInt;
 use rspack_core::DependencyLocation;
+use swc_core::atoms::Atom;
+use swc_core::common::Span;
 
 pub use self::eval_array_expr::eval_array_expression;
 pub use self::eval_binary_expr::eval_binary_expression;
 pub use self::eval_call_expr::eval_call_expression;
 pub use self::eval_cond_expr::eval_cond_expression;
 pub use self::eval_lit_expr::{eval_lit_expr, eval_prop_name};
+pub use self::eval_member_expr::eval_member_expression;
 pub use self::eval_new_expr::eval_new_expression;
 pub use self::eval_source::eval_source;
 pub use self::eval_tpl_expr::{
@@ -68,6 +72,9 @@ pub struct BasicEvaluatedExpression {
   regexp: Option<Regexp>,
   identifier: Option<String>,
   root_info: Option<ExportedVariableInfo>,
+  members: Option<Vec<Atom>>,
+  members_optionals: Option<Vec<bool>>,
+  member_ranges: Option<Vec<Span>>,
   items: Option<Vec<BasicEvaluatedExpression>>,
   quasis: Option<Vec<BasicEvaluatedExpression>>,
   parts: Option<Vec<BasicEvaluatedExpression>>,
@@ -102,6 +109,9 @@ impl BasicEvaluatedExpression {
       parts: None,
       identifier: None,
       root_info: None,
+      members: None,
+      members_optionals: None,
+      member_ranges: None,
       template_string_kind: None,
       options: None,
       string: None,
@@ -380,10 +390,20 @@ impl BasicEvaluatedExpression {
     }
   }
 
-  pub fn set_identifier(&mut self, name: String, root_info: ExportedVariableInfo) {
+  pub fn set_identifier(
+    &mut self,
+    name: String,
+    root_info: ExportedVariableInfo,
+    members: Option<Vec<Atom>>,
+    members_optionals: Option<Vec<bool>>,
+    member_ranges: Option<Vec<Span>>,
+  ) {
     self.ty = Ty::Identifier;
     self.identifier = Some(name);
     self.root_info = Some(root_info);
+    self.members = members;
+    self.members_optionals = members_optionals;
+    self.member_ranges = member_ranges;
     self.side_effects = true;
   }
 
@@ -439,7 +459,7 @@ impl BasicEvaluatedExpression {
     self.string.as_ref().expect("make sure string exist")
   }
 
-  pub fn identifier(&self) -> &String {
+  pub fn identifier(&self) -> &str {
     assert!(self.is_identifier());
     self
       .identifier
@@ -450,6 +470,21 @@ impl BasicEvaluatedExpression {
   pub fn root_info(&self) -> &ExportedVariableInfo {
     assert!(self.is_identifier());
     self.root_info.as_ref().expect("make sure identifier exist")
+  }
+
+  pub fn members(&self) -> Option<&Vec<Atom>> {
+    assert!(self.is_identifier());
+    self.members.as_ref()
+  }
+
+  pub fn members_optionals(&self) -> Option<&Vec<bool>> {
+    assert!(self.is_identifier());
+    self.members_optionals.as_ref()
+  }
+
+  pub fn member_ranges(&self) -> Option<&Vec<Span>> {
+    assert!(self.is_identifier());
+    self.member_ranges.as_ref()
   }
 
   pub fn regexp(&self) -> &Regexp {
@@ -531,7 +566,13 @@ pub fn evaluate_to_identifier(
   end: u32,
 ) -> BasicEvaluatedExpression {
   let mut eval = BasicEvaluatedExpression::with_range(start, end);
-  eval.set_identifier(identifier, ExportedVariableInfo::Name(root_info));
+  eval.set_identifier(
+    identifier,
+    ExportedVariableInfo::Name(root_info),
+    None,
+    None,
+    None,
+  );
   eval.set_side_effects(false);
   match truthy {
     Some(v) => {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -17,7 +17,9 @@ use swc_core::ecma::atoms::Atom;
 
 pub use self::context_dependency_helper::create_context_dependency;
 pub use self::context_helper::{scanner_context_module, ContextModuleScanResult};
-pub use self::parser::{CallExpressionInfo, CallHooksName, ExportedVariableInfo, PathIgnoredSpans};
+pub use self::parser::{
+  AllowedMemberTypes, CallExpressionInfo, CallHooksName, ExportedVariableInfo, PathIgnoredSpans,
+};
 pub use self::parser::{JavascriptParser, MemberExpressionInfo, TagInfoData, TopLevelScope};
 pub use self::util::*;
 use crate::dependency::Specifier;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
@@ -7,15 +7,15 @@ use crate::visitors::scope_info::{FreeName, VariableInfoId};
 /// webpack use HookMap and filter at callHooksForName/callHooksForInfo
 /// we need to pass the name to hook to filter in the hook
 pub trait CallHooksName {
-  fn call_hooks_name<F>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<bool>
+  fn call_hooks_name<F, T>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<T>
   where
-    F: Fn(&mut JavascriptParser, &str) -> Option<bool>;
+    F: Fn(&mut JavascriptParser, &str) -> Option<T>;
 }
 
 impl CallHooksName for &str {
-  fn call_hooks_name<F>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<bool>
+  fn call_hooks_name<F, T>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<T>
   where
-    F: Fn(&mut JavascriptParser, &str) -> Option<bool>,
+    F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
     if let Some(id) = parser
       .get_variable_info(self.as_ref())
@@ -31,31 +31,31 @@ impl CallHooksName for &str {
 }
 
 impl CallHooksName for String {
-  fn call_hooks_name<'parser, F>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<bool>
+  fn call_hooks_name<'parser, F, T>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<T>
   where
-    F: Fn(&mut JavascriptParser, &str) -> Option<bool>,
+    F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
     self.as_str().call_hooks_name(parser, hook_call)
   }
 }
 
 impl CallHooksName for Atom {
-  fn call_hooks_name<'parser, F>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<bool>
+  fn call_hooks_name<'parser, F, T>(&self, parser: &mut JavascriptParser, hook_call: F) -> Option<T>
   where
-    F: Fn(&mut JavascriptParser, &str) -> Option<bool>,
+    F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
     self.as_str().call_hooks_name(parser, hook_call)
   }
 }
 
 impl CallHooksName for ExportedVariableInfo {
-  fn call_hooks_name<'parser, F>(
+  fn call_hooks_name<'parser, F, T>(
     &self,
     parser: &mut JavascriptParser,
     hooks_call: F,
-  ) -> Option<bool>
+  ) -> Option<T>
   where
-    F: Fn(&mut JavascriptParser, &str) -> Option<bool>,
+    F: Fn(&mut JavascriptParser, &str) -> Option<T>,
   {
     match self {
       ExportedVariableInfo::Name(n) => n.call_hooks_name(parser, hooks_call),
@@ -64,16 +64,16 @@ impl CallHooksName for ExportedVariableInfo {
   }
 }
 
-fn call_hooks_info<F>(
+fn call_hooks_info<F, T>(
   id: VariableInfoId,
   parser: &mut JavascriptParser,
   hook_call: F,
-) -> Option<bool>
+) -> Option<T>
 where
-  F: Fn(&mut JavascriptParser, &str) -> Option<bool>,
+  F: Fn(&mut JavascriptParser, &str) -> Option<T>,
 {
   // avoid ownership
-  let mut for_name_list = Vec::with_capacity(32);
+  let mut for_name_list = Vec::new();
   let info = parser.definitions_db.expect_get_variable(&id);
   let mut next_tag_info = info.tag_info.as_ref();
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -36,9 +36,9 @@ use crate::visitors::scope_info::{
   FreeName, ScopeInfoDB, ScopeInfoId, TagInfo, TagInfoId, VariableInfo, VariableInfoId,
 };
 
-pub trait TagInfoData: Clone {
-  fn serialize(data: &Self) -> serde_json::Value;
-  fn deserialize(value: serde_json::Value) -> Self;
+pub trait TagInfoData {
+  fn into_any(data: Self) -> Box<dyn anymap::CloneAny>;
+  fn downcast(any: Box<dyn anymap::CloneAny>) -> Self;
 }
 
 #[derive(Debug)]
@@ -502,7 +502,7 @@ impl<'parser> JavascriptParser<'parser> {
     tag: &'static str,
     data: Option<Data>,
   ) {
-    let data = data.as_ref().map(|data| TagInfoData::serialize(data));
+    let data = data.map(|data| TagInfoData::into_any(data));
     let new_info = if let Some(old_info_id) = self.definitions_db.get(&self.definitions, &name) {
       let old_info = self.definitions_db.expect_get_variable(&old_info_id);
       if let Some(old_tag_info) = old_info.tag_info {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -23,16 +23,17 @@ use swc_core::common::util::take::Take;
 use swc_core::common::{BytePos, SourceFile, Span, Spanned};
 use swc_core::ecma::ast::{
   ArrayPat, AssignPat, AssignTargetPat, CallExpr, Callee, MetaPropExpr, MetaPropKind, ObjectPat,
-  ObjectPatProp, Pat, Program, Stmt, ThisExpr,
+  ObjectPatProp, OptCall, OptChainBase, OptChainExpr, Pat, Program, Stmt, ThisExpr,
 };
 use swc_core::ecma::ast::{Expr, Ident, Lit, MemberExpr, RestPat};
+use swc_core::ecma::utils::ExprFactory;
 
 use super::ExtraSpanInfo;
 use super::ImportMap;
 use crate::parser_plugin::{self, JavaScriptParserPluginDrive, JavascriptParserPlugin};
 use crate::utils::eval::{self, BasicEvaluatedExpression};
 use crate::visitors::scope_info::{
-  FreeName, ScopeInfoDB, ScopeInfoId, TagInfo, VariableInfo, VariableInfoId,
+  FreeName, ScopeInfoDB, ScopeInfoId, TagInfo, TagInfoId, VariableInfo, VariableInfoId,
 };
 
 pub trait TagInfoData: Clone {
@@ -44,6 +45,7 @@ pub trait TagInfoData: Clone {
 pub struct ExtractedMemberExpressionChainData {
   object: Expr,
   members: Vec<Atom>,
+  members_optionals: Vec<bool>,
   member_ranges: Vec<Span>,
 }
 
@@ -66,12 +68,18 @@ pub struct CallExpressionInfo {
   pub call: CallExpr,
   pub callee_name: String,
   pub root_info: ExportedVariableInfo,
+  pub members: Vec<Atom>,
+  pub members_optionals: Vec<bool>,
+  pub member_ranges: Vec<Span>,
 }
 
 #[derive(Debug)]
 pub struct ExpressionExpressionInfo {
   pub name: String,
   pub root_info: ExportedVariableInfo,
+  pub members: Vec<Atom>,
+  pub members_optionals: Vec<bool>,
+  pub member_ranges: Vec<Span>,
 }
 
 #[derive(Debug, Clone)]
@@ -236,6 +244,7 @@ pub struct JavascriptParser<'parser> {
   pub(crate) enter_new_expr: bool,
   // TODO: delete `enter_callee`
   pub(crate) enter_callee: bool,
+  pub(crate) member_expr_in_optional_chain: bool,
   pub(crate) stmt_level: u32,
   pub(crate) last_stmt_is_expr_stmt: bool,
   // TODO: delete `properties_in_destructuring`
@@ -246,6 +255,7 @@ pub struct JavascriptParser<'parser> {
   // TODO: Used as a way to skip AST visits in `InnerGraphPlugin`,
   // which does not follow ParserPlugin's AST skipping in const plugin.
   pub(crate) path_ignored_spans: &'parser mut PathIgnoredSpans,
+  pub(crate) current_tag_info: Option<TagInfoId>,
   // ===== scope info =======
   pub(crate) in_try: bool,
   pub(crate) in_short_hand: bool,
@@ -393,9 +403,11 @@ impl<'parser> JavascriptParser<'parser> {
       rewrite_usage_span,
       enter_new_expr: false,
       enter_callee: false,
+      member_expr_in_optional_chain: false,
       properties_in_destructuring: Default::default(),
       semicolons,
       statement_path: Default::default(),
+      current_tag_info: None,
       prev_statement: None,
       path_ignored_spans,
     }
@@ -461,7 +473,7 @@ impl<'parser> JavascriptParser<'parser> {
     {
       return;
     }
-    let info = VariableInfo::new(definitions, None, None);
+    let info = VariableInfo::create(&mut self.definitions_db, definitions, None, None);
     self.definitions_db.set(definitions, name, info);
   }
 
@@ -470,7 +482,12 @@ impl<'parser> JavascriptParser<'parser> {
     if name == variable {
       self.definitions_db.delete(id, &name);
     } else {
-      let variable = VariableInfo::new(id, Some(FreeName::String(variable)), None);
+      let variable = VariableInfo::create(
+        &mut self.definitions_db,
+        id,
+        Some(FreeName::String(variable)),
+        None,
+      );
       self.definitions_db.set(id, name, variable);
     }
   }
@@ -488,33 +505,42 @@ impl<'parser> JavascriptParser<'parser> {
     let data = data.as_ref().map(|data| TagInfoData::serialize(data));
     let new_info = if let Some(old_info_id) = self.definitions_db.get(&self.definitions, &name) {
       let old_info = self.definitions_db.expect_get_variable(&old_info_id);
-      if let Some(old_tag_info) = &old_info.tag_info {
+      if let Some(old_tag_info) = old_info.tag_info {
+        let declared_scope = old_info.declared_scope;
         // FIXME: remove `.clone`
         let free_name = old_info.free_name.clone();
-        let tag_info = Some(TagInfo {
+        let tag_info = Some(TagInfo::create(
+          &mut self.definitions_db,
           tag,
           data,
-          // FIXME: remove `.clone`
-          next: Some(Box::new(old_tag_info.clone())),
-        });
-        VariableInfo::new(old_info.declared_scope, free_name, tag_info)
+          Some(old_tag_info),
+        ));
+        VariableInfo::create(
+          &mut self.definitions_db,
+          declared_scope,
+          free_name,
+          tag_info,
+        )
       } else {
+        let declared_scope = old_info.declared_scope;
         let free_name = Some(FreeName::True);
-        let tag_info = Some(TagInfo {
-          tag,
-          data,
-          next: None,
-        });
-        VariableInfo::new(old_info.declared_scope, free_name, tag_info)
+        let tag_info = Some(TagInfo::create(&mut self.definitions_db, tag, data, None));
+        VariableInfo::create(
+          &mut self.definitions_db,
+          declared_scope,
+          free_name,
+          tag_info,
+        )
       }
     } else {
       let free_name = Some(FreeName::String(name.clone()));
-      let tag_info = Some(TagInfo {
-        tag,
-        data,
-        next: None,
-      });
-      VariableInfo::new(self.definitions, free_name, tag_info)
+      let tag_info = Some(TagInfo::create(&mut self.definitions_db, tag, data, None));
+      VariableInfo::create(
+        &mut self.definitions_db,
+        self.definitions,
+        free_name,
+        tag_info,
+      )
     };
     self.definitions_db.set(self.definitions, name, new_info);
   }
@@ -522,8 +548,9 @@ impl<'parser> JavascriptParser<'parser> {
   fn _get_member_expression_info(
     &mut self,
     object: Expr,
-    members: Vec<Atom>,
-    _members_range: Vec<Span>,
+    mut members: Vec<Atom>,
+    mut members_optionals: Vec<bool>,
+    mut member_ranges: Vec<Span>,
     allowed_types: AllowedMemberTypes,
   ) -> Option<MemberExpressionInfo> {
     match object {
@@ -542,12 +569,18 @@ impl<'parser> JavascriptParser<'parser> {
           return None;
         };
         let callee_name = object_and_members_to_name(resolved_root, &members);
+        members.reverse();
+        members_optionals.reverse();
+        member_ranges.reverse();
         Some(MemberExpressionInfo::Call(CallExpressionInfo {
           call: expr,
           callee_name,
           root_info: root_info
             .map(|i| ExportedVariableInfo::VariableInfo(i.id()))
             .unwrap_or_else(|| ExportedVariableInfo::Name(root_name.to_string())),
+          members,
+          members_optionals,
+          member_ranges,
         }))
       }
       Expr::MetaProp(_) | Expr::Ident(_) | Expr::This(_) => {
@@ -565,11 +598,17 @@ impl<'parser> JavascriptParser<'parser> {
           return None;
         };
         let name = object_and_members_to_name(resolved_root, &members);
+        members.reverse();
+        members_optionals.reverse();
+        member_ranges.reverse();
         Some(MemberExpressionInfo::Expression(ExpressionExpressionInfo {
           name,
           root_info: root_info
             .map(|i| ExportedVariableInfo::VariableInfo(i.id()))
             .unwrap_or_else(|| ExportedVariableInfo::Name(root_name.to_string())),
+          members,
+          members_optionals,
+          member_ranges,
         }))
       }
       _ => None,
@@ -584,10 +623,12 @@ impl<'parser> JavascriptParser<'parser> {
     expr
       .as_member()
       .and_then(|member| self.get_member_expression_info(member, allowed_types))
-      .or_else(|| self._get_member_expression_info(expr.clone(), vec![], vec![], allowed_types))
+      .or_else(|| {
+        self._get_member_expression_info(expr.clone(), vec![], vec![], vec![], allowed_types)
+      })
   }
 
-  fn get_member_expression_info(
+  pub fn get_member_expression_info(
     &mut self,
     expr: &MemberExpr,
     allowed_types: AllowedMemberTypes,
@@ -595,42 +636,69 @@ impl<'parser> JavascriptParser<'parser> {
     let ExtractedMemberExpressionChainData {
       object,
       members,
+      members_optionals,
       member_ranges,
-    } = Self::extract_member_expression_chain(expr);
-    self._get_member_expression_info(object, members, member_ranges, allowed_types)
+    } = self.extract_member_expression_chain(expr);
+    self._get_member_expression_info(
+      object,
+      members,
+      members_optionals,
+      member_ranges,
+      allowed_types,
+    )
   }
 
-  fn extract_member_expression_chain(expr: &MemberExpr) -> ExtractedMemberExpressionChainData {
+  fn extract_member_expression_chain(
+    &self,
+    expr: &MemberExpr,
+  ) -> ExtractedMemberExpressionChainData {
     let mut object = Expr::Member(expr.clone());
     let mut members = Vec::new();
+    let mut members_optionals = Vec::new();
     let mut member_ranges = Vec::new();
-    while let Some(expr) = object.as_mut_member() {
-      if let Some(computed) = expr.prop.as_computed() {
-        let Expr::Lit(lit) = &*computed.expr else {
-          break;
-        };
-        let value = match lit {
-          Lit::Str(s) => s.value.clone(),
-          Lit::Bool(b) => if b.value { "true" } else { "false" }.into(),
-          Lit::Null(_) => "null".into(),
-          Lit::Num(n) => n.value.to_string().into(),
-          Lit::BigInt(i) => i.value.to_string().into(),
-          Lit::Regex(r) => r.exp.clone(),
-          Lit::JSXText(_) => unreachable!(),
-        };
-        members.push(value);
-        member_ranges.push(expr.obj.span());
-      } else if let Some(ident) = expr.prop.as_ident() {
-        members.push(ident.sym.clone());
-        member_ranges.push(expr.obj.span());
-      } else {
-        break;
+    let mut in_optional_chain = self.member_expr_in_optional_chain;
+    loop {
+      match &mut object {
+        Expr::Member(expr) => {
+          if let Some(computed) = expr.prop.as_computed() {
+            let Expr::Lit(lit) = &*computed.expr else {
+              break;
+            };
+            let value = match lit {
+              Lit::Str(s) => s.value.clone(),
+              Lit::Bool(b) => if b.value { "true" } else { "false" }.into(),
+              Lit::Null(_) => "null".into(),
+              Lit::Num(n) => n.value.to_string().into(),
+              Lit::BigInt(i) => i.value.to_string().into(),
+              Lit::Regex(r) => r.exp.clone(),
+              Lit::JSXText(_) => unreachable!(),
+            };
+            members.push(value);
+            member_ranges.push(expr.obj.span());
+          } else if let Some(ident) = expr.prop.as_ident() {
+            members.push(ident.sym.clone());
+            member_ranges.push(expr.obj.span());
+          } else {
+            break;
+          }
+          members_optionals.push(in_optional_chain);
+          object = *expr.obj.take();
+        }
+        Expr::OptChain(expr) => {
+          in_optional_chain = expr.optional;
+          if let OptChainBase::Member(member) = &mut *expr.base {
+            object = Expr::Member(member.take());
+          } else {
+            break;
+          }
+        }
+        _ => break,
       }
-      object = *expr.obj.take();
     }
     ExtractedMemberExpressionChainData {
       object,
       members,
+      members_optionals,
       member_ranges,
     }
   }
@@ -717,6 +785,28 @@ impl<'parser> JavascriptParser<'parser> {
     }
   }
 
+  fn enter_optional_chain<C, M, R>(&mut self, expr: &OptChainExpr, on_call: C, on_member: M) -> R
+  where
+    C: FnOnce(&mut Self, &OptCall) -> R,
+    M: FnOnce(&mut Self, &MemberExpr) -> R,
+  {
+    let member_expr_in_optional_chain = self.member_expr_in_optional_chain;
+    let ret = match &*expr.base {
+      OptChainBase::Call(call) => {
+        if call.callee.is_member() {
+          self.member_expr_in_optional_chain = expr.optional;
+        }
+        on_call(self, call)
+      }
+      OptChainBase::Member(member) => {
+        self.member_expr_in_optional_chain = expr.optional;
+        on_member(self, member)
+      }
+    };
+    self.member_expr_in_optional_chain = member_expr_in_optional_chain;
+    ret
+  }
+
   pub fn walk_program(&mut self, ast: &Program) {
     if self.plugin_drive.clone().program(self, ast).is_none() {
       match ast {
@@ -800,25 +890,22 @@ impl<'parser> JavascriptParser<'parser> {
       Expr::New(new) => eval::eval_new_expression(self, new),
       Expr::Call(call) => eval::eval_call_expression(self, call),
       Expr::Paren(paren) => self.evaluating(&paren.expr),
-      Expr::Member(member) => {
-        if let Some(MemberExpressionInfo::Expression(info)) =
-          self.get_member_expression_info(member, AllowedMemberTypes::Expression)
-        {
-          self
-            .plugin_drive
-            .clone()
-            .evaluate_identifier(self, &info.name, member.span.real_lo(), member.span.hi().0)
-            .or_else(|| {
-              // TODO: fallback with `evaluateDefinedIdentifier`
-              let mut eval =
-                BasicEvaluatedExpression::with_range(member.span.real_lo(), member.span.hi().0);
-              eval.set_identifier(info.name, info.root_info);
-              Some(eval)
-            })
-        } else {
-          None
-        }
-      }
+      Expr::OptChain(opt_chain) => self.enter_optional_chain(
+        opt_chain,
+        |parser, call| {
+          eval::eval_call_expression(
+            parser,
+            &CallExpr {
+              span: call.span,
+              callee: call.callee.clone().as_callee(),
+              args: call.args.clone(),
+              type_args: None,
+            },
+          )
+        },
+        |parser, member| eval::eval_member_expression(parser, member),
+      ),
+      Expr::Member(member) => eval::eval_member_expression(self, member),
       Expr::Ident(ident) => {
         let name = &ident.sym;
         if name.eq("undefined") {
@@ -841,6 +928,9 @@ impl<'parser> JavascriptParser<'parser> {
                 eval.set_identifier(
                   ident.sym.to_string(),
                   ExportedVariableInfo::VariableInfo(info.id()),
+                  None,
+                  None,
+                  None,
                 );
                 Some(eval)
               } else {
@@ -852,6 +942,9 @@ impl<'parser> JavascriptParser<'parser> {
               eval.set_identifier(
                 ident.sym.to_string(),
                 ExportedVariableInfo::Name(name.to_string()),
+                None,
+                None,
+                None,
               );
               Some(eval)
             }
@@ -864,6 +957,9 @@ impl<'parser> JavascriptParser<'parser> {
           eval.set_identifier(
             "this".to_string(),
             ExportedVariableInfo::Name("this".to_string()),
+            None,
+            None,
+            None,
           );
           Some(eval)
         };

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
@@ -143,29 +143,33 @@ impl<'parser> JavascriptParser<'parser> {
     for specifier in &decl.specifiers {
       match specifier {
         ImportSpecifier::Named(named) => {
-          let identifier_name = named.local.sym.as_str();
-          let export_name = named.imported.as_ref().map(|imported| match imported {
-            ModuleExportName::Ident(ident) => ident.sym.as_str(),
-            ModuleExportName::Str(s) => s.value.as_str(),
-          });
+          let identifier_name = &named.local.sym;
+          let export_name = named
+            .imported
+            .as_ref()
+            .map(|imported| match imported {
+              ModuleExportName::Ident(ident) => &ident.sym,
+              ModuleExportName::Str(s) => &s.value,
+            })
+            .unwrap_or_else(|| &named.local.sym);
           if drive
-            .import_specifier(self, decl, source, export_name, identifier_name)
+            .import_specifier(self, decl, source, Some(export_name), identifier_name)
             .unwrap_or_default()
           {
             self.define_variable(identifier_name.to_string())
           }
         }
         ImportSpecifier::Default(default) => {
-          let identifier_name = default.local.sym.as_str();
+          let identifier_name = &default.local.sym;
           if drive
-            .import_specifier(self, decl, source, Some("default"), identifier_name)
+            .import_specifier(self, decl, source, Some(&"default".into()), identifier_name)
             .unwrap_or_default()
           {
             self.define_variable(identifier_name.to_string())
           }
         }
         ImportSpecifier::Namespace(namespace) => {
-          let identifier_name = namespace.local.sym.as_str();
+          let identifier_name = &namespace.local.sym;
           if drive
             .import_specifier(self, decl, source, None, identifier_name)
             .unwrap_or_default()

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -22,6 +22,15 @@ impl VariableInfoId {
   }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TagInfoId(u32);
+
+impl TagInfoId {
+  fn init() -> TagInfoId {
+    TagInfoId(0)
+  }
+}
+
 #[derive(Debug)]
 pub struct VariableInfoDB {
   count: VariableInfoId,
@@ -41,13 +50,26 @@ impl VariableInfoDB {
       map: Default::default(),
     }
   }
+}
 
-  fn insert(&mut self, mut variable_info: VariableInfo) -> VariableInfoId {
-    let id = self.next();
-    variable_info.set_id(id);
-    let prev = self.map.insert(id, variable_info);
-    assert!(prev.is_none());
+#[derive(Debug)]
+pub struct TagInfoDB {
+  count: TagInfoId,
+  map: FxHashMap<TagInfoId, TagInfo>,
+}
+
+impl TagInfoDB {
+  fn next(&mut self) -> TagInfoId {
+    let id = self.count;
+    self.count.0 += 1;
     id
+  }
+
+  fn new() -> Self {
+    Self {
+      count: TagInfoId::init(),
+      map: Default::default(),
+    }
   }
 }
 
@@ -56,6 +78,7 @@ pub struct ScopeInfoDB {
   count: ScopeInfoId,
   map: FxHashMap<ScopeInfoId, ScopeInfo>,
   variable_info_db: VariableInfoDB,
+  tag_info_db: TagInfoDB,
 }
 
 impl Default for ScopeInfoDB {
@@ -76,6 +99,7 @@ impl ScopeInfoDB {
       count: ScopeInfoId::init(),
       map: Default::default(),
       variable_info_db: VariableInfoDB::new(),
+      tag_info_db: TagInfoDB::new(),
     }
   }
 
@@ -141,6 +165,22 @@ impl ScopeInfoDB {
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
+  pub fn expect_get_tag_info(&self, id: &TagInfoId) -> &TagInfo {
+    self
+      .tag_info_db
+      .map
+      .get(id)
+      .unwrap_or_else(|| panic!("{id:#?} should exist"))
+  }
+
+  pub fn expect_get_mut_tag_info(&mut self, id: &TagInfoId) -> &mut TagInfo {
+    self
+      .tag_info_db
+      .map
+      .get_mut(id)
+      .unwrap_or_else(|| panic!("{id:#?} should exist"))
+  }
+
   pub fn get<S: AsRef<str>>(&mut self, id: &ScopeInfoId, key: S) -> Option<VariableInfoId> {
     let definitions = self.expect_get_scope(id);
     if let Some(&top_value) = definitions.map.get(key.as_ref()) {
@@ -171,8 +211,7 @@ impl ScopeInfoDB {
     }
   }
 
-  pub fn set(&mut self, id: ScopeInfoId, key: String, info: VariableInfo) {
-    let variable_info_id = self.variable_info_db.insert(info);
+  pub fn set(&mut self, id: ScopeInfoId, key: String, variable_info_id: VariableInfoId) {
     let scope = self.expect_get_mut_scope(&id);
     scope.map.insert(key, variable_info_id);
   }
@@ -191,9 +230,34 @@ impl ScopeInfoDB {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TagInfo {
+  id: TagInfoId,
   pub tag: &'static str,
   pub data: Option<serde_json::Value>,
-  pub next: Option<Box<TagInfo>>,
+  pub next: Option<TagInfoId>,
+}
+
+impl TagInfo {
+  pub fn create(
+    definitions_db: &mut ScopeInfoDB,
+    tag: &'static str,
+    data: Option<serde_json::Value>,
+    next: Option<TagInfoId>,
+  ) -> TagInfoId {
+    let id = definitions_db.tag_info_db.next();
+    let tag_info = TagInfo {
+      id,
+      tag,
+      data,
+      next,
+    };
+    let prev = definitions_db.tag_info_db.map.insert(id, tag_info);
+    assert!(prev.is_none());
+    id
+  }
+
+  pub fn id(&self) -> TagInfoId {
+    self.id
+  }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -204,37 +268,39 @@ pub enum FreeName {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct VariableInfo {
-  id: Option<VariableInfoId>,
+  id: VariableInfoId,
   pub declared_scope: ScopeInfoId,
   pub free_name: Option<FreeName>,
-  pub tag_info: Option<TagInfo>,
+  pub tag_info: Option<TagInfoId>,
 }
 
 impl VariableInfo {
   const TOMBSTONE: VariableInfoId = VariableInfoId(0);
   const UNDEFINED: VariableInfoId = VariableInfoId(1);
 
-  pub fn new(
+  pub fn create(
+    definitions_db: &mut ScopeInfoDB,
     declared_scope: ScopeInfoId,
     free_name: Option<FreeName>,
-    tag_info: Option<TagInfo>,
-  ) -> Self {
-    Self {
-      id: None,
+    tag_info: Option<TagInfoId>,
+  ) -> VariableInfoId {
+    let id = definitions_db.variable_info_db.next();
+    let variable_info = VariableInfo {
+      id,
       declared_scope,
       free_name,
       tag_info,
-    }
-  }
-
-  fn set_id(&mut self, id: VariableInfoId) {
-    self.id = Some(id);
+    };
+    let prev = definitions_db
+      .variable_info_db
+      .map
+      .insert(id, variable_info);
+    assert!(prev.is_none());
+    id
   }
 
   pub fn id(&self) -> VariableInfoId {
-    self
-      .id
-      .expect("should already store VariableInfo to VariableInfoDB")
+    self.id
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -228,11 +228,11 @@ impl ScopeInfoDB {
   }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug)]
 pub struct TagInfo {
   id: TagInfoId,
   pub tag: &'static str,
-  pub data: Option<serde_json::Value>,
+  pub data: Option<Box<dyn anymap::CloneAny>>,
   pub next: Option<TagInfoId>,
 }
 
@@ -240,7 +240,7 @@ impl TagInfo {
   pub fn create(
     definitions_db: &mut ScopeInfoDB,
     tag: &'static str,
-    data: Option<serde_json::Value>,
+    data: Option<Box<dyn anymap::CloneAny>>,
     next: Option<TagInfoId>,
   ) -> TagInfoId {
     let id = definitions_db.tag_info_db.next();

--- a/packages/rspack-test-tools/src/case/diff.ts
+++ b/packages/rspack-test-tools/src/case/diff.ts
@@ -154,7 +154,7 @@ function checkCompareResults(
 					.map(i => i.name)
 			).toEqual([]);
 		});
-		it("should not have any respack-only module", () => {
+		it("should not have any rspack-only module", () => {
 			expect(
 				getResults()
 					.filter(i => i.type === ECompareResultType.OnlySource)

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/rspack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/rspack.config.js
@@ -1,0 +1,52 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		a: "./src/a",
+		b: "./src/b",
+		c1: "./src/c",
+		c2: "./src/c",
+		ax: "./src/ax",
+		bx: "./src/bx",
+		cx1: "./src/cx",
+		cx2: "./src/cx",
+		d1: "./src/d1",
+		d2: "./src/d2"
+	},
+	target: "web",
+	mode: "production",
+	devtool: false,
+	output: {
+		filename: "[name].js",
+		library: { type: "commonjs-module" }
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		chunkIds: "named",
+		providedExports: true,
+		usedExports: true,
+		concatenateModules: false,
+		innerGraph: false,
+		splitChunks: {
+			cacheGroups: {
+				forceMerge: {
+					test: /shared/,
+					enforce: true,
+					name: "shared",
+					chunks: "all"
+				}
+			}
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /dep/,
+				sideEffects: false
+			}
+		]
+	},
+	experiments: {
+		topLevelAwait: true
+	}
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/a.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/a.js
@@ -1,0 +1,6 @@
+import { val, val2b } from "./shared";
+
+it("should have the correct value", () => {
+	expect(val).toBe(84);
+	expect(val2b).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/ax.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/ax.js
@@ -1,0 +1,6 @@
+import { val, val2b } from "./concatenated-shared";
+
+it("should have the correct value", () => {
+	expect(val).toBe(84);
+	expect(val2b).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/b.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/b.js
@@ -1,0 +1,8 @@
+import { other, val2c, Test } from "./shared";
+
+it("should have the correct value", () => {
+	expect(other).toBe("other");
+	expect(val2c).toBe(42);
+	expect(Test).toBeTypeOf("function");
+	expect(new Test()).toBeInstanceOf(Test);
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/bx.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/bx.js
@@ -1,0 +1,8 @@
+import { other, val2c, Test } from "./concatenated-shared";
+
+it("should have the correct value", () => {
+	expect(other).toBe("other");
+	expect(val2c).toBe(42);
+	expect(Test).toBeTypeOf("function");
+	expect(new Test()).toBeInstanceOf(Test);
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/c.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/c.js
@@ -1,0 +1,5 @@
+import { other } from "./shared";
+
+it("should have the correct value", () => {
+	expect(other).toBe("other");
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/concatenated-shared.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/concatenated-shared.js
@@ -1,0 +1,1 @@
+export * from "./shared?1";

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/cx.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/cx.js
@@ -1,0 +1,5 @@
+import { other } from "./concatenated-shared";
+
+it("should have the correct value", () => {
+	expect(other).toBe("other");
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/d1.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/d1.js
@@ -1,0 +1,6 @@
+import { value2, value3 } from "./shared2";
+
+it("should have the correct value", () => {
+	expect(value2).toBe(42);
+	expect(value3).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/d2.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/d2.js
@@ -1,0 +1,6 @@
+import { other2, value3 } from "./shared2";
+
+it("should have the correct value", () => {
+	expect(other2).toBe("other");
+	expect(value3).toBe(42);
+});

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep-shared3.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep-shared3.js
@@ -1,0 +1,4 @@
+import { setOther2 } from "./shared2";
+
+export default 42;
+setOther2("wrong");

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep-shared4.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep-shared4.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep2.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/dep2.js
@@ -1,0 +1,1 @@
+module.exports = 42;

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/shared.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/shared.js
@@ -1,0 +1,16 @@
+import value from "./dep";
+import value2 from "./dep2";
+import * as dep2 from "./dep2";
+import Super from "./super";
+
+const derived = value;
+
+export const val = /*#__PURE__*/ (() => value + derived)();
+
+export const val2a = value2;
+export const val2b = value2;
+export const val2c = value2;
+
+export const other = "other";
+
+export class Test extends Super {}

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/shared2.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/shared2.js
@@ -1,0 +1,12 @@
+import value from "./dep-shared3";
+import value4 from "./dep-shared4";
+
+export function setOther2(value) {
+	other2 = value;
+}
+
+export const value2 = value;
+export const value3 = value4;
+export var other2;
+
+if (other2 === undefined) other2 = "other";

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/super.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/src/super.js
@@ -1,0 +1,1 @@
+export default class Super {}

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/test.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/test.config.js
@@ -1,0 +1,18 @@
+/** @type {import("../../..").TDiffCaseConfig} */
+module.exports = {
+	modules: true,
+	runtimeModules: false,
+	files: [
+		"shared.js",
+		"a.js",
+		"b.js",
+		"c1.js",
+		"c2.js",
+		"ax.js",
+		"bx.js",
+		"cx1.js",
+		"cx2.js",
+		"d1.js",
+		"d2.js"
+	]
+};

--- a/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/webpack.config.js
+++ b/packages/rspack-test-tools/tests/runtimeDiffCases/module-interop/runtime-condition-no-inner-graph/webpack.config.js
@@ -1,0 +1,52 @@
+/** @type {import("webpack").Configuration} */
+module.exports = {
+	entry: {
+		a: "./src/a",
+		b: "./src/b",
+		c1: "./src/c",
+		c2: "./src/c",
+		ax: "./src/ax",
+		bx: "./src/bx",
+		cx1: "./src/cx",
+		cx2: "./src/cx",
+		d1: "./src/d1",
+		d2: "./src/d2"
+	},
+	target: "web",
+	mode: "production",
+	devtool: false,
+	output: {
+		filename: "[name].js",
+		library: { type: "commonjs-module" }
+	},
+	optimization: {
+		minimize: false,
+		moduleIds: "named",
+		chunkIds: "named",
+		providedExports: true,
+		usedExports: true,
+		concatenateModules: false,
+		innerGraph: false,
+		splitChunks: {
+			cacheGroups: {
+				forceMerge: {
+					test: /shared/,
+					enforce: true,
+					name: "shared",
+					chunks: "all"
+				}
+			}
+		}
+	},
+	module: {
+		rules: [
+			{
+				test: /dep/,
+				sideEffects: false
+			}
+		]
+	},
+	experiments: {
+		topLevelAwait: true
+	}
+};

--- a/webpack-test/configCases/graph/issue-11856.2/test.filter.js
+++ b/webpack-test/configCases/graph/issue-11856.2/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}

--- a/webpack-test/configCases/graph/issue-11856/test.filter.js
+++ b/webpack-test/configCases/graph/issue-11856/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}

--- a/webpack-test/configCases/graph/issue-11863/test.filter.js
+++ b/webpack-test/configCases/graph/issue-11863/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- add diff test for runtime condition (`innerGraph: false`, will enable it once innerGraphVisitor is refactored to parser plugin)
- refactor harmony import dependency parser plugin, fix an issue which cause the above added test failed
  - other parser plugin also need to refactor, currently there are so many additional state exist just for workaround (and I hate workaround...

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
