### PR TITLE
ci: fix the action that does not use biome in fact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Lint js
         if: steps.changes.outputs.src == 'true'
-        run: pnpm run lint:js
+        run: pnpm run lint-ci:js
       - name: Prettier
         if: steps.changes.outputs.src == 'true'
         run: pnpm run format-ci:js

--- a/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SwcCssMinimizerPlugin.ts
@@ -1,6 +1,6 @@
 import {
 	BuiltinPluginName,
-	RawSwcCssMinimizerRspackPluginOptions
+	type RawSwcCssMinimizerRspackPluginOptions
 } from "@rspack/binding";
 
 import { create } from "./base";


### PR DESCRIPTION


## Summary

use the biome right script to lint on ci

https://github.com/web-infra-dev/rspack/actions/runs/9925906232/job/27419030108

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e8fc031d-da58-49a3-9467-f1a46e97916e">

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->


