### PR TITLE
perf: reduce allocation for filename render

### DIFF
--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -16,25 +16,25 @@ use rspack_util::MergeFrom;
 use crate::{parse_resource, AssetInfo, PathData, ResourceParsedData};
 
 pub static FILE_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[file]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[file\]").expect("Should generate regex"));
 pub static BASE_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[base]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[base\]").expect("Should generate regex"));
 pub static NAME_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[name]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[name\]").expect("Should generate regex"));
 pub static PATH_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[path]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[path\]").expect("Should generate regex"));
 pub static EXT_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[ext]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[ext\]").expect("Should generate regex"));
 pub static QUERY_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[query]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[query\]").expect("Should generate regex"));
 pub static FRAGMENT_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[fragment]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[fragment\]").expect("Should generate regex"));
 pub static ID_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[id]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[id\]").expect("Should generate regex"));
 pub static RUNTIME_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[runtime]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[runtime\]").expect("Should generate regex"));
 pub static URL_PLACEHOLDER: Lazy<Regex> =
-  Lazy::new(|| Regex::new("[url]").expect("Should generate regex"));
+  Lazy::new(|| Regex::new(r"\[url\]").expect("Should generate regex"));
 pub static HASH_PLACEHOLDER: Lazy<Regex> =
   Lazy::new(|| Regex::new(r"\[hash(:(\d*))?]").expect("Invalid regex"));
 pub static CHUNK_HASH_PLACEHOLDER: Lazy<Regex> =
@@ -194,8 +194,8 @@ impl<F: LocalFilenameFn> Filename<F> {
   }
 }
 
-fn render_template<'s>(
-  template: Cow<'s, str>,
+fn render_template(
+  template: Cow<str>,
   options: PathData,
   mut asset_info: Option<&mut AssetInfo>,
 ) -> String {
@@ -257,7 +257,7 @@ fn render_template<'s>(
           )
         })
         .map(|t| QUERY_PLACEHOLDER.replace(t, &query.unwrap_or_default()))
-        .map(|t| FRAGMENT_PLACEHOLDER.replace(&t, &fragment.unwrap_or_default()));
+        .map(|t| FRAGMENT_PLACEHOLDER.replace(t, &fragment.unwrap_or_default()));
     }
   }
   if let Some(content_hash) = options.content_hash {

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -210,14 +210,14 @@ fn render_template(
       )
       .map(|exts| exts[0]);
       t = t
-        .map(|t| FILE_PLACEHOLDER.replace(t, ""))
-        .map(|t| QUERY_PLACEHOLDER.replace(t, ""))
-        .map(|t| FRAGMENT_PLACEHOLDER.replace(t, ""))
-        .map(|t| PATH_PLACEHOLDER.replace(t, ""))
-        .map(|t| BASE_PLACEHOLDER.replace(t, ""))
-        .map(|t| NAME_PLACEHOLDER.replace(t, ""))
+        .map(|t| FILE_PLACEHOLDER.replace_all(t, ""))
+        .map(|t| QUERY_PLACEHOLDER.replace_all(t, ""))
+        .map(|t| FRAGMENT_PLACEHOLDER.replace_all(t, ""))
+        .map(|t| PATH_PLACEHOLDER.replace_all(t, ""))
+        .map(|t| BASE_PLACEHOLDER.replace_all(t, ""))
+        .map(|t| NAME_PLACEHOLDER.replace_all(t, ""))
         .map(|t| {
-          EXT_PLACEHOLDER.replace(t, &ext.map(|ext| format!(".{}", ext)).unwrap_or_default())
+          EXT_PLACEHOLDER.replace_all(t, &ext.map(|ext| format!(".{}", ext)).unwrap_or_default())
         });
     } else if let Some(ResourceParsedData {
       path: file,
@@ -226,9 +226,9 @@ fn render_template(
     }) = parse_resource(filename)
     {
       t = t
-        .map(|t| FILE_PLACEHOLDER.replace(t, file.to_string_lossy()))
+        .map(|t| FILE_PLACEHOLDER.replace_all(t, file.to_string_lossy()))
         .map(|t| {
-          EXT_PLACEHOLDER.replace(
+          EXT_PLACEHOLDER.replace_all(
             t,
             file
               .extension()
@@ -238,14 +238,14 @@ fn render_template(
         });
 
       if let Some(base) = file.file_name().map(|p| p.to_string_lossy()) {
-        t = t.map(|t| BASE_PLACEHOLDER.replace(t, &base));
+        t = t.map(|t| BASE_PLACEHOLDER.replace_all(t, &base));
       }
       if let Some(name) = file.file_stem().map(|p| p.to_string_lossy()) {
-        t = t.map(|t| NAME_PLACEHOLDER.replace(t, &name));
+        t = t.map(|t| NAME_PLACEHOLDER.replace_all(t, &name));
       }
       t = t
         .map(|t| {
-          PATH_PLACEHOLDER.replace(
+          PATH_PLACEHOLDER.replace_all(
             t,
             &file
               .parent()
@@ -256,8 +256,8 @@ fn render_template(
               .unwrap_or_default(),
           )
         })
-        .map(|t| QUERY_PLACEHOLDER.replace(t, &query.unwrap_or_default()))
-        .map(|t| FRAGMENT_PLACEHOLDER.replace(t, &fragment.unwrap_or_default()));
+        .map(|t| QUERY_PLACEHOLDER.replace_all(t, &query.unwrap_or_default()))
+        .map(|t| FRAGMENT_PLACEHOLDER.replace_all(t, &fragment.unwrap_or_default()));
     }
   }
   if let Some(content_hash) = options.content_hash {
@@ -292,12 +292,12 @@ fn render_template(
   }
   if let Some(chunk) = options.chunk {
     if let Some(id) = &options.id {
-      t = t.map(|t| ID_PLACEHOLDER.replace(t, *id));
+      t = t.map(|t| ID_PLACEHOLDER.replace_all(t, *id));
     } else if let Some(id) = &chunk.id {
-      t = t.map(|t| ID_PLACEHOLDER.replace(t, id));
+      t = t.map(|t| ID_PLACEHOLDER.replace_all(t, id));
     }
     if let Some(name) = chunk.name_for_filename_template() {
-      t = t.map(|t| NAME_PLACEHOLDER.replace(t, name));
+      t = t.map(|t| NAME_PLACEHOLDER.replace_all(t, name));
     }
     if let Some(d) = chunk.rendered_hash.as_ref() {
       t = t.map(|t| {
@@ -315,17 +315,17 @@ fn render_template(
   }
 
   if let Some(id) = &options.id {
-    t = t.map(|t| ID_PLACEHOLDER.replace(t, *id));
+    t = t.map(|t| ID_PLACEHOLDER.replace_all(t, *id));
   } else if let Some(module) = options.module {
     if let Some(chunk_graph) = options.chunk_graph {
       if let Some(id) = chunk_graph.get_module_id(module.identifier()) {
-        t = t.map(|t| ID_PLACEHOLDER.replace(t, id));
+        t = t.map(|t| ID_PLACEHOLDER.replace_all(t, id));
       }
     }
   }
-  t = t.map(|t| RUNTIME_PLACEHOLDER.replace(t, options.runtime.unwrap_or("_")));
+  t = t.map(|t| RUNTIME_PLACEHOLDER.replace_all(t, options.runtime.unwrap_or("_")));
   if let Some(url) = options.url {
-    t = t.map(|t| URL_PLACEHOLDER.replace(t, url));
+    t = t.map(|t| URL_PLACEHOLDER.replace_all(t, url));
   }
   t.into_owned()
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`String::replace` allocates `String` on each iteration and `Regex::replace_all` only returns `Cow::Owned(...)` if there's an actual replacement takes place. Thus, we are moving from `String::replace` to `Regex::replace_all`.

For test cases: 
- 0: "[id].[name].css"
- 1: "[id].[name].[fullhash][ext][[query]"
- 2: "[id].[name].[fullhash][ext][[query][id].[name].[fullhash][ext][[query]"

**Case: "[id].[name].css"** (22% faster)
```
Replace/String::replace/0
                        time:   [31.403 µs 31.468 µs 31.529 µs]
                        change: [+0.3228% +0.7846% +1.2319%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
Replace/Regex::replace/0
                        time:   [24.505 µs 24.594 µs 24.692 µs]
                        change: [-0.0425% +0.2968% +0.6560%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
```

**Case: "[id].[name].[fullhash][ext][[query]"** (32% faster)
```
Replace/String::replace/1
                        time:   [40.020 µs 40.107 µs 40.190 µs]
Replace/Regex::replace/1
                        time:   [26.951 µs 27.099 µs 27.277 µs]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```

**Case: "[id].[name].[fullhash][ext][[query][id].[name].[fullhash][ext][[query]"** (42% faster)
```
Replace/String::replace/2
                        time:   [54.491 µs 54.649 µs 54.795 µs]
Replace/Regex::replace/2
                        time:   [31.855 µs 31.955 µs 32.060 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```

![Replace benchmark lines](https://github.com/user-attachments/assets/d72f8a1e-00ec-4f4d-9d58-acc124728546)



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
