### PR TITLE
feat: support `test`, `include` and `exclude` options for `LightningCssMinimizerRspackPlugin`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,6 +3720,8 @@ dependencies = [
  "rspack_error",
  "rspack_hash",
  "rspack_hook",
+ "rspack_regex",
+ "rspack_util",
  "tracing",
 ]
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1163,6 +1163,9 @@ export interface RawLightningCssMinimizerRspackPluginOptions {
   unusedSymbols: Array<string>
   removeUnusedLocalIdents: boolean
   browserslist: Array<string>
+  test?: string | RegExp | (string | RegExp)[]
+  include?: string | RegExp | (string | RegExp)[]
+  exclude?: string | RegExp | (string | RegExp)[]
 }
 
 export interface RawLimitChunkCountPluginOptions {

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_lightning_css_minimizer.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_lightning_css_minimizer.rs
@@ -1,6 +1,15 @@
+use napi::{bindgen_prelude::Either3, Either};
 use napi_derive::napi;
 use rspack_error::Result;
-use rspack_plugin_lightning_css_minimizer::LightningCssMinimizerOptions;
+use rspack_napi::regexp::{JsRegExp, JsRegExpExt};
+use rspack_plugin_lightning_css_minimizer::{
+  LightningCssMinimizerOptions, LightningCssMinimizerRule, LightningCssMinimizerRules,
+};
+
+type RawLightningCssMinimizerRule = Either<String, JsRegExp>;
+type RawLightningCssMinimizerRules = Either3<String, JsRegExp, Vec<RawLightningCssMinimizerRule>>;
+struct RawLightningCssMinimizerRuleWrapper(RawLightningCssMinimizerRule);
+struct RawLightningCssMinimizerRulesWrapper(RawLightningCssMinimizerRules);
 
 #[derive(Debug)]
 #[napi(object)]
@@ -9,6 +18,16 @@ pub struct RawLightningCssMinimizerRspackPluginOptions {
   pub unused_symbols: Vec<String>,
   pub remove_unused_local_idents: bool,
   pub browserslist: Vec<String>,
+  #[napi(ts_type = "string | RegExp | (string | RegExp)[]")]
+  pub test: Option<RawLightningCssMinimizerRules>,
+  #[napi(ts_type = "string | RegExp | (string | RegExp)[]")]
+  pub include: Option<RawLightningCssMinimizerRules>,
+  #[napi(ts_type = "string | RegExp | (string | RegExp)[]")]
+  pub exclude: Option<RawLightningCssMinimizerRules>,
+}
+
+fn into_condition(c: Option<RawLightningCssMinimizerRules>) -> Option<LightningCssMinimizerRules> {
+  c.map(|test| RawLightningCssMinimizerRulesWrapper(test).into())
 }
 
 impl TryFrom<RawLightningCssMinimizerRspackPluginOptions> for LightningCssMinimizerOptions {
@@ -20,6 +39,32 @@ impl TryFrom<RawLightningCssMinimizerRspackPluginOptions> for LightningCssMinimi
       unused_symbols: value.unused_symbols,
       remove_unused_local_idents: value.remove_unused_local_idents,
       browserlist: value.browserslist,
+      test: into_condition(value.test),
+      include: into_condition(value.include),
+      exclude: into_condition(value.exclude),
     })
+  }
+}
+
+impl From<RawLightningCssMinimizerRuleWrapper> for LightningCssMinimizerRule {
+  fn from(x: RawLightningCssMinimizerRuleWrapper) -> Self {
+    match x.0 {
+      Either::A(v) => Self::String(v),
+      Either::B(v) => Self::Regexp(v.to_rspack_regex()),
+    }
+  }
+}
+
+impl From<RawLightningCssMinimizerRulesWrapper> for LightningCssMinimizerRules {
+  fn from(value: RawLightningCssMinimizerRulesWrapper) -> Self {
+    match value.0 {
+      Either3::A(v) => Self::String(v),
+      Either3::B(v) => Self::Regexp(v.to_rspack_regex()),
+      Either3::C(v) => Self::Array(
+        v.into_iter()
+          .map(|v| RawLightningCssMinimizerRuleWrapper(v).into())
+          .collect(),
+      ),
+    }
   }
 }

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -19,6 +19,8 @@ rspack_core  = { path = "../rspack_core" }
 rspack_error = { path = "../rspack_error" }
 rspack_hash  = { path = "../rspack_hash" }
 rspack_hook  = { path = "../rspack_hook" }
+rspack_regex = { path = "../rspack_regex" }
+rspack_util  = { path = "../rspack_util" }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -48,7 +48,7 @@ Object {
       "files": Array [
         "main.js",
       ],
-      "hash": "90a887a17a80d0e19be5",
+      "hash": "3047419ba1e2f16c20ec",
       "id": "909",
       "idHints": Array [],
       "initial": true,
@@ -166,7 +166,7 @@ Object {
   "errorsCount": 0,
   "filteredAssets": undefined,
   "filteredModules": undefined,
-  "hash": "c54fcee237a48276e019",
+  "hash": "cff2f148f1ee5ac48614",
   "modules": Array [
     Object {
       "assets": Array [],
@@ -304,7 +304,7 @@ Object {
       "files": Array [
         "main.js",
       ],
-      "hash": "5c934183f195b15a0942",
+      "hash": "ff560eb800e3f8e0d81a",
       "id": "909",
       "idHints": Array [],
       "initial": true,
@@ -642,7 +642,7 @@ Object {
   "errorsCount": 0,
   "filteredAssets": undefined,
   "filteredModules": undefined,
-  "hash": "c361435884d1304f092d",
+  "hash": "d04de68b0015c16c1b32",
   "modules": Array [
     Object {
       "assets": Array [],
@@ -1346,7 +1346,7 @@ Object {
       "files": Array [
         "main.js",
       ],
-      "hash": "90a887a17a80d0e19be5",
+      "hash": "3047419ba1e2f16c20ec",
       "id": "909",
       "idHints": Array [],
       "initial": true,
@@ -1454,7 +1454,7 @@ Object {
       "files": Array [
         "main.js",
       ],
-      "hash": "405eb59ae1d20f89b39f",
+      "hash": "dc2b86478abba2403142",
       "id": "909",
       "idHints": Array [],
       "initial": true,
@@ -1776,7 +1776,7 @@ exports.c = require(\\"./c?c=3\\");
   "errorsCount": 0,
   "filteredAssets": undefined,
   "filteredModules": undefined,
-  "hash": "38e04132ef7ebc852f6a",
+  "hash": "8693983d0934a0640bbf",
   "modules": Array [
     Object {
       "assets": Array [],

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/a.css
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/a.css
@@ -1,0 +1,3 @@
+html {
+	margin: 0;
+}

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/a.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/a.js
@@ -1,0 +1,1 @@
+require("./a.css");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/b.css
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/b.css
@@ -1,0 +1,3 @@
+html {
+	margin: 0;
+}

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/b.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/b.js
@@ -1,0 +1,1 @@
+require("./b.css");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+it("[minify-exclude-css]: chunk a should be minified", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "a.css"), "utf-8");
+	expect(content).not.toMatch("\n");
+});
+
+it("[minify-exclude-css]: chunk b should not be minified", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "b.css"), "utf-8");
+	expect(content).toMatch("\n");
+});

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/rspack.config.js
@@ -1,0 +1,29 @@
+const rspack = require("@rspack/core");
+/**
+ * @type {import("@rspack/core").Configuration}
+ */
+module.exports = {
+	entry: {
+		a: "./a.js",
+		b: "./b.js",
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	module: {
+		generator: {
+			"css/auto": {
+				exportsOnly: false
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.LightningCssMinimizerRspackPlugin({
+				exclude: [/b\.css/]
+			})
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-exclude-lightning-css/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/a.css
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/a.css
@@ -1,0 +1,3 @@
+html {
+	margin: 0;
+}

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/a.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/a.js
@@ -1,0 +1,1 @@
+require("./a.css");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/b.css
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/b.css
@@ -1,0 +1,3 @@
+html {
+	margin: 0;
+}

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/b.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/b.js
@@ -1,0 +1,1 @@
+require("./b.css");

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/index.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/index.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+it("[minify-exclude-css]: chunk a should be minified", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "a.css"), "utf-8");
+	expect(content).not.toMatch("\n");
+});
+
+it("[minify-exclude-css]: chunk b should not be minified", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "b.css"), "utf-8");
+	expect(content).toMatch("\n");
+});

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/rspack.config.js
@@ -1,0 +1,29 @@
+const rspack = require("@rspack/core");
+/**
+ * @type {import("@rspack/core").Configuration}
+ */
+module.exports = {
+	entry: {
+		a: "./a.js",
+		b: "./b.js",
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].js"
+	},
+	module: {
+		generator: {
+			"css/auto": {
+				exportsOnly: false
+			}
+		}
+	},
+	optimization: {
+		minimize: true,
+		minimizer: [
+			new rspack.LightningCssMinimizerRspackPlugin({
+				include: [/a\.css/]
+			})
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/minify-include-lightning-css/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/statsAPICases/basic.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/basic.js
@@ -39,7 +39,7 @@ module.exports = {
 		  entry ./fixtures/a
 		  cjs self exports reference self [585]
 		  
-		Rspack compiled successfully (c54fcee237a48276e019)"
+		Rspack compiled successfully (cff2f148f1ee5ac48614)"
 	`);
 	}
 };

--- a/packages/rspack-test-tools/tests/statsAPICases/chunks.js
+++ b/packages/rspack-test-tools/tests/statsAPICases/chunks.js
@@ -26,7 +26,7 @@ module.exports = {
 		    "files": Array [
 		      "chunkB.js",
 		    ],
-		    "hash": "e9b9cfaf734ee7b137b7",
+		    "hash": "c5b5ebf5a1a8e08296a9",
 		    "id": "250",
 		    "idHints": Array [],
 		    "initial": false,
@@ -134,7 +134,7 @@ module.exports = {
 		    "files": Array [
 		      "main.js",
 		    ],
-		    "hash": "d38a996f51bebe958d5c",
+		    "hash": "f42d32afe239ff7620e2",
 		    "id": "909",
 		    "idHints": Array [],
 		    "initial": true,

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -4875,9 +4875,9 @@ export type LightningcssLoaderOptions = {
 
 // @public (undocumented)
 export const LightningCssMinimizerRspackPlugin: {
-    new (options?: Partial<RawLightningCssMinimizerRspackPluginOptions> | undefined): {
+    new (options?: LightningCssMinimizerRspackPluginOptions | undefined): {
         name: BuiltinPluginName;
-        _args: [options?: Partial<RawLightningCssMinimizerRspackPluginOptions> | undefined];
+        _args: [options?: LightningCssMinimizerRspackPluginOptions | undefined];
         affectedHooks: "done" | "compilation" | "failed" | "environment" | "emit" | "make" | "compile" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "shutdown" | "watchRun" | "watchClose" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
         raw(compiler: Compiler_2): BuiltinPlugin;
         apply(compiler: Compiler_2): void;
@@ -4885,7 +4885,11 @@ export const LightningCssMinimizerRspackPlugin: {
 };
 
 // @public (undocumented)
-export type LightningCssMinimizerRspackPluginOptions = Partial<RawLightningCssMinimizerRspackPluginOptions>;
+export type LightningCssMinimizerRspackPluginOptions = Partial<RawLightningCssMinimizerRspackPluginOptions> & {
+    test?: MinifyConditions_2;
+    exclude?: MinifyConditions_2;
+    include?: MinifyConditions_2;
+};
 
 // @public (undocumented)
 type LimitChunkCountOptions = {

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -5204,10 +5204,16 @@ type MinifyCondition = string | RegExp;
 type MinifyCondition_2 = string | RegExp;
 
 // @public (undocumented)
+type MinifyCondition_3 = string | RegExp;
+
+// @public (undocumented)
 type MinifyConditions = MinifyCondition | MinifyCondition[];
 
 // @public (undocumented)
 type MinifyConditions_2 = MinifyCondition_2 | MinifyCondition_2[];
+
+// @public (undocumented)
+type MinifyConditions_3 = MinifyCondition_3 | MinifyCondition_3[];
 
 // @public (undocumented)
 export type Mode = z.infer<typeof mode>;
@@ -13581,9 +13587,9 @@ export const SwcCssMinimizerRspackPlugin: {
 
 // @public (undocumented)
 type SwcCssMinimizerRspackPluginOptions = {
-    test?: MinifyConditions_2;
-    exclude?: MinifyConditions_2;
-    include?: MinifyConditions_2;
+    test?: MinifyConditions_3;
+    exclude?: MinifyConditions_3;
+    include?: MinifyConditions_3;
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/builtin-plugin/LightningCssMiminizerRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/LightningCssMiminizerRspackPlugin.ts
@@ -5,8 +5,15 @@ import {
 
 import { create } from "./base";
 
+type MinifyCondition = string | RegExp;
+type MinifyConditions = MinifyCondition | MinifyCondition[];
+
 export type LightningCssMinimizerRspackPluginOptions =
-	Partial<RawLightningCssMinimizerRspackPluginOptions>;
+	Partial<RawLightningCssMinimizerRspackPluginOptions> & {
+		test?: MinifyConditions;
+		exclude?: MinifyConditions;
+		include?: MinifyConditions;
+	};
 
 export const LightningCssMinimizerRspackPlugin = create(
 	BuiltinPluginName.LightningCssMinimizerRspackPlugin,
@@ -17,7 +24,10 @@ export const LightningCssMinimizerRspackPlugin = create(
 			errorRecovery: options?.errorRecovery ?? true,
 			unusedSymbols: options?.unusedSymbols ?? [],
 			removeUnusedLocalIdents: options?.removeUnusedLocalIdents ?? true,
-			browserslist: options?.browserslist ?? ["defaults"]
+			browserslist: options?.browserslist ?? ["defaults"],
+			test: options?.test,
+			include: options?.include,
+			exclude: options?.exclude
 		};
 	}
 );

--- a/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -10,7 +10,7 @@ This plugin uses [lightningcss](https://lightningcss.dev/) to minify CSS assets.
 module.exports = {
   // ...
   optimization: {
-    minimizer: [new rspack.LightningCssMinimizerRspackPlugin()],
+    minimizer: [new rspack.LightningCssMinimizerRspackPlugin(options)],
   },
 };
 ```
@@ -68,3 +68,24 @@ At this point, the information that class name b is unused will be obtained via 
 - **Default:** `["defaults"]`
 
 Browserslist targets to compile the CSS for.
+
+### include
+
+- **Type:** `string | RegExp | (string | RegExp)[]`
+- **Default:** `undefined`
+
+Use this to specify which files should be minified.
+
+### exclude
+
+- **Type:** `string | RegExp | (string | RegExp)[]`
+- **Default:** `undefined`
+
+Use this to specify which files should be excluded from minification.
+
+### test
+
+- **Type:** `string | RegExp | (string | RegExp)[]`
+- **Default:** `undefined`
+
+Use this to provide a pattern that css files are matched against. If the filename matches the given pattern, it will be minified, otherwise it won't be.


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Implements the missing `include`, `exclude` and `test` options for the `LightningCssMinimizerRspackPlugin`.

Fixes #7135 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
