### PR TITLE
feat(dev-server): export package version

### DIFF
--- a/packages/rspack-dev-server/etc/api.md
+++ b/packages/rspack-dev-server/etc/api.md
@@ -72,6 +72,8 @@ export class RspackDevServer extends WebpackDevServer {
     // (undocumented)
     staticWatchers: FSWatcher[];
     // (undocumented)
+    static version: string;
+    // (undocumented)
     webSocketServer: WebpackDevServer.WebSocketServerImplementation | undefined;
 }
 

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -12,6 +12,8 @@ import path from "node:path";
 import type { Server } from "node:http";
 import type { Socket } from "node:net";
 import { type Compiler, MultiCompiler } from "@rspack/core";
+// @ts-ignore 'package.json' is not under 'rootDir'
+import { version } from "../package.json";
 import type { FSWatcher } from "chokidar";
 import rdm from "webpack-dev-middleware";
 import WebpackDevServer from "webpack-dev-server";
@@ -35,7 +37,10 @@ export class RspackDevServer extends WebpackDevServer {
 	// TODO: remove @ts-ignore here
 	/** @ts-ignore */
 	public compiler: Compiler | MultiCompiler;
-	webSocketServer: WebpackDevServer.WebSocketServerImplementation | undefined;
+	public webSocketServer:
+		| WebpackDevServer.WebSocketServerImplementation
+		| undefined;
+	static version: string = version;
 
 	constructor(options: DevServer, compiler: Compiler | MultiCompiler) {
 		super(options, compiler as any);

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -12,11 +12,11 @@ import path from "node:path";
 import type { Server } from "node:http";
 import type { Socket } from "node:net";
 import { type Compiler, MultiCompiler } from "@rspack/core";
-// @ts-ignore 'package.json' is not under 'rootDir'
-import { version } from "../package.json";
 import type { FSWatcher } from "chokidar";
 import rdm from "webpack-dev-middleware";
 import WebpackDevServer from "webpack-dev-server";
+// @ts-ignore 'package.json' is not under 'rootDir'
+import { version } from "../package.json";
 
 import type { DevServer, ResolvedDevServer } from "./config";
 import { applyDevServerPatch } from "./patch";

--- a/packages/rspack-dev-server/tsconfig.json
+++ b/packages/rspack-dev-server/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": [
-    "src"
-  ],
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
-  }
+    "rootDir": "src",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
 }

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -13339,7 +13339,7 @@ export interface RspackPluginInstance {
 }
 
 // @public (undocumented)
-export const rspackVersion: any;
+export const rspackVersion: string;
 
 // @public
 type Rule = RegExp | string;
@@ -14726,7 +14726,7 @@ export const util: {
 };
 
 // @public (undocumented)
-export const version: any;
+export const version: string;
 
 // @public (undocumented)
 interface Wasm {

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -1,5 +1,13 @@
-const { version: rspackVersion, webpackVersion } = require("../package.json");
-export { rspackVersion, webpackVersion as version };
+import {
+	version as _version,
+	webpackVersion as _webpackVersion
+	// @ts-ignore 'package.json' is not under 'rootDir'
+} from "../package.json";
+
+const rspackVersion = _version as string;
+const version = _webpackVersion as string;
+
+export { rspackVersion, version };
 
 export type {
 	Asset,

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -4,6 +4,7 @@ import {
 	// @ts-ignore 'package.json' is not under 'rootDir'
 } from "../package.json";
 
+// this is a hack to be compatible with plugin which detect webpack's version
 const rspackVersion = _version as string;
 const version = _webpackVersion as string;
 

--- a/packages/rspack/tsconfig.json
+++ b/packages/rspack/tsconfig.json
@@ -18,16 +18,11 @@
       "json-parse-even-better-errors": [
         "../compiled/json-parse-even-better-errors"
       ],
-      "webpack-sources": [
-        "../compiled/webpack-sources"
-      ]
+      "webpack-sources": ["../compiled/webpack-sources"]
     }
   },
   "include": ["src", "src/**/*.json"],
-  "exclude": [
-    "src/config/schema.check.js",
-    "src/container/default.runtime.js"
-  ],
+  "exclude": ["src/config/schema.check.js", "src/container/default.runtime.js"],
   "ts-node": {
     "transpileOnly": true
   },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

I was looking in a convenient way of getting the version of the `@rsapck/dev-server` similar to what is available in `@rspack/core`

Export version from `package.json` (similar to the `@rspack/core`)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
