### PR TITLE
refactor: allows minimal/detailed/summary stats presets in configuration

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -4074,14 +4074,14 @@ const infrastructureLogging: z.ZodObject<{
     colors?: boolean | undefined;
     console?: Console | undefined;
     debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-    level?: "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+    level?: "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
     stream?: NodeJS.WritableStream | undefined;
 }, {
     appendOnly?: boolean | undefined;
     colors?: boolean | undefined;
     console?: Console | undefined;
     debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-    level?: "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+    level?: "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
     stream?: NodeJS.WritableStream | undefined;
 }>;
 
@@ -9724,14 +9724,14 @@ export const rspackOptions: z.ZodObject<{
         colors?: boolean | undefined;
         console?: Console | undefined;
         debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-        level?: "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        level?: "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         stream?: NodeJS.WritableStream | undefined;
     }, {
         appendOnly?: boolean | undefined;
         colors?: boolean | undefined;
         console?: Console | undefined;
         debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-        level?: "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        level?: "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         stream?: NodeJS.WritableStream | undefined;
     }>>;
     cache: z.ZodOptional<z.ZodBoolean>;
@@ -9772,9 +9772,9 @@ export const rspackOptions: z.ZodObject<{
         stdin?: boolean | undefined;
     }>>;
     watch: z.ZodOptional<z.ZodBoolean>;
-    stats: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["none", "errors-only", "errors-warnings", "normal", "verbose"]>, z.ZodBoolean]>, z.ZodObject<{
+    stats: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>, z.ZodObject<{
         all: z.ZodOptional<z.ZodBoolean>;
-        preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings"]>]>>;
+        preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>>;
         assets: z.ZodOptional<z.ZodBoolean>;
         chunks: z.ZodOptional<z.ZodBoolean>;
         modules: z.ZodOptional<z.ZodBoolean>;
@@ -9846,7 +9846,7 @@ export const rspackOptions: z.ZodObject<{
         moduleTrace: z.ZodOptional<z.ZodBoolean>;
     }, "strict", z.ZodTypeAny, {
         all?: boolean | undefined;
-        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
         chunks?: boolean | undefined;
         modules?: boolean | undefined;
@@ -9870,7 +9870,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         source?: boolean | undefined;
-        logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
@@ -9918,7 +9918,7 @@ export const rspackOptions: z.ZodObject<{
         moduleTrace?: boolean | undefined;
     }, {
         all?: boolean | undefined;
-        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
         chunks?: boolean | undefined;
         modules?: boolean | undefined;
@@ -9942,7 +9942,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         source?: boolean | undefined;
-        logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
@@ -11406,7 +11406,7 @@ export const rspackOptions: z.ZodObject<{
         colors?: boolean | undefined;
         console?: Console | undefined;
         debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-        level?: "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        level?: "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         stream?: NodeJS.WritableStream | undefined;
     } | undefined;
     cache?: boolean | undefined;
@@ -11427,9 +11427,9 @@ export const rspackOptions: z.ZodObject<{
         stdin?: boolean | undefined;
     } | undefined;
     watch?: boolean | undefined;
-    stats?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | {
+    stats?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
         all?: boolean | undefined;
-        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
         chunks?: boolean | undefined;
         modules?: boolean | undefined;
@@ -11453,7 +11453,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         source?: boolean | undefined;
-        logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
@@ -11931,7 +11931,7 @@ export const rspackOptions: z.ZodObject<{
         colors?: boolean | undefined;
         console?: Console | undefined;
         debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-        level?: "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        level?: "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         stream?: NodeJS.WritableStream | undefined;
     } | undefined;
     cache?: boolean | undefined;
@@ -11952,9 +11952,9 @@ export const rspackOptions: z.ZodObject<{
         stdin?: boolean | undefined;
     } | undefined;
     watch?: boolean | undefined;
-    stats?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | {
+    stats?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
         all?: boolean | undefined;
-        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+        preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
         chunks?: boolean | undefined;
         modules?: boolean | undefined;
@@ -11978,7 +11978,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         source?: boolean | undefined;
-        logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+        logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
         loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
@@ -12770,7 +12770,7 @@ export type StatsOptions = z.infer<typeof statsOptions>;
 // @public (undocumented)
 const statsOptions: z.ZodObject<{
     all: z.ZodOptional<z.ZodBoolean>;
-    preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings"]>]>>;
+    preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>>;
     assets: z.ZodOptional<z.ZodBoolean>;
     chunks: z.ZodOptional<z.ZodBoolean>;
     modules: z.ZodOptional<z.ZodBoolean>;
@@ -12842,7 +12842,7 @@ const statsOptions: z.ZodObject<{
     moduleTrace: z.ZodOptional<z.ZodBoolean>;
 }, "strict", z.ZodTypeAny, {
     all?: boolean | undefined;
-    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
     chunks?: boolean | undefined;
     modules?: boolean | undefined;
@@ -12866,7 +12866,7 @@ const statsOptions: z.ZodObject<{
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     source?: boolean | undefined;
-    logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+    logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
     loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
@@ -12914,7 +12914,7 @@ const statsOptions: z.ZodObject<{
     moduleTrace?: boolean | undefined;
 }, {
     all?: boolean | undefined;
-    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
     chunks?: boolean | undefined;
     modules?: boolean | undefined;
@@ -12938,7 +12938,7 @@ const statsOptions: z.ZodObject<{
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     source?: boolean | undefined;
-    logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+    logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
     loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
@@ -13017,9 +13017,9 @@ type StatsProfile = KnownStatsProfile & Record<string, any>;
 export type StatsValue = z.infer<typeof statsValue>;
 
 // @public (undocumented)
-const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["none", "errors-only", "errors-warnings", "normal", "verbose"]>, z.ZodBoolean]>, z.ZodObject<{
+const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>, z.ZodObject<{
     all: z.ZodOptional<z.ZodBoolean>;
-    preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings"]>]>>;
+    preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>>;
     assets: z.ZodOptional<z.ZodBoolean>;
     chunks: z.ZodOptional<z.ZodBoolean>;
     modules: z.ZodOptional<z.ZodBoolean>;
@@ -13091,7 +13091,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["none", "errors-only", "err
     moduleTrace: z.ZodOptional<z.ZodBoolean>;
 }, "strict", z.ZodTypeAny, {
     all?: boolean | undefined;
-    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
     chunks?: boolean | undefined;
     modules?: boolean | undefined;
@@ -13115,7 +13115,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["none", "errors-only", "err
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     source?: boolean | undefined;
-    logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+    logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
     loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
@@ -13163,7 +13163,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["none", "errors-only", "err
     moduleTrace?: boolean | undefined;
 }, {
     all?: boolean | undefined;
-    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | undefined;
+    preset?: boolean | "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
     chunks?: boolean | undefined;
     modules?: boolean | undefined;
@@ -13187,7 +13187,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["none", "errors-only", "err
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     source?: boolean | undefined;
-    logging?: boolean | "info" | "error" | "none" | "verbose" | "warn" | "log" | undefined;
+    logging?: boolean | "info" | "none" | "verbose" | "error" | "warn" | "log" | undefined;
     loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1014,12 +1014,19 @@ export type CacheOptions = z.infer<typeof cacheOptions>;
 //#endregion
 
 //#region Stats
+const statsPresets = z.enum([
+	"normal",
+	"none",
+	"verbose",
+	"errors-only",
+	"errors-warnings",
+	"minimal",
+	"detailed",
+	"summary"
+]);
 const statsOptions = z.strictObject({
 	all: z.boolean().optional(),
-	preset: z
-		.boolean()
-		.or(z.enum(["normal", "none", "verbose", "errors-only", "errors-warnings"]))
-		.optional(),
+	preset: z.boolean().or(statsPresets).optional(),
 	assets: z.boolean().optional(),
 	chunks: z.boolean().optional(),
 	modules: z.boolean().optional(),
@@ -1116,10 +1123,7 @@ const statsOptions = z.strictObject({
 });
 export type StatsOptions = z.infer<typeof statsOptions>;
 
-const statsValue = z
-	.enum(["none", "errors-only", "errors-warnings", "normal", "verbose"])
-	.or(z.boolean())
-	.or(statsOptions);
+const statsValue = z.boolean().or(statsPresets).or(statsOptions);
 export type StatsValue = z.infer<typeof statsValue>;
 //#endregion
 

--- a/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsFactoryPlugin.ts
@@ -811,7 +811,7 @@ const SIMPLE_EXTRACTORS: SimpleExtractors = {
 			);
 			const limited = spaceLimited(
 				groupedAssets,
-				options.assetsSpace || Number.POSITIVE_INFINITY
+				options.assetsSpace ?? Number.POSITIVE_INFINITY
 			);
 			object.assets = limited.children;
 			object.filteredAssets = limited.filteredChildren;

--- a/packages/rspack/src/stats/DefaultStatsPresetPlugin.ts
+++ b/packages/rspack/src/stats/DefaultStatsPresetPlugin.ts
@@ -52,7 +52,7 @@ const NAMED_PRESETS: Record<string, StatsOptions> = {
 		// warningsSpace: Infinity,
 		modulesSpace: Number.POSITIVE_INFINITY,
 		// chunkModulesSpace: Infinity,
-		// assetsSpace: Infinity,
+		assetsSpace: Number.POSITIVE_INFINITY,
 		// reasonsSpace: Infinity,
 		children: true
 	},
@@ -78,8 +78,8 @@ const NAMED_PRESETS: Record<string, StatsOptions> = {
 		// exclude: false,
 		// errorsSpace: 1000,
 		// warningsSpace: 1000,
-		modulesSpace: 1000
-		// assetsSpace: 1000,
+		modulesSpace: 1000,
+		assetsSpace: 1000
 		// reasonsSpace: 1000
 	},
 	minimal: {
@@ -91,7 +91,7 @@ const NAMED_PRESETS: Record<string, StatsOptions> = {
 		// warningsSpace: 0,
 		modulesSpace: 0,
 		assets: true,
-		// assetsSpace: 0,
+		assetsSpace: 0,
 		errors: true,
 		errorsCount: true,
 		warnings: true,

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1136,14 +1136,14 @@ Rspack compiled successfully"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-minimal-simple 1`] = `
-"asset main.js 36 bytes [emitted] (name: main)
+"1 asset
 1 module
 Rspack x.x.x compiled successfully in X s"
 `;
 
 exports[`StatsTestCases should print correct stats for preset-mixed-array 1`] = `
 "minimal:
-  asset minimal.js 44 bytes [emitted] (name: main)
+  1 asset
   1 module
   minimal (Rspack x.x.x) compiled successfully in X s
 

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -32,7 +32,7 @@ Generate packaging information that can be used to analyze module dependencies a
 | `'verbose'`         | Output everything                                              |
 | `'errors-only'`     | Output only error-related information                          |
 | `'errors-warnings'` | Output only error and warning related information              |
-| `'minimal'`         | Only output when errors or new compilation happen              |
+| `'minimal'`         | Output only when errors or new compilation happen              |
 | `'detailed'`        | Output everything except `chunkModules` and `chunkRootModules` |
 | `'summary'`         | Output only the summary information                            |
 

--- a/website/docs/en/config/stats.mdx
+++ b/website/docs/en/config/stats.mdx
@@ -25,13 +25,16 @@ Generate packaging information that can be used to analyze module dependencies a
 
 ## Stats Presets
 
-| Preset              | Description                                       |
-| ------------------- | ------------------------------------------------- |
-| `'normal'` (`true`) | Output by default value of stats options          |
-| `'none'` (`false`)  | Output nothing                                    |
-| `'verbose'`         | Output everything                                 |
-| `'errors-only'`     | Output only error-related information             |
-| `'errors-warnings'` | Output only error and warning related information |
+| Preset              | Description                                                    |
+| ------------------- | -------------------------------------------------------------- |
+| `'normal'` (`true`) | Output by default value of stats options                       |
+| `'none'` (`false`)  | Output nothing                                                 |
+| `'verbose'`         | Output everything                                              |
+| `'errors-only'`     | Output only error-related information                          |
+| `'errors-warnings'` | Output only error and warning related information              |
+| `'minimal'`         | Only output when errors or new compilation happen              |
+| `'detailed'`        | Output everything except `chunkModules` and `chunkRootModules` |
+| `'summary'`         | Output only the summary information                            |
 
 ## Stats Options
 

--- a/website/docs/zh/config/stats.mdx
+++ b/website/docs/zh/config/stats.mdx
@@ -25,13 +25,16 @@ import WebpackLicense from '@components/webpack-license';
 
 ## 预设（Stats Presets）
 
-| 预设                | 描述                            |
-| ------------------- | ------------------------------- |
-| `'normal'` (`true`) | 按照 stats options 的默认值输出 |
-| `'none'` (`false`)  | 不输出任何信息                  |
-| `'verbose'`         | 输出所有信息                    |
-| `'errors-only'`     | 只输出错误相关信息              |
-| `'errors-warnings'` | 只输出错误和警告相关信息        |
+| 预设                | 描述                                                       |
+| ------------------- | ---------------------------------------------------------- |
+| `'normal'` (`true`) | 按照 stats options 的默认值输出                            |
+| `'none'` (`false`)  | 不输出任何信息                                             |
+| `'verbose'`         | 输出所有信息                                               |
+| `'errors-only'`     | 只输出错误相关信息                                         |
+| `'errors-warnings'` | 只输出错误和警告相关信息                                   |
+| `'minimal'`         | 只在编译或者错误发生时输出                                 |
+| `'detailed'`        | 输出除了 `chunkModules` 之外 `chunkRootModules` 的所有信息 |
+| `'summary'`         | 只输出摘要                                                 |
 
 ## 详细选项（Stats Options）
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

1. Add  `minimal`, `detailed`, `summary` to stats presets's zod type and configuration doc.
2. Fix `assetsSpace: 0` being treated as `Infinity`
3. Fix missing `{count} assets` on console output when assets are filtered

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
