### PR TITLE
chore: use catelog to unify npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "url": "https://github.com/web-infra-dev/rspack"
   },
   "engines": {
-    "pnpm": "9.3.0"
+    "pnpm": "9.5.0-beta.3"
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.0",
@@ -74,5 +74,5 @@
     "webpack": "5.92.0",
     "webpack-cli": "5.1.4"
   },
-  "packageManager": "pnpm@9.3.0"
+  "packageManager": "pnpm@9.5.0-beta.3"
 }

--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_ENV=production rspack build"
   },
   "dependencies": {
-    "react": "^18.2.0",
+    "react": "catalog:default",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {

--- a/packages/create-rspack/template-react/package.json
+++ b/packages/create-rspack/template-react/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_ENV=production rspack build"
   },
   "dependencies": {
-    "react": "^18.2.0",
+    "react": "catalog:default",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    react:
+      specifier: 18.0.0
+      version: 18.0.0
+
 importers:
 
   .:
@@ -123,11 +129,11 @@ importers:
   packages/create-rspack/template-react:
     dependencies:
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: catalog:default
+        version: 18.0.0
       react-dom:
         specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        version: 18.2.0(react@18.0.0)
     devDependencies:
       '@rspack/cli':
         specifier: workspace:*
@@ -154,11 +160,11 @@ importers:
   packages/create-rspack/template-react-ts:
     dependencies:
       react:
-        specifier: ^18.2.0
-        version: 18.2.0
+        specifier: catalog:default
+        version: 18.0.0
       react-dom:
         specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
+        version: 18.2.0(react@18.0.0)
     devDependencies:
       '@rspack/cli':
         specifier: workspace:*
@@ -7826,10 +7832,6 @@ packages:
     resolution: {integrity: sha512-x+VL6wbT4JRVPm7EGxXhZ8w8LTROaxPXOqhlGyVSrv0sB1jkyFGgXxJ8LVoPRLvPR6/CIZGFmfzqUa2NYeMr2A==}
     engines: {node: '>=0.10.0'}
 
-  react@18.2.0:
-    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
-    engines: {node: '>=0.10.0'}
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -9819,7 +9821,7 @@ snapshots:
 
   '@babel/helper-environment-visitor@7.24.7':
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.24.7
 
   '@babel/helper-function-name@7.23.0':
     dependencies:
@@ -9829,7 +9831,7 @@ snapshots:
   '@babel/helper-function-name@7.24.7':
     dependencies:
       '@babel/template': 7.24.7
-      '@babel/types': 7.22.5
+      '@babel/types': 7.24.7
 
   '@babel/helper-hoist-variables@7.22.5':
     dependencies:
@@ -18032,10 +18034,10 @@ snapshots:
       react: 18.0.0
       scheduler: 0.21.0
 
-  react-dom@18.2.0(react@18.2.0):
+  react-dom@18.2.0(react@18.0.0):
     dependencies:
       loose-envify: 1.4.0
-      react: 18.2.0
+      react: 18.0.0
       scheduler: 0.23.0
 
   react-dom@18.3.1(react@18.3.1):
@@ -18171,10 +18173,6 @@ snapshots:
       object-assign: 4.1.1
 
   react@18.0.0:
-    dependencies:
-      loose-envify: 1.4.0
-
-  react@18.2.0:
     dependencies:
       loose-envify: 1.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,8 @@ packages:
   - "tests/plugin-test"
   - "tests/webpack-cli-test"
   - "tests/diff-test/*"
+
+catalog:
+  react: 18.0.0
+  react-dom: 18.0.0
+  react-refresh: 0.14.0


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
catelog is great feature which is similar with cargo's dependencies.workspace feature, we can use it to unify npm version in monorepo
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
