### PR TITLE
perf: put visited_chunk_group_keys out of the loop and use FxHashMap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,6 +3279,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/crates/rspack_plugin_ensure_chunk_conditions/Cargo.toml
+++ b/crates/rspack_plugin_ensure_chunk_conditions/Cargo.toml
@@ -11,3 +11,4 @@ version    = "0.1.0"
 rspack_core  = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 rspack_hook  = { path = "../rspack_hook" }
+rustc-hash   = { workspace = true }


### PR DESCRIPTION
Internal project performance improvement.

Before:

```
LOG from rspack.EnsureChunkConditionsPlugin
<t> ensure chunk conditions: 11436 ms
```

After:

```
LOG from rspack.EnsureChunkConditionsPlugin
<t> ensure chunk conditions: 3463 ms
```

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
