### PR TITLE
refactor!: remove resolve tsConfigPath

### DIFF
--- a/packages/rspack-test-tools/rspack.config.js
+++ b/packages/rspack-test-tools/rspack.config.js
@@ -10,7 +10,7 @@ module.exports = {
 	},
 	resolve: {
 		extensions: ["*", ".js", ".jsx", ".tsx", ".ts"],
-		tsConfigPath: path.resolve(__dirname, "tsconfig.assets.json")
+		tsConfig: path.resolve(__dirname, "tsconfig.assets.json")
 	},
 	devtool: false,
 	output: {

--- a/packages/rspack-test-tools/tests/configCases/resolve/tsconfig-paths-map/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/resolve/tsconfig-paths-map/rspack.config.js
@@ -6,6 +6,6 @@ module.exports = {
 		main: "./index.js"
 	},
 	resolve: {
-		tsConfigPath: path.resolve(__dirname, "./tsconfig.json")
+		tsConfig: path.resolve(__dirname, "./tsconfig.json")
 	}
 };

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -581,8 +581,7 @@ const baseResolveOptions: z.ZodObject<{
     enforceExtension: z.ZodOptional<z.ZodBoolean>;
     importsFields: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     descriptionFiles: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-    tsConfigPath: z.ZodOptional<z.ZodString>;
-    tsConfig: z.ZodOptional<z.ZodObject<{
+    tsConfig: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
         configFile: z.ZodString;
         references: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodLiteral<"auto">]>>;
     }, "strict", z.ZodTypeAny, {
@@ -591,7 +590,7 @@ const baseResolveOptions: z.ZodObject<{
     }, {
         configFile: string;
         references?: string[] | "auto" | undefined;
-    }>>;
+    }>]>>;
     fullySpecified: z.ZodOptional<z.ZodBoolean>;
     exportsFields: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     extensionAlias: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>>;
@@ -612,8 +611,7 @@ const baseResolveOptions: z.ZodObject<{
     enforceExtension?: boolean | undefined;
     importsFields?: string[] | undefined;
     descriptionFiles?: string[] | undefined;
-    tsConfigPath?: string | undefined;
-    tsConfig?: {
+    tsConfig?: string | {
         configFile: string;
         references?: string[] | "auto" | undefined;
     } | undefined;
@@ -637,8 +635,7 @@ const baseResolveOptions: z.ZodObject<{
     enforceExtension?: boolean | undefined;
     importsFields?: string[] | undefined;
     descriptionFiles?: string[] | undefined;
-    tsConfigPath?: string | undefined;
-    tsConfig?: {
+    tsConfig?: string | {
         configFile: string;
         references?: string[] | "auto" | undefined;
     } | undefined;
@@ -8140,10 +8137,10 @@ export type ResolveOptions = z.infer<typeof baseResolveOptions> & {
 type ResolveRequest = BaseResolveRequest & Partial<ParsedIdentifier>;
 
 // @public (undocumented)
-export type ResolveTsconfig = z.infer<typeof resolveTsconfig>;
+export type ResolveTsConfig = z.infer<typeof resolveTsConfig>;
 
 // @public (undocumented)
-const resolveTsconfig: z.ZodObject<{
+const resolveTsConfig: z.ZodUnion<[z.ZodString, z.ZodObject<{
     configFile: z.ZodString;
     references: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodLiteral<"auto">]>>;
 }, "strict", z.ZodTypeAny, {
@@ -8152,7 +8149,7 @@ const resolveTsconfig: z.ZodObject<{
 }, {
     configFile: string;
     references?: string[] | "auto" | undefined;
-}>;
+}>]>;
 
 // @public (undocumented)
 type ResourceData = {
@@ -8421,7 +8418,7 @@ declare namespace rspackExports {
         Environment,
         Output,
         ResolveAlias,
-        ResolveTsconfig,
+        ResolveTsConfig,
         ResolveOptions,
         Resolve,
         RuleSetCondition,

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -170,9 +170,24 @@ function getRawResolveByDependency(
 	);
 }
 
+function getRawTsConfig(
+	tsConfig: Resolve["tsConfig"]
+): RawOptions["resolve"]["tsconfig"] {
+	assert(
+		typeof tsConfig !== "string",
+		"should resolve string tsConfig in normalization"
+	);
+	if (tsConfig === undefined) return tsConfig;
+	const { configFile, references } = tsConfig;
+	return {
+		configFile,
+		referencesType:
+			references == "auto" ? "auto" : references ? "manual" : "disabled",
+		references: references == "auto" ? undefined : references
+	};
+}
+
 function getRawResolve(resolve: Resolve): RawOptions["resolve"] {
-	let references = resolve.tsConfig?.references;
-	let tsconfigConfigFile = resolve.tsConfigPath ?? resolve.tsConfig?.configFile;
 	return {
 		...resolve,
 		alias: getRawAlias(resolve.alias),
@@ -181,14 +196,7 @@ function getRawResolve(resolve: Resolve): RawOptions["resolve"] {
 			string,
 			Array<string>
 		>,
-		tsconfig: tsconfigConfigFile
-			? {
-					configFile: tsconfigConfigFile,
-					referencesType:
-						references == "auto" ? "auto" : references ? "manual" : "disabled",
-					references: references == "auto" ? undefined : references
-				}
-			: undefined,
+		tsconfig: getRawTsConfig(resolve.tsConfig),
 		byDependency: getRawResolveByDependency(resolve.byDependency)
 	};
 }

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -213,10 +213,20 @@ export const getNormalizedRspackOptions = (
 			};
 		}),
 		resolve: nestedConfig(config.resolve, resolve => ({
-			...resolve
+			...resolve,
+			tsConfig: optionalNestedConfig(resolve.tsConfig, tsConfig => {
+				return typeof tsConfig === "string"
+					? { configFile: tsConfig }
+					: tsConfig;
+			})
 		})),
 		resolveLoader: nestedConfig(config.resolveLoader, resolve => ({
-			...resolve
+			...resolve,
+			tsConfig: optionalNestedConfig(resolve.tsConfig, tsConfig => {
+				return typeof tsConfig === "string"
+					? { configFile: tsConfig }
+					: tsConfig;
+			})
 		})),
 		module: nestedConfig(config.module, module => ({
 			noParse: module.noParse,

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -396,12 +396,14 @@ const resolveAlias = z.record(
 );
 export type ResolveAlias = z.infer<typeof resolveAlias>;
 
-const resolveTsconfig = z.strictObject({
-	configFile: z.string(),
-	references: z.array(z.string()).or(z.literal("auto")).optional()
-});
-
-export type ResolveTsconfig = z.infer<typeof resolveTsconfig>;
+const resolveTsConfigFile = z.string();
+const resolveTsConfig = resolveTsConfigFile.or(
+	z.strictObject({
+		configFile: resolveTsConfigFile,
+		references: z.array(z.string()).or(z.literal("auto")).optional()
+	})
+);
+export type ResolveTsConfig = z.infer<typeof resolveTsConfig>;
 
 const baseResolveOptions = z.strictObject({
 	alias: resolveAlias.optional(),
@@ -417,8 +419,7 @@ const baseResolveOptions = z.strictObject({
 	enforceExtension: z.boolean().optional(),
 	importsFields: z.array(z.string()).optional(),
 	descriptionFiles: z.array(z.string()).optional(),
-	tsConfigPath: z.string().optional(),
-	tsConfig: resolveTsconfig.optional(),
+	tsConfig: resolveTsConfig.optional(),
 	fullySpecified: z.boolean().optional(),
 	exportsFields: z.array(z.string()).optional(),
 	extensionAlias: z.record(z.string().or(z.array(z.string()))).optional(),

--- a/website/components/i18n/en.json
+++ b/website/components/i18n/en.json
@@ -10,7 +10,7 @@
   "mini-css-extract-plugin-desc": "Use [CssExtractRspackPlugin](/plugins/rspack/css-extract-rspack-plugin) instead",
   "terser-webpack-plugin-desc": "Rspack provides [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) to deliver better performance",
   "css-minimizer-webpack-plugin-desc": "Rspack provides [LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin) and [SwcCssMinimizerRspackPlugin](/plugins/rspack/swc-css-minimizer-rspack-plugin) to deliver better performance",
-  "tsconfig-paths-webpack-plugin-desc": "Use [resolve.tsconfigPath](/config/resolve#resolvetsconfigpath) instead",
+  "tsconfig-paths-webpack-plugin-desc": "Use [resolve.tsConfig](/config/resolve#resolvetsconfig) instead",
   "image-minimizer-webpack-plugin-desc": "Only supports using [loader](https://www.npmjs.com/package/image-minimizer-webpack-plugin#standalone-loader) standalone",
   "case-sensitive-paths-webpack-plugin-desc": "`useBeforeEmitHook` option not supported",
   "moment-locales-webpack-plugin-desc": "Support for this plugin was implemented in v0.7.0, please upgrade the Rspack version to use it",

--- a/website/components/i18n/zh.json
+++ b/website/components/i18n/zh.json
@@ -10,7 +10,7 @@
   "mini-css-extract-plugin-desc": "使用 [CssExtractRspackPlugin](/plugins/rspack/css-extract-rspack-plugin) 替代",
   "terser-webpack-plugin-desc": "Rspack 提供 [SwcJsMinimizerRspackPlugin](/plugins/rspack/swc-js-minimizer-rspack-plugin) 以带来更好的性能",
   "css-minimizer-webpack-plugin-desc": "Rspack 提供 [LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin) 和 [SwcCssMinimizerRspackPlugin](/plugins/rspack/swc-css-minimizer-rspack-plugin) 以带来更好的性能",
-  "tsconfig-paths-webpack-plugin-desc": "使用 [resolve.tsconfigPath](/config/resolve#resolvetsconfigpath) 替代",
+  "tsconfig-paths-webpack-plugin-desc": "使用 [resolve.tsConfig](/config/resolve#resolvetsconfig) 替代",
   "case-sensitive-paths-webpack-plugin-desc": "不支持 `useBeforeEmitHook` 选项",
   "moment-locales-webpack-plugin-desc": "在 v0.7.0 已实现对该插件的支持，请升级 Rspack 版本来使用",
   "image-minimizer-webpack-plugin-desc": "仅支持 [loader](https://www.npmjs.com/package/image-minimizer-webpack-plugin#standalone-loader) 用法",

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -243,10 +243,6 @@ const config = {
 module.exports = config;
 ```
 
-:::warning
-`tsconfig.json#extends` is not supported.
-:::
-
 ## resolve.tsConfig
 
 <ApiMeta addedVersion="0.3.7" />
@@ -271,10 +267,6 @@ module.exports = {
 ```
 
 [Click to see the example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts).
-
-:::warning
-`tsconfig.json#extends` is not supported.
-:::
 
 ### resolve.tsConfig.configFile
 

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -222,6 +222,8 @@ Opt for absolute paths when resolving, in relation to `resolve.roots`.
 
 ## resolve.tsConfigPath
 
+<ApiMeta removedVersion="1.0.0-alpha.0" />
+
 - **Type:** `string | undefined`
 - **Default:** `undefined`
 
@@ -241,25 +243,26 @@ const config = {
 module.exports = config;
 ```
 
-[Click to see the example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts).
-
 :::warning
-
 `tsconfig.json#extends` is not supported.
-
 :::
 
 ## resolve.tsConfig
 
 <ApiMeta addedVersion="0.3.7" />
 
-- **Type:** `object`
+- **Type:** `string | object | undefined`
 - **Default:** `undefined`
+
+The replacement of [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin) in Rspack.
 
 ```js title="rspack.config.js"
 module.exports = {
   resolve: {
-    tsconfig: {
+    // string
+    tsConfig: path.resolve(__dirname, './tsconfig.json'),
+    // or object
+    tsConfig: {
       configFile: path.resolve(__dirname, './tsconfig.json'),
       references: 'auto',
     },
@@ -267,11 +270,15 @@ module.exports = {
 };
 ```
 
+[Click to see the example](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts).
+
+:::warning
+`tsconfig.json#extends` is not supported.
+:::
+
 ### resolve.tsConfig.configFile
 
 - **Type:** `string`
-
-Same as [resolve.tsConfigPath](#resolvetsconfigpath).
 
 If you pass the path of `tsconfig.json` via the option, Rspack will try to resolve modules based on the `paths` and `baseUrl` of `tsconfig.json`, functionally equivalent to [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin).
 

--- a/website/docs/en/guide/tech/typescript.mdx
+++ b/website/docs/en/guide/tech/typescript.mdx
@@ -38,7 +38,7 @@ Enabling TSX|JSX support can be done through [`builtin:swc-loader`](/guide/featu
 
 ## Alias
 
-See [resolve.tsConfigPath](/config/resolve#resolvetsconfigpath) for details.
+See [resolve.tsConfig](/config/resolve#resolvetsconfig) for details.
 
 ## Client types
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -222,6 +222,8 @@ module.exports = {
 
 ## resolve.tsConfigPath
 
+<ApiMeta removedVersion="1.0.0-alpha.0" />
+
 - **类型：** `string | undefined`
 - **默认值：** `undefined`
 
@@ -241,24 +243,25 @@ const config = {
 module.exports = config;
 ```
 
-[点击查看例子](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts)。
-
 :::warning
-
 不支持 `tsconfig.json#extends` 字段。
-
 :::
 
 ## resolve.tsConfig
 
+Rspack 中用来替代 [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin) 的配置。
+
 <ApiMeta addedVersion="0.3.7" />
 
-- **类型：** `object`
+- **类型：** `string | object | undefined`
 - **默认值:** `undefined`
 
 ```js title="rspack.config.js"
 module.exports = {
   resolve: {
+    // string
+    tsConfig: path.resolve(__dirname, './tsconfig.json'),
+    // or object
     tsconfig: {
       configFile: path.resolve(__dirname, './tsconfig.json'),
       references: 'auto',
@@ -267,11 +270,15 @@ module.exports = {
 };
 ```
 
+[点击查看例子](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts)。
+
+:::warning
+不支持 `tsconfig.json#extends` 字段。
+:::
+
 ### resolve.tsConfig.configFile
 
 - **类型：** `string`
-
-同 [resolve.tsConfigPath](#resolvetsconfigpath).
 
 这个选项接受的是 `tsconfig.json` 的文件路径。在开启这个选项后， Rspack 会基于 `tsconfig.json` 中 的 `paths` 和 `baseUrl` 来寻找模块，其功能等同于 [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin)。
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -243,10 +243,6 @@ const config = {
 module.exports = config;
 ```
 
-:::warning
-不支持 `tsconfig.json#extends` 字段。
-:::
-
 ## resolve.tsConfig
 
 Rspack 中用来替代 [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package/tsconfig-paths-webpack-plugin) 的配置。
@@ -271,10 +267,6 @@ module.exports = {
 ```
 
 [点击查看例子](https://github.com/rspack-contrib/rspack-examples/tree/main/rspack/basic-ts)。
-
-:::warning
-不支持 `tsconfig.json#extends` 字段。
-:::
 
 ### resolve.tsConfig.configFile
 

--- a/website/docs/zh/guide/tech/typescript.mdx
+++ b/website/docs/zh/guide/tech/typescript.mdx
@@ -39,7 +39,7 @@
 
 ## Alias
 
-点击 [resolve.tsConfigPath](/config/resolve#resolvetsconfigpath) 查看详情。
+点击 [resolve.tsConfig](/config/resolve#resolvetsconfig) 查看详情。
 
 ## Client 类型
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- remove `resolve.tsConfigPath`
- supports string for `resolve.tsConfig`

and update example PR: https://github.com/rspack-contrib/rspack-examples/pull/93

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
