### PR TITLE
fix: use entrypoint.options.runtime as key for chunk_graph.runtime_ids map if possible

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -31,10 +31,10 @@ use crate::{
   prepare_get_exports_type, to_identifier, BoxDependency, BoxModule, CacheCount, CacheOptions,
   Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkKind,
   ChunkUkey, CodeGenerationResults, CompilationLogger, CompilationLogging, CompilerOptions,
-  DependencyId, DependencyType, Entry, EntryData, EntryOptions, Entrypoint, ExecuteModuleId,
-  Filename, ImportVarMap, LocalFilenameFn, Logger, Module, ModuleFactory, ModuleGraph,
-  ModuleGraphPartial, ModuleIdentifier, PathData, ResolverFactory, RuntimeGlobals, RuntimeModule,
-  RuntimeSpec, SharedPluginDriver, SourceType, Stats,
+  DependencyId, DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint,
+  ExecuteModuleId, Filename, ImportVarMap, LocalFilenameFn, Logger, Module, ModuleFactory,
+  ModuleGraph, ModuleGraphPartial, ModuleIdentifier, PathData, ResolverFactory, RuntimeGlobals,
+  RuntimeModule, RuntimeSpec, SharedPluginDriver, SourceType, Stats,
 };
 
 pub type BuildDependency = (
@@ -1160,7 +1160,10 @@ impl Compilation {
       let runtime = entrypoint
         .kind
         .get_entry_options()
-        .and_then(|o| o.name.clone())
+        .and_then(|o| match &o.runtime {
+          Some(EntryRuntime::String(s)) => Some(s.to_owned()),
+          _ => None,
+        })
         .or(entrypoint.name().map(|n| n.to_string()));
       if let (Some(runtime), Some(chunk)) = (
         runtime,


### PR DESCRIPTION
## Summary

Aligning `Compilation#assign_runtime_ids` with [webpack implementation](https://github.com/webpack/webpack/blob/dd44b206a9c50f4b4cb4d134e1a0bd0387b159a3/lib/Compilation.js#L3987).

Found this mismatch while experimenting with rspack on the old large project.
Before these changes, the dump of `ChunkGraph.runtime_ids` looked like this:
```
{
  "__calculator_worker__": Some("__calculator_worker__"),
  "RichTextWebWorker": Some("RichTextWebWorker"),
  "__functions_worker__": Some("__functions_worker__"),
  "appInlineEntry": Some("runtime~appInlineEntry")
}
```
while in webpack it looked like this:
```
{
  'runtime~appInlineEntry' => 'runtime~appInlineEntry',
  'a00dc51364804200' => 3,
  '56698110d4fe00db' => 'RichTextWebWorker',
  '8d8141fedf82c897' => 1,
  '92429ff87222e258' => 2,
  '65e8ae716b25791d' => 0,
  '32d7fdacd7d4ed93' => '__calculator_worker__',
  'b0a0ef755369e916' => '__functions_worker__'
}
```
That difference led to [`runtime_condition_expression`](https://github.com/web-infra-dev/rspack/blob/fdc768561db0019bffa938aa04b554c9ee565874/crates/rspack_core/src/dependency/runtime_template.rs#L16) generating `"false"` for certain modules, so they got unreachable in runtime.

After the fix, `ChunkGraph.runtime_ids` is
```
{
    "runtime~appInlineEntry": Some("runtime~appInlineEntry"),
    "33ad7c9687358993d985": Some("__functions_worker__"),
    "12c8a9682de15914962d": Some("packages_widget-comments_src_controllers_ClusteringWorker_worker_ts"),
    "e6bb2872f0008add76c4": Some("RichTextWebWorker"),
    "4b002f1e6edcccc5c47f": Some("__calculator_worker__"),
    "eea89330ff05454cc19a": Some("1"),
    "0fa545de2cfe3ca062bf": Some("packages_analytics-core_src_stats-api_stats-api_ts"),
    "afab41ba2be5f5683100": Some("0")
}
```
which is still a bit different, but at least all expected keys are in place.


This is my first contribution,  so I'm unsure about the test case. Would love to get any help!

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
