### PR TITLE
docs: use CssExtractRspackPlugin and experiments.css together

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -132,7 +132,8 @@ module.exports = {
 -          CssExtractWebpackPlugin.loader,
 +          rspack.CssExtractRspackPlugin.loader,
           "css-loader"
-        ]
+        ],
++        type: 'javascript/auto'
       }
     ]
   }

--- a/website/docs/en/guide/tech/css.mdx
+++ b/website/docs/en/guide/tech/css.mdx
@@ -2,15 +2,31 @@ import { PackageManagerTabs } from '@theme';
 
 # CSS
 
-CSS is a first-class citizen with Rspack. Rspack has the ability to handle CSS out-of-box, so additional configuration isn't required.
+CSS is a first-class citizen with Rspack. Rspack has the ability to handle CSS out-of-box, just need to set `experiments.css` to `true`.
 
-By default, files ending in `*.css` are treated as CSS types. Files ending in `*.module.css` are treated as [CSS Modules](https://github.com/css-modules/css-modules) module types.
+By default, files ending in `*.css` are treated as `css/auto` module type, Files ending in `*.module.css` are treated as [CSS Modules](https://github.com/css-modules/css-modules).
 
-If you're migrating from webpack, you can remove the `css-loader` or `style-loader` components from your configuration to use Rspack's built-in CSS processing capabilities, as described in [migration guide](/guide/migration/webpack#removing-css-loader-and-style-loader-and-mini-css-extract-plugin).
+You can also customize which modules are CSS modules by configuring `type: 'css/auto'`.
+
+```js title=rspack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        type: 'css/auto', // 👈
+        use: ['less-loader'],
+      },
+    ],
+  },
+};
+```
+
+If you're migrating from webpack, see [migration guide](/guide/migration/webpack#removing-css-loader-and-style-loader-and-mini-css-extract-plugin).
 
 ## CSS Modules
 
-By default, Rspack treats files with a `*.module.css` extension as CSS Modules. You can import them into your JavaScript files, and then access each class defined in the CSS file as an export from the module.
+By default, Rspack treats files with a `*.module.css` extension as [CSS Modules](https://github.com/css-modules/css-modules). You can import them into your JavaScript files, and then access each class defined in the CSS file as an export from the module.
 
 ```css title="index.module.css"
 .red {

--- a/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -169,8 +169,40 @@ module.exports = {
       {
         test: /\.css$/i,
         use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+        type: 'javascript/auto',
       },
     ],
   },
 };
 ```
+
+:::info
+Please note when opening built-in CSS support. (`experiments.css`), Files ending with `.css` will be automatically treated as `css/auto` modules. If you want to use this plugin, make sure that the rule types with `CssExtractRspackPlugin.loader` set are all overridden by `javascript/auto` instead of the default `css/auto`.
+
+For example:
+
+```ts title="rspack.config.js"
+const rspack = require('@rspack/core');
+
+module.exports = {
+  plugins: [new rspack.CssExtractRspackPlugin({})],
+  module: {
+    rules: [
+      {
+        test: /src\/legacy-project\/.*\.css$/,
+        type: 'javascript/auto', // Cover the default css module type and treat it as a regular js file.
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+      {
+        test: /src\/new-project\/.*\.css$/,
+        type: 'css/auto', // Handle with built-in CSS
+      },
+    ],
+  },
+  experiments: {
+    css: true,
+  },
+};
+```
+
+:::

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -129,7 +129,8 @@ module.exports = {
 -          CssExtractWebpackPlugin.loader,
 +          rspack.CssExtractRspackPlugin.loader,
           "css-loader"
-        ]
+        ],
++        type: 'javascript/auto'
       }
     ]
   }

--- a/website/docs/zh/guide/tech/css.mdx
+++ b/website/docs/zh/guide/tech/css.mdx
@@ -2,15 +2,31 @@ import { PackageManagerTabs } from '@theme';
 
 # CSS
 
-CSS 是 Rspack 的一等公民，Rspack 内置了对 CSS 的处理能力，你无需额外的配置即可使用。
+CSS 是 Rspack 的一等公民，Rspack 内置了对 CSS 的处理能力，只需要配置 `experiments.css` 为 `true` 即可。
 
-我们默认会将 `*.css` 结尾的文件视为 CSS 模块类型，将 `*.module.css` 结尾的文件视为 [CSS Modules](https://github.com/css-modules/css-modules) 模块类型。
+我们默认会将 `*.css` 结尾的文件视为 `css/auto` 模块类型，将 `*.module.css` 结尾的文件视为 [CSS Modules](https://github.com/css-modules/css-modules)。
 
-如果你打算从 webpack 进行迁移，那么你可以去除配置中的 `css-loader` 或 `style-loader` 以使用 Rspack 内置的 CSS 处理能力，详情可以参考[迁移指南](/guide/migration/webpack#去除-css-loader-和-style-loader-和-mini-css-extract-plugin)。
+你也可以通过配置 `type: 'css/auto'` 自定义哪些模块为 `css` 模块。
+
+```js title=rspack.config.js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        type: 'css/auto', // 👈
+        use: ['less-loader'],
+      },
+    ],
+  },
+};
+```
+
+如果你打算从 webpack 进行迁移，详情可以参考[迁移指南](/guide/migration/webpack#去除-css-loader-和-style-loader-和-mini-css-extract-plugin)。
 
 ## CSS Modules
 
-Rspack 默认将扩展名为 `*.module.css` 的文件视为 CSS Modules，你可以在 JavaScript 文件中导入它，然后将 CSS 文件中定义的每个类作为模块的导出来访问。
+Rspack 默认将扩展名为 `*.module.css` 的文件视为 [CSS Modules](https://github.com/css-modules/css-modules)，你可以在 JavaScript 文件中导入它，然后将 CSS 文件中定义的每个类作为模块的导出来访问。
 
 ```css title="index.module.css"
 .red {

--- a/website/docs/zh/plugins/rspack/css-extract-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/css-extract-rspack-plugin.mdx
@@ -165,8 +165,40 @@ module.exports = {
       {
         test: /\.css$/i,
         use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+        type: 'javascript/auto',
       },
     ],
   },
 };
 ```
+
+:::info
+请注意当打开内置 CSS 支持（`experiments.css`）时，`.css` 结尾的文件会默认视为 `css/auto` 模块，此时如果想要使用该插件，请确保设置了 `CssExtractRspackPlugin.loader` 的 rule 类型都用 `javascript/auto` 覆盖了默认的 `css/auto` 类型。
+
+例如
+
+```ts title="rspack.config.js"
+const rspack = require('@rspack/core');
+
+module.exports = {
+  plugins: [new rspack.CssExtractRspackPlugin({})],
+  module: {
+    rules: [
+      {
+        test: /src\/legacy-project\/.*\.css$/,
+        type: 'javascript/auto', // 覆盖默认的 css 模块类型，视为普通 js 文件
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+      {
+        test: /src\/new-project\/.*\.css$/,
+        type: 'css/auto', // 使用内置 css 处理
+      },
+    ],
+  },
+  experiments: {
+    css: true,
+  },
+};
+```
+
+:::


### PR DESCRIPTION
## Summary

Adds description about how to use `CssExtractRspackPlugin` and `experiments.css` together, and how to customize css module type for certain modules

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
