### PR TITLE
feat(rspack_plugin_schemes): http uri support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   },
   "editor.formatOnSave": true,
   "git.ignoreLimitWarning": true,
-  "eslint.enable": false,
+  "eslint.enable": true,
   "cSpell.allowCompoundWords": true,
   "cSpell.caseSensitive": true,
   "rust-analyzer.procMacro.enable": true,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,6 +354,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.11.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ded684142010808eb980d9974ef794da2bcf97d13396143b1515e9f0fb4a10e"
+dependencies = [
+ "crypto-common 0.2.0-pre.5",
+]
+
+[[package]]
 name = "browserslist-rs"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,9 +447,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
 
 [[package]]
 name = "cfg-if"
@@ -484,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.0-pre.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e3352a27098ba6b09546e5f13b15165e6a88b5c2723afecb3ea9576b27e3ea"
+
+[[package]]
 name = "const-str"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,10 +546,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147be55d677052dabc6b22252d5dd0fd4c29c8c27aa4f2fbef0f94aa003b406f"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.4"
+name = "core-foundation"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "corosensei"
@@ -706,6 +737,17 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.0-pre.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7aa2ec04f5120b830272a481e8d9d8ba4dda140d2cda59b0f1110d5eb93c38e"
+dependencies = [
+ "getrandom",
+ "hybrid-array",
+ "rand_core",
 ]
 
 [[package]]
@@ -949,8 +991,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.0-pre.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065d93ead7c220b85d5b4be4795d8398eac4ff68b5ee63895de0a3c1fb6edf25"
+dependencies = [
+ "block-buffer 0.11.0-pre.5",
+ "const-oid",
+ "crypto-common 0.2.0-pre.5",
 ]
 
 [[package]]
@@ -1007,6 +1060,15 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -1130,6 +1192,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1356,6 +1433,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
+name = "h2"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,6 +1601,128 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.2.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d306b679262030ad8813a82d4915fc04efff97776e4db7f8eb5137039d56400"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http 1.1.0",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2 0.5.7",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1823,12 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-macro"
@@ -1803,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
@@ -1942,7 +2166,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2088,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
@@ -2163,6 +2387,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2294,6 +2535,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f6640c6bda7731b1fdbab747981a0f896dd1fedaf9f4a53fa237a04a84431f4"
 dependencies = [
  "loom",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2456,7 +2741,7 @@ checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2",
+ "sha2 0.10.8",
 ]
 
 [[package]]
@@ -2580,6 +2865,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "pmutil"
@@ -2908,6 +3199,64 @@ name = "replace_with"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
+
+[[package]]
+name = "reqwest"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 1.1.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rkyv"
@@ -3555,7 +3904,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "sugar_path",
  "swc_core",
  "swc_html",
@@ -3783,12 +4132,16 @@ name = "rspack_plugin_schemes"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "once_cell",
  "regex",
+ "reqwest",
  "rspack_base64",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
+ "sha2 0.11.0-pre.3",
+ "tokio",
  "url",
  "urlencoding",
 ]
@@ -4024,6 +4377,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4061,6 +4454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4104,6 +4506,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
+dependencies = [
+ "bitflags 2.5.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317936bbbd05227752583946b9e66d7ce3b489f84e11a94a510b4437fef407d7"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "self_cell"
@@ -4209,6 +4634,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,7 +4666,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4240,7 +4677,18 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0-pre.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f33549bf3064b62478926aa89cbfc7c109aab66ae8f0d5d2ef839e482cc30d6"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.11.0-pre.8",
 ]
 
 [[package]]
@@ -4338,6 +4786,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4473,6 +4931,12 @@ checksum = "42ee6433ecef213b2e72f587ef64a2f5943e7cd16fbd82dbe8bc07486c534c86"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sugar_path"
@@ -5827,6 +6291,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6026,10 +6517,14 @@ checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
+ "libc",
+ "mio",
  "num_cpus",
  "parking_lot",
  "pin-project-lite",
+ "socket2 0.5.7",
  "tokio-macros",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6041,6 +6536,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.63",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -6101,6 +6630,33 @@ dependencies = [
  "toml_datetime",
  "winnow 0.6.5",
 ]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -6186,6 +6742,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "trybuild"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6218,9 +6780,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
@@ -6305,6 +6867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6352,6 +6920,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
@@ -6408,7 +6982,7 @@ dependencies = [
  "futures",
  "mio",
  "serde",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tracing",
 ]
@@ -6568,6 +7142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6596,6 +7179,18 @@ dependencies = [
  "quote",
  "syn 1.0.109",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -6843,7 +7438,7 @@ dependencies = [
  "getrandom",
  "heapless",
  "hex",
- "http",
+ "http 0.2.12",
  "lazy_static",
  "libc",
  "linked_hash_set",
@@ -6861,7 +7456,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.8",
  "shared-buffer",
  "tempfile",
  "term_size",
@@ -6956,6 +7551,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webc"
 version = "5.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6976,7 +7581,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "sha2",
+ "sha2 0.10.8",
  "shared-buffer",
  "tar",
  "tempfile",
@@ -7227,6 +7832,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7275,3 +7890,9 @@ dependencies = [
  "quote",
  "syn 2.0.63",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.83"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 dependencies = [
  "backtrace",
 ]
@@ -4131,6 +4131,7 @@ dependencies = [
 name = "rspack_plugin_schemes"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "base64 0.22.1",
  "once_cell",

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -8,6 +8,7 @@ version    = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow        = "1.0.86"
 async-trait   = { workspace = true }
 base64        = "0.22.1"
 once_cell     = { workspace = true }
@@ -20,7 +21,6 @@ rspack_hook   = { path = "../rspack_hook" }
 sha2          = "0.11.0-pre.3"
 url           = { workspace = true }
 urlencoding   = { workspace = true }
-
 [dependencies.tokio]
 optional  = true
 workspace = true

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -9,11 +9,18 @@ version    = "0.1.0"
 
 [dependencies]
 async-trait   = { workspace = true }
+base64        = "0.22.1"
 once_cell     = { workspace = true }
 regex         = { workspace = true }
+reqwest       = "0.12.5"
 rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
 rspack_hook   = { path = "../rspack_hook" }
+sha2          = "0.11.0-pre.3"
 url           = { workspace = true }
 urlencoding   = { workspace = true }
+
+[dependencies.tokio]
+optional  = true
+workspace = true

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -18,13 +18,8 @@ rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
 rspack_hook   = { path = "../rspack_hook" }
+serde         = { workspace = true }
 sha2          = "0.11.0-pre.3"
+tokio         = { workspace = true }
 url           = { workspace = true }
 urlencoding   = { workspace = true }
-[dependencies.tokio]
-optional  = false
-workspace = true
-
-[dependencies.serde]
-optional  = false
-workspace = true

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -17,8 +17,10 @@ reqwest       = "0.12.5"
 rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
+rspack_fs     = { path = "../rspack_fs" }
 rspack_hook   = { path = "../rspack_hook" }
 serde         = { workspace = true }
+serde_json    = { workspace = true }
 sha2          = "0.11.0-pre.3"
 tokio         = { workspace = true }
 url           = { workspace = true }

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -22,9 +22,9 @@ sha2          = "0.11.0-pre.3"
 url           = { workspace = true }
 urlencoding   = { workspace = true }
 [dependencies.tokio]
-optional  = true
+optional  = false
 workspace = true
 
 [dependencies.serde]
-optional  = true
+optional  = false
 workspace = true

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -24,3 +24,7 @@ urlencoding   = { workspace = true }
 [dependencies.tokio]
 optional  = true
 workspace = true
+
+[dependencies.serde]
+optional  = true
+workspace = true

--- a/crates/rspack_plugin_schemes/Cargo.toml
+++ b/crates/rspack_plugin_schemes/Cargo.toml
@@ -17,7 +17,6 @@ reqwest       = "0.12.5"
 rspack_base64 = { path = "../rspack_base64" }
 rspack_core   = { path = "../rspack_core" }
 rspack_error  = { path = "../rspack_error" }
-rspack_fs     = { path = "../rspack_fs" }
 rspack_hook   = { path = "../rspack_hook" }
 serde         = { workspace = true }
 serde_json    = { workspace = true }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,10 +1,4 @@
-use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-
-use anyhow::{Context, Result};
+use anyhow::Context;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use reqwest::Client;
@@ -13,24 +7,11 @@ use rspack_core::{
   NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
   ResourceData,
 };
-use rspack_error::AnyhowError;
+use rspack_error::{AnyhowError, Result};
 use rspack_hook::{plugin, plugin_hook};
-use serde::{Deserialize, Serialize};
 
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
-
-static CACHE: Lazy<Arc<Mutex<HashMap<String, CacheEntry>>>> =
-  Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
-
-const CACHE_DURATION: Duration = Duration::from_secs(60 * 60); // Cache duration of 1 hour
-const CACHE_FILE: &str = "http_uri_cache.json"; // Cache file path
-
-#[derive(Serialize, Deserialize, Clone)]
-struct CacheEntry {
-  content: Vec<u8>,
-  timestamp: Instant,
-}
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -52,24 +33,9 @@ async fn resolve_for_scheme(
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
   if resource_data.get_scheme().is_http() {
-    let url = &resource_data.resource;
-    let mut cache = CACHE.lock().unwrap();
-
-    // Check if the URL is already in the cache and if it's still valid
-    if let Some(entry) = cache.get(url) {
-      if entry.timestamp.elapsed() < CACHE_DURATION {
-        return Ok(Some(Content::Buffer(entry.content.clone())));
-      } else {
-        // Remove expired cache entry
-        cache.remove(url);
-      }
-    }
-
-    drop(cache); // Release the lock before making the HTTP request
-
     let client = Client::new();
     let response = client
-      .get(url)
+      .get(&resource_data.resource)
       .send()
       .await
       .context("Failed to send HTTP request")
@@ -78,87 +44,10 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       .bytes()
       .await
       .context("Failed to read response bytes")
-      .map_err(|err| AnyhowError::from(err))?
-      .to_vec();
-
-    // Store the response content in the cache
-    let mut cache = CACHE.lock().unwrap();
-    cache.insert(
-      url.clone(),
-      CacheEntry {
-        content: content.clone(),
-        timestamp: Instant::now(),
-      },
-    );
-
-    // Save the cache to disk
-    if let Err(err) = save_cache_to_disk(&*cache).await {
-      eprintln!("Failed to save cache to disk: {}", err);
-    }
-
-    return Ok(Some(Content::Buffer(content)));
+      .map_err(|err| AnyhowError::from(err))?;
+    return Ok(Some(Content::Buffer(content.to_vec())));
   }
   Ok(None)
-}
-
-async fn load_cache_from_disk() -> Result<HashMap<String, CacheEntry>> {
-  if Path::new(CACHE_FILE).exists() {
-    let data = fs::read(CACHE_FILE)
-      .await
-      .context("Failed to read cache file")?;
-    let cache: HashMap<String, CacheEntry> =
-      serde_json::from_slice(&data).context("Failed to deserialize cache")?;
-    Ok(cache)
-  } else {
-    Ok(HashMap::new())
-  }
-}
-
-async fn save_cache_to_disk(cache: &HashMap<String, CacheEntry>) -> Result<()> {
-  let data = serde_json::to_vec(cache).context("Failed to serialize cache")?;
-  fs::write(CACHE_FILE, data)
-    .await
-    .context("Failed to write cache file")?;
-  Ok(())
-}
-
-fn parse_cache_control(
-  cache_control: Option<&str>,
-  request_time: Instant,
-) -> (bool, bool, Instant) {
-  let mut store_cache = true;
-  let mut store_lock = true;
-  let mut valid_until = Instant::now();
-
-  if let Some(cache_control) = cache_control {
-    let parsed = parse_key_value_pairs(cache_control);
-    if parsed.get("no-cache").is_some() {
-      store_cache = false;
-      store_lock = false;
-    }
-    if let Some(max_age) = parsed.get("max-age") {
-      if let Ok(max_age) = max_age.parse::<u64>() {
-        valid_until = request_time + Duration::from_secs(max_age);
-      }
-    }
-    if parsed.get("must-revalidate").is_some() {
-      valid_until = request_time;
-    }
-  }
-
-  (store_cache, store_lock, valid_until)
-}
-
-fn parse_key_value_pairs(input: &str) -> HashMap<String, String> {
-  input
-    .split(',')
-    .map(|item| {
-      let mut parts = item.splitn(2, '=');
-      let key = parts.next().unwrap().trim().to_string();
-      let value = parts.next().unwrap_or("").trim().to_string();
-      (key, value)
-    })
-    .collect()
 }
 
 #[async_trait::async_trait]
@@ -167,17 +56,11 @@ impl Plugin for HttpUriPlugin {
     "rspack.HttpUriPlugin"
   }
 
-  async fn apply(
-    &self,
-    ctx: PluginContext<&mut ApplyContext>,
+  fn apply<'a>(
+    &'a self,
+    ctx: PluginContext<&'a mut ApplyContext>,
     _options: &mut CompilerOptions,
   ) -> Result<()> {
-    // Load the cache from disk
-    let loaded_cache = load_cache_from_disk().await?;
-    let mut cache = CACHE.lock().unwrap();
-    *cache = loaded_cache;
-    drop(cache);
-
     ctx
       .context
       .normal_module_factory_hooks

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -103,7 +103,8 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     };
     let replaced_content = content_str
       .replace("import \"./", &format!("import \"{}/", origin))
-      .replace("import \"/", &format!("import \"{}/", origin));
+      .replace("import \"./", &format!("import \"{}/", origin));
+
     dbg!(&replaced_content);
     let final_content = replaced_content.into_bytes();
 

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -34,6 +34,7 @@ async fn resolve_for_scheme(
   }
   Ok(None)
 }
+
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
   dbg!("reading resource");

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -103,8 +103,8 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     };
     let replaced_content = content_str
       .replace("import \"./", &format!("import \"{}/", origin))
-      .replace("import \"./", &format!("import \"{}/", origin));
-
+      .replace("import \"/", &format!("import \"{}/", origin))
+      .replace("from \"/", &format!("from \"{}/", origin));
     dbg!(&replaced_content);
     let final_content = replaced_content.into_bytes();
 

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -93,8 +93,9 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       Err(_) => "".to_string(),
     };
     let replaced_content = content_str
-      .replace("import \"/", &format!("import \"{}/", origin))
-      .replace("from \"/", &format!("from \"{}/", origin));
+      .replace("from \"/", &format!("from \"{}/", origin))
+      .replace("import \"/", &format!("import \"{}/", origin));
+
     dbg!(&replaced_content);
 
     fs::create_dir_all(HTTP_CACHE_DIR)
@@ -110,9 +111,11 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         AnyhowError::from(err)
       })?;
 
-    let final_content = replaced_content.into_bytes();
+    // let final_content = replaced_content.into_bytes();
 
-    return Ok(Some(Content::Buffer(final_content.to_vec())));
+    return Ok(Some(Content::Buffer(
+      replaced_content.to_string().into_bytes(),
+    )));
   }
   Ok(None)
 }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -102,7 +102,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       Err(_) => "".to_string(),
     };
     let replaced_content = content_str
-      .replace("import \"./", &format!("import \"{}/", origin))
       .replace("import \"/", &format!("import \"{}/", origin))
       .replace("from \"/", &format!("from \"{}/", origin));
     dbg!(&replaced_content);

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -37,6 +37,7 @@ struct CacheEntry {
 pub struct HttpUriPlugin;
 
 #[plugin_hook(NormalModuleFactoryResolveForScheme for HttpUriPlugin)]
+#[plugin_hook(NormalModuleFactoryResolveForScheme for HttpUriPlugin)]
 async fn resolve_for_scheme(
   &self,
   _data: &mut ModuleFactoryCreateData,

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -52,6 +52,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     dbg!(&resource_data.resource);
 
     // Check cache first
+    /*
     let cache_path = format!(
       "{}/{}",
       HTTP_CACHE_DIR,
@@ -67,6 +68,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         })?;
       return Ok(Some(Content::Buffer(cached_content)));
     }
+    */
 
     let client = Client::new();
     let response = client
@@ -89,6 +91,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     dbg!("Response body: {:?}", &content); // Log the response body
 
     // Cache the response
+    /*
     fs::create_dir_all(HTTP_CACHE_DIR)
       .context("Failed to create cache directory")
       .map_err(|err| {
@@ -101,6 +104,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         error!(err.to_string());
         AnyhowError::from(err)
       })?;
+    */
 
     return Ok(Some(Content::Buffer(content.to_vec())));
   }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,21 +1,17 @@
 use anyhow::Context;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use reqwest::Client; // Add reqwest for HTTP requests
+use reqwest::Client;
 use rspack_core::{
   ApplyContext, CompilerOptions, Content, ModuleFactoryCreateData,
   NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
   ResourceData,
 };
-use rspack_error::error;
-use rspack_error::{AnyhowError, Error, Result};
-use rspack_hook::{plugin, plugin_hook}; // Add this import
+use rspack_error::{AnyhowError, Result};
+use rspack_hook::{plugin, plugin_hook};
+
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
-static EXTERNAL_HTTP_STD_REQUEST: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^(//|https?://|std:)").expect("Invalid regex"));
-static EXTERNAL_CSS_REQUEST: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^\.css(\?|$)").expect("Invalid regex"));
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -29,39 +25,31 @@ async fn resolve_for_scheme(
 ) -> Result<Option<bool>> {
   if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {
-    dbg!(&resource_data.resource);
     return Ok(None);
   }
   Ok(None)
 }
+
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
-  if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
-  {
-    dbg!(&resource_data.resource);
+  if resource_data.get_scheme().is_http() {
     let client = Client::new();
     let response = client
       .get(&resource_data.resource)
       .send()
       .await
       .context("Failed to send HTTP request")
-      .map_err(|err| {
-        error!(err.to_string());
-        AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
-      })?; // Use `into()` to convert anyhow::Error to rspack_error::Error
+      .map_err(|err| AnyhowError::from(err))?;
     let content = response
       .bytes()
       .await
       .context("Failed to read response bytes")
-      .map_err(|err| {
-        error!(err.to_string());
-        AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
-      })?;
-    dbg!("Response body: {:?}", &content); // Log the response body
+      .map_err(|err| AnyhowError::from(err))?;
     return Ok(Some(Content::Buffer(content.to_vec())));
   }
   Ok(None)
 }
+
 #[async_trait::async_trait]
 impl Plugin for HttpUriPlugin {
   fn name(&self) -> &'static str {

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,7 +1,5 @@
-use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
 
 use anyhow::Context;
 use once_cell::sync::Lazy;
@@ -13,16 +11,11 @@ use rspack_core::{
   ResourceData,
 };
 use rspack_error::error;
-use rspack_error::{AnyhowError, Error, Result};
+use rspack_error::{AnyhowError, Result}; // Removed `Error` import
 use rspack_hook::{plugin, plugin_hook}; // Add this import
-use tokio::sync::RwLock;
 
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
-static EXTERNAL_HTTP_STD_REQUEST: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^(//|https?://|std:)").expect("Invalid regex"));
-static EXTERNAL_CSS_REQUEST: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"^\.css(\?|$)").expect("Invalid regex"));
 
 static HTTP_CACHE_DIR: &str = "http_cache";
 
@@ -52,7 +45,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     dbg!(&resource_data.resource);
 
     // Check cache first
-    /*
     let cache_path = format!(
       "{}/{}",
       HTTP_CACHE_DIR,
@@ -68,7 +60,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         })?;
       return Ok(Some(Content::Buffer(cached_content)));
     }
-    */
 
     let client = Client::new();
     let response = client
@@ -107,10 +98,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     dbg!(&replaced_content);
     let final_content = replaced_content.into_bytes();
 
-    // Use reference to avoid move
-    // Log the response body
-    // Cache the response
-    /*
     fs::create_dir_all(HTTP_CACHE_DIR)
       .context("Failed to create cache directory")
       .map_err(|err| {
@@ -123,7 +110,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         error!(err.to_string());
         AnyhowError::from(err)
       })?;
-    */
 
     return Ok(Some(Content::Buffer(final_content.to_vec())));
   }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,12 +1,14 @@
+use anyhow::Context;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use reqwest::Client; // Add reqwest for HTTP requests
 use rspack_core::{
   ApplyContext, CompilerOptions, Content, ModuleFactoryCreateData,
   NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
   ResourceData,
 };
 use rspack_error::Result;
-use rspack_hook::{plugin, plugin_hook};
+use rspack_hook::{plugin, plugin_hook}; // Add this import
 
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
@@ -38,7 +40,18 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
   if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {
     dbg!(&resource_data.resource);
-    // Implement your logic for reading HTTP resources here
+    let client = Client::new();
+    let response = client
+      .get(&resource_data.resource)
+      .send()
+      .await
+      .context("Failed to send HTTP request")?; // Wrap error with context
+    dbg!(&response); // Log the fetched response
+    let content = response
+      .bytes()
+      .await
+      .context("Failed to read response bytes")?; // Wrap error with context
+    return Ok(Some(Content::from(content.to_vec())));
   }
   Ok(None)
 }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,17 +1,21 @@
 use anyhow::Context;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use reqwest::Client;
+use reqwest::Client; // Add reqwest for HTTP requests
 use rspack_core::{
   ApplyContext, CompilerOptions, Content, ModuleFactoryCreateData,
   NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
   ResourceData,
 };
-use rspack_error::{AnyhowError, Result};
-use rspack_hook::{plugin, plugin_hook};
-
+use rspack_error::error;
+use rspack_error::{AnyhowError, Error, Result};
+use rspack_hook::{plugin, plugin_hook}; // Add this import
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
+static EXTERNAL_HTTP_STD_REQUEST: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^(//|https?://|std:)").expect("Invalid regex"));
+static EXTERNAL_CSS_REQUEST: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^\.css(\?|$)").expect("Invalid regex"));
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -25,40 +29,49 @@ async fn resolve_for_scheme(
 ) -> Result<Option<bool>> {
   if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {
+    dbg!(&resource_data.resource);
     return Ok(None);
   }
   Ok(None)
 }
-
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
-  if resource_data.get_scheme().is_http() {
+  dbg!("reading resource");
+  if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
+  {
+    dbg!(&resource_data.resource);
     let client = Client::new();
     let response = client
       .get(&resource_data.resource)
       .send()
       .await
       .context("Failed to send HTTP request")
-      .map_err(|err| AnyhowError::from(err))?;
+      .map_err(|err| {
+        error!(err.to_string());
+        AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
+      })?; // Use `into()` to convert anyhow::Error to rspack_error::Error
     let content = response
       .bytes()
       .await
       .context("Failed to read response bytes")
-      .map_err(|err| AnyhowError::from(err))?;
+      .map_err(|err| {
+        error!(err.to_string());
+        AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
+      })?;
+    dbg!("Response body: {:?}", &content); // Log the response body
     return Ok(Some(Content::Buffer(content.to_vec())));
   }
   Ok(None)
 }
-
 #[async_trait::async_trait]
 impl Plugin for HttpUriPlugin {
   fn name(&self) -> &'static str {
     "rspack.HttpUriPlugin"
   }
 
-  fn apply<'a>(
-    &'a self,
-    ctx: PluginContext<&'a mut ApplyContext>,
+  fn apply(
+    &self,
+    ctx: PluginContext<&mut ApplyContext>,
     _options: &mut CompilerOptions,
   ) -> Result<()> {
     ctx

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -37,7 +37,6 @@ struct CacheEntry {
 pub struct HttpUriPlugin;
 
 #[plugin_hook(NormalModuleFactoryResolveForScheme for HttpUriPlugin)]
-#[plugin_hook(NormalModuleFactoryResolveForScheme for HttpUriPlugin)]
 async fn resolve_for_scheme(
   &self,
   _data: &mut ModuleFactoryCreateData,

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,0 +1,67 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+use rspack_core::{
+  ApplyContext, CompilerOptions, Content, ModuleFactoryCreateData,
+  NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
+  ResourceData,
+};
+use rspack_error::Result;
+use rspack_hook::{plugin, plugin_hook};
+
+static URI_REGEX: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"(?i)^https?:\/\/[^\s/$.?#].[^\s]*$").expect("Invalid Regex"));
+
+#[plugin]
+#[derive(Debug, Default)]
+pub struct HttpUriPlugin;
+
+#[plugin_hook(NormalModuleFactoryResolveForScheme for HttpUriPlugin)]
+async fn resolve_for_scheme(
+  &self,
+  _data: &mut ModuleFactoryCreateData,
+  resource_data: &mut ResourceData,
+) -> Result<Option<bool>> {
+  if resource_data.get_scheme().is_http()
+    && let Some(captures) = URI_REGEX.captures(&resource_data.resource)
+  {
+    dbg!(&captures);
+    return Ok(None);
+  }
+  Ok(None)
+}
+
+#[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
+async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
+  if resource_data.get_scheme().is_http()
+    && let Some(captures) = URI_REGEX.captures(&resource_data.resource)
+  {
+    dbg!(&captures);
+    // Implement your logic for reading HTTP resources here
+  }
+  Ok(None)
+}
+
+#[async_trait::async_trait]
+impl Plugin for HttpUriPlugin {
+  fn name(&self) -> &'static str {
+    "rspack.HttpUriPlugin"
+  }
+
+  fn apply(
+    &self,
+    ctx: PluginContext<&mut ApplyContext>,
+    _options: &mut CompilerOptions,
+  ) -> Result<()> {
+    ctx
+      .context
+      .normal_module_factory_hooks
+      .resolve_for_scheme
+      .tap(resolve_for_scheme::new(self));
+    ctx
+      .context
+      .normal_module_hooks
+      .read_resource
+      .tap(read_resource::new(self));
+    Ok(())
+  }
+}

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -8,8 +8,12 @@ use rspack_core::{
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 
-static URI_REGEX: Lazy<Regex> =
-  Lazy::new(|| Regex::new(r"(?i)^https?:\/\/[^\s/$.?#].[^\s]*$").expect("Invalid Regex"));
+static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
+static EXTERNAL_HTTP_STD_REQUEST: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^(//|https?://|std:)").expect("Invalid regex"));
+static EXTERNAL_CSS_REQUEST: Lazy<Regex> =
+  Lazy::new(|| Regex::new(r"^\.css(\?|$)").expect("Invalid regex"));
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -21,10 +25,9 @@ async fn resolve_for_scheme(
   _data: &mut ModuleFactoryCreateData,
   resource_data: &mut ResourceData,
 ) -> Result<Option<bool>> {
-  if resource_data.get_scheme().is_http()
-    && let Some(captures) = URI_REGEX.captures(&resource_data.resource)
+  if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {
-    dbg!(&captures);
+    dbg!(&resource_data.resource);
     return Ok(None);
   }
   Ok(None)
@@ -32,10 +35,9 @@ async fn resolve_for_scheme(
 
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
-  if resource_data.get_scheme().is_http()
-    && let Some(captures) = URI_REGEX.captures(&resource_data.resource)
+  if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
   {
-    dbg!(&captures);
+    dbg!(&resource_data.resource);
     // Implement your logic for reading HTTP resources here
   }
   Ok(None)

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -97,28 +97,31 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       })?;
 
     let base_url = &resource_data.resource;
+    let origin = match url::Url::parse(base_url) {
+      Ok(url) => url.origin().ascii_serialization(),
+      Err(_) => "".to_string(),
+    };
     let replaced_content = content_str
-      .replace("import \"./", &format!("import \"{}/", base_url))
-      .replace("import \"/", &format!("import \"{}/", base_url));
+      .replace("import \"./", &format!("import \"{}/", origin))
+      .replace("import \"/", &format!("import \"{}/", origin));
 
     let final_content = replaced_content.into_bytes();
     dbg!("Response body: {:?}", &final_content); // Log the response body
-
-    // Cache the response
-    /*
-    fs::create_dir_all(HTTP_CACHE_DIR)
-      .context("Failed to create cache directory")
-      .map_err(|err| {
-        error!(err.to_string());
-        AnyhowError::from(err)
-      })?;
-    fs::write(&cache_path, &content)
-      .context("Failed to write cache content")
-      .map_err(|err| {
-        error!(err.to_string());
-        AnyhowError::from(err)
-      })?;
-    */
+                                                 // Cache the response
+                                                 /*
+                                                 fs::create_dir_all(HTTP_CACHE_DIR)
+                                                   .context("Failed to create cache directory")
+                                                   .map_err(|err| {
+                                                     error!(err.to_string());
+                                                     AnyhowError::from(err)
+                                                   })?;
+                                                 fs::write(&cache_path, &content)
+                                                   .context("Failed to write cache content")
+                                                   .map_err(|err| {
+                                                     error!(err.to_string());
+                                                     AnyhowError::from(err)
+                                                   })?;
+                                                 */
 
     return Ok(Some(Content::Buffer(final_content.to_vec())));
   }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -104,6 +104,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     let replaced_content = content_str
       .replace("import \"./", &format!("import \"{}/", origin))
       .replace("import \"/", &format!("import \"{}/", origin));
+    dbg!(&replaced_content);
     let final_content = replaced_content.into_bytes();
 
     // Use reference to avoid move

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -49,7 +49,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         error!(err.to_string());
         AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
       })?; // Use `into()` to convert anyhow::Error to rspack_error::Error
-    dbg!("Fetched response: {:?}", &response); // Log the fetched response using tracing
     let content = response
       .bytes()
       .await
@@ -58,6 +57,7 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         error!(err.to_string());
         AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
       })?;
+    dbg!("Response body: {:?}", &content); // Log the response body
     return Ok(Some(Content::Buffer(content.to_vec())));
   }
   Ok(None)

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -104,24 +104,25 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
     let replaced_content = content_str
       .replace("import \"./", &format!("import \"{}/", origin))
       .replace("import \"/", &format!("import \"{}/", origin));
-
     let final_content = replaced_content.into_bytes();
-    dbg!("Response body: {:?}", &final_content); // Log the response body
-                                                 // Cache the response
-                                                 /*
-                                                 fs::create_dir_all(HTTP_CACHE_DIR)
-                                                   .context("Failed to create cache directory")
-                                                   .map_err(|err| {
-                                                     error!(err.to_string());
-                                                     AnyhowError::from(err)
-                                                   })?;
-                                                 fs::write(&cache_path, &content)
-                                                   .context("Failed to write cache content")
-                                                   .map_err(|err| {
-                                                     error!(err.to_string());
-                                                     AnyhowError::from(err)
-                                                   })?;
-                                                 */
+
+    // Use reference to avoid move
+    // Log the response body
+    // Cache the response
+    /*
+    fs::create_dir_all(HTTP_CACHE_DIR)
+      .context("Failed to create cache directory")
+      .map_err(|err| {
+        error!(err.to_string());
+        AnyhowError::from(err)
+      })?;
+    fs::write(&cache_path, &content)
+      .context("Failed to write cache content")
+      .map_err(|err| {
+        error!(err.to_string());
+        AnyhowError::from(err)
+      })?;
+    */
 
     return Ok(Some(Content::Buffer(final_content.to_vec())));
   }

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -1,4 +1,10 @@
-use anyhow::Context;
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use reqwest::Client;
@@ -7,11 +13,24 @@ use rspack_core::{
   NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
   ResourceData,
 };
-use rspack_error::{AnyhowError, Result};
+use rspack_error::AnyhowError;
 use rspack_hook::{plugin, plugin_hook};
+use serde::{Deserialize, Serialize};
 
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
+
+static CACHE: Lazy<Arc<Mutex<HashMap<String, CacheEntry>>>> =
+  Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+
+const CACHE_DURATION: Duration = Duration::from_secs(60 * 60); // Cache duration of 1 hour
+const CACHE_FILE: &str = "http_uri_cache.json"; // Cache file path
+
+#[derive(Serialize, Deserialize, Clone)]
+struct CacheEntry {
+  content: Vec<u8>,
+  timestamp: Instant,
+}
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -33,9 +52,24 @@ async fn resolve_for_scheme(
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
   if resource_data.get_scheme().is_http() {
+    let url = &resource_data.resource;
+    let mut cache = CACHE.lock().unwrap();
+
+    // Check if the URL is already in the cache and if it's still valid
+    if let Some(entry) = cache.get(url) {
+      if entry.timestamp.elapsed() < CACHE_DURATION {
+        return Ok(Some(Content::Buffer(entry.content.clone())));
+      } else {
+        // Remove expired cache entry
+        cache.remove(url);
+      }
+    }
+
+    drop(cache); // Release the lock before making the HTTP request
+
     let client = Client::new();
     let response = client
-      .get(&resource_data.resource)
+      .get(url)
       .send()
       .await
       .context("Failed to send HTTP request")
@@ -44,10 +78,87 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       .bytes()
       .await
       .context("Failed to read response bytes")
-      .map_err(|err| AnyhowError::from(err))?;
-    return Ok(Some(Content::Buffer(content.to_vec())));
+      .map_err(|err| AnyhowError::from(err))?
+      .to_vec();
+
+    // Store the response content in the cache
+    let mut cache = CACHE.lock().unwrap();
+    cache.insert(
+      url.clone(),
+      CacheEntry {
+        content: content.clone(),
+        timestamp: Instant::now(),
+      },
+    );
+
+    // Save the cache to disk
+    if let Err(err) = save_cache_to_disk(&*cache).await {
+      eprintln!("Failed to save cache to disk: {}", err);
+    }
+
+    return Ok(Some(Content::Buffer(content)));
   }
   Ok(None)
+}
+
+async fn load_cache_from_disk() -> Result<HashMap<String, CacheEntry>> {
+  if Path::new(CACHE_FILE).exists() {
+    let data = fs::read(CACHE_FILE)
+      .await
+      .context("Failed to read cache file")?;
+    let cache: HashMap<String, CacheEntry> =
+      serde_json::from_slice(&data).context("Failed to deserialize cache")?;
+    Ok(cache)
+  } else {
+    Ok(HashMap::new())
+  }
+}
+
+async fn save_cache_to_disk(cache: &HashMap<String, CacheEntry>) -> Result<()> {
+  let data = serde_json::to_vec(cache).context("Failed to serialize cache")?;
+  fs::write(CACHE_FILE, data)
+    .await
+    .context("Failed to write cache file")?;
+  Ok(())
+}
+
+fn parse_cache_control(
+  cache_control: Option<&str>,
+  request_time: Instant,
+) -> (bool, bool, Instant) {
+  let mut store_cache = true;
+  let mut store_lock = true;
+  let mut valid_until = Instant::now();
+
+  if let Some(cache_control) = cache_control {
+    let parsed = parse_key_value_pairs(cache_control);
+    if parsed.get("no-cache").is_some() {
+      store_cache = false;
+      store_lock = false;
+    }
+    if let Some(max_age) = parsed.get("max-age") {
+      if let Ok(max_age) = max_age.parse::<u64>() {
+        valid_until = request_time + Duration::from_secs(max_age);
+      }
+    }
+    if parsed.get("must-revalidate").is_some() {
+      valid_until = request_time;
+    }
+  }
+
+  (store_cache, store_lock, valid_until)
+}
+
+fn parse_key_value_pairs(input: &str) -> HashMap<String, String> {
+  input
+    .split(',')
+    .map(|item| {
+      let mut parts = item.splitn(2, '=');
+      let key = parts.next().unwrap().trim().to_string();
+      let value = parts.next().unwrap_or("").trim().to_string();
+      (key, value)
+    })
+    .collect()
 }
 
 #[async_trait::async_trait]
@@ -56,11 +167,17 @@ impl Plugin for HttpUriPlugin {
     "rspack.HttpUriPlugin"
   }
 
-  fn apply(
+  async fn apply(
     &self,
     ctx: PluginContext<&mut ApplyContext>,
     _options: &mut CompilerOptions,
   ) -> Result<()> {
+    // Load the cache from disk
+    let loaded_cache = load_cache_from_disk().await?;
+    let mut cache = CACHE.lock().unwrap();
+    *cache = loaded_cache;
+    drop(cache);
+
     ctx
       .context
       .normal_module_factory_hooks

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -7,9 +7,9 @@ use rspack_core::{
   NormalModuleFactoryResolveForScheme, NormalModuleReadResource, Plugin, PluginContext,
   ResourceData,
 };
-use rspack_error::Result;
+use rspack_error::error;
+use rspack_error::{AnyhowError, Error, Result};
 use rspack_hook::{plugin, plugin_hook}; // Add this import
-
 static EXTERNAL_HTTP_REQUEST: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"^(//|https?://|#)").expect("Invalid regex"));
 static EXTERNAL_HTTP_STD_REQUEST: Lazy<Regex> =
@@ -34,7 +34,6 @@ async fn resolve_for_scheme(
   }
   Ok(None)
 }
-
 #[plugin_hook(NormalModuleReadResource for HttpUriPlugin)]
 async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Content>> {
   if resource_data.get_scheme().is_http() && EXTERNAL_HTTP_REQUEST.is_match(&resource_data.resource)
@@ -45,17 +44,24 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       .get(&resource_data.resource)
       .send()
       .await
-      .context("Failed to send HTTP request")?; // Wrap error with context
-    dbg!(&response); // Log the fetched response
+      .context("Failed to send HTTP request")
+      .map_err(|err| {
+        error!(err.to_string());
+        AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
+      })?; // Use `into()` to convert anyhow::Error to rspack_error::Error
+    dbg!("Fetched response: {:?}", &response); // Log the fetched response using tracing
     let content = response
       .bytes()
       .await
-      .context("Failed to read response bytes")?; // Wrap error with context
-    return Ok(Some(Content::from(content.to_vec())));
+      .context("Failed to read response bytes")
+      .map_err(|err| {
+        error!(err.to_string());
+        AnyhowError::from(err) // Convert to AnyhowError which implements Diagnostic
+      })?;
+    return Ok(Some(Content::Buffer(content.to_vec())));
   }
   Ok(None)
 }
-
 #[async_trait::async_trait]
 impl Plugin for HttpUriPlugin {
   fn name(&self) -> &'static str {

--- a/crates/rspack_plugin_schemes/src/http_uri.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri.rs
@@ -96,7 +96,6 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
       .replace("import \"/", &format!("import \"{}/", origin))
       .replace("from \"/", &format!("from \"{}/", origin));
     dbg!(&replaced_content);
-    let final_content = replaced_content.into_bytes();
 
     fs::create_dir_all(HTTP_CACHE_DIR)
       .context("Failed to create cache directory")
@@ -104,12 +103,14 @@ async fn read_resource(&self, resource_data: &ResourceData) -> Result<Option<Con
         error!(err.to_string());
         AnyhowError::from(err)
       })?;
-    fs::write(&cache_path, &content)
+    fs::write(&cache_path, &replaced_content)
       .context("Failed to write cache content")
       .map_err(|err| {
         error!(err.to_string());
         AnyhowError::from(err)
       })?;
+
+    let final_content = replaced_content.into_bytes();
 
     return Ok(Some(Content::Buffer(final_content.to_vec())));
   }

--- a/crates/rspack_plugin_schemes/src/lib.rs
+++ b/crates/rspack_plugin_schemes/src/lib.rs
@@ -3,5 +3,7 @@
 mod data_uri;
 mod file_uri;
 
+mod http_uri;
+
 pub use data_uri::DataUriPlugin;
 pub use file_uri::FileUriPlugin;

--- a/crates/rspack_plugin_schemes/src/lib.rs
+++ b/crates/rspack_plugin_schemes/src/lib.rs
@@ -2,8 +2,8 @@
 
 mod data_uri;
 mod file_uri;
-
 mod http_uri;
 
 pub use data_uri::DataUriPlugin;
 pub use file_uri::FileUriPlugin;
+pub use http_uri::HttpUriPlugin;

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -61,6 +61,42 @@ orphan modules 76 bytes [orphan]
 Rspack compiled successfully (c12084bf03e12a353092)"
 `;
 
+exports[`statsOutput statsOutput/auxiliary-files-test should print correct stats for auxiliary-files-test 1`] = `
+"PublicPath: auto
+asset a09d8e0f399c215faa79.png 7 bytes {909} [emitted] [from: raw.png] (name: main)
+asset bundle.js 2.58 KiB {909} [emitted] (name: main)
+Entrypoint main 2.58 KiB = bundle.js
+chunk {909} bundle.js (main) [entry]
+  ./raw.png [193] {909}
+    [no exports]
+    [no exports used]
+    esm import ./raw.png [10]
+  ./index.js [10] {909}
+    [no exports]
+    [no exports used]
+    entry ./index
+./raw.png [193] {909}
+  [no exports]
+  [no exports used]
+  esm import ./raw.png [10]
+./index.js [10] {909}
+  [no exports]
+  [no exports used]
+  entry ./index
+./stringModule.js [orphan]
+  [no exports]
+  [module unused]
+  esm import ./stringModule [10]
+webpack/runtime/global {909}
+  [no exports]
+  [used exports unknown]
+webpack/runtime/auto_public_path {909}
+  [no exports]
+  [used exports unknown]
+  
+Rspack compiled successfully (ecb93a91f44e8655019a)"
+`;
+
 exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `
 "ERROR in ./index.ts
   × Module build failed:
@@ -76,12 +112,38 @@ exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print cor
 Rspack compiled with 1 error"
 `;
 
+exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for builtin-swc-loader-parse-error 1`] = `
+"ERROR in ./index.ts
+  × Module build failed:
+  ├─▶   ×
+  │     │   x Expected '{', got 'error'
+  │     │    ,-[Xdir/builtin-swc-loader-parse-error/index.ts:1:1]
+  │     │  1 | export error;
+  │     │    :        ^^^^^
+  │     │    \`----
+  │     │
+  │   
+  ╰─▶ Syntax Error
+  help: File was processed with this loader: 'builtin:swc-loader??ruleSet[1].rules[0].use[0]'
+
+Rspack compiled with 1 error"
+`;
+
 exports[`statsOutput statsOutput/concatenated-modules should print correct stats for 1`] = `
 "asset main.js 264 bytes [emitted] (name: main)
 Entrypoint main 264 bytes = main.js
 orphan modules 141 bytes [orphan] 4 modules
 ./index.js + 3 modules 141 bytes [code generated]
 Rspack x.x.x compiled successfully in X s"
+`;
+
+exports[`statsOutput statsOutput/concatenated-modules should print correct stats for concatenated-modules 1`] = `
+"PublicPath: auto
+asset main.js 267 bytes [emitted] (name: main)
+Entrypoint main 267 bytes = main.js
+orphan modules [orphan] 4 modules
+./index.js + 3 modules
+Rspack x.x.x compiled successfully in X s (a5fa0e6ed492c937f4a3)"
 `;
 
 exports[`statsOutput statsOutput/css-concat-error should print correct stats for 1`] = `
@@ -91,6 +153,16 @@ Entrypoint main 49 bytes = main.js
 ERROR in × Resolve error: Can't resolve './src' in 'Xdir/css-concat-error'
 
 Rspack x.x.x compiled with 1 error in X s"
+`;
+
+exports[`statsOutput statsOutput/css-concat-error should print correct stats for css-concat-error 1`] = `
+"PublicPath: auto
+asset main.js 49 bytes [emitted] (name: main)
+Entrypoint main 49 bytes = main.js
+
+ERROR in × Resolve error: Can't resolve './src' in 'Xdir/css-concat-error'
+
+Rspack x.x.x compiled with 1 error in X s (ab49ea8e12ee2eaedeac)"
 `;
 
 exports[`statsOutput statsOutput/filename should print correct stats for 1`] = `
@@ -104,12 +176,32 @@ cacheable modules 70 bytes
 Rspack x.x.x compiled successfully in X s"
 `;
 
+exports[`statsOutput statsOutput/filename should print correct stats for filename 1`] = `
+"PublicPath: auto
+asset 521.xxxx.js 335 bytes [emitted]
+asset 909.xxxx.js 8.78 KiB [emitted] (name: main)
+Entrypoint main 8.78 KiB = 909.xxxx.js
+runtime modules 11 modules
+./index.js
+./dynamic.js
+Rspack x.x.x compiled successfully in X s (1441f057611125a5f036)"
+`;
+
 exports[`statsOutput statsOutput/hot+production should print correct stats for 1`] = `
 "asset main.js 32.4 KiB [emitted] (name: main)
 Entrypoint main 32.4 KiB = main.js
 runtime modules 30.1 KiB 11 modules
 ./index.js 25 bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s"
+`;
+
+exports[`statsOutput statsOutput/hot+production should print correct stats for hot+production 1`] = `
+"PublicPath: auto
+asset main.js 32.3 KiB [emitted] (name: main)
+Entrypoint main 32.3 KiB = main.js
+runtime modules 11 modules
+./index.js
+Rspack x.x.x compiled successfully in X s (4a3dde925f48823cbd0d)"
 `;
 
 exports[`statsOutput statsOutput/ignore-plugin should print correct stats for 1`] = `
@@ -119,13 +211,52 @@ Xdir/ignore-plugin/locals|sync|/^\\\\.\\\\/.*$/ 160 bytes [built] [code generate
 ./locals/en.js 30 bytes [built] [code generated]"
 `;
 
+exports[`statsOutput statsOutput/ignore-plugin should print correct stats for ignore-plugin 1`] = `
+"runtime modules 1 module
+./index.js
+./locals/en.js
+Xdir/ignore-plugin/locals|sync|/^\\.\\/.*$/"
+`;
+
 exports[`statsOutput statsOutput/ignore-warning should print correct stats for 1`] = `"Rspack compiled successfully"`;
+
+exports[`statsOutput statsOutput/ignore-warning should print correct stats for ignore-warning 1`] = `"Rspack compiled successfully"`;
 
 exports[`statsOutput statsOutput/issue-3558 should print correct stats for 1`] = `"Rspack compiled successfully"`;
 
+exports[`statsOutput statsOutput/issue-3558 should print correct stats for issue-3558 1`] = `"Rspack compiled successfully"`;
+
 exports[`statsOutput statsOutput/legacy-ie-css-warning should print correct stats for 1`] = `"Rspack compiled successfully"`;
 
+exports[`statsOutput statsOutput/legacy-ie-css-warning should print correct stats for legacy-ie-css-warning 1`] = `"Rspack compiled successfully"`;
+
 exports[`statsOutput statsOutput/let-keyword-as-variable-name-error should print correct stats for 1`] = `
+"ERROR in ./index.js
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error: \`let\` cannot be used as an identifier in strict mode
+         ╭────
+       1 │ let let = let;
+         ·           ───
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+ERROR in ./index.js
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error: \`let\` cannot be used as an identifier in strict mode
+         ╭────
+       1 │ let let = let;
+         ·     ───
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+Rspack compiled with 2 errors"
+`;
+
+exports[`statsOutput statsOutput/let-keyword-as-variable-name-error should print correct stats for let-keyword-as-variable-name-error 1`] = `
 "ERROR in ./index.js
   × Module parse failed:
   ╰─▶   × JavaScript parsing error: \`let\` cannot be used as an identifier in strict mode
@@ -205,7 +336,78 @@ exports[`statsOutput statsOutput/limit-chunk-count-plugin should print correct s
   4 chunks (Rspack x.x.x) compiled successfully in X s"
 `;
 
+exports[`statsOutput statsOutput/limit-chunk-count-plugin should print correct stats for limit-chunk-count-plugin 1`] = `
+"1 chunks:
+  PublicPath: auto
+  asset bundle1.js 3.69 KiB [emitted] (name: main)
+  Entrypoint main 3.69 KiB = bundle1.js
+  chunk bundle1.js (main) <{909}> >{909}< [entry]
+    ./b.js
+    ./c.js
+    ./d.js
+    ./e.js
+    ./index.js
+  1 chunks (Rspack x.x.x) compiled successfully in X s (777d79960f54c02a411f)
+
+2 chunks:
+  PublicPath: auto
+  asset 76.bundle2.js 495 bytes [emitted] (name: c)
+  asset bundle2.js 10.3 KiB [emitted] (name: main)
+  Entrypoint main 10.3 KiB = bundle2.js
+  chunk 76.bundle2.js (c) <{76}> <{909}> >{76}<
+    ./c.js
+    ./d.js
+    ./e.js
+  chunk bundle2.js (main) >{76}< [entry]
+    ./b.js
+    ./index.js
+  2 chunks (Rspack x.x.x) compiled successfully in X s (8032657b6d1236128b3e)
+
+3 chunks:
+  PublicPath: auto
+  asset 345.bundle3.js 182 bytes [emitted]
+  asset 76.bundle3.js 389 bytes [emitted] (name: c)
+  asset bundle3.js 10.3 KiB [emitted] (name: main)
+  Entrypoint main 10.3 KiB = bundle3.js
+  chunk 345.bundle3.js <{76}>
+    ./d.js
+    ./e.js
+  chunk 76.bundle3.js (c) <{909}> >{345}<
+    ./c.js
+  chunk bundle3.js (main) >{76}< [entry]
+    ./b.js
+    ./index.js
+  3 chunks (Rspack x.x.x) compiled successfully in X s (38f4a0a213dd867cba24)
+
+4 chunks:
+  PublicPath: auto
+  asset 697.bundle4.js 128 bytes [emitted]
+  asset 753.bundle4.js 128 bytes [emitted]
+  asset 76.bundle4.js 389 bytes [emitted] (name: c)
+  asset bundle4.js 10.3 KiB [emitted] (name: main)
+  Entrypoint main 10.3 KiB = bundle4.js
+  chunk 697.bundle4.js <{76}>
+    ./e.js
+  chunk 753.bundle4.js <{76}>
+    ./d.js
+  chunk 76.bundle4.js (c) <{909}> >{697}< >{753}<
+    ./c.js
+  chunk bundle4.js (main) >{76}< [entry]
+    ./b.js
+    ./index.js
+  4 chunks (Rspack x.x.x) compiled successfully in X s (b301d29aba57cb3237c3)"
+`;
+
 exports[`statsOutput statsOutput/logging-loader should print correct stats for 1`] = `
+"DEBUG LOG from TestLoader|Xdir/logging-loader/index.js
+<-> group
+  <i> info something
+      log something
+    -------
+"
+`;
+
+exports[`statsOutput statsOutput/logging-loader should print correct stats for logging-loader 1`] = `
 "DEBUG LOG from TestLoader|Xdir/logging-loader/index.js
 <-> group
   <i> info something
@@ -226,9 +428,26 @@ exports[`statsOutput statsOutput/minify-error should print correct stats for 1`]
 Rspack compiled with 1 error"
 `;
 
+exports[`statsOutput statsOutput/minify-error should print correct stats for minify-error 1`] = `
+"ERROR in × JavaScript parsing error: Expected a semicolon
+   ╭─[1:1]
+ 1 │ const a {}
+   ·         ─
+ 2 │ (() => { // webpackBootstrap
+ 3 │ var __webpack_exports__ = {};
+   ╰────
+
+Rspack compiled with 1 error"
+`;
+
 exports[`statsOutput statsOutput/named-chunk-group should print correct stats for 1`] = `
 "Entrypoint main 8.8 KiB = main.js
 Chunk Group cimanyd 337 bytes = cimanyd.js"
+`;
+
+exports[`statsOutput statsOutput/named-chunk-group should print correct stats for named-chunk-group 1`] = `
+"Entrypoint main 8.77 KiB = main.js
+Chunk Group cimanyd 335 bytes = cimanyd.js"
 `;
 
 exports[`statsOutput statsOutput/nonexistent-import-source-error should print correct stats for 1`] = `
@@ -236,6 +455,17 @@ exports[`statsOutput statsOutput/nonexistent-import-source-error should print co
   × Resolve error: Can't resolve 'not-exist' in 'Xdir/nonexistent-import-source-error'
    ╭────
  1 │ import \\"not-exist\\";
+   ·        ───────────
+   ╰────
+
+Rspack compiled with 1 error"
+`;
+
+exports[`statsOutput statsOutput/nonexistent-import-source-error should print correct stats for nonexistent-import-source-error 1`] = `
+"ERROR in ./index.js
+  × Resolve error: Can't resolve 'not-exist' in 'Xdir/nonexistent-import-source-error'
+   ╭────
+ 1 │ import "not-exist";
    ·        ───────────
    ╰────
 
@@ -261,6 +491,15 @@ chunk (runtime: e2~runtime) e2.js (e2) 27 bytes [entry] [rendered]
 chunk (runtime: e2~runtime) e2~runtime.js (e2~runtime) 2.58 KiB [initial] [rendered]"
 `;
 
+exports[`statsOutput statsOutput/optimization-runtime-chunk should print correct stats for optimization-runtime-chunk 1`] = `
+"Entrypoint e1 4.01 KiB = e1~runtime.js 3.68 KiB e1.js 336 bytes
+Entrypoint e2 4.01 KiB = e2~runtime.js 3.68 KiB e2.js 336 bytes
+chunk e1.js (e1) [entry]
+chunk e1~runtime.js (e1~runtime) [initial]
+chunk e2.js (e2) [entry]
+chunk e2~runtime.js (e2~runtime) [initial]"
+`;
+
 exports[`statsOutput statsOutput/optimization-runtime-chunk-multiple should print correct stats for 1`] = `
 "Entrypoint e1 4.07 KiB = runtime~e1.js 3.68 KiB e1.js 391 bytes
 Entrypoint e2 4.07 KiB = runtime~e2.js 3.68 KiB e2.js 391 bytes
@@ -270,12 +509,29 @@ chunk (runtime: runtime~e1) runtime~e1.js (runtime~e1) 2.58 KiB [initial] [rende
 chunk (runtime: runtime~e2) runtime~e2.js (runtime~e2) 2.58 KiB [initial] [rendered]"
 `;
 
+exports[`statsOutput statsOutput/optimization-runtime-chunk-multiple should print correct stats for optimization-runtime-chunk-multiple 1`] = `
+"Entrypoint e1 4.01 KiB = runtime~e1.js 3.68 KiB e1.js 336 bytes
+Entrypoint e2 4.01 KiB = runtime~e2.js 3.68 KiB e2.js 336 bytes
+chunk e1.js (e1) [entry]
+chunk e2.js (e2) [entry]
+chunk runtime~e1.js (runtime~e1) [initial]
+chunk runtime~e2.js (runtime~e2) [initial]"
+`;
+
 exports[`statsOutput statsOutput/optimization-runtime-chunk-single should print correct stats for 1`] = `
 "Entrypoint e1 4.06 KiB = runtime.js 3.68 KiB e1.js 391 bytes
 Entrypoint e2 4.06 KiB = runtime.js 3.68 KiB e2.js 391 bytes
 chunk (runtime: runtime) e1.js (e1) 27 bytes [entry] [rendered]
 chunk (runtime: runtime) e2.js (e2) 27 bytes [entry] [rendered]
 chunk (runtime: runtime) runtime.js (runtime) 2.58 KiB [initial] [rendered]"
+`;
+
+exports[`statsOutput statsOutput/optimization-runtime-chunk-single should print correct stats for optimization-runtime-chunk-single 1`] = `
+"Entrypoint e1 4.01 KiB = runtime.js 3.68 KiB e1.js 336 bytes
+Entrypoint e2 4.01 KiB = runtime.js 3.68 KiB e2.js 336 bytes
+chunk e1.js (e1) [entry]
+chunk e2.js (e2) [entry]
+chunk runtime.js (runtime) [initial]"
 `;
 
 exports[`statsOutput statsOutput/optimization-runtime-chunk-true should print correct stats for 1`] = `
@@ -287,7 +543,35 @@ chunk (runtime: runtime~e1) runtime~e1.js (runtime~e1) 2.58 KiB [initial] [rende
 chunk (runtime: runtime~e2) runtime~e2.js (runtime~e2) 2.58 KiB [initial] [rendered]"
 `;
 
+exports[`statsOutput statsOutput/optimization-runtime-chunk-true should print correct stats for optimization-runtime-chunk-true 1`] = `
+"Entrypoint e1 4.01 KiB = runtime~e1.js 3.68 KiB e1.js 336 bytes
+Entrypoint e2 4.01 KiB = runtime~e2.js 3.68 KiB e2.js 336 bytes
+chunk e1.js (e1) [entry]
+chunk e2.js (e2) [entry]
+chunk runtime~e1.js (runtime~e1) [initial]
+chunk runtime~e2.js (runtime~e2) [initial]"
+`;
+
 exports[`statsOutput statsOutput/parse-error should print correct stats for 1`] = `
+"ERROR in ./b.js
+  × Module parse failed:
+  ╰─▶   × JavaScript parsing error: Expected ';', '}' or <eof>
+         ╭─[4:1]
+       4 │ includes
+       5 │ a
+       6 │ parser )
+         ·        ─
+       7 │ error
+       8 │ in
+         ╰────
+      
+  help: 
+        You may need an appropriate loader to handle this file type.
+
+Rspack compiled with 1 error"
+`;
+
+exports[`statsOutput statsOutput/parse-error should print correct stats for parse-error 1`] = `
 "ERROR in ./b.js
   × Module parse failed:
   ╰─▶   × JavaScript parsing error: Expected ';', '}' or <eof>
@@ -322,6 +606,22 @@ cacheable modules 293 KiB
 Rspack x.x.x compiled successfully in X s"
 `;
 
+exports[`statsOutput statsOutput/performance-disabled should print correct stats for performance-disabled 1`] = `
+"PublicPath: auto
+asset 697.js 128 bytes [emitted]
+asset 753.js 128 bytes [emitted]
+asset main.js 303 KiB [emitted] (name: main)
+Entrypoint main 303 KiB = main.js
+runtime modules 12 modules
+./a.js
+./b.js
+./c.js
+./d.js
+./e.js
+./index.js
+Rspack x.x.x compiled successfully in X s"
+`;
+
 exports[`statsOutput statsOutput/performance-error should print correct stats for 1`] = `
 "asset main.js 303 KiB [emitted] (name: main)
 asset 697.js 130 bytes [emitted]
@@ -348,6 +648,32 @@ ERROR in × entrypoint size limit: The following entrypoint(s) combined asset si
 Rspack x.x.x compiled with 2 errors in X s"
 `;
 
+exports[`statsOutput statsOutput/performance-error should print correct stats for performance-error 1`] = `
+"PublicPath: auto
+asset 697.js 128 bytes [emitted]
+asset 753.js 128 bytes [emitted]
+asset main.js 303 KiB [emitted] (name: main)
+Entrypoint main 303 KiB = main.js
+runtime modules 12 modules
+./a.js
+./b.js
+./c.js
+./d.js
+./e.js
+./index.js
+
+ERROR in × asset size limit: The following asset(s) exceed the recommended size limit (244.141 KiB). This can impact web performance.Assets:
+  │   main.js (303.486 KiB)
+
+
+ERROR in × entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244.141 KiB). This can impact web performance.Entrypoints:
+  │   main (303.486 KiB)
+  │       main.js
+
+
+Rspack x.x.x compiled with 2 errors in X s"
+`;
+
 exports[`statsOutput statsOutput/performance-no-hints should print correct stats for 1`] = `
 "asset main.js 303 KiB [emitted] (name: main)
 asset 697.js 130 bytes [emitted]
@@ -361,6 +687,22 @@ cacheable modules 293 KiB
   ./c.js 28 bytes [built] [code generated]
   ./d.js 22 bytes [built] [code generated]
   ./e.js 22 bytes [built] [code generated]
+Rspack x.x.x compiled successfully in X s"
+`;
+
+exports[`statsOutput statsOutput/performance-no-hints should print correct stats for performance-no-hints 1`] = `
+"PublicPath: auto
+asset 697.js 128 bytes [emitted]
+asset 753.js 128 bytes [emitted]
+asset main.js 303 KiB [emitted] (name: main)
+Entrypoint main 303 KiB = main.js
+runtime modules 12 modules
+./a.js
+./b.js
+./c.js
+./d.js
+./e.js
+./index.js
 Rspack x.x.x compiled successfully in X s"
 `;
 
@@ -378,12 +720,34 @@ chunk (runtime: main) b1.js (b1) 1 bytes <{751}> [rendered]
 chunk (runtime: main) main.js (main) 195 bytes (javascript) 11.6 KiB (runtime) >{74}< >{751}< >{76}< (prefetch: {74} {751} {76}) [entry] [rendered]"
 `;
 
+exports[`statsOutput statsOutput/prefetch-preload-mixed should print correct stats for prefetch-preload-mixed 1`] = `
+"chunk a1.js (a1) <{74}>
+chunk c2.js (c2) <{76}>
+chunk c1.js (c1) <{76}>
+chunk b3.js (b3) <{751}>
+chunk b2.js (b2) <{751}>
+chunk a.js (a) <{909}> >{330}< >{740}< (prefetch: {330} {740})
+chunk a2.js (a2) <{74}>
+chunk b.js (b) <{909}> >{438}< >{439}< >{826}< (prefetch: {826} {438}) (preload: {439})
+chunk c.js (c) <{909}> >{380}< >{433}< (preload: {433} {380})
+chunk b1.js (b1) <{751}>
+chunk main.js (main) >{74}< >{751}< >{76}< (prefetch: {74} {751} {76}) [entry]"
+`;
+
 exports[`statsOutput statsOutput/reasons should print correct stats for 1`] = `
 "./index.js 44 bytes [built] [code generated]
   entry ./index
 ./a.js 55 bytes [built] [code generated]
   cjs self exports reference self
   cjs require ./a"
+`;
+
+exports[`statsOutput statsOutput/reasons should print correct stats for reasons 1`] = `
+"./a.js
+  cjs self exports reference self
+  cjs require ./a
+./index.js
+  entry ./index"
 `;
 
 exports[`statsOutput statsOutput/resolve-overflow-error should print correct stats for 1`] = `
@@ -403,6 +767,24 @@ ERROR in ./index.js
 Rspack x.x.x compiled with 1 error in X s"
 `;
 
+exports[`statsOutput statsOutput/resolve-overflow-error should print correct stats for resolve-overflow-error 1`] = `
+"PublicPath: auto
+asset main.js 378 bytes [emitted] (name: main)
+Entrypoint main 378 bytes = main.js
+./index.js
+
+ERROR in ./index.js
+  × Resolve error: Can't resolve 'cycle-alias/a' in 'Xdir/resolve-overflow-error'
+   ╭─[1:1]
+ 1 │ import { a } from "cycle-alias/a";
+   ·                   ───────────────
+ 2 │ console.log(a);
+   ╰────
+  help: maybe it had cyclic aliases
+
+Rspack x.x.x compiled with 1 error in X s (e320e5265f17893abcb2)"
+`;
+
 exports[`statsOutput statsOutput/resolve-unexpected-exports-in-pkg-error should print correct stats for 1`] = `
 "asset bundle.js 1.38 KiB [emitted] (name: main)
 Entrypoint main 1.38 KiB = bundle.js
@@ -415,11 +797,31 @@ ERROR in ./index.js
 Rspack x.x.x compiled with 1 error in X s"
 `;
 
+exports[`statsOutput statsOutput/resolve-unexpected-exports-in-pkg-error should print correct stats for resolve-unexpected-exports-in-pkg-error 1`] = `
+"PublicPath: auto
+asset bundle.js 945 bytes [emitted] (name: main)
+Entrypoint main 945 bytes = bundle.js
+runtime modules 1 module
+./index.js
+
+ERROR in ./index.js
+  × Invalid "exports" target "../../index.js" defined for '.' in the package config Xdir/resolve-unexpected-exports-in-pkg-error/node_modules/pkg-a/package.json
+
+Rspack x.x.x compiled with 1 error in X s (65e45aeef39f4464d5f7)"
+`;
+
 exports[`statsOutput statsOutput/runtime-modules should print correct stats for 1`] = `
 "webpack/runtime/has_own_property 107 bytes [code generated]
 webpack/runtime/make_namespace_object 280 bytes [code generated]
 webpack/runtime/define_property_getters 290 bytes [code generated]
 ./index.js 19 bytes [built] [code generated]"
+`;
+
+exports[`statsOutput statsOutput/runtime-modules should print correct stats for runtime-modules 1`] = `
+"./index.js
+webpack/runtime/has_own_property
+webpack/runtime/make_namespace_object
+webpack/runtime/define_property_getters"
 `;
 
 exports[`statsOutput statsOutput/runtime-specific-exports should print correct stats for 1`] = `
@@ -437,6 +839,22 @@ Entrypoint main 1.67 KiB = main.js
 Rspack x.x.x compiled successfully in X s"
 `;
 
+exports[`statsOutput statsOutput/runtime-specific-exports should print correct stats for runtime-specific-exports 1`] = `
+"PublicPath: auto
+asset main.js 1.79 KiB [emitted] (name: main)
+Entrypoint main 1.79 KiB = main.js
+./math.js
+  [exports: add, multiply]
+  [only some exports used: add]
+./example.js
+  [no exports]
+  [no exports used]
+./increment.js
+  [exports: decrement, increment, incrementBy2]
+  [only some exports used: increment]
+Rspack x.x.x compiled successfully in X s (a74012a3fffb51e812fe)"
+`;
+
 exports[`statsOutput statsOutput/side-effects-bailouts should print correct stats for 1`] = `
 "asset main.js 207 bytes {909} [emitted] (name: main)
 Entrypoint main 207 bytes = main.js
@@ -450,12 +868,41 @@ orphan modules 91 bytes [orphan] 2 modules
 Rspack x.x.x compiled successfully in X s"
 `;
 
+exports[`statsOutput statsOutput/side-effects-bailouts should print correct stats for side-effects-bailouts 1`] = `
+"PublicPath: auto
+asset main.js 1.86 KiB {909} [emitted] (name: main)
+Entrypoint main 1.86 KiB = main.js
+chunk {909} main.js (main) [entry]
+runtime modules 2 modules
+./lib.js [467] {909}
+  [exports: test]
+  [all exports used]
+  Statement with side_effects in source code at ./lib.js:3:0-9
+  esm import ./lib.js [10]
+  esm import specifier ./lib.js [10]
+./index.js [10] {909}
+  [no exports]
+  [no exports used]
+  entry ./index.js
+  
+Rspack x.x.x compiled successfully in X s (60c70856f42105a844ca)"
+`;
+
 exports[`statsOutput statsOutput/simple-export should print correct stats for 1`] = `
 "asset bundle.js 1.71 KiB [emitted] (name: main)
 Entrypoint main 1.71 KiB = bundle.js
 runtime modules 677 bytes 3 modules
 ./index.js 26 bytes [built] [code generated]
 Rspack x.x.x compiled successfully in X s"
+`;
+
+exports[`statsOutput statsOutput/simple-export should print correct stats for simple-export 1`] = `
+"PublicPath: auto
+asset bundle.js 1.25 KiB [emitted] (name: main)
+Entrypoint main 1.25 KiB = bundle.js
+runtime modules 3 modules
+./index.js
+Rspack x.x.x compiled successfully in X s (2291cf9010086b87df21)"
 `;
 
 exports[`statsOutput statsOutput/simple-module-source should print correct stats for 1`] = `
@@ -469,11 +916,30 @@ cacheable modules 82 bytes
 Rspack compiled successfully"
 `;
 
+exports[`statsOutput statsOutput/simple-module-source should print correct stats for simple-module-source 1`] = `
+"PublicPath: auto
+asset bundle.js 2.1 KiB [emitted] (name: main)
+Entrypoint main 2.1 KiB = bundle.js
+runtime modules 3 modules
+orphan modules [orphan] 1 module
+./raw.png
+./index.js
+Rspack compiled successfully (bf8a828b2158bcb51e2e)"
+`;
+
 exports[`statsOutput statsOutput/stats-hooks should print correct stats for 1`] = `
 "asset main.js 99 bytes [emitted111] (name: main) [testA: aaaaaa]
 Entrypoint main 99 bytes = main.js
 ./index.js 26 bytes [built] [code generated]
 Rspack compiled successfully"
+`;
+
+exports[`statsOutput statsOutput/stats-hooks should print correct stats for stats-hooks 1`] = `
+"PublicPath: auto
+asset main.js 99 bytes [emitted111] (name: main) [testA: aaaaaa]
+Entrypoint main 99 bytes = main.js
+./index.js
+Rspack compiled successfully (f4dda9cb00eba2407136)"
 `;
 
 exports[`statsOutput statsOutput/try-require-module should print correct stats for 1`] = `
@@ -485,6 +951,19 @@ exports[`statsOutput statsOutput/try-require-module should print correct stats f
    ·     ───────────────────────────
  3 │ } catch (e) {
  4 │ 
+   ╰────
+
+Rspack compiled with 1 warning"
+`;
+
+exports[`statsOutput statsOutput/try-require-module should print correct stats for try-require-module 1`] = `
+"WARNING in ./index.js
+  ⚠ Resolve error: Can't resolve './missing-module' in 'Xdir/try-require-module'
+   ╭─[1:1]
+ 1 │ try {
+ 2 │     require('./missing-module');
+   ·     ───────────────────────────
+ 3 │ } catch (e) {}
    ╰────
 
 Rspack compiled with 1 warning"
@@ -504,6 +983,19 @@ exports[`statsOutput statsOutput/try-require-resolve-module should print correct
 Rspack compiled with 1 warning"
 `;
 
+exports[`statsOutput statsOutput/try-require-resolve-module should print correct stats for try-require-resolve-module 1`] = `
+"WARNING in ./index.js
+  ⚠ Resolve error: Can't resolve './missing-module' in 'Xdir/try-require-resolve-module'
+   ╭─[1:1]
+ 1 │ try {
+ 2 │     require.resolve('./missing-module');
+   ·     ───────────────────────────────────
+ 3 │ } catch (e) {}
+   ╰────
+
+Rspack compiled with 1 warning"
+`;
+
 exports[`statsOutput statsOutput/try-require-resolve-weak-module should print correct stats for 1`] = `
 "WARNING in ./index.js
   ⚠ Resolve error: Can't resolve './missing-module' in 'Xdir/try-require-resolve-weak-module'
@@ -513,6 +1005,19 @@ exports[`statsOutput statsOutput/try-require-resolve-weak-module should print co
    ·     ───────────────────────────────────────
  3 │ } catch (e) {
  4 │ 
+   ╰────
+
+Rspack compiled with 1 warning"
+`;
+
+exports[`statsOutput statsOutput/try-require-resolve-weak-module should print correct stats for try-require-resolve-weak-module 1`] = `
+"WARNING in ./index.js
+  ⚠ Resolve error: Can't resolve './missing-module' in 'Xdir/try-require-resolve-weak-module'
+   ╭─[1:1]
+ 1 │ try {
+ 2 │     require.resolveWeak('./missing-module');
+   ·     ───────────────────────────────────────
+ 3 │ } catch (e) {}
    ╰────
 
 Rspack compiled with 1 warning"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
Http URI Plugin and schema for bundling http imports directly. 

Problems remaining: 

- [ ] resolving relative imports from a http url like "./some-path" or "/some/path" - currently i have to string replace import from with urls in the loaded source code in order to get all modules to bundle 


<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
