### PR TITLE
refactor: remove module graph accessor

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -30,13 +30,13 @@ use crate::{
   build_chunk_graph::build_chunk_graph,
   get_chunk_from_ukey, get_mut_chunk_from_ukey, is_source_equal,
   old_cache::{use_code_splitting_cache, Cache as OldCache, CodeSplittingCache},
-  prepare_get_exports_type, to_identifier, BoxDependency, BoxModule, CacheCount, CacheOptions,
-  Chunk, ChunkByUkey, ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkKind,
-  ChunkUkey, CodeGenerationResults, CompilationLogger, CompilationLogging, CompilerOptions,
-  DependencyId, DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint,
-  ExecuteModuleId, Filename, ImportVarMap, LocalFilenameFn, Logger, Module, ModuleFactory,
-  ModuleGraph, ModuleGraphPartial, ModuleIdentifier, PathData, ResolverFactory, RuntimeGlobals,
-  RuntimeModule, RuntimeSpec, SharedPluginDriver, SourceType, Stats,
+  to_identifier, BoxDependency, BoxModule, CacheCount, CacheOptions, Chunk, ChunkByUkey,
+  ChunkContentHash, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkKind, ChunkUkey,
+  CodeGenerationResults, CompilationLogger, CompilationLogging, CompilerOptions, DependencyId,
+  DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint, ExecuteModuleId,
+  Filename, ImportVarMap, LocalFilenameFn, Logger, Module, ModuleFactory, ModuleGraph,
+  ModuleGraphPartial, ModuleIdentifier, PathData, ResolverFactory, RuntimeGlobals, RuntimeModule,
+  RuntimeSpec, SharedPluginDriver, SourceType, Stats,
 };
 
 pub type BuildDependency = (
@@ -751,13 +751,6 @@ impl Compilation {
 
       Ok(())
     }
-
-    // FIXME:
-    // Webpack may modify the moduleGraph in module.getExportsType()
-    // and it is widely called after compilation.finish()
-    // so add this method to trigger moduleGraph modification and
-    // then make sure that moduleGraph is immutable
-    prepare_get_exports_type(&mut self.get_module_graph_mut());
 
     run_iteration(self, &mut codegen_cache_counter, |(_, module)| {
       module.get_code_generation_dependencies().is_none()

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -11,7 +11,7 @@ use crate::{
   utils::task_loop::{Task, TaskResult, TaskType},
   BoxDependency, CompilerOptions, Context, DependencyId, ExportInfo, ExportsInfo, ModuleFactory,
   ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleProfile,
-  Resolve, UsageState,
+  Resolve,
 };
 
 #[derive(Debug)]
@@ -58,12 +58,8 @@ impl Task<MakeTaskContext> for FactorizeTask {
       .or(self.issuer_layer.as_ref())
       .cloned();
 
-    let other_exports_info = ExportInfo::new(None, UsageState::Unknown, None);
-    let side_effects_only_info = ExportInfo::new(
-      Some("*side effects only*".into()),
-      UsageState::Unknown,
-      None,
-    );
+    let other_exports_info = ExportInfo::new(None, None);
+    let side_effects_only_info = ExportInfo::new(Some("*side effects only*".into()), None);
     let exports_info = ExportsInfo::new(other_exports_info.id, side_effects_only_info.id);
     let factorize_result_task = FactorizeResultTask {
       //      dependency: dep_id,

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1829,7 +1829,7 @@ impl ConcatenatedModule {
     let module = mg
       .module_by_identifier(&info.id())
       .expect("should have module");
-    let exports_type = module.get_exports_type_readonly(mg, strict_harmony_module);
+    let exports_type = module.get_exports_type(mg, strict_harmony_module);
 
     if export_name.is_empty() {
       match exports_type {

--- a/crates/rspack_core/src/dependency/runtime_template.rs
+++ b/crates/rspack_core/src/dependency/runtime_template.rs
@@ -257,17 +257,11 @@ pub fn get_exports_type(
   id: &DependencyId,
   parent_module: &ModuleIdentifier,
 ) -> ExportsType {
-  let module = module_graph
-    .module_identifier_by_dependency_id(id)
-    .expect("should have module");
   let strict = module_graph
     .module_by_identifier(parent_module)
     .expect("should have mgm")
     .get_strict_harmony_module();
-  module_graph
-    .module_by_identifier(module)
-    .expect("should have mgm")
-    .get_exports_type_readonly(module_graph, strict)
+  get_exports_type_with_strict(module_graph, id, strict)
 }
 
 pub fn get_exports_type_with_strict(
@@ -281,7 +275,7 @@ pub fn get_exports_type_with_strict(
   module_graph
     .module_by_identifier(module)
     .expect("should have module")
-    .get_exports_type_readonly(module_graph, strict)
+    .get_exports_type(module_graph, strict)
 }
 
 // information content of the comment

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -104,7 +104,7 @@ impl CommonJsExportRequireDependency {
     let is_namespace_import = matches!(
       mg.module_by_identifier(imported_module)
         .expect("Should get imported module")
-        .get_exports_type_readonly(mg, false),
+        .get_exports_type(mg, false),
       ExportsType::Namespace
     );
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -69,7 +69,7 @@ impl Dependency for CommonJsFullRequireDependency {
       && module_graph
         .module_graph_module_by_dependency_id(&self.id)
         .and_then(|mgm| module_graph.module_by_identifier(&mgm.module_identifier))
-        .map(|m| m.get_exports_type_readonly(module_graph, false))
+        .map(|m| m.get_exports_type(module_graph, false))
         .is_some_and(|t| !matches!(t, ExportsType::Namespace))
     {
       if self.names.is_empty() {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -220,7 +220,7 @@ pub fn harmony_import_dependency_get_linking_error<T: ModuleDependency>(
   let parent_module = module_graph
     .module_by_identifier(parent_module_identifier)
     .expect("should have module");
-  let exports_type = imported_module.get_exports_type_readonly(
+  let exports_type = imported_module.get_exports_type(
     module_graph,
     parent_module
       .build_meta()

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -32,7 +32,7 @@ pub fn create_import_dependency_referenced_exports(
         else {
           return create_exports_object_referenced();
         };
-        let exports_type = imported_module.get_exports_type_readonly(mg, strict);
+        let exports_type = imported_module.get_exports_type(mg, strict);
         if matches!(
           exports_type,
           ExportsType::DefaultOnly | ExportsType::DefaultWithNamed

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -6,8 +6,8 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   ApplyContext, BuildMetaExportsType, Compilation, CompilationFinishModules, CompilerOptions,
   DependenciesBlock, DependencyId, ExportInfoProvided, ExportNameOrSpec, ExportsInfoId,
-  ExportsOfExportsSpec, ExportsSpec, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
-  MutableModuleGraph, Plugin, PluginContext,
+  ExportsOfExportsSpec, ExportsSpec, ModuleGraph, ModuleGraphConnection, ModuleIdentifier, Plugin,
+  PluginContext,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -322,8 +322,7 @@ impl<'a> FlagDependencyExportsProxy<'a> {
       }
 
       // Recalculate target exportsInfo
-      let mut mga = MutableModuleGraph::new(self.mg);
-      let target = export_info_id.get_target(&mut mga, None);
+      let target = export_info_id.get_target(self.mg, None);
 
       let mut target_exports_info: Option<ExportsInfoId> = None;
       if let Some(target) = target {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -12,9 +12,9 @@ use rspack_core::concatenated_module::{
 use rspack_core::{
   filter_runtime, merge_runtime, runtime_to_string, ApplyContext, Compilation,
   CompilationOptimizeChunkModules, CompilerModuleContext, CompilerOptions, ExportInfoProvided,
-  ExtendedReferencedExport, ImmutableModuleGraph, LibIdentOptions, Logger, Module, ModuleExt,
-  ModuleGraph, ModuleGraphModule, ModuleIdentifier, Plugin, PluginContext, ProvidedExports,
-  RunnerContext, RuntimeCondition, RuntimeSpec, SourceType,
+  ExtendedReferencedExport, LibIdentOptions, Logger, Module, ModuleExt, ModuleGraph,
+  ModuleGraphModule, ModuleIdentifier, Plugin, PluginContext, ProvidedExports, RunnerContext,
+  RuntimeCondition, RuntimeSpec, SourceType,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -771,8 +771,7 @@ impl ModuleConcatenationPlugin {
           .iter()
           .filter(|id| {
             let export_info = id.get_export_info(&module_graph).clone();
-            let mut mga = ImmutableModuleGraph::new(&module_graph);
-            export_info.is_reexport() && export_info.id.get_target(&mut mga, None).is_none()
+            export_info.is_reexport() && export_info.id.get_target(&module_graph, None).is_none()
           })
           .copied()
           .collect::<Vec<_>>();

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -7,9 +7,8 @@ use once_cell::sync::Lazy;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, FactoryMeta,
-  ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, MutableModuleGraph,
-  NormalModuleCreateData, NormalModuleFactoryModule, Plugin, ResolvedExportInfoTarget,
-  SideEffectsBailoutItemWithSpan,
+  ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, NormalModuleCreateData,
+  NormalModuleFactoryModule, Plugin, ResolvedExportInfoTarget, SideEffectsBailoutItemWithSpan,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -740,9 +739,8 @@ fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<
       if !ids.is_empty() {
         let export_info_id = cur_exports_info_id.get_export_info(&ids[0], &mut module_graph);
 
-        let mut mga = MutableModuleGraph::new(&mut module_graph);
         let target = export_info_id.get_target(
-          &mut mga,
+          &module_graph,
           Some(Arc::new(
             |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
               mg.module_by_identifier(&target.module)


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`max_target` is a cache for cacheing the result of `get_max_target`, actually in most cases, `get_max_target` will just return `export_info.target` (the fast path), and in slow path, the calculate is not complex at all (checkout https://github.com/webpack/webpack/pull/13068), so remove the cache to let `get_max_target` require a `&ModuleGraph`, and we don't need the `ModuleGraphAccessor` anymore

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
