### PR TITLE
fix: add `await` to async module export

### DIFF
--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -67,6 +67,13 @@ fn render_startup(
   let module_graph = compilation.get_module_graph();
   source.add(render_source.source.clone());
   let mut exports = vec![];
+  if let Some(is_async) = module_graph.is_async(module)
+    && is_async
+  {
+    source.add(RawSource::from(
+      "__webpack_exports__ = await __webpack_exports__;\n",
+    ));
+  }
   let exports_info = module_graph.get_exports_info(module);
   for id in exports_info.get_ordered_exports() {
     let info = id.get_export_info(&module_graph);

--- a/packages/rspack-test-tools/tests/configCases/output/library-async-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-async-module/index.js
@@ -1,0 +1,4 @@
+import { handler } from "./lambda.js"
+it("handle should be a function", async function () {
+  expect(handler()).toBe(1);
+});

--- a/packages/rspack-test-tools/tests/configCases/output/library-async-module/lambda.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-async-module/lambda.js
@@ -2,11 +2,8 @@ const bb = async () => {
   return "asdsadasda";
 };
 
-console.log(await bb());
-
-console.log(123);
+await bb();
 
 export const handler = () => {
-  console.log("555")
   return 1;
 };

--- a/packages/rspack-test-tools/tests/configCases/output/library-async-module/lambda.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-async-module/lambda.js
@@ -1,0 +1,12 @@
+const bb = async () => {
+  return "asdsadasda";
+};
+
+console.log(await bb());
+
+console.log(123);
+
+export const handler = () => {
+  console.log("555")
+  return 1;
+};

--- a/packages/rspack-test-tools/tests/configCases/output/library-async-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/library-async-module/rspack.config.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import('@rspack/cli').Configuration}
+ */
+module.exports = {
+  entry: "./index.js",
+  experiments: {
+    outputModule: true,
+  },
+  output: {
+    chunkFormat: "module",
+    library: {
+      type: "module",
+    },
+  },
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

🤔 It's confusing why this code is missing.

webpack: https://github.com/webpack/webpack/blob/aa7174671e33cb61b52271d0806a0f7c9e0d08df/lib/library/ModuleLibraryPlugin.js#L83

closes https://github.com/web-infra-dev/rspack/issues/7146

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
