### PR TITLE
fix: invalid "javascript/auto" rule.type in getRawGeneratorOptions

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/module/generator-js/index.js
+++ b/packages/rspack-test-tools/tests/configCases/module/generator-js/index.js
@@ -1,0 +1,9 @@
+import { lib } from "./lib";
+import fs from 'node:fs';
+import path from 'node:path';
+
+it("compiled success and generator should ignored", () => {
+	expect(lib).toEqual(42);
+	const content = fs.readFileSync(path.resolve(__dirname, "main.js"), "utf-8");
+	expect(content).toMatch("42");
+});

--- a/packages/rspack-test-tools/tests/configCases/module/generator-js/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/module/generator-js/lib.js
@@ -1,0 +1,1 @@
+export const lib = 42;

--- a/packages/rspack-test-tools/tests/configCases/module/generator-js/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/generator-js/rspack.config.js
@@ -1,0 +1,21 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	output: {
+		publicPath: "/",
+		filename: 'main.js'
+	},
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				type: "javascript/auto",
+				generator: {
+					filename: "custom/lib.js"
+				}
+			},
+		]
+	}
+};

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -570,7 +570,9 @@ function getRawGeneratorOptionsByModuleType(
 	parser: GeneratorOptionsByModuleType
 ): Record<string, RawGeneratorOptions> {
 	return Object.fromEntries(
-		Object.entries(parser).map(([k, v]) => [k, getRawGeneratorOptions(v, k)])
+		Object.entries(parser)
+			.map(([k, v]) => [k, getRawGeneratorOptions(v, k)])
+			.filter(([k, v]) => v !== undefined)
 	);
 }
 
@@ -706,7 +708,7 @@ function getRawCssParserOptions(
 function getRawGeneratorOptions(
 	generator: { [k: string]: any },
 	type: string
-): RawGeneratorOptions {
+): RawGeneratorOptions | undefined {
 	if (type === "asset") {
 		return {
 			type: "asset",
@@ -747,6 +749,18 @@ function getRawGeneratorOptions(
 			cssModule: getRawCssAutoOrModuleGeneratorOptions(generator)
 		};
 	}
+
+	if (
+		[
+			"javascript",
+			"javascript/auto",
+			"javascript/dynamic",
+			"javascript/esm"
+		].includes(type)
+	) {
+		return undefined;
+	}
+
 	throw new Error(`unreachable: unknow module type: ${type}`);
 }
 


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix invalid "javascript/auto" rule.type in getRawGeneratorOptions:

![image](https://github.com/user-attachments/assets/9fdbbf29-4110-4fd8-9dc8-4207aa9e8b8d)

No generator options are supported for module type `javascript/auto` / `javascript` / `javascript/dynamic` / `javascript/esm`,  it should be ignored instead of throw an error.


https://github.com/web-infra-dev/rspack/issues/6873#issuecomment-2228082861

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
