### PR TITLE
docs: remove invalid OG image

### DIFF
--- a/website/docs/en/blog/announcing-1-0-alpha.mdx
+++ b/website/docs/en/blog/announcing-1-0-alpha.mdx
@@ -1,9 +1,5 @@
 ---
 date: 2024-06-29 16:00:00
-head:
-  - - meta
-    - name: og:image
-      content: 'https://assets.rspack.dev/rspack/assets/rspack-og-image-v1-0-alpha.png'
 ---
 
 import { PackageManagerTabs } from '@theme';

--- a/website/docs/zh/blog/announcing-1-0-alpha.mdx
+++ b/website/docs/zh/blog/announcing-1-0-alpha.mdx
@@ -1,9 +1,5 @@
 ---
 date: 2024-06-29 16:00:00
-head:
-  - - meta
-    - name: og:image
-      content: 'https://assets.rspack.dev/rspack/assets/rspack-og-image-v1-0-alpha.png'
 ---
 
 import { PackageManagerTabs } from '@theme';

--- a/website/docs/zh/blog/announcing-1-0-alpha.mdx
+++ b/website/docs/zh/blog/announcing-1-0-alpha.mdx
@@ -1,12 +1,12 @@
 ---
-date: 2024-06-29 16:00:00
+date: 2024-06-28 16:00:00
 ---
 
 import { PackageManagerTabs } from '@theme';
 
 # Rspack v1.0 Alpha 发布公告
 
-> 2024 年 6 月 29 日
+> 2024 年 6 月 28 日
 
 ![](https://assets.rspack.dev/rspack/rspack-banner-v1-0-alpha.png)
 


### PR DESCRIPTION
## Summary

Remove invalid OG image tags.

![image](https://github.com/web-infra-dev/rspack/assets/7237365/5ebcb0bb-1d9d-48a8-848b-0af6f42bcd07)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
