### PR TITLE
fix: panic in hmr cause by auxiliary_assets

### DIFF
--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -22,9 +22,8 @@ fn get_asset_size(file: &str, compilation: &Compilation) -> f64 {
   compilation
     .assets()
     .get(file)
-    .unwrap_or_else(|| panic!("Could not find asset by name: {file:?}"))
-    .get_source()
-    .map_or(-1f64, |s| s.size() as f64)
+    .and_then(|asset| asset.get_source().map(|s| s.size() as f64))
+    .unwrap_or(-1f64)
 }
 
 #[derive(Debug, Clone)]

--- a/crates/rspack_core/src/stats.rs
+++ b/crates/rspack_core/src/stats.rs
@@ -481,21 +481,24 @@ impl Stats<'_> {
       .flatten()
       .collect::<Vec<_>>();
 
-    let auxiliary_assets = cg
-      .chunks
-      .par_iter()
-      .map(|c| {
-        let chunk = self.compilation.chunk_by_ukey.expect_get(c);
-        chunk
-          .auxiliary_files
-          .par_iter()
-          .map(|file| StatsChunkGroupAsset {
-            name: file.clone(),
-            size: get_asset_size(file, self.compilation),
-          })
-      })
-      .flatten()
-      .collect::<Vec<_>>();
+    let auxiliary_assets = if chunk_group_auxiliary {
+      cg.chunks
+        .par_iter()
+        .map(|c| {
+          let chunk = self.compilation.chunk_by_ukey.expect_get(c);
+          chunk
+            .auxiliary_files
+            .par_iter()
+            .map(|file| StatsChunkGroupAsset {
+              name: file.clone(),
+              size: get_asset_size(file, self.compilation),
+            })
+        })
+        .flatten()
+        .collect::<Vec<_>>()
+    } else {
+      vec![]
+    };
 
     let children = chunk_group_children.then(|| {
       let ordered_children = cg.get_children_by_orders(self.compilation);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

fix: panic in hmr cause by auxiliary_assets

Prevent panic when a file is not found in assets. Aligns with webpack's behavior in https://github.com/webpack/webpack/blob/main/lib/stats/DefaultStatsFactoryPlugin.js#L1007.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
