### PR TITLE
fix: increase stack size limit to 4mb

### DIFF
--- a/crates/node_binding/src/env.rs
+++ b/crates/node_binding/src/env.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::ffi::OsStr;
+
+pub fn set_env_if_unset<K, V>(k: K, v: V)
+where
+  K: AsRef<OsStr>,
+  V: AsRef<OsStr>,
+{
+  match env::var(&k) {
+    Ok(_) => (),
+    Err(_) => {
+      env::set_var(&k, v);
+    }
+  }
+}

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -16,9 +16,11 @@ use rspack_error::Diagnostic;
 use rspack_fs_node::{AsyncNodeWritableFileSystem, ThreadsafeNodeFS};
 
 mod compiler;
-mod env;
 mod panic;
 mod plugins;
+
+#[cfg(not(debug_assertions))]
+mod env;
 
 use plugins::*;
 use rspack_binding_options::*;

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -16,6 +16,7 @@ use rspack_error::Diagnostic;
 use rspack_fs_node::{AsyncNodeWritableFileSystem, ThreadsafeNodeFS};
 
 mod compiler;
+mod env;
 mod panic;
 mod plugins;
 
@@ -181,6 +182,13 @@ enum TraceState {
 
 #[ctor]
 fn init() {
+  #[cfg(not(debug_assertions))]
+  {
+    // 4mb stack size if not set
+    // For the case where its code has a lot of recursions, for example:
+    // https://github.com/highlightjs/highlight.js/blob/b9ae5fea90514b864f2c9b2889d7d3302d6156dc/src/languages/isbl.js#L21
+    env::set_env_if_unset("RUST_MIN_STACK", "4194304");
+  }
   panic::install_panic_handler();
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Increase stack size limit to 4mb for deep recursions.
Limited to **production builds**, otherwise it's too error-prone.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
