### PR TITLE
docs: add semver declaration

### DIFF
--- a/crates/node_binding/README.md
+++ b/crates/node_binding/README.md
@@ -5,7 +5,9 @@
 
 # @rspack/binding
 
-Node binding for rspack.
+Private node binding crate for rspack.
+
+This package does *NOT* follow [semantic versioning](https://semver.org/).
 
 ## Documentation
 

--- a/scripts/build-npm.cjs
+++ b/scripts/build-npm.cjs
@@ -165,7 +165,9 @@ for (const binding of bindings) {
 
 # ${pkgJson.name}
 
-Node binding for rspack.
+Private node binding crate for rspack.
+
+This package does *NOT* follow [semantic versioning](https://semver.org/).
 
 ## Documentation
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`@rspack/binding-*` and `@rspack/binding` does not follow semver rule.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description of the `@rspack/binding` crate to clarify it is a private node binding crate and does not follow semantic versioning.
  - Revised the package description in build scripts to reflect it is a private node binding crate and note the lack of semantic versioning.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->