### PR TITLE
Revert "chore(deps): update crates"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ async-trait        = { version = "0.1.79" }
 bitflags           = { version = "2.5.0" }
 concat-string      = "1.0.1"
 css-module-lexer   = "0.0.14"
-dashmap            = { version = "6.0.0" }
+dashmap            = { version = "6.0.0-rc.1" }
 derivative         = { version = "2.2.0" }
 futures            = { version = "0.3.30" }
 glob               = { version = "0.3.1" }


### PR DESCRIPTION
This reverts commit 898163983de2806ad0f112e570abf071810a090f.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
dashmap 0.6.0 is yanked, which cause install rspack by git url failed, so revert it
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
