### PR TITLE
docs: add link for Rspack 0.x website

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Come chat with us on [Discord](https://discord.gg/79ZZ66GH9E)! Rspack team and R
 
 | Name                                                                                 | Description                                                                   |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [Rspack website](https://rspack.dev)                                                 | Official documentation for Rspack                                             |
-| [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                  | An Rspack-based build tool                                                    |
+| [Rspack latest documentation](https://rspack.dev/)                                   | Documentation for the latest version of Rspack                                |
+| [Rspack 0.x documentation](https://v0.rspack.dev/)                                   | Documentation for Rspack 0.x version                                          |
 | [Rspress](https://github.com/web-infra-dev/rspress)                                  | A fast static site generator based on Rsbuild                                 |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | A one-stop build analyzer for Rspack and webpack                              |
 | [Rslib](https://github.com/web-infra-dev/rslib)                                      | A library build tool powered by Rsbuild                                       |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,7 +44,8 @@ Rspack 是一个基于 Rust 编写的高性能 JavaScript 打包工具，它提�
 
 | 名称                                                                                 | 描述                                                                         |
 | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
-| [Rspack 文档](https://rspack.dev/zh/)                                                | Rspack 官方文档                                                              |
+| [Rspack 最新文档](https://rspack.dev/zh/)                                            | Rspack 最新版本的文档                                                        |
+| [Rspack 0.x 文档](https://v0.rspack.dev/zh/)                                         | Rspack 0.x 版本的文档                                                        |
 | [Rsbuild](https://github.com/web-infra-dev/rsbuild)                                  | 基于 Rspack 的构建工具                                                       |
 | [Rspress](https://github.com/web-infra-dev/rspress)                                  | 基于 Rsbuild 的静态站点生成器                                                |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor)                                | 针对 Rspack 和 webpack 的一站式构建分析工具                                  |

--- a/website/docs/en/_meta.json
+++ b/website/docs/en/_meta.json
@@ -33,5 +33,18 @@
     "text": "Contribute",
     "link": "/contribute/index",
     "activeMatch": "/contribute"
+  },
+  {
+    "text": "Version",
+    "items": [
+      {
+        "text": "Changelog",
+        "link": "https://github.com/web-infra-dev/rspack/releases"
+      },
+      {
+        "text": "Rspack 0.x Doc",
+        "link": "http://v0.rspack.dev/"
+      }
+    ]
   }
 ]

--- a/website/docs/zh/_meta.json
+++ b/website/docs/zh/_meta.json
@@ -33,5 +33,18 @@
     "text": "贡献",
     "link": "/contribute/index",
     "activeMatch": "/contribute"
+  },
+  {
+    "text": "版本",
+    "items": [
+      {
+        "text": "更新日志",
+        "link": "https://github.com/web-infra-dev/rspack/releases"
+      },
+      {
+        "text": "Rspack 0.x 文档",
+        "link": "http://v0.rspack.dev/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Add link for Rspack 0.x website.

- https://v0.rspack.dev/ is hosted on Netlify.
- The website is deployed from the Rspack repo [v0.x branch](https://github.com/web-infra-dev/rspack/tree/v0.x).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
