### PR TITLE
perf: cache `compilation.entrypoints`

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -40,7 +40,6 @@ import { Stats, StatsAsset, StatsError, StatsModule } from "./Stats";
 import { LogType, Logger } from "./logging/Logger";
 import { StatsFactory } from "./stats/StatsFactory";
 import { StatsPrinter } from "./stats/StatsPrinter";
-import { concatErrorMsgAndStack } from "./util";
 import { type AssetInfo, JsAssetInfo } from "./util/AssetInfo";
 import MergeCaller from "./util/MergeCaller";
 import { createFakeCompilationDependencies } from "./util/fake";
@@ -142,7 +141,8 @@ export type NormalizedStatsOptions = KnownNormalizedStatsOptions &
 
 export class Compilation {
 	#inner: JsCompilation;
-	#cachedAssets: Record<string, Source>;
+	#cachedAssets?: Record<string, Source>;
+	#cachedEntrypoints?: ReadonlyMap<string, Entrypoint>;
 
 	hooks: Readonly<{
 		processAssets: liteTapable.AsyncSeriesHook<Assets>;
@@ -224,7 +224,6 @@ export class Compilation {
 
 	constructor(compiler: Compiler, inner: JsCompilation) {
 		this.#inner = inner;
-		this.#cachedAssets = this.#createCachedAssets();
 		this.#customModules = {};
 
 		const processAssetsHook = new liteTapable.AsyncSeriesHook<Assets>([
@@ -342,6 +341,9 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 * Get a map of all assets.
 	 */
 	get assets(): Record<string, Source> {
+		if (!this.#cachedAssets) {
+			this.#cachedAssets = this.#createCachedAssets();
+		}
 		return this.#cachedAssets;
 	}
 
@@ -349,12 +351,15 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 * Get a map of all entrypoints.
 	 */
 	get entrypoints(): ReadonlyMap<string, Entrypoint> {
-		return new Map(
-			Object.entries(this.#inner.entrypoints).map(([n, e]) => [
-				n,
-				Entrypoint.__from_binding(e, this.#inner)
-			])
-		);
+		if (!this.#cachedEntrypoints) {
+			this.#cachedEntrypoints = new Map(
+				Object.entries(this.#inner.entrypoints).map(([n, e]) => [
+					n,
+					Entrypoint.__from_binding(e, this.#inner)
+				])
+			);
+		}
+		return this.#cachedEntrypoints;
 	}
 
 	get modules(): ReadonlySet<Module> {


### PR DESCRIPTION
## Summary

Cache `compilation.entrypoints` to improve performance, it is similar to `compilation.#cachedAssets`.

The performance cost of `compilation.entrypoints` is noticeable when using [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin/blob/41f4a7b952e80eea4878d96638b4021f4a762750/index.js#L1296).

I have tested it in a MPA project (https://github.com/liangyuetian/rsbuild-hmr-slow-demo) with 200+ entries:

- without cache, it took 500ms (total) to get `compilation.entrypoints`:

<img width="461" alt="截屏2024-07-06 19 31 24" src="https://github.com/web-infra-dev/rspack/assets/7237365/37e52f1e-5ecb-4c0e-9e49-70a5e70ed625">

- with cache, it took 2.5ms (total) to get `compilation.entrypoints`:

<img width="469" alt="截屏2024-07-06 20 02 30" src="https://github.com/web-infra-dev/rspack/assets/7237365/a4939d73-28ff-451f-82e7-2b71c75b2016">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
