### PR TITLE
feat: align webpack target and stats api

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -27,6 +27,7 @@ export class JsCompilation {
   getModules(): Array<JsModule>
   getOptimizationBailout(): Array<JsStatsOptimizationBailout>
   getChunks(): Array<JsChunk>
+  getNamedChunkKeys(): Array<string>
   getNamedChunk(name: string): JsChunk | null
   setAssetSource(name: string, source: JsCompatSource): void
   deleteAssetSource(name: string): void

--- a/crates/rspack_binding_values/src/compilation.rs
+++ b/crates/rspack_binding_values/src/compilation.rs
@@ -176,6 +176,11 @@ impl JsCompilation {
   }
 
   #[napi]
+  pub fn get_named_chunk_keys(&self) -> Vec<String> {
+    self.0.named_chunks.keys().cloned().collect::<Vec<_>>()
+  }
+
+  #[napi]
   pub fn get_named_chunk(&self, name: String) -> Option<JsChunk> {
     self
       .0

--- a/crates/rspack_core/src/options/target.rs
+++ b/crates/rspack_core/src/options/target.rs
@@ -38,6 +38,7 @@ impl Target {
           "browserslist" => TargetEsVersion::BrowsersList,
           "es3" => TargetEsVersion::Esx(EsVersion::Es3),
           "es5" => TargetEsVersion::Esx(EsVersion::Es5),
+          "es6" => TargetEsVersion::Esx(EsVersion::Es2015),
           "es2015" => TargetEsVersion::Esx(EsVersion::Es2015),
           "es2016" => TargetEsVersion::Esx(EsVersion::Es2016),
           "es2017" => TargetEsVersion::Esx(EsVersion::Es2017),

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -12382,11 +12382,15 @@ export class Stats {
     // (undocumented)
     compilation: Compilation;
     // (undocumented)
+    get endTime(): number | undefined;
+    // (undocumented)
     hasErrors(): boolean;
     // (undocumented)
     get hash(): Readonly<string | null>;
     // (undocumented)
     hasWarnings(): boolean;
+    // (undocumented)
+    get startTime(): number | undefined;
     // (undocumented)
     toJson(opts?: StatsValue, forToString?: boolean): StatsCompilation;
     // (undocumented)

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -15,8 +15,7 @@ import {
 	type JsModule,
 	type JsPathData,
 	JsRspackSeverity,
-	type JsRuntimeModule,
-	type JsStatsError
+	type JsRuntimeModule
 } from "@rspack/binding";
 import * as liteTapable from "@rspack/lite-tapable";
 import { Source } from "webpack-sources";
@@ -376,10 +375,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	/**
 	 * Get the named chunks.
 	 *
-	 * Note: This is a proxy for webpack internal API, only method `get` is supported now.
+	 * Note: This is a proxy for webpack internal API, only method `get` and `keys` is supported now.
 	 */
 	get namedChunks(): ReadonlyMap<string, Readonly<Chunk>> {
 		return {
+			keys: (): IterableIterator<string> => {
+				const names = this.#inner.getNamedChunkKeys();
+				return names[Symbol.iterator]();
+			},
 			get: (property: unknown) => {
 				if (typeof property === "string") {
 					const chunk = this.#inner.getNamedChunk(property) || undefined;

--- a/packages/rspack/src/Stats.ts
+++ b/packages/rspack/src/Stats.ts
@@ -47,6 +47,14 @@ export class Stats {
 		return this.compilation.hash;
 	}
 
+	get startTime() {
+		return this.compilation.startTime;
+	}
+
+	get endTime() {
+		return this.compilation.endTime;
+	}
+
 	hasErrors() {
 		return this.#inner.getErrors().length > 0;
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

1. Support for `target` to use `'es6'`:

This enhancement is especially useful for frameworks such as Next.js that utilize `'es6'` in their build configurations. For reference, see how Next.js configures their webpack build [here](https://github.com/vercel/next.js/blob/b2625477c002343e7fe083204c45af1fdd7cd407/packages/next/src/build/webpack/config/blocks/base.ts#L20).

2. Add `startTime` and `endTime` in `Stats`:

These timestamps are used for plugins like `friendly-errors-webpack-plugin`, which relies on these metrics for enhanced error reporting. For more details, see the plugin implementation [here](https://github.com/geowarin/friendly-errors-webpack-plugin/blob/51745900c9dcc582aa250033a856216ca2f64377/src/friendly-errors-plugin.js#L126).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
