### PR TITLE
fix: remove useless "module" external runtime

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -281,14 +281,10 @@ impl ExternalModule {
                 )
                 .boxed(),
               );
-              runtime_requirements.insert(RuntimeGlobals::DEFINE_PROPERTY_GETTERS);
               format!(
                 r#"
-    var x = y => {{ var x = {{}}; {}(x, y); return x; }}
-    var y = x => () => x
-    {} = __WEBPACK_EXTERNAL_MODULE_{}__;
-    "#,
-                RuntimeGlobals::DEFINE_PROPERTY_GETTERS,
+{} = __WEBPACK_EXTERNAL_MODULE_{}__;
+"#,
                 get_namespace_object_export(concatenation_scope),
                 id.clone()
               )


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

The code deleted in this pull request is located at [here](https://github.com/webpack/webpack/blob/001cab14692eb9a833c6b56709edbab547e291a1/lib/ExternalModule.js#L362) in webpack. However, the code will never be called in Rspack because it is not fully implemented. I am deleting it now to reduce the runtime code for Rslib, and we can reimplement it when we are ready.

Additionally, I attempted to delete the corresponding code in webpack, but no CI tests were broken.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
