### PR TITLE
fix: check SuperProp in walk_call_expression

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -960,6 +960,10 @@ impl<'parser> JavascriptParser<'parser> {
             if let Some(computed) = member.prop.as_computed() {
               self.walk_expression(&computed.expr);
             }
+          } else if let Some(member) = callee.as_super_prop() {
+            if let Some(computed) = member.prop.as_computed() {
+              self.walk_expression(&computed.expr);
+            }
           } else {
             self.walk_expression(callee);
           }

--- a/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/a.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/a.js
@@ -1,0 +1,1 @@
+export const foo = 'methodName';

--- a/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/a.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/a.js
@@ -1,1 +1,4 @@
-export const foo = 'methodName';
+export const foo = "methodName";
+export class Base {
+	[foo]() {}
+}

--- a/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/index.js
@@ -1,8 +1,8 @@
-import { foo } from './a.js'
-class Derived extends Object {
-  [foo]() {
-    super[foo]();
-  }
+import { foo, Base } from "./a.js";
+class Derived extends Base {
+	[foo]() {
+		super[foo](); // <-- ERROR HERE
+	}
 }
 
 const instance = new Derived();

--- a/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/super-member-call/index.js
@@ -1,0 +1,9 @@
+import { foo } from './a.js'
+class Derived extends Object {
+  [foo]() {
+    super[foo]();
+  }
+}
+
+const instance = new Derived();
+instance[foo]();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Webpack reguard `super[foo]()` as MemberExpression, but swc distinguishes them. So there should be an extra check.

closes https://github.com/web-infra-dev/rspack/issues/7477

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
