### PR TITLE
fix: add `strict: true` to RawModule

### DIFF
--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -117,6 +117,7 @@ impl Module for RawModule {
       build_info: BuildInfo {
         hash: Some(hasher.digest(&build_context.compiler_options.output.hash_digest)),
         cacheable: true,
+        strict: true,
         ..Default::default()
       },
       dependencies: vec![],

--- a/packages/rspack-test-tools/tests/configCases/ignore/concatenated-strict/ignored-module.js
+++ b/packages/rspack-test-tools/tests/configCases/ignore/concatenated-strict/ignored-module.js
@@ -1,0 +1,1 @@
+module.exports = "ignored";

--- a/packages/rspack-test-tools/tests/configCases/ignore/concatenated-strict/index.mjs
+++ b/packages/rspack-test-tools/tests/configCases/ignore/concatenated-strict/index.mjs
@@ -1,0 +1,13 @@
+/** @type {import('fs')} */
+const fs = __non_webpack_require__("fs");
+
+import ignored from "./ignored-module";
+
+it("should startsWith use strict", function () {
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source.length).not.toBe(0);
+	expect(ignored).toEqual({});
+	expect(
+		source.startsWith('"use strict"') || source.startsWith("'use strict'")
+	).toBeTruthy();
+});

--- a/packages/rspack-test-tools/tests/configCases/ignore/concatenated-strict/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/ignore/concatenated-strict/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.mjs",
+	resolve: {
+		alias: {
+			"./ignored-module": false
+		}
+	},
+	output: {
+		iife: false
+	},
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/ignore/strict/ignored-module.js
+++ b/packages/rspack-test-tools/tests/configCases/ignore/strict/ignored-module.js
@@ -1,0 +1,1 @@
+module.exports = "ignored";

--- a/packages/rspack-test-tools/tests/configCases/ignore/strict/index.mjs
+++ b/packages/rspack-test-tools/tests/configCases/ignore/strict/index.mjs
@@ -1,0 +1,13 @@
+/** @type {import('fs')} */
+const fs = __non_webpack_require__("fs");
+
+import ignored from "./ignored-module";
+
+it("should startsWith use strict", function () {
+	const source = fs.readFileSync(__filename, "utf-8");
+	expect(source.length).not.toBe(0);
+	expect(ignored).toEqual({});
+	expect(
+		source.startsWith('"use strict"') || source.startsWith("'use strict'")
+	).toBeTruthy();
+});

--- a/packages/rspack-test-tools/tests/configCases/ignore/strict/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/ignore/strict/rspack.config.js
@@ -1,0 +1,12 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.mjs",
+	resolve: {
+		alias: {
+			"./ignored-module": false
+		}
+	},
+	output: {
+		iife: false
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Add `strict: true` to RawModule.

This prevents the ignored modules from being non-strict and makes the entry module wrapped in an IIFE.

Also see: https://github.com/webpack/webpack/discussions/18367#discussion-6580398

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
