### PR TITLE
docs: remove examples page

### DIFF
--- a/website/docs/en/guide/compatibility/_meta.json
+++ b/website/docs/en/guide/compatibility/_meta.json
@@ -1,1 +1,1 @@
-["plugin", "examples", "config-diff"]
+["plugin", "config-diff"]

--- a/website/docs/en/guide/compatibility/examples.mdx
+++ b/website/docs/en/guide/compatibility/examples.mdx
@@ -1,7 +1,0 @@
-import { CompatibleCardList } from '@components/RspackCompatible.tsx';
-
-# Compatibility example
-
-This page shows examples of [rspack-compat](https://github.com/web-infra-dev/rspack-compat/tree/main). This repository is intended to represent rspack's compatibility with the webpack ecosystem, and you can click on each plugin link to see its supported usage.
-
-<CompatibleCardList></CompatibleCardList>

--- a/website/docs/en/guide/compatibility/plugin.mdx
+++ b/website/docs/en/guide/compatibility/plugin.mdx
@@ -10,4 +10,6 @@ Note that the table only lists some common community plugins. For plugins that a
 
 <CommunityPluginCompatibleTable lang="en" />
 
+You can view examples of common plugins in the [rspack-examples](https://github.com/rspack-contrib/rspack-examples).
+
 Additionally, you can check out the community Rspack plugins at [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack).

--- a/website/docs/en/guide/compatibility/plugin.mdx
+++ b/website/docs/en/guide/compatibility/plugin.mdx
@@ -10,6 +10,6 @@ Note that the table only lists some common community plugins. For plugins that a
 
 <CommunityPluginCompatibleTable lang="en" />
 
-You can view examples of common plugins in the [rspack-examples](https://github.com/rspack-contrib/rspack-examples).
+You can view examples of common plugins at [rspack-examples](https://github.com/rspack-contrib/rspack-examples).
 
 Additionally, you can check out the community Rspack plugins at [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack).

--- a/website/docs/zh/guide/compatibility/_meta.json
+++ b/website/docs/zh/guide/compatibility/_meta.json
@@ -1,1 +1,1 @@
-["plugin", "examples", "config-diff"]
+["plugin", "config-diff"]

--- a/website/docs/zh/guide/compatibility/examples.mdx
+++ b/website/docs/zh/guide/compatibility/examples.mdx
@@ -1,7 +1,0 @@
-import { CompatibleCardList } from '@components/RspackCompatible.tsx';
-
-# 兼容性示例
-
-此页面展示了 [rspack-compat](https://github.com/web-infra-dev/rspack-compat/tree/main) 的示例。这个仓库旨在体现 Rspack 对 webpack 生态的兼容性，你可以点击每个插件链接，查看其支持的用法。
-
-<CompatibleCardList></CompatibleCardList>

--- a/website/docs/zh/guide/compatibility/plugin.mdx
+++ b/website/docs/zh/guide/compatibility/plugin.mdx
@@ -10,4 +10,6 @@ Rspack 对 webpack 内置插件的支持情况可以参考 [Webpack 内置插件
 
 <CommunityPluginCompatibleTable lang="zh" />
 
+你可以在 [rspack-examples](https://github.com/rspack-contrib/rspack-examples) 中查看常用插件的使用示例。
+
 此外，你可以在 [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack) 中查看社区提供的 Rspack 插件。


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The `examples` page is no longer important, users can directly view the plugin's readme or rspack-example repository.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
