### PR TITLE
fix: use max_entrypoint_size in add_entrypoints_over_size_limit_warning

### DIFF
--- a/crates/rspack_plugin_size_limits/src/lib.rs
+++ b/crates/rspack_plugin_size_limits/src/lib.rs
@@ -193,7 +193,7 @@ async fn after_emit(&self, compilation: &mut Compilation) -> Result<()> {
     if !entrypoints_over_limit.is_empty() {
       Self::add_entrypoints_over_size_limit_warning(
         &entrypoints_over_limit,
-        max_asset_size,
+        max_entrypoint_size,
         hints,
         &mut diagnostics,
       );


### PR DESCRIPTION
## Summary

Due to the typo in `rspack_plugin_size_limits` the `add_entrypoints_over_size_limit_warning` was reported with `max_asset_size` instead of `max_entrypoint_size`. On my project, it looks like this:
```
config.performance = {
	maxEntrypointSize: 43000, // 41.992 KiB
	maxAssetSize: 30000000, // 28.610 MiB
}
```

```
ERROR in × entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (28.610 MiB). This can impact web performance.
  │ Entrypoints:
  │   appInlineEntry (42.025 KiB)
  │       runtime~appInlineEntry.36a7dc3a8518e752.js
  │       appInlineEntry.476b756676281597.js

```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
