### PR TITLE
feat: add `factoryMeta` to `JsModule` and optimize `InnerGraphPlugin` for variable decl with iife

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -360,6 +360,10 @@ export interface JsExecuteModuleResult {
   id: number
 }
 
+export interface JsFactoryMeta {
+  sideEffectFree?: boolean
+}
+
 export interface JsLoaderContext {
   resourceData: Readonly<JsResourceData>
   /** Will be deprecated. Use module.module_identifier instead */
@@ -403,6 +407,7 @@ export interface JsModule {
   request?: string
   userRequest?: string
   rawRequest?: string
+  factoryMeta?: JsFactoryMeta
 }
 
 export interface JsNormalModuleFactoryCreateModuleArgs {

--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -7,6 +7,12 @@ use crate::{JsChunk, JsCodegenerationResults};
 
 #[derive(Default)]
 #[napi(object)]
+pub struct JsFactoryMeta {
+  pub side_effect_free: Option<bool>,
+}
+
+#[derive(Default)]
+#[napi(object)]
 pub struct JsModule {
   pub context: Option<String>,
   pub original_source: Option<JsCompatSource>,
@@ -16,6 +22,7 @@ pub struct JsModule {
   pub request: Option<String>,
   pub user_request: Option<String>,
   pub raw_request: Option<String>,
+  pub factory_meta: Option<JsFactoryMeta>,
 }
 
 pub trait ToJsModule {
@@ -50,6 +57,11 @@ impl ToJsModule for dyn Module {
         request: Some(normal_module.request().to_string()),
         user_request: Some(normal_module.user_request().to_string()),
         raw_request: Some(normal_module.raw_request().to_string()),
+        factory_meta: normal_module
+          .factory_meta()
+          .map(|factory_meta| JsFactoryMeta {
+            side_effect_free: factory_meta.side_effect_free,
+          }),
       })
       .or_else(|_| {
         self.try_as_raw_module().map(|_| JsModule {
@@ -61,6 +73,7 @@ impl ToJsModule for dyn Module {
           raw_request: None,
           user_request: None,
           request: None,
+          factory_meta: None,
         })
       })
       .or_else(|_| {
@@ -73,6 +86,7 @@ impl ToJsModule for dyn Module {
           raw_request: None,
           user_request: None,
           request: None,
+          factory_meta: None,
         })
       })
       .or_else(|_| {
@@ -85,6 +99,7 @@ impl ToJsModule for dyn Module {
           raw_request: None,
           user_request: None,
           request: None,
+          factory_meta: None,
         })
       })
       .or_else(|_| {
@@ -112,6 +127,9 @@ impl ToJsModule for CompilerModuleContext {
       request: self.request.clone(),
       user_request: self.user_request.clone(),
       raw_request: self.raw_request.clone(),
+      factory_meta: self.factory_meta.as_ref().map(|fm| JsFactoryMeta {
+        side_effect_free: fm.side_effect_free,
+      }),
     };
     Ok(module)
   }

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -33,7 +33,8 @@ impl CompilerModuleContext {
       user_request: normal_module.map(|normal_module| normal_module.user_request().to_owned()),
       raw_request: normal_module.map(|normal_module| normal_module.raw_request().to_owned()),
       factory_meta: normal_module
-        .and_then(|normal_module| normal_module.factory_meta().map(|fm| fm.clone())),
+        .and_then(|normal_module| normal_module.factory_meta())
+        .map(|factory_meta| factory_meta.to_owned()),
     }
   }
 }

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -5,7 +5,8 @@ pub use rspack_loader_runner::{run_loaders, Content, Loader, LoaderContext};
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
-  CompilerOptions, Context, Module, ModuleIdentifier, ResolverFactory, SharedPluginDriver,
+  CompilerOptions, Context, FactoryMeta, Module, ModuleIdentifier, ResolverFactory,
+  SharedPluginDriver,
 };
 
 #[derive(Debug, Clone)]
@@ -17,6 +18,7 @@ pub struct CompilerModuleContext {
   pub request: Option<String>,
   pub user_request: Option<String>,
   pub raw_request: Option<String>,
+  pub factory_meta: Option<FactoryMeta>,
 }
 
 impl CompilerModuleContext {
@@ -30,6 +32,8 @@ impl CompilerModuleContext {
       request: normal_module.map(|normal_module| normal_module.request().to_owned()),
       user_request: normal_module.map(|normal_module| normal_module.user_request().to_owned()),
       raw_request: normal_module.map(|normal_module| normal_module.raw_request().to_owned()),
+      factory_meta: normal_module
+        .and_then(|normal_module| normal_module.factory_meta().map(|fm| fm.clone())),
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/plugin/inner_graph_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/inner_graph_plugin.rs
@@ -380,7 +380,6 @@ impl<'a> Visit for InnerGraphPlugin<'a> {
           self.clear_symbol_if_is_top_level();
         }
         _ => {
-          init_.visit_children_with(self);
           if is_pure_expression(init, self.unresolved_ctxt, self.comments.as_ref()) {
             self.set_symbol_if_is_top_level(symbol);
             let start = init.span().real_lo();
@@ -396,7 +395,10 @@ impl<'a> Visit for InnerGraphPlugin<'a> {
                 }
               },
             ));
+            init_.visit_children_with(self);
             self.clear_symbol_if_is_top_level();
+          } else {
+            init_.visit_children_with(self);
           }
         }
       }

--- a/packages/rspack-test-tools/tests/configCases/loader/context-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/loader/context-module/rspack.config.js
@@ -10,6 +10,7 @@ module.exports = {
 		rules: [
 			{
 				test: path.join(__dirname, "a.js"),
+				sideEffects: false,
 				use: [
 					{
 						loader: "./my-loader.js"
@@ -31,6 +32,7 @@ module.exports = {
 									hasModule = true;
 									assert(module.buildInfo.LOADER_ACCESS === true);
 									assert(module.buildMeta.LOADER_ACCESS === true);
+									assert(module.factoryMeta.sideEffectFree === true);
 								}
 							}
 						}

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
@@ -1,13 +1,28 @@
 ```js title=main.js
 "use strict";
 (self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
-"./index.js": (function () {
+"./b.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.d(__webpack_exports__, {
+  A: function() { return A; }
+});
+const A = 1;
+const B = 1;
+
+
+
+
+}),
+"./index.js": (function (__unused_webpack_module, __unused_webpack___webpack_exports__, __webpack_require__) {
+/* harmony import */var _b__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__("./b.js");
 
 
 let obj = /*#__PURE__*/ (/* unused pure expression or super */ null && ((() => {
 	return B;
 })()));
 
+let obj2 = (() => {
+	console.log(_b__WEBPACK_IMPORTED_MODULE_0__.A);
+})();
 
 }),
 

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/__snapshots__/treeshaking.snap.txt
@@ -1,0 +1,20 @@
+```js title=main.js
+"use strict";
+(self['webpackChunkwebpack'] = self['webpackChunkwebpack'] || []).push([["main"], {
+"./index.js": (function () {
+
+
+let obj = /*#__PURE__*/ (/* unused pure expression or super */ null && ((() => {
+	return B;
+})()));
+
+
+}),
+
+},function(__webpack_require__) {
+var __webpack_exec__ = function(moduleId) { return __webpack_require__(__webpack_require__.s = moduleId) }
+var __webpack_exports__ = (__webpack_exec__("./index.js"));
+
+}
+]);
+```

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/b.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/b.js
@@ -1,3 +1,4 @@
+const A = 1;
 const B = 1;
 
-export { B };
+export { A, B };

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/b.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/b.js
@@ -1,0 +1,3 @@
+const B = 1;
+
+export { B };

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/index.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/index.js
@@ -1,5 +1,9 @@
-import { B } from "./b";
+import { A, B } from "./b";
 
 let obj = /*#__PURE__*/ (() => {
 	return B;
+})();
+
+let obj2 = (() => {
+	console.log(A);
 })();

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/index.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/index.js
@@ -1,0 +1,5 @@
+import { B } from "./b";
+
+let obj = /*#__PURE__*/ (() => {
+	return B;
+})();

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/rspack.config.js
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure-iife-return/rspack.config.js
@@ -1,0 +1,11 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		sideEffects: true
+	},
+	builtins: {
+		define: {
+			"process.env.NODE_ENV": "'development'"
+		}
+	}
+};

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -31,6 +31,7 @@ import { JsChunkGroup } from '@rspack/binding';
 import { JsCodegenerationResult } from '@rspack/binding';
 import { JsCompilation } from '@rspack/binding';
 import { JsCreateData } from '@rspack/binding';
+import { JsFactoryMeta } from '@rspack/binding';
 import { JsLoaderItem } from '@rspack/binding';
 import { JsModule } from '@rspack/binding';
 import { JsPathData } from '@rspack/binding';
@@ -5011,6 +5012,8 @@ export class Module {
     buildMeta: Record<string, any>;
     // (undocumented)
     context?: Readonly<string>;
+    // (undocumented)
+    factoryMeta?: Readonly<JsFactoryMeta>;
     // (undocumented)
     identifier(): string;
     // (undocumented)

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -2,6 +2,7 @@ import {
 	JsCodegenerationResult,
 	JsCodegenerationResults,
 	JsCreateData,
+	JsFactoryMeta,
 	JsModule
 } from "@rspack/binding";
 import { Source } from "webpack-sources";
@@ -55,6 +56,7 @@ export class Module {
 	userRequest?: Readonly<string>;
 	rawRequest?: Readonly<string>;
 
+	factoryMeta?: Readonly<JsFactoryMeta>;
 	/**
 	 * Records the dynamically added fields for Module on the JavaScript side.
 	 * These fields are generally used within a plugin, so they do not need to be passed back to the Rust side.
@@ -81,6 +83,7 @@ export class Module {
 		this.userRequest = module.userRequest;
 		this.rawRequest = module.rawRequest;
 
+		this.factoryMeta = module.factoryMeta;
 		const customModule = compilation?.__internal__getCustomModule(
 			module.moduleIdentifier
 		);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

releated: https://github.com/web-infra-dev/rspack/issues/6436

After my debugging, I find some causes: 

1. In the reproduction of this issue, a loader that marks the module as side effect free and a corresponding optimization loader were configured, but factoryMeta is currently not being passed back to the js side.
2. Tree shaking fails for the following code:
```js
// index.js
import { B } from "./b";
let obj = /*#__PURE__*/ (() => {
	return B;
})();

// b.js
const B = 1;
export { B };
```
webpack output: 
```js
/******/ (() => { // webpackBootstrap
/******/ 	"use strict";
var __webpack_exports__ = {};


let obj = /*#__PURE__*/ (/* unused pure expression or super */ null && ((() => {
	return B;
})()));

/******/ })()
;
```
while rspack output:
```js
(() => { // webpackBootstrap
"use strict";
var __webpack_modules__ = ({
"996": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
__webpack_require__.d(__webpack_exports__, {
  B: function() { return B; }
});
const B = 1;
}),

});
// Some runtime...

var __webpack_exports__ = {};
/* harmony import */var _b__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(996);
let obj = /*#__PURE__*/ (/* unused pure expression or super */ null && ((() => {
	return _b__WEBPACK_IMPORTED_MODULE_0__.B;
})()));
})()
;
//# sourceMappingURL=main.js.map
```

The cause of the problem is that InnerGraphPlugin does not set the top symbol to the variable's name before  `init_.visit_children_with` in `visit_var_declarator`, which leads to the lack of dependency relationship between the usage of the identifiers in decl init function and the usage of the declared variable. Instead, it directly considers the identifiers in iife as used in top level, thus preventing optimization.

3. Differences between swc minifier and terser:

|                | origin | swc(TerserPlguin.swcMinify)                               | terser(TerserPlugin)             |
| -------------- | ------ | --------------------------------- | ------------------- |
| webpack        | 2.1MB  | 231KB     | 217KB |
| rspack(before) | 2.1MB  | 319KB | 310KB   |
| rspack(after)  | 2.1MB  | 281KB | 194KB   |


I will also debug the swc minifier if I have time.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
