### PR TITLE
fix: CopyRspackPlugin transform option type

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -816,7 +816,7 @@ export interface RawCopyPattern {
   priority: number
   globOptions: RawCopyGlobOptions
   info?: RawInfo
-  transform?: (input: string | Buffer, absoluteFilename: string) => string | Buffer
+  transform?: (input: Buffer, absoluteFilename: string) => string | Buffer | Promise<string> | Promise<Buffer>
 }
 
 export interface RawCopyRspackPluginOptions {

--- a/plugin-test/copy-plugin/CopyPlugin.test.js
+++ b/plugin-test/copy-plugin/CopyPlugin.test.js
@@ -463,6 +463,40 @@ describe("CopyPlugin", () => {
 			});
 		});
 
+		it("should work with transform async fn", async () => {
+			const compiler = rspack([
+				{
+					mode: "development",
+					context: path.resolve(__dirname, "./fixtures"),
+					plugins: [
+						new rspack.CopyRspackPlugin({
+							patterns: [
+								{
+									from: path.resolve(__dirname, "./fixtures/directory"),
+									transform: source => {
+										expect(Buffer.isBuffer(source)).toBeTruthy();
+										return Promise.resolve(source + "transform aaaa");
+									}
+								}
+							]
+						})
+					],
+					entry: path.resolve(__dirname, "./helpers/enter.js"),
+					output: {
+						path: path.resolve(__dirname, "./outputs/dist/b")
+					}
+				}
+			]);
+
+			const { stats } = await compile(compiler);
+
+			stats.stats.forEach((item, index) => {
+				expect(readAssets(compiler.compilers[index], item)).toMatchSnapshot(
+					"assets"
+				);
+			});
+		});
+
 		it("should work with to fn", async () => {
 			const compiler = rspack([
 				{

--- a/plugin-test/copy-plugin/__snapshots__/CopyPlugin.test.js.snap
+++ b/plugin-test/copy-plugin/__snapshots__/CopyPlugin.test.js.snap
@@ -38,6 +38,16 @@ Object {
 }
 `;
 
+exports[`CopyPlugin basic should work with transform async fn: assets 1`] = `
+Object {
+  ".dottedfile": "dottedfile contents
+transform aaaa",
+  "directoryfile.txt": "newtransform aaaa",
+  "nested/deep-nested/deepnested.txt": "transform aaaa",
+  "nested/nestedfile.txt": "transform aaaa",
+}
+`;
+
 exports[`CopyPlugin basic should work with transform fn: assets 1`] = `
 Object {
   ".dottedfile": "dottedfile contents

--- a/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/copy-rspack-plugin.mdx
@@ -41,9 +41,9 @@ new rspack.CopyRspackPlugin(options);
             ignore?: string[]; // ignore specific path
           };
           transform?: (
-            input: string | Buffer,
+            input: Buffer,
             absoluteFilename: string,
-          ) => string | Buffer;
+          ) => string | Buffer | Promise<string> | Promise<Buffer>;
         }
     )[];
   };

--- a/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/copy-rspack-plugin.mdx
@@ -41,9 +41,9 @@ new rspack.CopyRspackPlugin(options);
             ignore?: string[]; // 忽略特定路径
           };
           transform?: (
-            input: string | Buffer,
+            input: Buffer,
             absoluteFilename: string,
-          ) => string | Buffer;
+          ) => string | Buffer | Promise<string> | Promise<Buffer>;
         }
     )[];
   };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

transform input is always `Buffer` type, and the returns support async.


resolve: https://github.com/web-infra-dev/rspack/issues/6895

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
