### PR TITLE
feat(node-stuff): implement `node-module` shim

### DIFF
--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -5,8 +5,8 @@ use rspack_sources::{BoxSource, ReplaceSource};
 use rspack_util::ext::AsAny;
 
 use crate::{
-  AsDependency, CodeGenerationData, Compilation, ConcatenationScope, DependencyId, Module,
-  ModuleInitFragments, RuntimeGlobals, RuntimeSpec,
+  AsDependency, ChunkInitFragments, CodeGenerationData, Compilation, ConcatenationScope,
+  DependencyId, Module, ModuleInitFragments, RuntimeGlobals, RuntimeSpec,
 };
 
 pub struct TemplateContext<'a, 'b, 'c> {
@@ -17,6 +17,24 @@ pub struct TemplateContext<'a, 'b, 'c> {
   pub runtime: Option<&'a RuntimeSpec>,
   pub concatenation_scope: Option<&'c mut ConcatenationScope>,
   pub data: &'a mut CodeGenerationData,
+}
+
+impl TemplateContext<'_, '_, '_> {
+  pub fn chunk_init_fragments(&mut self) -> &mut ChunkInitFragments {
+    let data_fragments = self.data.get::<ChunkInitFragments>();
+    if data_fragments.is_some() {
+      return self
+        .data
+        .get_mut::<ChunkInitFragments>()
+        .expect("should have chunk_init_fragments");
+    } else {
+      self.data.insert(ChunkInitFragments::default());
+      return self
+        .data
+        .get_mut::<ChunkInitFragments>()
+        .expect("should have chunk_init_fragments");
+    }
+  }
 }
 
 pub type TemplateReplaceSource = ReplaceSource<BoxSource>;

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -224,7 +224,7 @@ impl ExternalModule {
                 .to_string(),
               InitFragmentStage::StageHarmonyImports,
               0,
-              InitFragmentKey::ExternalModule("node-commonjs".to_string()),
+              InitFragmentKey::ModuleExternal("node-commonjs".to_string()),
               None,
             )
             .boxed(),
@@ -276,7 +276,7 @@ impl ExternalModule {
                   ),
                   InitFragmentStage::StageHarmonyImports,
                   0,
-                  InitFragmentKey::ExternalModule(request.primary().into()),
+                  InitFragmentKey::ModuleExternal(request.primary().into()),
                   None,
                 )
                 .boxed(),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -1,0 +1,51 @@
+use rspack_core::{
+  AsDependency, DependencyId, DependencyTemplate, ExternalModuleInitFragment, InitFragmentExt,
+  InitFragmentStage, TemplateContext, TemplateReplaceSource,
+};
+
+#[derive(Debug, Clone)]
+pub struct ExternalModuleDependency {
+  id: DependencyId,
+  module: String,
+  import_specifier: Vec<(String, String)>,
+  default_import: Option<String>,
+}
+
+impl ExternalModuleDependency {
+  pub fn new(
+    module: String,
+    import_specifier: Vec<(String, String)>,
+    default_import: Option<String>,
+  ) -> Self {
+    Self {
+      id: DependencyId::new(),
+      module,
+      import_specifier,
+      default_import,
+    }
+  }
+}
+
+impl DependencyTemplate for ExternalModuleDependency {
+  fn apply(
+    &self,
+    _source: &mut TemplateReplaceSource,
+    code_generatable_context: &mut TemplateContext,
+  ) {
+    let chunk_init_fragments = code_generatable_context.chunk_init_fragments();
+    let fragment = ExternalModuleInitFragment::new(
+      self.module.clone(),
+      self.import_specifier.clone(),
+      self.default_import.clone(),
+      InitFragmentStage::StageConstants,
+      0,
+    );
+    chunk_init_fragments.push(fragment.boxed());
+  }
+
+  fn dependency_id(&self) -> Option<DependencyId> {
+    Some(self.id)
+  }
+}
+
+impl AsDependency for ExternalModuleDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/mod.rs
@@ -1,3 +1,4 @@
+mod external_module_dependency;
 mod harmony_compatibility_dependency;
 mod harmony_export_expression_dependency;
 mod harmony_export_header_dependency;
@@ -13,6 +14,7 @@ use rspack_core::DependencyCategory;
 use rspack_core::ImportAttributes;
 use rspack_util::json_stringify;
 
+pub use self::external_module_dependency::ExternalModuleDependency;
 pub use self::harmony_compatibility_dependency::HarmonyCompatibilityDependency;
 pub use self::harmony_export_expression_dependency::*;
 pub use self::harmony_export_header_dependency::HarmonyExportHeaderDependency;

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -111,7 +111,7 @@ impl DependencyTemplate for ProvideDependency {
       ),
       InitFragmentStage::StageProvides,
       1,
-      InitFragmentKey::ExternalModule(format!("provided {}", self.identifier)),
+      InitFragmentKey::ModuleExternal(format!("provided {}", self.identifier)),
       None,
     )));
     source.replace(self.start, self.end, &self.identifier, None);

--- a/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/api_plugin.rs
@@ -41,7 +41,7 @@ fn render_module_content(
         "import { createRequire as __WEBPACK_EXTERNAL_createRequire } from 'module';\n".to_string(),
         InitFragmentStage::StageHarmonyImports,
         0,
-        InitFragmentKey::ExternalModule("node-commonjs".to_string()),
+        InitFragmentKey::ModuleExternal("node-commonjs".to_string()),
         None,
       )
       .boxed(),

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -75,7 +75,11 @@ pub fn render_module(
     return Ok(None);
   };
   let hooks = JsPlugin::get_compilation_hooks(compilation);
-  let mut module_chunk_init_fragments = ChunkInitFragments::default();
+  let mut module_chunk_init_fragments = match code_gen_result.data.get::<ChunkInitFragments>() {
+    Some(fragments) => fragments.clone(),
+    None => ChunkInitFragments::default(),
+  };
+
   let mut render_source = RenderSource {
     source: origin_source.clone(),
   };

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -7137,17 +7137,17 @@ export { Node_2 as Node }
 
 // @public (undocumented)
 const node_2: z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
-    __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only"]>]>>;
-    __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only"]>]>>;
+    __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
+    __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
     global: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"warn">]>>;
 }, "strict", z.ZodTypeAny, {
     global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
 }, {
     global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
 }>]>;
 
 // @public (undocumented)
@@ -7186,17 +7186,17 @@ export type NodeOptions = z.infer<typeof nodeOptions>;
 
 // @public (undocumented)
 const nodeOptions: z.ZodObject<{
-    __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only"]>]>>;
-    __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only"]>]>>;
+    __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
+    __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
     global: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"warn">]>>;
 }, "strict", z.ZodTypeAny, {
     global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
 }, {
     global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
 }>;
 
 // @public (undocumented)
@@ -11075,17 +11075,17 @@ export const rspackOptions: z.ZodObject<{
     context: z.ZodOptional<z.ZodString>;
     devtool: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["eval", "cheap-source-map", "cheap-module-source-map", "source-map", "inline-cheap-source-map", "inline-cheap-module-source-map", "inline-source-map", "inline-nosources-cheap-source-map", "inline-nosources-cheap-module-source-map", "inline-nosources-source-map", "nosources-cheap-source-map", "nosources-cheap-module-source-map", "nosources-source-map", "hidden-nosources-cheap-source-map", "hidden-nosources-cheap-module-source-map", "hidden-nosources-source-map", "hidden-cheap-source-map", "hidden-cheap-module-source-map", "hidden-source-map", "eval-cheap-source-map", "eval-cheap-module-source-map", "eval-source-map", "eval-nosources-cheap-source-map", "eval-nosources-cheap-module-source-map", "eval-nosources-source-map"]>]>>;
     node: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
-        __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only"]>]>>;
-        __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only"]>]>>;
+        __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
+        __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
         global: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"warn">]>>;
     }, "strict", z.ZodTypeAny, {
         global?: boolean | "warn" | undefined;
-        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
     }, {
         global?: boolean | "warn" | undefined;
-        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
     }>]>>;
     loader: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodAny>>;
     ignoreWarnings: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Error, z.ZodTypeDef, Error>, z.ZodType<Compilation, z.ZodTypeDef, Compilation>], z.ZodUnknown>, z.ZodBoolean>]>, "many">>;
@@ -12782,8 +12782,8 @@ export const rspackOptions: z.ZodObject<{
     }>>) | undefined;
     node?: false | {
         global?: boolean | "warn" | undefined;
-        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
     } | undefined;
     profile?: boolean | undefined;
     cache?: boolean | undefined;
@@ -13350,8 +13350,8 @@ export const rspackOptions: z.ZodObject<{
     }>>) | undefined;
     node?: false | {
         global?: boolean | "warn" | undefined;
-        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
-        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | undefined;
+        __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
+        __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
     } | undefined;
     profile?: boolean | undefined;
     cache?: boolean | undefined;

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -124,7 +124,10 @@ export const applyRspackOptionsDefaults = (
 				: "var";
 	});
 
-	applyNodeDefaults(options.node, { targetProperties });
+	applyNodeDefaults(options.node, {
+		targetProperties,
+		outputModule: options.output.module
+	});
 
 	applyLoaderDefaults(options.loader, {
 		targetProperties,
@@ -858,7 +861,10 @@ const applyLoaderDefaults = (
 
 const applyNodeDefaults = (
 	node: Node,
-	{ targetProperties }: { targetProperties: any }
+	{
+		outputModule,
+		targetProperties
+	}: { targetProperties: any; outputModule?: boolean }
 ) => {
 	if (node === false) return;
 
@@ -869,12 +875,14 @@ const applyNodeDefaults = (
 	});
 	// IGNORE(node.__dirname): The default value of `__dirname` is determined by `futureDefaults` in webpack.
 	F(node, "__dirname", () => {
-		if (targetProperties?.node) return "eval-only";
+		if (targetProperties?.node)
+			return outputModule ? "node-module" : "eval-only";
 		return "warn-mock";
 	});
 	// IGNORE(node.__filename): The default value of `__filename` is determined by `futureDefaults` in webpack.
 	F(node, "__filename", () => {
-		if (targetProperties?.node) return "eval-only";
+		if (targetProperties?.node)
+			return outputModule ? "node-module" : "eval-only";
 		return "warn-mock";
 	});
 };

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1010,11 +1010,11 @@ export type DevTool = z.infer<typeof devTool>;
 const nodeOptions = z.strictObject({
 	__dirname: z
 		.boolean()
-		.or(z.enum(["warn-mock", "mock", "eval-only"]))
+		.or(z.enum(["warn-mock", "mock", "eval-only", "node-module"]))
 		.optional(),
 	__filename: z
 		.boolean()
-		.or(z.enum(["warn-mock", "mock", "eval-only"]))
+		.or(z.enum(["warn-mock", "mock", "eval-only", "node-module"]))
 		.optional(),
 	global: z.boolean().or(z.literal("warn")).optional()
 });

--- a/tests/webpack-test/configCases/output-module/node-globals/cjs/file.js
+++ b/tests/webpack-test/configCases/output-module/node-globals/cjs/file.js
@@ -1,0 +1,6 @@
+const fileURLToPath = "";
+const file = __filename;
+const dir = __dirname;
+const dir2 = `${__dirname}/`;
+
+module.exports = { file, dir, dir2 };

--- a/tests/webpack-test/configCases/output-module/node-globals/cjs/package.json
+++ b/tests/webpack-test/configCases/output-module/node-globals/cjs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cjs",
+  "type": "commonjs"
+}

--- a/tests/webpack-test/configCases/output-module/node-globals/index.js
+++ b/tests/webpack-test/configCases/output-module/node-globals/index.js
@@ -1,0 +1,10 @@
+import { dir, dir2, file } from './cjs/file.js'
+
+it("should generate correct __dirname", () => {
+	expect(dir).toMatch(/[\\/]node-globals$/);
+	expect(dir2).toMatch(/[\\/]node-globals\/$/);
+});
+
+it("should generate correct __filename", () => {
+	expect(file).toMatch(/[\\/]main.mjs$/);
+});

--- a/tests/webpack-test/configCases/output-module/node-globals/test.config.js
+++ b/tests/webpack-test/configCases/output-module/node-globals/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return "./main.mjs";
+	}
+};

--- a/tests/webpack-test/configCases/output-module/node-globals/webpack.config.js
+++ b/tests/webpack-test/configCases/output-module/node-globals/webpack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].mjs",
+		module: true
+	},
+	experiments: {
+		outputModule: true
+	},
+	target: "node14"
+};

--- a/website/docs/en/config/node.mdx
+++ b/website/docs/en/config/node.mdx
@@ -22,21 +22,21 @@ Options:
 ## node.\_\_filename
 
 - **Type:** `boolean` `'mock' | 'warn-mock' | 'eval-only'`
-- **Default:** `'warn-mock'`
+- **Default:** `'warn-mock'`, `'node-module'` when `output.module` is enabled
 
 Options:
 
 - `true`: The filename of the input file relative to the [`context`](/config/context) option.
-- `false`: Rspack won't touch your `\_\_filename` code, which means you have the regular Node.js `\_\_filename` behavior. The filename of the **output** file when run in a Node.js environment.
+- `false`: Rspack won't touch your `__filename` code, which means you have the regular Node.js `__filename` behavior. The filename of the **output** file when run in a Node.js environment.
 - `'mock'`: The fixed value `'/index.js'`.
 - `'warn-mock'`: Use the fixed value of `'/index.js'` but show a warning.
-- `'node-module'`: Replace `\_\_filename` in CommonJS modules to `fileURLToPath(import.meta.url)` when `output.module` is enabled.
+- `'node-module'`: Replace `__filename` in CommonJS modules to `fileURLToPath(import.meta.url)` when `output.module` is enabled.
 - `'eval-only'`: Equivalent to `false`.
 
 ## node.\_\_dirname
 
 - **Type:** `boolean` `'mock' | 'warn-mock' | 'eval-only'`
-- **Default:** `'warn-mock'`
+- **Default:** `'warn-mock'`, `'node-module'` when `output.module` is enabled
 
 Options:
 
@@ -44,4 +44,5 @@ Options:
 - `false`: Rspack won't touch your `__dirname` code, which means you have the regular Node.js `__dirname` behavior. The dirname of the **output** file when run in a Node.js environment.
 - `'mock'`: The fixed value `'/'`.
 - `'warn-mock'`: Use the fixed value of `'/'` but show a warning.
+- `'node-module'`: Replace `__dirname` in CommonJS modules to `fileURLToPath(import.meta.url + "/..")` when `output.module` is enabled.
 - `'eval-only'`: Equivalent to `false`.

--- a/website/docs/zh/config/node.mdx
+++ b/website/docs/zh/config/node.mdx
@@ -20,21 +20,21 @@ import WebpackLicense from '@components/webpack-license';
 ## node.\_\_filename
 
 - **类型：** `boolean | 'mock' | 'warn-mock' | 'eval-only'`
-- **默认值：** `'warn-mock'`
+- **默认值：** `'warn-mock'`，当启用 `output.module` 时为 `'node-module'`
 
 选项：
 
 - `true`：输入文件的文件名，是相对于 [`context`](/config/context) 选项。
-- `false`：Rspack 不会更改 `\_\_filename` 的代码。在 Node.js 环境中运行时输出文件的文件名。
+- `false`：Rspack 不会更改 `__filename` 的代码。在 Node.js 环境中运行时输出文件的文件名。
 - `'mock'`：固定值为 '/index.js'。
 - `'warn-mock'`：使用固定值 '/index.js'，但会发出警告。
-- `'node-module'`：当 `output.module` 启用时，将 CommonJS 模块中的 `\_\_filename` 替换为 `fileURLToPath(import.meta.url)`。
+- `'node-module'`：当 `output.module` 启用时，将 CommonJS 模块中的 `__filename` 替换为 `fileURLToPath(import.meta.url)`。
 - `'eval-only'`：等同于 `false`。
 
 ## node.\_\_dirname
 
 - **类型：** `boolean | 'mock' | 'warn-mock' | 'eval-only'`
-- **默认值：** `'warn-mock'`
+- **默认值：** `'warn-mock'`，当启用 `output.module` 时为 `'node-module'`
 
 选项：
 
@@ -42,4 +42,5 @@ import WebpackLicense from '@components/webpack-license';
 - `false`：webpack 不会更改 `__dirname` 的代码，这意味着你有常规 Node.js 中的 `__dirname` 的行为。在 Node.js 环境中运行时，**输出** 文件的目录名。
 - `'mock'`：value 填充为 `'/'`。
 - `'warn-mock'`：使用 `'/'` 但是会显示一个警告。
+- `'node-module'`: 当启用 `output.module` 时，将 CommonJS 模块中的 `__dirname` 替换为 `fileURLToPath(import.meta.url + "/..")`。
 - `'eval-only'`：等同于 `false`。


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Port https://webpack.js.org/configuration/node/#root:~:text=%27node%2Dmodule%27%3A%20Replace%20__filename%20in%20CommonJS%20modules%20to%20fileURLToPath(import.meta.url)%20when%20output.module%20is%20enabled.

Rename the former `ExternalModule` enum to `ModuleExternal` in `InitFragmentKey` (https://github.com/webpack/webpack/blob/main/lib/ExternalModule.js#L225), and add new `ExternalModule` type (https://github.com/webpack/webpack/blob/main/lib/dependencies/ExternalModuleInitFragment.js#L20) to comply with webpack's naming.

Resolve https://github.com/web-infra-dev/rslib/issues/32.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
