### PR TITLE
perf: reduce allocation for adding dependencies

### DIFF
--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -2,7 +2,6 @@ use std::{fmt::Debug, path::PathBuf, sync::Arc};
 
 use rspack_error::{Diagnostic, Result};
 use rustc_hash::FxHashSet as HashSet;
-use sugar_path::SugarPath;
 
 use crate::{BoxDependency, BoxModule, CompilerOptions, Context, ModuleIdentifier, Resolve};
 
@@ -32,34 +31,28 @@ impl ModuleFactoryCreateData {
 
   pub fn add_file_dependency(&mut self, file: PathBuf) {
     if file.is_absolute() {
-      self.file_dependencies.insert(file.normalize());
+      self.file_dependencies.insert(file);
     }
   }
 
   pub fn add_file_dependencies(&mut self, files: impl IntoIterator<Item = PathBuf>) {
-    self
-      .file_dependencies
-      .extend(files.into_iter().map(|x| x.normalize()));
+    self.file_dependencies.extend(files.into_iter());
   }
 
   pub fn add_context_dependency(&mut self, context: PathBuf) {
-    self.context_dependencies.insert(context.normalize());
+    self.context_dependencies.insert(context);
   }
 
   pub fn add_context_dependencies(&mut self, contexts: impl IntoIterator<Item = PathBuf>) {
-    self
-      .context_dependencies
-      .extend(contexts.into_iter().map(|x| x.normalize()));
+    self.context_dependencies.extend(contexts.into_iter());
   }
 
   pub fn add_missing_dependency(&mut self, missing: PathBuf) {
-    self.missing_dependencies.insert(missing.normalize());
+    self.missing_dependencies.insert(missing);
   }
 
   pub fn add_missing_dependencies(&mut self, missing: impl IntoIterator<Item = PathBuf>) {
-    self
-      .missing_dependencies
-      .extend(missing.into_iter().map(|x| x.normalize()));
+    self.missing_dependencies.extend(missing);
   }
 }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

(Also the heavy computation)

Dependency paths returned from oxc-resolver had already been normalized.
See: https://github.com/oxc-project/oxc-resolver/blob/f4c3ef5b4765ec8fcfb0f0d74a7562a6baa1456c/src/lib.rs#L380

Reduced memory cost for about 28.7% (at peak) for the case of [10000 modules](https://github.com/web-infra-dev/rspack-ecosystem-benchmark/tree/main/cases/10000) (Rspack was compiled with debug profile).

Before:
![img_v3_02d3_ac33769d-7e05-409d-b613-ef293732b7eg](https://github.com/user-attachments/assets/2b1a965e-1390-4d61-9eaf-c7cb870b520e)

After:
![img_v3_02d3_02b6b4ec-5889-4c24-839d-6e57f984ea9g](https://github.com/user-attachments/assets/be882623-bfc8-483e-953c-a917a20e7f16)


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or **not required**).
- [X] Documentation updated (or **not required**).
