### PR TITLE
chore(workflow): fix permissions for prod release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,8 @@ jobs:
     name: Release
     permissions:
       contents: write
+      # To publish packages with provenance
+      id-token: write
     runs-on: ubuntu-latest
     needs: build
     if: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

Fix permissions for prod release, see:

https://github.com/web-infra-dev/rspack/actions/runs/9710373465/job/26802316724

![image](https://github.com/web-infra-dev/rspack/assets/7237365/499a93d9-8716-4e19-89f7-4de5b2e394c7)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
