### PR TITLE
fix: deep merge module resolve options

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -15,8 +15,8 @@ use rspack_core::{
   DynamicImportMode, ExportPresenceMode, FuncUseCtx, GeneratorOptions,
   GeneratorOptionsByModuleType, JavascriptParserOptions, JavascriptParserOrder,
   JavascriptParserUrl, ModuleNoParseRule, ModuleNoParseRules, ModuleNoParseTestFn, ModuleOptions,
-  ModuleRule, ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, ModuleType, OverrideStrict,
-  ParserOptions, ParserOptionsByModuleType,
+  ModuleRule, ModuleRuleEffect, ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, ModuleType,
+  OverrideStrict, ParserOptions, ParserOptionsByModuleType,
 };
 use rspack_error::error;
 use rspack_napi::regexp::{JsRegExp, JsRegExpExt};
@@ -769,13 +769,6 @@ impl TryFrom<RawModuleRule> for ModuleRule {
       resource: value.resource.map(|raw| raw.try_into()).transpose()?,
       description_data,
       with,
-      r#use: uses.transpose()?.unwrap_or_default(),
-      r#type: module_type,
-      layer: value.layer,
-      parser: value.parser.map(|raw| raw.into()),
-      generator: value.generator.map(|raw| raw.into()),
-      resolve: value.resolve.map(|raw| raw.try_into()).transpose()?,
-      side_effects: value.side_effects,
       issuer: value.issuer.map(|raw| raw.try_into()).transpose()?,
       issuer_layer: value.issuer_layer.map(|raw| raw.try_into()).transpose()?,
       dependency: value.dependency.map(|raw| raw.try_into()).transpose()?,
@@ -783,7 +776,16 @@ impl TryFrom<RawModuleRule> for ModuleRule {
       mimetype: value.mimetype.map(|raw| raw.try_into()).transpose()?,
       one_of,
       rules,
-      enforce,
+      effect: ModuleRuleEffect {
+        r#use: uses.transpose()?.unwrap_or_default(),
+        r#type: module_type,
+        layer: value.layer,
+        parser: value.parser.map(|raw| raw.into()),
+        generator: value.generator.map(|raw| raw.into()),
+        resolve: value.resolve.map(|raw| raw.try_into()).transpose()?,
+        side_effects: value.side_effects,
+        enforce,
+      },
     })
   }
 }

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -649,7 +649,7 @@ impl NormalModuleFactory {
         }
       }
     }
-    resolved.map(|r| Box::new(r))
+    resolved.map(Box::new)
   }
 
   fn calculate_side_effects(&self, module_rules: &[&ModuleRuleEffect]) -> Option<bool> {

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -13,7 +13,7 @@ use crate::{
   diagnostics::EmptyDependency, module_rules_matcher, parse_resource, resolve,
   stringify_loaders_and_resource, BoxLoader, BoxModule, CompilerOptions, Context, Dependency,
   DependencyCategory, FuncUseCtx, GeneratorOptions, ModuleExt, ModuleFactory,
-  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleRule,
+  ModuleFactoryCreateData, ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleRuleEffect,
   ModuleRuleEnforce, ModuleRuleUse, ModuleRuleUseLoader, ModuleType, NormalModule,
   ParserAndGenerator, ParserOptions, RawModule, Resolve, ResolveArgs,
   ResolveOptionsWithDependencyType, ResolveResult, Resolver, ResolverFactory, ResourceData,
@@ -623,7 +623,7 @@ impl NormalModuleFactory {
     dependency: &dyn Dependency,
     issuer: Option<&'a str>,
     issuer_layer: Option<&'a str>,
-  ) -> Result<Vec<&'a ModuleRule>> {
+  ) -> Result<Vec<&'a ModuleRuleEffect>> {
     let mut rules = Vec::new();
     module_rules_matcher(
       &self.options.module.rules,
@@ -638,17 +638,21 @@ impl NormalModuleFactory {
     Ok(rules)
   }
 
-  fn calculate_resolve_options(&self, module_rules: &[&ModuleRule]) -> Option<Box<Resolve>> {
-    let mut resolved = None;
-    module_rules.iter().for_each(|rule| {
-      if let Some(resolve) = rule.resolve.as_ref() {
-        resolved = Some(Box::new(resolve.to_owned()));
+  fn calculate_resolve_options(&self, module_rules: &[&ModuleRuleEffect]) -> Option<Box<Resolve>> {
+    let mut resolved: Option<Resolve> = None;
+    for rule in module_rules {
+      if let Some(rule_resolve) = &rule.resolve {
+        if let Some(r) = resolved {
+          resolved = Some(r.merge(rule_resolve.to_owned()));
+        } else {
+          resolved = Some(rule_resolve.to_owned());
+        }
       }
-    });
-    resolved
+    }
+    resolved.map(|r| Box::new(r))
   }
 
-  fn calculate_side_effects(&self, module_rules: &[&ModuleRule]) -> Option<bool> {
+  fn calculate_side_effects(&self, module_rules: &[&ModuleRuleEffect]) -> Option<bool> {
     let mut side_effect_res = None;
     // side_effects from module rule has higher priority
     module_rules.iter().for_each(|rule| {
@@ -661,7 +665,7 @@ impl NormalModuleFactory {
 
   fn calculate_parser_and_generator_options(
     &self,
-    module_rules: &[&ModuleRule],
+    module_rules: &[&ModuleRuleEffect],
   ) -> (Option<ParserOptions>, Option<GeneratorOptions>) {
     let mut resolved_parser = None;
     let mut resolved_generator = None;
@@ -727,7 +731,7 @@ impl NormalModuleFactory {
   fn calculate_module_type(
     &self,
     matched_module_type: Option<ModuleType>,
-    module_rules: &[&ModuleRule],
+    module_rules: &[&ModuleRuleEffect],
   ) -> ModuleType {
     let mut resolved_module_type = matched_module_type.unwrap_or(ModuleType::JsAuto);
     module_rules.iter().for_each(|module_rule| {
@@ -742,7 +746,7 @@ impl NormalModuleFactory {
   fn calculate_module_layer(
     &self,
     issuer_layer: Option<&ModuleLayer>,
-    module_rules: &[&ModuleRule],
+    module_rules: &[&ModuleRuleEffect],
   ) -> Option<ModuleLayer> {
     let mut resolved_module_layer = issuer_layer;
     module_rules.iter().for_each(|module_rule| {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -635,7 +635,7 @@ pub struct ModuleRuleUseLoader {
 pub type FnUse =
   Box<dyn Fn(FuncUseCtx) -> BoxFuture<'static, Result<Vec<ModuleRuleUseLoader>>> + Sync + Send>;
 
-#[derive(Derivative, Default)]
+#[derive(Derivative)]
 #[derivative(Debug)]
 pub struct ModuleRule {
   /// A conditional match matching an absolute path + query + fragment.
@@ -659,6 +659,14 @@ pub struct ModuleRule {
   pub mimetype: Option<RuleSetCondition>,
   pub description_data: Option<DescriptionData>,
   pub with: Option<With>,
+  pub one_of: Option<Vec<ModuleRule>>,
+  pub rules: Option<Vec<ModuleRule>>,
+  pub effect: ModuleRuleEffect,
+}
+
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct ModuleRuleEffect {
   pub side_effects: Option<bool>,
   /// The `ModuleType` to use for the matched resource.
   pub r#type: Option<ModuleType>,
@@ -668,8 +676,6 @@ pub struct ModuleRule {
   pub parser: Option<ParserOptions>,
   pub generator: Option<GeneratorOptions>,
   pub resolve: Option<Resolve>,
-  pub one_of: Option<Vec<ModuleRule>>,
-  pub rules: Option<Vec<ModuleRule>>,
   pub enforce: ModuleRuleEnforce,
 }
 

--- a/crates/rspack_core/src/utils/module_rules.rs
+++ b/crates/rspack_core/src/utils/module_rules.rs
@@ -4,7 +4,7 @@ use async_recursion::async_recursion;
 use rspack_error::Result;
 use rspack_loader_runner::ResourceData;
 
-use crate::{DependencyCategory, ImportAttributes, ModuleRule};
+use crate::{DependencyCategory, ImportAttributes, ModuleRule, ModuleRuleEffect};
 
 pub async fn module_rules_matcher<'a>(
   rules: &'a [ModuleRule],
@@ -13,7 +13,7 @@ pub async fn module_rules_matcher<'a>(
   issuer_layer: Option<&'a str>,
   dependency: &DependencyCategory,
   attributes: Option<&ImportAttributes>,
-  matched_rules: &mut Vec<&'a ModuleRule>,
+  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Result<()> {
   for rule in rules {
     module_rule_matcher(
@@ -39,7 +39,7 @@ pub async fn module_rule_matcher<'a>(
   issuer_layer: Option<&'a str>,
   dependency: &DependencyCategory,
   attributes: Option<&ImportAttributes>,
-  matched_rules: &mut Vec<&'a ModuleRule>,
+  matched_rules: &mut Vec<&'a ModuleRuleEffect>,
 ) -> Result<bool> {
   if let Some(test_rule) = &module_rule.rspack_resource
     && !test_rule
@@ -222,6 +222,6 @@ pub async fn module_rule_matcher<'a>(
       return Ok(false);
     }
   }
-  matched_rules.push(module_rule);
+  matched_rules.push(&module_rule.effect);
   Ok(true)
 }

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/index.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/index.js
@@ -1,0 +1,7 @@
+import { lib } from "lib";
+import * as reexports from "./reexports";
+
+it("should use correct resolve options", () => {
+	expect(lib).toBe("lib");
+	expect(reexports.lib).toBe("lib2");
+})

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib/package.json
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "lib",
+  "exports": {
+    "server": "./right.js",
+    "default": "./wrong.js"
+  }
+}

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib/right.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib/right.js
@@ -1,0 +1,1 @@
+export const lib = "lib"

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib/wrong.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib/wrong.js
@@ -1,0 +1,1 @@
+throw new Error("wrong conditionNames")

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib2/package.json
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib2/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "server-lib",
+  "exports": {
+    "server": "./right.js",
+    "default": "./wrong.js"
+  }
+}

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib2/right.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib2/right.js
@@ -1,0 +1,1 @@
+export const lib = "lib2"

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib2/wrong.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/modules/lib2/wrong.js
@@ -1,0 +1,1 @@
+throw new Error("wrong conditionNames")

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/reexports.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/reexports.js
@@ -1,0 +1,1 @@
+export * from "server-lib";

--- a/packages/rspack-test-tools/tests/configCases/module/merge-resolve/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/module/merge-resolve/rspack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	module: {
+		rules: [
+			{
+				test: /\.js/,
+				resolve: {
+					conditionNames: ["server"],
+				}
+			},
+			{
+				test: /reexports\.js/,
+				resolve: {
+					alias: {
+						"server-lib": "lib2",
+					}
+				}
+			},
+		]
+	},
+	resolve: {
+		modules: ["modules"]
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- fix deep merge module resolve options
- optimize perf with ModuleRuleEffect, we only need ModuleRuleEffect when calculate_module_xxx, and this will be helpful for debugging `dbg!(rules)`

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
