### PR TITLE
fix(modern-module): export syntax detect more invalid chars

### DIFF
--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -146,9 +146,12 @@ fn render_startup(
 
       let final_name = exports_final_names.get(used_name.as_str());
 
+      let contains_char =
+        |string: &str, chars: &str| -> bool { string.chars().any(|c| chars.contains(c)) };
+
       if let Some(final_name) = final_name {
         // Currently, there's not way to determine if a final_name contains a property access.
-        if final_name.contains('.') || final_name.contains("()") {
+        if contains_char(final_name, "[]().") {
           exports_with_property_access.push((final_name, info_name));
         } else if info_name == final_name {
           exports.push(info_name.to_string());

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/foo.cjs
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/foo.cjs
@@ -1,0 +1,1 @@
+module.exports = 'foo'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/index.js
@@ -1,0 +1,5 @@
+import defaultImport from 'external-module'
+import { namedImport } from 'external-module'
+import cjsInterop from './foo.cjs'
+
+export { defaultImport, namedImport, cjsInterop }

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -1,0 +1,39 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		"index": "./index.js",
+	},
+	output: {
+		filename: `[name].js`,
+		module: true,
+		libraryTarget: "modern-module",
+		iife: false,
+		chunkFormat: "module",
+	},
+	externalsType: 'module-import',
+	experiments: {
+		outputModule: true
+	},
+	externals: "external-module",
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	},
+	plugins: [
+		function () {
+			/**
+			 * @param {import("@rspack/core").Compilation} compilation compilation
+			 * @returns {void}
+			 */
+			const handler = compilation => {
+				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
+					const bundle = Object.values(assets)[0]._value
+					expect(bundle).toContain(`var __webpack_exports__cjsInterop = (foo_default());
+var __webpack_exports__defaultImport = external_external_module_namespaceObject["default"];
+var __webpack_exports__namedImport = external_external_module_namespaceObject.namedImport;`)
+				});
+			};
+			this.hooks.compilation.tap("testcase", handler);
+		}
+	]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Detect mode invalid chars when exporting in `modern-module` and add test cases.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
