### PR TITLE
fix: fix panic about runtime order

### DIFF
--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -94,7 +94,13 @@ pub fn is_runtime_equal(a: &RuntimeSpec, b: &RuntimeSpec) -> bool {
     return false;
   }
 
-  a.iter().zip(b.iter()).all(|(a, b)| a == b)
+  for a in a.iter() {
+    if !b.contains(a) {
+      return false;
+    }
+  }
+
+  true
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes panic:

```log
packages/rspack-test-tools test: DebugInfo:
packages/rspack-test-tools test: context: /home/runner/work/rspack/rspack/packages/rspack-test-tools/tests/hotCases/worker/issue-5597
packages/rspack-test-tools test: DebugInfo:
packages/rspack-test-tools test: context: /home/runner/work/rspack/rspack/packages/rspack-test-tools/tests/hotCases/worker/issue-5597
packages/rspack-test-tools test: Panic occurred at runtime. Please file an issue on GitHub with the backtrace below: https://github.com/web-infra-dev/rspack/issues
packages/rspack-test-tools test: Message:  Failed to code generation result for /home/runner/work/rspack/rspack/packages/rspack-test-tools/dist/helper/legacy/fake-update-loader.js??ruleSet[1].rules[0].use[0]!/home/runner/work/rspack/rspack/packages/rspack-test-tools/tests/hotCases/worker/issue-5597/moduleBs.js with runtime RuntimeSpec({"547a406b67ef879cca93", "65eb585de0586d89cbd5"}) 
packages/rspack-test-tools test:  RuntimeSpecMap { mode: SingleEntry, map: {}, single_runtime: Some(RuntimeSpec({"65eb585de0586d89cbd5", "547a406b67ef879cca93"})), single_value: Some(CodeGenResultId(1847)) }
packages/rspack-test-tools test: Location: crates/rspack_core/src/code_generation_results.rs:233
packages/rspack-test-tools test: Run with COLORBT_SHOW_HIDDEN=1 environment variable to disable frame filtering.
packages/rspack-test-tools test: Run with RUST_BACKTRACE=full to include source snippets.
```

that only happened when the test was running on a shared github linux runner.

example:

- https://github.com/web-infra-dev/rspack/actions/runs/10011661529/job/27676014771
- https://github.com/xc2/rspack/actions/runs/10011158495/job/27674460749

![image](https://github.com/user-attachments/assets/b13865c6-b2e1-447d-886d-b38338f77e2d)


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or **not required**).
- [x] Documentation updated (or **not required**).
