### PR TITLE
chore(deps): use typescript latest version and `"module": "NodeNext"`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -122,7 +122,6 @@
         "@playwright/test",
         "react",
         "react-dom",
-        "typescript",
         "pnpm"
       ]
     },

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -40,7 +40,8 @@
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
-    "@napi-rs/cli": "3.0.0-alpha.45"
+    "@napi-rs/cli": "3.0.0-alpha.45",
+    "typescript": "5.5.3"
   },
   "napi": {
     "binaryName": "rspack"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "prettier-2": "npm:prettier@2.8.8",
     "rimraf": "3.0.2",
     "ts-jest": "29.1.2",
-    "typescript": "5.0.2",
+    "typescript": "5.5.3",
     "webpack": "^5.92.0",
     "webpack-cli": "5.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -52,12 +52,17 @@
   "engines": {
     "pnpm": "9.3.0"
   },
+  "pnpm": {
+    "overrides": {
+      "@microsoft/api-extractor>typescript": "5.5.3"
+    }
+  },
   "devDependencies": {
     "zx": "7.2.3",
     "@biomejs/biome": "1.8.0",
     "check-dependency-version-consistency": "^4.1.0",
     "@microsoft/api-extractor": "^7.43.1",
-    "@microsoft/api-extractor-model": "^7.28.14",
+    "@microsoft/api-extractor-model": "^7.29.3",
     "@rspack/cli": "workspace:*",
     "@taplo/cli": "^0.7.0",
     "@types/is-ci": "^3.0.4",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -28,6 +28,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-refresh": "^0.14.0",
+    "typescript": "5.5.3",
     "tailwindcss": "^3.3.0",
     "vue": "^3.4.21",
     "vue-loader": "^17.3.1",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -38,6 +38,7 @@
     "@types/semver": "^7.5.6",
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "@types/yargs": "17.0.32",
+    "typescript": "5.5.3",
     "ts-node": "^10.9.2",
     "concat-stream": "^2.0.0",
     "cross-env": "^7.0.3",

--- a/packages/rspack-dev-server/etc/api.md
+++ b/packages/rspack-dev-server/etc/api.md
@@ -4,8 +4,6 @@
 
 ```ts
 
-/// <reference types="node" />
-
 import { Compiler } from '@rspack/core';
 import { DevServer as Configuration } from '@rspack/core';
 import type { FSWatcher } from 'chokidar';

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -36,6 +36,7 @@
     "directory": "packages/rspack-dev-server"
   },
   "devDependencies": {
+    "typescript": "5.5.3",
     "@rspack/core": "workspace:*",
     "@rspack/dev-server": "workspace:*",
     "@rspack/plugin-react-refresh": "workspace:*",

--- a/packages/rspack-lite-tapable/etc/api.md
+++ b/packages/rspack-lite-tapable/etc/api.md
@@ -43,7 +43,7 @@ export class AsyncSeriesHook<T, AdditionalOptions = UnsetAdditionalOptions> exte
 
 // @public (undocumented)
 export class AsyncSeriesWaterfallHook<T, AdditionalOptions = UnsetAdditionalOptions> extends HookBase<T, AsArray<T>[0], AdditionalOptions> {
-    constructor(args?: FixedSizeArray<AsArray<T>["length"], string>, name?: string);
+    constructor(args?: ArgumentNames<AsArray<T>>, name?: string);
     // (undocumented)
     callAsyncStageRange(queried: QueriedHook<T, AsArray<T>[0], AdditionalOptions>, ...args: Append<AsArray<T>, Callback<Error, AsArray<T>[0]>>): void;
 }
@@ -103,7 +103,7 @@ export interface Hook<T = any, R = any, AdditionalOptions = UnsetAdditionalOptio
 
 // @public (undocumented)
 export class HookBase<T, R, AdditionalOptions = UnsetAdditionalOptions> implements Hook<T, R, AdditionalOptions> {
-    constructor(args?: FixedSizeArray<AsArray<T>["length"], string>, name?: string);
+    constructor(args?: ArgumentNames<AsArray<T>>, name?: string);
     // (undocumented)
     args: ArgumentNames<AsArray<T>>;
     // (undocumented)
@@ -318,7 +318,7 @@ export class SyncHook<T, R = void, AdditionalOptions = UnsetAdditionalOptions> e
 
 // @public (undocumented)
 export class SyncWaterfallHook<T, AdditionalOptions = UnsetAdditionalOptions> extends HookBase<T, AsArray<T>[0], AdditionalOptions> {
-    constructor(args?: FixedSizeArray<AsArray<T>["length"], string>, name?: string);
+    constructor(args?: ArgumentNames<AsArray<T>>, name?: string);
     // (undocumented)
     call(...args: AsArray<T>): AsArray<T>[0];
     // (undocumented)

--- a/packages/rspack-lite-tapable/package.json
+++ b/packages/rspack-lite-tapable/package.json
@@ -14,6 +14,9 @@
       "default": "./dist/index.js"
     }
   },
+  "devDependencies": {
+    "typescript": "5.5.3"
+  },
   "scripts": {
     "build": "tsc -b ./tsconfig.build.json",
     "build:force": "tsc -b ./tsconfig.build.json --force",

--- a/packages/rspack-plugin-preact-refresh/package.json
+++ b/packages/rspack-plugin-preact-refresh/package.json
@@ -42,7 +42,8 @@
     "@rspack/test-tools": "workspace:*",
     "@swc/plugin-prefresh": "^2.0.7",
     "@swc/helpers": "0.5.8",
-    "preact": "^10.15.1"
+    "preact": "^10.15.1",
+    "typescript": "5.5.3"
   },
   "peerDependencies": {
     "@prefresh/core": "^1.5.0",

--- a/packages/rspack-plugin-react-refresh/package.json
+++ b/packages/rspack-plugin-react-refresh/package.json
@@ -38,7 +38,8 @@
   "devDependencies": {
     "@rspack/core": "workspace:*",
     "@rspack/plugin-react-refresh": "workspace:*",
-    "react-refresh": "^0.14.0"
+    "react-refresh": "^0.14.0",
+    "typescript": "5.5.3"
   },
   "dependencies": {
     "error-stack-parser": "^2.0.6",

--- a/packages/rspack-test-tools/etc/api.md
+++ b/packages/rspack-test-tools/etc/api.md
@@ -4,10 +4,6 @@
 
 ```ts
 
-/// <reference types="../jest.d.ts" />
-/// <reference types="jest" />
-/// <reference types="node" />
-
 import type { Compiler } from '@rspack/core';
 import type { Compiler as Compiler_2 } from 'webpack';
 import type { Configuration } from 'webpack';

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -113,6 +113,7 @@
     "style-loader": "^3.3.3",
     "source-map-loader": "^5.0.0",
     "terser": "5.27.2",
+    "typescript": "5.5.3",
     "wast-loader": "^1.12.1"
   },
   "peerDependencies": {

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -13,7 +13,8 @@ import Cache_2 = require('./lib/Cache');
 import CacheFacade = require('./lib/CacheFacade');
 import type { Callback } from '@rspack/lite-tapable';
 import { cleanupGlobalTrace } from '@rspack/binding';
-import { Compiler as Compiler_2 } from '../Compiler';
+import { Compiler as Compiler_2 } from '..';
+import { Compiler as Compiler_5 } from '../Compiler';
 import { RawEvalDevToolModulePluginOptions as EvalDevToolModulePluginOptions } from '@rspack/binding';
 import { EventEmitter } from 'events';
 import { ExternalObject } from '@rspack/binding';
@@ -1258,10 +1259,10 @@ export class Compiler {
 type Compiler_3 = any;
 
 // @public (undocumented)
-type Compiler_4 = Compiler_2;
+type Compiler_4 = Compiler_5;
 
 // @public (undocumented)
-type Compiler_5 = any;
+type Compiler_6 = any;
 
 // @public (undocumented)
 type Config = {
@@ -4994,7 +4995,7 @@ type LoaderOptionsPluginOptions = any;
 // @public
 export class LoaderTargetPlugin {
     constructor(target: string);
-    apply(compiler: Compiler_5): void;
+    apply(compiler: Compiler_6): void;
     // (undocumented)
     target: string;
 }
@@ -6284,13 +6285,9 @@ type NormalizedStatsOptions = KnownNormalizedStatsOptions & Omit<StatsOptions, k
 export class NormalModule {
     // (undocumented)
     static getCompilationHooks(compilation: Compilation): {
-        loader: liteTapable.SyncHook<[LoaderContext<{}>], void, {
-            _UnsetAdditionalOptions: true;
-        }>;
+        loader: liteTapable.SyncHook<[LoaderContext]>;
         readResourceForScheme: any;
-        readResource: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[LoaderContext<{}>], string | Buffer, {
-            _UnsetAdditionalOptions: true;
-        }>>;
+        readResource: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[LoaderContext], string | Buffer>>;
     };
 }
 
@@ -13824,7 +13821,7 @@ const uniqueName: z.ZodString;
 // @public (undocumented)
 export const util: {
     createHash: (algorithm: any) => any;
-    cleverMerge: <T, O>(first: T, second: O) => T | O | (T & O);
+    cleverMerge: <T, O>(first: T, second: O) => (T & O) | T | O;
 };
 
 // @public (undocumented)

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -57,6 +57,7 @@
     "json-parse-even-better-errors": "^3.0.0",
     "neo-async": "2.6.2",
     "prebundle": "^1.1.0",
+    "typescript": "5.5.3",
     "tsc-alias": "^1.8.8",
     "watchpack": "^2.4.0",
     "webpack-sources": "3.2.3",

--- a/packages/rspack/src/lib/CacheFacade.js
+++ b/packages/rspack/src/lib/CacheFacade.js
@@ -59,6 +59,7 @@ class MultiItemCache {
 	getPromise() {
 		// @ts-expect-error
 		const next = i => {
+			// @ts-expect-error
 			return this._items[i].getPromise().then(result => {
 				if (result !== undefined) return result;
 				if (++i < this._items.length) return next(i);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@microsoft/api-extractor>typescript': 5.5.3
+
 importers:
 
   .:
@@ -15,8 +18,8 @@ importers:
         specifier: ^7.43.1
         version: 7.43.1(@types/node@20.12.7)
       '@microsoft/api-extractor-model':
-        specifier: ^7.28.14
-        version: 7.28.14(@types/node@20.12.7)
+        specifier: ^7.29.3
+        version: 7.29.3(@types/node@20.12.7)
       '@rspack/cli':
         specifier: workspace:*
         version: link:packages/rspack-cli
@@ -52,10 +55,10 @@ importers:
         version: 3.0.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-cli:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-environment-node:
         specifier: 29.7.0
         version: 29.7.0
@@ -73,10 +76,10 @@ importers:
         version: 3.0.2
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)))(typescript@5.0.2)
+        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)))(typescript@5.5.3)
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.5.3
+        version: 5.5.3
       webpack:
         specifier: ^5.92.0
         version: 5.92.0(webpack-cli@5.1.4)
@@ -105,6 +108,9 @@ importers:
       '@napi-rs/cli':
         specifier: 3.0.0-alpha.45
         version: 3.0.0-alpha.45
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
 
   crates/rspack_fs_node:
     devDependencies:
@@ -219,7 +225,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.4.2)
+        version: 3.4.21(typescript@5.5.3)
     devDependencies:
       '@rspack/cli':
         specifier: workspace:*
@@ -232,7 +238,7 @@ importers:
         version: 7.0.3
       vue-loader:
         specifier: ^17.3.1
-        version: 17.4.2(vue@3.4.21(typescript@5.4.2))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
+        version: 17.4.2(vue@3.4.21(typescript@5.5.3))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
 
   packages/create-rspack/template-vue-ts:
     dependencies:
@@ -302,7 +308,7 @@ importers:
         version: 8.4.38
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.4.2)(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -314,13 +320,16 @@ importers:
         version: 0.14.0
       tailwindcss:
         specifier: ^3.3.0
-        version: 3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.2))
+        version: 3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
       vue:
         specifier: ^3.4.21
-        version: 3.4.21(typescript@5.4.2)
+        version: 3.4.21(typescript@5.5.3)
       vue-loader:
         specifier: ^17.3.1
-        version: 17.4.2(vue@3.4.21(typescript@5.4.2))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
+        version: 17.4.2(vue@3.4.21(typescript@5.5.3))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
       webpack-dev-server:
         specifier: 4.13.1
         version: 4.13.1(webpack-cli@5.1.4(webpack@5.92.0))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
@@ -381,10 +390,13 @@ importers:
         version: 2.6.2
       prebundle:
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.4.2)
+        version: 1.1.0(typescript@5.5.3)
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
       watchpack:
         specifier: ^2.4.0
         version: 2.4.1
@@ -463,7 +475,10 @@ importers:
         version: 6.2.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.4.0)(@types/node@20.12.7)(typescript@5.4.2)
+        version: 10.9.2(@swc/core@1.4.0)(@types/node@20.12.7)(typescript@5.5.3)
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
 
   packages/rspack-dev-server:
     dependencies:
@@ -513,8 +528,15 @@ importers:
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
 
-  packages/rspack-lite-tapable: {}
+  packages/rspack-lite-tapable:
+    devDependencies:
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
 
   packages/rspack-plugin-minify:
     dependencies:
@@ -551,6 +573,9 @@ importers:
       preact:
         specifier: ^10.15.1
         version: 10.22.0
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
 
   packages/rspack-plugin-react-refresh:
     dependencies:
@@ -570,6 +595,9 @@ importers:
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
 
   packages/rspack-test-tools:
     dependencies:
@@ -744,7 +772,7 @@ importers:
         version: 6.2.0
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.4.2)(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0)))
       postcss-pxtorem:
         specifier: ^6.0.0
         version: 6.1.0(postcss@8.4.38)
@@ -775,6 +803,9 @@ importers:
       terser:
         specifier: 5.27.2
         version: 5.27.2
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
       wast-loader:
         specifier: ^1.12.1
         version: 1.12.1
@@ -802,6 +833,9 @@ importers:
       semver:
         specifier: ^7.6.2
         version: 7.6.2
+      typescript:
+        specifier: 5.5.3
+        version: 5.5.3
       zx:
         specifier: 7.2.3
         version: 7.2.3
@@ -889,7 +923,7 @@ importers:
         version: link:../../../packages/rspack-plugin-react-refresh
       '@svgr/webpack':
         specifier: ^8.0.0
-        version: 8.1.0(typescript@5.4.2)
+        version: 8.1.0(typescript@5.5.3)
       '@swc/core':
         specifier: 1.4.0
         version: 1.4.0(@swc/helpers@0.5.8)
@@ -916,7 +950,7 @@ importers:
         version: 2.9.0(webpack@5.92.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.92.0)))
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.4.2)(webpack@5.92.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.92.0)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.92.0)))
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -967,7 +1001,7 @@ importers:
         version: link:../../packages/rspack-cli
       jest-watch-typeahead:
         specifier: ^2.2.2
-        version: 2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)))
+        version: 2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)))
 
   tests/webpack-examples:
     devDependencies:
@@ -2411,6 +2445,9 @@ packages:
   '@microsoft/api-extractor-model@7.28.14':
     resolution: {integrity: sha512-Bery/c8A8SsKPSvA82cTTuy/+OcxZbLRmKhPkk91/AJOQzxZsShcrmHFAGeiEqSIrv1nPZ3tKq9kfMLdCHmsqg==}
 
+  '@microsoft/api-extractor-model@7.29.3':
+    resolution: {integrity: sha512-kEWjLr2ygL3ku9EGyjeTnL2S5IxyH9NaF1k1UoI0Nzwr4xEJBSWCVsWuF2+0lPUrRPA6mTY95fR264SJ5ETKQA==}
+
   '@microsoft/api-extractor@7.43.1':
     resolution: {integrity: sha512-ohg40SsvFFgzHFAtYq5wKJc8ZDyY46bphjtnSvhSSlXpPTG7GHwyyXkn48UZiUCBwr2WC7TRC1Jfwz7nreuiyQ==}
     hasBin: true
@@ -2418,8 +2455,14 @@ packages:
   '@microsoft/tsdoc-config@0.16.2':
     resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
 
+  '@microsoft/tsdoc-config@0.17.0':
+    resolution: {integrity: sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==}
+
   '@microsoft/tsdoc@0.14.2':
     resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
+
+  '@microsoft/tsdoc@0.15.0':
+    resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
 
   '@module-federation/runtime-tools@0.2.3':
     resolution: {integrity: sha512-capN8CVTCEqNAjnl102girrkevczoQfnQYyiYC4WuyKsg7+LUqfirIe1Eiyv6VSE2UgvOTZDnqvervA6rBOlmg==}
@@ -2964,6 +3007,14 @@ packages:
 
   '@rushstack/node-core-library@4.1.0':
     resolution: {integrity: sha512-qz4JFBZJCf1YN5cAXa1dP6Mki/HrsQxc/oYGAGx29dF2cwF2YMxHoly0FBhMw3IEnxo5fMj0boVfoHVBkpkx/w==}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@rushstack/node-core-library@5.5.0':
+    resolution: {integrity: sha512-Cl3MYQ74Je5Y/EngMxcA3SpHjGZ/022nKbAO1aycGfQ+7eKyNCBu0oywj5B1f367GCzuHBgy+3BlVLKysHkXZw==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
@@ -3926,6 +3977,14 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-errors@1.0.1:
     resolution: {integrity: sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==}
     peerDependencies:
@@ -3933,6 +3992,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -3957,6 +4024,9 @@ packages:
 
   ajv@8.12.0:
     resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
+  ajv@8.13.0:
+    resolution: {integrity: sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==}
 
   align-text@0.1.4:
     resolution: {integrity: sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==}
@@ -8925,13 +8995,13 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.5.3:
+    resolution: {integrity: sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10881,7 +10951,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -10895,7 +10965,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -11088,6 +11158,14 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@microsoft/api-extractor-model@7.29.3(@types/node@20.12.7)':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.5.0(@types/node@20.12.7)
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@microsoft/api-extractor@7.43.1(@types/node@20.12.7)':
     dependencies:
       '@microsoft/api-extractor-model': 7.28.14(@types/node@20.12.7)
@@ -11102,7 +11180,7 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
       source-map: 0.6.1
-      typescript: 5.4.2
+      typescript: 5.5.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -11113,7 +11191,16 @@ snapshots:
       jju: 1.4.0
       resolve: 1.19.0
 
+  '@microsoft/tsdoc-config@0.17.0':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.0
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.8
+
   '@microsoft/tsdoc@0.14.2': {}
+
+  '@microsoft/tsdoc@0.15.0': {}
 
   '@module-federation/runtime-tools@0.2.3':
     dependencies:
@@ -11678,6 +11765,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.7
 
+  '@rushstack/node-core-library@5.5.0(@types/node@20.12.7)':
+    dependencies:
+      ajv: 8.13.0
+      ajv-draft-04: 1.0.0(ajv@8.13.0)
+      ajv-formats: 3.0.1(ajv@8.13.0)
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.8
+      semver: 7.5.4
+    optionalDependencies:
+      '@types/node': 20.12.7
+
   '@rushstack/rig-package@0.5.2':
     dependencies:
       resolve: 1.22.8
@@ -11755,12 +11855,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.24.4)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.24.4)
 
-  '@svgr/core@8.1.0(typescript@5.4.2)':
+  '@svgr/core@8.1.0(typescript@5.5.3)':
     dependencies:
       '@babel/core': 7.24.4
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.4)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.4.2)
+      cosmiconfig: 8.3.6(typescript@5.5.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -11771,35 +11871,35 @@ snapshots:
       '@babel/types': 7.23.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.4.2))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.5.3))':
     dependencies:
       '@babel/core': 7.24.4
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.4)
-      '@svgr/core': 8.1.0(typescript@5.4.2)
+      '@svgr/core': 8.1.0(typescript@5.5.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.4.2))(typescript@5.4.2)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.5.3))(typescript@5.5.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.4.2)
-      cosmiconfig: 8.3.6(typescript@5.4.2)
+      '@svgr/core': 8.1.0(typescript@5.5.3)
+      cosmiconfig: 8.3.6(typescript@5.5.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@5.4.2)':
+  '@svgr/webpack@8.1.0(typescript@5.5.3)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-transform-react-constant-elements': 7.24.7(@babel/core@7.24.4)
       '@babel/preset-env': 7.24.7(@babel/core@7.24.4)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.4)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.4)
-      '@svgr/core': 8.1.0(typescript@5.4.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.2))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.4.2))(typescript@5.4.2)
+      '@svgr/core': 8.1.0(typescript@5.5.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.5.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.5.3))(typescript@5.5.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13091,6 +13191,12 @@ snapshots:
       '@vue/shared': 3.4.21
       vue: 3.4.21(typescript@5.4.2)
 
+  '@vue/server-renderer@3.4.21(vue@3.4.21(typescript@5.5.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.4.21
+      '@vue/shared': 3.4.21
+      vue: 3.4.21(typescript@5.5.3)
+
   '@vue/shared@3.4.21': {}
 
   '@webassemblyjs/ast@1.12.1':
@@ -13260,6 +13366,10 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
+  ajv-draft-04@1.0.0(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
+
   ajv-errors@1.0.1(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
@@ -13267,6 +13377,10 @@ snapshots:
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
+
+  ajv-formats@3.0.1(ajv@8.13.0):
+    optionalDependencies:
+      ajv: 8.13.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
@@ -13292,6 +13406,13 @@ snapshots:
       uri-js: 4.4.1
 
   ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
+  ajv@8.13.0:
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -14340,23 +14461,23 @@ snapshots:
     optionalDependencies:
       typescript: 4.9.5
 
-  cosmiconfig@8.3.6(typescript@5.4.2):
+  cosmiconfig@8.3.6(typescript@5.5.3):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.4.2
+      typescript: 5.5.3
 
-  cosmiconfig@9.0.0(typescript@5.4.2):
+  cosmiconfig@9.0.0(typescript@5.5.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.4.2
+      typescript: 5.5.3
 
   create-ecdh@4.0.4:
     dependencies:
@@ -14380,13 +14501,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)):
+  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -16268,16 +16389,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)):
+  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.2
@@ -16287,7 +16408,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)):
+  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
       '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
@@ -16313,7 +16434,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.7
-      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.0.2)
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.5.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -16536,11 +16657,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.3.0
-      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -16571,12 +16692,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)):
+  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -17565,13 +17686,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.38
 
-  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.2)):
+  postcss-load-config@4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
       lilconfig: 3.1.1
       yaml: 2.4.1
     optionalDependencies:
       postcss: 8.4.38
-      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.4.2)
+      ts-node: 10.9.2(@types/node@20.12.7)(typescript@5.5.3)
 
   postcss-loader@7.3.4(postcss@8.4.38)(typescript@4.9.5)(webpack@5.92.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.92.0))):
     dependencies:
@@ -17583,9 +17704,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.4.2)(webpack@5.92.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.92.0))):
+  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.92.0))):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.4.2)
+      cosmiconfig: 9.0.0(typescript@5.5.3)
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.6.0
@@ -17595,9 +17716,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.4.2)(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0))):
+  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.38)(typescript@5.5.3)(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0))):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.4.2)
+      cosmiconfig: 9.0.0(typescript@5.5.3)
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.6.0
@@ -17652,11 +17773,11 @@ snapshots:
 
   preact@10.22.0: {}
 
-  prebundle@1.1.0(typescript@5.4.2):
+  prebundle@1.1.0(typescript@5.5.3):
     dependencies:
       '@vercel/ncc': 0.38.1
       rollup: 4.17.2
-      rollup-plugin-dts: 6.1.0(rollup@4.17.2)(typescript@5.4.2)
+      rollup-plugin-dts: 6.1.0(rollup@4.17.2)(typescript@5.5.3)
     transitivePeerDependencies:
       - typescript
 
@@ -18266,11 +18387,11 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rollup-plugin-dts@6.1.0(rollup@4.17.2)(typescript@5.4.2):
+  rollup-plugin-dts@6.1.0(rollup@4.17.2)(typescript@5.5.3):
     dependencies:
       magic-string: 0.30.9
       rollup: 4.17.2
-      typescript: 5.4.2
+      typescript: 5.5.3
     optionalDependencies:
       '@babel/code-frame': 7.24.2
 
@@ -18933,7 +19054,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.2)):
+  tailwindcss@3.4.3(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -18952,7 +19073,7 @@ snapshots:
       postcss: 8.4.38
       postcss-import: 15.1.0(postcss@8.4.38)
       postcss-js: 4.0.1(postcss@8.4.38)
-      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.2))
+      postcss-load-config: 4.0.2(postcss@8.4.38)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       postcss-nested: 6.0.1(postcss@8.4.38)
       postcss-selector-parser: 6.0.16
       resolve: 1.22.8
@@ -19139,17 +19260,17 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2)))(typescript@5.0.2):
+  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3)))(typescript@5.5.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2))
+      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.2
-      typescript: 5.0.2
+      typescript: 5.5.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.24.4
@@ -19196,7 +19317,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.0
 
-  ts-node@10.9.2(@types/node@20.12.7)(typescript@5.0.2):
+  ts-node@10.9.2(@swc/core@1.4.0)(@types/node@20.12.7)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -19210,12 +19331,13 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.0.2
+      typescript: 5.5.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
+    optionalDependencies:
+      '@swc/core': 1.4.0
 
-  ts-node@10.9.2(@types/node@20.12.7)(typescript@5.4.2):
+  ts-node@10.9.2(@types/node@20.12.7)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -19229,7 +19351,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.4.2
+      typescript: 5.5.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -19316,9 +19438,9 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.0.2: {}
-
   typescript@5.4.2: {}
+
+  typescript@5.5.3: {}
 
   ua-parser-js@1.0.37: {}
 
@@ -19505,14 +19627,14 @@ snapshots:
     optionalDependencies:
       vue: 3.4.21(typescript@5.4.2)
 
-  vue-loader@17.4.2(vue@3.4.21(typescript@5.4.2))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0))):
+  vue-loader@17.4.2(vue@3.4.21(typescript@5.5.3))(webpack@5.92.0(webpack-cli@5.1.4(webpack@5.92.0))):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
       webpack: 5.92.0(webpack-cli@5.1.4(webpack@5.92.0))
     optionalDependencies:
-      vue: 3.4.21(typescript@5.4.2)
+      vue: 3.4.21(typescript@5.5.3)
 
   vue@3.4.21(typescript@5.4.2):
     dependencies:
@@ -19523,6 +19645,16 @@ snapshots:
       '@vue/shared': 3.4.21
     optionalDependencies:
       typescript: 5.4.2
+
+  vue@3.4.21(typescript@5.5.3):
+    dependencies:
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/runtime-dom': 3.4.21
+      '@vue/server-renderer': 3.4.21(vue@3.4.21(typescript@5.5.3))
+      '@vue/shared': 3.4.21
+    optionalDependencies:
+      typescript: 5.5.3
 
   w-json@1.3.10: {}
 

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,13 +8,14 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "typecheck": "pnpm tsc --noEmit"
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",
     "@pnpm/find-workspace-packages": "6.0.9",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
+    "typescript": "5.5.3",
     "jest-environment-jsdom": "^29.7.0",
     "glob":"^10.3.10",
     "semver": "^7.6.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "CommonJS", // DO NOT CHANGE: https://github.com/web-infra-dev/rspack/pull/4650
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2021",
     "esModuleInterop": true,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

1. have a try to use latest typescript version and `"module": "NodeNext"`
2. typescript is also a phantom dependence, we are using the surprising version of `tsc` which caused local build failed

https://github.com/web-infra-dev/rspack/pull/4650
https://github.com/web-infra-dev/rspack/issues/7156

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
