### PR TITLE
docs(blog): correcting the description of decorator configuration in v0.4

### DIFF
--- a/website/docs/en/blog/announcing-0-4.mdx
+++ b/website/docs/en/blog/announcing-0-4.mdx
@@ -28,7 +28,7 @@ This feature primarily addresses three categories of problems: [builtins](/confi
 - [builtins.react](/config/builtins#builtinsreact): moved to `jsc.transform.react`
 - [builtins.emotion](/config/builtins#builtinsemotion): moved to `rspackExperiments.emotion`
 - [builtins.pluginImport](/config/builtins#builtinspluginimport): moved to `rspackExperiments.import`
-- [builtins.decorator](/config/builtins#builtinsdecorator): moved to `jsc.parser.decorator`
+- [builtins.decorator](/config/builtins#builtinsdecorator): moved to `jsc.parser.decorators`
 - [builtins.presetEnv](/config/builtins#builtinspresetenv): moved to `jsc.env`
 
 ```js

--- a/website/docs/zh/blog/announcing-0-4.mdx
+++ b/website/docs/zh/blog/announcing-0-4.mdx
@@ -28,7 +28,7 @@ Rspack 不再支持 Node.js 14，现在需要 Node.js 16+。
 - [builtins.react](/config/builtins#builtinsreact)：移动到 `jsc.transform.react`
 - [builtins.emotion](/config/builtins#builtinsemotion)：移动到 `rspackExperiments.emotion`
 - [builtins.pluginImport](/config/builtins#builtinspluginimport)：移动到 `rspackExperiments.import`
-- [builtins.decorator](/config/builtins#builtinsdecorator)：移动到 `jsc.parser.decorator`
+- [builtins.decorator](/config/builtins#builtinsdecorator)：移动到 `jsc.parser.decorators`
 - [builtins.presetEnv](/config/builtins#builtinspresetenv)：移动到 `jsc.env`
 
 ```javascript


### PR DESCRIPTION
## Summary
just an incorrect description that `builtins.decorator 移动到 jsc.parser.decorator` shoule be `jsc.parser.decorators`

<img width="1148" alt="image" src="https://github.com/user-attachments/assets/44ea566f-f69d-4119-ae9a-b45b553e34cb">


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
