### PR TITLE
fix(fs): remove generic in `FileSystem` trait

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -245,7 +245,7 @@ where
           .filter_map(|(filename, _version)| {
             if !assets.contains_key(filename) {
               let file_path = Path::new(&self.options.output.path).join(filename);
-              Some(self.output_filesystem.remove_file(file_path))
+              Some(self.output_filesystem.remove_file(&file_path))
             } else {
               None
             }
@@ -319,7 +319,7 @@ where
 
       self
         .output_filesystem
-        .write(&file_path, source.buffer())
+        .write(&file_path, source.buffer().as_ref())
         .await?;
 
       self.compilation.emitted_assets.insert(filename.to_string());

--- a/crates/rspack_fs/src/async.rs
+++ b/crates/rspack_fs/src/async.rs
@@ -15,27 +15,27 @@ pub trait AsyncWritableFileSystem {
   /// - User lacks permissions to create directory at path.
   /// - A parent of the given path doesn’t exist. (To create a directory and all its missing parents at the same time, use the create_dir_all function.)
   /// - Path already exists.
-  fn create_dir<P: AsRef<Path>>(&self, dir: P) -> BoxFuture<'_, Result<()>>;
+  fn create_dir(&self, dir: &Path) -> BoxFuture<'_, Result<()>>;
 
   /// Recursively create a directory and all of its parent components if they are missing.
-  fn create_dir_all<P: AsRef<Path>>(&self, dir: P) -> BoxFuture<'_, Result<()>>;
+  fn create_dir_all(&self, dir: &Path) -> BoxFuture<'_, Result<()>>;
 
   /// Write a slice as the entire contents of a file.
   /// This function will create a file if it does not exist, and will entirely replace its contents if it does.
-  fn write<P: AsRef<Path>, D: AsRef<[u8]>>(&self, file: P, data: D) -> BoxFuture<'_, Result<()>>;
+  fn write(&self, file: &Path, data: &[u8]) -> BoxFuture<'_, Result<()>>;
 
   /// Removes a file from the filesystem.
-  fn remove_file<P: AsRef<Path>>(&self, file: P) -> BoxFuture<'_, Result<()>>;
+  fn remove_file(&self, file: &Path) -> BoxFuture<'_, Result<()>>;
 
   /// Removes a directory at this path, after removing all its contents. Use carefully.
-  fn remove_dir_all<P: AsRef<Path>>(&self, dir: P) -> BoxFuture<'_, Result<()>>;
+  fn remove_dir_all(&self, dir: &Path) -> BoxFuture<'_, Result<()>>;
 }
 
 pub trait AsyncReadableFileSystem {
   /// Read the entire contents of a file into a bytes vector.
   ///
   /// Error: This function will return an error if path does not already exist.
-  fn read<P: AsRef<Path>>(&self, file: P) -> BoxFuture<'_, Result<Vec<u8>>>;
+  fn read(&self, file: &Path) -> BoxFuture<'_, Result<Vec<u8>>>;
 }
 
 /// Async readable and writable file system representation.

--- a/crates/rspack_fs/src/native.rs
+++ b/crates/rspack_fs/src/native.rs
@@ -9,22 +9,22 @@ use super::{
 pub struct NativeFileSystem;
 
 impl WritableFileSystem for NativeFileSystem {
-  fn create_dir<P: AsRef<Path>>(&self, dir: P) -> Result<()> {
-    fs::create_dir(dir.as_ref()).map_err(Error::from)
+  fn create_dir(&self, dir: &Path) -> Result<()> {
+    fs::create_dir(dir).map_err(Error::from)
   }
 
-  fn create_dir_all<P: AsRef<std::path::Path>>(&self, dir: P) -> Result<()> {
-    fs::create_dir_all(dir.as_ref()).map_err(Error::from)
+  fn create_dir_all(&self, dir: &Path) -> Result<()> {
+    fs::create_dir_all(dir).map_err(Error::from)
   }
 
-  fn write<P: AsRef<std::path::Path>, D: AsRef<[u8]>>(&self, file: P, data: D) -> Result<()> {
-    fs::write(file.as_ref(), data.as_ref()).map_err(Error::from)
+  fn write(&self, file: &Path, data: &[u8]) -> Result<()> {
+    fs::write(file, data).map_err(Error::from)
   }
 }
 
 impl ReadableFileSystem for NativeFileSystem {
-  fn read<P: AsRef<Path>>(&self, file: P) -> Result<Vec<u8>> {
-    fs::read(file.as_ref()).map_err(Error::from)
+  fn read(&self, file: &Path) -> Result<Vec<u8>> {
+    fs::read(file).map_err(Error::from)
   }
 }
 
@@ -35,45 +35,45 @@ cfg_async! {
   pub struct AsyncNativeFileSystem;
 
   impl AsyncWritableFileSystem for AsyncNativeFileSystem {
-    fn create_dir<P: AsRef<Path>>(&self, dir: P) -> BoxFuture<'_, Result<()>> {
-      let dir = dir.as_ref().to_string_lossy().to_string();
+    fn create_dir(&self, dir: &Path) -> BoxFuture<'_, Result<()>> {
+      let dir = dir.to_string_lossy().to_string();
       let fut = async move { tokio::fs::create_dir(dir).await.map_err(Error::from) };
       Box::pin(fut)
     }
 
-    fn create_dir_all<P: AsRef<std::path::Path>>(&self, dir: P) -> BoxFuture<'_, Result<()>> {
-      let dir = dir.as_ref().to_string_lossy().to_string();
+    fn create_dir_all(&self, dir: &Path) -> BoxFuture<'_, Result<()>> {
+      let dir = dir.to_string_lossy().to_string();
       let fut = async move { tokio::fs::create_dir_all(dir).await.map_err(Error::from) };
       Box::pin(fut)
     }
 
-    fn write<P: AsRef<std::path::Path>, D: AsRef<[u8]>>(
+    fn write(
       &self,
-      file: P,
-      data: D,
+      file: &Path,
+      data: &[u8],
     ) -> BoxFuture<'_, Result<()>> {
-      let file = file.as_ref().to_string_lossy().to_string();
-      let data = data.as_ref().to_vec();
+      let file = file.to_string_lossy().to_string();
+      let data = data.to_vec();
       let fut = async move { tokio::fs::write(file, data).await.map_err(Error::from) };
       Box::pin(fut)
     }
 
-    fn remove_file<P: AsRef<Path>>(&self, file: P) -> BoxFuture<'_, Result<()>> {
-      let file = file.as_ref().to_string_lossy().to_string();
+    fn remove_file(&self, file: &Path) -> BoxFuture<'_, Result<()>> {
+      let file = file.to_string_lossy().to_string();
       let fut = async move { tokio::fs::remove_file(file).await.map_err(Error::from) };
       Box::pin(fut)
     }
 
-    fn remove_dir_all<P: AsRef<Path>>(&self, dir: P) -> BoxFuture<'_, Result<()>> {
-      let dir = dir.as_ref().to_string_lossy().to_string();
+    fn remove_dir_all(&self, dir: &Path) -> BoxFuture<'_, Result<()>> {
+      let dir = dir.to_string_lossy().to_string();
       let fut = async move { tokio::fs::remove_dir_all(dir).await.map_err(Error::from) };
       Box::pin(fut)
     }
   }
 
   impl AsyncReadableFileSystem for AsyncNativeFileSystem {
-    fn read<P: AsRef<Path>>(&self, file: P) -> BoxFuture<'_, Result<Vec<u8>>> {
-      let file = file.as_ref().to_string_lossy().to_string();
+    fn read(&self, file: &Path) -> BoxFuture<'_, Result<Vec<u8>>> {
+      let file = file.to_string_lossy().to_string();
       let fut = async move { tokio::fs::read(file).await.map_err(Error::from) };
       Box::pin(fut)
     }

--- a/crates/rspack_fs/src/sync.rs
+++ b/crates/rspack_fs/src/sync.rs
@@ -13,21 +13,21 @@ pub trait WritableFileSystem {
   /// - User lacks permissions to create directory at path.
   /// - A parent of the given path doesn’t exist. (To create a directory and all its missing parents at the same time, use the create_dir_all function.)
   /// - Path already exists.
-  fn create_dir<P: AsRef<Path>>(&self, dir: P) -> Result<()>;
+  fn create_dir(&self, dir: &Path) -> Result<()>;
 
   /// Recursively create a directory and all of its parent components if they are missing.
-  fn create_dir_all<P: AsRef<Path>>(&self, dir: P) -> Result<()>;
+  fn create_dir_all(&self, dir: &Path) -> Result<()>;
 
   /// Write a slice as the entire contents of a file.
   /// This function will create a file if it does not exist, and will entirely replace its contents if it does.
-  fn write<P: AsRef<Path>, D: AsRef<[u8]>>(&self, file: P, data: D) -> Result<()>;
+  fn write(&self, file: &Path, data: &[u8]) -> Result<()>;
 }
 
 pub trait ReadableFileSystem {
   /// Read the entire contents of a file into a bytes vector.
   ///
   /// Error: This function will return an error if path does not already exist.
-  fn read<P: AsRef<Path>>(&self, file: P) -> Result<Vec<u8>>;
+  fn read(&self, file: &Path) -> Result<Vec<u8>>;
 }
 
 /// Readable and writable file system representation.

--- a/crates/rspack_fs_node/src/async.rs
+++ b/crates/rspack_fs_node/src/async.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use futures::future::BoxFuture;
 use rspack_fs::r#async::AsyncWritableFileSystem;
 
@@ -12,8 +14,8 @@ impl AsyncNodeWritableFileSystem {
 }
 
 impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
-  fn create_dir<P: AsRef<std::path::Path>>(&self, dir: P) -> BoxFuture<'_, rspack_fs::Result<()>> {
-    let dir = dir.as_ref().to_string_lossy().to_string();
+  fn create_dir(&self, dir: &Path) -> BoxFuture<'_, rspack_fs::Result<()>> {
+    let dir = dir.to_string_lossy().to_string();
     let fut = async move {
       self.0.mkdir.call(dir).await.map_err(|e| {
         rspack_fs::Error::Io(std::io::Error::new(
@@ -26,11 +28,8 @@ impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
     Box::pin(fut)
   }
 
-  fn create_dir_all<P: AsRef<std::path::Path>>(
-    &self,
-    dir: P,
-  ) -> BoxFuture<'_, rspack_fs::Result<()>> {
-    let dir = dir.as_ref().to_string_lossy().to_string();
+  fn create_dir_all(&self, dir: &Path) -> BoxFuture<'_, rspack_fs::Result<()>> {
+    let dir = dir.to_string_lossy().to_string();
     let fut = async move {
       self
         .0
@@ -48,13 +47,9 @@ impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
     Box::pin(fut)
   }
 
-  fn write<P: AsRef<std::path::Path>, D: AsRef<[u8]>>(
-    &self,
-    file: P,
-    data: D,
-  ) -> BoxFuture<'_, rspack_fs::Result<()>> {
-    let file = file.as_ref().to_string_lossy().to_string();
-    let data = data.as_ref().to_vec();
+  fn write(&self, file: &Path, data: &[u8]) -> BoxFuture<'_, rspack_fs::Result<()>> {
+    let file = file.to_string_lossy().to_string();
+    let data = data.to_vec();
     let fut = async move {
       self
         .0
@@ -71,11 +66,8 @@ impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
     Box::pin(fut)
   }
 
-  fn remove_file<P: AsRef<std::path::Path>>(
-    &self,
-    file: P,
-  ) -> BoxFuture<'_, rspack_fs::Result<()>> {
-    let file = file.as_ref().to_string_lossy().to_string();
+  fn remove_file(&self, file: &Path) -> BoxFuture<'_, rspack_fs::Result<()>> {
+    let file = file.to_string_lossy().to_string();
     let fut = async move {
       self
         .0
@@ -93,11 +85,8 @@ impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
     Box::pin(fut)
   }
 
-  fn remove_dir_all<P: AsRef<std::path::Path>>(
-    &self,
-    dir: P,
-  ) -> BoxFuture<'_, rspack_fs::Result<()>> {
-    let dir = dir.as_ref().to_string_lossy().to_string();
+  fn remove_dir_all(&self, dir: &Path) -> BoxFuture<'_, rspack_fs::Result<()>> {
+    let dir = dir.to_string_lossy().to_string();
     let fut = async move {
       self
         .0

--- a/crates/rspack_fs_node/src/sync.rs
+++ b/crates/rspack_fs_node/src/sync.rs
@@ -22,8 +22,8 @@ impl NodeWritableFileSystem {
 }
 
 impl WritableFileSystem for NodeWritableFileSystem {
-  fn create_dir<P: AsRef<Path>>(&self, dir: P) -> Result<()> {
-    let dir = dir.as_ref().to_string_lossy();
+  fn create_dir(&self, dir: &Path) -> Result<()> {
+    let dir = dir.to_string_lossy();
     let mkdir = self.fs_ref.mkdir.get().expect("Failed to get mkdir");
     mkdir
       .call(
@@ -43,8 +43,8 @@ impl WritableFileSystem for NodeWritableFileSystem {
     Ok(())
   }
 
-  fn create_dir_all<P: AsRef<Path>>(&self, dir: P) -> Result<()> {
-    let dir = dir.as_ref().to_string_lossy();
+  fn create_dir_all(&self, dir: &Path) -> Result<()> {
+    let dir = dir.to_string_lossy();
     let mkdirp = self.fs_ref.mkdirp.get().expect("Failed to get mkdirp");
     mkdirp
       .call(
@@ -64,9 +64,9 @@ impl WritableFileSystem for NodeWritableFileSystem {
     Ok(())
   }
 
-  fn write<P: AsRef<Path>, D: AsRef<[u8]>>(&self, file: P, data: D) -> Result<()> {
-    let file = file.as_ref().to_string_lossy();
-    let buf = data.as_ref().to_vec();
+  fn write(&self, file: &Path, data: &[u8]) -> Result<()> {
+    let file = file.to_string_lossy();
+    let buf = data.to_vec();
     let write_file = self
       .fs_ref
       .write_file


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
rspack_fs is not object safe now which cause it's hard to box it, remove the generic signature since it's not useful right now
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
