### PR TITLE
feat: support tree shaking with awaiting dynamic import

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/index.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/index.js
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const path = require("path");
+
+it("should tree shaking dynamic import await", async () => {
+  const { a, b } = await import('./lib');
+  expect(a).toBe("property-a");
+  expect(b).toBe("property-b");
+  const content = fs.readFileSync(path.join(path.dirname(__filename), 'chunk.js'));
+  expect(content.includes("property-c")).toBe(false);
+  expect(content.includes("property-d")).toBe(false);
+});

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/lib.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/lib.js
@@ -1,0 +1,4 @@
+export const a = "property-a";
+export const b = "property-b";
+export const c = "property-c";
+export const d = "property-d";

--- a/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/tree-shaking/dynamic-import-unused/rspack.config.js
@@ -1,0 +1,14 @@
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+	context: __dirname,
+	output: {
+		chunkFilename: "chunk.js"
+	},
+	optimization: {
+		minimize: true,
+		providedExports: true,
+		usedExports: true,
+		sideEffects: true,
+		innerGraph: true
+	},
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/webpack-exports-warning/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/webpack-exports-warning/index.js
@@ -1,0 +1,4 @@
+(async function () {
+  const { a, b } = await import(/* webpackExports: ["a", "b", "c"] */ './lib');
+  (a, b)
+})();

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/webpack-exports-warning/lib.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/webpack-exports-warning/lib.js
@@ -1,0 +1,4 @@
+export const a = "property-a";
+export const b = "property-b";
+export const c = "property-c";
+export const d = "property-d";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/webpack-exports-warning/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/webpack-exports-warning/stats.err
@@ -1,0 +1,10 @@
+WARNING in ./index.js
+  ⚠ Module parse warning:
+  ╰─▶   ⚠ Magic comments parse failed: `webpackExports` could not be used with destructuring assignment.
+         ╭─[1:1]
+       1 │ (async function () {
+       2 │   const { a, b } = await import(/* webpackExports: ["a", "b", "c"] */ './lib');
+         ·                          ─────────────────────────────────────────────────────
+       3 │   (a, b)
+       4 │ })();
+         ╰────

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -892,9 +892,9 @@ Rspack x.x.x compiled successfully in X.23"
 `;
 
 exports[`StatsTestCases should print correct stats for output-module 1`] = `
-"asset main.mjs 8.24 KiB [emitted] [javascript module] (name: main)
-asset 8.mjs 329 bytes [emitted] [javascript module]
-runtime modules 6.48 KiB 9 modules
+"asset main.mjs 7.91 KiB [emitted] [javascript module] (name: main)
+asset 8.mjs 285 bytes [emitted] [javascript module]
+runtime modules 6.2 KiB 8 modules
 orphan modules 225 bytes [orphan] 2 modules
 cacheable modules 263 bytes
   ./index.js + 1 modules 225 bytes [code generated]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Close https://github.com/web-infra-dev/rspack/issues/5551

Support tree shaking while awaiting dynamic import, just like webpack

```js
(async function() {
	const { a, b } = import("./lib");
    // only export ["a", "b"] were imported
})();
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
