### PR TITLE
fix(rust-core): no need to pass resolve_factory when using rust api

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -69,8 +69,8 @@ impl Rspack {
       plugins,
       AsyncNodeWritableFileSystem::new(output_filesystem)
         .map_err(|e| Error::from_reason(format!("Failed to create writable filesystem: {e}",)))?,
-      resolver_factory,
-      loader_resolver_factory,
+      Some(resolver_factory),
+      Some(loader_resolver_factory),
     );
 
     Ok(Self {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -74,8 +74,9 @@ where
     options: CompilerOptions,
     plugins: Vec<BoxPlugin>,
     output_filesystem: T,
-    resolver_factory: Arc<ResolverFactory>,
-    loader_resolver_factory: Arc<ResolverFactory>,
+    // no need to pass resolve_factory in rust api
+    resolver_factory: Option<Arc<ResolverFactory>>,
+    loader_resolver_factory: Option<Arc<ResolverFactory>>,
   ) -> Self {
     #[cfg(debug_assertions)]
     {
@@ -83,6 +84,10 @@ where
         debug_info.with_context(options.context.to_string());
       }
     }
+    let resolver_factory =
+      resolver_factory.unwrap_or_else(|| Arc::new(ResolverFactory::new(options.resolve.clone())));
+    let loader_resolver_factory = loader_resolver_factory
+      .unwrap_or_else(|| Arc::new(ResolverFactory::new(options.resolve_loader.clone())));
     let (plugin_driver, options) = PluginDriver::new(options, plugins, resolver_factory.clone());
     let old_cache = Arc::new(OldCache::new(options.clone()));
     let module_executor = ModuleExecutor::default();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Simplify the rust api interface, generate resolver_factory in compiler
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
