### PR TITLE
docs: update ecosystem links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,17 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 ## Links
 
-| Name                                                                                     | Description                                                                   |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Rspack website](https://rspack.dev)                                                     | Official documentation for Rspack                                             |
-| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                        | A curated list of awesome things related to Rspack                            |
-| [rspack-examples](https://github.com/rspack-contrib/rspack-examples)                     | Rspack configuration examples                                                 |
-| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                        | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
-| [rspack-migration-showcase](https://github.com/web-infra-dev/rspack-migration-showcase)  | Migration showcases for Rspack                                                |
-| [rspack-compat](https://github.com/web-infra-dev/rspack-compat)                          | Rspack compatible loaders and plugins examples                                |
-| [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) | Design resources for Rspack, Rsbuild, Rspress and Rsdoctor                    |
+| Name                                                                                 | Description                                                                   |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
+| [Rspack website](https://rspack.dev)                                                 | Official documentation for Rspack                                             |
+| [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                  | The Rspack-based build tool                                                   |
+| [Rspress](https://github.com/web-infra-dev/rspress)                                  | A fast static site generator based on Rsbuild                                 |
+| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | A one-stop build analyzer for Rspack and webpack                              |
+| [Rslib](https://github.com/web-infra-dev/rslib)                                      | The library build tool powered by Rsbuild                                     |
+| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                    | A curated list of awesome things related to Rspack                            |
+| [rspack-examples](https://github.com/rspack-contrib/rspack-examples)                 | Lots of Rspack example projects                                               |
+| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust port of [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
+| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Design resources for Rstack                                                   |
 
 ## Contributors
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,15 +42,17 @@ Rspack 是一个基于 Rust 编写的高性能 JavaScript 打包工具，它提�
 
 ## 链接
 
-| 名称                                                                                     | 描述                                                                         |
-| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| [Rspack 文档](https://rspack.dev/zh/)                                                    | Rspack 官方文档                                                              |
-| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                        | 与 Rspack 相关的精彩内容列表                                                 |
-| [rspack-examples](https://github.com/rspack-contrib/rspack-examples)                     | Rspack 配置示例                                                              |
-| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                        | Rust 版本的 [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
-| [rspack-migration-showcase](https://github.com/web-infra-dev/rspack-migration-showcase)  | 迁移到 Rspack 的示例项目                                                     |
-| [rspack-compat](https://github.com/web-infra-dev/rspack-compat)                          | 兼容 Rspack 的 webpack 插件 和 Loader 示例                                   |
-| [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) | Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源                              |
+| 名称                                                                                 | 描述                                                                         |
+| ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| [Rspack 文档](https://rspack.dev/zh/)                                                | Rspack 官方文档                                                              |
+| [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                  | 基于 Rspack 的构建工具                                                       |
+| [Rspress](https://github.com/web-infra-dev/rspress)                                  | 基于 Rsbuild 的静态站点生成器                                                |
+| [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | 针对 Rspack 和 webpack 的一站式构建分析工具                                  |
+| [Rslib](https://github.com/web-infra-dev/rslib)                                      | 基于 Rsbuild 的 library 构建工具                                             |
+| [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)                    | 与 Rspack 相关的精彩内容列表                                                 |
+| [rspack-examples](https://github.com/rspack-contrib/rspack-examples)                 | 丰富的 Rspack 示例项目                                                       |
+| [rspack-sources](https://github.com/web-infra-dev/rspack-sources)                    | Rust 版本的 [webpack-sources](https://www.npmjs.com/package/webpack-sources) |
+| [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) | Rstack 的设计资源                                                            |
 
 ## 致谢
 

--- a/website/README.md
+++ b/website/README.md
@@ -23,7 +23,7 @@ If you have any problems using the Rspress, please create a new issue at [Rspres
 
 ## Image Assets
 
-For images you use in the document, it's better to upload them to the [rspack-contrib/rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) repository, so the size of the current repository doesn't get too big.
+For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 
 After you upload the images there, they will be automatically deployed under the <https://assets.rspack.dev/>.
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -95,16 +95,17 @@ If you need to migrate from an existing project to Rspack or Rsbuild, you can re
 - [Migrating from Vite to Rsbuild](https://rsbuild.dev/guide/migration/vite)
 - [Migrating from Storybook](/guide/migration/storybook)
 
-> Visit [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) to discover more projects within the Rspack ecosystem.
-
 ## Community ecosystem
 
 There are already some Rspack-based toolchains in the community:
 
 - If you want to build a static site, you can try [Rspress](https://rspress.dev).
+- If you want to build a library or UI component, you can try [Rslib](https://rspress.dev).
 - If you want to analyze the build process and build artifacts, you can try [Rsdoctor](https://rsdoctor.dev).
 - If you're looking for a full-stack React framework, you can try [Modern.js](https://modernjs.dev/en/).
 - If you want a fast and production-ready setup that works in a monorepo, you can try [Nx](https://nx.dev).
+
+> Visit [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) to discover more projects within the Rspack ecosystem.
 
 ### Rspress
 

--- a/website/docs/en/misc/branding/guideline.mdx
+++ b/website/docs/en/misc/branding/guideline.mdx
@@ -18,6 +18,6 @@ Rspack logo is a small crab as fast as lightning, representing fast compilation 
 
 ## Design Resources
 
-You can find all of Rspack's design resources under the [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) repository.
+You can find all of Rspack's design resources under the [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository.
 
 The design resources of Rspack are licensed under the [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en) license.

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -99,10 +99,11 @@ npm init -y
 
 社区中已经有一些基于 Rspack 的工具链：
 
-- 如果你需要开发一个静态站点（如文档站），你可以尝试 [Rspress](https://rspress.dev)。
-- 如果你需要分析构建过程和构建产物，你可以尝试 [Rsdoctor](https://rsdoctor.dev)。
-- 如果你需要一个 React 全栈框架来构建 Web 应用，你可以尝试 [Modern.js](https://modernjs.dev/)。
-- 如果你需要在 Monorepo 中使用 Rspack，打造快速、可扩展的构建系统，你可以尝试 [Nx](https://nx.dev)。
+- 如果你需要开发一个静态站点（如文档站），可以尝试 [Rspress](https://rspress.dev)。
+- 如果你需要开发一个工具库或组件库，可以尝试 [Rslib](https://rspress.dev)。
+- 如果你需要分析构建过程和构建产物，可以尝试 [Rsdoctor](https://rsdoctor.dev)。
+- 如果你需要一个 React 全栈框架来构建 Web 应用，可以尝试 [Modern.js](https://modernjs.dev/)。
+- 如果你需要在 Monorepo 中使用 Rspack，打造快速、可扩展的构建系统，可以尝试 [Nx](https://nx.dev)。
 
 > 访问 [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) 来发现更多 Rspack 生态中的项目。
 

--- a/website/docs/zh/misc/branding/guideline.mdx
+++ b/website/docs/zh/misc/branding/guideline.mdx
@@ -18,6 +18,6 @@ Rspack 的 Logo 是一个如闪电一样迅速的小螃蟹，代表了 Rspack �
 
 ## 设计资源
 
-你可以在 [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) 仓库下找到 Rspack 相关的所有设计资源。
+你可以在 [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) 仓库下找到 Rspack 相关的所有设计资源。
 
 Rspack 的设计资源遵循 [Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.en) 协议。

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -118,8 +118,8 @@ recognise
 Rollup
 rome
 rsbuild
-Rsdoctor
 rsdoctor
+Rsdoctor
 rsdoctors
 rsfamily
 Rslib
@@ -128,6 +128,7 @@ Rspack
 rspackplugin
 rspress
 Rspress
+rstack
 ruid
 ruleoneof
 ruleparserdataurlcondition

--- a/website/theme/components/HomeFooter/index.tsx
+++ b/website/theme/components/HomeFooter/index.tsx
@@ -67,8 +67,8 @@ function useFooterData() {
           link: 'https://rsdoctor.dev/',
         },
         {
-          title: 'Modern.js',
-          link: 'https://modernjs.dev/en/',
+          title: 'Rslib',
+          link: 'https://github.com/web-infra-dev/rslib',
         },
       ],
     },


### PR DESCRIPTION

## Summary

Update ecosystem links:

- Add Rslib
- Remove rspack-compat (deprecated) and rspack-migration-showcase (no longer maintained)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
