### PR TITLE
refactor: reuse binary evaluation expression and support null coalescing

### DIFF
--- a/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-nullish-coalescing/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-nullish-coalescing/index.js
@@ -1,0 +1,7 @@
+it("nullish coalescing: undefined", function () {
+  expect(undefined ?? "foo").toBe("foo");
+});
+
+it("nullish coalescing: false", function () {
+  expect(false ?? "foo").toBe(false);
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align evaluation of `&&`, `||` expression with webpack to reuse the evaluation object, and also support `??`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
