### PR TITLE
feat: use warning for css parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "css-module-lexer"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1c26dfe1c30e8ac9cad7da57e3f25ec432206ed787c570b0760332d622c00d"
+checksum = "56aab41e6e7074a2cc5b5606ebee14164eb107ed8aa931bf1487e898fe2df5f0"
 dependencies = [
  "smallvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ async-scoped       = { version = "0.9.0" }
 async-trait        = { version = "0.1.79" }
 bitflags           = { version = "2.5.0" }
 concat-string      = "1.0.1"
-css-module-lexer   = "0.0.12"
+css-module-lexer   = "0.0.13"
 dashmap            = { version = "5.5.3" }
 derivative         = { version = "2.2.0" }
 futures            = { version = "0.3.30" }

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -13,7 +13,9 @@ use rspack_core::{
   ParserAndGenerator, RuntimeSpec, SourceType, TemplateContext, UsageState,
 };
 use rspack_core::{ModuleInitFragments, RuntimeGlobals};
-use rspack_error::{miette::Diagnostic, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray};
+use rspack_error::{
+  miette::Diagnostic, IntoTWithDiagnosticArray, Result, Severity, TWithDiagnosticArray,
+};
 
 use crate::utils::export_locals_convention;
 use crate::utils::{css_modules_exports_to_string, LocalIdentOptions};
@@ -317,12 +319,19 @@ impl ParserAndGenerator for CssParserAndGenerator {
     }
     for warning in warnings {
       let range = warning.range();
-      diagnostics.push(Box::new(css_parsing_traceable_error(
+      let mut error = css_parsing_traceable_error(
         source_code.clone(),
         range.start,
         range.end,
         warning.to_string(),
-      )));
+      );
+      if !matches!(
+        warning.kind(),
+        css_module_lexer::WarningKind::NotPrecededAtImport
+      ) {
+        error = error.with_severity(Severity::Warn);
+      }
+      diagnostics.push(Box::new(error));
     }
 
     Ok(

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/at-import-in-the-middle/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/at-import-in-the-middle/stats.err
@@ -1,6 +1,6 @@
 ERROR in ./b.css
   × Module parse failed:
-  ╰─▶   × CSS parsing warning: Any '@import' rules must precede all other rules
+  ╰─▶   × CSS parsing error: Any '@import' rules must precede all other rules
          ╭─[3:1]
        3 │ }
        4 │
@@ -15,7 +15,7 @@ ERROR in ./b.css
 
 ERROR in ./c.css
   × Module parse failed:
-  ╰─▶   × CSS parsing warning: Any '@import' rules must precede all other rules
+  ╰─▶   × CSS parsing error: Any '@import' rules must precede all other rules
          ╭─[2:1]
        2 │   background: red;
        3 │ }
@@ -30,7 +30,7 @@ ERROR in ./c.css
 
 ERROR in ./c.css
   × Module parse failed:
-  ╰─▶   × CSS parsing warning: Any '@import' rules must precede all other rules
+  ╰─▶   × CSS parsing error: Any '@import' rules must precede all other rules
          ╭─[3:1]
        3 │ }
        4 │ @import "./a.css";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/invalid-css-local-class/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/invalid-css-local-class/index.js
@@ -1,0 +1,2 @@
+import * as styles from "./index.module.css"
+styles;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/invalid-css-local-class/index.module.css
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/invalid-css-local-class/index.module.css
@@ -1,0 +1,3 @@
+.a:not(.b:not(:global .c):local .d) {
+  color: red;
+}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/invalid-css-local-class/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/invalid-css-local-class/stats.err
@@ -1,0 +1,9 @@
+WARNING in ./index.module.css
+  ⚠ Module parse warning:
+  ╰─▶   ⚠ CSS parsing warning: Missing leading whitespace
+         ╭─[1:1]
+       1 │ .a:not(.b:not(:global .c):local .d) {
+         ·                          ──────
+       2 │   color: red;
+       3 │ }
+         ╰────


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Only treat `Any '@import' rules must precede all other rules` as error, treat others as warning

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
