### PR TITLE
fix: Add `in_function_scope` for walking method function

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -594,8 +594,13 @@ impl<'parser> JavascriptParser<'parser> {
         self.walk_prop_name(&method.key);
         let was_top_level = self.top_level_scope;
         self.top_level_scope = TopLevelScope::False;
-        // FIXME: maybe we need in_function_scope here
-        self.walk_function(&method.function);
+        self.in_function_scope(
+          true,
+          method.function.params.iter().map(|p| Cow::Borrowed(&p.pat)),
+          |parser| {
+            parser.walk_function(&method.function);
+          },
+        );
         self.top_level_scope = was_top_level;
       }
     }

--- a/packages/rspack-test-tools/tests/normalCases/parsing/method-function-in-scope/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/method-function-in-scope/index.js
@@ -1,0 +1,17 @@
+import { f as a } from "./utils";
+
+function g() {
+  return {
+    f1() {
+      var a = 2;
+      return a;
+    },
+    f2() {
+      return a();
+    },
+  };
+}
+
+it("a should refer to f in utils.js", () => {
+  expect(g().f2()).toBe(1);
+});

--- a/packages/rspack-test-tools/tests/normalCases/parsing/method-function-in-scope/utils.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/method-function-in-scope/utils.js
@@ -1,0 +1,3 @@
+export function f() {
+  return 1;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

closes https://github.com/web-infra-dev/rspack/issues/6648.

Maybe some test cases need to be added but I can't find where to add them.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

```ts
import { f1 as a } from "./utils";

function authExchange() {
  return {
    mutate() {
      var a = 1;
      return a + 1;
    },
    appendHeaders() {
      return a();
    },
  };
}
```

In this case, if there is no `in_function_scope` for method functions, the variable declaration `var a = 1` will be defined in the scope of the `authExchange` function. When walking `a` identifier in `appendHeaders`, the `a` defined in mutate will be found first. Then, during code generation, the `a` in `appendHeaders` will not be recognized as an import specifier and will not be replaced with harmony import.

This change is aligned with webpack https://github.com/webpack/webpack/blob/941d3a6017cec12545118da2c2048a5449394d27/lib/javascript/JavascriptParser.js#L3059, where the ast node type of method declaration is function expression.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
