### PR TITLE
fix: zod is pre-bundled twice

### DIFF
--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -1,13 +1,18 @@
 // @ts-check
 import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath } from "node:url";
 
 /** @type {import('prebundle').Config} */
 export default {
 	dependencies: [
 		"zod",
-		"zod-validation-error",
+		{
+			name: "zod-validation-error",
+			externals: {
+				zod: "../zod"
+			}
+		},
 		"json-parse-even-better-errors",
 		"neo-async",
 		"graceful-fs",
@@ -67,7 +72,10 @@ export default {
 			afterBundle(task) {
 				const __filename = fileURLToPath(import.meta.url);
 				const __dirname = dirname(__filename);
-				const dtsInputPath = join(__dirname, "declarations/webpack-sources.d.ts");
+				const dtsInputPath = join(
+					__dirname,
+					"declarations/webpack-sources.d.ts"
+				);
 				const dtsContent = readFileSync(dtsInputPath, "utf-8");
 				const dtsOutputPath = join(task.distPath, "index.d.ts");
 				writeFileSync(dtsOutputPath, dtsContent, "utf-8");


### PR DESCRIPTION
## Summary

Fix zod is pre-bundled twice because we do not configure externals for `zod-validation-error` correctly.

`compiled/zod-validation-error/index.js`: from `157kb` to `8kb`.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
