### PR TITLE
chore: run `prebundle` when prepare

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -20,9 +20,10 @@
     "./module": "./module.d.ts"
   },
   "scripts": {
-    "build": "prebundle && tsc -b ./tsconfig.build.json && tsc-alias -p tsconfig.build.json && npm run prepare-container-runtime",
-    "build:force": "prebundle && tsc -b ./tsconfig.build.json --force && tsc-alias -p tsconfig.build.json && npm run prepare-container-runtime",
-    "dev": "prebundle && tsc -w",
+    "build": "tsc -b ./tsconfig.build.json && tsc-alias -p tsconfig.build.json && npm run prepare-container-runtime",
+    "build:force": "tsc -b ./tsconfig.build.json --force && tsc-alias -p tsconfig.build.json && npm run prepare-container-runtime",
+    "dev": "tsc -w",
+    "prepare": "prebundle",
     "prepare-container-runtime": "node ./scripts/prepare-container-runtime.js",
     "doc-coverage": "node scripts/check-documentation-coverage.mjs",
     "api-extractor": "api-extractor run --verbose",


### PR DESCRIPTION


<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

We don't need to run prebundle for every build, but only when dependencies change.

So moving to `prepare` would work and also speed up the build.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
