### PR TITLE
feat: generating provenance statements

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -8,6 +8,10 @@ on:
         type: string
         description: "Commit SHA"
 
+permissions:
+  # To publish packages with provenance
+  id-token: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels
@@ -83,3 +87,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # To publish packages with provenance
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -87,5 +87,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # To publish packages with provenance
-          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -87,8 +87,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
-          # To publish packages with provenance
-          NPM_CONFIG_PROVENANCE: true
     outputs:
       version: ${{ steps.publish.outputs.version }}
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -6,6 +6,10 @@ on:
     # 08:00 AM Beijing Time. Except Tuesday, which is for full release
     - cron: "0 0 * * 0,1,3,4,5,6"
 
+permissions:
+  # To publish packages with provenance
+  id-token: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels
@@ -83,6 +87,8 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+          # To publish packages with provenance
+          NPM_CONFIG_PROVENANCE: true
     outputs:
       version: ${{ steps.publish.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ on:
         description: "push tags to github"
         required: true
         default: true
+
+permissions:
+  # To publish packages with provenance
+  id-token: write
+
 jobs:
   get-runner-labels:
     name: Get Runner Labels
@@ -100,6 +105,9 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+          # To publish packages with provenance
+          NPM_CONFIG_PROVENANCE: true
+
       - name: Release Nightly(After Full)
         run: |
           ./x version snapshot
@@ -110,3 +118,5 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
+          # To publish packages with provenance
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,6 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
-          # To publish packages with provenance
-          NPM_CONFIG_PROVENANCE: true
 
       - name: Release Nightly(After Full)
         run: |
@@ -118,5 +116,3 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           REF: ${{ github.ref }}
           ONLY_RELEASE_TAG: true
-          # To publish packages with provenance
-          NPM_CONFIG_PROVENANCE: true

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -6,7 +6,8 @@
   "main": "binding.js",
   "types": "binding.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "binding.js",

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/web-infra-dev/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "rspack.darwin-arm64.node"

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/web-infra-dev/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "rspack.darwin-x64.node"

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/web-infra-dev/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "rspack.linux-x64-gnu.node"

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -11,7 +11,8 @@
     "url": "https://github.com/web-infra-dev/rspack"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "files": [
     "rspack.win32-x64-msvc.node"

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "create-rspack": "index.js"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -3,6 +3,10 @@
   "version": "0.7.4",
   "license": "MIT",
   "description": "CLI for rspack",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bin": {
     "rspack": "./bin/rspack"
   },

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -5,6 +5,10 @@
   "description": "Development server for rspack",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "default": "./dist/index.js"

--- a/packages/rspack-plugin-minify/package.json
+++ b/packages/rspack-plugin-minify/package.json
@@ -22,7 +22,8 @@
     "directory": "packages/rspack-plugin-minify"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "dependencies": {
     "esbuild": "0.16.3",

--- a/packages/rspack-plugin-preact-refresh/package.json
+++ b/packages/rspack-plugin-preact-refresh/package.json
@@ -25,7 +25,8 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-plugin-react-refresh/package.json
+++ b/packages/rspack-plugin-react-refresh/package.json
@@ -25,7 +25,8 @@
     "dist"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -33,7 +33,8 @@
     "jest.d.ts"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -6,6 +6,10 @@
   "description": "The fast Rust-based web bundler with webpack-compatible API",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "default": "./dist/index.js"


### PR DESCRIPTION
## Summary

Generate NPM provenance statements for all Rspack packages.

This  allows us to publish Rspack packages on GitHub Actions only and increase supply-chain security.

See: https://docs.npmjs.com/generating-provenance-statements

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
