### PR TITLE
fix: concatenation should merge module’s chunk init fragments

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1655,11 +1655,16 @@ impl ConcatenatedModule {
       let codegen_res = module.code_generation(compilation, runtime, Some(concatenation_scope))?;
       let CodeGenerationResult {
         mut inner,
-        chunk_init_fragments,
+        mut chunk_init_fragments,
         runtime_requirements,
         concatenation_scope,
         ..
       } = codegen_res;
+
+      if let Some(fragments) = codegen_res.data.get::<ChunkInitFragments>() {
+        chunk_init_fragments.extend(fragments.iter().cloned());
+      }
+
       let concatenation_scope = concatenation_scope.expect("should have concatenation_scope");
       let source = inner
         .remove(&SourceType::JavaScript)

--- a/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/file.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/file.js
@@ -1,0 +1,6 @@
+const fileURLToPath = "";
+const file = __filename;
+const dir = __dirname;
+const dir2 = `${__dirname}/`;
+
+export { file, dir, dir2 };

--- a/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/index.js
@@ -1,0 +1,10 @@
+import { dir, dir2, file } from './file.js'
+
+it("should generate correct __dirname", () => {
+	expect(dir).toMatch(/[\\/]node-shims-in-concatenated-module$/);
+	expect(dir2).toMatch(/[\\/]node-shims-in-concatenated-module\/$/);
+});
+
+it("should generate correct __filename", () => {
+	expect(file).toMatch(/[\\/]main.mjs$/);
+});

--- a/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/rspack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		main: "./index.js"
+	},
+	output: {
+		filename: "[name].mjs",
+		module: true
+	},
+	experiments: {
+		outputModule: true
+	},
+	target: "node14"
+};

--- a/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/output-module/node-shims-in-concatenated-module/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return "./main.mjs";
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Following https://github.com/web-infra-dev/rspack/pull/7465.

When the module is concatenated, the `chunk_init_fragments` in `codegen_res.data` should be merged as well.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
