### PR TITLE
fix!: align webpack defaults

### DIFF
--- a/packages/rspack-test-tools/tests/Defaults.test.js
+++ b/packages/rspack-test-tools/tests/Defaults.test.js
@@ -69,7 +69,7 @@ function assertWebpackConfig(config) {
 	expect(rspackBaseConfig).toEqual(webpackBaseConfig);
 }
 
-describe.skip("Base Defaults Snapshot", () => {
+describe("Base Defaults Snapshot", () => {
 	const baseConfig = DefaultsConfigProcessor.getDefaultConfig(cwd, { mode: "none" });
 
 	it("should have the correct base config", () => {

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -18,6 +18,7 @@ Object {
   "experiments": Object {
     "asyncWebAssembly": false,
     "css": undefined,
+    "futureDefaults": false,
     "lazyCompilation": false,
     "rspackFuture": Object {
       "bundlerInfo": Object {
@@ -249,7 +250,7 @@ Object {
     "nodeEnv": false,
     "providedExports": true,
     "realContentHash": false,
-    "removeAvailableModules": true,
+    "removeAvailableModules": false,
     "removeEmptyChunks": true,
     "runtimeChunk": false,
     "sideEffects": "flag",

--- a/packages/rspack-test-tools/tests/defaultsCases/experiments/both-wasm.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/experiments/both-wasm.js
@@ -6,42 +6,42 @@ module.exports = {
 	}),
 	diff: e =>
 		e.toMatchInlineSnapshot(`
-			- Expected
-			+ Received
+		- Expected
+		+ Received
 
-			@@ ... @@
-			-     "asyncWebAssembly": false,
-			+     "asyncWebAssembly": true,
-			@@ ... @@
-			+     "syncWebAssembly": true,
-			@@ ... @@
-			+       },
-			+       Object {
-			+         "rules": Array [
-			+           Object {
-			+             "descriptionData": Object {
-			+               "type": "module",
-			+             },
-			+             "resolve": Object {
-			+               "fullySpecified": true,
-			+             },
-			+           },
-			+         ],
-			+         "test": /\\.wasm$/i,
-			+         "type": "webassembly/async",
-			+       },
-			+       Object {
-			+         "mimetype": "application/wasm",
-			+         "rules": Array [
-			+           Object {
-			+             "descriptionData": Object {
-			+               "type": "module",
-			+             },
-			+             "resolve": Object {
-			+               "fullySpecified": true,
-			+             },
-			+           },
-			+         ],
-			+         "type": "webassembly/async",
-		`)
+		@@ ... @@
+		-     "asyncWebAssembly": false,
+		+     "asyncWebAssembly": true,
+		@@ ... @@
+		+     "syncWebAssembly": true,
+		@@ ... @@
+		+       },
+		+       Object {
+		+         "rules": Array [
+		+           Object {
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "test": /\\.wasm$/i,
+		+         "type": "webassembly/async",
+		+       },
+		+       Object {
+		+         "mimetype": "application/wasm",
+		+         "rules": Array [
+		+           Object {
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "type": "webassembly/async",
+	`)
 };

--- a/packages/rspack-test-tools/tests/defaultsCases/experiments/future-defaults-with-css.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/experiments/future-defaults-with-css.js
@@ -13,9 +13,42 @@ module.exports = {
 		+ Received
 
 		@@ ... @@
+		-     "asyncWebAssembly": false,
 		-     "css": undefined,
+		-     "futureDefaults": false,
+		+     "asyncWebAssembly": true,
 		+     "css": false,
 		+     "futureDefaults": true,
+		@@ ... @@
+		+       },
+		+       Object {
+		+         "rules": Array [
+		+           Object {
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "test": /\\.wasm$/i,
+		+         "type": "webassembly/async",
+		@@ ... @@
+		+         "mimetype": "application/wasm",
+		+         "rules": Array [
+		+           Object {
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "type": "webassembly/async",
+		+       },
+		+       Object {
 		@@ ... @@
 		-     "hashDigestLength": 20,
 		-     "hashFunction": "md4",

--- a/packages/rspack-test-tools/tests/defaultsCases/experiments/future-defaults.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/experiments/future-defaults.js
@@ -12,10 +12,41 @@ module.exports = {
 		+ Received
 
 		@@ ... @@
+		-     "asyncWebAssembly": false,
 		-     "css": undefined,
+		-     "futureDefaults": false,
+		+     "asyncWebAssembly": true,
 		+     "css": true,
 		+     "futureDefaults": true,
 		@@ ... @@
+		+       },
+		+       Object {
+		+         "rules": Array [
+		+           Object {
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "test": /\\.wasm$/i,
+		+         "type": "webassembly/async",
+		@@ ... @@
+		+       Object {
+		+         "mimetype": "application/wasm",
+		+         "rules": Array [
+		@@ ... @@
+		+             "descriptionData": Object {
+		+               "type": "module",
+		+             },
+		+             "resolve": Object {
+		+               "fullySpecified": true,
+		+             },
+		+           },
+		+         ],
+		+         "type": "webassembly/async",
 		+       },
 		+       Object {
 		+         "resolve": Object {
@@ -38,9 +69,10 @@ module.exports = {
 		+         "resolve": Object {
 		+           "fullySpecified": true,
 		+           "preferRelative": true,
-		@@ ... @@
+		+         },
 		+         "type": "css",
 		+       },
+		+       Object {
 		@@ ... @@
 		-     "generator": Object {},
 		+     "generator": Object {
@@ -62,16 +94,16 @@ module.exports = {
 		+       },
 		+     },
 		@@ ... @@
-		+         },
 		+       },
 		+       "css": Object {
 		+         "namedExports": true,
-		+       },
+		@@ ... @@
 		+       "css/auto": Object {
 		+         "namedExports": true,
-		@@ ... @@
+		+       },
 		+       "css/module": Object {
 		+         "namedExports": true,
+		+       },
 		@@ ... @@
 		+         "css",
 		@@ ... @@

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -81,14 +81,11 @@ export const applyRspackOptionsDefaults = (
 	// IGNORE(bail): bail is default to false in webpack, but it's set in `Compilation`
 	D(options, "bail", false);
 
-	const futureDefaults = options.experiments.futureDefaults ?? false;
 	// IGNORE(cache): cache is default to { type: "memory" } in webpack when the mode is development,
 	// but Rspack currently does not support this option
 	F(options, "cache", () => development);
 
-	applyExperimentsDefaults(options.experiments, {
-		cache: options.cache!
-	});
+	applyExperimentsDefaults(options.experiments);
 
 	applySnapshotDefaults(options.snapshot, { production });
 
@@ -109,7 +106,7 @@ export const applyRspackOptionsDefaults = (
 		outputModule: options.experiments.outputModule,
 		development,
 		entry: options.entry,
-		futureDefaults
+		futureDefaults: options.experiments.futureDefaults!
 	});
 
 	applyExternalsPresetsDefaults(options.externalsPresets, {
@@ -184,14 +181,11 @@ const applyInfrastructureLoggingDefaults = (
 	D(infrastructureLogging, "appendOnly", !tty);
 };
 
-const applyExperimentsDefaults = (
-	experiments: ExperimentsNormalized,
-	{ cache }: { cache: boolean }
-) => {
+const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
+	D(experiments, "futureDefaults", false);
 	// IGNORE(experiments.lazyCompilation): In webpack, lazyCompilation is undefined by default
 	D(experiments, "lazyCompilation", false);
-	// IGNORE(experiments.asyncWebAssembly): The default value of `asyncWebAssembly` is determined by `futureDefaults` in webpack.
-	D(experiments, "asyncWebAssembly", false);
+	D(experiments, "asyncWebAssembly", experiments.futureDefaults);
 	D(experiments, "css", experiments.futureDefaults ? true : undefined);
 	D(experiments, "topLevelAwait", true);
 
@@ -272,6 +266,7 @@ const applyModuleDefaults = (
 	assertNotNill(module.parser);
 	assertNotNill(module.generator);
 
+	// IGNORE(module.parser): already check to align in 2024.6.27
 	F(module.parser, ASSET_MODULE_TYPE, () => ({}));
 	assertNotNill(module.parser.asset);
 	F(module.parser.asset, "dataUrlCondition", () => ({}));
@@ -317,6 +312,7 @@ const applyModuleDefaults = (
 		assertNotNill(module.parser["css/module"]);
 		D(module.parser["css/module"], "namedExports", true);
 
+		// IGNORE(module.generator): already check to align in 2024.6.27
 		F(module.generator, "css", () => ({}));
 		assertNotNill(module.generator.css);
 		D(
@@ -913,8 +909,7 @@ const applyOptimizationDefaults = (
 		css
 	}: { production: boolean; development: boolean; css: boolean }
 ) => {
-	// IGNORE(optimization.removeAvailableModules): In webpack, removeAvailableModules is false by default
-	D(optimization, "removeAvailableModules", true);
+	D(optimization, "removeAvailableModules", false);
 	D(optimization, "removeEmptyChunks", true);
 	D(optimization, "mergeDuplicateChunks", true);
 	// IGNORE(optimization.moduleIds): set to "natural" by default in rspack 1.0


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

`asyncWebAssembly` default value depend on `experiments.futureDefaults` to close and open.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
