### PR TITLE
docs: enable sitemap for SEO

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -28,8 +28,8 @@
     "tailwindcss": "^3.2.7"
   },
   "devDependencies": {
-    "@rspress/plugin-rss": "^1.25.2",
-    "@rspress/shared": "^1.25.2",
+    "@rspress/plugin-rss": "^1.26.0",
+    "@rspress/shared": "^1.26.0",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.27",
     "@types/semver": "^7.5.2",
@@ -39,8 +39,9 @@
     "prettier": "3.2.5",
     "rsbuild-plugin-google-analytics": "1.0.0",
     "rsbuild-plugin-open-graph": "1.0.0",
-    "rspress": "^1.25.2",
+    "rspress": "^1.26.0",
     "rspress-plugin-font-open-sans": "1.0.0",
+    "rspress-plugin-sitemap": "^1.0.1",
     "typescript": "^5.0.4"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -40,11 +40,11 @@ importers:
         version: 3.4.1
     devDependencies:
       '@rspress/plugin-rss':
-        specifier: ^1.25.2
-        version: 1.25.2(react@18.2.0)(rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0))
+        specifier: ^1.26.0
+        version: 1.26.0(react@18.2.0)(rspress@1.26.0(webpack@5.91.0))
       '@rspress/shared':
-        specifier: ^1.25.2
-        version: 1.25.2
+        specifier: ^1.26.0
+        version: 1.26.0
       '@types/node':
         specifier: ^18.11.18
         version: 18.19.31
@@ -68,16 +68,19 @@ importers:
         version: 3.2.5
       rsbuild-plugin-google-analytics:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@0.7.8)
+        version: 1.0.0(@rsbuild/core@1.0.0-alpha.6)
       rsbuild-plugin-open-graph:
         specifier: 1.0.0
-        version: 1.0.0(@rsbuild/core@0.7.8)
+        version: 1.0.0(@rsbuild/core@1.0.0-alpha.6)
       rspress:
-        specifier: ^1.25.2
-        version: 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
+        specifier: ^1.26.0
+        version: 1.26.0(webpack@5.91.0)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
+      rspress-plugin-sitemap:
+        specifier: ^1.0.1
+        version: 1.0.1
       typescript:
         specifier: ^5.0.4
         version: 5.4.3
@@ -333,20 +336,20 @@ packages:
     peerDependencies:
       react: '>=16'
 
-  '@modern-js/utils@2.54.5':
-    resolution: {integrity: sha512-pSczSIGLPc7rckMLIvq/gwM+8/mBv9P9OoAPrPbLrog1EZ+MvM4d4eDGx9m3HH4GR0liSAtTuY9qbvUGwUisoQ==}
+  '@modern-js/utils@2.54.6':
+    resolution: {integrity: sha512-tOgHJhRu9GpZF+lVqTt3iM+3BU/dpUGz+S0I30e5wljJnSvbuUv9uSJubz9MsfJuzVLndRRbfLUmA2dGGjPgrQ==}
 
-  '@module-federation/runtime-tools@0.1.6':
-    resolution: {integrity: sha512-7ILVnzMIa0Dlc0Blck5tVZG1tnk1MmLnuZpLOMpbdW+zl+N6wdMjjHMjEZFCUAJh2E5XJ3BREwfX8Ets0nIkLg==}
+  '@module-federation/runtime-tools@0.2.3':
+    resolution: {integrity: sha512-capN8CVTCEqNAjnl102girrkevczoQfnQYyiYC4WuyKsg7+LUqfirIe1Eiyv6VSE2UgvOTZDnqvervA6rBOlmg==}
 
-  '@module-federation/runtime@0.1.6':
-    resolution: {integrity: sha512-nj6a+yJ+QxmcE89qmrTl4lphBIoAds0PFPVGnqLRWflwAP88jrCcrrTqRhARegkFDL+wE9AE04+h6jzlbIfMKg==}
+  '@module-federation/runtime@0.2.3':
+    resolution: {integrity: sha512-N+ZxBUb1mkmfO9XT1BwgYQgShtUTlijHbukqQ4afFka5lRAT+ayC7RKfHJLz0HbuexKPCmPBDfdmCnErR5WyTQ==}
 
-  '@module-federation/sdk@0.1.6':
-    resolution: {integrity: sha512-qifXpyYLM7abUeEOIfv0oTkguZgRZuwh89YOAYIZJlkP6QbRG7DJMQvtM8X2yHXm9PTk0IYNnOJH0vNQCo6auQ==}
+  '@module-federation/sdk@0.2.3':
+    resolution: {integrity: sha512-W9zrPchLocyCBc/B8CW21akcfJXLl++9xBe1L1EtgxZGfj/xwHt0GcBWE/y+QGvYTL2a1iZjwscbftbUhxgxXg==}
 
-  '@module-federation/webpack-bundler-runtime@0.1.6':
-    resolution: {integrity: sha512-K5WhKZ4RVNaMEtfHsd/9CNCgGKB0ipbm/tgweNNeC11mEuBTNxJ09Y630vg3WPkKv9vfMCuXg2p2Dk+Q/KWTSA==}
+  '@module-federation/webpack-bundler-runtime@0.2.3':
+    resolution: {integrity: sha512-L/jt2uJ+8dwYiyn9GxryzDR6tr/Wk8rpgvelM2EBeLIhu7YxCHSmSjQYhw3BTux9zZIr47d1K9fGjBFsVRd/SQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -368,79 +371,80 @@ packages:
     resolution: {integrity: sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==}
     engines: {node: '>=14.0.0'}
 
-  '@rsbuild/core@0.7.8':
-    resolution: {integrity: sha512-TAXMh+gP3D3t8ThpsSyy+sAGNtzwGpjUxmONf9IeByIsucNaP/ltWVENYqGn8g035ZAvwfXIgJOvWHCSWFSAYw==}
-    engines: {node: '>=16.0.0'}
+  '@rsbuild/core@1.0.0-alpha.6':
+    resolution: {integrity: sha512-BgZGaqbd0EspNbE4P19DopzyHV/QKCr47tdUm2jsEeMZCEbkPVIE8eT5Nh5ubeTkdM7DLHu3/+DLb7Un2xFeaw==}
+    engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/plugin-less@0.7.8':
-    resolution: {integrity: sha512-fsknrGMNlz3vjPBOoLD6O9pK+50nrSDibXt+hl0PpOAXv15P4+mrikEI839JFyEgga7G0/TUE5qH7NiAV56FmA==}
+  '@rsbuild/plugin-less@1.0.0-alpha.6':
+    resolution: {integrity: sha512-dygUrnmJw539PIkZ4nY2+zj14zQhbsKJIJy7N4HFQpMn9qCI151Qya3QG4bH8jUiA9snX/qcQ0N04hj5SB6lZg==}
     peerDependencies:
-      '@rsbuild/core': ^0.7.8
+      '@rsbuild/core': ^1.0.0-alpha.6
 
-  '@rsbuild/plugin-react@0.7.8':
-    resolution: {integrity: sha512-FDqSZVoGxdxtOZcLGOJTQJ3CPzJm5cPqwllntMxuwF4r3JaJVCrx5vdblYVA/9KWxDzAq4OR82VIfUNV5G8UuA==}
+  '@rsbuild/plugin-react@1.0.0-alpha.6':
+    resolution: {integrity: sha512-sYrLavNv6y3282k1/LdAarfDUfAksa4xwJq+4grcjspcO2kH6aoOi2qJWs1/0QKBe3yyqmprioLQ6Ax+3kDsjg==}
     peerDependencies:
-      '@rsbuild/core': ^0.7.8
+      '@rsbuild/core': ^1.0.0-alpha.6
 
-  '@rsbuild/plugin-sass@0.7.8':
-    resolution: {integrity: sha512-HEwCUT2ixlguN5fyvRTI++wTXXUt7XVcxZVAnnt0tTfLNBxfr8rOZxWnDnp/b1dyM33K8xFnPF8tj+FVgKZJyA==}
+  '@rsbuild/plugin-sass@1.0.0-alpha.6':
+    resolution: {integrity: sha512-GXmrMlVOsP5IqijK+wOR78CST+ikq5DryHb4fnz2hLOYY/sEbMGuuGjYeQQnLXI0BopbCJ/FgT3p2ED8QMn8Wg==}
     peerDependencies:
-      '@rsbuild/core': ^0.7.8
+      '@rsbuild/core': ^1.0.0-alpha.6
 
-  '@rsbuild/shared@0.7.8':
-    resolution: {integrity: sha512-HyX294wfBVj63BFjuR4M3wYh/xQHPlzlObLHpfrX/FFfrNo+elDdnYb0SVKfuv0V8eTpaYuaWjjYq+kk+M+mIw==}
-
-  '@rspack/binding-darwin-arm64@0.7.3':
-    resolution: {integrity: sha512-3Gg5yosndYYV0NpYiQ/+Z5UErKv5R7yijE59qVnXBRI80BbkSKUFA8Ulb4btc39l3Rx35ud4EBOALXHlLNA9CQ==}
+  '@rspack/binding-darwin-arm64@1.0.0-alpha.2':
+    resolution: {integrity: sha512-TPxUVWQKLS65erwi5BW5h5/LtaQt2ieXViLXrVCMzAohewkBrrrnwYOGI19KAoXIiX3G9nWf0M7g3Cgqfw5CxQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@0.7.3':
-    resolution: {integrity: sha512-VMOyiIGHOrwkPvvd3V8NKb0UW91hUnqJoQXdttoqbn+FNz9is/3GxPSiEyc+BISuoH1e9J9FATAq6diLqdJAAw==}
+  '@rspack/binding-darwin-x64@1.0.0-alpha.2':
+    resolution: {integrity: sha512-Rue3q4i4JSTRXGb6RabqJtEYjZwpgWGyq/eoytYe+Gtjwun4hIEGPbw8fmuk+dmvl52B+LgyMw994Irxt0t9RQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@0.7.3':
-    resolution: {integrity: sha512-Y1jArNhYSugH/BScvLGyodrjD0j3do1lNozSIOMXfmq0st/S5G+AmWWrxX06Ov6DudHW0EXEqC5oF9d9AbPKTg==}
+  '@rspack/binding-linux-arm64-gnu@1.0.0-alpha.2':
+    resolution: {integrity: sha512-a3F6rjsegVnaNUz9EbE8ojj/puBcMvjLTz94sv8W+KVlKrefOLOHFRqUh1ZQd50+X8wlYKh9YrtXqVm/BiprnQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@rspack/binding-linux-arm64-musl@0.7.3':
-    resolution: {integrity: sha512-R5PhdHBRUsVVtKdQNbRZyKEd7MsML3yuzXzM/3KhyYLyBUqkyMcVxgjDyFGtZsRZXmGv+N0xYKGpJVvhbukzrg==}
+  '@rspack/binding-linux-arm64-musl@1.0.0-alpha.2':
+    resolution: {integrity: sha512-jdXTZDI4i1WVVlTfUb2y5OfVyB13nPWIONhkLxHuetIJURoLJVUEqqigEB5Xa9TM1LaZi8rhxs62+Cou4gUZ+A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@rspack/binding-linux-x64-gnu@0.7.3':
-    resolution: {integrity: sha512-XX60MwIilJ4Pbvy4FVWf5CkROOa7ywnL/k8aVo6OMip62L2jiTpYfd85v/G2IQbeVDcE4967Pm782bpDFRCYfw==}
+  '@rspack/binding-linux-x64-gnu@1.0.0-alpha.2':
+    resolution: {integrity: sha512-dA+DVgN5dt1h+toOjEwQhRFhaoBpOsui50cXOZ99TvP5h99g52Dk4in5VG3W7jWYpvfMAQWISjGW+9znwzpWXQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@rspack/binding-linux-x64-musl@0.7.3':
-    resolution: {integrity: sha512-oIRXO2NoXnWj/oIXJuNUbCIRnumfLndqR8rXui1vni91TZ+yUFkE9S7mGPrbrBAUXovOaSaHxB0YYi5hZ8fy4A==}
+  '@rspack/binding-linux-x64-musl@1.0.0-alpha.2':
+    resolution: {integrity: sha512-SoGloDsN/D/aN8d72iMsXJJC/pOj06McVnPodLpNzcRy+kMFo+N+BzTtziXYKjxqQFHtXd3MvuJMLjJDh+jSQw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@rspack/binding-win32-arm64-msvc@0.7.3':
-    resolution: {integrity: sha512-XeQ6z6Oc8wkkLJCAkG8TyLkciui6PB7reJLOes3yy0AXUJnd6l7gfiDcjzeHJGATVRzuuJojP/FXurBMCQ76uA==}
+  '@rspack/binding-win32-arm64-msvc@1.0.0-alpha.2':
+    resolution: {integrity: sha512-2SYQQc/Oo31lwMJhFMjAwl3Fbr2Esy0p8O7Gnlo1wkttNCWa4UEBoyhL6sh0is4rcLYj9OcI9mLBXYSnISEtTQ==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@0.7.3':
-    resolution: {integrity: sha512-MWwswm5+v1Wd3DDJxFbCenOHOy8x+gGp0oBdLj0jlC5UntaaSvzfdb0H85AeVMYWPp584fOpAZfx0QPg3cg8yw==}
+  '@rspack/binding-win32-ia32-msvc@1.0.0-alpha.2':
+    resolution: {integrity: sha512-1+LutdpPU/qU3pogi6B2A0GBIuuiK++FYMvuUlyc4dQyi2UQ2n9ICt6g1tw26BMJRAXeQlkLsihm4fRex3LnMA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@0.7.3':
-    resolution: {integrity: sha512-GzOTQxuJedTghyoUbW/RGbzbGRW+R1dRuZxer8Gtlv4558wxbCUj1d621nC2eZmELFc4RWbN9NFTwaecavttvQ==}
+  '@rspack/binding-win32-x64-msvc@1.0.0-alpha.2':
+    resolution: {integrity: sha512-GtZgFMSuAQWr3tvQv7/WwQAKZGSKyh7G2DMfdtRK36yYW13jxidAxZGeULWlAYjrBlEVCeZH7pxEU8tSQPF6WA==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@0.7.3':
-    resolution: {integrity: sha512-VYPOtaCb1lphNrHozZXy9L5ODGU76kp7ozCpYbF/CTFq8xaSkvkhNHwWMGXE2TIOvWZImMBRBuYX8/kjz/HiSA==}
+  '@rspack/binding@1.0.0-alpha.2':
+    resolution: {integrity: sha512-1akICB3skW+kemHJ2GHlvykTom3qpywPDd8i38Bs2LfN16oqxgVtbvyCEWe4InhsYP/QadzDQqtAdt21Babavw==}
 
-  '@rspack/core@0.7.3':
-    resolution: {integrity: sha512-SUvt4P1nMML3Int2YE1Z2+noDIxjT/hzNtcKMXXqeFp4yFys37s7vC+BnCyzonvIbpxUg2gH+bCMCgav7+xR4A==}
+  '@rspack/core@1.0.0-alpha.2':
+    resolution: {integrity: sha512-YQLxjnR9IoHjjZWaJrjWaTrJLjgsXPHX6XHo9MVK6KeqE6sLJc9bl2gF88KLS5d/OM6GBTY1y63doLQUOe99cQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -448,16 +452,20 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/plugin-react-refresh@0.7.3':
-    resolution: {integrity: sha512-fuXXqb6Lhlt1Ynz35E3OAmb1po9EGWYtDJgDqzXVfA9DPcnCPIZpbx6hOLLTYQRYLic74w11J0H2FCUXMHVg1g==}
+  '@rspack/lite-tapable@1.0.0-alpha.2':
+    resolution: {integrity: sha512-SYrWNryAkjBmjF+u1G2jqVkFrH8c+mui2QJJRA9e/UK+xz0l6+9e+CjP3taiT2YYmB3wc1pSUqJZFB9FZViRog==}
+    engines: {node: '>=16.0.0'}
+
+  '@rspack/plugin-react-refresh@1.0.0-alpha.2':
+    resolution: {integrity: sha512-4NhLYTPo6S/7G5JT0pW++w7PmBFeDdo6ebW4uy9FhwAWKthuJSLH63qJFWTylzMtORmidwgUoczspd9cpX4zog==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       react-refresh:
         optional: true
 
-  '@rspress/core@1.25.2':
-    resolution: {integrity: sha512-fh6a/uQvgJrNw62bbPbpgQExIPpM5tLHFeVHVncXltAMhmF2d0uP9jxxenGrEFU/syr4aCdQjfZIv00ioS+b1w==}
+  '@rspress/core@1.26.0':
+    resolution: {integrity: sha512-DZmNNMxjwXMsM+ed9gC9WPAFqy1sVe5lw1RQgci3fmIBHkI39DEnbKAcNnY5d7m5C5pG/tTVZrO8vfOml1f2zg==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.5.7':
@@ -512,44 +520,47 @@ packages:
     resolution: {integrity: sha512-Ie9TqTeMF7yCBqKAOxyLD1W2cDhRZkMsIFD4UJ9nAJTuV4zMj1aXoaKL94phsnl6ImDykF/dohTeuBUrwch08g==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.25.2':
-    resolution: {integrity: sha512-0kVs9uorw0mXGV1VVh67Vko0oyd4041M74ZsTYs8gK899k6C9+nKOV7IqGrxftJCY1dhGE437UX1T1ouo2dCIA==}
+  '@rspress/plugin-auto-nav-sidebar@1.26.0':
+    resolution: {integrity: sha512-cRxBs2o7XmHGzuy6tobz5FZqeWDn0lrGTiNzYjpdTBJIMdvDI/t1u1WTXrXtsc8vbK2P+QP3RoW2wEc/dzXmtw==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-container-syntax@1.25.2':
-    resolution: {integrity: sha512-3c7vVgxchOvZOWEgydgA8aPqPN9oXQsBl8TNbX/mDMB6ubUPpW3BCefca0amzPvplrcdHJAwuuS7J5vueNfwjQ==}
+  '@rspress/plugin-container-syntax@1.26.0':
+    resolution: {integrity: sha512-TFcgK6byW0XdZU2TikGovp/P+l5yBZIejwq/wQYpncw+nprVYMPz+xsyQbZIsX31HHO23DsHzTVP5eW+5TkP+Q==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@1.25.2':
-    resolution: {integrity: sha512-jG5mDSMudIqr5FV+SVQYxx3h9HrorB5sGDem7+DfpVxeP46BjK6h4oLNsl451ivzkya12EjP4Q1A68FR5sNqnw==}
+  '@rspress/plugin-last-updated@1.26.0':
+    resolution: {integrity: sha512-GX/HRUNH+AdrAc356hLfrw4Py4Alu2a38z4ITc3Jc9T12DjvqU+1sc4dlNmkJ4vPtaUIiR6TNBu3mdP7jwEFVg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@1.25.2':
-    resolution: {integrity: sha512-47fy7Rl4xB0FEiNwa3blGsrjTHSSYPN/hav1AiVOC1Jrb/kXLplTqVknRHpFGcNpaLOUwDj5TjbalAn/YIeAFQ==}
+  '@rspress/plugin-medium-zoom@1.26.0':
+    resolution: {integrity: sha512-b5GUzBiFCSxC/fyHtffqAoi07lQlZOAyvpbwjHqgilnc77ikp+Yy4qAE8ohm4XSwT+yZm6zsZZJv0ECTElfcWg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       '@rspress/runtime': ^1.0.2
 
-  '@rspress/plugin-rss@1.25.2':
-    resolution: {integrity: sha512-xSyWzUe/1Wm2GUXSXlUbRvj6oUMTiNDhXYYkCo1xBCV1TK14pS4qIVqfv88My5seDDwJTDRuV/yThuoYJascNA==}
+  '@rspress/plugin-rss@1.26.0':
+    resolution: {integrity: sha512-evUpPnpT7vJl9/kXwy9ElcAuB9WyImQk3mbpR6NJiM5bZNheF3+tiNKyCVmGglk0X9/QBzThTTqMmBZn4RJyWg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
       rspress: ^1.17.0
 
-  '@rspress/runtime@1.25.2':
-    resolution: {integrity: sha512-XyFKObPG/ze4YPRESKtmGOKzYoZwtrxPSmfaLcQN9QmTFVd9dlVWekJMLo/SkGf4YpqnDbPPP6ehIi42FQpYHQ==}
+  '@rspress/runtime@1.26.0':
+    resolution: {integrity: sha512-rqbrXMzPV/AYh5W5Ocbb1Z0wv1hdST87GMmO3mnVRqBXXRAwP+dIsnDwpHQl6KVD7rldeUloF4W4cg+1OTFcxQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@1.25.2':
-    resolution: {integrity: sha512-qtqrMTuUu2fIwjHmyvB51iBcpi92FR4nlZnU/JIXwfF0hgF+OzKEiTv3NQEmqtw1E/Ryue5DigSIBOJBej1yjA==}
+  '@rspress/shared@1.26.0':
+    resolution: {integrity: sha512-lcNAOje3VJv8TfBJOgFvkJAvyc8a+RtY3mvJpT3xHIXHxa8XoHWGdGfrX41qooPZ5aM1DCnIxnJ9J7CRZ08wsQ==}
 
-  '@rspress/theme-default@1.25.2':
-    resolution: {integrity: sha512-WUEIGzMgJs6+kTmBsj95FMP4A6wmfuRAyx7HTdxq0rNgobVlT5LrIMi35s7vonodrb4JyON5JBcUMrHtdrurpw==}
+  '@rspress/theme-default@1.26.0':
+    resolution: {integrity: sha512-fP/DwIgny7UEZ+hHbr/iYHAmu5TRRftbjwgp6Kykq2Hq4SF8CIJdNUUw6JXhzSWclqBdFNI97NHx07le788hyQ==}
     engines: {node: '>=14.17.6'}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@swc/helpers@0.5.11':
+    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
   '@swc/helpers@0.5.3':
     resolution: {integrity: sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==}
@@ -759,6 +770,11 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  browserslist@4.23.2:
+    resolution: {integrity: sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   buffer-builder@0.2.0:
     resolution: {integrity: sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==}
 
@@ -779,6 +795,9 @@ packages:
 
   caniuse-lite@1.0.30001638:
     resolution: {integrity: sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==}
+
+  caniuse-lite@1.0.30001641:
+    resolution: {integrity: sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==}
 
   case-police@0.6.1:
     resolution: {integrity: sha512-tOgkG3HhtzNVHU+HVHqbpVJ3CICPDihtlgoM2C4dx0RLeo6qcNVeBgiYJN5Bln+stxKrnKrw89CFgqYQDqwZQg==}
@@ -875,8 +894,8 @@ packages:
   copy-to-clipboard@3.3.3:
     resolution: {integrity: sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==}
 
-  core-js@3.36.1:
-    resolution: {integrity: sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==}
+  core-js@3.37.1:
+    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -1021,6 +1040,9 @@ packages:
   electron-to-chromium@1.4.713:
     resolution: {integrity: sha512-vDarADhwntXiULEdmWd77g2dV6FrNGa8ecAC29MZ4TwPut2fvosD0/5sJd1qWNNe8HcJFAC+F5Lf9jW1NPtWmw==}
 
+  electron-to-chromium@1.4.823:
+    resolution: {integrity: sha512-4h+oPeAiGQOHFyUJOqpoEcPj/xxlicxBzOErVeYVMMmAiXUXsGpsFd0QXBMaUUbnD8hhSfLf9uw+MlsoIA7j5w==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1041,6 +1063,9 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-module-lexer@1.5.0:
     resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
@@ -1314,8 +1339,8 @@ packages:
   html-entities@2.5.2:
     resolution: {integrity: sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==}
 
-  html-rspack-plugin@5.7.2:
-    resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
+  html-rspack-plugin@6.0.0-beta.3:
+    resolution: {integrity: sha512-H1jVj3GnyqbZmhycUHwdlGvSdXHmzdtVaZcFIsTJ+i0q0hH+gGe+t+d0y5SIGfsozeTjjSdOZPWfzI/hM/5OXQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -1856,6 +1881,9 @@ packages:
   picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
+  picocolors@1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -1911,6 +1939,10 @@ packages:
 
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.4.39:
+    resolution: {integrity: sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier@3.2.5:
@@ -2016,6 +2048,9 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  reduce-configs@1.0.0:
+    resolution: {integrity: sha512-/JCYSgL/QeXXsq0Lv/7kOZfqvof7vyzHWfyNQPt3c6vc73mU4WRyT8RJ6ZH5Ci08vUOqXwk7jkZy6BycHTDD9w==}
+
   refractor@3.6.0:
     resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
 
@@ -2098,8 +2133,11 @@ packages:
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
 
-  rspress@1.25.2:
-    resolution: {integrity: sha512-BvElBR8+Iwv7jau5B+dRCvXRIdsmPSr9mlwFsMMUeTFpy05OP1I/yO7HjE2TehzKfYitKDBJIKVo82eWDB4yuQ==}
+  rspress-plugin-sitemap@1.0.1:
+    resolution: {integrity: sha512-1hLh2v2OMTjPD+jnHxKPnMRNWojUwao5gPyBFwd6YR8URRU4TNg5pvd9TSpszid1WNGt4OokqYwnL96tZGaDZQ==}
+
+  rspress@1.26.0:
+    resolution: {integrity: sha512-kFubO+bZb4fgbLqDGtIv2H8mWCYjRctPV+ExvM06fulTFdwqvp+3/86XhVnqGKmvmcD5gQDVt63OphxHNlNFBQ==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -2305,6 +2343,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2463,6 +2504,12 @@ packages:
 
   update-browserslist-db@1.0.13:
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  update-browserslist-db@1.1.0:
+    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -2836,28 +2883,28 @@ snapshots:
       '@types/react': 18.2.75
       react: 18.2.0
 
-  '@modern-js/utils@2.54.5':
+  '@modern-js/utils@2.54.6':
     dependencies:
       '@swc/helpers': 0.5.3
       caniuse-lite: 1.0.30001638
       lodash: 4.17.21
       rslog: 1.2.1
 
-  '@module-federation/runtime-tools@0.1.6':
+  '@module-federation/runtime-tools@0.2.3':
     dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/webpack-bundler-runtime': 0.1.6
+      '@module-federation/runtime': 0.2.3
+      '@module-federation/webpack-bundler-runtime': 0.2.3
 
-  '@module-federation/runtime@0.1.6':
+  '@module-federation/runtime@0.2.3':
     dependencies:
-      '@module-federation/sdk': 0.1.6
+      '@module-federation/sdk': 0.2.3
 
-  '@module-federation/sdk@0.1.6': {}
+  '@module-federation/sdk@0.2.3': {}
 
-  '@module-federation/webpack-bundler-runtime@0.1.6':
+  '@module-federation/webpack-bundler-runtime@0.2.3':
     dependencies:
-      '@module-federation/runtime': 0.1.6
-      '@module-federation/sdk': 0.1.6
+      '@module-federation/runtime': 0.2.3
+      '@module-federation/sdk': 0.2.3
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -2876,124 +2923,114 @@ snapshots:
 
   '@remix-run/router@1.15.3': {}
 
-  '@rsbuild/core@0.7.8':
+  '@rsbuild/core@1.0.0-alpha.6':
     dependencies:
-      '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
-      '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
-      '@swc/helpers': 0.5.3
-      core-js: 3.36.1
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3))
-      postcss: 8.4.38
-
-  '@rsbuild/plugin-less@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
-    dependencies:
-      '@rsbuild/core': 0.7.8
-      '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@rsbuild/plugin-react@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
-    dependencies:
-      '@rsbuild/core': 0.7.8
-      '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
-      '@rspack/plugin-react-refresh': 0.7.3(react-refresh@0.14.2)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@rsbuild/plugin-sass@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
-    dependencies:
-      '@rsbuild/core': 0.7.8
-      '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
-      loader-utils: 2.0.4
-      postcss: 8.4.38
-      sass-embedded: 1.77.5
-    transitivePeerDependencies:
-      - '@swc/helpers'
-
-  '@rsbuild/shared@0.7.8(@swc/helpers@0.5.3)':
-    dependencies:
-      '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
-      caniuse-lite: 1.0.30001638
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3))
-      postcss: 8.4.38
+      '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
+      '@swc/helpers': 0.5.11
+      caniuse-lite: 1.0.30001641
+      core-js: 3.37.1
+      html-rspack-plugin: 6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
+      postcss: 8.4.39
     optionalDependencies:
       fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
-  '@rspack/binding-darwin-arm64@0.7.3':
-    optional: true
-
-  '@rspack/binding-darwin-x64@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@0.7.3':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@0.7.3':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@0.7.3':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@0.7.3':
-    optional: true
-
-  '@rspack/binding@0.7.3':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.3
-      '@rspack/binding-darwin-x64': 0.7.3
-      '@rspack/binding-linux-arm64-gnu': 0.7.3
-      '@rspack/binding-linux-arm64-musl': 0.7.3
-      '@rspack/binding-linux-x64-gnu': 0.7.3
-      '@rspack/binding-linux-x64-musl': 0.7.3
-      '@rspack/binding-win32-arm64-msvc': 0.7.3
-      '@rspack/binding-win32-ia32-msvc': 0.7.3
-      '@rspack/binding-win32-x64-msvc': 0.7.3
-
-  '@rspack/core@0.7.3(@swc/helpers@0.5.3)':
+  '@rsbuild/plugin-less@1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)':
     dependencies:
-      '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.3
-      caniuse-lite: 1.0.30001638
-      tapable: 2.2.1
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      '@swc/helpers': 0.5.3
+      '@rsbuild/core': 1.0.0-alpha.6
+      deepmerge: 4.3.1
+      reduce-configs: 1.0.0
 
-  '@rspack/plugin-react-refresh@0.7.3(react-refresh@0.14.2)':
+  '@rsbuild/plugin-react@1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)':
+    dependencies:
+      '@rsbuild/core': 1.0.0-alpha.6
+      '@rspack/plugin-react-refresh': 1.0.0-alpha.2(react-refresh@0.14.2)
+      react-refresh: 0.14.2
+
+  '@rsbuild/plugin-sass@1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)':
+    dependencies:
+      '@rsbuild/core': 1.0.0-alpha.6
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.4.39
+      reduce-configs: 1.0.0
+      sass-embedded: 1.77.5
+
+  '@rspack/binding-darwin-arm64@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.0.0-alpha.2':
+    optional: true
+
+  '@rspack/binding@1.0.0-alpha.2':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.0.0-alpha.2
+      '@rspack/binding-darwin-x64': 1.0.0-alpha.2
+      '@rspack/binding-linux-arm64-gnu': 1.0.0-alpha.2
+      '@rspack/binding-linux-arm64-musl': 1.0.0-alpha.2
+      '@rspack/binding-linux-x64-gnu': 1.0.0-alpha.2
+      '@rspack/binding-linux-x64-musl': 1.0.0-alpha.2
+      '@rspack/binding-win32-arm64-msvc': 1.0.0-alpha.2
+      '@rspack/binding-win32-ia32-msvc': 1.0.0-alpha.2
+      '@rspack/binding-win32-x64-msvc': 1.0.0-alpha.2
+
+  '@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.2.3
+      '@rspack/binding': 1.0.0-alpha.2
+      '@rspack/lite-tapable': 1.0.0-alpha.2
+      caniuse-lite: 1.0.30001641
+    optionalDependencies:
+      '@swc/helpers': 0.5.11
+
+  '@rspack/lite-tapable@1.0.0-alpha.2': {}
+
+  '@rspack/plugin-react-refresh@1.0.0-alpha.2(react-refresh@0.14.2)':
+    dependencies:
+      error-stack-parser: 2.1.4
+      html-entities: 2.5.2
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspress/core@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)':
+  '@rspress/core@1.26.0(webpack@5.91.0)':
     dependencies:
       '@loadable/component': 5.16.4(react@18.2.0)
       '@mdx-js/loader': 2.3.0(webpack@5.91.0)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.2.0)
-      '@modern-js/utils': 2.54.5
-      '@rsbuild/core': 0.7.8
-      '@rsbuild/plugin-less': 0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)
-      '@rsbuild/plugin-react': 0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)
-      '@rsbuild/plugin-sass': 0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)
+      '@modern-js/utils': 2.54.6
+      '@rsbuild/core': 1.0.0-alpha.6
+      '@rsbuild/plugin-less': 1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)
+      '@rsbuild/plugin-react': 1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)
+      '@rsbuild/plugin-sass': 1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)
       '@rspress/mdx-rs': 0.5.7
-      '@rspress/plugin-auto-nav-sidebar': 1.25.2
-      '@rspress/plugin-container-syntax': 1.25.2
-      '@rspress/plugin-last-updated': 1.25.2
-      '@rspress/plugin-medium-zoom': 1.25.2(@rspress/runtime@1.25.2)
-      '@rspress/runtime': 1.25.2
-      '@rspress/shared': 1.25.2
-      '@rspress/theme-default': 1.25.2
+      '@rspress/plugin-auto-nav-sidebar': 1.26.0
+      '@rspress/plugin-container-syntax': 1.26.0
+      '@rspress/plugin-last-updated': 1.26.0
+      '@rspress/plugin-medium-zoom': 1.26.0(@rspress/runtime@1.26.0)
+      '@rspress/runtime': 1.26.0
+      '@rspress/shared': 1.26.0
+      '@rspress/theme-default': 1.26.0
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       enhanced-resolve: 5.17.0
@@ -3028,7 +3065,6 @@ snapshots:
       unist-util-visit-children: 2.0.2
       yaml-front-matter: 4.1.1
     transitivePeerDependencies:
-      - '@swc/helpers'
       - supports-color
       - webpack
 
@@ -3067,52 +3103,52 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.5.7
       '@rspress/mdx-rs-win32-x64-msvc': 0.5.7
 
-  '@rspress/plugin-auto-nav-sidebar@1.25.2':
+  '@rspress/plugin-auto-nav-sidebar@1.26.0':
     dependencies:
-      '@rspress/shared': 1.25.2
+      '@rspress/shared': 1.26.0
 
-  '@rspress/plugin-container-syntax@1.25.2':
+  '@rspress/plugin-container-syntax@1.26.0':
     dependencies:
-      '@rspress/shared': 1.25.2
+      '@rspress/shared': 1.26.0
 
-  '@rspress/plugin-last-updated@1.25.2':
+  '@rspress/plugin-last-updated@1.26.0':
     dependencies:
-      '@rspress/shared': 1.25.2
+      '@rspress/shared': 1.26.0
 
-  '@rspress/plugin-medium-zoom@1.25.2(@rspress/runtime@1.25.2)':
+  '@rspress/plugin-medium-zoom@1.26.0(@rspress/runtime@1.26.0)':
     dependencies:
-      '@rspress/runtime': 1.25.2
+      '@rspress/runtime': 1.26.0
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.25.2(react@18.2.0)(rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0))':
+  '@rspress/plugin-rss@1.26.0(react@18.2.0)(rspress@1.26.0(webpack@5.91.0))':
     dependencies:
-      '@rspress/shared': 1.25.2
+      '@rspress/shared': 1.26.0
       feed: 4.2.2
       react: 18.2.0
-      rspress: 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
+      rspress: 1.26.0(webpack@5.91.0)
 
-  '@rspress/runtime@1.25.2':
+  '@rspress/runtime@1.26.0':
     dependencies:
-      '@rspress/shared': 1.25.2
+      '@rspress/shared': 1.26.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-helmet-async: 1.3.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react-router-dom: 6.22.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@rspress/shared@1.25.2':
+  '@rspress/shared@1.26.0':
     dependencies:
-      '@rsbuild/core': 0.7.8
+      '@rsbuild/core': 1.0.0-alpha.6
       chalk: 4.1.2
       execa: 5.1.1
       fs-extra: 11.2.0
       gray-matter: 4.0.3
       unified: 10.1.2
 
-  '@rspress/theme-default@1.25.2':
+  '@rspress/theme-default@1.26.0':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.2.0)
-      '@rspress/runtime': 1.25.2
-      '@rspress/shared': 1.25.2
+      '@rspress/runtime': 1.26.0
+      '@rspress/shared': 1.26.0
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.6.32
@@ -3135,6 +3171,10 @@ snapshots:
     dependencies:
       domhandler: 5.0.3
       selderee: 0.11.0
+
+  '@swc/helpers@0.5.11':
+    dependencies:
+      tslib: 2.6.2
 
   '@swc/helpers@0.5.3':
     dependencies:
@@ -3366,6 +3406,13 @@ snapshots:
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
 
+  browserslist@4.23.2:
+    dependencies:
+      caniuse-lite: 1.0.30001641
+      electron-to-chromium: 1.4.823
+      node-releases: 2.0.14
+      update-browserslist-db: 1.1.0(browserslist@4.23.2)
+
   buffer-builder@0.2.0: {}
 
   buffer-from@1.1.2: {}
@@ -3377,6 +3424,8 @@ snapshots:
   camelcase-css@2.0.1: {}
 
   caniuse-lite@1.0.30001638: {}
+
+  caniuse-lite@1.0.30001641: {}
 
   case-police@0.6.1: {}
 
@@ -3468,7 +3517,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  core-js@3.36.1: {}
+  core-js@3.37.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -3648,6 +3697,8 @@ snapshots:
 
   electron-to-chromium@1.4.713: {}
 
+  electron-to-chromium@1.4.823: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -3662,6 +3713,10 @@ snapshots:
   entities@2.2.0: {}
 
   entities@4.5.0: {}
+
+  error-stack-parser@2.1.4:
+    dependencies:
+      stackframe: 1.3.4
 
   es-module-lexer@1.5.0: {}
 
@@ -3995,9 +4050,11 @@ snapshots:
 
   html-entities@2.5.2: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3)):
+  html-rspack-plugin@6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11)):
+    dependencies:
+      '@rspack/lite-tapable': 1.0.0-alpha.2
     optionalDependencies:
-      '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
+      '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
 
   html-tags@3.3.1: {}
 
@@ -4747,6 +4804,8 @@ snapshots:
 
   picocolors@1.0.0: {}
 
+  picocolors@1.0.1: {}
+
   picomatch@2.3.1: {}
 
   pify@2.3.0: {}
@@ -4794,6 +4853,12 @@ snapshots:
     dependencies:
       nanoid: 3.3.7
       picocolors: 1.0.0
+      source-map-js: 1.2.0
+
+  postcss@8.4.39:
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
       source-map-js: 1.2.0
 
   prettier@3.2.5: {}
@@ -4896,6 +4961,10 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  reduce-configs@1.0.0:
+    dependencies:
+      browserslist: 4.23.2
+
   refractor@3.6.0:
     dependencies:
       hastscript: 6.0.0
@@ -4988,13 +5057,13 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rsbuild-plugin-google-analytics@1.0.0(@rsbuild/core@0.7.8):
+  rsbuild-plugin-google-analytics@1.0.0(@rsbuild/core@1.0.0-alpha.6):
     optionalDependencies:
-      '@rsbuild/core': 0.7.8
+      '@rsbuild/core': 1.0.0-alpha.6
 
-  rsbuild-plugin-open-graph@1.0.0(@rsbuild/core@0.7.8):
+  rsbuild-plugin-open-graph@1.0.0(@rsbuild/core@1.0.0-alpha.6):
     optionalDependencies:
-      '@rsbuild/core': 0.7.8
+      '@rsbuild/core': 1.0.0-alpha.6
 
   rsfamily-nav-icon@1.0.3: {}
 
@@ -5006,16 +5075,17 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.0: {}
 
-  rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0):
+  rspress-plugin-sitemap@1.0.1: {}
+
+  rspress@1.26.0(webpack@5.91.0):
     dependencies:
-      '@rsbuild/core': 0.7.8
-      '@rspress/core': 1.25.2(@swc/helpers@0.5.3)(webpack@5.91.0)
-      '@rspress/shared': 1.25.2
+      '@rsbuild/core': 1.0.0-alpha.6
+      '@rspress/core': 1.26.0(webpack@5.91.0)
+      '@rspress/shared': 1.26.0
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.6.0
     transitivePeerDependencies:
-      - '@swc/helpers'
       - supports-color
       - webpack
 
@@ -5170,6 +5240,8 @@ snapshots:
   space-separated-tokens@2.0.2: {}
 
   sprintf-js@1.0.3: {}
+
+  stackframe@1.3.4: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5360,6 +5432,12 @@ snapshots:
       browserslist: 4.23.0
       escalade: 3.1.2
       picocolors: 1.0.0
+
+  update-browserslist-db@1.1.0(browserslist@4.23.2):
+    dependencies:
+      browserslist: 4.23.2
+      escalade: 3.1.2
+      picocolors: 1.0.1
 
   uri-js@4.4.1:
     dependencies:

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -4,6 +4,7 @@ import { pluginRss } from '@rspress/plugin-rss';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
+import pluginSitemap from 'rspress-plugin-sitemap';
 import { defineConfig } from 'rspress/config';
 
 const PUBLISH_URL = 'https://rspack.dev';
@@ -28,6 +29,9 @@ export default defineConfig({
     cleanUrls: true,
   },
   plugins: [
+    pluginSitemap({
+      domain: PUBLISH_URL,
+    }),
     pluginFontOpenSans(),
     pluginRss({
       siteUrl: PUBLISH_URL,


### PR DESCRIPTION
## Summary

- Enable sitemap for SEO.
- Bump Rspress v1.26.0

## Related Links

https://github.com/jl917/rspress-plugin-sitemap

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
