### PR TITLE
fix: context passed into the `ModuleFactory` is not correct

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -40,9 +40,13 @@ impl Task<MakeTaskContext> for FactorizeTask {
     let dependency = self.dependency;
     //    let dep_id = *dependency.id();
 
-    let context = if let Some(context) = dependency.get_context() {
+    let context = if let Some(context) = dependency.get_context()
+      && !context.is_empty()
+    {
       context
-    } else if let Some(context) = &self.original_module_context {
+    } else if let Some(context) = &self.original_module_context
+      && !context.is_empty()
+    {
       context
     } else {
       &self.options.context

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -269,7 +269,6 @@ impl NormalModuleFactory {
     let resource_data = if scheme.is_some() {
       // resource with scheme
       let mut resource_data = ResourceData::new(unresolved_resource.to_owned(), "".into());
-      // resource with scheme
       plugin_driver
         .normal_module_factory_hooks
         .resolve_for_scheme


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Partially fixed the compile issue of  https://github.com/web-infra-dev/rspack/issues/5554

This is still not be able to turn on:

```
  ● ConfigTestCases › inner-graph › basic › exported tests › myFunction should have the correct exports used for ./assert

    expect(received).toEqual(expected) // deep equality

    Expected: ["__usedExports", "deepEqual", "equal"]
    Received: undefined
```

`__webpack_exports_info__.usedExports` is not supported.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
