### PR TITLE
fix: panic when resolve failed and enable concatenateModule

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -487,10 +487,8 @@ impl DependencyTemplate for HarmonyImportSideEffectDependency {
     } = code_generatable_context;
     let module_graph = compilation.get_module_graph();
     if let Some(scope) = concatenation_scope {
-      let module = module_graph
-        .get_module_by_dependency_id(&self.id)
-        .expect("should have module");
-      if scope.is_module_in_scope(&module.identifier()) {
+      let module = module_graph.get_module_by_dependency_id(&self.id);
+      if module.is_some_and(|m| scope.is_module_in_scope(&m.identifier())) {
         return;
       }
     }

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/index.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/index.ts
@@ -1,0 +1,4 @@
+import { foo } from './reexport';
+
+// should not panic at crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+foo;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/a.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/a.ts
@@ -1,0 +1,2 @@
+export * from "./b.js";
+export * from "./c.js";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/b.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/b.ts
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/c.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/c.ts
@@ -1,0 +1,1 @@
+export const c = 1;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/package.json
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "some-module",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./a.ts"
+    }
+  }
+}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/reexport.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/reexport.ts
@@ -1,0 +1,2 @@
+export * as foo from 'some-module';
+

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/rspack.config.js
@@ -3,10 +3,9 @@ module.exports = {
   mode: "production",
   entry: "./index.ts",
   resolve: {
-    extensions: [".tsx", ".ts", ".js"],
+    extensions: [".ts", ".js"],
   },
   optimization: {
-    minimize: true,
     concatenateModules: true,
   },
   module: {
@@ -16,13 +15,6 @@ module.exports = {
         loader: "builtin:swc-loader",
         options: {
           target: "es5",
-          jsc: {
-            externalHelpers: true,
-          },
-          env: {
-            mode: "usage",
-            coreJs: "3.37.1",
-          },
         },
         type: "javascript/auto",
       },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/rspack.config.js
@@ -1,0 +1,31 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: "production",
+  entry: "./index.ts",
+  resolve: {
+    extensions: [".tsx", ".ts", ".js"],
+  },
+  optimization: {
+    minimize: true,
+    concatenateModules: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(j|t)s$/,
+        loader: "builtin:swc-loader",
+        options: {
+          target: "es5",
+          jsc: {
+            externalHelpers: true,
+          },
+          env: {
+            mode: "usage",
+            coreJs: "3.37.1",
+          },
+        },
+        type: "javascript/auto",
+      },
+    ],
+  },
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/stats.err
@@ -1,0 +1,15 @@
+ERROR in ./node_modules/some-module/a.ts
+  × Resolve error: Can't resolve './b.js' in '<PROJECT_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module'
+   ╭─[1:1]
+ 1 │ export * from "./b.js";
+   ·               ────────
+ 2 │ export * from "./c.js";
+   ╰────
+
+ERROR in ./node_modules/some-module/a.ts
+  × Resolve error: Can't resolve './c.js' in '<PROJECT_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-conflict/node_modules/some-module'
+   ╭─[1:1]
+ 1 │ export * from "./b.js";
+ 2 │ export * from "./c.js";
+   ·               ────────
+   ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/index.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/index.ts
@@ -1,0 +1,4 @@
+import { foo } from './reexport';
+
+// should not panic at crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+foo;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module/a.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module/a.ts
@@ -1,0 +1,1 @@
+export * from "./b.js";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module/b.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module/b.ts
@@ -1,0 +1,1 @@
+export const b = 1;

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module/package.json
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "some-module",
+  "version": "0.0.1",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./a.ts"
+    }
+  }
+}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/reexport.ts
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/reexport.ts
@@ -1,0 +1,2 @@
+export * as foo from 'some-module';
+

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/rspack.config.js
@@ -3,10 +3,9 @@ module.exports = {
   mode: "production",
   entry: "./index.ts",
   resolve: {
-    extensions: [".tsx", ".ts", ".js"],
+    extensions: [".ts", ".js"],
   },
   optimization: {
-    minimize: true,
     concatenateModules: true,
   },
   module: {
@@ -16,13 +15,6 @@ module.exports = {
         loader: "builtin:swc-loader",
         options: {
           target: "es5",
-          jsc: {
-            externalHelpers: true,
-          },
-          env: {
-            mode: "usage",
-            coreJs: "3.37.1",
-          },
         },
         type: "javascript/auto",
       },

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/rspack.config.js
@@ -1,0 +1,31 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: "production",
+  entry: "./index.ts",
+  resolve: {
+    extensions: [".tsx", ".ts", ".js"],
+  },
+  optimization: {
+    minimize: true,
+    concatenateModules: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(j|t)s$/,
+        loader: "builtin:swc-loader",
+        options: {
+          target: "es5",
+          jsc: {
+            externalHelpers: true,
+          },
+          env: {
+            mode: "usage",
+            coreJs: "3.37.1",
+          },
+        },
+        type: "javascript/auto",
+      },
+    ],
+  },
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/stats.err
@@ -1,0 +1,6 @@
+ERROR in ./node_modules/some-module/a.ts
+  × Resolve error: Can't resolve './b.js' in '<PROJECT_ROOT>/tests/diagnosticsCases/factorize/cannot-resolve-with-concatenate-import/node_modules/some-module'
+   ╭────
+ 1 │ export * from "./b.js";
+   ·               ────────
+   ╰────


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

When dependency was resolved and failed, the module graph module does not exists during code generation. So 
 that can not just use `.expect()` to mgm.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
