### PR TITLE
fix(playground/cases): replace window.onmessage with self.onmessage in worker test case

### DIFF
--- a/packages/playground/cases/react/worker/src/worker.js
+++ b/packages/playground/cases/react/worker/src/worker.js
@@ -1,6 +1,6 @@
 import Button from "./Button";
 
-window.onmessage = () => {
+self.onmessage = () => {
 	Button.add();
 	postMessage(Button.get());
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
This error was introduced by #7387 , which incorrectly used the global `window` object in a `Web Worker` context.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
