### PR TITLE
docs: fix rspack exports in javascript-api.mdx

### DIFF
--- a/website/docs/en/api/javascript-api.mdx
+++ b/website/docs/en/api/javascript-api.mdx
@@ -24,7 +24,7 @@ npm install --save-dev @rspack/core
 Then require the `@rspack/core` module in your JavaScript file:
 
 ```js title="build.js"
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 ```
 
 ## rspack()
@@ -32,7 +32,7 @@ import rspack from '@rspack/core';
 The imported rspack function is fed a Rspack Configuration Object and runs the Rspack compiler if a callback function is provided:
 
 ```js
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 rspack({}, (err, stats) => {
   if (err || stats.hasErrors()) {
@@ -72,7 +72,7 @@ The API only supports a single concurrent compilation at a time. When using `run
 Calling the `run` method on the `Compiler` instance is much like the quick run method mentioned above:
 
 ```js
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 const compiler = rspack({
   // ...
@@ -100,7 +100,7 @@ watch(watchOptions, callback);
 ```
 
 ```js
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 const compiler = rspack({
   // ...
@@ -204,7 +204,7 @@ stats.toString({
 Here’s an example of `stats.toString()` usage:
 
 ```js
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 rspack(
   {
@@ -231,7 +231,7 @@ rspack(
 The `MultiCompiler` module allows Rspack to run multiple configurations in separate compilers. If the `options` parameter in the Rspack's JavaScript API is an array of options, Rspack applies separate compilers and calls the callback after all compilers have been executed.
 
 ```js
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 rspack(
   [
@@ -259,7 +259,7 @@ For good error handling, you need to account for these three types of errors:
 Here’s an example that does all that:
 
 ```js
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 rspack(
   {
@@ -303,7 +303,7 @@ By default, Rspack reads files and writes files to disk using a normal file syst
 
 ```js
 import { createFsFromVolume, Volume } from 'memfs';
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 
 const fs = createFsFromVolume(new Volume());
 const compiler = rspack({


### PR DESCRIPTION
## Summary

The documentation seems to be showing the wrong import 
![image](https://github.com/web-infra-dev/rspack/assets/57541158/a1a0a50f-cece-4518-8051-c02e9b45bf8e)

The correct import should be something like this 
<img width="574" alt="Screenshot 2024-06-23 at 3 36 13 PM" src="https://github.com/web-infra-dev/rspack/assets/57541158/d5b8ffd9-28a9-4a20-9290-06c7c96aa064">


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
