### PR TITLE
feat(create-rspack): add custom template pkg name

### DIFF
--- a/packages/create-rspack/index.js
+++ b/packages/create-rspack/index.js
@@ -38,13 +38,15 @@ yargs(hideBin(process.argv))
 			);
 
 		await promptProjectDir();
-		let root = path.resolve(process.cwd(), getProjectDir(targetDir));
+		let projectDir = getProjectDir(targetDir);
+		let root = path.resolve(process.cwd(), projectDir);
 		while (fs.existsSync(root)) {
 			console.log(
 				`${targetDir} is not empty, please choose another project name`
 			);
 			await promptProjectDir();
-			root = path.resolve(process.cwd(), getProjectDir(targetDir));
+			projectDir = getProjectDir(targetDir);
+			root = path.resolve(process.cwd(), projectDir);
 		}
 
 		// choose template
@@ -73,7 +75,7 @@ yargs(hideBin(process.argv))
 		copyFolder(srcFolder, root, targetDir);
 		const pkgManager = getPkgManager();
 		console.log("\nDone. Now run:\n");
-		console.log(`cd ${getProjectDir(targetDir)}\n`);
+		console.log(`cd ${projectDir}\n`);
 		console.log(`${pkgManager} install\n`);
 		console.log(`${pkgManager} run dev\n`);
 	})
@@ -127,27 +129,24 @@ function copyFolder(src, dst, targetDir) {
 }
 
 function getPkgName(targetDir) {
-  const scopeMatch = matchScopedPackageName(targetDir);
-  if (scopeMatch) {
-    return targetDir; // Scoped package name
-  } else {
-    return path.basename(targetDir); // Use the base name of the target directory
-  }
+	const scopeMatch = matchScopedPackageName(targetDir);
+	if (scopeMatch) {
+		return targetDir; // Scoped package name
+	}
+	return path.basename(targetDir); // Use the base name of the target directory
 }
 
 function getProjectDir(targetDir) {
-  const scopeMatch = matchScopedPackageName(targetDir);
-  if (scopeMatch) {
-    return scopeMatch[1]; // Subdirectory project name for scoped packages
-  } else {
-    return targetDir;
-  }
+	const scopeMatch = matchScopedPackageName(targetDir);
+	if (scopeMatch) {
+		return scopeMatch[1]; // Subdirectory project name for scoped packages
+	}
+	return targetDir;
 }
 
 function matchScopedPackageName(targetDir) {
-  return targetDir.match(/^@[^/]+\/(.+)/);
+	return targetDir.match(/^@[^/]+\/(.+)/);
 }
-
 
 function getPkgManager() {
 	const ua = process.env.npm_config_user_agent;

--- a/packages/create-rspack/index.js
+++ b/packages/create-rspack/index.js
@@ -20,6 +20,7 @@ yargs(hideBin(process.argv))
 		const defaultProjectName = "rspack-project";
 		let template = "react";
 		let targetDir = defaultProjectName;
+
 		const promptProjectDir = async () =>
 			await prompts(
 				[
@@ -37,13 +38,13 @@ yargs(hideBin(process.argv))
 			);
 
 		await promptProjectDir();
-		let root = path.resolve(process.cwd(), targetDir);
+		let root = path.resolve(process.cwd(), getProjectDir(targetDir));
 		while (fs.existsSync(root)) {
 			console.log(
 				`${targetDir} is not empty, please choose another project name`
 			);
 			await promptProjectDir();
-			root = path.resolve(process.cwd(), targetDir);
+			root = path.resolve(process.cwd(), getProjectDir(targetDir));
 		}
 
 		// choose template
@@ -69,17 +70,17 @@ yargs(hideBin(process.argv))
 
 		fs.mkdirSync(root, { recursive: true });
 		const srcFolder = path.resolve(__dirname, `template-${template}`);
-		copyFolder(srcFolder, targetDir);
+		copyFolder(srcFolder, root, targetDir);
 		const pkgManager = getPkgManager();
 		console.log("\nDone. Now run:\n");
-		console.log(`cd ${targetDir}\n`);
+		console.log(`cd ${getProjectDir(targetDir)}\n`);
 		console.log(`${pkgManager} install\n`);
 		console.log(`${pkgManager} run dev\n`);
 	})
 	.help()
 	.parse();
 
-function copyFolder(src, dst) {
+function copyFolder(src, dst, targetDir) {
 	const renameFiles = {
 		_gitignore: ".gitignore"
 	};
@@ -95,7 +96,7 @@ function copyFolder(src, dst) {
 			: path.resolve(dst, file);
 		const stat = fs.statSync(srcFile);
 		if (stat.isDirectory()) {
-			copyFolder(srcFile, dstFile);
+			copyFolder(srcFile, dstFile, targetDir);
 		} else {
 			// use create-rspack version as @rspack/xxx version in template
 			if (file === "package.json") {
@@ -115,7 +116,7 @@ function copyFolder(src, dst) {
 					}
 				}
 				if (pkg.name) {
-					pkg.name = dst;
+					pkg.name = getPkgName(targetDir);
 				}
 				fs.writeFileSync(dstFile, JSON.stringify(pkg, null, 2), "utf-8");
 			} else {
@@ -124,6 +125,29 @@ function copyFolder(src, dst) {
 		}
 	}
 }
+
+function getPkgName(targetDir) {
+  const scopeMatch = matchScopedPackageName(targetDir);
+  if (scopeMatch) {
+    return targetDir; // Scoped package name
+  } else {
+    return path.basename(targetDir); // Use the base name of the target directory
+  }
+}
+
+function getProjectDir(targetDir) {
+  const scopeMatch = matchScopedPackageName(targetDir);
+  if (scopeMatch) {
+    return scopeMatch[1]; // Subdirectory project name for scoped packages
+  } else {
+    return targetDir;
+  }
+}
+
+function matchScopedPackageName(targetDir) {
+  return targetDir.match(/^@[^/]+\/(.+)/);
+}
+
 
 function getPkgManager() {
 	const ua = process.env.npm_config_user_agent;

--- a/packages/create-rspack/index.js
+++ b/packages/create-rspack/index.js
@@ -114,6 +114,9 @@ function copyFolder(src, dst) {
 						}
 					}
 				}
+				if (pkg.name) {
+					pkg.name = dst;
+				}
 				fs.writeFileSync(dstFile, JSON.stringify(pkg, null, 2), "utf-8");
 			} else {
 				fs.copyFileSync(srcFile, dstFile);


### PR DESCRIPTION
Automatically set the folder name entered by the user to the name of pkg.

Scenario: The package in the monorepo is usually the same as the entered folder name, so there is no need to modify it manually

将用户输入的文件夹名称自动渲染到pkg的name。

场景：monorepo中的包一般和输入的文件夹名称一样，就不需要手动修改了