### PR TITLE
perf: a bunch of small improvement for ConcatenatedModule

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -407,7 +407,7 @@ impl ConcatenatedModule {
   ) -> String {
     let mut identifiers = vec![];
     for m in modules {
-      identifiers.push(m.shorten_id.clone());
+      identifiers.push(m.shorten_id.as_str());
     }
     identifiers.sort();
     let mut hash = RspackHash::new(&hash_function.unwrap_or(HashFunction::MD4));
@@ -426,8 +426,8 @@ impl ConcatenatedModule {
     self.id
   }
 
-  pub fn get_modules(&self) -> Vec<ConcatenatedInnerModule> {
-    self.modules.clone()
+  pub fn get_modules(&self) -> &[ConcatenatedInnerModule] {
+    self.modules.as_slice()
   }
 }
 
@@ -584,9 +584,7 @@ impl Module for ConcatenatedModule {
       }
       let mut diagnostics_guard = self.diagnostics.lock().expect("should have diagnostics");
       // populate diagnostic
-      for d in module.get_diagnostics() {
-        diagnostics_guard.push(d.clone());
-      }
+      diagnostics_guard.extend(module.get_diagnostics());
 
       // release guard ASAP
       drop(diagnostics_guard);

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -871,7 +871,7 @@ impl Module for ConcatenatedModule {
       {
         let final_name = Self::get_final_name(
           &compilation.get_module_graph(),
-          &referenced_info_id,
+          referenced_info_id,
           export_name,
           &mut module_to_info_map,
           runtime,

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -763,13 +763,14 @@ impl ModuleConcatenationPlugin {
         candidates.push_back(import);
       }
 
+      let mut import_candidates = IdentifierSet::default();
       while let Some(imp) = candidates.pop_front() {
         if candidates_visited.contains(&imp) {
           continue;
         } else {
           candidates_visited.insert(imp);
         }
-        let mut import_candidates = IdentifierSet::default();
+        import_candidates.clear();
         match Self::try_to_add(
           compilation,
           &mut current_configuration,

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -893,7 +893,7 @@ impl ModuleConcatenationPlugin {
         build_meta: box_module.build_meta().cloned(),
       };
       let modules = modules_set
-        .par_iter()
+        .iter()
         .map(|id| {
           let module = module_graph
             .module_by_identifier(id)

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -219,7 +219,7 @@ impl ModuleConcatenationPlugin {
     let module = module_graph
       .module_by_identifier(module_id)
       .expect("should have module");
-    let module_readable_identifier = module.readable_identifier(&options.context).to_string();
+    let module_readable_identifier = module.readable_identifier(&options.context);
 
     if !possible_modules.contains(module_id) {
       statistics.invalid_module += 1;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

😆 This is my practice using the profile tool for the first time, and here is what I do:
1. Remove unnecessary clones.
2. Remove `ModuleInfoOrReference`, as I find `ModuleInfo` is sufficient and `ModuleInfoOrReference` can be queried using the module id.
3. Replaced `LinkedHashSet` with `IndexSet`. Based on my benchmarking, `IndexSet::insert` and `IndexSet::pop` perform better.
4. Replaced the check `self.modules.iter().any(|item| Some(&item.id) == module_id_of_dep)` in each loop with a pre-constructed `HashSet` to reduce time complexity.

Since my local performance test results are very unstable, if there is a performance regression, I will further modify or close this PR.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
