### PR TITLE
feat: allow to reference client module types

### DIFF
--- a/packages/rspack/module.d.ts
+++ b/packages/rspack/module.d.ts
@@ -1,0 +1,244 @@
+/**
+ * The following code is modified based on
+ * https://github.com/webpack/webpack/blob/v5.92.0/module.d.ts
+ *
+ * MIT Licensed
+ * Author Tobias Koppers @sokra
+ * Copyright (c) JS Foundation and other contributors
+ * https://github.com/webpack/webpack/blob/main/LICENSE
+ */
+
+declare namespace Rspack {
+	type DeclinedEvent =
+		| {
+				type: "declined";
+				/** The module in question. */
+				moduleId: number | string;
+				/** the chain from where the update was propagated. */
+				chain: (number | string)[];
+				/** the module id of the declining parent */
+				parentId: number | string;
+		  }
+		| {
+				type: "self-declined";
+				/** The module in question. */
+				moduleId: number | string;
+				/** the chain from where the update was propagated. */
+				chain: (number | string)[];
+		  };
+
+	type UnacceptedEvent = {
+		type: "unaccepted";
+		/** The module in question. */
+		moduleId: number | string;
+		/** the chain from where the update was propagated. */
+		chain: (number | string)[];
+	};
+
+	type AcceptedEvent = {
+		type: "accepted";
+		/** The module in question. */
+		moduleId: number | string;
+		/** the modules that are outdated and will be disposed */
+		outdatedModules: (number | string)[];
+		/** the accepted dependencies that are outdated */
+		outdatedDependencies: {
+			[id: number]: (number | string)[];
+		};
+	};
+
+	type DisposedEvent = {
+		type: "disposed";
+		/** The module in question. */
+		moduleId: number | string;
+	};
+
+	type ErroredEvent =
+		| {
+				type: "accept-error-handler-errored";
+				/** The module in question. */
+				moduleId: number | string;
+				/** the module id owning the accept handler. */
+				dependencyId: number | string;
+				/** the thrown error */
+				error: Error;
+				/** the error thrown by the module before the error handler tried to handle it. */
+				originalError: Error;
+		  }
+		| {
+				type: "self-accept-error-handler-errored";
+				/** The module in question. */
+				moduleId: number | string;
+				/** the thrown error */
+				error: Error;
+				/** the error thrown by the module before the error handler tried to handle it. */
+				originalError: Error;
+		  }
+		| {
+				type: "accept-errored";
+				/** The module in question. */
+				moduleId: number | string;
+				/** the module id owning the accept handler. */
+				dependencyId: number | string;
+				/** the thrown error */
+				error: Error;
+		  }
+		| {
+				type: "self-accept-errored";
+				/** The module in question. */
+				moduleId: number | string;
+				/** the thrown error */
+				error: Error;
+		  };
+
+	type HotEvent =
+		| DeclinedEvent
+		| UnacceptedEvent
+		| AcceptedEvent
+		| DisposedEvent
+		| ErroredEvent;
+
+	interface ApplyOptions {
+		ignoreUnaccepted?: boolean;
+		ignoreDeclined?: boolean;
+		ignoreErrored?: boolean;
+		onDeclined?: (event: DeclinedEvent) => void;
+		onUnaccepted?: (event: UnacceptedEvent) => void;
+		onAccepted?: (event: AcceptedEvent) => void;
+		onDisposed?: (event: DisposedEvent) => void;
+		onErrored?: (event: ErroredEvent) => void;
+	}
+
+	const enum HotUpdateStatus {
+		idle = "idle",
+		check = "check",
+		prepare = "prepare",
+		ready = "ready",
+		dispose = "dispose",
+		apply = "apply",
+		abort = "abort",
+		fail = "fail"
+	}
+
+	interface Hot {
+		accept: {
+			(
+				modules: string | string[],
+				callback?: (outdatedDependencies: string[]) => void,
+				errorHandler?: (
+					err: Error,
+					context: { moduleId: string | number; dependencyId: string | number }
+				) => void
+			): void;
+			(
+				errorHandler?: (
+					err: Error,
+					ids: { moduleId: string | number; module: NodeJS.Module }
+				) => void
+			): void;
+		};
+		status(): HotUpdateStatus;
+		decline(module?: string | string[]): void;
+		dispose(callback: (data: object) => void): void;
+		addDisposeHandler(callback: (data: object) => void): void;
+		removeDisposeHandler(callback: (data: object) => void): void;
+		invalidate(): void;
+		addStatusHandler(callback: (status: HotUpdateStatus) => void): void;
+		removeStatusHandler(callback: (status: HotUpdateStatus) => void): void;
+		data: object;
+		check(
+			autoApply?: boolean | ApplyOptions
+		): Promise<(string | number)[] | null>;
+		apply(options?: ApplyOptions): Promise<(string | number)[] | null>;
+	}
+
+	interface ExportInfo {
+		used: boolean;
+		provideInfo: boolean | null | undefined;
+		useInfo: boolean | null | undefined;
+		canMangle: boolean;
+	}
+
+	interface ExportsInfo {
+		[k: string]: ExportInfo & ExportsInfo;
+	}
+
+	interface Context {
+		resolve(dependency: string): string | number;
+		keys(): Array<string>;
+		id: string | number;
+		(dependency: string): unknown;
+	}
+}
+
+interface ImportMeta {
+	url: string;
+	// TODO: unsupported
+	// webpack: number;
+	webpackHot: Rspack.Hot;
+	webpackContext: (
+		request: string,
+		options?: {
+			recursive?: boolean;
+			regExp?: RegExp;
+			include?: RegExp;
+			exclude?: RegExp;
+			preload?: boolean | number;
+			prefetch?: boolean | number;
+			fetchPriority?: "low" | "high" | "auto";
+			chunkName?: string;
+			exports?: string | string[][];
+			mode?: "sync" | "eager" | "weak" | "lazy" | "lazy-once";
+		}
+	) => Rspack.Context;
+}
+
+declare const __resourceQuery: string;
+declare var __webpack_public_path__: string;
+declare var __webpack_nonce__: string;
+declare const __webpack_chunkname__: string;
+declare var __webpack_base_uri__: string;
+declare var __webpack_runtime_id__: string;
+declare const __webpack_hash__: string;
+declare const __webpack_modules__: Record<string | number, NodeJS.Module>;
+declare const __webpack_require__: (id: string | number) => unknown;
+declare var __webpack_chunk_load__: (chunkId: string | number) => Promise<void>;
+declare var __webpack_get_script_filename__: (
+	chunkId: string | number
+) => string;
+declare var __webpack_is_included__: (request: string) => boolean;
+declare var __webpack_exports_info__: Rspack.ExportsInfo;
+declare const __webpack_share_scopes__: Record<
+	string,
+	Record<
+		string,
+		{ loaded?: 1; get: () => Promise<unknown>; from: string; eager: boolean }
+	>
+>;
+declare var __webpack_init_sharing__: (scope: string) => Promise<void>;
+declare var __non_webpack_require__: (id: any) => unknown;
+declare const __system_context__: object;
+
+declare namespace NodeJS {
+	interface Module {
+		hot: Rspack.Hot;
+	}
+
+	interface Require {
+		ensure(
+			dependencies: string[],
+			callback: (require: (module: string) => void) => void,
+			errorCallback?: (error: Error) => void,
+			chunkName?: string
+		): void;
+		context(
+			request: string,
+			includeSubdirectories?: boolean,
+			filter?: RegExp,
+			mode?: "sync" | "eager" | "weak" | "lazy" | "lazy-once"
+		): Rspack.Context;
+		include(dependency: string): void;
+		resolveWeak(dependency: string): void;
+		onError?: (error: Error) => void;
+	}
+}

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -12,7 +12,8 @@
     },
     "./hot/*": "./hot/*.js",
     "./hot/*.js": "./hot/*.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./module": "./module.d.ts"
   },
   "scripts": {
     "build": "prebundle && tsc -b ./tsconfig.build.json && tsc-alias -p tsconfig.build.json",
@@ -25,7 +26,8 @@
   "files": [
     "dist",
     "hot",
-    "compiled"
+    "compiled",
+    "module.d.ts"
   ],
   "engines": {
     "node": ">=16.0.0"

--- a/website/docs/en/guide/tech/typescript.mdx
+++ b/website/docs/en/guide/tech/typescript.mdx
@@ -39,3 +39,25 @@ Enabling TSX|JSX support can be done through [`builtin:swc-loader`](/guide/featu
 ## Alias
 
 See [resolve.tsConfigPath](/config/resolve#resolvetsconfigpath) for details.
+
+## Client types
+
+It's possible to use webpack or Rspack specific features in your TypeScript code, such as [import.meta.webpackContext](/api/modules/module-variables#importmetawebpackcontext).
+
+Rspack provides client module types via `@rspack/core/module`, you can add a TypeScript reference directive to declare them:
+
+```ts title="src/index.ts"
+/// <reference types="@rspack/core/module" />
+
+console.log(import.meta.webpackContext); // without reference declared above, TypeScript will throw an error
+```
+
+You can also add `@rspack/core/module` to the `types` field of tsconfig.json. This way, you no longer need to add the TypeScript reference directive in each file.
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rspack/core/module"]
+  }
+}
+```

--- a/website/docs/zh/guide/tech/typescript.mdx
+++ b/website/docs/zh/guide/tech/typescript.mdx
@@ -40,3 +40,25 @@
 ## Alias
 
 点击 [resolve.tsConfigPath](/config/resolve#resolvetsconfigpath) 查看详情。
+
+## Client 类型
+
+在 TypeScript 代码中，可以使用 webpack 或 Rspack 特有的功能，例如 [import.meta.webpackContext](/api/modules/module-variables#importmetawebpackcontext)。
+
+Rspack 通过 `@rspack/core/module` 提供 Client 模块的类型，你可以添加 TypeScript reference 指令来声明它们：
+
+```ts title="src/index.ts"
+/// <reference types="@rspack/core/module" />
+
+console.log(import.meta.webpackContext); // 如果没有上面的引用声明，TypeScript 将会抛出错误
+```
+
+你也可以将 `@rspack/core/module` 添加到 tsconfig.json 的 `types` 字段中。这样你就不需要在每个文件中添加 TypeScript reference 指令。
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "types": ["@rspack/core/module"]
+  }
+}
+```


### PR DESCRIPTION
## Summary

Allow to reference client module types, the usage is the same as webpack.

## Usage

Rspack provides client module types via `@rspack/core/module`, you can add a TypeScript reference directive to declare them:

```ts title="src/index.ts"
/// <reference types="@rspack/core/module" />

console.log(import.meta.webpackContext); // without reference declared above, TypeScript will throw an error
```

You can also add `@rspack/core/module` to the `types` field of tsconfig.json. This way, you no longer need to add the TypeScript reference directive in each file.

```json title="tsconfig.json"
{
  "compilerOptions": {
    "types": ["@rspack/core/module"]
  }
}
```

## Reference

- https://github.com/webpack/webpack/blob/main/module.d.ts
- https://webpack.js.org/guides/typescript/#client-types

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
