### PR TITLE
fix: should insert semi after import, export, debugger and class field

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
@@ -2,6 +2,7 @@ use rustc_hash::FxHashSet;
 use swc_core::{
   common::{BytePos, Span, Spanned},
   ecma::{
+    ast::ClassMember,
     parser::token::{Token, TokenAndSpan},
     visit::{Visit, VisitWith},
   },
@@ -116,5 +117,49 @@ impl<'a> Visit for InsertedSemicolons<'a> {
     if let Some(arg) = &n.arg {
       arg.visit_children_with(self)
     }
+  }
+
+  fn visit_import_decl(&mut self, n: &swc_core::ecma::ast::ImportDecl) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
+  }
+
+  fn visit_export_decl(&mut self, n: &swc_core::ecma::ast::ExportDecl) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
+  }
+
+  fn visit_named_export(&mut self, n: &swc_core::ecma::ast::NamedExport) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
+  }
+
+  fn visit_export_default_decl(&mut self, n: &swc_core::ecma::ast::ExportDefaultDecl) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
+  }
+
+  fn visit_export_default_expr(&mut self, n: &swc_core::ecma::ast::ExportDefaultExpr) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
+  }
+
+  fn visit_export_all(&mut self, n: &swc_core::ecma::ast::ExportAll) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self)
+  }
+
+  fn visit_debugger_stmt(&mut self, n: &swc_core::ecma::ast::DebuggerStmt) {
+    self.post_semi(&n.span);
+    n.visit_children_with(self);
+  }
+
+  fn visit_class_member(&mut self, n: &swc_core::ecma::ast::ClassMember) {
+    match n {
+      ClassMember::ClassProp(prop) => self.post_semi(&prop.span),
+      ClassMember::PrivateProp(prop) => self.post_semi(&prop.span),
+      _ => {}
+    };
+    n.visit_children_with(self);
   }
 }

--- a/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
@@ -1,7 +1,24 @@
 import { foo } from "./a"
+foo()
+
 var a = {
 	a: 1
 }
 foo()
 const b = (function() { throw new Error("do not callme") })
+foo()
+
+export const fooA = foo
+foo()
+
+export { foo as fooB }
+foo()
+
+export default a
+foo()
+
+export * from "./a.js"
+foo()
+
+debugger
 foo()


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#automatic_semicolon_insertion and [acorn](https://github.com/acornjs/acorn/blob/master/acorn/src/statement.js) (search `this.semicolon()`)

But I dont know how to construct the test case for ClassField

closes https://github.com/web-infra-dev/rspack/issues/7527

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
