### PR TITLE
fix: panic when get max target in find target

### DIFF
--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1293,11 +1293,17 @@ impl ExportInfoId {
     if !export_info.target_is_set || export_info.target.is_empty() {
       return FindTargetRetEnum::Undefined;
     }
-    let raw_target = export_info
-      .get_max_target_readonly()
-      .values()
-      .next()
-      .cloned();
+
+    let raw_target = if export_info.max_target_is_set {
+      export_info
+        .get_max_target_readonly()
+        .values()
+        .next()
+        .cloned()
+    } else {
+      export_info._get_max_target().values().next().cloned()
+    };
+
     let Some(raw_target) = raw_target else {
       return FindTargetRetEnum::Undefined;
     };

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1724,6 +1724,8 @@ impl ExportInfo {
     map
   }
 
+  /// Panics:
+  /// Panics if max target is not set before.
   fn get_max_target_readonly(&self) -> &HashMap<Option<DependencyId>, ExportInfoTargetValue> {
     assert!(self.max_target_is_set);
     &self.max_target

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/index.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/index.js
@@ -1,0 +1,5 @@
+import { QueryClient } from 'mocklib';
+
+it("should compile", () => {
+  expect(QueryClient).toBe(1)
+});

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/core.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/core.js
@@ -1,0 +1,2 @@
+export { QueryClient } from './queryclient';
+export * from './empty';

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/lib.js
@@ -1,0 +1,1 @@
+export * from './core';

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/package.json
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mocklib",
+  "main": "./lib.js",
+  "module": "./lib.js",
+  "sideEffects": [
+    "lib.js"
+  ]
+}

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/queryclient.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/node_modules/mocklib/queryclient.js
@@ -1,0 +1,1 @@
+export var QueryClient = 1;

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/get-max-target-panic/rspack.config.js
@@ -1,0 +1,13 @@
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+  mode: "development",
+  entry: {
+    main: "./index.js"
+  },
+  optimization: {
+    providedExports: true,
+    usedExports: true,
+    concatenateModules: true,
+    minimize: false
+  },
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/7057
fix https://github.com/web-infra-dev/rspack/issues/7062
fix https://github.com/web-infra-dev/rspack/issues/7077
fix https://github.com/web-infra-dev/rspack/issues/7078

In webpack, module graph is always mutable and will insert the max target of export info while getting it, even during the code gen.

But in rspack, module graph should be immutable during the code gen. So can only get max target when it has been set. If it is not exists, export info should generate it but not set it into export info. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
