### PR TITLE
feat(create-rspack): improve the templates

### DIFF
--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -16,6 +16,8 @@
     "@rspack/plugin-react-refresh": "workspace:*",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
-    "react-refresh": "^0.14.0"
+    "react-refresh": "^0.14.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
   }
 }

--- a/packages/create-rspack/template-react-ts/rspack.config.ts
+++ b/packages/create-rspack/template-react-ts/rspack.config.ts
@@ -1,10 +1,10 @@
-const rspack = require("@rspack/core");
-const refreshPlugin = require("@rspack/plugin-react-refresh");
+import { defineConfig } from "@rspack/cli";
+import { rspack } from "@rspack/core";
+import * as RefreshPlugin from "@rspack/plugin-react-refresh";
+
 const isDev = process.env.NODE_ENV === "development";
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+
+export default defineConfig({
 	context: __dirname,
 	entry: {
 		main: "./src/main.tsx"
@@ -59,6 +59,9 @@ module.exports = {
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		isDev ? new refreshPlugin() : null
-	].filter(Boolean)
-};
+		isDev ? new RefreshPlugin() : null
+	].filter(Boolean),
+	experiments: {
+		css: true
+	}
+});

--- a/packages/create-rspack/template-react-ts/tsconfig.json
+++ b/packages/create-rspack/template-react-ts/tsconfig.json
@@ -1,18 +1,22 @@
 {
   "compilerOptions": {
-    "target": "ES6",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
     "module": "ESNext",
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react-jsx",
     "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  }
 }

--- a/packages/create-rspack/template-react/rspack.config.mjs
+++ b/packages/create-rspack/template-react/rspack.config.mjs
@@ -1,10 +1,13 @@
-const rspack = require("@rspack/core");
-const refreshPlugin = require("@rspack/plugin-react-refresh");
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "@rspack/cli";
+import { rspack } from "@rspack/core";
+import RefreshPlugin from "@rspack/plugin-react-refresh";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === "development";
-/**
- * @type {import('@rspack/cli').Configuration}
- */
-module.exports = {
+
+export default defineConfig({
 	context: __dirname,
 	entry: {
 		main: "./src/main.jsx"
@@ -59,6 +62,9 @@ module.exports = {
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		isDev ? new refreshPlugin() : null
-	].filter(Boolean)
-};
+		isDev ? new RefreshPlugin() : null
+	].filter(Boolean),
+	experiments: {
+		css: true
+	}
+});

--- a/packages/create-rspack/template-vanilla/rspack.config.js
+++ b/packages/create-rspack/template-vanilla/rspack.config.js
@@ -1,7 +1,0 @@
-const rspack = require("@rspack/core");
-module.exports = {
-	entry: {
-		main: "./src/index.js"
-	},
-	plugins: [new rspack.HtmlRspackPlugin({ template: "./index.html" })]
-};

--- a/packages/create-rspack/template-vanilla/rspack.config.mjs
+++ b/packages/create-rspack/template-vanilla/rspack.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from "@rspack/cli";
+import { rspack } from "@rspack/core";
+
+export default defineConfig({
+	entry: {
+		main: "./src/index.js"
+	},
+	plugins: [new rspack.HtmlRspackPlugin({ template: "./index.html" })]
+});

--- a/packages/create-rspack/template-vue-ts/package.json
+++ b/packages/create-rspack/template-vue-ts/package.json
@@ -1,12 +1,10 @@
 {
-  "name": "rspack-vue-starter",
+  "name": "rspack-vue-ts-starter",
   "version": "1.0.0",
-  "description": "",
   "private": true,
-  "main": "index.js",
   "scripts": {
-    "dev": "rspack serve",
-    "build": "rspack build"
+    "dev": "NODE_ENV=development rspack serve",
+    "build": "NODE_ENV=production rspack build"
   },
   "dependencies": {
     "vue": "3.4.21"
@@ -14,11 +12,8 @@
   "devDependencies": {
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
-    "vue-loader": "^17.2.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+    "typescript": "^5.3.3",
+    "vue-loader": "^17.2.2"
+  }
 }

--- a/packages/create-rspack/template-vue-ts/rspack.config.ts
+++ b/packages/create-rspack/template-vue-ts/rspack.config.ts
@@ -1,28 +1,23 @@
-import {
-	Configuration,
-	DefinePlugin,
-	HtmlRspackPlugin,
-	RspackPluginFunction
-} from "@rspack/core";
+import { defineConfig } from "@rspack/cli";
+import { type RspackPluginFunction, rspack } from "@rspack/core";
 import { VueLoaderPlugin } from "vue-loader";
 
-const isDev = process.env.NODE_ENV == "development";
-
-const config: Configuration = {
+export default defineConfig({
 	context: __dirname,
 	entry: {
 		main: "./src/main.ts"
 	},
 	resolve: {
-		extensions: ["...", ".ts"]
+		extensions: ["...", ".ts", ".vue"]
 	},
 	plugins: [
 		new VueLoaderPlugin() as RspackPluginFunction,
-		new HtmlRspackPlugin({
+		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
-		new DefinePlugin({
-			__VUE_PROD_DEVTOOLS__: isDev
+		new rspack.DefinePlugin({
+			__VUE_OPTIONS_API__: true,
+			__VUE_PROD_DEVTOOLS__: false
 		})
 	],
 	module: {
@@ -43,8 +38,7 @@ const config: Configuration = {
 							sourceMap: true,
 							jsc: {
 								parser: {
-									syntax: "typescript",
-									tsx: false
+									syntax: "typescript"
 								}
 							},
 							env: {
@@ -64,7 +58,8 @@ const config: Configuration = {
 				type: "asset/resource"
 			}
 		]
+	},
+	experiments: {
+		css: true
 	}
-};
-
-export default config;
+});

--- a/packages/create-rspack/template-vue-ts/src/main.ts
+++ b/packages/create-rspack/template-vue-ts/src/main.ts
@@ -1,7 +1,5 @@
 import "./style.css";
-
 import { createApp } from "vue";
-
 import App from "./App.vue";
 
 createApp(App).mount("#app");

--- a/packages/create-rspack/template-vue-ts/tsconfig.json
+++ b/packages/create-rspack/template-vue-ts/tsconfig.json
@@ -1,20 +1,23 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "lib": [
-      "DOM",
-      "ES2020"
-    ],
-    "module": "CommonJS",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
     "jsx": "preserve",
     "jsxImportSource": "vue",
     "strict": true,
+    "noEmit": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "useDefineForClassFields": true
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"],
+  "ts-node": {
+    "compilerOptions": {
+      "module": "CommonJS"
+    }
+  }
 }

--- a/packages/create-rspack/template-vue/package.json
+++ b/packages/create-rspack/template-vue/package.json
@@ -1,12 +1,10 @@
 {
   "name": "rspack-vue-starter",
   "version": "1.0.0",
-  "description": "",
   "private": true,
-  "main": "index.js",
   "scripts": {
-    "dev": "rspack serve",
-    "build": "rspack build"
+    "dev": "NODE_ENV=development rspack serve",
+    "build": "NODE_ENV=production rspack build"
   },
   "dependencies": {
     "vue": "3.2.45"
@@ -15,8 +13,5 @@
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
     "vue-loader": "^17.2.2"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+  }
 }

--- a/packages/create-rspack/template-vue/rspack.config.mjs
+++ b/packages/create-rspack/template-vue/rspack.config.mjs
@@ -1,19 +1,27 @@
-const rspack = require("@rspack/core");
-const { VueLoaderPlugin } = require("vue-loader");
-const isDev = process.env.NODE_ENV == "development";
-/** @type {import('@rspack/cli').Configuration} */
-const config = {
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "@rspack/cli";
+import { rspack } from "@rspack/core";
+import { VueLoaderPlugin } from "vue-loader";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
 	context: __dirname,
 	entry: {
 		main: "./src/main.js"
 	},
 	resolve: {
-		extensions: ["...", ".ts"]
+		extensions: ["...", ".ts", ".vue"]
 	},
 	plugins: [
 		new VueLoaderPlugin(),
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
+			__VUE_OPTIONS_API__: true,
+			__VUE_PROD_DEVTOOLS__: false
 		})
 	],
 	module: {
@@ -33,8 +41,7 @@ const config = {
 						options: {
 							jsc: {
 								parser: {
-									syntax: "typescript",
-									tsx: false
+									syntax: "typescript"
 								}
 							},
 							env: {
@@ -54,6 +61,8 @@ const config = {
 				type: "asset/resource"
 			}
 		]
+	},
+	experiments: {
+		css: true
 	}
-};
-module.exports = config;
+});

--- a/packages/create-rspack/template-vue/src/main.js
+++ b/packages/create-rspack/template-vue/src/main.js
@@ -1,7 +1,5 @@
 import "./style.css";
-
 import { createApp } from "vue";
-
 import App from "./App.vue";
 
 createApp(App).mount("#app");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,6 +305,12 @@ importers:
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@swc/core@1.4.0)(@types/node@20.12.7)(typescript@5.4.2)
+      typescript:
+        specifier: ^5.3.3
+        version: 5.4.2
 
   packages/create-rspack/template-vanilla:
     devDependencies:


### PR DESCRIPTION
## Summary

Improve the templates:

- Enable `experiments.css` to support CSS, see https://github.com/web-infra-dev/rspack/pull/6910
- Use `rspack.config.mjs` for JS templates.
- Use `rspack.config.ts` for TS templates.
- Use `defineConfig` to provide autocomplete.
- Update tsconfig.json and align with Rsbuild.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
