### PR TITLE
docs: add Module Federation to features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Rspack is a high performance JavaScript bundler written in Rust. It offers stron
 - 🚀 **Fast Startup**: Based on Rust, the build speed is extremely fast, bringing you the ultimate development experience.
 - ⚡ **Lightning HMR**: With a built-in incremental compilation mechanism, HMR is extremely fast and fully capable of developing large-scale projects.
 - 📦 **Webpack Compatible**: Compatible with plugins and loaders in the webpack ecosystem, seamlessly integrating excellent libraries built by the community.
-- 🎨 **Batteries Included**: Out-of-the-box support for TypeScript, JSX, CSS, CSS Modules, Sass, and more.
+- 🎨 **Module Federation**: Provide first-class support for Module Federation to facilitate the development of large-scale web applications.
 - 🛠️ **Production Optimization**: Various optimization strategies are built in by default, such as tree shaking, minification, etc.
 - 🎯 **Framework Agnostic**: Not bound to any frontend framework, ensuring enough flexibility.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,7 +32,7 @@ Rspack 是一个基于 Rust 编写的高性能 JavaScript 打包工具，它提�
 - 🚀 **启动速度极快**: 基于 Rust 实现，构建速度极快，带给你极致的开发体验。
 - ⚡ **闪电般的 HMR**: 内置增量编译机制，HMR 速度极快，完全胜任大型项目的开发。
 - 📦 **兼容 webpack 生态**: 兼容 webpack 生态中的 plugin 和 loader，无缝衔接社区中沉淀的优秀库。
-- 🎨 **内置常见构建能力**: 对 TypeScript、JSX、CSS、CSS Modules、Sass 等提供开箱即用的支持。
+- 🎨 **模块联邦**: 为 Module Federation 提供一流的支持，助力开发规模化的 Web 应用。
 - 🛠️ **默认生产优化**: 默认内置多种优化策略，如 Tree Shaking、代码压缩等等。
 - 🎯 **框架无关**: 不和任何前端框架绑定，保证足够的灵活性。
 

--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -57,7 +57,7 @@ Rspack was initially created to solve performance problems encountered at ByteDa
 
 ## Current status of Rspack
 
-Rspack has been under continuous development since April 2022, and was launched as open source in March 2023. Rspack has finished implementing most important features of webpack and these features can meet the needs of most projects. Some ByteDance internal projects have already achieved a 5-10 times improvement moving from webpack to Rspack, and there's still room for future optimizations.
+Rspack has been under continuous development since April 2022, and was launched as open source in March 2023. Rspack has already implemented most important features of webpack and these features can meet the needs of most projects. Some ByteDance internal projects have already achieved a 5-10 times improvement moving from webpack to Rspack, and there's still room for future optimizations.
 
 Rspack is compatible with webpack's configuration schema and loader architecture. You can seamlessly use familiar loaders such as `babel-loader`, `less-loader`, `sass-loader`, `vue-loader`, etc.
 
@@ -65,7 +65,7 @@ Currently, Rspack's cache support is relatively simple, only supporting memory-l
 
 ## The future of Rspack
 
-Although Rspack already meets the needs of many projects, there is still a big gap to reach the full capabilities of webpack. Prioritization will be based on community feedback, so please tell us about your requirements!
+Although Rspack already meets the needs of many projects, there are still some gaps to reach the full capabilities of webpack. Prioritization will be based on community feedback, so please tell us about your requirements!
 
 ### Collaboration with community partners
 

--- a/website/docs/en/index.md
+++ b/website/docs/en/index.md
@@ -33,10 +33,10 @@ features:
     details: Compatible with plugins and loaders in the webpack ecosystem, seamlessly integrating excellent libraries built by the community.
     icon: 📦
     link: /guide/compatibility/plugin
-  - title: Batteries Included
-    details: Out-of-the-box support for TypeScript, JSX, CSS, CSS Modules, Sass, and more.
+  - title: Module Federation
+    details: Provide first-class support for Module Federation to facilitate the development of large-scale web applications.
     icon: 🎨
-    link: /guide/tech/typescript
+    link: /guide/features/module-federation
   - title: Production Optimizations
     details: Core optimizations such as tree shaking and minification have integrated implementations rather than deferring to plugins.
     icon: 🛠️

--- a/website/docs/zh/guide/start/introduction.mdx
+++ b/website/docs/zh/guide/start/introduction.mdx
@@ -64,7 +64,7 @@ import rspackAudio from '../../../public/rspack.mp3';
 
 ## Rspack 目前的状态
 
-虽然 Rspack 已经实现了 webpack 大部分的主要功能，目前的功能已经能够满足大多数项目的需求。同时，我们已经在内部的几百个业务上完成了落地，取得了 5~10 倍编译性能的提升。目前的性能仍然存在较大提升空间，我们会持续对 Rspack 进行更深入的性能优化。
+Rspack 已经实现了 webpack 绝大部分的功能，目前的功能也能够满足大多数项目的需求。同时，我们已经在内部的几百个业务上完成了落地，取得了 5~10 倍编译性能的提升。目前的性能仍然存在较大提升空间，我们会持续对 Rspack 进行更深入的性能优化。
 
 Rspack 已经完成了对 webpack 主要配置的兼容，并且适配了 webpack 的 loader 架构。目前，你已经可以在 Rspack 中无缝使用你熟悉的各种 loader，如 babel-loader、less-loader、sass-loader、vue-loader 等等。
 
@@ -72,7 +72,7 @@ Rspack 已经完成了对 webpack 主要配置的兼容，并且适配了 webpac
 
 ## Rspack 的未来
 
-虽然 Rspack 目前提供的能力已经能够满足大多数项目的使用，但是相比于 webpack 提供的完整能力，Rspack 仍然存在很大差距。因此，我们会根据社区的反馈，持续丰富 Rspack 的能力，从而满足更多构建场景的需求。
+虽然 Rspack 目前提供的能力已经能够满足大多数项目的使用，但是相比于 webpack 提供的完整能力，Rspack 仍然存在一些差距。因此，我们会根据社区的反馈，持续丰富 Rspack 的能力，从而满足更多构建场景的需求。
 
 ### 和社区的伙伴合作
 

--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -33,10 +33,10 @@ features:
     details: 兼容 webpack 生态中的 plugin 和 loader，无缝衔接社区中沉淀的优秀库。
     icon: 📦
     link: /zh/guide/compatibility/plugin
-  - title: 内置常见构建能力
-    details: 对 Typescript、JSX、CSS、CSS Modules、Sass 等提供开箱即用的支持。
+  - title: 模块联邦
+    details: 为 Module Federation 提供一流的支持，助力开发规模化的 Web 应用。
     icon: 🎨
-    link: /zh/guide/tech/typescript
+    link: /guide/features/module-federation
   - title: 默认生产优化
     details: 默认内置多种优化策略，如 Tree Shaking、代码压缩等等。
     icon: 🛠️


### PR DESCRIPTION
## Summary

Add Module Federation to features list and remove `Batteries Included`, since Rspack now aligns with webpack and no longer provides builtin TypeScript / Sass support.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
