### PR TITLE
perf: reduce allocation for `TraceableError`

### DIFF
--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 
 use crate::RspackSeverity;
 
+#[allow(clippy::rc_buffer)]
 static EMPTY_STRING: Lazy<Arc<String>> = Lazy::new(|| Arc::new("".to_string()));
 
 #[derive(Debug, Error)]
@@ -51,6 +52,7 @@ pub struct TraceableError {
   kind: DiagnosticKind,
   message: String,
   severity: Severity,
+  #[allow(clippy::rc_buffer)]
   src: Arc<String>,
   label: SourceSpan,
   help: Option<String>,

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -1,12 +1,13 @@
-use std::{fmt::Display, path::Path};
+use std::{fmt::Display, sync::Arc};
 
-use miette::{
-  Diagnostic, IntoDiagnostic, LabeledSpan, MietteDiagnostic, Severity, SourceCode, SourceSpan,
-};
+use miette::{Diagnostic, LabeledSpan, MietteDiagnostic, Severity, SourceCode, SourceSpan};
+use once_cell::sync::Lazy;
 use swc_core::common::SourceFile;
 use thiserror::Error;
 
 use crate::RspackSeverity;
+
+static EMPTY_STRING: Lazy<Arc<String>> = Lazy::new(|| Arc::new("".to_string()));
 
 #[derive(Debug, Error)]
 #[error(transparent)]
@@ -50,7 +51,7 @@ pub struct TraceableError {
   kind: DiagnosticKind,
   message: String,
   severity: Severity,
-  src: String,
+  src: Arc<String>,
   label: SourceSpan,
   help: Option<String>,
   url: Option<String>,
@@ -128,24 +129,25 @@ impl TraceableError {
     title: String,
     message: String,
   ) -> Self {
-    let file_src = source_file.src.to_string();
-    let start = if start >= file_src.len() { 0 } else { start };
-    let end = if end >= file_src.len() { 0 } else { end };
-    Self {
-      title,
-      kind: Default::default(),
-      message,
-      severity: Default::default(),
-      src: file_src,
-      label: SourceSpan::new(start.into(), end.saturating_sub(start).into()),
-      help: None,
-      url: None,
-      hide_stack: None,
-    }
+    Self::from_arc_string(source_file.src.clone(), start, end, title, message)
   }
 
   pub fn from_file(
     file_src: String,
+    start: usize,
+    end: usize,
+    title: String,
+    message: String,
+  ) -> Self {
+    Self::from_arc_string(Arc::new(file_src), start, end, title, message)
+  }
+
+  pub fn from_empty_file(start: usize, end: usize, title: String, message: String) -> Self {
+    Self::from_arc_string(EMPTY_STRING.clone(), start, end, title, message)
+  }
+
+  pub fn from_arc_string(
+    src: Arc<String>,
     start: usize,
     end: usize,
     title: String,
@@ -156,39 +158,12 @@ impl TraceableError {
       kind: Default::default(),
       message,
       severity: Default::default(),
-      src: file_src,
+      src,
       label: SourceSpan::new(start.into(), end.saturating_sub(start).into()),
       help: None,
       url: None,
       hide_stack: None,
     }
-  }
-
-  pub fn from_empty_file(start: usize, end: usize, title: String, message: String) -> Self {
-    Self {
-      title,
-      kind: Default::default(),
-      message,
-      severity: Default::default(),
-      src: "".to_string(),
-      label: SourceSpan::new(start.into(), end.saturating_sub(start).into()),
-      help: None,
-      url: None,
-      hide_stack: None,
-    }
-  }
-
-  pub fn from_real_file_path(
-    path: &Path,
-    start: usize,
-    end: usize,
-    title: String,
-    message: String,
-  ) -> Result<Self, miette::Error> {
-    let file_src = std::fs::read_to_string(path).into_diagnostic()?;
-    let start = if start >= file_src.len() { 0 } else { start };
-    let end = if end >= file_src.len() { 0 } else { end };
-    Ok(Self::from_file(file_src, start, end, title, message))
   }
 
   pub fn hide_stack(&self) -> Option<bool> {

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -343,6 +343,7 @@ pub fn normalize_url(s: &str) -> String {
   result.to_string()
 }
 
+#[allow(clippy::rc_buffer)]
 pub fn css_parsing_traceable_error(
   source_code: Arc<String>,
   start: css_module_lexer::Pos,

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::Write;
 use std::hash::Hasher;
+use std::sync::Arc;
 
 use heck::{ToKebabCase, ToLowerCamelCase};
 use indexmap::{IndexMap, IndexSet};
@@ -343,14 +344,14 @@ pub fn normalize_url(s: &str) -> String {
 }
 
 pub fn css_parsing_traceable_error(
-  source_code: impl Into<String>,
+  source_code: Arc<String>,
   start: css_module_lexer::Pos,
   end: css_module_lexer::Pos,
   message: impl Into<String>,
   severity: RspackSeverity,
 ) -> TraceableError {
-  TraceableError::from_file(
-    source_code.into(),
+  TraceableError::from_arc_string(
+    source_code,
     start as usize,
     end as usize,
     match severity {
@@ -365,14 +366,14 @@ pub fn css_parsing_traceable_error(
 pub fn replace_module_request_prefix<'s>(
   specifier: &'s str,
   diagnostics: &mut Vec<Box<dyn Diagnostic + Send + Sync>>,
-  source_code: &str,
+  source_code: impl Fn() -> Arc<String>,
   start: css_module_lexer::Pos,
   end: css_module_lexer::Pos,
 ) -> &'s str {
   if let Some(specifier) = specifier.strip_prefix('~') {
     diagnostics.push(
       css_parsing_traceable_error(
-        source_code,
+        source_code(),
         start,
         end,
         "'@import' or 'url()' with a request starts with '~' is deprecated.".to_string(),

--- a/packages/rspack-test-tools/tests/diagnosticsCases/builtins/html_syntax_error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/builtins/html_syntax_error/stats.err
@@ -9,5 +9,5 @@ ERROR in × HTML parsing error: Stray end tag "something"
    ╭─[1:1]
  1 │ <head>
  2 │   </something>
-   ·   ▲
+   ·   ────────────
    ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/multiple_file_syntax_error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/multiple_file_syntax_error/stats.err
@@ -5,7 +5,7 @@ ERROR in ./a.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 
@@ -34,7 +34,7 @@ ERROR in ./b.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 
@@ -63,7 +63,7 @@ ERROR in ./c.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 
@@ -92,7 +92,7 @@ ERROR in ./d.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 
@@ -121,7 +121,7 @@ ERROR in ./e.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 
@@ -150,7 +150,7 @@ ERROR in ./f.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 
@@ -179,7 +179,7 @@ ERROR in ./g.js
        4 │     d = 10
        5 │     g = CONST
        6 │ }
-         · ▲
+         · ─
          ╰────
       
   help: 

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/non_support_warning/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/non_support_warning/stats.err
@@ -3,5 +3,5 @@ WARNING in ./index.js
   ╰─▶   ⚠ Unsupported feature: require.include() is not supported by Rspack.
          ╭────
        1 │ require.include("aaa")
-         · ▲
+         · ──────────────────────
          ╰────


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Replaced `src: String` with `src: Arc<String>`. `Arc<String>` is an internal representation of `SourceFile` source.
The type should not be `Arc<str>` as it creates additional heap allocations.

Removed duplicated `String` allocations in `TraceableError` of `CssPlugin`.

Removed normalization code for `start` and `end` position.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
