### PR TITLE
refactor: allow passing function type to assets generator.filename

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -747,7 +747,7 @@ export interface RawAssetGeneratorDataUrlOptions {
 
 export interface RawAssetGeneratorOptions {
   emit?: boolean
-  filename?: string
+  filename?: JsFilename
   publicPath?: string
   dataUrl?: RawAssetGeneratorDataUrlOptions | ((arg: RawAssetGeneratorDataUrlFnArgs) => string)
 }
@@ -771,7 +771,7 @@ export interface RawAssetParserOptions {
 
 export interface RawAssetResourceGeneratorOptions {
   emit?: boolean
-  filename?: string
+  filename?: JsFilename
   publicPath?: string
 }
 

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -5,7 +5,7 @@ use derivative::Derivative;
 use napi::bindgen_prelude::Either3;
 use napi::Either;
 use napi_derive::napi;
-use rspack_binding_values::RawRegex;
+use rspack_binding_values::{JsFilename, RawRegex};
 use rspack_core::{
   AssetGeneratorDataUrl, AssetGeneratorDataUrlFnArgs, AssetGeneratorDataUrlOptions,
   AssetGeneratorOptions, AssetInlineGeneratorOptions, AssetParserDataUrl,
@@ -483,7 +483,7 @@ impl From<RawGeneratorOptions> for GeneratorOptions {
 #[napi(object, object_to_js = false)]
 pub struct RawAssetGeneratorOptions {
   pub emit: Option<bool>,
-  pub filename: Option<String>,
+  pub filename: Option<JsFilename>,
   pub public_path: Option<String>,
   #[derivative(Debug = "ignore")]
   #[napi(
@@ -527,10 +527,10 @@ impl From<RawAssetInlineGeneratorOptions> for AssetInlineGeneratorOptions {
 }
 
 #[derive(Debug, Default)]
-#[napi(object)]
+#[napi(object, object_to_js = false)]
 pub struct RawAssetResourceGeneratorOptions {
   pub emit: Option<bool>,
-  pub filename: Option<String>,
+  pub filename: Option<JsFilename>,
   pub public_path: Option<String>,
 }
 

--- a/packages/rspack-test-tools/tests/configCases/asset/filename/index.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/filename/index.js
@@ -1,0 +1,11 @@
+import png from "../_images/file.png";
+import png1 from "../_images/file.png?custom1";
+import png2 from "../_images/file.png?custom2";
+import jpeg2 from "../_images/file.jpg?custom2";
+
+it("should change filenames", () => {
+	expect(png).toEqual("images/failure.png");
+	expect(png1).toEqual("custom-images/success1.png");
+	expect(png2).toEqual("custom-images/success2.png");
+	expect(jpeg2).toEqual("images/failure2.jpg");
+});

--- a/packages/rspack-test-tools/tests/configCases/asset/filename/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/asset/filename/rspack.config.js
@@ -1,0 +1,38 @@
+/**
+ * this test case is in addition to webpack-test/configCases/asset-modules/assetModuleFilename
+ */
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	output: {
+		assetModuleFilename: "images/failure[ext]"
+	},
+	module: {
+		rules: [
+			{
+				test: /\.(png|jpg)$/,
+				type: "asset/resource",
+				rules: [
+					{
+						resourceQuery: "?custom1",
+						generator: {
+							filename: "custom-images/success1[ext]"
+						}
+					},
+
+					{
+						resourceQuery: "?custom2",
+						generator: {
+							filename: ({ filename }) => {
+								if (filename.endsWith(".png?custom2")) {
+									return "custom-images/success2[ext]";
+								}
+								return "images/failure2[ext]";
+							}
+						}
+					}
+				]
+			}
+		]
+	}
+};

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -192,7 +192,7 @@ const assetGeneratorOptions: z.ZodObject<{
         content: string;
     }>], z.ZodUnknown>, z.ZodString>]>>;
     emit: z.ZodOptional<z.ZodBoolean>;
-    filename: z.ZodOptional<z.ZodString>;
+    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
     publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
 }, "strict", z.ZodTypeAny, {
     dataUrl?: {
@@ -203,7 +203,7 @@ const assetGeneratorOptions: z.ZodObject<{
         content: string;
     }, ...args_1: unknown[]) => string) | undefined;
     emit?: boolean | undefined;
-    filename?: string | undefined;
+    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
     publicPath?: string | undefined;
 }, {
     dataUrl?: {
@@ -214,7 +214,7 @@ const assetGeneratorOptions: z.ZodObject<{
         content: string;
     }, ...args_1: unknown[]) => string) | undefined;
     emit?: boolean | undefined;
-    filename?: string | undefined;
+    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
     publicPath?: string | undefined;
 }>;
 
@@ -321,15 +321,15 @@ export type AssetResourceGeneratorOptions = z.infer<typeof assetResourceGenerato
 // @public (undocumented)
 const assetResourceGeneratorOptions: z.ZodObject<{
     emit: z.ZodOptional<z.ZodBoolean>;
-    filename: z.ZodOptional<z.ZodString>;
+    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
     publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
 }, "strict", z.ZodTypeAny, {
     emit?: boolean | undefined;
-    filename?: string | undefined;
+    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
     publicPath?: string | undefined;
 }, {
     emit?: boolean | undefined;
-    filename?: string | undefined;
+    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
     publicPath?: string | undefined;
 }>;
 
@@ -3339,7 +3339,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
             content: string;
         }>], z.ZodUnknown>, z.ZodString>]>>;
         emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodString>;
+        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
     }, "strict", z.ZodTypeAny, {
         dataUrl?: {
@@ -3350,7 +3350,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }, {
         dataUrl?: {
@@ -3361,7 +3361,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }>>;
     "asset/inline": z.ZodOptional<z.ZodObject<{
@@ -3403,15 +3403,15 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
     }>>;
     "asset/resource": z.ZodOptional<z.ZodObject<{
         emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodString>;
+        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
     }, "strict", z.ZodTypeAny, {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }, {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }>>;
     css: z.ZodOptional<z.ZodObject<{
@@ -3466,7 +3466,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     "asset/inline"?: {
@@ -3480,7 +3480,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
     } | undefined;
     "asset/resource"?: {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     css?: {
@@ -3509,7 +3509,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     "asset/inline"?: {
@@ -3523,7 +3523,7 @@ const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
     } | undefined;
     "asset/resource"?: {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     css?: {
@@ -3570,7 +3570,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
             content: string;
         }>], z.ZodUnknown>, z.ZodString>]>>;
         emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodString>;
+        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
     }, "strict", z.ZodTypeAny, {
         dataUrl?: {
@@ -3581,7 +3581,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }, {
         dataUrl?: {
@@ -3592,7 +3592,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }>>;
     "asset/inline": z.ZodOptional<z.ZodObject<{
@@ -3634,15 +3634,15 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
     }>>;
     "asset/resource": z.ZodOptional<z.ZodObject<{
         emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodString>;
+        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
     }, "strict", z.ZodTypeAny, {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }, {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     }>>;
     css: z.ZodOptional<z.ZodObject<{
@@ -3697,7 +3697,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     "asset/inline"?: {
@@ -3711,7 +3711,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
     } | undefined;
     "asset/resource"?: {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     css?: {
@@ -3740,7 +3740,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
             content: string;
         }, ...args_1: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     "asset/inline"?: {
@@ -3754,7 +3754,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
     } | undefined;
     "asset/resource"?: {
         emit?: boolean | undefined;
-        filename?: string | undefined;
+        filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
     } | undefined;
     css?: {
@@ -5490,7 +5490,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }>], z.ZodUnknown>, z.ZodString>]>>;
             emit: z.ZodOptional<z.ZodBoolean>;
-            filename: z.ZodOptional<z.ZodString>;
+            filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
             publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
         }, "strict", z.ZodTypeAny, {
             dataUrl?: {
@@ -5501,7 +5501,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }, ...args_1: unknown[]) => string) | undefined;
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         }, {
             dataUrl?: {
@@ -5512,7 +5512,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }, ...args_1: unknown[]) => string) | undefined;
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         }>>;
         "asset/inline": z.ZodOptional<z.ZodObject<{
@@ -5554,15 +5554,15 @@ const moduleOptions: z.ZodObject<{
         }>>;
         "asset/resource": z.ZodOptional<z.ZodObject<{
             emit: z.ZodOptional<z.ZodBoolean>;
-            filename: z.ZodOptional<z.ZodString>;
+            filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
             publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
         }, "strict", z.ZodTypeAny, {
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         }, {
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         }>>;
         css: z.ZodOptional<z.ZodObject<{
@@ -5617,7 +5617,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }, ...args_1: unknown[]) => string) | undefined;
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         "asset/inline"?: {
@@ -5631,7 +5631,7 @@ const moduleOptions: z.ZodObject<{
         } | undefined;
         "asset/resource"?: {
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         css?: {
@@ -5660,7 +5660,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }, ...args_1: unknown[]) => string) | undefined;
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         "asset/inline"?: {
@@ -5674,7 +5674,7 @@ const moduleOptions: z.ZodObject<{
         } | undefined;
         "asset/resource"?: {
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         css?: {
@@ -5784,7 +5784,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }, ...args_1: unknown[]) => string) | undefined;
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         "asset/inline"?: {
@@ -5798,7 +5798,7 @@ const moduleOptions: z.ZodObject<{
         } | undefined;
         "asset/resource"?: {
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         css?: {
@@ -5908,7 +5908,7 @@ const moduleOptions: z.ZodObject<{
                 content: string;
             }, ...args_1: unknown[]) => string) | undefined;
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         "asset/inline"?: {
@@ -5922,7 +5922,7 @@ const moduleOptions: z.ZodObject<{
         } | undefined;
         "asset/resource"?: {
             emit?: boolean | undefined;
-            filename?: string | undefined;
+            filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
         } | undefined;
         css?: {
@@ -10719,7 +10719,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }>], z.ZodUnknown>, z.ZodString>]>>;
                 emit: z.ZodOptional<z.ZodBoolean>;
-                filename: z.ZodOptional<z.ZodString>;
+                filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
                 publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
             }, "strict", z.ZodTypeAny, {
                 dataUrl?: {
@@ -10730,7 +10730,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             }, {
                 dataUrl?: {
@@ -10741,7 +10741,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             }>>;
             "asset/inline": z.ZodOptional<z.ZodObject<{
@@ -10783,15 +10783,15 @@ export const rspackOptions: z.ZodObject<{
             }>>;
             "asset/resource": z.ZodOptional<z.ZodObject<{
                 emit: z.ZodOptional<z.ZodBoolean>;
-                filename: z.ZodOptional<z.ZodString>;
+                filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
                 publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodString]>>;
             }, "strict", z.ZodTypeAny, {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             }, {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             }>>;
             css: z.ZodOptional<z.ZodObject<{
@@ -10846,7 +10846,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             "asset/inline"?: {
@@ -10860,7 +10860,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/resource"?: {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             css?: {
@@ -10889,7 +10889,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             "asset/inline"?: {
@@ -10903,7 +10903,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/resource"?: {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             css?: {
@@ -11013,7 +11013,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             "asset/inline"?: {
@@ -11027,7 +11027,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/resource"?: {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             css?: {
@@ -11137,7 +11137,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             "asset/inline"?: {
@@ -11151,7 +11151,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/resource"?: {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             css?: {
@@ -11674,7 +11674,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             "asset/inline"?: {
@@ -11688,7 +11688,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/resource"?: {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             css?: {
@@ -12201,7 +12201,7 @@ export const rspackOptions: z.ZodObject<{
                     content: string;
                 }, ...args_1: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             "asset/inline"?: {
@@ -12215,7 +12215,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/resource"?: {
                 emit?: boolean | undefined;
-                filename?: string | undefined;
+                filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
                 publicPath?: string | undefined;
             } | undefined;
             css?: {

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -663,7 +663,7 @@ export type AssetInlineGeneratorOptions = z.infer<
 
 const assetResourceGeneratorOptions = z.strictObject({
 	emit: z.boolean().optional(),
-	filename: filenameTemplate.optional(),
+	filename: filename.optional(),
 	publicPath: publicPath.optional()
 });
 export type AssetResourceGeneratorOptions = z.infer<


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

allow passing function type to `generator.filename` of `asset` and `asset/resource` type.

it is a missing feature of #7191.

it was reported in https://discord.com/channels/977448667919286283/1263141418881519706

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
