### PR TITLE
fix: change some `walk_block_statement` to `walk_statement`

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1436,7 +1436,7 @@ impl<'parser> JavascriptParser<'parser> {
           ClassMember::StaticBlock(block) => {
             let was_top_level = this.top_level_scope;
             this.top_level_scope = TopLevelScope::False;
-            this.walk_block_statement(Statement::Block(&block.body));
+            this.walk_block_statement(&block.body);
             this.top_level_scope = was_top_level;
           }
           ClassMember::Empty(_) => {}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -541,7 +541,7 @@ impl<'parser> JavascriptParser<'parser> {
         let was_top_level = self.top_level_scope;
         self.top_level_scope = TopLevelScope::False;
         if let Some(body) = &getter.body {
-          self.walk_block_statement(body);
+          self.walk_statement(Statement::Block(body));
         }
         self.top_level_scope = was_top_level;
       }
@@ -550,7 +550,7 @@ impl<'parser> JavascriptParser<'parser> {
         let was_top_level = self.top_level_scope;
         self.top_level_scope = TopLevelScope::False;
         if let Some(body) = &setter.body {
-          self.walk_block_statement(body);
+          self.walk_statement(Statement::Block(body));
         }
         self.top_level_scope = was_top_level;
       }
@@ -1436,7 +1436,7 @@ impl<'parser> JavascriptParser<'parser> {
           ClassMember::StaticBlock(block) => {
             let was_top_level = this.top_level_scope;
             this.top_level_scope = TopLevelScope::False;
-            this.walk_block_statement(&block.body);
+            this.walk_statement(Statement::Block(&block.body));
             this.top_level_scope = was_top_level;
           }
           ClassMember::Empty(_) => {}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1436,7 +1436,7 @@ impl<'parser> JavascriptParser<'parser> {
           ClassMember::StaticBlock(block) => {
             let was_top_level = this.top_level_scope;
             this.top_level_scope = TopLevelScope::False;
-            this.walk_statement(Statement::Block(&block.body));
+            this.walk_block_statement(Statement::Block(&block.body));
             this.top_level_scope = was_top_level;
           }
           ClassMember::Empty(_) => {}

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1349,9 +1349,9 @@ impl<'parser> JavascriptParser<'parser> {
               if let Some(body) = &ctor.body {
                 this.detect_mode(&body.stmts);
                 let prev = this.prev_statement;
-                this.pre_walk_block_statement(body);
+                this.pre_walk_statement(Statement::Block(body));
                 this.prev_statement = prev;
-                this.walk_block_statement(body);
+                this.walk_statement(Statement::Block(body));
               }
             });
 

--- a/packages/rspack-test-tools/tests/normalCases/parsing/ctor-import-asi/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/ctor-import-asi/index.js
@@ -1,0 +1,17 @@
+import { destroyMaybe as i } from "./util.js";
+class j {
+	constructor() {
+    // should automatically insert semicolon
+		this.ground = 1
+	}
+	destroy() {
+		i(),
+		i();
+		return 1;
+	}
+}
+
+it("methods after the ctor should not insert unexpected semicolon", () => {
+  expect(new j().destroy()).toBe(1);
+});
+

--- a/packages/rspack-test-tools/tests/normalCases/parsing/ctor-import-asi/util.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/ctor-import-asi/util.js
@@ -1,0 +1,3 @@
+export function destroyMaybe(i) {
+	return i;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

webpack only directly call `walkBlockStatement` at `walkStatement` and `walkClass`(StaticBlock).

The difference between calling directly and calling via `walk_statement` is that `walk_statement` updates the `statement_path` and `prev_statement` in `enter_statement`.

Omitting to update `prev_statement` results in `asi_safe` error, which causes an unexpected semicolon to be inserted after the comma in the `SequentialStatement`.

closes https://github.com/web-infra-dev/rspack/issues/7397

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
