### PR TITLE
docs: update teams page, add Rsfamily members

### DIFF
--- a/website/components/RandomMemberList.module.scss
+++ b/website/components/RandomMemberList.module.scss
@@ -48,6 +48,7 @@
   margin: 0 0 18px;
   text-align: center;
   height: 50px;
+  line-height: 22px;
 }
 
 .icons {

--- a/website/components/RandomMemberList.tsx
+++ b/website/components/RandomMemberList.tsx
@@ -40,42 +40,37 @@ const coreTeam: Member[] = [
   {
     id: 'zoolsher',
     avatar: 'https://avatars.githubusercontent.com/u/9161085?s=120&v=4',
-    x: 'https://twitter.com/zoolsher',
+    x: 'https://x.com/zoolsher',
     desc: 'Rspack contributor',
   },
   {
     id: 'hardfist',
     avatar: 'https://avatars.githubusercontent.com/u/8898718?s=120&v=4',
-    x: 'https://twitter.com/hardfist_1',
+    x: 'https://x.com/hardfist_1',
     desc: 'Rspack contributor',
   },
   {
     id: 'jkzing',
-    desc: 'Rspack contributor',
+    desc: 'Rspack / Vue contributor',
     avatar: 'https://avatars.githubusercontent.com/u/2851517?v=4',
   },
   {
     id: 'ahabhgk',
     avatar: 'https://avatars.githubusercontent.com/u/42857895?s=120&v=4',
-    x: 'https://twitter.com/ahabhgk',
-    desc: 'Rspack / Webpack contributor',
+    x: 'https://x.com/ahabhgk',
+    desc: 'Rspack / webpack contributor',
   },
   {
     id: 'bvanjoi',
     avatar: 'https://avatars.githubusercontent.com/u/30187863?s=120&v=4',
-    desc: 'Rspack / Rust contributor',
+    desc: 'Rspack / Rust language contributor',
   },
   {
     id: 'h-a-n-a',
     name: 'Hana',
     avatar: 'https://avatars.githubusercontent.com/u/10465670?s=120&v=4',
-    x: 'https://twitter.com/_h_ana___',
+    x: 'https://x.com/_h_ana___',
     desc: 'Rspack / NAPI contributor',
-  },
-  {
-    id: 'IWANABETHATGUY',
-    avatar: 'https://avatars.githubusercontent.com/u/17974631?s=120&v=4',
-    desc: 'Rspack contributor',
   },
   {
     id: 'jerrykingxyz',
@@ -85,13 +80,13 @@ const coreTeam: Member[] = [
   {
     id: 'chenjiahan',
     avatar: 'https://avatars.githubusercontent.com/u/7237365?s=120&v=4',
-    x: 'https://twitter.com/jait_chen',
-    desc: 'Rspack / Rsbuild / Rspress contributor',
+    x: 'https://x.com/jait_chen',
+    desc: 'Rspack / Rsbuild / Rspress contributor, project lead of Vant',
   },
   {
     id: 'JSerFeng',
     avatar: 'https://avatars.githubusercontent.com/u/57202839?s=120&v=4',
-    x: 'https://twitter.com/JSerFeng',
+    x: 'https://x.com/JSerFeng',
     desc: 'Rspack contributor',
   },
   {
@@ -102,13 +97,13 @@ const coreTeam: Member[] = [
   {
     id: 'sanyuan0704',
     avatar: 'https://avatars.githubusercontent.com/u/39261479?s=120&v=4',
-    x: 'https://twitter.com/sanyuan0704',
+    x: 'https://x.com/sanyuan0704',
     desc: 'Rspack / Rspress contributor',
   },
   {
     id: 'suxin2017',
     avatar: 'https://avatars.githubusercontent.com/u/28481035?v=4',
-    x: 'https://twitter.com/suxin2017',
+    x: 'https://x.com/suxin2017',
     desc: 'Rspack contributor',
   },
   {
@@ -120,19 +115,19 @@ const coreTeam: Member[] = [
     id: 'valorkin',
     avatar: 'https://avatars.githubusercontent.com/u/1107171?v=4',
     desc: 'Rspack contributor, CTO at ZephyrCloudIO',
-    x: 'https://twitter.com/valorkin',
+    x: 'https://x.com/valorkin',
   },
   {
     id: 'lingyucoder',
     avatar: 'https://avatars.githubusercontent.com/u/2663351?v=4',
-    x: 'https://twitter.com/lingyucoder',
+    x: 'https://x.com/lingyucoder',
     desc: 'Rspack contributor',
   },
   {
     id: 'ScriptedAlchemy',
     avatar: 'https://avatars.githubusercontent.com/u/25274700?v=4',
-    desc: 'Inventor of Module Federation, Rspack / Webpack contributor',
-    x: 'https://twitter.com/ScriptedAlchemy',
+    desc: 'Inventor of Module Federation, Rspack / webpack contributor',
+    x: 'https://x.com/ScriptedAlchemy',
   },
   {
     id: 'SyMind',
@@ -142,7 +137,30 @@ const coreTeam: Member[] = [
   {
     id: 'xc2',
     avatar: 'https://avatars.githubusercontent.com/u/18117084?v=4',
-    x: 'https://twitter.com/kfll',
+    x: 'https://x.com/kfll',
+    desc: 'Rspack / Rsbuild / Rspress contributor',
+  },
+  {
+    id: 'fi3ework',
+    avatar: 'https://avatars.githubusercontent.com/u/12322740?v=4',
+    desc: 'Rspack / Rslib / webpack contributor, creator of vite-plugin-checker',
+  },
+  {
+    id: 'easy1090',
+    avatar: 'https://avatars.githubusercontent.com/u/18437716?v=4',
+    x: 'https://x.com/yifan56737904',
+    desc: 'Rsdoctor contributor',
+  },
+  {
+    id: 'Timeless0911',
+    avatar: 'https://avatars.githubusercontent.com/u/50201324?v=4',
+    x: 'https://x.com/',
+    desc: 'Rspress / Rslib contributor',
+  },
+  {
+    id: 'SoonIter',
+    avatar: 'https://avatars.githubusercontent.com/u/79413249?v=4',
+    x: 'https://x.com/Soon_Iter',
     desc: 'Rspack / Rsbuild / Rspress contributor',
   },
 ];
@@ -189,7 +207,7 @@ export const RandomContributorsList = () => {
     {
       id: 'hyf0',
       avatar: 'https://avatars.githubusercontent.com/u/49502170?s=120&v=4',
-      x: 'https://twitter.com/_hyf0',
+      x: 'https://x.com/_hyf0',
       desc: 'Rspack / Rolldown contributor',
     },
     {
@@ -200,8 +218,13 @@ export const RandomContributorsList = () => {
     {
       id: 'Boshen',
       avatar: 'https://avatars.githubusercontent.com/u/1430279?s=120&v=4',
-      x: 'https://twitter.com/boshen_c',
+      x: 'https://x.com/boshen_c',
       desc: 'Rspack contributor / Creator of Oxc',
+    },
+    {
+      id: 'IWANABETHATGUY',
+      avatar: 'https://avatars.githubusercontent.com/u/17974631?s=120&v=4',
+      desc: 'Rspack / Rolldown contributor',
     },
   ];
 

--- a/website/docs/en/misc/team/core-team.mdx
+++ b/website/docs/en/misc/team/core-team.mdx
@@ -2,7 +2,7 @@ import { RandomMemberList } from '@components/RandomMemberList.tsx';
 
 # Core team
 
-The development of Rspack is led by a dedicated team who work full-time at ByteDance. Additionally, contributions are received from people all over the world.
+The development of Rspack is led by ByteDance's web infra team and driven together with community contributors on several core projects, including Rspack, Rsbuild, Rspress, Rsdoctor, and Rslib.
 
 Current members of the Rspack team are listed in random order below.
 

--- a/website/docs/zh/misc/team/core-team.mdx
+++ b/website/docs/zh/misc/team/core-team.mdx
@@ -2,7 +2,7 @@ import { RandomMemberList } from '@components/RandomMemberList.tsx';
 
 # 核心团队
 
-Rspack 的开发是由 ByteDance 的 Rspack 团队和社区贡献者驱动。
+Rspack 的开发由字节跳动的 web infra 团队主导，并与社区贡献者共同驱动多个核心项目的开发，包括 Rspack、Rsbuild、Rspress、Rsdoctor、 Rslib。
 
 目前工作团队成员如下，按照随机顺序排序。
 

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -41,6 +41,7 @@ externalstypecommonjs
 faga295
 fargs
 feishu
+fi3ework
 fnames
 funs
 Hana
@@ -116,6 +117,7 @@ rome
 rsbuild
 Rsdoctor
 rsfamily
+Rslib
 rspack
 Rspack
 rspackplugin


### PR DESCRIPTION
## Summary

- Update the teams page, add Rsfamily members: @SoonIter @Timeless0911 @fi3ework @easy1090  🎉
- Move `IWANABETHATGUY` to emeriti members, thanks to his great work ❤️

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
