### PR TITLE
ci: use @pnpm/exe in Node 16 CI

### DIFF
--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: pnpm/action-setup@v2
       with:
         dest: ${{ runner.tool_cache }}/pnpm
+        # Use `@pnpm/exe` for Node 16
         standalone: ${{ inputs.node-version == '16' }}
 
     - name: Get pnpm store directory

--- a/.github/actions/pnpm-cache/action.yml
+++ b/.github/actions/pnpm-cache/action.yml
@@ -30,6 +30,7 @@ runs:
       uses: pnpm/action-setup@v2
       with:
         dest: ${{ runner.tool_cache }}/pnpm
+        standalone: ${{ inputs.node-version == '16' }}
 
     - name: Get pnpm store directory
       id: pnpm-cache

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -235,7 +235,7 @@ jobs:
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
-        node: ${{ fromJSON(contains(inputs.target, 'linux') && github.ref_name == 'main' && '[18, 20]' || '[18]' )}}
+        node: ${{ fromJSON(contains(inputs.target, 'linux') && github.ref_name == 'main' && '[16, 18, 20]' || '[16, 18]' )}}
     name: Test Node ${{ matrix.node }}
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -235,7 +235,7 @@ jobs:
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
-        node: ${{ fromJSON(contains(inputs.target, 'linux') && github.ref_name == 'main' && '[16, 18, 20]' || '[18]' )}}
+        node: ${{ fromJSON(contains(inputs.target, 'linux') && github.ref_name == 'main' && '[18, 20]' || '[18]' )}}
     name: Test Node ${{ matrix.node }}
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -235,7 +235,7 @@ jobs:
     strategy:
       fail-fast: false # Build and test everything so we can look at all the errors
       matrix:
-        node: ${{ fromJSON(contains(inputs.target, 'linux') && github.ref_name == 'main' && '[16, 18, 20]' || '[16, 18]' )}}
+        node: ${{ fromJSON(contains(inputs.target, 'linux') && github.ref_name == 'main' && '[16, 18, 20]' || '[18]' )}}
     name: Test Node ${{ matrix.node }}
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: true


### PR DESCRIPTION
## Summary

pnpm v9 no longer supports Node 16 (https://github.com/web-infra-dev/rspack/pull/6767)

We can use the [standalone](https://github.com/pnpm/action-setup?tab=readme-ov-file#standalone) option to use `@pnpm/exe` in Node 16 CI.

- Node 16:

![image](https://github.com/web-infra-dev/rspack/assets/7237365/001ce31d-66ce-411d-a339-00bfc75b361f)

- Node 18:

![image](https://github.com/web-infra-dev/rspack/assets/7237365/bcce60e4-79e7-487b-bf6f-61479d2d1d1a)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
