### PR TITLE
fix(cli): update peerDep of rspack-cli

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -29,7 +29,7 @@
     "directory": "packages/rspack-cli"
   },
   "peerDependencies": {
-    "@rspack/core": ">=0.4.0"
+    "@rspack/core": ">=1.0.0"
   },
   "devDependencies": {
     "@rspack/core": "workspace:*",

--- a/packages/rspack/scripts/check-documentation-coverage.mjs
+++ b/packages/rspack/scripts/check-documentation-coverage.mjs
@@ -198,7 +198,11 @@ function checkConfigsDocumentationCoverage() {
 							break;
 						}
 					}
-					const title = line.substring(level).trim().split(' ')[0].replace(/\\/g, '');
+					const title = line
+						.substring(level)
+						.trim()
+						.split(" ")[0]
+						.replace(/\\/g, "");
 					section = {
 						title: title.includes(".") ? title : toCamelCase(title),
 						level,
@@ -262,6 +266,10 @@ function checkConfigsDocumentationCoverage() {
 			"output.workerWasmLoading",
 			"output.workerPublicPath",
 			"output.strictModuleExceptionHandling",
+			"output.auxiliaryComment.amd",
+			"output.auxiliaryComment.commonjs",
+			"output.auxiliaryComment.commonjs2",
+			"output.auxiliaryComment.root",
 
 			"stats",
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
^0.4.0 doesn't match 1.0.0-alpha anymore, which will cause npm install error, 
update peerDep @rspack/core to ^1.0.0 to match 1.0.0-alpha
![image](https://github.com/user-attachments/assets/98dc8c84-eeeb-40b9-8797-3a66bf9e081f)

![image](https://github.com/user-attachments/assets/24bfe1f9-6dbc-4d90-adff-4460b670ead0)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
