### PR TITLE
fix: make sure it would not read from property from an `undefined` value in DefinePlugin

### DIFF
--- a/packages/rspack/src/builtin-plugin/DefinePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/DefinePlugin.ts
@@ -7,7 +7,7 @@ export const DefinePlugin = create(
 	BuiltinPluginName.DefinePlugin,
 	function (define: DefinePluginOptions): NormalizedCodeValue {
 		const supportsBigIntLiteral =
-			this.options.output.environment?.bigIntLiteral ?? false;
+			this?.options?.output?.environment?.bigIntLiteral ?? false;
 		return normalizeValue(define, supportsBigIntLiteral);
 	},
 	"compilation"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

In the different environment, the keyword `this` would be assigned with different values.  One case I met is when I used the lib `cypress-rspack-dev-server` to run the cypress test, it reported the `undefined` error:

<img width="1382" alt="image" src="https://github.com/user-attachments/assets/a7da8d0b-fc5a-411f-8c40-1dc2ced0874c">

Add the question mark to all the properties to avoid this error.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
