### PR TITLE
fix: align resolverFactory resolveOptions parameter with resolve options

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -8340,7 +8340,10 @@ export type ResolveOptions = z.infer<typeof baseResolveOptions> & {
 const resolveOptions: z.ZodType<ResolveOptions>;
 
 // @public (undocumented)
-type ResolveOptionsWithDependencyType = binding.RawResolveOptionsWithDependencyType;
+type ResolveOptionsWithDependencyType = Resolve & {
+    dependencyCategory?: string;
+    resolveToContext?: boolean;
+};
 
 // @public (undocumented)
 type ResolveOptionsWithDependencyType_2 = Resolve & {

--- a/packages/rspack/src/ResolverFactory.ts
+++ b/packages/rspack/src/ResolverFactory.ts
@@ -1,8 +1,11 @@
 import * as binding from "@rspack/binding";
 import { Resolver } from "./Resolver";
+import { type Resolve, getRawResolve } from "./config";
 
-type ResolveOptionsWithDependencyType =
-	binding.RawResolveOptionsWithDependencyType;
+type ResolveOptionsWithDependencyType = Resolve & {
+	dependencyCategory?: string;
+	resolveToContext?: boolean;
+};
 
 export class ResolverFactory {
 	#binding: binding.JsResolverFactory;
@@ -21,7 +24,14 @@ export class ResolverFactory {
 		type: string,
 		resolveOptions?: ResolveOptionsWithDependencyType
 	): Resolver {
-		const binding = this.#binding.get(type, resolveOptions);
+		const { dependencyCategory, resolveToContext, ...resolve } =
+			resolveOptions || {};
+
+		const binding = this.#binding.get(type, {
+			...getRawResolve(resolve),
+			dependencyCategory,
+			resolveToContext
+		});
 		return new Resolver(binding);
 	}
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

align resolverFactory resolveOptions parameter with resolve options.

When I pass `compiler.options.resolve` as the resolverFactory parameter, a type error is reported, which is not make sense.

![59131bc8-706a-4c43-b0a9-a80849ffb6c0](https://github.com/user-attachments/assets/dc2fd9ea-ec79-4cb9-b6a6-4da58a56fb51)


Related PR: https://github.com/web-infra-dev/rspack/pull/4945

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
