### PR TITLE
fix: chunk hash unstable

### DIFF
--- a/crates/rspack_plugin_runtime/src/helpers.rs
+++ b/crates/rspack_plugin_runtime/src/helpers.rs
@@ -1,6 +1,6 @@
 use std::hash::Hash;
 
-use rspack_collections::{IdentifierLinkedMap, UkeySet};
+use rspack_collections::{IdentifierLinkedMap, UkeyIndexSet};
 use rspack_core::{
   get_chunk_from_ukey, get_chunk_group_from_ukey, get_js_chunk_filename_template,
   rspack_sources::{BoxSource, RawSource, SourceExt},
@@ -53,14 +53,14 @@ pub fn get_all_chunks(
   exclude_chunk1: &ChunkUkey,
   exclude_chunk2: Option<&ChunkUkey>,
   chunk_group_by_ukey: &ChunkGroupByUkey,
-) -> UkeySet<ChunkUkey> {
+) -> UkeyIndexSet<ChunkUkey> {
   fn add_chunks(
     chunk_group_by_ukey: &ChunkGroupByUkey,
-    chunks: &mut UkeySet<ChunkUkey>,
+    chunks: &mut UkeyIndexSet<ChunkUkey>,
     entrypoint_ukey: &ChunkGroupUkey,
     exclude_chunk1: &ChunkUkey,
     exclude_chunk2: Option<&ChunkUkey>,
-    visit_chunk_groups: &mut UkeySet<ChunkGroupUkey>,
+    visit_chunk_groups: &mut UkeyIndexSet<ChunkGroupUkey>,
   ) {
     if let Some(entrypoint) = get_chunk_group_from_ukey(entrypoint_ukey, chunk_group_by_ukey) {
       for chunk in &entrypoint.chunks {
@@ -96,8 +96,8 @@ pub fn get_all_chunks(
     }
   }
 
-  let mut chunks: UkeySet<ChunkUkey> = UkeySet::default();
-  let mut visit_chunk_groups = UkeySet::default();
+  let mut chunks = UkeyIndexSet::default();
+  let mut visit_chunk_groups = UkeyIndexSet::default();
 
   add_chunks(
     chunk_group_by_ukey,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

chunk hash may be unstable when entrypoint has multiple chunks, because hashmap cannot guarrenty the iter order

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
