### PR TITLE
fix: unset cjs exports type on access exports directly

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -714,13 +714,6 @@ export interface JsTap {
   stage: number
 }
 
-export interface NodeFS {
-  writeFile: (...args: any[]) => any
-  removeFile: (...args: any[]) => any
-  mkdir: (...args: any[]) => any
-  mkdirp: (...args: any[]) => any
-}
-
 export interface PathWithInfo {
   path: string
   info: JsAssetInfo
@@ -1598,13 +1591,5 @@ export interface RegisterJsTaps {
   registerContextModuleFactoryBeforeResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryBeforeResolveData) => Promise<false | JsContextModuleFactoryBeforeResolveData>); stage: number; }>
   registerContextModuleFactoryAfterResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryAfterResolveData) => Promise<false | JsContextModuleFactoryAfterResolveData>); stage: number; }>
   registerJavascriptModulesChunkHashTaps: (stages: Array<number>) => Array<{ function: ((arg: JsChunk) => Buffer); stage: number; }>
-}
-
-export interface ThreadsafeNodeFS {
-  writeFile: (name: string, content: Buffer) => Promise<void> | void
-  removeFile: (name: string) => Promise<void> | void
-  mkdir: (name: string) => Promise<void> | void
-  mkdirp: (name: string) => Promise<string | void> | string | void
-  removeDirAll: (name: string) => Promise<string | void> | string | void
 }
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -714,6 +714,13 @@ export interface JsTap {
   stage: number
 }
 
+export interface NodeFS {
+  writeFile: (...args: any[]) => any
+  removeFile: (...args: any[]) => any
+  mkdir: (...args: any[]) => any
+  mkdirp: (...args: any[]) => any
+}
+
 export interface PathWithInfo {
   path: string
   info: JsAssetInfo
@@ -1591,5 +1598,13 @@ export interface RegisterJsTaps {
   registerContextModuleFactoryBeforeResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryBeforeResolveData) => Promise<false | JsContextModuleFactoryBeforeResolveData>); stage: number; }>
   registerContextModuleFactoryAfterResolveTaps: (stages: Array<number>) => Array<{ function: ((arg: false | JsContextModuleFactoryAfterResolveData) => Promise<false | JsContextModuleFactoryAfterResolveData>); stage: number; }>
   registerJavascriptModulesChunkHashTaps: (stages: Array<number>) => Array<{ function: ((arg: JsChunk) => Buffer); stage: number; }>
+}
+
+export interface ThreadsafeNodeFS {
+  writeFile: (name: string, content: Buffer) => Promise<void> | void
+  removeFile: (name: string) => Promise<void> | void
+  mkdir: (name: string) => Promise<void> | void
+  mkdirp: (name: string) => Promise<string | void> | string | void
+  removeDirAll: (name: string) => Promise<string | void> | string | void
 }
 

--- a/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/a.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/a.js
@@ -1,0 +1,4 @@
+// set to Flagged
+exports.__esModule = true;
+// set to Unset, `Object.defineProperty(exports, 'a', ...)` is not at the statement level
+(() => {})(Object.defineProperty(exports,'a',{enumerable:!0,get:function(){return 'a'}}))

--- a/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/b.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/b.js
@@ -1,0 +1,10 @@
+const reexport = require("./a")
+// set to Flagged
+Object.defineProperty(exports, '__esModule', { value: true });
+// set to Unset, exports is used directly without member access
+Object.keys(reexport).forEach(function (k) {
+  if (k !== 'default' && !exports.hasOwnProperty(k)) Object.defineProperty(exports, k, {
+    enumerable: true,
+    get: function () { return reexport[k]; }
+  });
+});

--- a/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/cjs.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/cjs.js
@@ -1,2 +1,0 @@
-exports.__esModule = true; // set to Flagged
-(() => {})(Object.defineProperty(exports,'a',{enumerable:!0,get:function(){return 'a'}})) // Unset

--- a/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/cjs-unset-exports-type/index.js
@@ -1,2 +1,6 @@
-import { notExist } from "./cjs";
-notExist; // should not have exportsPresence warning
+// Should not have exportsPresence warning for these not exist exports
+
+import { notExist } from "./a";
+import { notExist2 } from "./b";
+notExist; 
+notExist2;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #7022

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
