### PR TITLE
chore: release force use github runner

### DIFF
--- a/.github/workflows/get-runner-labels.yml
+++ b/.github/workflows/get-runner-labels.yml
@@ -2,6 +2,12 @@ name: Get Runner Labels
 
 on:
   workflow_call:
+    inputs:
+      force-use-github-runner:
+        type: boolean
+        description: "Force use github runner"
+        required: false
+        default: false
     outputs:
       LINUX_RUNNER_LABELS:
         description: "linux runner labels"
@@ -25,7 +31,22 @@ jobs:
       - id: run
         shell: bash
         run: |
-          # set default value for vars.XXX_RUNNER_LABELS
-          echo 'LINUX_RUNNER_LABELS=${{ vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"' }}' >> "$GITHUB_OUTPUT"
-          echo 'MACOS_RUNNER_LABELS=${{ vars.MACOS_RUNNER_LABELS || '"macos-latest"' }}' >> "$GITHUB_OUTPUT"
-          echo 'WINDOWS_RUNNER_LABELS=${{ vars.WINDOWS_RUNNER_LABELS || '"windows-latest"' }}' >> "$GITHUB_OUTPUT"
+          if ${{ !inputs.force-use-github-runner }}; then
+            LINUX_RUNNER_LABELS='${{ vars.LINUX_RUNNER_LABELS }}';
+            MACOS_RUNNER_LABELS='${{ vars.MACOS_RUNNER_LABELS }}';
+            WINDOWS_RUNNER_LABELS='${{ vars.WINDOWS_RUNNER_LABELS }}';
+          fi
+          # set default value
+          if [[ -z "$LINUX_RUNNER_LABELS" ]]; then
+            LINUX_RUNNER_LABELS='"ubuntu-latest"';
+          fi
+          if [[ -z "$MACOS_RUNNER_LABELS" ]]; then
+            MACOS_RUNNER_LABELS='"macos-latest"';
+          fi
+          if [[ -z "$WINDOWS_RUNNER_LABELS" ]]; then
+            WINDOWS_RUNNER_LABELS='"windows-latest"';
+          fi
+          # set output
+          echo "LINUX_RUNNER_LABELS=$LINUX_RUNNER_LABELS" >> "$GITHUB_OUTPUT"
+          echo "MACOS_RUNNER_LABELS=$MACOS_RUNNER_LABELS" >> "$GITHUB_OUTPUT"
+          echo "WINDOWS_RUNNER_LABELS=$WINDOWS_RUNNER_LABELS" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -16,6 +16,8 @@ jobs:
   get-runner-labels:
     name: Get Runner Labels
     uses: ./.github/workflows/get-runner-labels.yml
+    with:
+      force-use-github-runner: true
 
   build:
     name: Build Canary

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -15,6 +15,8 @@ jobs:
     name: Get Runner Labels
     if: github.repository_owner == 'web-infra-dev'
     uses: ./.github/workflows/get-runner-labels.yml
+    with:
+      force-use-github-runner: true
 
   build:
     name: Build Nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
   get-runner-labels:
     name: Get Runner Labels
     uses: ./.github/workflows/get-runner-labels.yml
+    with:
+      force-use-github-runner: true
 
   build:
     needs: [get-runner-labels]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

add `force-use-github-runner` params to `get-runner-labels` workflow and make all of release workflow run on github runner

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
