### PR TITLE
perf: reduce large pre-allocations for `JavascriptParser::new`

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -138,9 +138,9 @@ impl Task<MakeTaskContext> for BuildResultTask {
     let mut queue = VecDeque::new();
     let mut all_dependencies = vec![];
     let mut handle_block = |dependencies: Vec<BoxDependency>,
-                            blocks: Vec<AsyncDependenciesBlock>,
-                            current_block: Option<AsyncDependenciesBlock>|
-     -> Vec<AsyncDependenciesBlock> {
+                            blocks: Vec<Box<AsyncDependenciesBlock>>,
+                            current_block: Option<Box<AsyncDependenciesBlock>>|
+     -> Vec<Box<AsyncDependenciesBlock>> {
       for dependency in dependencies {
         let dependency_id = *dependency.id();
         if current_block.is_none() {

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1085,7 +1085,10 @@ impl ContextModule {
     Ok(())
   }
 
-  fn resolve_dependencies(&self) -> Result<(Vec<BoxDependency>, Vec<AsyncDependenciesBlock>)> {
+  // Vec<Box<T: Sized>> makes sense if T is a large type (see #3530, 1st comment).
+  // #3530: https://github.com/rust-lang/rust-clippy/issues/3530
+  #[allow(clippy::vec_box)]
+  fn resolve_dependencies(&self) -> Result<(Vec<BoxDependency>, Vec<Box<AsyncDependenciesBlock>>)> {
     tracing::trace!("resolving context module path {}", self.options.resource);
 
     let resolver = &self.resolve_factory.get(ResolveOptionsWithDependencyType {
@@ -1133,7 +1136,7 @@ impl ContextModule {
       if let Some(group_options) = &self.options.context_options.group_options {
         block.set_group_options(group_options.clone());
       }
-      blocks.push(block);
+      blocks.push(Box::new(block));
     } else if matches!(self.options.context_options.mode, ContextMode::Lazy) {
       let mut index = 0;
       for context_element_dependency in context_element_dependencies {
@@ -1175,7 +1178,7 @@ impl ContextModule {
           prefetch_order,
           fetch_priority,
         )));
-        blocks.push(block);
+        blocks.push(Box::new(block));
       }
     } else {
       dependencies = context_element_dependencies

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -92,7 +92,10 @@ impl From<String> for AsyncDependenciesBlockIdentifier {
 pub struct AsyncDependenciesBlock {
   id: AsyncDependenciesBlockIdentifier,
   group_options: Option<GroupOptions>,
-  blocks: Vec<AsyncDependenciesBlock>,
+  // Vec<Box<T: Sized>> makes sense if T is a large type (see #3530, 1st comment).
+  // #3530: https://github.com/rust-lang/rust-clippy/issues/3530
+  #[allow(clippy::vec_box)]
+  blocks: Vec<Box<AsyncDependenciesBlock>>,
   block_ids: Vec<AsyncDependenciesBlockIdentifier>,
   dependency_ids: Vec<DependencyId>,
   dependencies: Vec<BoxDependency>,
@@ -164,7 +167,7 @@ impl AsyncDependenciesBlock {
     // self.blocks.push(block);
   }
 
-  pub fn take_blocks(&mut self) -> Vec<AsyncDependenciesBlock> {
+  pub fn take_blocks(&mut self) -> Vec<Box<AsyncDependenciesBlock>> {
     std::mem::take(&mut self.blocks)
   }
 

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -157,7 +157,7 @@ pub struct BuildResult {
   pub build_meta: BuildMeta,
   pub build_info: BuildInfo,
   pub dependencies: Vec<BoxDependency>,
-  pub blocks: Vec<AsyncDependenciesBlock>,
+  pub blocks: Vec<Box<AsyncDependenciesBlock>>,
   pub optimization_bailouts: Vec<String>,
 }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -46,7 +46,7 @@ pub struct ModuleGraphPartial {
   dependencies: HashMap<DependencyId, Option<BoxDependency>>,
 
   /// AsyncDependenciesBlocks indexed by `AsyncDependenciesBlockIdentifier`.
-  blocks: HashMap<AsyncDependenciesBlockIdentifier, Option<AsyncDependenciesBlock>>,
+  blocks: HashMap<AsyncDependenciesBlockIdentifier, Option<Box<AsyncDependenciesBlock>>>,
 
   /// ModuleGraphModule indexed by `ModuleIdentifier`.
   module_graph_modules: IdentifierMap<Option<ModuleGraphModule>>,
@@ -601,7 +601,7 @@ impl<'a> ModuleGraph<'a> {
     }
   }
 
-  pub fn add_block(&mut self, block: AsyncDependenciesBlock) {
+  pub fn add_block(&mut self, block: Box<AsyncDependenciesBlock>) {
     let Some(active_partial) = &mut self.active else {
       panic!("should have active partial");
     };
@@ -641,7 +641,10 @@ impl<'a> ModuleGraph<'a> {
     &self,
     block_id: &AsyncDependenciesBlockIdentifier,
   ) -> Option<&AsyncDependenciesBlock> {
-    self.loop_partials(|p| p.blocks.get(block_id))?.as_ref()
+    self
+      .loop_partials(|p| p.blocks.get(block_id))?
+      .as_ref()
+      .map(|b| &**b)
   }
 
   pub fn block_by_id_expect(

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -65,7 +65,7 @@ impl SideEffectsBailoutItemWithSpan {
 #[derive(Debug)]
 pub struct ParseResult {
   pub dependencies: Vec<BoxDependency>,
-  pub blocks: Vec<AsyncDependenciesBlock>,
+  pub blocks: Vec<Box<AsyncDependenciesBlock>>,
   pub presentational_dependencies: Vec<Box<dyn DependencyTemplate>>,
   pub code_generation_dependencies: Vec<Box<dyn ModuleDependency>>,
   pub source: BoxSource,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -142,7 +142,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
         chunk_prefetch,
         fetch_priority,
       )));
-      parser.blocks.push(block);
+      parser.blocks.push(Box::new(block));
       Some(true)
     } else {
       let ContextModuleScanResult {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -120,7 +120,7 @@ fn add_dependencies(
     depend_on: None,
   })));
 
-  parser.blocks.push(block);
+  parser.blocks.push(Box::new(block));
   if let Some(range) = range {
     parser
       .presentational_dependencies

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -26,7 +26,7 @@ use crate::BoxJavascriptParserPlugin;
 
 pub struct ScanDependenciesResult {
   pub dependencies: Vec<BoxDependency>,
-  pub blocks: Vec<AsyncDependenciesBlock>,
+  pub blocks: Vec<Box<AsyncDependenciesBlock>>,
   pub presentational_dependencies: Vec<BoxDependencyTemplate>,
   pub warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>>,
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -207,7 +207,10 @@ pub struct JavascriptParser<'parser> {
   pub(crate) warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>>,
   pub dependencies: Vec<BoxDependency>,
   pub(crate) presentational_dependencies: Vec<Box<dyn DependencyTemplate>>,
-  pub(crate) blocks: Vec<AsyncDependenciesBlock>,
+  // Vec<Box<T: Sized>> makes sense if T is a large type (see #3530, 1st comment).
+  // #3530: https://github.com/rust-lang/rust-clippy/issues/3530
+  #[allow(clippy::vec_box)]
+  pub(crate) blocks: Vec<Box<AsyncDependenciesBlock>>,
   // TODO: remove `additional_data` once we have builtin:css-extract-loader
   pub additional_data: AdditionalData,
   pub(crate) comments: Option<&'parser dyn Comments>,
@@ -262,11 +265,11 @@ impl<'parser> JavascriptParser<'parser> {
     parser_plugins: &'parser mut Vec<BoxJavascriptParserPlugin>,
     additional_data: AdditionalData,
   ) -> Self {
-    let warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>> = Vec::with_capacity(32);
-    let errors = Vec::with_capacity(32);
-    let dependencies = Vec::with_capacity(256);
-    let blocks = Vec::with_capacity(256);
-    let presentational_dependencies = Vec::with_capacity(256);
+    let warning_diagnostics: Vec<Box<dyn Diagnostic + Send + Sync>> = Vec::with_capacity(4);
+    let errors = Vec::with_capacity(4);
+    let dependencies = Vec::with_capacity(64);
+    let blocks = Vec::with_capacity(64);
+    let presentational_dependencies = Vec::with_capacity(64);
     let parser_exports_state: Option<bool> = None;
 
     let mut plugins: Vec<parser_plugin::BoxJavascriptParserPlugin> = Vec::with_capacity(32);

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -161,13 +161,13 @@ impl Module for LazyCompilationProxyModule {
     if self.active {
       let dep = LazyCompilationDependency::new(self.create_data.clone());
 
-      blocks.push(AsyncDependenciesBlock::new(
+      blocks.push(Box::new(AsyncDependenciesBlock::new(
         self.identifier,
         None,
         None,
         vec![Box::new(dep)],
         None,
-      ));
+      )));
     }
 
     let mut files = FxHashSet::default();

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -151,7 +151,7 @@ impl Module for ContainerEntryModule {
       block.set_group_options(GroupOptions::ChunkGroup(
         ChunkGroupOptions::default().name_optional(options.name.clone()),
       ));
-      blocks.push(block);
+      blocks.push(Box::new(block));
     }
     dependencies.push(Box::new(StaticExportsDependency::new(
       StaticExportsSpec::Array(vec!["get".into(), "init".into()]),

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -160,7 +160,7 @@ impl Module for ConsumeSharedModule {
         dependencies.push(dep as BoxDependency);
       } else {
         let block = AsyncDependenciesBlock::new(self.identifier, None, None, vec![dep], None);
-        blocks.push(block);
+        blocks.push(Box::new(block));
       }
     }
 

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -142,7 +142,7 @@ impl Module for ProvideSharedModule {
       dependencies.push(dep as BoxDependency);
     } else {
       let block = AsyncDependenciesBlock::new(self.identifier, None, None, vec![dep], None);
-      blocks.push(block);
+      blocks.push(Box::new(block));
     }
 
     Ok(BuildResult {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`AsyncDependenciesBlock` is of the size of 208 bytes. It was pre-allocated for the capacity of 256:

```
size_of::<AsyncDependenciesBlock>() = 208
```

Taking a project with 10000 modules. It will at least allocate (and destroy) the memory of `256 * 208 * 10000` bytes (507Mbs), causing a memory increment and decrement back and forth.

Since the layout `AsyncDependenciesBlock` is quite compat, two approaches remain:
- Change `Vec<AsyncDependenciesBlock>` to `Vec<Box<AsyncDependenciesBlock>>`
- Change initial capacity of the `Vec` to a smaller value

The first solution is to reduce the memory usage from `256 * 208` to `256 * 24`, giving us a significant memory reduce, however with some potential overhead for sending the value to the heap.
With the second capacity change from `256` to `64`. 

I also changed the initial capacity of other vecs, although it does not(and should not) have much memory cost difference.

### Performance for big projects
The performance difference between these two changes of our internal project of 38134 modules remain **unnoticeable**. It's around 30 seconds for each build on my computer (Apple M2 Max, 64 GB).

### Memory cost

The memory cost of this is a const value for each module. With the difference number of modules, it results in different amount of allocations created and destroyed. Taking [10000 modules case](https://github.com/web-infra-dev/rspack-ecosystem-benchmark/tree/main/cases/10000) as an example, we can notice the difference of memory being created and destroyed during each build:

Before:
![img_v3_02d2_979ee573-67e2-4211-8105-58e1a8a4d0eg](https://github.com/user-attachments/assets/b4825c5a-73d6-4eaa-83ac-818973e40d8b)

After:
![img_v3_02d2_a89f6588-d5ab-49b0-8877-f80ac9e4e88g](https://github.com/user-attachments/assets/95271262-dd03-4bcc-8b00-e6f28988cafe)

It's 12.5% improvement of the total memory being allocated.


## Clippy complaints of `Vec<Box<T>> where T: Sized`

Clippy is complaining that `T` of `Vec<T>` was already allocated on the heap. Since it's a huge struct with that much of pre-allocation, we can workaround this as it was said in the detail page: https://github.com/rust-lang/rust-clippy/issues/3530

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
