### PR TITLE
fix(modern-module): correct use bailout reason

### DIFF
--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -75,12 +75,17 @@ impl ModernModuleLibraryPlugin {
       .iter()
       .filter(|id| !concatenated_module_ids.contains(id))
       .filter(|id| {
-        let module = module_graph
-          .module_by_identifier(id)
+        let mgm = module_graph
+          .module_graph_module_by_identifier(id)
           .expect("should have module");
-        module
-          .get_concatenation_bailout_reason(&module_graph, &compilation.chunk_graph)
-          .is_none()
+        let reasons = &mgm.optimization_bailout;
+        reasons
+          .iter()
+          // We did want force concatenate entry point here.
+          // TODO: use constant variable to identify the reason.
+          .filter(|r| !r.contains("Module is an entry point"))
+          .collect::<Vec<_>>()
+          .is_empty()
       })
       .collect::<HashSet<_>>();
 

--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -458,6 +458,99 @@ const d = 'd'
 "
 `;
 
+exports[`config config/library/modern-module-force-concaten step  should pass: external module should bail out when bundling 1`] = `
+"import { createRequire as __WEBPACK_EXTERNAL_createRequire } from \\"module\\";
+var __webpack_modules__ = ({
+\\"17\\": (function (module) {
+module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)(\\"path\\");
+
+}),
+\\"441\\": (function (module, __unused_webpack_exports, __webpack_require__) {
+const path = __webpack_require__(17)
+
+module.exports = path.sep
+
+
+}),
+
+});
+/************************************************************************/
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+/************************************************************************/
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-harmony modules
+__webpack_require__.n = function (module) {
+	var getter = module && module.__esModule ?
+		function () { return module['default']; } :
+		function () { return module; };
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+
+
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = function(exports, definition) {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = function (obj, prop) {
+	return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+})();
+/************************************************************************/
+
+// EXTERNAL MODULE: ./f/bar.cjs
+var bar = __webpack_require__(\\"441\\");
+var bar_default = /*#__PURE__*/__webpack_require__.n(bar);
+;// CONCATENATED MODULE: ./f/foo.js
+const foo = 'foo'
+
+;// CONCATENATED MODULE: ./f/index.js
+
+
+
+const value = foo + (bar_default())
+
+
+
+export { value };
+"
+`;
+
 exports[`config config/library/modern-module-force-concaten step  should pass: harmony export should concat 1`] = `
 "
 ;// CONCATENATED MODULE: ./a.js

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/f/bar.cjs
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/f/bar.cjs
@@ -1,0 +1,3 @@
+const path = require('path')
+
+module.exports = path.sep

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/f/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/f/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/f/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/f/index.js
@@ -1,0 +1,6 @@
+import bar from './bar.cjs'
+import { foo } from './foo'
+
+const value = foo + bar
+
+export { value }

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
@@ -5,7 +5,11 @@ module.exports = {
 		"b": "./b.cjs",
 		"c": "./c.js",
 		"d": "./d.mjs",
-		"e": "./e/index.js"
+		"e": "./e/index.js",
+		"f": "./f/index.js"
+	},
+	externals: {
+		path: 'node-commonjs path',
 	},
 	output: {
 		filename: `[name].js`,
@@ -34,6 +38,7 @@ module.exports = {
 					expect(assets['c.js']._value).toMatchSnapshot("unambiguous should bail out");
 					expect(assets['d.js']._value).toMatchSnapshot(".mjs should concat");
 					expect(assets['e.js']._value).toMatchSnapshot(".cjs should bail out when bundling");
+					expect(assets['f.js']._value).toMatchSnapshot("external module should bail out when bundling");
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should access `optimization_bailout` from mgm to get the final bailout reason vec.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
