### PR TITLE
refactor: move context dependency `walk_expression` into `create_context_dependency`

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -19,12 +19,13 @@ use crate::visitors::{extract_require_call_info, is_require_call_start};
 fn create_commonjs_require_context_dependency(
   parser: &mut JavascriptParser,
   param: &BasicEvaluatedExpression,
+  expr: &Expr,
   callee_start: u32,
   callee_end: u32,
   args_end: u32,
   span: Option<ErrorSpan>,
 ) -> CommonJsRequireContextDependency {
-  let result = create_context_dependency(param, parser);
+  let result = create_context_dependency(param, expr, parser);
   let options = ContextOptions {
     mode: ContextMode::Sync,
     recursive: true,
@@ -136,14 +137,13 @@ impl CommonJsImportsParserPlugin {
     let dep = create_commonjs_require_context_dependency(
       parser,
       param,
+      &argument_expr,
       call_expr.callee.span().real_lo(),
       call_expr.callee.span().real_hi(),
       call_expr.span.real_hi(),
       Some(call_expr.span.into()),
     );
     parser.dependencies.push(Box::new(dep));
-    // FIXME: align `parser.walk_expression` to webpack, which put into `context_dependency_helper`
-    parser.walk_expression(argument_expr);
     Some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -137,7 +137,7 @@ impl CommonJsImportsParserPlugin {
     let dep = create_commonjs_require_context_dependency(
       parser,
       param,
-      &argument_expr,
+      argument_expr,
       call_expr.callee.span().real_lo(),
       call_expr.callee.span().real_hi(),
       call_expr.span.real_hi(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -121,7 +121,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
         query,
         fragment,
         replaces,
-      } = create_context_dependency(&param, parser);
+      } = create_context_dependency(&param, &dyn_imported.expr, parser);
       let reg_exp = context_reg_exp(&reg, "", Some(dyn_imported.span().into()), parser);
       parser
         .dependencies
@@ -156,8 +156,6 @@ impl JavascriptParserPlugin for ImportParserPlugin {
           Some(node.span.into()),
           parser.in_try,
         )));
-      // FIXME: align `parser.walk_expression` to webpack, which put into `context_dependency_helper`
-      parser.walk_expression(&dyn_imported.expr);
       Some(true)
     }
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -252,13 +252,15 @@ struct BasicEvaluatedExpressionVisitor<'a, F: FnMut(&Expr) -> ()> {
 
 impl<'a, F: FnMut(&Expr) -> ()> Visit for BasicEvaluatedExpressionVisitor<'a, F> {
   fn visit_expr(&mut self, n: &Expr) {
-    for t in self.targets.iter() {
+    self.targets.retain(|evaluted_expr| {
       let span = n.span();
-      let (lo, hi) = t.range();
+      let (lo, hi) = evaluted_expr.range();
       if span.real_lo() == lo && span.hi().0 == hi {
         (self.on_visit)(n);
+        return false;
       }
-    }
+      true
+    });
     n.visit_children_with(self);
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -175,6 +175,14 @@ pub fn create_context_dependency(
       ));
     }
 
+    if let Some(wrapped_inner_expressions) = param.wrapped_inner_expressions() {
+      let mut walker = ExprSpanFinder {
+        targets: wrapped_inner_expressions.iter().collect_vec(),
+        on_visit: |n| parser.walk_expression(n),
+      };
+      expr.visit_with(&mut walker);
+    }
+
     ContextModuleScanResult {
       context,
       reg,
@@ -182,7 +190,6 @@ pub fn create_context_dependency(
       fragment,
       replaces,
     }
-    // TODO: handle `param.wrappedInnerExpressions`
   } else {
     if parser.javascript_options.expr_context_critical {
       let range = param.range();
@@ -196,6 +203,7 @@ pub fn create_context_dependency(
         .with_severity(Severity::Warn),
       ));
     }
+    parser.walk_expression(expr);
     ContextModuleScanResult {
       context: String::from("."),
       reg: String::new(),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -95,7 +95,7 @@ pub fn create_context_dependency(
       }
     }
 
-    let mut walker = ExprSpanFinder {
+    let mut walker = BasicEvaluatedExpressionVisitor {
       targets: odd_parts,
       on_visit: |n| parser.walk_expression(n),
     };
@@ -183,7 +183,7 @@ pub fn create_context_dependency(
     }
 
     if let Some(wrapped_inner_expressions) = param.wrapped_inner_expressions() {
-      let mut walker = ExprSpanFinder {
+      let mut walker = BasicEvaluatedExpressionVisitor {
         targets: wrapped_inner_expressions.iter().collect_vec(),
         on_visit: |n| parser.walk_expression(n),
       };
@@ -245,12 +245,12 @@ pub fn quote_meta(str: &str) -> Cow<str> {
   META_REG.replace_all(str, "\\$0")
 }
 
-struct ExprSpanFinder<'a, F: FnMut(&Expr) -> ()> {
+struct BasicEvaluatedExpressionVisitor<'a, F: FnMut(&Expr) -> ()> {
   targets: Vec<&'a BasicEvaluatedExpression>,
   on_visit: F,
 }
 
-impl<'a, F: FnMut(&Expr) -> ()> Visit for ExprSpanFinder<'a, F> {
+impl<'a, F: FnMut(&Expr) -> ()> Visit for BasicEvaluatedExpressionVisitor<'a, F> {
   fn visit_expr(&mut self, n: &Expr) {
     for t in self.targets.iter() {
       let span = n.span();

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -59,17 +59,18 @@ pub fn create_context_dependency(
     );
 
     let mut replaces = Vec::new();
-    let (even_parts, odd_parts): (Vec<_>, Vec<_>) = param
-      .parts()
-      .into_iter()
-      .enumerate()
-      .partition_map(|(index, part)| {
-        if index % 2 == 0 {
-          Either::Left(part)
-        } else {
-          Either::Right(part)
-        }
-      });
+    let (even_parts, odd_parts): (Vec<_>, Vec<_>) =
+      param
+        .parts()
+        .iter()
+        .enumerate()
+        .partition_map(|(index, part)| {
+          if index % 2 == 0 {
+            Either::Left(part)
+          } else {
+            Either::Right(part)
+          }
+        });
     let last_index = even_parts.len() - 1;
 
     for (i, part) in even_parts.into_iter().enumerate() {
@@ -245,12 +246,12 @@ pub fn quote_meta(str: &str) -> Cow<str> {
   META_REG.replace_all(str, "\\$0")
 }
 
-struct BasicEvaluatedExpressionVisitor<'a, F: FnMut(&Expr) -> ()> {
+struct BasicEvaluatedExpressionVisitor<'a, F: FnMut(&Expr)> {
   targets: Vec<&'a BasicEvaluatedExpression>,
   on_visit: F,
 }
 
-impl<'a, F: FnMut(&Expr) -> ()> Visit for BasicEvaluatedExpressionVisitor<'a, F> {
+impl<'a, F: FnMut(&Expr)> Visit for BasicEvaluatedExpressionVisitor<'a, F> {
   fn visit_expr(&mut self, n: &Expr) {
     self.targets.retain(|evaluated_expr| {
       let span = n.span();

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -96,7 +96,7 @@ pub fn create_context_dependency(
     }
 
     // Webpack will walk only the expression parts of the template string
-    // but we walk the whole tempate string, which allows us don't need to implement
+    // but we walk the whole template string, which allows us don't need to implement
     // setExpression for BasicEvaluatedExpression (will introduce lots of lifetime)
     // This may have slight performance difference in some cases
     parser.walk_expression(expr);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -252,9 +252,9 @@ struct BasicEvaluatedExpressionVisitor<'a, F: FnMut(&Expr) -> ()> {
 
 impl<'a, F: FnMut(&Expr) -> ()> Visit for BasicEvaluatedExpressionVisitor<'a, F> {
   fn visit_expr(&mut self, n: &Expr) {
-    self.targets.retain(|evaluted_expr| {
+    self.targets.retain(|evaluated_expr| {
       let span = n.span();
-      let (lo, hi) = evaluted_expr.range();
+      let (lo, hi) = evaluated_expr.range();
       if span.real_lo() == lo && span.hi().0 == hi {
         (self.on_visit)(n);
         return false;

--- a/packages/rspack-test-tools/tests/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/rspack/dynamic-import/__snapshots__/output.snap.txt
@@ -71,13 +71,15 @@ __webpack_require__.e(/* import() */ "child_b_js").then(__webpack_require__.bind
 __webpack_require__("./child lazy recursive ^\\.\\/.*\\.js$")(`./${request}.js`).then(({ a }) =>
 	console.log("context_module_tpl", a)
 );
+__webpack_require__.e(/* import() */ "child_a_js").then(__webpack_require__.bind(__webpack_require__, "./child/a.js")).then(({ a }) =>
+	console.log("context_module_tpl_with_cond", a)
+);
 __webpack_require__("./child lazy recursive ^\\.\\/.*\\.js$")("./" + request + ".js").then(({ a }) =>
 	console.log("context_module_bin", a)
 );
 __webpack_require__("./child lazy recursive ^\\.\\/.*\\.js$")("./".concat(request, ".js")).then(({ a }) =>
 	console.log("context_module_concat", a)
 );
-
 
 }),
 

--- a/packages/rspack-test-tools/tests/builtinCases/rspack/dynamic-import/index.js
+++ b/packages/rspack-test-tools/tests/builtinCases/rspack/dynamic-import/index.js
@@ -4,6 +4,9 @@ import(`./child/b.js`).then(({ b }) => console.log("Template Literal", b));
 import(`./child/${request}.js`).then(({ a }) =>
 	console.log("context_module_tpl", a)
 );
+import(`./child/${true ? "a" : "b"}.js`).then(({ a }) =>
+	console.log("context_module_tpl_with_cond", a)
+);
 import("./child/" + request + ".js").then(({ a }) =>
 	console.log("context_module_bin", a)
 );


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix https://github.com/web-infra-dev/rspack/issues/6874

The cause of the problem is the direct walking of import call expression, which led to a conflict between the replacement generated by this walk and the replacement handled by ConstPlugin.

Webpack handles the import call expression in three cases:
TemplateLiteral: walk the parts with odd indices, see https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/dependencies/ContextDependencyHelpers.js#L151
Wrapped expr: process the inner expressions, see https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/dependencies/ContextDependencyHelpers.js#L218
Other cases: directly walk the import call expression, see https://github.com/webpack/webpack/blob/8241da7f1e75c5581ba535d127fa66aeb9eb2ac8/lib/dependencies/ContextDependencyHelpers.js#L241

My solution is to use a visitor to traverse the expression and find the corresponding `Expr` for `BasicEvaluatedExpressionVisitor` based on span. A better solution might be to add a reference to the corresponding `Expr` for `BasicEvaluatedExpressionVisitor` like webpack does. I tried this but couldn't resolve the lifetime issues.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
