### PR TITLE
chore: disable renovate update for swc

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,7 +67,8 @@
       ],
       "matchPackageNames": [
         "styled_components"
-      ]
+      ],
+      "enable": false // manually update swc and related crate since it may contain breaking change in minor | patch version
     },
     {
       "groupName": "napi",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
swc may introduce breaking during patch update which is not safe to do auto bump for rspack, 
we need to do manually update for swc related crated
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
