### PR TITLE
fix: dollar sign in filename

### DIFF
--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{borrow::Cow, convert::Infallible, ptr};
 
-use itertools::Itertools;
 use once_cell::sync::Lazy;
 use regex::{Captures, NoExpand, Regex};
 use rspack_error::error;

--- a/packages/rspack-test-tools/tests/configCases/output/dollar-sign/index.js
+++ b/packages/rspack-test-tools/tests/configCases/output/dollar-sign/index.js
@@ -1,0 +1,6 @@
+import './img$s/a$b.png';
+import fs from "fs";
+import path from "path";
+it("should replace filename with dollar sign", async function () {
+  expect(fs.existsSync(path.resolve(__dirname, './img$s/a$b.png'))).toBe(true);
+});

--- a/packages/rspack-test-tools/tests/configCases/output/dollar-sign/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output/dollar-sign/rspack.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: "./index.js",
+  module: {
+    rules: [
+      {
+        resource: /.png/,
+        type: 'asset/resource',
+        generator: {
+          filename: '[path][name][ext]'
+        }
+      },
+    ]
+  },
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

the dollar sign `$` is special while doing string replacement in rust. need to escape it to `$$`.

> see [regexp doc](https://docs.rs/regex/latest/regex/struct.Regex.html#replacement-string-syntax) for more details

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
