### PR TITLE
chore(workflow): enable dependency dashboard of renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "timezone": "Asia/Shanghai",
+  "extends": [":dependencyDashboard"],
   "schedule": [
     "before 8am on wednesday"
   ],


### PR DESCRIPTION
## Summary

Enable the dependency dashboard of renovate, this can help us to have an overview of Rspack's dependency status.

Ref:

- https://docs.renovatebot.com/key-concepts/dashboard/
- https://github.com/web-infra-dev/rsbuild/issues/1316

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
