### PR TITLE
chore: add provenance option to pnpm publish

### DIFF
--- a/scripts/release/publish.mjs
+++ b/scripts/release/publish.mjs
@@ -23,7 +23,7 @@ export async function publish_handler(mode, options) {
 	}
 	await $`pnpm publish -r ${options.dryRun ? "--dry-run" : ""} --tag ${
 		options.tag
-	} --no-git-checks`;
+	} --no-git-checks --provenance`;
 	const version = await getLastVersion(root);
 	core.setOutput("version", version);
 	core.notice(`Version: ${version}`);


### PR DESCRIPTION
## Summary

We have tried to generate provenance statements in https://github.com/web-infra-dev/rspack/pull/6896, and it worked for most packages like `@rspack/core`.

However, the binding packages (such as `@rspack/binding-darwin-arm64`) are still missing provenance statement, this PR added the `--provenance` option to try to fix this issue.

See:  https://github.com/napi-rs/napi-rs/blob/286c8d0cf46e683e642ce1b01e768d756e013567/cli/src/api/templates/ci-template.ts#L579

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
