### PR TITLE
fix: basically same codegen of arco-pro

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -422,14 +422,19 @@ impl ParserAndGenerator for CssParserAndGenerator {
           }
           return Ok(concate_source.boxed());
         } else {
-          let (ns_obj, left, right) = if self.es_module {
+          let mg = generate_context.compilation.get_module_graph();
+          let (ns_obj, left, right) = if self.es_module
+            && mg
+              .get_exports_info(&module.identifier())
+              .other_exports_info
+              .get_used(&mg, generate_context.runtime)
+              != UsageState::Unused
+          {
             (RuntimeGlobals::MAKE_NAMESPACE_OBJECT.name(), "(", ")")
           } else {
             ("", "", "")
           };
           if let Some(exports) = &self.exports {
-            let mg = generate_context.compilation.get_module_graph();
-
             let exports =
               get_used_exports(exports, module.identifier(), generate_context.runtime, &mg);
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -11,6 +11,7 @@ use swc_core::ecma::ast::{Expr, Lit, Prop, PropName, ThisExpr, UnaryOp};
 use super::JavascriptParserPlugin;
 use crate::dependency::{CommonJsExportRequireDependency, CommonJsExportsDependency};
 use crate::dependency::{CommonJsSelfReferenceDependency, ExportsBase, ModuleDecoratorDependency};
+use crate::utils::eval::{self, BasicEvaluatedExpression};
 use crate::visitors::expr_like::ExprLike;
 use crate::visitors::{expr_matcher, JavascriptParser, TopLevelScope};
 
@@ -545,6 +546,20 @@ impl JavascriptParserPlugin for CommonJsExportsParserPlugin {
       } else {
         None
       }
+    } else {
+      None
+    }
+  }
+
+  fn evaluate_typeof(
+    &self,
+    parser: &mut JavascriptParser,
+    expression: &Ident,
+    start: u32,
+    end: u32,
+  ) -> Option<BasicEvaluatedExpression> {
+    if parser.is_exports_ident(expression) || parser.is_module_ident(expression) {
+      Some(eval::evaluate_to_string("object".to_string(), start, end))
     } else {
       None
     }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -23,6 +23,7 @@ mod provide_plugin;
 mod require_context_dependency_parser_plugin;
 mod r#trait;
 mod url_plugin;
+mod use_strict_plugin;
 mod webpack_included_plugin;
 mod worker_plugin;
 /// TODO: should move to rspack_plugin_javascript once we drop old treeshaking
@@ -53,6 +54,7 @@ pub(crate) use self::r#const::{is_logic_op, ConstPlugin};
 pub(crate) use self::r#trait::{BoxJavascriptParserPlugin, JavascriptParserPlugin};
 pub(crate) use self::require_context_dependency_parser_plugin::RequireContextDependencyParserPlugin;
 pub(crate) use self::url_plugin::URLPlugin;
+pub(crate) use self::use_strict_plugin::UseStrictPlugin;
 pub(crate) use self::webpack_included_plugin::WebpackIsIncludedPlugin;
 pub(crate) use self::worker_plugin::WorkerPlugin;
 pub(crate) use self::worker_syntax_plugin::WorkerSyntaxScanner;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/use_strict_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/use_strict_plugin.rs
@@ -1,0 +1,36 @@
+use rspack_core::{ConstDependency, SpanExt};
+
+use super::JavascriptParserPlugin;
+use crate::visitors::JavascriptParser;
+
+pub struct UseStrictPlugin;
+
+impl JavascriptParserPlugin for UseStrictPlugin {
+  fn program(
+    &self,
+    parser: &mut JavascriptParser,
+    ast: &swc_core::ecma::ast::Program,
+  ) -> Option<bool> {
+    let first = match ast {
+      swc_core::ecma::ast::Program::Module(ast) => ast.body.first().and_then(|i| i.as_stmt()),
+      swc_core::ecma::ast::Program::Script(ast) => ast.body.first(),
+    }
+    .and_then(|i| i.as_expr());
+    if let Some(first) = first
+      && matches!(
+        first.expr.as_lit().and_then(|i| match i {
+          swc_core::ecma::ast::Lit::Str(s) => Some(s.value.as_str()),
+          _ => None,
+        }),
+        Some("use strict")
+      )
+    {
+      // Remove "use strict" expression. It will be added later by the renderer again.
+      // This is necessary in order to not break the strict mode when webpack prepends code.
+      let dep = ConstDependency::new(first.span.real_lo(), first.span.real_hi(), "".into(), None);
+      parser.presentational_dependencies.push(Box::new(dep));
+      parser.build_info.strict = true;
+    }
+    None
+  }
+}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -294,6 +294,7 @@ impl<'parser> JavascriptParser<'parser> {
     plugins.push(Box::new(parser_plugin::JavascriptMetaInfoPlugin));
     plugins.push(Box::new(parser_plugin::CheckVarDeclaratorIdent));
     plugins.push(Box::new(parser_plugin::ConstPlugin));
+    plugins.push(Box::new(parser_plugin::UseStrictPlugin));
     plugins.push(Box::new(
       parser_plugin::RequireContextDependencyParserPlugin,
     ));

--- a/diffcases/arco-pro/rspack.config.js
+++ b/diffcases/arco-pro/rspack.config.js
@@ -13,19 +13,24 @@ const config = {
 			{
 				test: /\.less$/,
 				use: "less-loader",
-				type: "css",
+				parser: {
+					namedExports: false
+				},
 				generator: {
 					exportsOnly: true
-				}
+				},
+				type: "css"
 			},
 			{
 				test: /\.module\.less$/,
 				use: "less-loader",
-				type: "css/module",
+				parser: {
+					namedExports: false
+				},
 				generator: {
-					exportsOnly: true,
-					localIdentName: "[uniqueName]---[path][name][ext]-[local]"
-				}
+					exportsOnly: true
+				},
+				type: "css/module"
 			},
 			{
 				test: /\.svg$/,
@@ -34,44 +39,52 @@ const config = {
 			{
 				test: /\.(j|t)s$/,
 				exclude: [/[\\/]node_modules[\\/]/],
-				loader: "builtin:swc-loader",
-				options: {
-					sourceMaps: false,
-					jsc: {
-						parser: {
-							syntax: "typescript"
-						},
-						externalHelpers: true
-					},
-					env: {
-						targets: "Chrome >= 48"
+				use: [
+					{
+						loader: "swc-loader",
+						options: {
+							sourceMaps: false,
+							jsc: {
+								parser: {
+									syntax: "typescript"
+								},
+								externalHelpers: true
+							},
+							env: {
+								targets: "Chrome >= 48"
+							}
+						}
 					}
-				}
+				]
 			},
 			{
 				test: /\.(j|t)sx$/,
-				loader: "builtin:swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
-				options: {
-					sourceMaps: false,
-					jsc: {
-						parser: {
-							syntax: "typescript",
-							tsx: true
-						},
-						transform: {
-							react: {
-								runtime: "automatic",
-								development: false,
-								refresh: false
+				use: [
+					{
+						loader: "swc-loader",
+						options: {
+							sourceMaps: false,
+							jsc: {
+								parser: {
+									syntax: "typescript",
+									tsx: true
+								},
+								transform: {
+									react: {
+										runtime: "automatic",
+										development: false,
+										refresh: false
+									}
+								},
+								externalHelpers: true
+							},
+							env: {
+								targets: "Chrome >= 48"
 							}
-						},
-						externalHelpers: true
-					},
-					env: {
-						targets: "Chrome >= 48"
+						}
 					}
-				}
+				]
 			},
 			{
 				test: /\.png$/,

--- a/diffcases/arco-pro/webpack.config.js
+++ b/diffcases/arco-pro/webpack.config.js
@@ -38,44 +38,52 @@ const config = {
 			{
 				test: /\.(j|t)s$/,
 				exclude: [/[\\/]node_modules[\\/]/],
-				loader: "swc-loader",
-				options: {
-					sourceMaps: false,
-					jsc: {
-						parser: {
-							syntax: "typescript"
-						},
-						externalHelpers: true
-					},
-					env: {
-						targets: "Chrome >= 48"
+				use: [
+					{
+						loader: "swc-loader",
+						options: {
+							sourceMaps: false,
+							jsc: {
+								parser: {
+									syntax: "typescript"
+								},
+								externalHelpers: true
+							},
+							env: {
+								targets: "Chrome >= 48"
+							}
+						}
 					}
-				}
+				]
 			},
 			{
 				test: /\.(j|t)sx$/,
-				loader: "swc-loader",
 				exclude: [/[\\/]node_modules[\\/]/],
-				options: {
-					sourceMaps: false,
-					jsc: {
-						parser: {
-							syntax: "typescript",
-							tsx: true
-						},
-						transform: {
-							react: {
-								runtime: "automatic",
-								development: false,
-								refresh: false
+				use: [
+					{
+						loader: "swc-loader",
+						options: {
+							sourceMaps: false,
+							jsc: {
+								parser: {
+									syntax: "typescript",
+									tsx: true
+								},
+								transform: {
+									react: {
+										runtime: "automatic",
+										development: false,
+										refresh: false
+									}
+								},
+								externalHelpers: true
+							},
+							env: {
+								targets: "Chrome >= 48"
 							}
-						},
-						externalHelpers: true
-					},
-					env: {
-						targets: "Chrome >= 48"
+						}
 					}
-				}
+				]
 			},
 			{
 				test: /\.png$/,

--- a/packages/rspack-test-tools/tests/configCases/parsing/eval-cjs-typeof/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/eval-cjs-typeof/index.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+
+it("should compile", () => {
+	if (typeof exports !== "object" || typeof module !== "object") {
+		throw new Error("wrong")
+	}
+	const file = fs.promises.readFile(__filename);
+	expect(file).not.toContain("typeof")
+});

--- a/packages/rspack-test-tools/tests/configCases/parsing/eval-cjs-typeof/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/eval-cjs-typeof/rspack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	node: {
+		__filename: false,
+	}
+};

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/__snapshots__/web/2.snap.txt
@@ -6,7 +6,7 @@
 ## Asset Files
 - Bundle: bundle.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 7891
+- Update: main.LAST_HASH.hot-update.js, size: 7865
 
 ## Manifest
 
@@ -32,9 +32,10 @@
 
 #### Changed Content
 ```js
+"use strict";
 self["webpackHotUpdate"]('main', {
 "../../../../../rspack/dist/builtin-plugin/css-extract/hmr/hotModuleReplacement.js": (function (module, __unused_webpack_exports, __webpack_require__) {
-"use strict";
+
 /* eslint-env browser */
 /*
   eslint-disable
@@ -260,7 +261,7 @@ module.exports = function (moduleId, options) {
 
 }),
 "../../../../../rspack/dist/builtin-plugin/css-extract/hmr/normalize-url.js": (function (module) {
-"use strict";
+
 /* eslint-disable */
 /**
  * @param {string[]} pathComponents
@@ -302,7 +303,6 @@ module.exports = function (urlString) {
 
 }),
 "./index.css?4025": (function (module, __webpack_exports__, __webpack_require__) {
-"use strict";
 __webpack_require__.r(__webpack_exports__);
 // extracted by css-extract-rspack-plugin
 

--- a/packages/rspack-test-tools/tests/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/cjs-export-computed-property/__snapshots__/treeshaking.snap.txt
@@ -1,7 +1,7 @@
 ```js title=main.js
+"use strict";
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
 "./antd/index.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-"use strict";
 __webpack_require__.d(__webpack_exports__, {
   locales: function() { return locales; }
 });
@@ -16,7 +16,6 @@ const locales = {
 
 }),
 "./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
-"use strict";
 /* harmony import */var _antd_index__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./antd/index.js");
 
 
@@ -26,7 +25,6 @@ function test() {}
 
 }),
 "./locale_zh.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
-"use strict";
 /* harmony import */var _zh_locale__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./zh_locale.js");
 
 
@@ -36,7 +34,7 @@ function test() {}
 }),
 "./zh_locale.js": (function (__unused_webpack_module, exports) {
 var __webpack_unused_export__;
-"use strict";
+
 
 __webpack_unused_export__ = ({
 	value: true

--- a/packages/rspack-test-tools/tests/treeShakingCases/css/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/css/__snapshots__/treeshaking.snap.txt
@@ -11,10 +11,10 @@ _index_module_css__WEBPACK_IMPORTED_MODULE_0__.compose;
 
 }),
 "./index.module.css": (function (module, __unused_webpack_exports, __webpack_require__) {
-__webpack_require__.r(module.exports = {
+module.exports = {
   "foo": "__rspack_test__-ec1c834ac8cc99e-foo",
   "compose": "__rspack_test__-ec1c834ac8cc99e-compose" + " " + "__rspack_test__-ec1c834ac8cc99e-bar",
-});
+};
 
 
 }),

--- a/plugin-test/css-extract/cases/hmr/expected/main.js
+++ b/plugin-test/css-extract/cases/hmr/expected/main.js
@@ -1,7 +1,8 @@
 (() => { // webpackBootstrap
+"use strict";
 var __webpack_modules__ = ({
 "../../../../packages/rspack/dist/builtin-plugin/css-extract/hmr/hotModuleReplacement.js": (function (module, __unused_webpack_exports, __webpack_require__) {
-"use strict";
+
 /* eslint-env browser */
 /*
   eslint-disable
@@ -227,7 +228,7 @@ module.exports = function (moduleId, options) {
 
 }),
 "../../../../packages/rspack/dist/builtin-plugin/css-extract/hmr/normalize-url.js": (function (module) {
-"use strict";
+
 /* eslint-disable */
 /**
  * @param {string[]} pathComponents
@@ -269,7 +270,6 @@ module.exports = function (urlString) {
 
 }),
 "./index.css?6fbf": (function (module, __webpack_exports__, __webpack_require__) {
-"use strict";
 __webpack_require__.r(__webpack_exports__);
 // extracted by css-extract-rspack-plugin
 

--- a/scripts/diff.cjs
+++ b/scripts/diff.cjs
@@ -21,7 +21,10 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
     report: true,
   });
   const htmlReporter = new DiffHtmlReporter({
-    dist: OUTPUT_DIR
+    dist: OUTPUT_DIR,
+    ignore: {
+      test: () => false,
+    },
   });
 
   while (cases.length) {
@@ -47,7 +50,6 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
           statsReporter.increment(name, results);
         },
         onCompareRuntimeModules: function (file, results) {
-          console.log(results);
           htmlReporter.increment(name, results);
           statsReporter.increment(name, results);
         },
@@ -64,7 +66,7 @@ const OUTPUT_DIR = path.join(__dirname, '../diff_output');
       await tester.prepare();
       do {
         await tester.compile();
-        await tester.check();
+        await tester.check({ expect: () => ({ toBe: (() => {}) }) });
       } while (tester.next());
       await tester.resume();
     } catch (e) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR includes:

- eval `typeof exports` and `typeof module` for cjs
- remove make nsobj (`__webpack_require__.r`) for css module if it's not necessary
- remove `"use strict"` in code and add them together by render module

Remaining inconsistent codegen result for arco-pro:

1. Rspack goes a step further than webpack in analyzing side effect statements, in this case webpack fallback to has side effect but Rspack successfully analyzed it is side effect free 

<img width="1426" alt="Screenshot 2024-06-17 at 16 58 59" src="https://github.com/web-infra-dev/rspack/assets/42857895/b9fb68f5-1c22-4ea5-88d2-ca14af8e8807">

2. Rspack doesn't support AMD

<img width="1797" alt="Screenshot 2024-06-17 at 17 05 08" src="https://github.com/web-infra-dev/rspack/assets/42857895/3c5d3014-b74f-42aa-b4d9-8897df3d0c75">

3. Rspack experiments css is not aligned with webpack currently

<img width="1797" alt="Screenshot 2024-06-17 at 17 06 26" src="https://github.com/web-infra-dev/rspack/assets/42857895/b86612e2-5d08-4c7d-a137-b33ca3b62287">

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
