### PR TITLE
fix(cli): wrong entry defaults from cli

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -24,13 +24,11 @@ import type {
 	RspackCLILogger,
 	RspackCLIOptions
 } from "./types";
-import findConfig from "./utils/findConfig";
 import { type LoadedRspackConfig, loadRspackConfig } from "./utils/loadConfig";
 import { normalizeEnv } from "./utils/options";
 
 type Command = "serve" | "build";
 
-const defaultEntry = "src/index";
 export class RspackCLI {
 	colors: RspackCLIColors;
 	program: yargs.Argv;
@@ -130,13 +128,6 @@ export class RspackCLI {
 			if (options.entry) {
 				item.entry = {
 					main: options.entry.map(x => path.resolve(process.cwd(), x))[0] // Fix me when entry supports array
-				};
-			} else if (!item.entry) {
-				const defaultEntryBase = path.resolve(process.cwd(), defaultEntry);
-				const defaultEntryPath =
-					findConfig(defaultEntryBase) || `${defaultEntryBase}.js`; // default entry is js
-				item.entry = {
-					main: defaultEntryPath
 				};
 			}
 			// to set output.path


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Fixes #7536 

Since rspack core handles entry defaults well, we no longer need to set a default entry from the cli. 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or **not required**).
- [x] Documentation updated (or **not required**).
