### PR TITLE
perf: enable "fat" LTO for production release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
     with:
       target: ${{ matrix.array.target }}
       runner: ${{ matrix.array.runner }}
+      profile: "release-prod"
 
   release:
     name: Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,13 @@ panic         = "abort"
 [profile.release]
 codegen-units = 1
 debug         = false
-# Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
+# Performs “fat” LTO which attempts to perform optimizations across all crates within the dependency graph.
 lto       = "fat"
 opt-level = 3
 panic     = "abort"
 strip     = true
+
+# Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
+[profile.release-thin]
+inherits = "release"
+lto      = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,13 +77,13 @@ panic         = "abort"
 [profile.release]
 codegen-units = 1
 debug         = false
-# Performs “fat” LTO which attempts to perform optimizations across all crates within the dependency graph.
-lto       = "fat"
+# Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
+lto       = "thin"
 opt-level = 3
 panic     = "abort"
 strip     = true
 
-# Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
-[profile.release-thin]
+[profile.release-prod]
 inherits = "release"
-lto      = "thin"
+# Performs “fat” LTO which attempts to perform optimizations across all crates within the dependency graph.
+lto = "fat"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ panic         = "abort"
 codegen-units = 1
 debug         = false
 # Performs “thin” LTO. This is similar to “fat”, but takes substantially less time to run while still achieving performance gains similar to “fat”.
-lto       = "thin"
+lto       = "fat"
 opt-level = 3
 panic     = "abort"
 strip     = true

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -25,6 +25,13 @@
     "build:release:x64": "cross-env RUST_TARGET=x86_64-apple-darwin node scripts/build.js --release",
     "build:release:linux": "cross-env RUST_TARGET=x86_64-unknown-linux-gnu node scripts/build.js --release",
     "build:release:win": "cross-env RUST_TARGET=x86_64-pc-windows-msvc node scripts/build.js --release",
+    "build:release-prod:all": "run-p build:release-prod:arm64 build:release-prod:x64 build:release-prod:linux && pnpm move-binding",
+    "build:release-prod": "node scripts/build.js --release-prod",
+    "watch:release-prod": "node scripts/build.js --release-prod --watch",
+    "build:release-prod:arm64": "cross-env RUST_TARGET=aarch64-apple-darwin node scripts/build.js --release-prod",
+    "build:release-prod:x64": "cross-env RUST_TARGET=x86_64-apple-darwin node scripts/build.js --release-prod",
+    "build:release-prod:linux": "cross-env RUST_TARGET=x86_64-unknown-linux-gnu node scripts/build.js --release-prod",
+    "build:release-prod:win": "cross-env RUST_TARGET=x86_64-pc-windows-msvc node scripts/build.js --release-prod",
     "move-binding": "node scripts/move-binding",
     "test": "tsc -p tsconfig.type-test.json"
   },

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -2,8 +2,12 @@ const { spawn } = require("child_process");
 
 const CARGO_SAFELY_EXIT_CODE = 0;
 
-let release = process.argv.includes("--release");
+// Faster release for CI testing with `thin` LTO
+let release = process.argv.includes("--release-production");
+// Slower release for production with `fat` LTO
+let releaseProd = process.argv.includes("--release-prod");
 let watch = process.argv.includes("--watch");
+
 build().then((value) => {
   // Regarding cargo's non-zero exit code as an error.
   if (value !== CARGO_SAFELY_EXIT_CODE) {
@@ -30,6 +34,9 @@ async function build() {
 		if (release) {
 			args.push("--release");
 		}
+		if (releaseProd) {
+			args.push('--profile release-prod');
+		}
 		if (watch) {
 			args.push("--watch");
 		}
@@ -43,6 +50,8 @@ async function build() {
 			args.push("--no-default-features");
 			args.push("--features plugin");
 		}
+
+		console.log(`Run command: napi ${args.join(' ')}`);
 
 		let cp = spawn("napi", args, {
 			stdio: "inherit",

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -2,8 +2,8 @@ const { spawn } = require("child_process");
 
 const CARGO_SAFELY_EXIT_CODE = 0;
 
-// Faster release for CI testing with `thin` LTO
-let release = process.argv.includes("--release-production");
+// Faster release for CI & canary with `thin` LTO
+let release = process.argv.includes("--release");
 // Slower release for production with `fat` LTO
 let releaseProd = process.argv.includes("--release-prod");
 let watch = process.argv.includes("--watch");

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:rs": "node ./scripts/check_rust_dependency.cjs",
     "build:binding:debug": "pnpm --filter @rspack/binding run build:debug",
     "build:binding:release": "pnpm --filter @rspack/binding run build:release",
+    "build:binding:release-prod": "pnpm --filter @rspack/binding run build:release-prod",
     "prepare": "is-ci || husky",
     "test:diff": "pnpm --filter \"@rspack/*\" test:diff",
     "test:hot": "pnpm --filter \"@rspack/*\" test:hot",


### PR DESCRIPTION
## Summary

### Pros

- Better performance (according to benchmark): **1% ~ 3% faster**
- Smaller binary size (rspack.darwin-arm64.node): **55.4 MB -> 51.7 MB**

### Cons

- Longer build time, only affect the production release: **4-5min -> 8-10min**

see: 

- https://github.com/web-infra-dev/rspack/pull/5507
- https://doc.rust-lang.org/cargo/reference/profiles.html#lto

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
