### PR TITLE
fix!: correct names of hash fields in asset.info

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -313,12 +313,12 @@ export interface JsAssetInfo {
    * the value(s) of the full hash used for this asset
    * the value(s) of the chunk hash used for this asset
    */
-  chunkHash: Array<string>
+  chunkhash: Array<string>
   /**
    * the value(s) of the module hash used for this asset
    * the value(s) of the content hash used for this asset
    */
-  contentHash: Array<string>
+  contenthash: Array<string>
   sourceFilename?: string
   /**
    * size in bytes, only set after asset has been emitted
@@ -609,8 +609,8 @@ export interface JsStatsAssetInfo {
   sourceFilename?: string
   immutable: boolean
   javascriptModule?: boolean
-  chunkHash: Array<string>
-  contentHash: Array<string>
+  chunkhash: Array<string>
+  contenthash: Array<string>
   related: Array<JsStatsAssetInfoRelated>
 }
 

--- a/crates/rspack_binding_values/src/asset.rs
+++ b/crates/rspack_binding_values/src/asset.rs
@@ -20,13 +20,13 @@ pub struct JsAssetInfo {
   /// whether the asset is minimized
   pub minimized: bool,
   /// the value(s) of the full hash used for this asset
-  // pub full_hash:
+  // pub fullhash:
   /// the value(s) of the chunk hash used for this asset
-  pub chunk_hash: Vec<String>,
+  pub chunkhash: Vec<String>,
   /// the value(s) of the module hash used for this asset
-  // pub module_hash:
+  // pub modulehash:
   /// the value(s) of the content hash used for this asset
-  pub content_hash: Vec<String>,
+  pub contenthash: Vec<String>,
   // when asset was created from a source file (potentially transformed), the original filename relative to compilation context
   pub source_filename: Option<String>,
   /// size in bytes, only set after asset has been emitted
@@ -55,9 +55,9 @@ impl From<JsAssetInfo> for rspack_core::AssetInfo {
       minimized: i.minimized,
       development: i.development,
       hot_module_replacement: i.hot_module_replacement,
-      chunk_hash: i.chunk_hash.into_iter().collect(),
+      chunk_hash: i.chunkhash.into_iter().collect(),
       related: i.related.into(),
-      content_hash: i.content_hash.into_iter().collect(),
+      content_hash: i.contenthash.into_iter().collect(),
       version: String::from(""),
       source_filename: i.source_filename,
       javascript_module: i.javascript_module,
@@ -89,8 +89,8 @@ impl From<rspack_core::AssetInfo> for JsAssetInfo {
       development: info.development,
       hot_module_replacement: info.hot_module_replacement,
       related: info.related.into(),
-      chunk_hash: info.chunk_hash.into_iter().collect(),
-      content_hash: info.content_hash.into_iter().collect(),
+      chunkhash: info.chunk_hash.into_iter().collect(),
+      contenthash: info.content_hash.into_iter().collect(),
       source_filename: info.source_filename,
       javascript_module: info.javascript_module,
       css_unused_idents: info.css_unused_idents.map(|i| i.into_iter().collect()),

--- a/crates/rspack_binding_values/src/stats.rs
+++ b/crates/rspack_binding_values/src/stats.rs
@@ -288,8 +288,8 @@ pub struct JsStatsAssetInfo {
   pub source_filename: Option<String>,
   pub immutable: bool,
   pub javascript_module: Option<bool>,
-  pub chunk_hash: Vec<String>,
-  pub content_hash: Vec<String>,
+  pub chunkhash: Vec<String>,
+  pub contenthash: Vec<String>,
   pub related: Vec<JsStatsAssetInfoRelated>,
 }
 
@@ -302,8 +302,8 @@ impl From<rspack_core::StatsAssetInfo> for JsStatsAssetInfo {
       source_filename: stats.source_filename,
       immutable: stats.immutable,
       javascript_module: stats.javascript_module,
-      chunk_hash: stats.chunk_hash,
-      content_hash: stats.content_hash,
+      chunkhash: stats.chunk_hash,
+      contenthash: stats.content_hash,
       related: stats
         .related
         .into_iter()

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -17,8 +17,8 @@ Object {
       "emitted": true,
       "filteredRelated": 0,
       "info": Object {
-        "chunkHash": Array [],
-        "contentHash": Array [],
+        "chunkhash": Array [],
+        "contenthash": Array [],
         "development": false,
         "hotModuleReplacement": false,
         "immutable": false,
@@ -272,8 +272,8 @@ Object {
       "emitted": true,
       "filteredRelated": 0,
       "info": Object {
-        "chunkHash": Array [],
-        "contentHash": Array [],
+        "chunkhash": Array [],
+        "contenthash": Array [],
         "development": false,
         "hotModuleReplacement": false,
         "immutable": false,
@@ -1316,8 +1316,8 @@ Object {
       ],
       "emitted": true,
       "info": Object {
-        "chunkHash": Array [],
-        "contentHash": Array [],
+        "chunkhash": Array [],
+        "contenthash": Array [],
         "development": false,
         "hotModuleReplacement": false,
         "immutable": false,
@@ -1420,8 +1420,8 @@ Object {
       "emitted": true,
       "filteredRelated": 0,
       "info": Object {
-        "chunkHash": Array [],
-        "contentHash": Array [],
+        "chunkhash": Array [],
+        "contenthash": Array [],
         "development": false,
         "hotModuleReplacement": false,
         "immutable": false,

--- a/packages/rspack-test-tools/tests/configCases/hooks/update-asset/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/update-asset/rspack.config.js
@@ -5,25 +5,35 @@ module.exports = {
 	},
 	plugins: [
 		function plugin(compiler) {
-			compiler.hooks.compilation.tap("test", (compilation) => {
-				compilation.hooks.processAssets.tap({
-					name: "test",
-					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
-				}, (assets) => {
-					Object.entries(assets).forEach(([filename, asset]) => {
-						const newContent = `// UPDATED\n${asset.source()}`;
-						compilation.updateAsset(filename, new compiler.webpack.sources.RawSource(newContent))
-					})
-				})
-				compilation.hooks.processAssets.tap({
-					name: "test",
-					stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH,
-				}, (assets) => {
-					compilation.getAssets().forEach(({ info }) => {
-						expect(info.contentHash.length).toBeGreaterThan(0)
-					})
-				})
-			})
+			compiler.hooks.compilation.tap("test", compilation => {
+				compilation.hooks.processAssets.tap(
+					{
+						name: "test",
+						stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+					},
+					assets => {
+						Object.entries(assets).forEach(([filename, asset]) => {
+							const newContent = `// UPDATED\n${asset.source()}`;
+							compilation.updateAsset(
+								filename,
+								new compiler.webpack.sources.RawSource(newContent)
+							);
+						});
+					}
+				);
+				compilation.hooks.processAssets.tap(
+					{
+						name: "test",
+						stage:
+							compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
+					},
+					assets => {
+						compilation.getAssets().forEach(({ info }) => {
+							expect(info.contenthash.length).toBeGreaterThan(0);
+						});
+					}
+				);
+			});
 		}
 	]
 };

--- a/packages/rspack-test-tools/tests/hookCases/compilation#processAssets/update-asset/test.js
+++ b/packages/rspack-test-tools/tests/hookCases/compilation#processAssets/update-asset/test.js
@@ -11,7 +11,7 @@ module.exports = {
 	options(context) {
 		return {
 			output: {
-				filename: '[name].[contenthash].js'
+				filename: "[name].[contenthash].js"
 			},
 			plugins: [
 				function plugin(compiler) {
@@ -41,7 +41,7 @@ module.exports = {
 							},
 							context.snapped(assets => {
 								compilation.getAssets().forEach(({ info }) => {
-									contentHashes.push(info.contentHash);
+									contentHashes.push(info.contenthash);
 								});
 							})
 						);
@@ -53,7 +53,7 @@ module.exports = {
 									compiler.webpack.Compilation
 										.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
 							},
-							(assets) => {
+							assets => {
 								files.push(...Object.keys(assets));
 							}
 						);

--- a/packages/rspack-test-tools/tests/statsAPICases/asset-info.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/asset-info.js
@@ -45,8 +45,8 @@ module.exports = {
 		    "emitted": true,
 		    "filteredRelated": 0,
 		    "info": Object {
-		      "chunkHash": Array [],
-		      "contentHash": Array [
+		      "chunkhash": Array [],
+		      "contenthash": Array [
 		        "89a353e9c515885abd8e",
 		      ],
 		      "development": false,
@@ -75,8 +75,8 @@ module.exports = {
 		    "emitted": true,
 		    "filteredRelated": 0,
 		    "info": Object {
-		      "chunkHash": Array [],
-		      "contentHash": Array [],
+		      "chunkhash": Array [],
+		      "contenthash": Array [],
 		      "development": false,
 		      "hotModuleReplacement": false,
 		      "immutable": false,

--- a/packages/rspack-test-tools/tests/statsAPICases/child-compiler.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/child-compiler.js
@@ -55,8 +55,8 @@ module.exports = {
 		      "chunkNames": Array [],
 		      "emitted": true,
 		      "info": Object {
-		        "chunkHash": Array [],
-		        "contentHash": Array [],
+		        "chunkhash": Array [],
+		        "contenthash": Array [],
 		        "development": false,
 		        "hotModuleReplacement": false,
 		        "immutable": false,
@@ -76,8 +76,8 @@ module.exports = {
 		      ],
 		      "emitted": true,
 		      "info": Object {
-		        "chunkHash": Array [],
-		        "contentHash": Array [],
+		        "chunkhash": Array [],
+		        "contenthash": Array [],
 		        "development": false,
 		        "hotModuleReplacement": false,
 		        "immutable": false,
@@ -107,8 +107,8 @@ module.exports = {
 		          ],
 		          "emitted": true,
 		          "info": Object {
-		            "chunkHash": Array [],
-		            "contentHash": Array [],
+		            "chunkhash": Array [],
+		            "contenthash": Array [],
 		            "development": false,
 		            "hotModuleReplacement": false,
 		            "immutable": false,

--- a/packages/rspack/src/util/AssetInfo.ts
+++ b/packages/rspack/src/util/AssetInfo.ts
@@ -11,8 +11,8 @@ class JsAssetInfo {
 			development,
 			hotModuleReplacement,
 			related,
-			chunkHash,
-			contentHash,
+			chunkhash,
+			contenthash,
 			javascriptModule,
 			sourceFilename,
 			extras
@@ -24,8 +24,8 @@ class JsAssetInfo {
 			development,
 			hotModuleReplacement,
 			related,
-			chunkHash,
-			contentHash,
+			chunkhash,
+			contenthash,
 			javascriptModule,
 			sourceFilename
 		};
@@ -38,8 +38,8 @@ class JsAssetInfo {
 			development = false,
 			hotModuleReplacement = false,
 			related = {},
-			chunkHash = [],
-			contentHash = [],
+			chunkhash = [],
+			contenthash = [],
 			javascriptModule,
 			sourceFilename,
 			...extras
@@ -51,8 +51,8 @@ class JsAssetInfo {
 			development,
 			hotModuleReplacement,
 			related,
-			chunkHash,
-			contentHash,
+			chunkhash,
+			contenthash,
 			extras
 		};
 	}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

There're 2 implemented hash related fields in `asset.info`, however their names are varied from which in webpack. They are:

| Rspack | Webpack |
| --- | --- |
| `chunkHash` | `chunkhash` |
| `contentHash` | `contenthash` |

This PR corrects these names.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests **updated** (or not required).
- [x] Documentation updated (or **not required**).
