### PR TITLE
perf: no need to require entire enhanced-resolve

### DIFF
--- a/packages/rspack/prebundle.config.mjs
+++ b/packages/rspack/prebundle.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { copyFileSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -53,6 +53,10 @@ export default {
 					join(depPath, "lib/CachedInputFileSystem.js"),
 					join(distPath, "CachedInputFileSystem.js")
 				);
+
+				// Rspack only depend on the `CachedInputFileSystem` module of enhanced-resolve
+				// so we can remove the index chunk because it is not used
+				unlinkSync(join(distPath, "index.js"));
 
 				// ResolveRequest type is used by Rspack but not exported
 				const dtsFile = join(distPath, "index.d.ts");


### PR DESCRIPTION
## Summary

Rspack only depend on the `CachedInputFileSystem` module of enhanced-resolve, so we can remove the index chunk because it is not used.

![image](https://github.com/user-attachments/assets/c6d17eb9-cd6f-4a14-b106-dc135689cddf)

- The startup time will be `6ms` faster:

![image](https://github.com/user-attachments/assets/8572c6bf-8b4f-45b8-9cd8-a5fd08c9dd49)

- Reduced 143KB install size:

![image](https://github.com/user-attachments/assets/f45256f5-b834-460b-8b03-9c547a54fa47)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
