### PR TITLE
fix(modern-module): compat with more export cases

### DIFF
--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -327,20 +327,9 @@ div {
 head{--webpack--120:&_13;}"
 `;
 
-exports[`config config/library/modern-module-force-concaten step  should pass 1`] = `
-"
-;// CONCATENATED MODULE: ./a.js
-const a = 'a'
-
-export { a };
-"
-`;
-
-exports[`config config/library/modern-module-force-concaten step  should pass 2`] = `
+exports[`config config/library/modern-module-force-concaten step  should pass: .cjs should bail out 1`] = `
 "var __webpack_modules__ = ({
-\\"772\\": (function (module) {
-
-;// CONCATENATED MODULE: ./b.cjs
+\\"851\\": (function (module) {
 module.exports = 'b'
 
 }),
@@ -374,23 +363,113 @@ return module.exports;
 // startup
 // Load entry module and return exports
 // This entry module is referenced by other modules so it can't be inlined
-var __webpack_exports__ = __webpack_require__(\\"772\\");
+var __webpack_exports__ = __webpack_require__(\\"851\\");
 "
 `;
 
-exports[`config config/library/modern-module-force-concaten step  should pass 3`] = `
-"
-;// CONCATENATED MODULE: ./c.js
-const c = 'c'
+exports[`config config/library/modern-module-force-concaten step  should pass: .cjs should bail out when bundling 1`] = `
+"var __webpack_modules__ = ({
+\\"997\\": (function (module) {
+module.exports = 'bar'
 
+}),
+
+});
+/************************************************************************/
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+/************************************************************************/
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-harmony modules
+__webpack_require__.n = function (module) {
+	var getter = module && module.__esModule ?
+		function () { return module['default']; } :
+		function () { return module; };
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+
+
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = function(exports, definition) {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = function (obj, prop) {
+	return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+})();
+/************************************************************************/
+
+;// CONCATENATED MODULE: ./e/foo.js
+const foo = 'foo'
+
+// EXTERNAL MODULE: ./e/bar.cjs
+var bar = __webpack_require__(\\"997\\");
+var bar_default = /*#__PURE__*/__webpack_require__.n(bar);
+;// CONCATENATED MODULE: ./e/index.js
+
+
+
+
+
+var __webpack_exports__bar = (bar_default());
+export { foo, __webpack_exports__bar as bar };
 "
 `;
 
-exports[`config config/library/modern-module-force-concaten step  should pass 4`] = `
+exports[`config config/library/modern-module-force-concaten step  should pass: .mjs should concat 1`] = `
 "
 ;// CONCATENATED MODULE: ./d.mjs
 const d = 'd'
-export { d };
+"
+`;
+
+exports[`config config/library/modern-module-force-concaten step  should pass: harmony export should concat 1`] = `
+"
+;// CONCATENATED MODULE: ./a.js
+const a = 'a'
+
+export { a };
+"
+`;
+
+exports[`config config/library/modern-module-force-concaten step  should pass: unambiguous should bail out 1`] = `
+"const c = 'c'
+
 "
 `;
 

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/d.mjs
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/d.mjs
@@ -1,1 +1,1 @@
-export const d = 'd'
+const d = 'd'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/e/bar.cjs
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/e/bar.cjs
@@ -1,0 +1,1 @@
+module.exports = 'bar'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/e/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/e/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/e/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/e/index.js
@@ -1,0 +1,4 @@
+import { foo } from './foo.js'
+import bar from './bar.cjs'
+
+export { foo, bar }

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
@@ -4,7 +4,8 @@ module.exports = {
 		"a": "./a.js",
 		"b": "./b.cjs",
 		"c": "./c.js",
-		"d": "./d.mjs"
+		"d": "./d.mjs",
+		"e": "./e/index.js"
 	},
 	output: {
 		filename: `[name].js`,
@@ -13,15 +14,6 @@ module.exports = {
 		iife: false,
 		chunkFormat: "module",
 	},
-	externalsType: "module",
-  externals: [
-    (data, callback) => {
-      if (data.contextInfo.issuer) {
-        return callback(null, data.request)
-      }
-      callback()
-    },
-  ],
 	experiments: {
 		outputModule: true
 	},
@@ -37,10 +29,11 @@ module.exports = {
 			 */
 			const handler = compilation => {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
-					expect(assets['a.js']._value).toMatchSnapshot();
-					expect(assets['b.js']._value).toMatchSnapshot();
-					expect(assets['c.js']._value).toMatchSnapshot();
-					expect(assets['d.js']._value).toMatchSnapshot();
+					expect(assets['a.js']._value).toMatchSnapshot("harmony export should concat");
+					expect(assets['b.js']._value).toMatchSnapshot(".cjs should bail out");
+					expect(assets['c.js']._value).toMatchSnapshot("unambiguous should bail out");
+					expect(assets['d.js']._value).toMatchSnapshot(".mjs should concat");
+					expect(assets['e.js']._value).toMatchSnapshot(".cjs should bail out when bundling");
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Using module's concatenate bailout reason to filter out module to trigger force concatation.
- Compat with export with `a.b` and `(some_cjs())` final_name. Directly detecting invalid characters to fallback to `module` style export. It's not elegant, but I think it should work in most cases.

   ```js
   var __webpack_exports__bar = (bar_default());
   export { foo, __webpack_exports__bar as bar };
   ```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
