### PR TITLE
fix(plugin-preact-refresh): missing plugin type

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -77,7 +77,7 @@ Rspack 是一个基于 Rust 编写的高性能 JavaScript 打包工具，它提�
 - [react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin) 项目（由 [@pmmmwh](https://github.com/pmmmwh) 创建），它启发了 Rspack 内的 ReactRefreshPlugin 实现。
 - [prefresh](https://github.com/preactjs/prefresh) 项目（由 [@Jovi De Croock](https://github.com/JoviDeCroock) 创建），它启发了 Rspack 内的 PreactRefreshPlugin 实现。
 - [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin) 项目（由 [@sokra](https://github.com/sokra) 创建），它启发了 Rspack 内的 CssExtractPlugin 实现。
-- [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin) 项目（由 [@kevlened](https://github.com/kevlened) 创建），它启发了 Rsapck 内的 CopyPlugin 实现。
+- [copy-webpack-plugin](https://github.com/webpack-contrib/copy-webpack-plugin) 项目（由 [@kevlened](https://github.com/kevlened) 创建），它启发了 Rspack 内的 CopyPlugin 实现。
 
 ## License
 

--- a/packages/rspack-plugin-preact-refresh/src/index.ts
+++ b/packages/rspack-plugin-preact-refresh/src/index.ts
@@ -50,9 +50,9 @@ const INTERNAL_PATHS = [
 
 const runtimeSource = fs.readFileSync(RUNTIME_INTERCEPT_PATH, "utf-8");
 
-const NAME = "PreactRefreshRsapckPlugin";
+const NAME = "PreactRefreshRspackPlugin";
 
-class PreactRefreshRsapckPlugin implements RspackPluginInstance {
+class PreactRefreshRspackPlugin implements RspackPluginInstance {
 	name = NAME;
 
 	constructor(private options: IPreactRefreshRspackPluginOptions) {
@@ -117,4 +117,5 @@ class PreactRefreshRsapckPlugin implements RspackPluginInstance {
 	}
 }
 
-module.exports = PreactRefreshRsapckPlugin;
+// @ts-expect-error output module.exports
+export = PreactRefreshRspackPlugin;


### PR DESCRIPTION
## Summary

Fix `@rspack/plugin-preact-refresh` missing plugin type.

- Before:

<img width="741" alt="Screenshot 2024-06-18 at 18 08 33" src="https://github.com/web-infra-dev/rspack/assets/7237365/7da64127-0924-4f3f-86ab-854ac58428cd">

- After:

<img width="1201" alt="Screenshot 2024-06-18 at 18 10 19" src="https://github.com/web-infra-dev/rspack/assets/7237365/f99ad2a5-47f2-4626-a926-6f9e43014203">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
