### PR TITLE
docs: polish up output config

### DIFF
--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -5,7 +5,7 @@ import { ApiMeta, Stability } from '../../../components/ApiMeta';
 
 # Output
 
-Used to indicate how and where Rspack outputs the contents of the generated file.
+The top-level output key contains a set of options instructing Rspack on how and where it should output your bundles, assets, and anything else you bundle or load with Rspack.
 
 - **Type:** `Object`
 
@@ -13,11 +13,12 @@ Used to indicate how and where Rspack outputs the contents of the generated file
 
 - **Type:** `string`
 - **Default:** `'[hash][ext][query]'`
-- **Supported Template String:**
-  - [Module Context](/config/output#module-context)
-  - [File Context](/config/output#file-context)
 
-The name of the file to be output by the Asset module. This value can be overridden by [Rule.generator.filename](/config/module#rulegeneratorfilename).
+The same as [`output.filename`](#outputfilename) but for [Asset Modules](/guide/features/asset-module).
+
+`[name]`, `[file]`, `[query]`, `[fragment]`, `[base]`, and `[path]` are set to an empty string for the assets built from data URI replacements.
+
+The name of the file to be output by the Asset module. This value can be overridden by [Rule.generator.filename](#outputfilename).
 
 :::info Asset module output as a separate file
 
@@ -26,105 +27,61 @@ The name of the file to be output by the Asset module. This value can be overrid
 
 :::
 
-## output.filename
+## output.asyncChunks
 
-- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **Default:** `'[name].js'`
+<ApiMeta addedVersion={'0.2.6'} />
 
-This option determines the name of the JavaScript bundle file to be output. These bundles will be written to the directory specified by `output.path`.
+- **Type:** `boolean`
+- **Default:** `true`
 
-For a single [Entry](/config/entry.html), you can use a static name such as:
+Create async chunks that are loaded on demand.
+
+## output.chunkFilename
+
+- **Type:** `string = '[id].js' | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **Default:** Determined by [`output.filename`](/config/output#outputfilename) when it is not a function, otherwise `'[id].js'`.
+
+This option determines the name of non-initial chunk files. See [`output.filename`](/config/output#outputfilename) option for details on the possible values.
+
+Note that these filenames need to be generated at runtime to send the requests for chunks. Because of this, placeholders like `[name]` and `[chunkhash]` need to add a mapping from chunk id to placeholder value to the output bundle with the Rspack runtime. This increases the size and may invalidate the bundle when placeholder value for any chunk changes.
+
+By default `[id].js` is used or a value inferred from [`output.filename`](/config/output#outputfilename)(`[name]` is replaced with `[id]` or `[id].` is prepended).
 
 ```js title="rspack.config.js"
 module.exports = {
+  //...
   output: {
-    filename: 'bundle.js',
+    //...
+    chunkFilename: '[id].js',
   },
 };
 ```
 
-For multiple [Entry](/config/entry.html), or other cases where multiple bundles can be split, you need to dynamically generate the filename of the bundle in the following way:
-
-:::info Description of other cases where multiple bundles can be split
-
-Rspack performs code splitting optimizations on user input code, which may include, but are not limited to, code splitting, bundle splitting, or splitting implemented through other plugins.
-These splitting actions can result in multiple bundles being generated, so the filenames of the bundles need to be generated dynamically.
-
-{
-// TODO: Add Glossary link
-}
-
-:::
-
-Use [Entry](/config/entry.html) name.
+Usage as a function:
 
 ```js title="rspack.config.js"
 module.exports = {
+  //...
   output: {
-    filename: '[name].bundle.js',
-  },
-};
-```
-
-Using the internally generated chunk id.
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: '[id].bundle.js',
-  },
-};
-```
-
-Using hash generated from file content.
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: '[contenthash].bundle.js',
-  },
-};
-```
-
-Of course you can also use a combination of each.
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: '[name].[contenthash].bundle.js',
-  },
-};
-```
-
-Using the function to return the filename.
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: pathData => {
+    chunkFilename: pathData => {
       return pathData.chunk.name === 'main' ? '[name].js' : '[name]/[name].js';
     },
   },
 };
 ```
 
-More can be found in [Template String](/config/output#template-string).
-
-## output.chunkFilename
-
-- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **Default:** inferred from [`output.filename`](/config/output#outputfilename)
-- **Supported Template String:**
-  - [Compilation Context](/config/output#compilation-context)
-  - [Chunk Context](/config/output#chunk-context)
-
-This option determines the name of the non-initial JavaScript chunk file.
-
 ## output.chunkFormat
 
-- **Type:** `false | 'array-push' | 'commonjs' | 'module'`
+- **Type:** `false | 'array-push' | 'commonjs' | 'module' | string`
+- **Default:** Determined by [`target`](/config/target) and [`output.module`](#outputmodule)
 
-The format of chunks, The default value of this option depends on the [`target`](/config/target) and [`output.module`](#outputmodule) setting. In general, the `'array-push'` format is used when the target is web or webworker, the `'module'` format is used when it is ESM, and the `'commonjs'` format is used when it is node.js.
+The format of chunks (formats included by default are `'array-push'` (web/WebWorker), `'commonjs'` (node.js), `'module'` (ESM), but others might be added by plugins).
+
+:::tip
+
+The default value of this option depends on the [`target`](/config/target) and [`output.module`](#outputmodule setting. For more details, search for "chunkFormat" [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
+
+:::
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -134,27 +91,12 @@ module.exports = {
 };
 ```
 
-## output.chunkLoading
-
-- **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
-
-The method to load chunks, The default value of this option depends on the [`target`](/config/target) and [`chunkFormat`](#outputchunkformat) setting. In general, `'jsonp'` is used to load chunks when target is web; `'import'` is used to load chunks when ESM; `'import-scripts'` is used to load chunks when webworker; `'require'` is used to load chunks when node.js; `'async-node'` (`fs.readFile` + `vm.runInThisContext`) is used to load chunks when async node.js.
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    chunkLoading: 'async-node',
-  },
-};
-```
-
 ## output.chunkLoadingGlobal
 
 - **Type:** `string`
-- **Default:** inferred from [`output.uniqueName`](/config/output#outputuniquename)
-  - `webpackChunk${output.uniqueName}`
+- **Default:** Determined by [`output.uniqueName`](/config/output#outputuniquename)
 
-This option determines the global variable is used by Rspack for loading chunks.
+The global variable is used by Rspack for loading chunks.
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -164,108 +106,41 @@ module.exports = {
 };
 ```
 
-## output.devtoolFallbackModuleFilenameTemplate
+## output.chunkLoading
 
-- **Type:** `string` | `function (info)`
+- **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
 
-A fallback is used when the template string or function above yields duplicates.
+The method to load chunks (methods included by default are `'jsonp'` (web), `'import'` (ESM), `'importScripts'` (WebWorker), `'require'` (sync node.js), `'async-node'` (async node.js), but others might be added by plugins). The default value will be determined based on the configuration of [`target`](#target) and [`chunkFormat`](#outputchunkformat).
 
-See [`output.devtoolModuleFilenameTemplate`](/config/output#outputdevtoolmodulefilenametemplate).
+:::tip
 
-## output.devtoolModuleFilenameTemplate
+The default value of this option depends on the [`target`](/config/target) and [`chunkFormat `](#chunkFormat) setting. For more details, search for `"chunkLoading"` [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
 
-- **Type:** `string = 'webpack://[namespace]/[resource-path]?[loaders]'` | `function (info) => string`
+:::
 
-This option is only used when [`devtool`](/config/devtool.html) uses an option that requires module names.
-
-Customize the names used in each source map's `sources` array. This can be done by passing a template string or function. For example, when using `devtool: 'eval'`.
-
-```js
+```js title="rspack.config.js"
 module.exports = {
-  //...
   output: {
-    devtoolModuleFilenameTemplate:
-      'webpack://[namespace]/[resource-path]?[loaders]',
+    chunkLoading: 'async-node',
   },
 };
 ```
 
-The following substitutions are available in template strings:
-
-| Template                 | Description                                                                                         |
-| ------------------------ | --------------------------------------------------------------------------------------------------- |
-| [absolute-resource-path] | The absolute filename                                                                               |
-| [all-loaders]            | Automatic and explicit loaders and params up to the name of the first loader                        |
-| [hash]                   | The hash of the module identifier                                                                   |
-| [id]                     | The module identifier                                                                               |
-| [loaders]                | Explicit loaders and params up to the name of the first loader                                      |
-| [resource]               | The path used to resolve the file and any query params used on the first loader                     |
-| [resource-path]          | The path used to resolve the file without any query params                                          |
-| [namespace]              | The modules namespace. This is usually the library name when building as a library, empty otherwise |
-
-When using a function, the same options are available camel-cased via the `info` parameter:
-
-```js
-module.exports = {
-  //...
-  output: {
-    devtoolModuleFilenameTemplate: info => {
-      return `webpack:///${info.resourcePath}?${info.loaders}`;
-    },
-  },
-};
-```
-
-If multiple modules would result in the same name, [`output.devtoolFallbackModuleFilenameTemplate`](/config/output#outputdevtoolfallbackmodulefilenametemplate) is used instead for these modules.
-
-## output.devtoolNamespace
-
-This option determines the module's namespace used with the [`output.devtoolModuleFilenameTemplate`](/config/output#outputdevtoolmodulefilenametemplate). When not specified, it will default to the value of: [`output.uniqueName`](/config/output#outputuniquename). It's used to prevent source file path collisions in sourcemaps when loading multiple libraries built with Rspack.
-
-For example, if you have 2 libraries, with namespaces `library1` and `library2`, which both have a file `./src/index.js` (with potentially different contents), they will expose these files as `webpack://library1/./src/index.js` and `webpack://library2/./src/index.js`.
-
-## output.enabledChunkLoadingTypes
-
-- **Type:** `string[]`
-
-Enables available runtime module bundling of chunkLoadingType.
-
-```javascript
-module.exports = {
-  //...
-  output: {
-    enabledChunkLoadingTypes: ['import'],
-  },
-};
-```
-
-## output.environment
-
-Tell Rspack what kind of ES-features may be used in the generated runtime-code.
-
-### output.environment.arrowFunction
+## output.clean
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false`
 
-The environment supports async function and await (`async function () { await ... }`).
+Before generating the products, delete all files in the output directory.
 
-## output.cssFilename
-
-- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **Default:** inferred from [`output.filename`](/config/output#outputfilename)
-
-This option determines the name of the CSS file.
-
-## output.cssChunkFilename
-
-- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **Default:** inferred from [`output.chunkFilename`](/config/output#outputchunkfilename)
-- **Supported Template String:**
-  - [Compilation Context](/config/output#compilation-context)
-  - [Chunk Context](/config/output#chunk-context)
-
-This option determines the name of the non-initial CSS chunk file.
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    clean: true, // Clean the output directory before emit.
+  },
+};
+```
 
 ## output.crossOriginLoading
 
@@ -276,7 +151,7 @@ The `crossOriginLoading` config allows you to set the [crossorigin attribute](ht
 
 If `target` is `'web'`, Rspack will dynamically create `<script>` and `<link>` tags to load asynchronous JavaScript and CSS resources. Rspack will add the `crossorigin` attribute to the `<script>` and `<link>` tags if the URLs of these resources are on other domains and `crossOriginLoading` is not `false`.
 
-### Optional values
+**Optional values**
 
 `crossOriginLoading` has the following optional values:
 
@@ -284,7 +159,7 @@ If `target` is `'web'`, Rspack will dynamically create `<script>` and `<link>` t
 - `'anonymous'`: Set `crossorigin` to `'anonymous'` to enable cross-origin without user credentials.
 - `'use-credentials'`: Set `crossorigin` to `'use-credentials'` enable cross-origin with user credentials.
 
-### Example
+**Example**
 
 For example, set `output.publicPath` to `https://example.com/` and `output.crossOriginLoading` to `'anonymous'`:
 
@@ -305,152 +180,266 @@ When Rspack dynamically loads JavaScript resources, it will generate the followi
 <script src="https://example.com/foo.js" crossorigin="anonymous"></script>
 ```
 
-## output.path
+## output.cssChunkFilename
 
-- **Type:** `string`
-- **Default:** `path.resolve(process.cwd(), 'dist')`
+- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **Default:** Determined by [`output.chunkFilename`](/config/output#outputchunkfilename) when it is not a function, otherwise `'[id].css'`.
 
-Output the absolute path to the file directory.
+This option determines the name of non-initial CSS output files on disk. See [`output.filename`](/config/output#outputfilename) option for details on the possible values.
 
-```js title="rspack.config.js"
-const path = require('path');
+You **must not** specify an absolute path here. However, feel free to include folders separated by `'/'`. This specified path combines with the [`output.path`](#outputpath) value to pinpoint the location on the disk.
 
-module.exports = {
-  output: {
-    path: path.resolve(__dirname, 'dist/assets'),
-  },
-};
-```
+## output.cssFilename
 
-## output.pathinfo
+- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **Default:** Determined by [`output.filename`](/config/output#outputfilename)
 
-- **Type:** `boolean | 'verbose'`
-- **Default:** `true`
+This option determines the name of CSS output files on disk. See [`output.filename`](/config/output#outputfilename) option for details on the possible values.
 
-Tells Rspack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` [mode](/config/mode) respectively. `'verbose'` shows more information like exports, runtime requirements and bailouts.
+You **must not** specify an absolute path here. However, feel free to include folders separated by `'/'`. This specified path combines with the [`output.path`](#outputpath) value to pinpoint the location on the disk.
 
-:::warning
-While the data these comments can provide is useful during development when reading the generated code, it **should not** be used in production.
-:::
+## output.devtoolFallbackModuleFilenameTemplate
 
-```js title="rspack.config.js"
-module.exports = {
-  //...
-  output: {
-    pathinfo: true,
-  },
-};
-```
+- **Type:** `string` | `function (info)`
+- **Default:** `undefined`
 
-## output.publicPath
+A fallback is used when the template string or function above yields duplicates.
 
-- **Type:** `string`
-- **Default:** targets are `'web'` or `'web-worker'` when it is `'auto'`
+See [`output.devtoolModuleFilenameTemplate`](/config/output#outputdevtoolmodulefilenametemplate).
 
-This option determines the URL prefix of the referenced resource, such as: image, file, etc.
+## output.devtoolModuleFilenameTemplate
 
-For example, given a configuration file.
+- **Type:** `string = 'webpack://[namespace]/[resource-path]?[loaders]'` | `function (info) => string`
+- **Default:** `undefined`
 
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    publicPath: '/assets/',
-    chunkFilename: '[id].chunk.js',
-    assetModuleFilename: '[name][ext]',
-  },
-};
-```
+This option is only used when [`devtool`](/config/devtool.html) uses an option that requires module names.
 
-For a non-initial chunk file, its request URL looks like this: `/assets/1.chunk.js`.
-
-For a reference to an image, the request URL looks like this: `/assets/logo.png`.
-
-Also, it is useful when you deploy the product using a CDN
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    publicPath: 'https://cdn.example.com/assets/',
-    assetModuleFilename: '[name][ext]',
-  },
-};
-```
-
-For all asset resources, their request URLs look like this: `https://cdn.example.com/assets/logo.png`.
-
-### Dynamically set publicPath
-
-You can set `publicPath` dynamically using `__webpack_public_path__` in the runtime code, and the `__webpack_public_path__` will override the `publicPath` in the Rspack config, but it will only take effect for dynamically loaded resources.
-
-First create a `publicPath.js`:
-
-```js title="publicPath.js"
-__webpack_public_path__ = 'https://cdn.example.com/assets/';
-```
-
-Then import it into the first line of the entry file:
-
-```js title="entry.js"
-import './publicPath.js';
-import './others.js';
-```
-
-## output.scriptType
-
-- **Type:** `'module' | 'text/javascript' | boolean`
-- **Default:** `false`
-
-This option allows loading asynchronous chunks with a custom script type, such as `<script type="module" ...>`.
-
-:::tip
-If `output.module` is set to `true`, `output.scriptType` will default to `'module'` instead of `false`.
-:::
+Customize the names used in each source map's `sources` array. This can be done by passing a template string or function. For example, when using `devtool: 'eval'`.
 
 ```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    scriptType: 'module',
+    devtoolModuleFilenameTemplate:
+      'webpack://[namespace]/[resource-path]?[loaders]',
   },
 };
 ```
 
-## output.sourceMapFilename
+The following substitutions are available in template strings
 
-- **Type:** `string`
-- **Default:** `'[file].map[query]'`
+| 模板                     | 描述                                                                                                |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| [absolute-resource-path] | The absolute filename                                                                               |
+| [all-loaders]            | Automatic and explicit loaders and params up to the name of the first loader                        |
+| [hash]                   | The hash of the module identifier                                                                   |
+| [id]                     | The module identifier                                                                               |
+| [loaders]                | Explicit loaders and params up to the name of the first loader                                      |
+| [resource]               | The path used to resolve the file and any query params used on the first loader                     |
+| [resource-path]          | The path used to resolve the file without any query params                                          |
+| [namespace]              | The modules namespace. This is usually the library name when building as a library, empty otherwise |
 
-Configure how source maps are named. Only takes effect when [`devtool`](/config/devtool) is set to `'source-map'`, which writes an output file.
-
-The `[name]`, `[id]`, `[fullhash]` and `[chunkhash]` substitutions from [`output.filename`](#outputfilename) can be used. In addition to those, you can use substitutions listed under Filename-level in [Template strings](#template-string).
-
-## output.strictModuleErrorHandling
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Handle module loading errors according to the ES Module specification, with performance loss.
-
-## output.trustedTypes
-
-- **Type:** `object`
-
-Controls [Trusted Types](https://web.dev/trusted-types) compatibility. When enabled, Rspack will detect Trusted Types support and, if they are supported, use Trusted Types policies to create script URLs it loads dynamically. Use when the application runs under a [require-trusted-types-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) Content Security Policy directive.
-
-It is disabled by default (no compatibility, script URLs are strings).
-
-The policy name is taken from the object's `policyName` property.
+When using a function, the same options are available camel-cased via the `info` parameter:
 
 ```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    trustedTypes: {
-      policyName: 'my-application#webpack',
+    devtoolModuleFilenameTemplate: info => {
+      return `webpack:///${info.resourcePath}?${info.loaders}`;
     },
   },
 };
 ```
+
+If multiple modules would result in the same name, [`output.devtoolFallbackModuleFilenameTemplate`](#outputdevtoolfallbackmodulefilenametemplate) is used instead for these modules.
+
+## output.devtoolNamespace
+
+- **Type:** `string`
+- **Default:** `undefined`
+
+This option determines the module's namespace used with the [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplate). When not specified, it will default to the value of: [`output.uniqueName`](#outputuniquename). It's used to prevent source file path collisions in sourcemaps when loading multiple libraries built with Rspack.
+
+For example, if you have 2 libraries, with namespaces `library1` and `library2`, which both have a file `./src/index.js` (with potentially different contents), they will expose these files as `webpack://library1/./src/index.js` and `webpack://library2/./src/index.js`.
+
+## output.enabledChunkLoadingTypes
+
+- **Type:** `('jsonp' | 'import-scripts' | 'require' | 'async-node' | string)[]`
+- **Default:** Determined by [`output.chunkLoading`](#outputchunkloading), [`output.workerChunkLoading`](#workerChunkLoading) and Entry's chunkLoading config.
+
+List of chunk loading types enabled for use by entry points. Will be automatically filled by Rspack. Only needed when using a function as entry option and returning chunkLoading option from there.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    enabledChunkLoadingTypes: ['jsonp', 'require'],
+  },
+};
+```
+
+## output.enabledLibraryTypes
+
+- **Type:** `string[]`
+- **Default:** Determined by [output.library](#outputlibrary) and [Entry](/config/entry)
+
+List of library types enabled for use by entry points.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    enabledLibraryTypes: ['module'],
+  },
+};
+```
+
+## output.enabledWasmLoadingTypes
+
+- **Type:** `('fetch-streaming' | 'fetch' | 'async-node' | string | false)[]`
+- **Default:** Determined by [`output.wasmLoading`](#outputwasmloading) and [`output.workerWasmLoading`](#workerWasmLoading)
+
+List of wasm loading types enabled for use by entry points.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    enabledWasmLoadingTypes: ['fetch'],
+  },
+};
+```
+
+## output.environment
+
+Tell Rspack what kind of ES-features may be used in the generated runtime-code.
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    environment: {
+      // The environment supports arrow functions ('() => { ... }').
+      arrowFunction: true,
+      // The environment supports async function and await ('async function () { await ... }').
+      asyncFunction: true,
+      // The environment supports BigInt as literal (123n).
+      bigIntLiteral: false,
+      // The environment supports const and let for variable declarations.
+      const: true,
+      // The environment supports destructuring ('{ a, b } = obj').
+      destructuring: true,
+      // The environment supports an async import() function to import EcmaScript modules.
+      dynamicImport: false,
+      // The environment supports an async import() when creating a worker, only for web targets at the moment.
+      dynamicImportInWorker: false,
+      // The environment supports 'for of' iteration ('for (const x of array) { ... }').
+      forOf: true,
+      // The environment supports 'globalThis'.
+      globalThis: true,
+      // The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...').
+      module: false,
+      // Determines if the node: prefix is generated for core module imports in environments that support it.
+      // This is only applicable to Webpack runtime code.
+      nodePrefixForCoreModules: false,
+      // The environment supports optional chaining ('obj?.a' or 'obj?.()').
+      optionalChaining: true,
+      // The environment supports template literals.
+      templateLiteral: true,
+    },
+  },
+};
+```
+
+## output.filename
+
+- **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **Default:** [output.module](#outputmodule) 为 `true` 时为 `'[name].mjs'`，否则为 `'[name].js'`
+
+This option determines the name of each output bundle. The bundle is written to the directory specified by the [`output.path`](#outputpath) option.
+
+For a single [`entry`](/config/entry.html) point, this can be a static name.
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    filename: 'bundle.js',
+  },
+};
+```
+
+However, when creating multiple bundles via more than one entry point, code splitting, or various plugins, you should use one of the following substitutions to give each bundle a unique name...
+
+:::info Description of other cases where multiple bundles can be split
+
+Rspack performs code splitting optimizations on user input code, which may include, but are not limited to, code splitting, bundle splitting, or splitting implemented through other plugins. These splitting actions can result in multiple bundles being generated, so the filenames of the bundles need to be generated dynamically.
+
+{
+// TODO: 补充 Glossary link
+}
+
+:::
+
+Use [Entry](/config/entry.html) name:
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[name].bundle.js',
+  },
+};
+```
+
+Using internal chunk id:
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[id].bundle.js',
+  },
+};
+```
+
+Using hashes generated from the generated content:
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[contenthash].bundle.js',
+  },
+};
+```
+
+Combining multiple substitutions:
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[name].[contenthash].bundle.js',
+  },
+};
+```
+
+Using the function to return the filename:
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: pathData => {
+      return pathData.chunk.name === 'main' ? '[name].js' : '[name]/[name].js';
+    },
+  },
+};
+```
+
+Note this option is called filename but you are still allowed to use something like `'js/[name]/bundle.js'` to create a folder structure.
+
+Note this option does not affect output files for on-demand-loaded chunks. It only affects output files that are initially loaded. For on-demand-loaded chunk files, the [`output.chunkFilename`](#outputchunkfilename) option is used. Files created by loaders also aren't affected. In this case, you would have to try the specific loader's available options.
 
 ## Template String
 
@@ -489,95 +478,76 @@ Content that can be replaced at the module level.
 
 Content that can be replaced at the file level.
 
-| template | description                                                                                           |
-| -------- | ----------------------------------------------------------------------------------------------------- |
-| [query]  | The file query, containing `? `                                                                       |
-| [path]   | The path to the file, without the filename                                                            |
-| [name]   | file name, without extension and file path                                                            |
-| [ext]    | extension, contains `. ` (only available in [output.assetModuleFilename](#outputassetmodulefilename)) |
+| Template   | Description                                                                       |
+| ---------- | --------------------------------------------------------------------------------- |
+| [file]     | Filename and path, without query or fragment                                      |
+| [query]    | Query with leading `?`                                                            |
+| [fragment] | Fragment with leading `#`                                                         |
+| [base]     | Only filename (including extensions), without path                                |
+| [filebase] | Same, but deprecated                                                              |
+| [path]     | Only path, without filename                                                       |
+| [name]     | Only filename without extension or path                                           |
+| [ext]      | Extension with leading `.` (not available for [output.filename](#outputfilename)) |
 
-## output.auxiliaryComment
+Substitutions available on URL-level:
 
-Prefer to use [`output.library.auxiliaryComment`](#outputlibraryauxiliarycomment) instead.
+| Template | Description |
+| -------- | ----------- |
+| [url]    | URL         |
 
-- **Type:** `string` | `object`
+:::tip
 
-When used in tandem with [`output.library`](#outputlibrary) and [`output.libraryTarget`](#outputlibrarytarget), this option allows users to insert comments within the export wrapper. To insert the same comment for each `libraryTarget` type, set `auxiliaryComment` to a string:
+`[file]` equals `[path][base]`. `[base]` equals `[name][ext]`. The full path is `[path][name][ext][query][fragment]` or `[path][base][query][fragment]` or `[file][query][fragment]`.
 
-```javascript title=rspack.config.js
-module.exports = {
-  //...
-  output: {
-    library: 'someLibName',
-    libraryTarget: 'umd',
-    filename: 'someLibName.js',
-    auxiliaryComment: 'Test Comment',
-  },
-};
-```
+:::
 
-which will yield the following:
+The length of hashes (`[hash]`, `[contenthash]` or `[chunkhash]`) can be specified using `[hash:16]` (defaults to 20). Alternatively, specify [`output.hashDigestLength`](#outputhashdigestlength) to configure the length globally.
 
-**someLibName.js**
+It is possible to filter out placeholder replacement when you want to use one of the placeholders in the actual file name. For example, to output a file `[name].js`, you have to escape the `[name]` placeholder by adding backslashes between the brackets. So that `[\name\]` generates `[name]` instead of getting replaced with the `name` of the asset.
 
-```javascript
-(function webpackUniversalModuleDefinition(root, factory) {
-  // Test Comment
-  if (typeof exports === 'object' && typeof module === 'object')
-    module.exports = factory(require('lodash'));
-  // Test Comment
-  else if (typeof define === 'function' && define.amd)
-    define(['lodash'], factory);
-  // Test Comment
-  else if (typeof exports === 'object')
-    exports['someLibName'] = factory(require('lodash'));
-  // Test Comment
-  else root['someLibName'] = factory(root['_']);
-})(this, function (__WEBPACK_EXTERNAL_MODULE_1__) {
-  // ...
-});
-```
+Example: `[\id\]` generates `[id]` instead of getting replaced with the `id`.
 
-For fine-grained control over each `libraryTarget` comment, pass an object:
-
-```javascript title=rspack.config.js
-module.exports = {
-  //...
-  output: {
-    //...
-    auxiliaryComment: {
-      root: 'Root Comment',
-      commonjs: 'CommonJS Comment',
-      commonjs2: 'CommonJS2 Comment',
-      amd: 'AMD Comment',
-    },
-  },
-};
-```
-
-## output.enabledLibraryTypes
-
-- **Type:** `[string]`
-
-List of library types enabled for use by entry points.
+If using a function for this option, the function will be passed an object containing data for the substitutions in the table above.
+Substitutions will be applied to the returned string too.
+The passed object will have this type: (properties available depending on context)
 
 ```javascript
-module.exports = {
-  //...
-  output: {
-    enabledLibraryTypes: ['module'],
-  },
+type PathData = {
+  hash: string;
+  hashWithLength: (number) => string;
+  chunk: Chunk | ChunkPathData;
+  module: Module | ModulePathData;
+  contentHashType: string;
+  contentHash: string;
+  contentHashWithLength: (number) => string;
+  filename: string;
+  url: string;
+  runtime: string | SortableSet<string>;
+  chunkGraph: ChunkGraph;
+};
+type ChunkPathData = {
+  id: string | number;
+  name: string;
+  hash: string;
+  hashWithLength: (number) => string;
+  contentHash: Record<string, string>;
+  contentHashWithLength: Record<string, (number) => string>;
+};
+type ModulePathData = {
+  id: string | number;
+  hash: string;
+  hashWithLength: (number) => string;
 };
 ```
 
 ## output.globalObject
 
 - **Type:** `string`
-- **Default:** `self`
+- **Default:** `'self'`
 
-When targeting a library, especially when `libraryTarget` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`. Defaults to `self` for Web-like targets.
+When targeting a library, especially when `library.type` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`. Defaults to `self` for Web-like targets.
 
-The return value of your entry point will be assigned to the global object using the value of `output.library.name`. Depending on the value of the `target` option, the global object could change respectively, e.g., `self`, `global`, or `globalThis`.
+The return value of your entry point will be assigned to the global object using the value of `output.library.name`. Depending on the value of the `type` option, the global object could change respectively, e.g., `self`, `global`, or `globalThis`.
 
 For example:
 
@@ -603,9 +573,13 @@ The encoding to use when generating the hash. Using `'base64'` for filenames mig
 ## output.hashDigestLength
 
 - **Type:** `number`
-- **Default:** `'20'`
+- **Default:** `20`
 
 The prefix length of the hash digest to use.
+
+:::tip
+The default value for `hashDigestLength` is `20`. When the feature [`experiments.futureDefaults`](/config/experiments#experimentsfuturedefaults) is enabled, it will use `16` as the default value.
+:::
 
 ## output.hashFunction
 
@@ -614,18 +588,96 @@ The prefix length of the hash digest to use.
 
 The hashing algorithm to use.
 
+```javascript title=rspack.config.js
+module.exports = {
+  //...
+  output: {
+    hashFunction: 'xxhash64',
+  },
+};
+```
+
 :::tip
 `hashFunction` supports `xxhash64` as a faster algorithm, which will be used as default when [`experiments.futureDefaults`](/config/experiments#experimentsfuturedefaults) is enabled.
 :::
 
 ## output.hashSalt
 
+- **Type:** `string`
+- **Default:** `undefined`
+
 An optional salt to update the hash.
+
+## output.hotUpdateChunkFilename
+
+<ApiMeta addedVersion={'0.3.5'} />
+
+- **Type:** `string`
+- **Default:** `"[id].[fullhash].hot-update.js"`
+
+Customize the filenames of hot update chunks. See [`output.filename`](#outputfilename) option for details on the possible values.
+
+The only placeholders allowed here are `[id]` and `[fullhash]`, the default being:
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    hotUpdateChunkFilename: '[id].[fullhash].hot-update.js',
+  },
+};
+```
+
+:::tip
+Typically you don't need to change `output.hotUpdateChunkFilename`.
+:::
+
+## output.hotUpdateGlobal
+
+<ApiMeta addedVersion={'0.3.5'} />
+
+- **Type:** `string`
+- **Default:** `"webpackHotUpdate" + output.uniqueName`
+
+Only used when [`target`](/config/target) is set to `'web'`, which uses JSONP for loading hot updates.
+
+A JSONP function is used to asynchronously load hot-update chunks.
+
+For details see [`output.chunkLoadingGlobal`](#outputchunkloadingglobal).
+
+## output.hotUpdateMainFilename
+
+<ApiMeta addedVersion={'0.3.5'} />
+
+- **Type:** `string`
+- **Default:** `"[runtime].[fullhash].hot-update.json"`
+
+Customize the main hot update filename. `[fullhash]` and `[runtime]` are available as placeholder.
+
+:::tip
+Typically you don't need to change `output.hotUpdateMainFilename`.
+:::
+
+## output.iife
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Tells Rspack to add [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) wrapper around emitted code.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    iife: true,
+  },
+};
+```
 
 ## output.importFunctionName
 
 - **Type:** `string`
-- **Default:** `import`
+- **Default:** `'import'`
 
 The name of the native `import()` function. Can be used for polyfilling, e.g. with [`dynamic-import-polyfill`](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
 
@@ -680,7 +732,7 @@ In the above example, we're passing a single entry file to `entry`, however, Rsp
    ```js
    module.exports = {
      // …
-     entry: ['./src/a.js', './src/b.js'], // only exports in b.js will be exposed
+     entry: ['./src/a.js', './src/b.js'], // 只有在 b.js 中导出的内容才会被暴露
      output: {
        library: 'MyLibrary',
      },
@@ -744,6 +796,10 @@ window['clientContainer'].define(/*define args*/); // or 'amd-require' window['c
 
 ### output.library.name
 
+Specify a name for the library.
+
+- **Type:** `string | string[] | {amd?: string, commonjs?: string, root?: string | string[]}`
+
 ```js
 module.exports = {
   // …
@@ -754,14 +810,6 @@ module.exports = {
   },
 };
 ```
-
-Specify a name for the library.
-
-- **Type:**
-
-  ```js
-  string | string[] | {amd?: string, commonjs?: string, root?: string | string[]}
-  ```
 
 ### output.library.type
 
@@ -779,7 +827,7 @@ These options assign the return value of the entry point (e.g. whatever the entr
 
 ##### type: 'var'
 
-```js
+```js title="rspack.config.js"
 module.exports = {
   // …
   output: {
@@ -796,7 +844,7 @@ When your library is loaded, the **return value of your entry point** will be as
 ```javascript
 var MyLibrary = _entry_return_;
 
-// In a separate script with `MyLibrary` loaded…
+// 在加载了 `MyLibrary` 的单独脚本中
 MyLibrary.doSomething();
 ```
 
@@ -877,9 +925,9 @@ The **return value of your entry point** will be assigned to `this` under the pr
 ```javascript
 this['MyLibrary'] = _entry_return_;
 
-// In a separate script...
+// 在一个单独的脚本中
 this.MyLibrary.doSomething();
-MyLibrary.doSomething(); // if `this` is window
+MyLibrary.doSomething(); // 如果 `this` 为 window 对象
 ```
 
 ##### type: 'window'
@@ -948,11 +996,34 @@ exports['MyLibrary'] = _entry_return_;
 require('MyLibrary').doSomething();
 ```
 
+:::warning
 Note that not setting a `output.library.name` will cause all properties returned by the entry point to be assigned to the given object; there are no checks against existing property names.
+:::
 
 #### Module Definition Systems
 
 These options will result in a bundle that comes with a complete header to ensure compatibility with various module systems. The `output.library.name` option will take on a different meaning under the following `output.library.type` options.
+
+##### type: 'module'
+
+```js title="rspack.config.js"
+module.exports = {
+  // …
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    library: {
+      // do not specify a `name` here
+      type: 'module',
+    },
+  },
+};
+```
+
+Output ES Module.
+
+However this feature is still experimental and not fully supported yet, so make sure to enable [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) beforehand. In addition, you can track the development progress in [this thread](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975).
 
 ##### type: 'commonjs2'
 
@@ -978,7 +1049,9 @@ require('MyLibrary').doSomething();
 
 If we specify `output.library.name` with `type: commmonjs2`, the return value of your entry point will be assigned to the `module.exports.[output.library.name]`.
 
-Wondering the difference between CommonJS and CommonJS2 is? While they are similar, there are some subtle differences between them that are not usually relevant in the context of rspack. (For further details, please [read this issue](https://github.com/webpack/webpack/issues/1114).)
+:::tip
+Wondering the difference between CommonJS and CommonJS2 is? While they are similar, there are some subtle differences between them that are not usually relevant in the context of Rspack. (For further details, please [read this issue](https://github.com/webpack/webpack/issues/1114).)
+:::
 
 ##### type: 'commonjs-static'
 
@@ -1024,7 +1097,75 @@ Consumption (ESM):
 import { doSomething } from './output.cjs'; // doSomething => [Function: doSomething]
 ```
 
+:::tip
 This is useful when source code is written in ESM and the output should be compatible with both CJS and ESM. For further details, please [read this issue](https://github.com/webpack/webpack/issues/14998) or [this article](https://dev.to/jakobjingleheimer/configuring-commonjs-es-modules-for-nodejs-12ed) (specifically, [this section](https://dev.to/jakobjingleheimer/configuring-commonjs-es-modules-for-nodejs-12ed#publish-only-a-cjs-distribution-with-property-exports)).
+:::
+
+##### type: 'amd'
+
+This will expose your library as an AMD module.
+
+AMD modules require that the entry chunk (e.g. the first script loaded by the `<script>` tag) be defined with specific properties, such as to `define` and `require` which is typically provided by RequireJS or any compatible loaders (such as almond). Otherwise, loading the resulting AMD bundle directly will result in an error like `define is not defined`.
+
+With the following configuration...
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'amd',
+    },
+  },
+};
+```
+
+The generated output will be defined with the name `"MyLibrary"`, i.e.:
+
+```js
+define('MyLibrary', [], function () {
+  return _entry_return_;
+});
+```
+
+The bundle can be included as part of a script tag, and the bundle can be invoked like so:
+
+```js
+require(['MyLibrary'], function (MyLibrary) {
+  // Do something with the library...
+});
+```
+
+If `output.library.name` is undefined, the following is generated instead.
+
+```js
+define(function () {
+  return _entry_return_;
+});
+```
+
+This bundle will not work as expected, or not work at all (in the case of the almond loader) if loaded directly with a `<script>` tag. It will only work through a RequireJS compatible asynchronous module loader through the actual path to that file, so in this case, the `output.path` and `output.filename` may become important for this particular setup if these are exposed directly on the server.
+
+##### type: 'amd-require'
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'amd-require',
+    },
+  },
+};
+```
+
+This packages your output with an immediately executed AMD `require(dependencies, factory)` wrapper.
+
+The `'amd-require'` type allows for the use of AMD dependencies without needing a separate later invocation. As with the `'amd'` type, this depends on the appropriate [`require` function](https://github.com/amdjs/amdjs-api/blob/master/require.md) being available in the environment in which the Rspack output is loaded.
+
+With this type, the library name can't be used.
 
 ##### type: 'umd'
 
@@ -1107,7 +1248,7 @@ module.exports = {
 
 This will expose your library as a [`System.register`](https://github.com/systemjs/systemjs/blob/master/docs/system-register.md) module.
 
-System modules require that a global variable `System` is present in the browser when the bundle is executed. Compiling to `System.register` format allows you to `System.import('/bundle.js')` without additional configuration and has your bundle loaded into the System module registry.
+System modules require that a global variable `System` is present in the browser when the Rspack bundle is executed. Compiling to `System.register` format allows you to `System.import('/bundle.js')` without additional configuration and has your Rspack bundle loaded into the System module registry.
 
 ```javascript
 module.exports = {
@@ -1148,33 +1289,84 @@ System.register(
 );
 ```
 
-##### type: 'module'
+#### Other Types
 
-```js
+**type: 'jsonp'**
+
+```js title="rspack.config.js"
 module.exports = {
   // …
-  experiments: {
-    outputModule: true,
-  },
   output: {
-    chunkFormat: 'module',
     library: {
-      // do not specify a `name` here
-      type: 'module',
+      name: 'MyLibrary',
+      type: 'jsonp',
     },
   },
 };
 ```
 
-Output ES Module.
+This will wrap the return value of your entry point into a jsonp wrapper.
 
-However this feature is still experimental and not fully supported yet, so make sure to enable [experiments.outputModule](/config/experiments.html) beforehand.
+```js
+MyLibrary(_entry_return_);
+```
+
+The dependencies for your library will be defined by the [`externals`](/config/externals) config.
+
+### output.library.export
+
+Specify which export should be exposed as a library.
+
+- **Type:** `string | string[]`
+- **Default:** `undefined`
+
+It is `undefined` by default, which will export the whole (namespace) object. The examples below demonstrate the effect of this configuration when using [`output.library.type: 'var'`](#type-var).
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'var',
+      export: 'default',
+    },
+  },
+};
+```
+
+The default export of your entry point will be assigned to the library name:
+
+```js
+// 如果你的库有默认导出
+var MyLibrary = _entry_return_.default;
+```
+
+You can pass an array to `output.library.export` as well, it will be interpreted as a path to a module to be assigned to the library name:
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'var',
+      export: ['default', 'subModule'],
+    },
+  },
+};
+```
+
+And here's the library code:
+
+```js
+var MyLibrary = _entry_return_.default.subModule;
+```
 
 ### output.library.auxiliaryComment
 
 Add a comment in the UMD wrapper.
 
 - **Type:** `string | { amd?: string, commonjs?: string, commonjs2?: string, root?: string }`
+- **Default:** `undefined`
 
 To insert the same comment for each `umd` type, set `auxiliaryComment` to a string:
 
@@ -1231,56 +1423,10 @@ module.exports = {
 };
 ```
 
-### output.library.export
-
-Specify which export should be exposed as a library.
-
-- **Type:** `string | string[]`
-
-It is `undefined` by default, which will export the whole (namespace) object. The examples below demonstrate the effect of this configuration when using [`output.library.type: 'var'`](#type-var).
-
-```js
-module.exports = {
-  output: {
-    library: {
-      name: 'MyLibrary',
-      type: 'var',
-      export: 'default',
-    },
-  },
-};
-```
-
-The default export of your entry point will be assigned to the library name:
-
-```js
-// if your entry has a default export
-var MyLibrary = _entry_return_.default;
-```
-
-You can pass an array to `output.library.export` as well, it will be interpreted as a path to a module to be assigned to the library name:
-
-```js
-module.exports = {
-  output: {
-    library: {
-      name: 'MyLibrary',
-      type: 'var',
-      export: ['default', 'subModule'],
-    },
-  },
-};
-```
-
-And here's the library code:
-
-```js
-var MyLibrary = _entry_return_.default.subModule;
-```
-
-## output.library.umdNamedDefine
+### output.library.umdNamedDefine
 
 - **Type:** `boolean`
+- **Default:** `undefined`
 
 When using `output.library.type: "umd"`, setting `output.library.umdNamedDefine` to `true` will name the AMD module of the UMD build. Otherwise, an anonymous `define` is used.
 
@@ -1303,69 +1449,196 @@ The AMD module will be:
 define('MyLibrary', [], factory);
 ```
 
-## output.libraryExport \{#outputlibraryexport-1}
+## output.module
 
-:::warning
-We might drop support for this, so prefer to use [output.library.export](#outputlibraryexport) which works the same as `libraryExport`.
-:::
-
-- **Type:** `string` | `string[]`
-
-Configure which module or modules will be exposed via the `libraryTarget`. It is `undefined` by default, same behaviour will be applied if you set `libraryTarget` to an empty string e.g. `''` it will export the whole (namespace) object. The examples below demonstrate the effect of this configuration when using `libraryTarget: 'var'`.
-
-The following configurations are supported:
-
-`libraryExport: 'default'` - The **default export of your entry point** will be assigned to the library target:
-
-```javascript
-// if your entry has a default export of `MyDefaultModule`
-var MyDefaultModule = _entry_return_.default;
-```
-
-`libraryExport: 'MyModule'` - The **specified module** will be assigned to the library target:
-
-```javascript
-var MyModule = _entry_return_.MyModule;
-```
-
-`libraryExport: ['MyModule', 'MySubModule']` - The array is interpreted as a **path to a module** to be assigned to the library target:
-
-```javascript
-var MySubModule = _entry_return_.MyModule.MySubModule;
-```
-
-With the `libraryExport` configurations specified above, the resulting libraries could be utilized as such:
-
-```javascript
-MyDefaultModule.doSomething();
-MyModule.doSomething();
-MySubModule.doSomething();
-```
-
-## output.libraryTarget
-
-- **Type:** `string`
-- **Default:** `var`
-
-:::warning
-Please use [`output.library.type`](#outputlibrarytype) instead as we might drop support for `output.libraryTarget` in the future.
-:::
-
-## output.umdNamedDefine
-
-:::warning
-Prefer to use [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine) instead.
-:::
+<ApiMeta stability={Stability.Experimental} />
 
 - **Type:** `boolean`
+- **Default:** `false`
 
-When using `libraryTarget: "umd"`, setting `output.umdNamedDefine` to `true` will name the AMD module of the UMD build. Otherwise an anonymous `define` is used.
+Output JavaScript files as module type. Disabled by default as it's an experimental feature. To use it, you must set [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) to `true`.
 
-```javascript
+When enabled, Rspack will set [`output.iife`](#outputiife) to `false`, [`output.scriptType`](#outputscripttype) to `'module'` and `terserOptions.module` to `true` internally.
+
+If you're using Rspack to compile a library to be consumed by others, make sure to set [`output.libraryTarget`](#librarytarget-module) to `'module'` when `output.module` is `true`.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    module: true,
+  },
+};
+```
+
+## output.path
+
+- **Type:** `string`
+- **Default:** `path.resolve(process.cwd(), 'dist')`
+
+The output directory as an **absolute** path.
+
+```js title="rspack.config.js"
+const path = require('path');
+
+module.exports = {
+  output: {
+    path: path.resolve(__dirname, 'dist/assets'),
+  },
+};
+```
+
+Note that `[fullhash]` in this parameter will be replaced with a hash of the compilation.
+
+:::warning
+The path must not contain an exclamation mark (`!`) as it is reserved by Rspack for loader syntax).
+:::
+
+## output.pathinfo
+
+- **Type:** `boolean | 'verbose'`
+- **Default:** `true`
+
+Tells Rspack to include comments in bundles with information about the contained modules. This option defaults to `true` in `development` and `false` in `production` [mode](/config/mode) respectively. `'verbose'` shows more information like exports, runtime requirements and bailouts.
+
+:::warning
+While the data these comments can provide is useful during development when reading the generated code, it **should not** be used in production.
+:::
+
+```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    umdNamedDefine: true,
+    pathinfo: true,
+  },
+};
+```
+
+:::tip
+It also adds some info about tree shaking to the generated bundle.
+:::
+
+## output.publicPath
+
+- **Type:** `string`
+- **Default:** targets 为 `'web'` 或 `'webworker'` 时为 `'auto'`
+
+This option determines the URL prefix of the referenced resource, such as: image, file, etc.
+
+For example, given a configuration file.
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    publicPath: '/assets/',
+    chunkFilename: '[id].chunk.js',
+    assetModuleFilename: '[name][ext]',
+  },
+};
+```
+
+For a non-initial chunk file, its request URL looks like this: `/assets/1.chunk.js`.
+
+For a reference to an image, the request URL looks like this: `/assets/logo.png`.
+
+Also, it is useful when you deploy the product using a CDN
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    publicPath: 'https://cdn.example.com/assets/',
+    assetModuleFilename: '[name][ext]',
+  },
+};
+```
+
+For all asset resources, their request URLs look like this: `https://cdn.example.com/assets/logo.png`.
+
+**Dynamically set publicPath**
+
+You can set `publicPath` dynamically using `__webpack_public_path__` in the runtime code, and the `__webpack_public_path__` will override the `publicPath` in the Rspack config, but it will only take effect for dynamically loaded resources.
+
+First create a `publicPath.js`:
+
+```js title="publicPath.js"
+__webpack_public_path__ = 'https://cdn.example.com/assets/';
+```
+
+Then import it into the first line of the entry file:
+
+```js title="entry.js"
+import './publicPath.js';
+import './others.js';
+```
+
+## output.scriptType
+
+- **Type:** `'module' | 'text/javascript' | boolean`
+- **Default:** `false`
+
+This option allows loading asynchronous chunks with a custom script type, such as `<script type="module" ...>`.
+
+:::tip
+If [`output.module`](#outputmodule) is set to `true`, `output.scriptType` will default to `'module'` instead of `false`.
+:::
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    scriptType: 'module',
+  },
+};
+```
+
+## output.sourceMapFilename
+
+- **Type:** `string`
+- **Default:** `'[file].map[query]'`
+
+Configure how source maps are named. Only takes effect when [`devtool`](/config/devtool) is set to `'source-map'`, which writes an output file.
+
+The `[name]`, `[id]`, `[fullhash]` and `[chunkhash]` substitutions from [`output.filename`](#outputfilename) can be used. In addition to those, you can use substitutions listed under Filename-level in [Template strings](#template-strings).
+
+## output.strictModuleErrorHandling
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Handle error in module loading as per EcmaScript Modules spec at a performance cost.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    strictModuleErrorHandling: true,
+  },
+};
+```
+
+## output.trustedTypes
+
+- **Type:** `true | string | object`
+- **Default:** `undefined`
+
+Controls [Trusted Types](https://web.dev/trusted-types) compatibility. When enabled, Rspack will detect Trusted Types support and, if they are supported, use Trusted Types policies to create script URLs it loads dynamically. Use when the application runs under a [`require-trusted-types-for`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) Content Security Policy directive.
+
+It is disabled by default (no compatibility, script URLs are strings).
+
+- When set to `true`, Rspack will use [`output.uniqueName`](#outputuniquename) as the Trusted Types policy name.
+- When set to a non-empty string, its value will be used as a policy name.
+- When set to an object, the policy name is taken from the object's `policyName` property.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    trustedTypes: {
+      policyName: 'my-application#webpack',
+    },
   },
 };
 ```
@@ -1373,13 +1646,13 @@ module.exports = {
 ## output.uniqueName
 
 - **Type:** `string`
-- **Default:** It defaults to [`output.library`](/config/output#outputlibrary) name or the package name from package.json in the context, if both aren't found, it is set to an ''.
+- **Default:** It defaults to [`output.library`](#outputlibrary) name or the package name from `package.json` in the context, if both aren't found, it is set to an `''`.
 
-This option determines the unique name of the Rspack build to avoid multiple Rspack runtimes to conflict when using globals.
+A unique name of the Rspack build to avoid multiple Rspack runtimes to conflict when using globals.
 
 `output.uniqueName` will be used to generate unique globals for:
 
-- [`output.chunkLoadingGlobal`](/config/output#outputchunkloadingglobal)
+- [`output.chunkLoadingGlobal`](#outputchunkloadingglobal)
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -1389,40 +1662,33 @@ module.exports = {
 };
 ```
 
-## output.clean
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Clean the output directory before emit.
-
-## output.module
-
-<ApiMeta stability={Stability.Experimental} />
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Output JavaScript files as module type. Disabled by default as it's an experimental feature. `output.module` is an experimental feature and can only be enabled by setting [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) to true.
-
 ## output.wasmLoading
 
 - **Type:** `false | 'fetch', 'async-node'`
 - **Default:** `'fetch'`
 
-Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/webworker), `'async-node'` (Node.js).
+Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/WebWorker), `'async-node'` (Node.js), but others might be added by plugins.
 
-The default value can be affected by different target:
+The default value can be affected by different [`target`](/config/target):
 
-- Defaults to `'fetch'` if target is set to `'web'`, `'webworker'`, `'electron-renderer'` or `'node-webkit'`.
-- Defaults to `'async-node'` if target is set to `'node'`, `'async-node'`, `'electron-main'` or `'electron-preload'`.
+- Defaults to `'fetch'` if [`target`](/config/target) is set to `'web'`, `'webworker'`, `'electron-renderer'` or `'node-webkit'`.
+- Defaults to `'async-node'` if [`target`](/config/target) is set to `'node'`, `'async-node'`, `'electron-main'` or `'electron-preload'`.
+
+```javascript title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    wasmLoading: 'fetch',
+  },
+};
+```
 
 ## output.webassemblyModuleFilename
 
 - **Type:** `string`
 - **Default:** `'[hash].module.wasm'`
 
-Specifies the filename of WebAssembly modules. It should be provided as a relative path within the `output.path` directory.
+Specifies the filename of WebAssembly modules. It should be provided as a relative path within the `output.path` directory
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -1433,60 +1699,80 @@ module.exports = {
 };
 ```
 
-## output.enabledWasmLoadingTypes
+## output.workerChunkLoading
 
-Enables available runtime module bundling of wasmLoadingType.
+- **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
+- **Default:** `false`
 
-- **Type:** `false | 'fetch', 'async-node'`
+The new option `workerChunkLoading` controls the chunk loading of workers.
 
-## output.asyncChunks
-
-<ApiMeta addedVersion={'0.2.6'} />
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Create async chunks that are loaded on demand.
-
-## output.hotUpdateChunkFilename
-
-<ApiMeta addedVersion={'0.3.5'} />
-
-- **Type:** `string`
-- **Default:** `"[id].[fullhash].hot-update.js"`
-
-Customize the filenames of hot update chunks, only placeholders allowed here are `[id]` and `[fullhash]`.
-
-## output.hotUpdateMainFilename
-
-<ApiMeta addedVersion={'0.3.5'} />
-
-- **Type:** `string`
-- **Default:** `"[runtime].[fullhash].hot-update.json"`
-
-Customize the main hot update filename. `[fullhash]` and `[runtime]` are available as placeholder.
-
-## output.hotUpdateGlobal
-
-<ApiMeta addedVersion={'0.3.5'} />
-
-- **Type:** `string`
-- **Default:** `"webpackHotUpdate" + output.uniqueName`
-
-Only used when [chunkLoading](/config/output#outputchunkloading) is `"jsonp"` or `"import-scripts"`. This global variable is used for loading hot update chunks.
-
-## output.iife
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Tells Rspack to add IIFE wrapper around emitted code.
+:::tip
+The default value of this option depends on the [`target`](/config/target) setting. For more details, search for `"workerChunkLoading"` [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
+:::
 
 ```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    iife: true,
+    workerChunkLoading: false,
   },
 };
 ```
+
+## output.workerPublicPath
+
+- **Type:** `string`
+- **Default:** `""`
+
+Set a public path for Worker, defaults to value of [output.publicPath](#outputpublicpath). Only use this option if your worker scripts are located in a different path from your other scripts.
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    workerPublicPath: '/workerPublicPath2/',
+  },
+};
+```
+
+## output.workerWasmLoading
+
+- **Type:** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
+- **Default:** `false`
+
+Option to set the method of loading WebAssembly Modules in workers, defaults to the value of [output.wasmLoading](#outputwasmloading).
+
+````js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    workerWasmLoading: 'fetch',
+  },
+};
+```import { de } from 'date-fns/locale';
+
+````
+
+## output.auxiliaryComment
+
+:::warning
+Prefer to use [`output.library.auxiliaryComment`](#outputlibraryauxiliarycomment) instead.
+:::
+
+## output.libraryExport \{#outputlibraryexport-1}
+
+:::warning
+We might drop support for this, so prefer to use [output.library.export](#outputlibraryexport) which works the same as `libraryExport`.
+:::
+
+## output.libraryTarget
+
+:::warning
+Please use [`output.library.type`](#outputlibrarytype) instead as we might drop support for `output.libraryTarget` in the future.
+:::
+
+## output.umdNamedDefine
+
+:::warning
+Prefer to use [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine) instead.
+:::

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -925,7 +925,7 @@ The **return value of your entry point** will be assigned to `this` under the pr
 ```javascript
 this['MyLibrary'] = _entry_return_;
 
-// 在一个单独的脚本中
+// In a separate script
 this.MyLibrary.doSomething();
 MyLibrary.doSomething(); // 如果 `this` 为 window 对象
 ```

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -110,7 +110,7 @@ module.exports = {
 
 - **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
 
-The method to load chunks (methods included by default are `'jsonp'` (web), `'import'` (ESM), `'importScripts'` (WebWorker), `'require'` (sync node.js), `'async-node'` (async node.js), but others might be added by plugins). The default value will be determined based on the configuration of [`target`](#target) and [`chunkFormat`](#outputchunkformat).
+The method to load chunks (methods included by default are `'jsonp'` (web), `'import'` (ESM), `'importScripts'` (webworker), `'require'` (sync node.js), `'async-node'` (async node.js), but others might be added by plugins). The default value will be determined based on the configuration of [`target`](#target) and [`chunkFormat`](#outputchunkformat).
 
 :::tip
 
@@ -228,7 +228,7 @@ module.exports = {
 
 The following substitutions are available in template strings
 
-| Template                     | Description                                                                                                |
+| Template                 | Description                                                                                         |
 | ------------------------ | --------------------------------------------------------------------------------------------------- |
 | [absolute-resource-path] | The absolute filename                                                                               |
 | [all-loaders]            | Automatic and explicit loaders and params up to the name of the first loader                        |
@@ -511,7 +511,7 @@ If using a function for this option, the function will be passed an object conta
 Substitutions will be applied to the returned string too.
 The passed object will have this type: (properties available depending on context)
 
-```javascript
+```ts
 type PathData = {
   hash: string;
   hashWithLength: (number) => string;
@@ -1667,7 +1667,7 @@ module.exports = {
 - **Type:** `false | 'fetch', 'async-node'`
 - **Default:** `'fetch'`
 
-Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/WebWorker), `'async-node'` (Node.js), but others might be added by plugins.
+Option to set the method of loading WebAssembly Modules. Methods included by default are `'fetch'` (web/webworker), `'async-node'` (Node.js), but others might be added by plugins.
 
 The default value can be affected by different [`target`](/config/target):
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -927,7 +927,7 @@ this['MyLibrary'] = _entry_return_;
 
 // In a separate script
 this.MyLibrary.doSomething();
-MyLibrary.doSomething(); // 如果 `this` 为 window 对象
+MyLibrary.doSomething(); // if `this` is window
 ```
 
 ##### type: 'window'

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -79,7 +79,7 @@ The format of chunks (formats included by default are `'array-push'` (web/WebWor
 
 :::tip
 
-The default value of this option depends on the [`target`](/config/target) and [`output.module`](#outputmodule setting. For more details, search for "chunkFormat" [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
+The default value of this option depends on the [`target`](/config/target) and [`output.module`](#outputmodule) setting. For more details, search for "chunkFormat" [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
 
 :::
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -114,7 +114,7 @@ The method to load chunks (methods included by default are `'jsonp'` (web), `'im
 
 :::tip
 
-The default value of this option depends on the [`target`](/config/target) and [`chunkFormat `](#chunkFormat) setting. For more details, search for `"chunkLoading"` [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
+The default value of this option depends on the [`target`](/config/target) and [`chunkFormat`](#chunkFormat) setting. For more details, search for `"chunkLoading"` [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
 
 :::
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -375,7 +375,7 @@ However, when creating multiple bundles via more than one entry point, code spli
 Rspack performs code splitting optimizations on user input code, which may include, but are not limited to, code splitting, bundle splitting, or splitting implemented through other plugins. These splitting actions can result in multiple bundles being generated, so the filenames of the bundles need to be generated dynamically.
 
 {
-// TODO: 补充 Glossary link
+// TODO: add the Glossary link
 }
 
 :::

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -354,7 +354,7 @@ module.exports = {
 ## output.filename
 
 - **Type:** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **Default:** [output.module](#outputmodule) 为 `true` 时为 `'[name].mjs'`，否则为 `'[name].js'`
+- **Default:** When `[output.module](#outputmodule)` is `true`, it is `'[name].mjs'`, otherwise it is `'[name].js'`.
 
 This option determines the name of each output bundle. The bundle is written to the directory specified by the [`output.path`](#outputpath) option.
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -228,7 +228,7 @@ module.exports = {
 
 The following substitutions are available in template strings
 
-| 模板                     | 描述                                                                                                |
+| Template                     | Description                                                                                                |
 | ------------------------ | --------------------------------------------------------------------------------------------------- |
 | [absolute-resource-path] | The absolute filename                                                                               |
 | [all-loaders]            | Automatic and explicit loaders and params up to the name of the first loader                        |

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -75,7 +75,7 @@ module.exports = {
 - **Type:** `false | 'array-push' | 'commonjs' | 'module' | string`
 - **Default:** Determined by [`target`](/config/target) and [`output.module`](#outputmodule)
 
-The format of chunks (formats included by default are `'array-push'` (web/WebWorker), `'commonjs'` (node.js), `'module'` (ESM), but others might be added by plugins).
+The format of chunks (formats included by default are `'array-push'` (web/webworker), `'commonjs'` (node.js), `'module'` (ESM), but others might be added by plugins).
 
 :::tip
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1337,7 +1337,7 @@ module.exports = {
 The default export of your entry point will be assigned to the library name:
 
 ```js
-// 如果你的库有默认导出
+// If your library has a default export
 var MyLibrary = _entry_return_.default;
 ```
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -844,7 +844,7 @@ When your library is loaded, the **return value of your entry point** will be as
 ```javascript
 var MyLibrary = _entry_return_;
 
-// 在加载了 `MyLibrary` 的单独脚本中
+// In a separate script with `MyLibrary` loaded…
 MyLibrary.doSomething();
 ```
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1107,7 +1107,7 @@ This will expose your library as an AMD module.
 
 AMD modules require that the entry chunk (e.g. the first script loaded by the `<script>` tag) be defined with specific properties, such as to `define` and `require` which is typically provided by RequireJS or any compatible loaders (such as almond). Otherwise, loading the resulting AMD bundle directly will result in an error like `define is not defined`.
 
-With the following configuration...
+With the following configuration:
 
 ```js title="rspack.config.js"
 module.exports = {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -5,7 +5,7 @@ import { ApiMeta, Stability } from '../../../components/ApiMeta';
 
 # Output
 
-输出：该选项用于指示 Rspack 如何以及在哪里输出生成的文件内容。
+顶级的 `output` 包含一组选项，指导 Rspack 如何以及在哪里输出 bundles、assets，以及使用 Rspack 打包或加载的任何其他内容。
 
 - **类型：** `Object`
 
@@ -13,118 +13,73 @@ import { ApiMeta, Stability } from '../../../components/ApiMeta';
 
 - **类型：** `string`
 - **默认值：** `'[hash][ext][query]'`
-- **支持的 Template String：**
-  - [Module Context](/config/output#module-context)
-  - [File Context](/config/output#file-context)
+
+与 [`output.filename`](#outputfilename) 类似，但适用于[资源模块](/guide/features/asset-module)。
+
+`[name]`、`[file]`、`[query]`、`[fragment]`、`[base]` 和 `[path]` 在使用数据 URI 替换构建的资源中被设置为空字符串。
 
 Asset module 输出的文件名称。这个值可以被 [Rule.generator.filename](/config/module#rulegeneratorfilename) 覆盖。
 
 :::info Asset module 作为一个单独的文件输出的情况
 
-- 模块类型为 `'asset'` 且 asset 为满足 [`Rule.parser.dataUrlCondition`](/config/module#ruleparserdataurlcondition) 设定值
+- 模块类型为 `'asset'` 且 asset 满足 [`Rule.parser.dataUrlCondition`](/config/module#ruleparserdataurlcondition) 设定值
 - 模块类型为 `'asset/resource'`
 
 :::
 
-## output.filename
+## output.asyncChunks
 
-- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **默认值：** `'[name].js'`
+<ApiMeta addedVersion={'0.2.6'} />
 
-这个选项决定了输出的 JavaScript bundle 文件名称。这些 bundle 将会被写入 `output.path` 指定的目录下。
+- **类型：** `boolean`
+- **默认值：** `true`
 
-对于单个 [Entry](/config/entry.html) 来说，你可以使用一个静态名称，如：
+是否创建按需加载的异步 chunk。
+
+## output.chunkFilename
+
+- **类型：** `string = '[id].js' | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **默认值：** 当 [`output.filename`](/config/output#outputfilename) 不为函数时，推断 [`output.filename`](/config/output#outputfilename) 推断；否则为 `'[id].js'`。
+
+这个选项决定了非初始块文件的名称。有关可能值的详细信息，请参见 [`output.filename`](/config/output#outputfilename) 选项。
+
+注意，这些文件名需要在运行时生成，以便发送 chunk 的请求。因此，像 `[name]` 和 `[chunkhash]` 这样的占位符需要在 Rspack 运行时将 chunk id 映射到占位符值添加到输出 bundle 中。这会增加大小，并且可能会在任何 chunk 的占位符值更改时使 bundle 的缓存失效。
+
+默认情况下，使用 `[id].js` 或从 [`output.filename`](/config/output#outputfilename) 推断出的值（`[name]` 被替换为 `[id]` 或在前面加上 `[id].`）。
 
 ```js title="rspack.config.js"
 module.exports = {
+  //...
   output: {
-    filename: 'bundle.js',
+    //...
+    chunkFilename: '[id].js',
   },
 };
 ```
 
-而对于多个 [Entry](/config/entry.html)，或其他可以导致拆分出多个 bundle 的情况，你需要使用下面这种方式来动态生成 bundle 的文件名。
-
-:::info 对于拆分成多个 bundle 的情况的描述
-
-Rspack 会对用户输入的代码进行代码拆分优化，这些优化可能包括但不限于：code splitting、bundle splitting，或通过其他插件实现的代码拆分等。
-这些代码拆分的行为会导致生成多个 bundle，因此 bundle 的文件名需要动态生成。
-
-{
-// TODO: 补充 Glossary link
-}
-
-:::
-
-使用 [Entry](/config/entry.html) 名称：
+使用函数：
 
 ```js title="rspack.config.js"
 module.exports = {
+  //...
   output: {
-    filename: '[name].bundle.js',
-  },
-};
-```
-
-使用内部生成的 chunk id：
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: '[id].bundle.js',
-  },
-};
-```
-
-使用根据文件内容生成的 hash：
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: '[contenthash].bundle.js',
-  },
-};
-```
-
-当然你也可以组合使用：
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: '[name].[contenthash].bundle.js',
-  },
-};
-```
-
-使用函数来返回文件名：
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    filename: pathData => {
+    chunkFilename: pathData => {
       return pathData.chunk.name === 'main' ? '[name].js' : '[name]/[name].js';
     },
   },
 };
 ```
 
-更多可以参考 [Template String](/config/output#template-string)。
-
-## output.chunkFilename
-
-- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **默认值：** 根据 [`output.filename`](/config/output#outputfilename) 推断
-- **支持的 Template String：**
-  - [Compilation Context](/config/output#compilation-context)
-  - [Chunk Context](/config/output#chunk-context)
-
-此选项决定了非初始（non-initial）JavaScript chunk 文件的名称。
-
 ## output.chunkFormat
 
-- **类型：** `false | 'array-push' | 'commonjs' | 'module'`
+- **类型：** `false | 'array-push' | 'commonjs' | 'module' | string`
+- **默认值：** 根据 [`target`](/config/target) 和 [`output.module`](#outputmodule) 的配置推断
 
-chunk 产物的格式，默认值会根据 [`target`](/config/target) 和 [`output.module`](#outputmodule) 的配置而决定，一般来说，target 为 web 或 webworker 时会使用 `'array-push'` 格式；为 ESM 时会使用 `'module'` 格式；为 node.js 时会使用 `'commonjs'` 格式
+chunk 产物的格式，一般来说，target 为 web 或 Webworker 时会使用 `'array-push'` 格式；为 ESM 时会使用 `'module'` 格式；为 node.js 时会使用 `'commonjs'` 格式，插件可能会添加其他格式。
+
+:::tip
+这个选项的默认值取决于 [`target`](/config/target) 和 [`output.module`](#outputmodule) 设置。要了解更多详情，请在 Rspack [默认设置中](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts)搜索 `"chunkFormat"`。
+:::
 
 ```js title="rspack.config.js"
 module.exports = {
@@ -134,25 +89,10 @@ module.exports = {
 };
 ```
 
-## output.chunkLoading
-
-- **类型：** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
-
-加载 chunk 的方式，默认值会根据 [`target`](/config/target) 和 [`chunkFormat`](#outputchunkformat) 的配置而决定，一般来说，target 为 web 时会使用 `'jsonp'` 来加载 chunk；为 ESM 时会使用 `'import'` 来加载 chunk；为 webworker 时会使用 `'import-scripts'` 来加载 chunk；为 node.js 时会使用 `'require'` 来加载 chunk；为 async node.js 时会使用 `'async-node'`（`fs.readFile` + `vm.runInThisContext`）来加载 chunk
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    chunkLoading: 'async-node',
-  },
-};
-```
-
 ## output.chunkLoadingGlobal
 
 - **类型：** `string`
 - **默认值：** 根据 [`output.uniqueName`](/config/output#outputuniquename) 推断
-  - `webpackChunk${output.uniqueName}`
 
 此选项决定了 Rspack 用于加载 chunk 的全局变量。
 
@@ -164,9 +104,100 @@ module.exports = {
 };
 ```
 
+## output.chunkLoading
+
+- **类型：** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
+
+加载 chunk 的方式，默认值会根据 [`target`](/config/target) 和 [`chunkFormat`](#outputchunkformat) 的配置而决定，一般来说，target 为 web 时会使用 `'jsonp'` 来加载 chunk；为 ESM 时会使用 `'import'` 来加载 chunk；为 webworker 时会使用 `'import-scripts'` 来加载 chunk；为 node.js 时会使用 `'require'` 来加载 chunk；为 async node.js 时会使用 `'async-node'`（`fs.readFile` + `vm.runInThisContext`）来加载 chunk，插件可能会添加其他格式。
+
+:::tip
+这个选项的默认值取决于 [`target`](/config/target) 和 [`output.chunkFormat`](#chunkFormat) 设置。要了解更多详情，请在 Rspack [默认设置中](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts)搜索 `"chunkLoading"`。
+:::
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    chunkLoading: 'async-node',
+  },
+};
+```
+
+## output.clean
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+在生成产物前，删除输出目录下的所有文件。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    clean: true, // Clean the output directory before emit.
+  },
+};
+```
+
+## output.crossOriginLoading
+
+- **类型：** `false | 'anonymous' | 'use-credentials'`
+- **默认值：** `false`
+
+通过 `crossOriginLoading` 配置项，你可以为动态加载的 chunks 设置 [crossorigin 属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin)。
+
+当 `target` 为 `'web'` 时，Rspack 会动态创建 `<script>` 和 `<link>` 标签来加载异步的 JavaScript 和 CSS 资源。如果这些资源的 URL 在其他域名下，且 `crossOriginLoading` 不为 `false`，那么 Rspack 会为 `<script>` 和 `<link>` 标签添加 `crossorigin` 属性。
+
+**可选值**
+
+`crossOriginLoading` 有以下可选值：
+
+- `false`: 不设置 [crossorigin 属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin)。
+- `'anonymous'`：将 `crossorigin` 设置为 `'anonymous'`，不包含用户凭据来跨域加载资源。
+- `'use-credentials'`：将 `crossorigin` 设置为 `'use-credentials'`，包含用户凭据来跨域加载资源。
+
+**示例**
+
+比如将 `output.publicPath` 设置为 `https://example.com/`，并将 `output.crossOriginLoading` 设置为 `'anonymous'`：
+
+```js title="rspack.config.js"
+const path = require('path');
+
+module.exports = {
+  output: {
+    publicPath: 'https://example.com/',
+    crossOriginLoading: 'anonymous',
+  },
+};
+```
+
+当 Rspack 在加载异步的 JavaScript 资源时，会生成如下的 HTML：
+
+```html
+<script src="https://example.com/foo.js" crossorigin="anonymous"></script>
+```
+
+## output.cssChunkFilename
+
+- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **默认值：** 当 [`output.chunkFilename`](/config/output#outputchunkfilename) 不为函数时，根据 [`output.chunkFilename`](/config/output#outputchunkfilename) 推断；否则为 `'[id].css'`。
+
+此选项决定了非初始（non-initial）CSS chunk 文件的名称，参阅 [`output.filename`](/config/output#outputfilename)，了解可能的值。
+
+在这里不能指定绝对路径。不过，可以随意包括用 `'/'` 分隔的文件夹。这个指定的路径将与 [`output.path`](#outputpath) 值结合，以精确定位磁盘上的位置。
+
+## output.cssFilename
+
+- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **默认值：** 根据 [`output.filename`](/config/output#outputfilename) 推断
+
+此选项决定了 CSS 文件的名称，参阅 [`output.filename`](/config/output#outputfilename)，了解可能的值。
+
+在这里**不能**指定绝对路径。不过，可以随意包括用 `'/'` 分隔的文件夹。这个指定的路径将与 [`output.path`](#outputpath) 值结合，以精确定位磁盘上的位置。
+
 ## output.devtoolFallbackModuleFilenameTemplate
 
 - **类型：** `string` | `function (info)`
+- **默认值：** `undefined`
 
 当模板字符串或函数产生重复时使用的备用内容。
 
@@ -175,12 +206,13 @@ module.exports = {
 ## output.devtoolModuleFilenameTemplate
 
 - **类型：** `string = 'webpack://[namespace]/[resource-path]?[loaders]'` | `function (info) => string`
+- **默认值：** `undefined`
 
 此选项仅在 [`devtool`](/config/devtool.html) 使用了需要模块名称的选项时使用。
 
 自定义每个 source map 的 `sources` 数组中使用的名称。可以通过传递模板字符串或者函数来完成。例如，当使用 `devtool: 'eval'`，默认值是：
 
-```js
+```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
@@ -205,7 +237,7 @@ module.exports = {
 
 当使用一个函数，同样的选项要通过 `info` 参数并使用驼峰式：
 
-```js
+```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
@@ -220,235 +252,191 @@ module.exports = {
 
 ## output.devtoolNamespace
 
+- **类型：** `string`
+- **默认值：** `undefined`
+
 此选项确定 [`output.devtoolModuleFilenameTemplate`](/config/output#outputdevtoolmodulefilenametemplate) 使用的模块名称空间。未指定时的默认值为：[`output.uniqueName`](/config/output#outputuniquename)。在加载多个通过 Rspack 构建的 library 时，用于防止 source map 中源文件路径冲突。
 
 例如，如果你有两个 `library`，分别使用命名空间 `library1` 和 `library2`，并且都有一个文件 `./src/index.js`（可能具有不同内容），它们会将这些文件暴露为 `webpack://library1/./src/index.js` 和 `webpack://library2/./src/index.js`。
 
 ## output.enabledChunkLoadingTypes
 
-- **类型：** `string[]`
+- **类型：** `('jsonp' | 'import-scripts' | 'require' | 'async-node' | string)[]`
+- **默认值：** 根据 [`output.chunkLoading`](#outputchunkloading)、[`output.workerChunkLoading`](#workerChunkLoading) 及 Entry 的 chunkLoading 的配置推断
 
-开启可用的 chunkLoading 类型的运行时模块打包。
+启用用于入口 chunk 加载类型的列表。将由 Rspack 自动填充，仅在使用函数作为入口选项并从那里返回 chunkLoading 选项时需要。
 
-```javascript
+```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    enabledChunkLoadingTypes: ['import'],
+    enabledChunkLoadingTypes: ['jsonp', 'require'],
+  },
+};
+```
+
+## output.enabledLibraryTypes
+
+- **类型：** `string[]`
+- **默认值：** 根据 [output.library](#outputlibrary) 和 [Entry](/config/entry) 的配置推断
+
+入口点可用的 library 类型列表。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    enabledLibraryTypes: ['module'],
+  },
+};
+```
+
+## output.enabledWasmLoadingTypes
+
+- **类型：** `('fetch-streaming' | 'fetch' | 'async-node' | string | false)[]`
+- **默认值：** 根据 [`output.wasmLoading`](#outputwasmloading) 及 [`output.workerWasmLoading`](#workerWasmLoading) 的配置推断
+
+开启可用的 wasm 加载类型的运行时模块打包。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    enabledWasmLoadingTypes: ['fetch'],
   },
 };
 ```
 
 ## output.environment
 
-告诉 Rspack 可以在生成的运行时代码中使用哪种 ES 特性。
-
-### output.environment.arrowFunction
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-该环境支持 async 函数和 await（`async function () { await ... }`）。
-
-## output.cssFilename
-
-- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **默认值：** 根据 [`output.filename`](/config/output#outputfilename) 推断
-
-此选项决定了 CSS 文件的名称。
-
-## output.cssChunkFilename
-
-- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
-- **默认值：** 根据 [`output.chunkFilename`](/config/output#outputchunkfilename) 推断
-- **支持的 Template String：**
-  - [Compilation Context](/config/output#compilation-context)
-  - [Chunk Context](/config/output#chunk-context)
-
-此选项决定了非初始（non-initial）CSS chunk 文件的名称。
-
-## output.crossOriginLoading
-
-- **类型：** `false | 'anonymous' | 'use-credentials'`
-- **默认值：** `false`
-
-通过 `crossOriginLoading` 配置项，你可以为动态加载的 chunks 设置 [crossorigin 属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin)。
-
-当 `target` 为 `'web'` 时，Rspack 会动态创建 `<script>` 和 `<link>` 标签来加载异步的 JavaScript 和 CSS 资源。如果这些资源的 URL 在其他域名下，且 `crossOriginLoading` 不为 `false`，那么 Rspack 会为 `<script>` 和 `<link>` 标签添加 `crossorigin` 属性。
-
-### 可选值
-
-`crossOriginLoading` 有以下可选值：
-
-- `false`: 不设置 [crossorigin 属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-crossorigin)。
-- `'anonymous'`：将 `crossorigin` 设置为 `'anonymous'`，不包含用户凭据来跨域加载资源。
-- `'use-credentials'`：将 `crossorigin` 设置为 `'use-credentials'`，包含用户凭据来跨域加载资源。
-
-### 示例
-
-比如将 `output.publicPath` 设置为 `https://example.com/`，并将 `output.crossOriginLoading` 设置为 `'anonymous'`：
-
-```js title="rspack.config.js"
-const path = require('path');
-
-module.exports = {
-  output: {
-    publicPath: 'https://example.com/',
-    crossOriginLoading: 'anonymous',
-  },
-};
-```
-
-当 Rspack 在加载异步的 JavaScript 资源时，会生成如下的 HTML：
-
-```html
-<script src="https://example.com/foo.js" crossorigin="anonymous"></script>
-```
-
-## output.path
-
-- **类型：** `string`
-- **默认值：** `path.resolve(process.cwd(), 'dist')`
-
-输出文件目录的绝对路径。
-
-```js title="rspack.config.js"
-const path = require('path');
-
-module.exports = {
-  output: {
-    path: path.resolve(__dirname, 'dist/assets'),
-  },
-};
-```
-
-## output.pathinfo
-
-- **类型：** `boolean | 'verbose'`
-- **默认值：** `true`
-
-让 Rspack 在 bundle 中通过注释输出模块的信息。此选项在 [mode](/config/mode) 为 `'production'` 下默认为 `true`，为 `'development'` 下默认为 `false`。`'verbose'` 会打印更多信息，例如模块导出、运行时信息和 `bailout` 原因。
-
-:::warning
-在开发过程中分析生成的代码时，这些注释提供的信息很有用，但不应在生产环境中使用。
-:::
-
-```js title="rspack.config.js"
-module.exports = {
-  //...
-  output: {
-    pathinfo: true,
-  },
-};
-```
-
-## output.publicPath
-
-- **类型：** `string`
-- **默认值：** targets 为 `'web'` 或 `'webworker'` 时为 `'auto'`
-
-此选项决定了引用的资源的 URL 前缀，如: 图片、文件等等。
-
-例如，给定一个配置文件：
+指示 Rspack 可以在生成的运行时代码中使用哪种 ES 特性。
 
 ```js title="rspack.config.js"
 module.exports = {
   output: {
-    publicPath: '/assets/',
-    chunkFilename: '[id].chunk.js',
-    assetModuleFilename: '[name][ext]',
-  },
-};
-```
-
-对于某一个非初始（non-initial） chunk 文件，它的请求 URL 看起来像是这样： `/assets/1.chunk.js`。
-
-对于一个图片的引用，它的请求 URL 看起来像是这样：`/assets/logo.png`。
-
-同时，当你使用 CDN 对产物进行部署时则非常有用：
-
-```js title="rspack.config.js"
-module.exports = {
-  output: {
-    publicPath: 'https://cdn.example.com/assets/',
-    assetModuleFilename: '[name][ext]',
-  },
-};
-```
-
-对于所有 asset 资源，它们的请求 URL 看起来像是这样：`https://cdn.example.com/assets/logo.png`。
-
-### 动态设置 publicPath
-
-在运行时代码中，你可以通过 `__webpack_public_path__` 来动态设置 `publicPath`，`__webpack_public_path__` 会覆盖 Rspack 配置中的 `publicPath`，但只能对异步加载的资源生效。
-
-首先创建一个 `publicPath.js`：
-
-```js title="publicPath.js"
-__webpack_public_path__ = 'https://cdn.example.com/assets/';
-```
-
-然后在入口文件的第一行引入它即可：
-
-```js title="entry.js"
-import './publicPath.js';
-import './others.js';
-```
-
-## output.scriptType
-
-- **类型：** `'module' | 'text/javascript' | boolean`
-- **默认值：** `false`
-
-该选项允许使用自定义脚本类型（例如 `<script type="module" ...>`）来加载异步块。
-
-:::tip
-如果 `output.module` 设置为 `true`，则 `output.scriptType` 将默认为 `'module'` 而不是 `false`。
-:::
-
-```js title="rspack.config.js"
-module.exports = {
-  //...
-  output: {
-    scriptType: 'module',
-  },
-};
-```
-
-## output.sourceMapFilename
-
-- **类型：** `string`
-- **默认值：** `'[file].map[query]'`
-
-配置 source map 文件的命名方式。仅当 [`devtool`](/config/devtool) 设置为 `'source-map'` 时生效，此时会输出文件。
-
-可以使用 [`output.filename`](#outputfilename) 中的 `[name]`、`[id]`、`[fullhash]` 和 `[chunkhash]` 替换符。此外，还可以使用 [Template strings](#template-string) 中在文件级别列出的替换符。
-
-## output.strictModuleErrorHandling
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-按照 ES Module 规范处理 module 加载时的错误，会有性能损失。
-
-## output.trustedTypes
-
-控制 [Trusted Types](https://web.dev/trusted-types) 兼容性。启用此选项，Rspack 将检测已实现了 Trusted Types，并使用 Trusted Types 来创建它动态加载的脚本 URL。应用在运行带有 [require-trusted-types-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) 内容安全策略指令下的应用程序。
-
-默认情况下是不启用。
-
-策略名称取自 `policyName` 字段。
-
-```js title="rspack.config.js"
-module.exports = {
-  //...
-  output: {
-    trustedTypes: {
-      policyName: 'my-application#webpack',
+    environment: {
+      // The environment supports arrow functions ('() => { ... }').
+      arrowFunction: true,
+      // The environment supports async function and await ('async function () { await ... }').
+      asyncFunction: true,
+      // The environment supports BigInt as literal (123n).
+      bigIntLiteral: false,
+      // The environment supports const and let for variable declarations.
+      const: true,
+      // The environment supports destructuring ('{ a, b } = obj').
+      destructuring: true,
+      // The environment supports an async import() function to import EcmaScript modules.
+      dynamicImport: false,
+      // The environment supports an async import() when creating a worker, only for web targets at the moment.
+      dynamicImportInWorker: false,
+      // The environment supports 'for of' iteration ('for (const x of array) { ... }').
+      forOf: true,
+      // The environment supports 'globalThis'.
+      globalThis: true,
+      // The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...').
+      module: false,
+      // Determines if the node: prefix is generated for core module imports in environments that support it.
+      // This is only applicable to Webpack runtime code.
+      nodePrefixForCoreModules: false,
+      // The environment supports optional chaining ('obj?.a' or 'obj?.()').
+      optionalChaining: true,
+      // The environment supports template literals.
+      templateLiteral: true,
     },
   },
 };
 ```
+
+## output.filename
+
+- **类型：** `string | (pathData: PathData, assetInfo?: JsAssetInfo) => string`
+- **默认值：** [output.module](#outputmodule) 为 `true` 时为 `'[name].mjs'`，否则为 `'[name].js'`
+
+这个选项决定了输出的 JavaScript bundle 文件名称。这些 bundle 将会被写入 [`output.path`](#outputpath) 指定的目录下。
+
+对于单个 [Entry](/config/entry.html) 来说，你可以使用一个固定名称，如：
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    filename: 'bundle.js',
+  },
+};
+```
+
+然而，当通过多个 Entry、代码拆分或各种插件创建多个包时，您应该使用以下替换之一来给每个包一个唯一的名字...
+
+:::info 对于拆分成多个 bundle 的情况的描述
+
+Rspack 会对用户输入的代码进行代码拆分优化，这些优化可能包括但不限于：code splitting、bundle splitting，或通过其他插件实现的代码拆分等。
+这些代码拆分的行为会导致生成多个 bundle，因此 bundle 的文件名需要动态生成。
+
+{
+// TODO: 补充 Glossary link
+}
+
+:::
+
+使用 [Entry](/config/entry.html) 名称：
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[name].bundle.js',
+  },
+};
+```
+
+使用内部 chunk id
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[id].bundle.js',
+  },
+};
+```
+
+使用从生成内容中生成的哈希值：
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[contenthash].bundle.js',
+  },
+};
+```
+
+将多个替换组合起来：
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: '[name].[contenthash].bundle.js',
+  },
+};
+```
+
+使用函数返回文件名：
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    filename: pathData => {
+      return pathData.chunk.name === 'main' ? '[name].js' : '[name]/[name].js';
+    },
+  },
+};
+```
+
+这个选项被称为文件名，但你仍然可以使用类似 `js/[name]/bundle.js` 的东西来创建文件夹结构。
+
+请注意，此选项不会影响到按需加载块的输出文件。它只影响最初加载的输出文件。对于按需加载的块文件，使用的是 [`output.chunkFilename`](#outputchunkfilename) 选项。由加载器创建的文件也不会受到影响。在这种情况下，您可能需要尝试特定加载器提供的可用选项。
 
 ## Template String
 
@@ -487,84 +475,62 @@ module.exports = {
 
 可在 file 层面替换的内容：
 
-| 模板    | 描述                                                                                          |
-| ------- | --------------------------------------------------------------------------------------------- |
-| [query] | 文件 query，包含 `?`                                                                          |
-| [path]  | 文件路径，不包含文件名                                                                        |
-| [name]  | 文件名，不包含扩展名和文件路径                                                                |
-| [ext]   | 扩展名，包含 `.` （仅支持在 [output.assetModuleFilename](#outputassetmodulefilename) 里使用） |
+| 模板       | 描述                                                                                          |
+| ---------- | --------------------------------------------------------------------------------------------- |
+| [file]     | 文件名和路径，不包括查询或片段                                                                |
+| [query]    | 文件 query，包含 `?`                                                                          |
+| [fragment] | 以 `#` 开头的片段名                                                                           |
+| [base]     | 只翻译文件名（包括扩展名），不包括路径名                                                      |
+| [path]     | 文件路径，不包含文件名                                                                        |
+| [name]     | 文件名，不包含扩展名和文件路径                                                                |
+| [ext]      | 扩展名，包含 `.` （仅支持在 [output.assetModuleFilename](#outputassetmodulefilename) 里使用） |
 
-## output.auxiliaryComment
+在 URL 级别上可用的替换：
 
-最好使用 [`output.library.auxiliaryComment`](#outputlibraryauxiliarycomment)。
+| 模板  | 描述 |
+| ----- | ---- |
+| [url] | URL  |
 
-- **类型：** `string | object`
+:::tip
 
-在和 [`output.library`](#outputlibrary) 和 [`output.libraryTarget`](#outputlibrarytarget) 一起使用时，此选项允许用户向导出容器(export wrapper)中插入注释。要为 `libraryTarget` 每种类型都插入相同的注释，将 `auxiliaryComment` 设置为一个字符串：
+`[file]` 等于 `[path][base]`。`[base]` 等于 `[name][ext]`。完整路径是 `[path][name][ext][query][fragment]` 或 `[path][base][query][fragment]` 或 `[file][query][fragment]`。
 
-```javascript title=rspack.config.js
-module.exports = {
-  //...
-  output: {
-    library: 'someLibName',
-    libraryTarget: 'umd',
-    filename: 'someLibName.js',
-    auxiliaryComment: 'Test Comment',
-  },
-};
-```
+:::
 
-将会生成如下：
+Hash 的长度（`[hash]`、`[contenthash]` 或 `[chunkhash]`）可以使用 `[hash:16]` 来指定（默认为 20）。另外，可以使用 [output.hashDigestLength](#outputhashdigestlength) 来全局配置长度。
 
-**someLibName.js**
+当你想在实际文件名中使用占位符时，可以过滤掉占位符替换。例如，要输出一个文件 `[name].js`，你必须通过在括号之间添加反斜杠来转义 `[name]` 占位符。这样 `[\name\]` 会生成 `[name]` 而不是被替换为资源的名称。
 
-```javascript
-(function webpackUniversalModuleDefinition(root, factory) {
-  // Test Comment
-  if (typeof exports === 'object' && typeof module === 'object')
-    module.exports = factory(require('lodash'));
-  // Test Comment
-  else if (typeof define === 'function' && define.amd)
-    define(['lodash'], factory);
-  // Test Comment
-  else if (typeof exports === 'object')
-    exports['someLibName'] = factory(require('lodash'));
-  // Test Comment
-  else root['someLibName'] = factory(root['_']);
-})(this, function (__WEBPACK_EXTERNAL_MODULE_1__) {
-  // ...
-});
-```
+示例：`[\id\]` 会生成 `[id]` 而不是被替换为 id。
 
-对于 `libraryTarget` 每种类型的注释进行更细粒度地控制，请传入一个对象：
-
-```javascript title=rspack.config.js
-module.exports = {
-  //...
-  output: {
-    //...
-    auxiliaryComment: {
-      root: 'Root Comment',
-      commonjs: 'CommonJS Comment',
-      commonjs2: 'CommonJS2 Comment',
-      amd: 'AMD Comment',
-    },
-  },
-};
-```
-
-## output.enabledLibraryTypes
-
-- **类型：** `string[]`
-
-入口点可用的 library 类型列表。
+如果使用函数来设置这个选项，函数将会接收一个包含上表中替换数据的对象。替换也会应用到返回的字符串中。传递的对象将具有这种类型：（属性取决于上下文）
 
 ```javascript
-module.exports = {
-  //...
-  output: {
-    enabledLibraryTypes: ['module'],
-  },
+type PathData = {
+  hash: string;
+  hashWithLength: (number) => string;
+  chunk: Chunk | ChunkPathData;
+  module: Module | ModulePathData;
+  contentHashType: string;
+  contentHash: string;
+  contentHashWithLength: (number) => string;
+  filename: string;
+  url: string;
+  runtime: string | SortableSet<string>;
+  chunkGraph: ChunkGraph;
+};
+type ChunkPathData = {
+  id: string | number;
+  name: string;
+  hash: string;
+  hashWithLength: (number) => string;
+  contentHash: Record<string, string>;
+  contentHashWithLength: Record<string, (number) => string>;
+};
+type ModulePathData = {
+  id: string | number;
+  hash: string;
+  hashWithLength: (number) => string;
 };
 ```
 
@@ -579,7 +545,7 @@ module.exports = {
 
 示例：
 
-```javascript
+```javascript title=rspack.config.js
 module.exports = {
   // ...
   output: {
@@ -605,21 +571,9 @@ module.exports = {
 
 要使用的哈希摘要的长度。
 
-## output.importFunctionName
-
-- **类型：** `string`
-- **默认值：** `'import'`
-
-内部 `import()` 函数的名称. 可用于 polyfilling, 例如 通过 [`dynamic-import-polyfill`](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
-
-```javascript title=rspack.config.js
-module.exports = {
-  //...
-  output: {
-    importFunctionName: '__import__',
-  },
-};
-```
+:::tip
+`hashDigestLength` 默认值为 `20`，当启用 [`experiments.futureDefaults`](/config/experiments#experimentsfuturedefaults) 时将使用 `16` 作为默认值。
+:::
 
 ## output.hashFunction
 
@@ -643,7 +597,90 @@ module.exports = {
 
 ## output.hashSalt
 
+- **类型：** `string`
+- **默认值：** `undefined`
+
 可选的 salt，用于更新哈希值。
+
+## output.hotUpdateChunkFilename
+
+<ApiMeta addedVersion={'0.3.5'} />
+
+- **类型：** `string`
+- **默认值：** `"[id].[fullhash].hot-update.js"`
+
+自定义热更新文件的文件名，参阅 [`output.filename`](#outputfilename)，了解可能的值。只有 `[fullhash]` 和 `[id]` 可用作占位符。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    hotUpdateChunkFilename: '[id].[fullhash].hot-update.js',
+  },
+};
+```
+
+:::tip
+通常你不需要更改 `output.hotUpdateChunkFilename`。
+:::
+
+## output.hotUpdateGlobal
+
+<ApiMeta addedVersion={'0.3.5'} />
+
+- **类型：** `string`
+- **默认值：** `"webpackHotUpdate" + output.uniqueName`
+
+仅当 [`target`](/config/target) 设置为 `"web"` 时使用，它使用 JSONP 来加载热更新。
+
+JSONP函数用于异步加载热更新块。
+
+具体可以参阅 [output.chunkLoadingGlobal](#outputchunkLoadingGlobal)。
+
+## output.hotUpdateMainFilename
+
+<ApiMeta addedVersion={'0.3.5'} />
+
+- **类型：** `string`
+- **默认值：** `"[runtime].[fullhash].hot-update.json"`
+
+自定义热更新清单文件的文件名。只有 `[fullhash]` 和 `[runtime]` 可用作占位符。
+
+:::tip
+通常你不需要更改 `output.hotUpdateMainFilename`。
+:::
+
+## output.iife
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+让 Rspack 为生成的代码添加 [IIFE](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) 包装器。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    iife: true,
+  },
+};
+```
+
+## output.importFunctionName
+
+- **类型：** `string`
+- **默认值：** `'import'`
+
+内部 `import()` 函数的名称. 可用于 polyfilling，例如通过 [`dynamic-import-polyfill`](https://github.com/GoogleChromeLabs/dynamic-import-polyfill).
+
+```javascript title=rspack.config.js
+module.exports = {
+  //...
+  output: {
+    importFunctionName: '__import__',
+  },
+};
+```
 
 ## output.library
 
@@ -721,15 +758,9 @@ export function hello(name) {
    </script>
    ```
 
-   查看 [示例](https://github.com/webpack/webpack/tree/main/examples/multi-part-library) 获取更多内容。
-
 ### output.library.amdContainer
 
 - **类型：** `string`
-
-:::warning
-请使用 [`output.library.amdContainer`](#outputlibraryamdcontainer)，因为我们未来可能会停止支持 `output.amdContainer`。
-:::
 
 在全局为 AMD 模块添加 `define`/`require` 函数的容器。
 
@@ -757,6 +788,10 @@ window['clientContainer'].define(/*define args*/); // or 'amd-require' window['c
 
 ### output.library.name
 
+指定库的名称。
+
+- **类型：**`string | string[] | {amd?: string, commonjs?: string, root?: string | string[]}`
+
 ```js
 module.exports = {
   // …
@@ -768,31 +803,23 @@ module.exports = {
 };
 ```
 
-指定库的名称。
-
-- **类型：**
-
-  ```js
-  string | string[] | {amd?: string, commonjs?: string, root?: string | string[]}
-  ```
-
 ### output.library.type
 
 配置将库暴露的方式。
 
 - **类型：** `string`
 
-  类型默认包括 `'var'`、 `'module'`、`'system'`、 `'assign'`、 `'assign-properties'`、 `'this'`、 `'window'`、 `'self'`、 `'global'`、 `'commonjs'`、 `'commonjs2'`、 `'commonjs-module'`、 `'commonjs-static'`、 `'amd'`、 `'amd-require'`、 `'umd'`、 `'umd2'`，除此之外也可以通过插件添加。
+  类型默认包括 `'var'`、`'module'`、`'assign'`、`'assign-properties'`、`'this'`、`'window'`、`'self'`、`'global'`、`'commonjs'`、`'commonjs2'`、`'commonjs-module'`、`'commonjs-static'`、`'amd'`、`'amd-require'`、`'umd'`、`'umd2'`、`'jsonp'` 和 `'system'`，除此之外也可以通过插件添加。
 
 对于接下来的示例，我们将会使用 `_entry_return_` 表示被入口点返回的值。
 
-#### Expose a Variable
+#### 暴露一个变量
 
-These options assign the return value of the entry point (e.g. whatever the entry point exported) to the name provided by [`output.library.name`](#outputlibraryname) at whatever scope the bundle was included at.
+这些选项将入口点的返回值（例如，入口点导出的内容）分配给 [`output.library.name`](#outputlibraryname) 中配置的名称，无论 bundle 被包含在什么作用域中。
 
 ##### type: 'var'
 
-```js
+```js title="rspack.config.js"
 module.exports = {
   // …
   output: {
@@ -867,7 +894,7 @@ export function hello(name) {
 MyLibrary.hello('World');
 ```
 
-#### Expose Via Object Assignment
+#### 通过对象赋值暴露
 
 这些配置项分配入口点的返回值（例如：无论入口点导出的什么内容）到一个名为 [`output.library.name`](#outputlibraryname) 的对象中。
 
@@ -961,11 +988,34 @@ exports['MyLibrary'] = _entry_return_;
 require('MyLibrary').doSomething();
 ```
 
+:::warning
 注意，不设置 `output.library.name` 将导致入口起点返回的所有属性都被赋值给给定的对象；不检查现有的属性名。
+:::
 
-#### Module Definition Systems
+#### 模块定义系统
 
 这些配置项将生成一个带有完整 header 的 bundle，以确保与各种模块系统兼容。`output.library.name` 配置项在不同的 `output.library.type` 中有不同的含义。
+
+##### type: 'module'
+
+```js title="rspack.config.js"
+module.exports = {
+  // …
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    library: {
+      // do not specify a `name` here
+      type: 'module',
+    },
+  },
+};
+```
+
+输出 ESM 模块。
+
+但这个特性仍然是实验性的，还没有完全支持，所以在使用之前确保启用了 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule)。此外，你可以在这个 [issue](https://github.com/webpack/webpack/issues/2933#issuecomment-774253975) 中跟踪开发进度。
 
 ##### type: 'commonjs2'
 
@@ -991,7 +1041,9 @@ require('MyLibrary').doSomething();
 
 如果我们指定 `output.library.name` 为 `type: commmonjs2`，你的入口起点的返回值将会被赋值给 `module.exports.[output.library.name]`。
 
+:::tip
 在考虑 CommonJS 与 CommonJS2 之间的区别？虽然它们很相似，但是它们之间有一些细微的差别，这些差别在 Rspack 的上下文中通常是不相关的。（要获取更多详细内容，请 [阅读这个 issue](https://github.com/webpack/webpack/issues/1114)。）
+:::
 
 ##### type: 'commonjs-static'
 
@@ -1025,19 +1077,87 @@ function doSomething() {}
 exports.doSomething = __webpack_exports__.doSomething;
 ```
 
-Consumption (CommonJS):
+消费（CommonJS）:
 
 ```javascript
 const { doSomething } = require('./output.cjs'); // doSomething => [Function: doSomething]
 ```
 
-Consumption (ESM):
+消费（ESM）:
 
 ```javascript
 import { doSomething } from './output.cjs'; // doSomething => [Function: doSomething]
 ```
 
+:::tip
 当源代码是用 ESM 编写的，并且输出应该兼容 CJS 和 ESM 时，这是很有用的。获取更多详情，请阅读该 [issue](https://github.com/webpack/webpack/issues/14998) 或者 [这篇文档](https://dev.to/jakobjingleheimer/configuring-commonjs-es-modules-for-nodejs-12ed)（尤其是 [这个章节](https://dev.to/jakobjingleheimer/configuring-commonjs-es-modules-for-nodejs-12ed#publish-only-a-cjs-distribution-with-property-exports)）。
+:::
+
+##### type: 'amd'
+
+这将使库作为一个 AMD 模块暴露出来。
+
+AMD 模块要求入口 chunk（例如，通过 `<script>` 标签加载的第一个脚本）具有特定属性，例如 `define` 和 `require`，这些通常由 RequireJS 或任何兼容的加载器（如 almond）提供。否则，直接加载生成的 AMD 包将导致错误，例如 `define is not defined`。
+
+配置如下配置：
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'amd',
+    },
+  },
+};
+```
+
+生成的输出将被定义为名为 `"MyLibrary"`，比如：
+
+```js
+define('MyLibrary', [], function () {
+  return _entry_return_;
+});
+```
+
+包可以作为脚本标签的一部分被包含，并且可以像这样调用：
+
+```js
+require(['MyLibrary'], function (MyLibrary) {
+  // Do something with the library...
+});
+```
+
+如果 `output.library.name` 未定义，则生成以下内容。
+
+```js
+define(function () {
+  return _entry_return_;
+});
+```
+
+直接使用 `<script>` 标签加载这个包将无法按预期工作，或者根本无法工作（在使用 almond 加载器的情况下）。它只能通过 RequireJS 兼容的异步模块加载器并通过该文件的实际路径来工作。因此，在这种情况下，如果这些文件直接暴露在服务器上，`output.path` 和 `output.filename` 可能会变得非常重要。
+
+##### type: 'amd-require'
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'amd-require',
+    },
+  },
+};
+```
+
+这会将你的输出打包成一个立即执行的 AMD `require(dependencies, factory)` 包装器。
+
+`amd-require` 类型允许使用 AMD 依赖项，而不需要后续的单独调用。与 `amd` 类型一样，这取决于在加载 Rspack 输出的环境中是否有适当的 require 函数可用。
+
+使用这种类型时，库名称不能被使用。
 
 ##### type: 'umd'
 
@@ -1161,33 +1281,84 @@ System.register(
 );
 ```
 
-##### type: 'module'
+#### 其他类型
 
-```js
+**type: 'jsonp'**
+
+```js title="rspack.config.js"
 module.exports = {
   // …
-  experiments: {
-    outputModule: true,
-  },
   output: {
-    chunkFormat: 'module',
     library: {
-      // do not specify a `name` here
-      type: 'module',
+      name: 'MyLibrary',
+      type: 'jsonp',
     },
   },
 };
 ```
 
-输出 ES 模块。
+这将把您的入口返回值包装在一个 JSONP 中。
 
-然而该特性仍然是实验性的，并且没有完全支持，所以请确保事先启用 [experiments.outputModule](/config/experiments.html)。
+```js
+MyLibrary(_entry_return_);
+```
+
+库的依赖项将由 [externals](/config/externals) 配置定义。
+
+### output.library.export
+
+指定哪一个导出应该被暴露为一个库。
+
+- **类型：** `string | string[]`
+- **默认值：** `undefined`
+
+默认情况下为 `undefined`，将导出整个（命名空间）对象。下述 demo 演示了使用 [`output.library.type: 'var'`](#type-var) 配置型产生的作用。
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'var',
+      export: 'default',
+    },
+  },
+};
+```
+
+入口点的默认导出将会被赋值为库名称：
+
+```js
+// 如果你的库有默认导出
+var MyLibrary = _entry_return_.default;
+```
+
+你可以传递一个数组给 `output.library.export`，它将被解析为要分配给库名称的模块路径：
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    library: {
+      name: 'MyLibrary',
+      type: 'var',
+      export: ['default', 'subModule'],
+    },
+  },
+};
+```
+
+这里是库代码：
+
+```js
+var MyLibrary = _entry_return_.default.subModule;
+```
 
 ### output.library.auxiliaryComment
 
 在 UMD 包装器中添加注释。
 
 - **类型：** `string | { amd?: string, commonjs?: string, commonjs2?: string, root?: string }`
+- **默认值：** `undefined`
 
 为每个 `umd` 类型插入相同的注释，将 `auxiliaryComment` 设置为 string。
 
@@ -1244,56 +1415,10 @@ module.exports = {
 };
 ```
 
-### output.library.export
-
-指定哪一个导出应该被暴露为一个库。
-
-- **类型：** `string | string[]`
-
-默认情况下为 `undefined`，将导出整个（命名空间）对象。下述 demo 演示了使用 [`output.library.type: 'var'`](#type-var) 配置型产生的作用。
-
-```js
-module.exports = {
-  output: {
-    library: {
-      name: 'MyLibrary',
-      type: 'var',
-      export: 'default',
-    },
-  },
-};
-```
-
-入口点的默认导出将会被赋值为库名称：
-
-```js
-// 如果你的库有默认导出
-var MyLibrary = _entry_return_.default;
-```
-
-你可以传递一个数组给 `output.library.export`，它将被解析为要分配给库名称的模块路径：
-
-```js
-module.exports = {
-  output: {
-    library: {
-      name: 'MyLibrary',
-      type: 'var',
-      export: ['default', 'subModule'],
-    },
-  },
-};
-```
-
-这里是库代码：
-
-```js
-var MyLibrary = _entry_return_.default.subModule;
-```
-
 ### output.library.umdNamedDefine
 
 - **类型：** `boolean`
+- **默认值：** `undefined`
 
 当使用 `output.library.type: "umd"` 时，将 `output.library.umdNamedDefine` 设置为 `true` 将会把 AMD 模块命名为 UMD 构建。否则使用匿名 `define`。
 
@@ -1316,69 +1441,196 @@ AMD module 将会是这样：
 define('MyLibrary', [], factory);
 ```
 
-## output.libraryExport \{#outputlibraryexport-1}
+## output.module
 
-:::warning
-我们可能会停止对此的支持，所以最好使用 [output.library.export](#outputlibraryexport)，其作用与 `libraryExport` 一致。
-:::
-
-- **类型：** `string` | `string[]`
-
-通过配置 `libraryTarget` 决定暴露哪些模块。默认情况下为 `undefined`，如果你将 `libraryTarget` 设置为空字符串，则与默认情况具有相同的行为。例如，如果设置为 `''`，将导出整个（命名空间）对象。下述 demo 演示了当设置 `libraryTarget: 'var'` 时的效果。
-
-支持以下配置：
-
-`libraryExport: 'default'`——**入口的默认导出**将分配给 library target：
-
-```javascript
-// if your entry has a default export of `MyDefaultModule`
-var MyDefaultModule = _entry_return_.default;
-```
-
-`libraryExport: 'MyModule'` - 这个 **确定的模块** 将被分配给 library target：
-
-```javascript
-var MyModule = _entry_return_.MyModule;
-```
-
-`libraryExport: ['MyModule', 'MySubModule']` - 数组将被解析为要分配给 library target 的 **模块路径**：
-
-```javascript
-var MySubModule = _entry_return_.MyModule.MySubModule;
-```
-
-使用上述指定的 `libraryExport` 配置时，library 的结果可以这样使用：
-
-```javascript
-MyDefaultModule.doSomething();
-MyModule.doSomething();
-MySubModule.doSomething();
-```
-
-## output.libraryTarget
-
-- **类型：** `string`
-- **默认值：** `var`
-
-:::warning
-请使用 [`output.library.type`](#outputlibrarytype) 代替，因为我们可能在未来放弃对 `output.libraryTarget` 的支持。
-:::
-
-## output.umdNamedDefine
-
-:::warning
-最好使用 [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine)。
-:::
+<ApiMeta stability={Stability.Experimental} />
 
 - **类型：** `boolean`
+- **默认值：** `false`
 
-当使用 `libraryTarget: "umd"` 时，设置 `output.umdNamedDefine` 为 `true` 将命名由 UMD 构建的 AMD 模块。否则将使用一个匿名的 `define`。
+以 ESM 模块的形式输出 JavaScript 文件。由于此功能还处于实验阶段，默认关闭，想要使用的话必须将 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) 设置为 true。
 
-```javascript
+当启用时，Rspack 会将 [`output.iife`](#outputiife) 设置为 `false`， [`output.scriptType`](#outputscripttype) 设置为 `'module'`。
+
+如果你正在使用 Rspack 编译一个供他人使用的库，请确保在 `output.module` 为 `true` 时将 [`output.library.type`](#outputlibrarytype) 设置为 `'module'`。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    module: true,
+  },
+};
+```
+
+## output.path
+
+- **类型：** `string`
+- **默认值：** `path.resolve(process.cwd(), 'dist')`
+
+输出文件目录的绝对路径。
+
+```js title="rspack.config.js"
+const path = require('path');
+
+module.exports = {
+  output: {
+    path: path.resolve(__dirname, 'dist/assets'),
+  },
+};
+```
+
+注意 `[fullhash]` 将会被替换为构建过程中的 hash 值。
+
+:::warning
+路径中不能包含感叹号（!），因为感叹号在 Rspack 中被用作 loader 语法。
+:::
+
+## output.pathinfo
+
+- **类型：** `boolean | 'verbose'`
+- **默认值：** `true`
+
+让 Rspack 在 bundle 中通过注释输出模块的信息。此选项在 [mode](/config/mode) 为 `'development'` 下默认为 `true`，为 `'production'` 下默认为 `false`。`'verbose'` 会打印更多信息，例如模块导出、运行时信息和 `bailout` 原因。
+
+:::warning
+在开发过程中分析生成的代码时，这些注释提供的信息很有用，但不应在生产环境中使用。
+:::
+
+```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    umdNamedDefine: true,
+    pathinfo: true,
+  },
+};
+```
+
+:::tip
+它还在生成的 bundle 中添加了一些关于 tree shaking 的信息。
+:::
+
+## output.publicPath
+
+- **类型：** `string`
+- **默认值：** targets 为 `'web'` 或 `'webworker'` 时为 `'auto'`
+
+此选项决定了引用的资源的 URL 前缀，如: 图片、文件等等。
+
+例如，给定一个配置文件：
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    publicPath: '/assets/',
+    chunkFilename: '[id].chunk.js',
+    assetModuleFilename: '[name][ext]',
+  },
+};
+```
+
+对于某一个非初始（non-initial） chunk 文件，它的请求 URL 看起来像是这样： `/assets/1.chunk.js`。
+
+对于一个图片的引用，它的请求 URL 看起来像是这样：`/assets/logo.png`。
+
+同时，当你使用 CDN 对产物进行部署时则非常有用：
+
+```js title="rspack.config.js"
+module.exports = {
+  output: {
+    publicPath: 'https://cdn.example.com/assets/',
+    assetModuleFilename: '[name][ext]',
+  },
+};
+```
+
+对于所有 asset 资源，它们的请求 URL 看起来像是这样：`https://cdn.example.com/assets/logo.png`。
+
+**动态设置 publicPath**
+
+在运行时代码中，你可以通过 `__webpack_public_path__` 来动态设置 `publicPath`，`__webpack_public_path__` 会覆盖 Rspack 配置中的 `publicPath`，但只能对异步加载的资源生效。
+
+首先创建一个 `publicPath.js`：
+
+```js title="publicPath.js"
+__webpack_public_path__ = 'https://cdn.example.com/assets/';
+```
+
+然后在入口文件的第一行引入它即可：
+
+```js title="entry.js"
+import './publicPath.js';
+import './others.js';
+```
+
+## output.scriptType
+
+- **类型：** `'module' | 'text/javascript' | boolean`
+- **默认值：** `false`
+
+该选项允许使用自定义脚本类型（例如 `<script type="module" ...>`）来加载异步块。
+
+:::tip
+如果 `output.module` 设置为 `true`，则 `output.scriptType` 将默认为 `'module'` 而不是 `false`。
+:::
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    scriptType: 'module',
+  },
+};
+```
+
+## output.sourceMapFilename
+
+- **类型：** `string`
+- **默认值：** `'[file].map[query]'`
+
+配置 source map 文件的命名方式。仅当 [`devtool`](/config/devtool) 设置为 `'source-map'` 时生效，此时会输出文件。
+
+可以使用 [`output.filename`](#outputfilename) 中的 `[name]`、`[id]`、`[fullhash]` 和 `[chunkhash]` 替换符。此外，还可以使用 [Template strings](#template-string) 中在文件级别列出的替换符。
+
+## output.strictModuleErrorHandling
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+按照 ES Module 规范处理 module 加载时的错误，会有性能损失。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    strictModuleErrorHandling: true,
+  },
+};
+```
+
+## output.trustedTypes
+
+- **类型：** `true | string | object`
+- **默认值：** `undefined`
+
+控制 [Trusted Types](https://web.dev/trusted-types) 兼容性。启用此选项，Rspack 将检测已实现了 Trusted Types，并使用 Trusted Types 来创建它动态加载的脚本 URL。应用在运行带有 [require-trusted-types-for](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) 内容安全策略指令下的应用程序。
+
+默认情况下是不启用。
+
+- 当设置为 `true` 时，Rspack 将使用 [`output.uniqueName`](#outputuniquename) 作为 Trusted Types 策略名称。
+- 当设置为非空字符串时，其值将被用作策略名称。
+- 当设置为对象时，策略名称将从对象的 `policyName` 属性中获取。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    trustedTypes: {
+      policyName: 'my-application#webpack',
+    },
   },
 };
 ```
@@ -1386,7 +1638,7 @@ module.exports = {
 ## output.uniqueName
 
 - **类型：** `string`
-- **默认值：** 默认使用 [`output.library`](/config/output#outputlibrary) 名称或者上下文中的 package.json 的 包名称(package name)， 如果两者都不存在，值为 ''。
+- **默认值：** 默认使用 [`output.library`](/config/output#outputlibrary) 名称或者上下文中的 package.json 的 包名称（package name）， 如果两者都不存在，值为 `''`。
 
 此选项决定了在全局环境下为防止多个 Rspack 运行时 冲突所使用的唯一名称。
 
@@ -1402,22 +1654,6 @@ module.exports = {
 };
 ```
 
-## output.clean
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-在生成产物前，删除输出目录下的所有文件。
-
-## output.module
-
-<ApiMeta stability={Stability.Experimental} />
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-以 ESM 模块的形式输出 JavaScript 文件。由于此功能还处于实验阶段，默认关闭，想要使用的话必须将 [`experiments.outputModule`](/config/experiments#experimentsoutputmodule) 设置为 true
-
 ## output.wasmLoading
 
 - **类型：** `false | 'fetch', 'async-node'`
@@ -1429,6 +1665,15 @@ module.exports = {
 
 - 如果目标设置为 `'web'`、`'webworker'`、`'electron-renderer'` 或 `'node-webkit'`，默认值为 `'fetch'`。
 - 如果目标设置为 `'node'`、`'async-node'`、`'electron-main'` 或 `'electron-preload'`，则默认为 `'async-node'`。
+
+```javascript title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    wasmLoading: 'fetch',
+  },
+};
+```
 
 ## output.webassemblyModuleFilename
 
@@ -1446,60 +1691,78 @@ module.exports = {
 };
 ```
 
-## output.enabledWasmLoadingTypes
+## output.workerChunkLoading
 
-开启可用的 wasmLoading 类型的运行时模块打包。
+- **类型：** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import'`
+- **默认值：** `false`
 
-- **类型：** `false | 'fetch', 'async-node'`
+`workerChunkLoading` 控制 chunk 加载方式。
 
-## output.asyncChunks
-
-<ApiMeta addedVersion={'0.2.6'} />
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-是否创建按需加载的异步 chunk。
-
-## output.hotUpdateChunkFilename
-
-<ApiMeta addedVersion={'0.3.5'} />
-
-- **类型：** `string`
-- **默认值：** `"[id].[fullhash].hot-update.js"`
-
-自定义热更新文件的文件名。只有 `[fullhash]` 和 `[id]` 可用作占位符。
-
-## output.hotUpdateMainFilename
-
-<ApiMeta addedVersion={'0.3.5'} />
-
-- **类型：** `string`
-- **默认值：** `"[runtime].[fullhash].hot-update.json"`
-
-自定义热更新清单文件的文件名。只有 `[fullhash]` 和 `[runtime]` 可用作占位符。
-
-## output.hotUpdateGlobal
-
-<ApiMeta addedVersion={'0.3.5'} />
-
-- **类型：** `string`
-- **默认值：** `"webpackHotUpdate" + output.uniqueName`
-
-只在 [chunkLoading](/config/output#outputchunkloading) 为 `"jsonp"` 或 `"import-scripts"` 时会被使用。该全局变量会用来请求并加载热更新文件。
-
-## output.iife
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-让 Rspack 为生成的代码添加 IIFE 包装器。
+:::tip
+此选项的默认值取决于目标设置。要获取更多信息，请在 Rspack [默认设置中](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts)搜索 `"workerChunkLoading"`。
+:::
 
 ```js title="rspack.config.js"
 module.exports = {
   //...
   output: {
-    iife: true,
+    workerChunkLoading: false,
   },
 };
 ```
+
+## output.workerPublicPath
+
+- **类型：** `string`
+- **默认值：** `""`
+
+为 Worker 设置一个公共路径，默认为 `output.publicPath` 的值。只有在 Worker 脚本位于与其他脚本不同的路径时才使用此选项。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    workerPublicPath: '/workerPublicPath2/',
+  },
+};
+```
+
+## output.workerWasmLoading
+
+- **类型：** `false | 'fetch-streaming' | 'fetch' | 'async-node' | string`
+- **默认值：** `false`
+
+用来设置在 Worker 中加载 WebAssembly 模块的方式，默认为 [`output.wasmLoading`](#outputwasmloading) 的值。
+
+```js title="rspack.config.js"
+module.exports = {
+  //...
+  output: {
+    workerWasmLoading: 'fetch',
+  },
+};
+```
+
+## output.auxiliaryComment
+
+:::warning
+请优先使用 [`output.library.auxiliaryComment`](#outputlibraryauxiliarycomment)。
+:::
+
+## output.libraryExport \{#outputlibraryexport-1}
+
+:::warning
+我们可能会停止对此的支持，所以最好使用 [output.library.export](#outputlibraryexport)，其作用与 `libraryExport` 一致。
+:::
+
+## output.libraryTarget
+
+:::warning
+请使用 [`output.library.type`](#outputlibrarytype) 代替，因为我们可能在未来放弃对 `output.libraryTarget` 的支持。
+:::
+
+## output.umdNamedDefine
+
+:::warning
+最好使用 [`output.library.umdNamedDefine`](#outputlibraryumdnameddefine)。
+:::

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -633,7 +633,7 @@ module.exports = {
 
 仅当 [`target`](/config/target) 设置为 `"web"` 时使用，它使用 JSONP 来加载热更新。
 
-JSONP函数用于异步加载热更新块。
+JSONP 函数用于异步加载热更新块。
 
 具体可以参阅 [output.chunkLoadingGlobal](#outputchunkLoadingGlobal)。
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -505,7 +505,7 @@ Hash 的长度（`[hash]`、`[contenthash]` 或 `[chunkhash]`）可以使用 `[h
 
 如果使用函数来设置这个选项，函数将会接收一个包含上表中替换数据的对象。替换也会应用到返回的字符串中。传递的对象将具有这种类型：（属性取决于上下文）
 
-```javascript
+```ts
 type PathData = {
   hash: string;
   hashWithLength: (number) => string;

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -296,7 +296,7 @@ module.exports = {
 - **类型：** `('fetch-streaming' | 'fetch' | 'async-node' | string | false)[]`
 - **默认值：** 根据 [`output.wasmLoading`](#outputwasmloading) 及 [`output.workerWasmLoading`](#workerWasmLoading) 的配置推断
 
-开启可用的 wasm 加载类型的运行时模块打包。
+开启可用的 Wasm 加载类型的运行时模块打包。
 
 ```js title="rspack.config.js"
 module.exports = {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -388,7 +388,7 @@ module.exports = {
 };
 ```
 
-使用内部 chunk id
+使用内部 chunk id：
 
 ```js title="rspack.config.js"
 module.exports = {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -75,7 +75,7 @@ module.exports = {
 - **类型：** `false | 'array-push' | 'commonjs' | 'module' | string`
 - **默认值：** 根据 [`target`](/config/target) 和 [`output.module`](#outputmodule) 的配置推断
 
-chunk 产物的格式，一般来说，target 为 web 或 Webworker 时会使用 `'array-push'` 格式；为 ESM 时会使用 `'module'` 格式；为 node.js 时会使用 `'commonjs'` 格式，插件可能会添加其他格式。
+chunk 产物的格式，一般来说，target 为 web 或 webworker'时会使用 `'array-push'` 格式；为 ESM 时会使用 `'module'` 格式；为 node.js 时会使用 `'commonjs'` 格式，插件可能会添加其他格式。
 
 :::tip
 这个选项的默认值取决于 [`target`](/config/target) 和 [`output.module`](#outputmodule) 设置。要了解更多详情，请在 Rspack [默认设置中](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts)搜索 `"chunkFormat"`。

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -103,8 +103,10 @@ outputdevtoolfallbackmodulefilenametemplate
 outputdevtoolmodulefilenametemplate
 outputdevtoolnamespace
 outputenabledwasmloadingtypes
+outputiife
 outputlibraryamdcontainer
 outputlibraryumdnameddefine
+outputwasmloading
 perfetto
 pmmmwh
 proxied


### PR DESCRIPTION
## Summary

Polish up `output` documentation. The main target is to align with webpack's document if the abilities are aligned. Put legacy / tend to be deprecated fields to the end of the page and only provide a link to its substitute. 

### Configuration not aligned with webpack
- do not support `output.charset`
- do not support `output.chunkLoadTimeout`
- `output.clean` only supports boolean
- do not support `output.compareBeforeEmit`
- do not support `output.cssHeadDataCompression`
- do not support `output.ignoreBrowserWarnings`
- do not support `output.importMetaName`
- do not support `output.sourcePrefix`
- do not support `output.trustedTypes.onPolicyCreationFailure`
- `output.publicPath` only supports string
- do not support `strictModuleExceptionHandling` (deprecated)
- `output.assetModuleFilename` only supports string

I wonder, do we need to create a centralized issue to collect all config that misaligned with webpack and track in the future.

## Checklist

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
