### PR TITLE
chore: add deprecated notice for rspack-plugin-minify

### DIFF
--- a/crates/node_binding/README.md
+++ b/crates/node_binding/README.md
@@ -6,8 +6,7 @@
 # @rspack/binding
 
 Private node binding crate for rspack.
-
-This package does *NOT* follow [semantic versioning](https://semver.org/).
+> Rspack's internal package, don't use it directly in your project, This package does *NOT* follow [semantic versioning](https://semver.org/).
 
 ## Documentation
 

--- a/packages/rspack-plugin-minify/README.md
+++ b/packages/rspack-plugin-minify/README.md
@@ -7,6 +7,8 @@
 
 Minify plugin for rspack.
 
+> DEPRECATED, use [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin) instead.
+
 ## Documentation
 
 See [https://rspack.dev](https://rspack.dev) for details.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
since we're compatible with terser-webpack-plugin now, rspack-minify-plugin could be deprecated
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
