### PR TITLE
fix: corrects result for `truthy || any` and `falsy && any`

### DIFF
--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_binary_expr.rs
@@ -158,7 +158,7 @@ fn handle_logical_or(
   match left.as_bool() {
     Some(true) => {
       // truthy || unknown = true
-      res.set_bool(true);
+      res.set_truthy();
       res.set_side_effects(left.could_have_side_effects());
       Some(res)
     }
@@ -167,7 +167,11 @@ fn handle_logical_or(
       // falsy || unknown = unknown
       right.as_bool().map(|b| {
         // falsy || right = right
-        res.set_bool(b);
+        if b {
+          res.set_truthy();
+        } else {
+          res.set_falsy();
+        }
         res.set_side_effects(left.could_have_side_effects() || right.could_have_side_effects());
         res
       })
@@ -206,7 +210,7 @@ fn handle_logical_and(
     }
     Some(false) => {
       // false && any = false
-      res.set_bool(false);
+      res.set_falsy();
       res.set_side_effects(left.could_have_side_effects());
       Some(res)
     }

--- a/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-logical/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-logical/index.js
@@ -47,7 +47,15 @@ it("should not parse when logical or with `unknown || true has side effects`", f
 
 it("nested `unknown || true = unknown truthy`", function () {
 	var unknown1 = "";
-	var unknown2 = "1"
-	const x = ((unknown1 || "1") !== "1" || unknown2 !== "2") ? "yes" : "no";
-	expect(x).toBe("yes")
+	var unknown2 = "1";
+	const x = (unknown1 || "1") !== "1" || unknown2 !== "2" ? "yes" : "no";
+	expect(x).toBe("yes");
+});
+
+it("logical or: `truthy || any` should be truthy", function () {
+	expect("foobar" || undefined || undefined).toBe("foobar");
+});
+
+it("logical and: `falsy && any` should be falsy", function () {
+	expect(undefined && "foo" && "bar").toBe(undefined);
 });

--- a/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-logical/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-logical/index.js
@@ -48,7 +48,8 @@ it("should not parse when logical or with `unknown || true has side effects`", f
 it("nested `unknown || true = unknown truthy`", function () {
 	var unknown1 = "";
 	var unknown2 = "1";
-	const x = (unknown1 || "1") !== "1" || unknown2 !== "2" ? "yes" : "no";
+	// prettier-ignore
+	const x = ((unknown1 || "1") !== "1" || unknown2 !== "2") ? "yes" : "no";
 	expect(x).toBe("yes");
 });
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes #7264 

Fixed cases:

```js
"foobar" || undefined || undefined 
// Expected: `'foobar' || 0 || 0`
//           evaluated `'foobar'`
// Received: `true || 0`
//           evaluated `true`
```

```js
undefined && 'foo' && 'bar'
// Expected: `undefined && 'foo' && 'bar'`
//           evaluated `undefined`
// Received: `false && 0`
//           evaluated `false`
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests **updated** (or not required).
- [x] Documentation updated (or **not required**).
