### PR TITLE
feat: support `test`, `include` and `exclude` options for `SwcCssMinimizerRspackPlugin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3864,6 +3864,8 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
+ "rspack_regex",
+ "rspack_util",
  "swc_core",
  "tracing",
 ]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1499,6 +1499,12 @@ export interface RawStatsOptions {
   colors: boolean
 }
 
+export interface RawSwcCssMinimizerRspackPluginOptions {
+  test?: string | RegExp | (string | RegExp)[]
+  include?: string | RegExp | (string | RegExp)[]
+  exclude?: string | RegExp | (string | RegExp)[]
+}
+
 export interface RawSwcJsMinimizerRspackPluginOptions {
   extractComments?: RawExtractComments
   compress: any

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -11,11 +11,13 @@ mod raw_mf;
 mod raw_progress;
 mod raw_runtime_chunk;
 mod raw_size_limits;
+mod raw_swc_css_minimizer;
 mod raw_swc_js_minimizer;
 
 use napi::{bindgen_prelude::FromNapiValue, Env, JsUnknown};
 use napi_derive::napi;
 use raw_lightning_css_minimizer::RawLightningCssMinimizerRspackPluginOptions;
+use raw_swc_css_minimizer::RawSwcCssMinimizerRspackPluginOptions;
 use rspack_core::{BoxPlugin, Plugin, PluginExt};
 use rspack_error::Result;
 use rspack_ids::{
@@ -447,7 +449,11 @@ impl BuiltinPlugin {
         plugins.push(plugin);
       }
       BuiltinPluginName::SwcCssMinimizerRspackPlugin => {
-        plugins.push(SwcCssMinimizerRspackPlugin::default().boxed())
+        let plugin = SwcCssMinimizerRspackPlugin::new(
+          downcast_into::<RawSwcCssMinimizerRspackPluginOptions>(self.options)?.try_into()?,
+        )
+        .boxed();
+        plugins.push(plugin);
       }
       BuiltinPluginName::LightningCssMinimizerRspackPlugin => plugins.push(
         LightningCssMinimizerRspackPlugin::new(

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_css_minimizer.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_css_minimizer.rs
@@ -34,7 +34,6 @@ impl TryFrom<RawSwcCssMinimizerRspackPluginOptions> for SwcCssMinimizerRspackPlu
       test: into_condition(value.test),
       include: into_condition(value.include),
       exclude: into_condition(value.exclude),
-      ..Default::default()
     })
   }
 }

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_css_minimizer.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_swc_css_minimizer.rs
@@ -1,0 +1,63 @@
+use napi::{bindgen_prelude::Either3, Either};
+use napi_derive::napi;
+use rspack_error::Result;
+use rspack_napi::regexp::{JsRegExp, JsRegExpExt};
+use rspack_plugin_swc_css_minimizer::{
+  SwcCssMinimizerRspackPluginOptions, SwcCssMinimizerRule, SwcCssMinimizerRules,
+};
+
+type RawSwcCssMinimizerRule = Either<String, JsRegExp>;
+type RawSwcCssMinimizerRules = Either3<String, JsRegExp, Vec<RawSwcCssMinimizerRule>>;
+struct RawSwcCssMinimizerRuleWrapper(RawSwcCssMinimizerRule);
+struct RawSwcCssMinimizerRulesWrapper(RawSwcCssMinimizerRules);
+
+#[derive(Debug)]
+#[napi(object, object_to_js = false)]
+pub struct RawSwcCssMinimizerRspackPluginOptions {
+  #[napi(ts_type = "string | RegExp | (string | RegExp)[]")]
+  pub test: Option<RawSwcCssMinimizerRules>,
+  #[napi(ts_type = "string | RegExp | (string | RegExp)[]")]
+  pub include: Option<RawSwcCssMinimizerRules>,
+  #[napi(ts_type = "string | RegExp | (string | RegExp)[]")]
+  pub exclude: Option<RawSwcCssMinimizerRules>,
+}
+
+fn into_condition(c: Option<RawSwcCssMinimizerRules>) -> Option<SwcCssMinimizerRules> {
+  c.map(|test| RawSwcCssMinimizerRulesWrapper(test).into())
+}
+
+impl TryFrom<RawSwcCssMinimizerRspackPluginOptions> for SwcCssMinimizerRspackPluginOptions {
+  type Error = rspack_error::Error;
+
+  fn try_from(value: RawSwcCssMinimizerRspackPluginOptions) -> Result<Self> {
+    Ok(Self {
+      test: into_condition(value.test),
+      include: into_condition(value.include),
+      exclude: into_condition(value.exclude),
+      ..Default::default()
+    })
+  }
+}
+
+impl From<RawSwcCssMinimizerRuleWrapper> for SwcCssMinimizerRule {
+  fn from(x: RawSwcCssMinimizerRuleWrapper) -> Self {
+    match x.0 {
+      Either::A(v) => Self::String(v),
+      Either::B(v) => Self::Regexp(v.to_rspack_regex()),
+    }
+  }
+}
+
+impl From<RawSwcCssMinimizerRulesWrapper> for SwcCssMinimizerRules {
+  fn from(value: RawSwcCssMinimizerRulesWrapper) -> Self {
+    match value.0 {
+      Either3::A(v) => Self::String(v),
+      Either3::B(v) => Self::Regexp(v.to_rspack_regex()),
+      Either3::C(v) => Self::Array(
+        v.into_iter()
+          .map(|v| RawSwcCssMinimizerRuleWrapper(v).into())
+          .collect(),
+      ),
+    }
+  }
+}

--- a/crates/rspack_plugin_swc_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_swc_css_minimizer/Cargo.toml
@@ -16,6 +16,8 @@ rspack_error = { path = "../rspack_error" }
 rspack_hook  = { path = "../rspack_hook" }
 swc_core     = { workspace = true, features = ["css_codegen", "css_parser", "css_minifier"] }
 tracing      = { workspace = true }
+rspack_regex = { path = "../rspack_regex" }
+rspack_util  = { path = "../rspack_util" }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_regex::RspackRegex;
 use rspack_util::try_any_sync;
-use swc_css_compiler::{match_object, SwcCssCompiler, SwcCssSourceMapGenConfig};
+use swc_css_compiler::{SwcCssCompiler, SwcCssSourceMapGenConfig};
 
 static CSS_ASSET_REGEXP: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"\.css(\?.*)?$").expect("Invalid RegExp"));
@@ -139,4 +139,23 @@ impl SwcCssMinimizerRules {
       Self::Array(l) => try_any_sync(l, |i| i.try_match(data)),
     }
   }
+}
+
+pub fn match_object(obj: &SwcCssMinimizerRspackPluginOptions, str: &str) -> Result<bool> {
+  if let Some(condition) = &obj.test {
+    if !condition.try_match(str)? {
+      return Ok(false);
+    }
+  }
+  if let Some(condition) = &obj.include {
+    if !condition.try_match(str)? {
+      return Ok(false);
+    }
+  }
+  if let Some(condition) = &obj.exclude {
+    if condition.try_match(str)? {
+      return Ok(false);
+    }
+  }
+  Ok(true)
 }

--- a/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
@@ -20,13 +20,6 @@ pub struct SwcCssMinimizerRspackPluginOptions {
   pub exclude: Option<SwcCssMinimizerRules>,
 }
 
-impl std::hash::Hash for SwcCssMinimizerRspackPluginOptions {
-  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.test.hash(state);
-    self.include.hash(state);
-    self.exclude.hash(state);
-  }
-}
 
 #[plugin]
 #[derive(Debug, Default)]

--- a/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
@@ -20,7 +20,6 @@ pub struct SwcCssMinimizerRspackPluginOptions {
   pub exclude: Option<SwcCssMinimizerRules>,
 }
 
-
 #[plugin]
 #[derive(Debug, Default)]
 pub struct SwcCssMinimizerRspackPlugin {

--- a/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_css_minimizer/src/lib.rs
@@ -34,6 +34,12 @@ pub struct SwcCssMinimizerRspackPlugin {
   options: SwcCssMinimizerRspackPluginOptions,
 }
 
+impl SwcCssMinimizerRspackPlugin {
+  pub fn new(options: SwcCssMinimizerRspackPluginOptions) -> Self {
+    Self::new_inner(options)
+  }
+}
+
 #[plugin_hook(CompilationProcessAssets for SwcCssMinimizerRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE)]
 async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let minify_options = &self.options;

--- a/crates/rspack_plugin_swc_css_minimizer/src/swc_css_compiler.rs
+++ b/crates/rspack_plugin_swc_css_minimizer/src/swc_css_compiler.rs
@@ -12,8 +12,6 @@ use swc_core::css::minifier;
 use swc_core::css::parser::{lexer::Lexer, parser::ParserConfig};
 use swc_core::css::{ast::Stylesheet, parser::parser::Parser};
 
-use crate::SwcCssMinimizerRspackPluginOptions;
-
 #[derive(Default)]
 pub struct SwcCssCompiler {
   cm: Arc<swc_core::common::SourceMap>,
@@ -91,25 +89,6 @@ impl SwcCssCompiler {
       Ok(rspack_sources::RawSource::from(code).boxed())
     }
   }
-}
-
-pub fn match_object(obj: &SwcCssMinimizerRspackPluginOptions, str: &str) -> Result<bool> {
-  if let Some(condition) = &obj.test {
-    if !condition.try_match(str)? {
-      return Ok(false);
-    }
-  }
-  if let Some(condition) = &obj.include {
-    if !condition.try_match(str)? {
-      return Ok(false);
-    }
-  }
-  if let Some(condition) = &obj.exclude {
-    if condition.try_match(str)? {
-      return Ok(false);
-    }
-  }
-  Ok(true)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_plugin_swc_css_minimizer/src/swc_css_compiler.rs
+++ b/crates/rspack_plugin_swc_css_minimizer/src/swc_css_compiler.rs
@@ -12,6 +12,8 @@ use swc_core::css::minifier;
 use swc_core::css::parser::{lexer::Lexer, parser::ParserConfig};
 use swc_core::css::{ast::Stylesheet, parser::parser::Parser};
 
+use crate::SwcCssMinimizerRspackPluginOptions;
+
 #[derive(Default)]
 pub struct SwcCssCompiler {
   cm: Arc<swc_core::common::SourceMap>,
@@ -89,6 +91,25 @@ impl SwcCssCompiler {
       Ok(rspack_sources::RawSource::from(code).boxed())
     }
   }
+}
+
+pub fn match_object(obj: &SwcCssMinimizerRspackPluginOptions, str: &str) -> Result<bool> {
+  if let Some(condition) = &obj.test {
+    if !condition.try_match(str)? {
+      return Ok(false);
+    }
+  }
+  if let Some(condition) = &obj.include {
+    if !condition.try_match(str)? {
+      return Ok(false);
+    }
+  }
+  if let Some(condition) = &obj.exclude {
+    if condition.try_match(str)? {
+      return Ok(false);
+    }
+  }
+  Ok(true)
 }
 
 #[derive(Debug, Clone)]

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/a.css
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/a.css
@@ -1,0 +1,3 @@
+html {
+	margin: 0;
+}

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/a.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/a.js
@@ -1,0 +1,3 @@
+import "./a.css";
+
+consol.log("a");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/a.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/a.js
@@ -1,3 +1,1 @@
-import "./a.css";
-
-consol.log("a");
+require("./a.css");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/b.css
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/b.css
@@ -1,0 +1,3 @@
+html {
+	margin: 0;
+}

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/b.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/b.js
@@ -1,3 +1,1 @@
-import "./b.css";
-
-consol.log("b");
+require("./b.css");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/b.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/b.js
@@ -1,0 +1,3 @@
+import "./b.css";
+
+consol.log("b");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/index.js
@@ -8,6 +8,5 @@ it("[minify-exclude-css]: chunk a should be minified", () => {
 
 it("[minify-exclude-css]: chunk b should not be minified", () => {
 	const content = fs.readFileSync(path.resolve(__dirname, "b.css"), "utf-8");
-	expect(content).not.toMatch("\n");
-	expect(false).toBe(true);
+	expect(content).toMatch("\n");
 });

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/index.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+it("[minify-exclude-css]: chunk a should be minified", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "a.css"), "utf-8");
+	expect(content).not.toMatch("\n");
+});
+
+it("[minify-exclude-css]: chunk b should not be minified", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "b.css"), "utf-8");
+	expect(content).not.toMatch("\n");
+	expect(false).toBe(true);
+});

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/rspack.config.js
@@ -1,0 +1,25 @@
+const rspack = require("@rspack/core");
+/**
+ * @type {import("@rspack/core").Configuration}
+ */
+module.exports = {
+	entry: {
+		a: "./a.js",
+		b: "./b.js",
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	experiments: {
+		css: false
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.SwcCssMinimizerRspackPlugin({
+				exclude: [/b\.css/]
+			})
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/rspack.config.js
@@ -11,8 +11,12 @@ module.exports = {
 	output: {
 		filename: "[name].js"
 	},
-	experiments: {
-		css: false
+	module: {
+		generator: {
+			"css/auto": {
+				exportsOnly: false
+			}
+		}
 	},
 	optimization: {
 		minimize: true,

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-css/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -49,6 +49,8 @@ import type { RawOptions } from '@rspack/binding';
 import { RawProgressPluginOptions } from '@rspack/binding';
 import { RawRuntimeChunkOptions } from '@rspack/binding';
 import { RawSourceMapDevToolPluginOptions } from '@rspack/binding';
+import { RawSwcCssMinimizerRspackPluginOptions } from '@rspack/binding';
+import { RawSwcJsMinimizerRspackPluginOptions } from '@rspack/binding';
 import { registerGlobalTrace } from '@rspack/binding';
 import { RspackOptionsNormalized as RspackOptionsNormalized_2 } from '.';
 import sources = require('../compiled/webpack-sources');
@@ -13151,15 +13153,22 @@ const strictModuleExceptionHandling: z.ZodBoolean;
 export const SwcCssMinimizerRspackPlugin: {
     new (options?: SwcCssMinimizerRspackPluginOptions | undefined): {
         name: BuiltinPluginName;
+<<<<<<< HEAD
         _args: [options?: any];
         affectedHooks: "done" | "compilation" | "failed" | "environment" | "emit" | "make" | "compile" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "shutdown" | "watchRun" | "watchClose" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
         raw(compiler: Compiler_2): BuiltinPlugin;
+=======
+        _options: RawSwcCssMinimizerRspackPluginOptions;
+        affectedHooks: "make" | "compile" | "emit" | "afterEmit" | "invalid" | "done" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
+        raw(): BuiltinPlugin;
+>>>>>>> 3e341df52 (pass options top minimizer)
         apply(compiler: Compiler_2): void;
     };
 };
 
 // @public (undocumented)
 type SwcCssMinimizerRspackPluginOptions = {
+    test?: MinifyConditions_2;
     exclude?: MinifyConditions_2;
     include?: MinifyConditions_2;
 };

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -49,8 +49,6 @@ import type { RawOptions } from '@rspack/binding';
 import { RawProgressPluginOptions } from '@rspack/binding';
 import { RawRuntimeChunkOptions } from '@rspack/binding';
 import { RawSourceMapDevToolPluginOptions } from '@rspack/binding';
-import { RawSwcCssMinimizerRspackPluginOptions } from '@rspack/binding';
-import { RawSwcJsMinimizerRspackPluginOptions } from '@rspack/binding';
 import { registerGlobalTrace } from '@rspack/binding';
 import { RspackOptionsNormalized as RspackOptionsNormalized_2 } from '.';
 import sources = require('../compiled/webpack-sources');
@@ -13153,15 +13151,9 @@ const strictModuleExceptionHandling: z.ZodBoolean;
 export const SwcCssMinimizerRspackPlugin: {
     new (options?: SwcCssMinimizerRspackPluginOptions | undefined): {
         name: BuiltinPluginName;
-<<<<<<< HEAD
-        _args: [options?: any];
+        _args: [options?: SwcCssMinimizerRspackPluginOptions | undefined];
         affectedHooks: "done" | "compilation" | "failed" | "environment" | "emit" | "make" | "compile" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "shutdown" | "watchRun" | "watchClose" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
         raw(compiler: Compiler_2): BuiltinPlugin;
-=======
-        _options: RawSwcCssMinimizerRspackPluginOptions;
-        affectedHooks: "make" | "compile" | "emit" | "afterEmit" | "invalid" | "done" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
-        raw(): BuiltinPlugin;
->>>>>>> 3e341df52 (pass options top minimizer)
         apply(compiler: Compiler_2): void;
     };
 };

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -5005,7 +5005,13 @@ const matchPart: (str: string, test: Matcher) => boolean;
 type MinifyCondition = string | RegExp;
 
 // @public (undocumented)
+type MinifyCondition_2 = string | RegExp;
+
+// @public (undocumented)
 type MinifyConditions = MinifyCondition | MinifyCondition[];
+
+// @public (undocumented)
+type MinifyConditions_2 = MinifyCondition_2 | MinifyCondition_2[];
 
 // @public (undocumented)
 export type Mode = z.infer<typeof mode>;
@@ -13143,13 +13149,19 @@ const strictModuleExceptionHandling: z.ZodBoolean;
 
 // @public (undocumented)
 export const SwcCssMinimizerRspackPlugin: {
-    new (options?: any): {
+    new (options?: SwcCssMinimizerRspackPluginOptions | undefined): {
         name: BuiltinPluginName;
         _args: [options?: any];
         affectedHooks: "done" | "compilation" | "failed" | "environment" | "emit" | "make" | "compile" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "shutdown" | "watchRun" | "watchClose" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
         raw(compiler: Compiler_2): BuiltinPlugin;
         apply(compiler: Compiler_2): void;
     };
+};
+
+// @public (undocumented)
+type SwcCssMinimizerRspackPluginOptions = {
+    exclude?: MinifyConditions_2;
+    include?: MinifyConditions_2;
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
@@ -2,7 +2,15 @@ import { BuiltinPluginName } from "@rspack/binding";
 
 import { create } from "./base";
 
+type MinifyCondition = string | RegExp;
+type MinifyConditions = MinifyCondition | MinifyCondition[];
+
+export type SwcCssMinimizerRspackPluginOptions = {
+	exclude?: MinifyConditions;
+	include?: MinifyConditions;
+};
+
 export const SwcCssMinimizerRspackPlugin = create(
 	BuiltinPluginName.SwcCssMinimizerRspackPlugin,
-	(options?: any /* TODO: extend more options */) => undefined
+	(options?: SwcCssMinimizerRspackPluginOptions) => undefined
 );

--- a/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
@@ -1,4 +1,7 @@
-import { BuiltinPluginName } from "@rspack/binding";
+import {
+	BuiltinPluginName,
+	RawSwcCssMinimizerRspackPluginOptions
+} from "@rspack/binding";
 
 import { create } from "./base";
 
@@ -6,11 +9,20 @@ type MinifyCondition = string | RegExp;
 type MinifyConditions = MinifyCondition | MinifyCondition[];
 
 export type SwcCssMinimizerRspackPluginOptions = {
+	test?: MinifyConditions;
 	exclude?: MinifyConditions;
 	include?: MinifyConditions;
 };
 
 export const SwcCssMinimizerRspackPlugin = create(
 	BuiltinPluginName.SwcCssMinimizerRspackPlugin,
-	(options?: SwcCssMinimizerRspackPluginOptions) => undefined
+	(
+		options?: SwcCssMinimizerRspackPluginOptions
+	): RawSwcCssMinimizerRspackPluginOptions => {
+		return {
+			test: options?.test,
+			include: options?.include,
+			exclude: options?.exclude
+		};
+	}
 );

--- a/website/docs/en/plugins/rspack/swc-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/swc-css-minimizer-rspack-plugin.mdx
@@ -10,7 +10,22 @@ This plugin can be used to compress CSS assets. See [optimization.minimizer](/co
 module.exports = {
   // ...
   optimization: {
-    minimizer: [new rspack.SwcCssMinimizerRspackPlugin()],
+    minimizer: [new rspack.SwcCssMinimizerRspackPlugin(options)],
   },
 };
 ```
+
+- options
+
+  - **Type:**
+
+  ```ts
+  type SwcCssMinimizerRspackPluginOptions = {
+    test?: MinifyConditions;
+    exclude?: MinifyConditions;
+    include?: MinifyConditions;
+  };
+
+  type MinifyCondition = string | RegExp;
+  type MinifyConditions = MinifyCondition | MinifyCondition[];
+  ```


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The PR adds the `test`, `include` and `exclude` options to the `SwcCssMinimizerRspackPlugin`, similar to how it works with the `SwcJsMinimizerRspackPlugin`.

resolve #6898 

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
