### PR TITLE
feat!: improve HtmlRspackPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,6 +3628,7 @@ dependencies = [
  "swc_html",
  "swc_html_minifier",
  "tracing",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1229,6 +1229,11 @@ export interface RawGeneratorOptions {
   cssModule?: RawCssModuleGeneratorOptions
 }
 
+export interface RawHtmlRspackPluginBaseOptions {
+  href?: string
+  target?: "_self" | "_blank" | "_parent" | "_top"
+}
+
 export interface RawHtmlRspackPluginOptions {
   /** emitted file name in output path */
   filename?: string
@@ -1240,8 +1245,8 @@ export interface RawHtmlRspackPluginOptions {
   inject: "head" | "body" | "false"
   /** path or `auto` */
   publicPath?: string
-  /** `blocking`, `defer`, or `module` */
-  scriptLoading: "blocking" | "defer" | "module"
+  /** `blocking`, `defer`, `module` or `systemjs-module` */
+  scriptLoading: "blocking" | "defer" | "module" | "systemjs-module"
   /** entry_chunk_name (only entry chunks are supported) */
   chunks?: Array<string>
   excludeChunks?: Array<string>
@@ -1251,6 +1256,7 @@ export interface RawHtmlRspackPluginOptions {
   favicon?: string
   meta?: Record<string, Record<string, string>>
   hash?: boolean
+  base?: RawHtmlRspackPluginBaseOptions
 }
 
 export interface RawHttpExternalsRspackPluginOptions {

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1244,12 +1244,13 @@ export interface RawHtmlRspackPluginOptions {
   scriptLoading: "blocking" | "defer" | "module"
   /** entry_chunk_name (only entry chunks are supported) */
   chunks?: Array<string>
-  excludedChunks?: Array<string>
+  excludeChunks?: Array<string>
   sri?: "sha256" | "sha384" | "sha512"
   minify?: boolean
   title?: string
   favicon?: string
   meta?: Record<string, Record<string, string>>
+  hash?: boolean
 }
 
 export interface RawHttpExternalsRspackPluginOptions {

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_html.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_html.rs
@@ -33,13 +33,14 @@ pub struct RawHtmlRspackPluginOptions {
 
   /// entry_chunk_name (only entry chunks are supported)
   pub chunks: Option<Vec<String>>,
-  pub excluded_chunks: Option<Vec<String>>,
+  pub exclude_chunks: Option<Vec<String>>,
   #[napi(ts_type = "\"sha256\" | \"sha384\" | \"sha512\"")]
   pub sri: Option<RawHtmlSriHashFunction>,
   pub minify: Option<bool>,
   pub title: Option<String>,
   pub favicon: Option<String>,
   pub meta: Option<HashMap<String, HashMap<String, String>>>,
+  pub hash: Option<bool>,
 }
 
 impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
@@ -62,12 +63,13 @@ impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
       public_path: value.public_path,
       script_loading,
       chunks: value.chunks,
-      excluded_chunks: value.excluded_chunks,
+      exclude_chunks: value.exclude_chunks,
       sri,
       minify: value.minify.unwrap_or_default(),
       title: value.title,
       favicon: value.favicon,
       meta: value.meta,
+      hash: value.hash.unwrap_or_default(),
     }
   }
 }

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_html.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_html.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 
 use napi_derive::napi;
 use rspack_plugin_html::config::HtmlInject;
+use rspack_plugin_html::config::HtmlRspackPluginBaseOptions;
 use rspack_plugin_html::config::HtmlRspackPluginOptions;
 use rspack_plugin_html::config::HtmlScriptLoading;
 use rspack_plugin_html::sri::HtmlSriHashFunction;
@@ -27,8 +28,8 @@ pub struct RawHtmlRspackPluginOptions {
   pub inject: RawHtmlInject,
   /// path or `auto`
   pub public_path: Option<String>,
-  /// `blocking`, `defer`, or `module`
-  #[napi(ts_type = "\"blocking\" | \"defer\" | \"module\"")]
+  /// `blocking`, `defer`, `module` or `systemjs-module`
+  #[napi(ts_type = "\"blocking\" | \"defer\" | \"module\" | \"systemjs-module\"")]
   pub script_loading: RawHtmlScriptLoading,
 
   /// entry_chunk_name (only entry chunks are supported)
@@ -41,6 +42,7 @@ pub struct RawHtmlRspackPluginOptions {
   pub favicon: Option<String>,
   pub meta: Option<HashMap<String, HashMap<String, String>>>,
   pub hash: Option<bool>,
+  pub base: Option<RawHtmlRspackPluginBaseOptions>,
 }
 
 impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
@@ -65,11 +67,29 @@ impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
       chunks: value.chunks,
       exclude_chunks: value.exclude_chunks,
       sri,
-      minify: value.minify.unwrap_or_default(),
+      minify: value.minify,
       title: value.title,
       favicon: value.favicon,
       meta: value.meta,
-      hash: value.hash.unwrap_or_default(),
+      hash: value.hash,
+      base: value.base.map(|v| v.into()),
+    }
+  }
+}
+
+#[derive(Debug)]
+#[napi(object)]
+pub struct RawHtmlRspackPluginBaseOptions {
+  pub href: Option<String>,
+  #[napi(ts_type = "\"_self\" | \"_blank\" | \"_parent\" | \"_top\"")]
+  pub target: Option<String>,
+}
+
+impl From<RawHtmlRspackPluginBaseOptions> for HtmlRspackPluginBaseOptions {
+  fn from(value: RawHtmlRspackPluginBaseOptions) -> Self {
+    HtmlRspackPluginBaseOptions {
+      href: value.href,
+      target: value.target,
     }
   }
 }

--- a/crates/rspack_plugin_html/Cargo.toml
+++ b/crates/rspack_plugin_html/Cargo.toml
@@ -30,6 +30,7 @@ swc_core          = { workspace = true }
 swc_html          = { workspace = true }
 swc_html_minifier = { workspace = true }
 tracing           = { workspace = true }
+urlencoding       = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -84,7 +84,7 @@ pub struct HtmlRspackPluginOptions {
 
   /// entry_chunk_name (only entry chunks are supported)
   pub chunks: Option<Vec<String>>,
-  pub excluded_chunks: Option<Vec<String>>,
+  pub exclude_chunks: Option<Vec<String>>,
 
   /// hash func that used in subsource integrity
   /// sha384, sha256 or sha512
@@ -94,6 +94,7 @@ pub struct HtmlRspackPluginOptions {
   pub title: Option<String>,
   pub favicon: Option<String>,
   pub meta: Option<HashMap<String, HashMap<String, String>>>,
+  pub hash: bool,
 }
 
 fn default_filename() -> String {
@@ -119,12 +120,13 @@ impl Default for HtmlRspackPluginOptions {
       public_path: None,
       script_loading: default_script_loading(),
       chunks: None,
-      excluded_chunks: None,
+      exclude_chunks: None,
       sri: None,
       minify: false,
       title: None,
       favicon: None,
       meta: None,
+      hash: false,
     }
   }
 }

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -42,6 +42,7 @@ pub enum HtmlScriptLoading {
   Blocking,
   Defer,
   Module,
+  SystemjsModule,
 }
 
 impl FromStr for HtmlScriptLoading {
@@ -54,12 +55,22 @@ impl FromStr for HtmlScriptLoading {
       Ok(HtmlScriptLoading::Defer)
     } else if s.eq("module") {
       Ok(HtmlScriptLoading::Module)
+    } else if s.eq("systemjs-module") {
+      Ok(HtmlScriptLoading::SystemjsModule)
     } else {
       Err(anyhow::Error::msg(
         "scriptLoading in html config only support 'blocking', 'defer' or 'module'",
       ))
     }
   }
+}
+
+#[cfg_attr(feature = "testing", derive(JsonSchema))]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HtmlRspackPluginBaseOptions {
+  pub href: Option<String>,
+  pub target: Option<String>,
 }
 
 #[cfg_attr(feature = "testing", derive(JsonSchema))]
@@ -90,11 +101,12 @@ pub struct HtmlRspackPluginOptions {
   /// sha384, sha256 or sha512
   pub sri: Option<HtmlSriHashFunction>,
   #[serde(default)]
-  pub minify: bool,
+  pub minify: Option<bool>,
   pub title: Option<String>,
   pub favicon: Option<String>,
   pub meta: Option<HashMap<String, HashMap<String, String>>>,
-  pub hash: bool,
+  pub hash: Option<bool>,
+  pub base: Option<HtmlRspackPluginBaseOptions>,
 }
 
 fn default_filename() -> String {
@@ -122,11 +134,12 @@ impl Default for HtmlRspackPluginOptions {
       chunks: None,
       exclude_chunks: None,
       sri: None,
-      minify: false,
+      minify: None,
       title: None,
       favicon: None,
       meta: None,
-      hash: false,
+      hash: None,
+      base: None,
     }
   }
 }

--- a/crates/rspack_plugin_html/src/visitors/asset.rs
+++ b/crates/rspack_plugin_html/src/visitors/asset.rs
@@ -1,14 +1,13 @@
-use std::env;
 use std::path::PathBuf;
 
 use itertools::Itertools;
-use regex::Regex;
 use rspack_core::Compilation;
+use sugar_path::SugarPath;
 use swc_core::{common::DUMMY_SP, ecma::atoms::Atom};
 use swc_html::ast::{Attribute, Child, Element, Namespace, Text};
 use swc_html::visit::{VisitMut, VisitMutWith};
 
-use super::utils::{append_hash, create_element};
+use super::utils::{append_hash, create_element, generate_posix_path};
 use crate::config::{HtmlInject, HtmlRspackPluginOptions, HtmlScriptLoading};
 
 // the tag
@@ -59,6 +58,12 @@ impl HTMLPluginTag {
           attr_value: Some("module".to_string()),
         });
       }
+      HtmlScriptLoading::SystemjsModule => {
+        attributes.push(HtmlPluginAttribute {
+          attr_name: "type".to_string(),
+          attr_value: Some("systemjs-module".to_string()),
+        });
+      }
       _ => {}
     }
 
@@ -91,6 +96,7 @@ pub struct AssetWriter<'a, 'c> {
   head_tags: Vec<&'a HTMLPluginTag>,
   body_tags: Vec<&'a HTMLPluginTag>,
   compilation: &'c Compilation,
+  html_path: &'a str,
 }
 
 impl<'a, 'c> AssetWriter<'a, 'c> {
@@ -98,6 +104,7 @@ impl<'a, 'c> AssetWriter<'a, 'c> {
     config: &'a HtmlRspackPluginOptions,
     tags: &'a [HTMLPluginTag],
     compilation: &'c Compilation,
+    html_path: &'a str,
   ) -> AssetWriter<'a, 'c> {
     let mut head_tags: Vec<&HTMLPluginTag> = vec![];
     let mut body_tags: Vec<&HTMLPluginTag> = vec![];
@@ -117,6 +124,7 @@ impl<'a, 'c> AssetWriter<'a, 'c> {
       head_tags,
       body_tags,
       compilation,
+      html_path,
     }
   }
 }
@@ -160,7 +168,48 @@ impl VisitMut for AssetWriter<'_, '_> {
           }
         }
 
-        // add favicon
+        // add basic tag
+        if let Some(base) = &self.config.base {
+          let mut attributes = vec![];
+
+          if let Some(href) = &base.href {
+            attributes.push(Attribute {
+              span: Default::default(),
+              namespace: None,
+              prefix: None,
+              name: "href".into(),
+              raw_name: None,
+              value: Some(href.to_string().into()),
+              raw_value: None,
+            });
+          }
+
+          if let Some(target) = &base.target {
+            attributes.push(Attribute {
+              span: Default::default(),
+              namespace: None,
+              prefix: None,
+              name: "target".into(),
+              raw_name: None,
+              value: Some(target.to_string().into()),
+              raw_value: None,
+            });
+          }
+
+          if !attributes.is_empty() {
+            n.children.push(Child::Element(Element {
+              tag_name: Atom::from("base"),
+              children: vec![],
+              is_self_closing: true,
+              namespace: Namespace::HTML,
+              span: DUMMY_SP,
+              attributes,
+              content: None,
+            }));
+          }
+        }
+
+        // add favicon link
         if let Some(favicon) = &self.config.favicon {
           let favicon = PathBuf::from(favicon)
             .file_name()
@@ -171,21 +220,26 @@ impl VisitMut for AssetWriter<'_, '_> {
           let favicon_relative_path =
             PathBuf::from(self.config.get_relative_path(self.compilation, &favicon));
 
-          let mut favicon_path = PathBuf::from(self.config.get_public_path(
+          let mut favicon_path: PathBuf = PathBuf::from(self.config.get_public_path(
             self.compilation,
             favicon_relative_path.to_string_lossy().to_string().as_str(),
           ));
 
-          favicon_path.push(favicon_relative_path);
+          if favicon_path.to_str().unwrap_or_default().is_empty() {
+            favicon_path = self
+              .compilation
+              .options
+              .output
+              .path
+              .join(favicon_relative_path)
+              .relative(PathBuf::from(self.html_path).join(".."));
+          } else {
+            favicon_path.push(favicon_relative_path);
+          }
 
           let mut favicon_link_path = favicon_path.to_string_lossy().to_string();
 
-          if env::consts::OS == "windows" {
-            let reg = Regex::new(r"[/\\]").expect("Invalid RegExp");
-            favicon_link_path = reg.replace_all(favicon_link_path.as_str(), "/").to_string();
-          }
-
-          if self.config.hash {
+          if self.config.hash.unwrap_or_default() {
             if let Some(hash) = self.compilation.get_hash() {
               favicon_link_path = append_hash(&favicon_link_path, hash);
             }
@@ -213,7 +267,7 @@ impl VisitMut for AssetWriter<'_, '_> {
                 prefix: None,
                 name: "href".into(),
                 raw_name: None,
-                value: Some(favicon_link_path.into()),
+                value: Some(generate_posix_path(&favicon_link_path).into()),
                 raw_value: None,
               },
             ],

--- a/crates/rspack_plugin_html/src/visitors/asset.rs
+++ b/crates/rspack_plugin_html/src/visitors/asset.rs
@@ -8,7 +8,7 @@ use swc_core::{common::DUMMY_SP, ecma::atoms::Atom};
 use swc_html::ast::{Attribute, Child, Element, Namespace, Text};
 use swc_html::visit::{VisitMut, VisitMutWith};
 
-use super::utils::create_element;
+use super::utils::{append_hash, create_element};
 use crate::config::{HtmlInject, HtmlRspackPluginOptions, HtmlScriptLoading};
 
 // the tag
@@ -183,6 +183,12 @@ impl VisitMut for AssetWriter<'_, '_> {
           if env::consts::OS == "windows" {
             let reg = Regex::new(r"[/\\]").expect("Invalid RegExp");
             favicon_link_path = reg.replace_all(favicon_link_path.as_str(), "/").to_string();
+          }
+
+          if self.config.hash {
+            if let Some(hash) = self.compilation.get_hash() {
+              favicon_link_path = append_hash(&favicon_link_path, hash);
+            }
           }
 
           n.children.push(Child::Element(Element {

--- a/crates/rspack_plugin_html/src/visitors/mod.rs
+++ b/crates/rspack_plugin_html/src/visitors/mod.rs
@@ -1,2 +1,2 @@
 pub mod asset;
-mod utils;
+pub mod utils;

--- a/crates/rspack_plugin_html/src/visitors/utils.rs
+++ b/crates/rspack_plugin_html/src/visitors/utils.rs
@@ -11,7 +11,7 @@ pub fn create_attribute(name: &str, value: &Option<String>) -> Attribute {
     name: name.into(),
     raw_name: None,
     value: value.as_ref().map(|str| Atom::from(str.as_str())),
-    raw_value: value.as_ref().map(|str| Atom::from(str.as_str())),
+    raw_value: None,
   }
 }
 

--- a/crates/rspack_plugin_html/src/visitors/utils.rs
+++ b/crates/rspack_plugin_html/src/visitors/utils.rs
@@ -1,3 +1,6 @@
+use std::{borrow::Cow, env};
+
+use regex::Regex;
 use swc_core::{common::DUMMY_SP, ecma::atoms::Atom};
 use swc_html::ast::{Attribute, Element, Namespace};
 
@@ -45,4 +48,13 @@ pub fn append_hash(url: &str, hash: &str) -> String {
     },
     hash
   )
+}
+
+pub fn generate_posix_path(path: &str) -> Cow<'_, str> {
+  if env::consts::OS == "windows" {
+    let reg = Regex::new(r"[/\\]").expect("Invalid RegExp");
+    reg.replace_all(path, "/")
+  } else {
+    path.into()
+  }
 }

--- a/crates/rspack_plugin_html/src/visitors/utils.rs
+++ b/crates/rspack_plugin_html/src/visitors/utils.rs
@@ -11,7 +11,7 @@ pub fn create_attribute(name: &str, value: &Option<String>) -> Attribute {
     name: name.into(),
     raw_name: None,
     value: value.as_ref().map(|str| Atom::from(str.as_str())),
-    raw_value: None,
+    raw_value: value.as_ref().map(|str| Atom::from(str.as_str())),
   }
 }
 
@@ -32,4 +32,17 @@ pub fn create_element(tag: &HTMLPluginTag) -> Element {
     namespace: Namespace::HTML,
     span: DUMMY_SP,
   }
+}
+
+pub fn append_hash(url: &str, hash: &str) -> String {
+  format!(
+    "{}{}{}",
+    url,
+    if url.contains("?") {
+      "$$RSPACK_URL_AMP$$"
+    } else {
+      "?"
+    },
+    hash
+  )
 }

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/basic/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/basic/__snapshots__/output.snap.txt
@@ -1,11 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet" /></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet"></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/chunks/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/chunks/__snapshots__/output.snap.txt
@@ -1,14 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Rspack App</title>
-<script defer src="/runtime.js"></script><script defer src="/chunk1.js"></script></head>
-
-<body>
-
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>Rspack App</title><script defer src="/runtime.js"></script><script defer src="/chunk1.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/chunks/rspack.config.js
@@ -16,7 +16,7 @@ module.exports = {
 			{
 				template: "index.html",
 				chunks: ["chunk1", "chunk2"],
-				excludedChunks: ["chunk2"]
+				excludeChunks: ["chunk2"]
 			}
 		]
 	}

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/favicon/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/favicon/__snapshots__/output.snap.txt
@@ -1,11 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <link rel="icon" href="/favicon.ico" /><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><link rel="icon" href="/favicon.ico"><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/filename/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/filename/__snapshots__/output.snap.txt
@@ -1,26 +1,7 @@
 ```html title=default.28094d62af6f500a.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet" /></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet"></head><body></body></html>
 ```
 
 ```html title=index.28094d62af6f500a.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Rspack App</title>
-<script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet" /></head>
-
-<body>
-
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>Rspack App</title><script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet"></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/inject/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/inject/__snapshots__/output.snap.txt
@@ -1,35 +1,11 @@
 ```html title=inject_body.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <link href="/main.css" rel="stylesheet" /></head>
-  <body>
-  
-<script defer src="/runtime.js"></script><script defer src="/main.js"></script></body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><link href="/main.css" rel="stylesheet"></head><body><script defer src="/runtime.js"></script><script defer src="/main.js"></script></body></html>
 ```
 
 ```html title=inject_false.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  </head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title></head><body></body></html>
 ```
 
 ```html title=inject_head.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet" /></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><script defer src="/runtime.js"></script><script defer src="/main.js"></script><link href="/main.css" rel="stylesheet"></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/meta/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/meta/__snapshots__/output.snap.txt
@@ -1,11 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" /><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport"><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/minify/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/minify/__snapshots__/output.snap.txt
@@ -1,3 +1,3 @@
 ```html title=index.html
-<!doctype html><meta charset=utf-8><title>rspack</title><script defer src=/runtime.js></script><script defer src=/index.js></script>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/mpa/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/mpa/__snapshots__/output.snap.txt
@@ -1,44 +1,11 @@
 ```html title=chunk1.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Rspack App</title>
-<script defer src="/runtime.js"></script><script defer src="/chunk1.js"></script></head>
-
-<body>
-
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>Rspack App</title><script defer src="/runtime.js"></script><script defer src="/chunk1.js"></script></head><body></body></html>
 ```
 
 ```html title=chunk2.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Rspack App</title>
-<script defer src="/runtime.js"></script><script defer src="/chunk2.js"></script></head>
-
-<body>
-
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>Rspack App</title><script defer src="/runtime.js"></script><script defer src="/chunk2.js"></script></head><body></body></html>
 ```
 
 ```html title=chunk3.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Rspack App</title>
-<script defer src="/runtime.js"></script><script defer src="/chunk3.js"></script></head>
-
-<body>
-
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>Rspack App</title><script defer src="/runtime.js"></script><script defer src="/chunk3.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/public-path/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/public-path/__snapshots__/output.snap.txt
@@ -1,11 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>rspack</title>
-  <link rel="icon" href="/base/favicon.ico" /><script defer src="/base/runtime.js"></script><script defer src="/base/index.js"></script></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>rspack</title><link rel="icon" href="/base/favicon.ico"><script defer src="/base/runtime.js"></script><script defer src="/base/index.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/template+templateParameters/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/template+templateParameters/__snapshots__/output.snap.txt
@@ -1,13 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>bar</title>
-<script defer src="/runtime.js"></script><script defer src="/index.js"></script></head>
-
-<body>
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>bar</title><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/templateContent+templateParameters/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/templateContent+templateParameters/__snapshots__/output.snap.txt
@@ -1,5 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body><div>bar</div></body></html>
+<!doctype html><html><head><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body><div>bar</div></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/title/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/title/__snapshots__/output.snap.txt
@@ -1,11 +1,3 @@
 ```html title=index.html
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>Rspack title</title>
-  <script defer src="/runtime.js"></script><script defer src="/index.js"></script></head>
-  <body>
-  
-</body></html>
+<!doctype html><html><head><meta charset="utf-8"><title>Rspack title</title><script defer src="/runtime.js"></script><script defer src="/index.js"></script></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/builtinCases/plugin-html/variant/__snapshots__/output.snap.txt
+++ b/packages/rspack-test-tools/tests/builtinCases/plugin-html/variant/__snapshots__/output.snap.txt
@@ -1,14 +1,3 @@
 ```html title=output.html
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="UTF-8" />
-  <title>Rspack App</title>
-<script src="/runtime.js" crossorigin="anonymous" integrity="sha512-kDo61EPSNLg9Wx+HBfbwZ65YIb8vn08kq+4fLWmM5GNJZpwkCFhqHYikoRwXwU9guJc3S1DMHyW5GpvHloLqGw=="></script><script src="/index.js" crossorigin="anonymous" integrity="sha512-J01E4uoMbdYMH16mabUDwjqw/QWyCWGYTRNoT/5VOXK/+dLtm7h9B4KUgillt7GTUxQiIyLh4gtv7ICMF06YaA=="></script><link href="/index.css" rel="stylesheet" crossorigin="anonymous" integrity="sha512-NDDyIqkYQDfMwMNIUaCRfUwfeS0YqfkkvdFaWECGNXVRn0jmwUqlFGOm4fV7YXHoM7GP1rvE6zLAZOXi03rjBw==" /></head>
-
-<body>
-
-
-
-</body></html>
+<!doctype html><html><head><meta charset="UTF-8"><title>Rspack App</title><script src="/runtime.js" crossorigin integrity="sha512-kDo61EPSNLg9Wx+HBfbwZ65YIb8vn08kq+4fLWmM5GNJZpwkCFhqHYikoRwXwU9guJc3S1DMHyW5GpvHloLqGw=="></script><script src="/index.js" crossorigin integrity="sha512-J01E4uoMbdYMH16mabUDwjqw/QWyCWGYTRNoT/5VOXK/+dLtm7h9B4KUgillt7GTUxQiIyLh4gtv7ICMF06YaA=="></script><link href="/index.css" rel="stylesheet" crossorigin integrity="sha512-NDDyIqkYQDfMwMNIUaCRfUwfeS0YqfkkvdFaWECGNXVRn0jmwUqlFGOm4fV7YXHoM7GP1rvE6zLAZOXi03rjBw=="></head><body></body></html>
 ```

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-publicpath/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-publicpath/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path and public path", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes('<link rel="icon" href="/assets/favicon.ico" />')
-	).toBe(true);
+	expect(htmlContent).toContain('<link rel="icon" href="/assets/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-subdir-publicpath/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-subdir-publicpath/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path and public path", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes('<link rel="icon" href="/assets/favicon.ico" />')
-	).toBe(true);
+	expect(htmlContent).toContain('<link rel="icon" href="/assets/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-subdir/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute-subdir/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path in subdirectory", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes('<link rel="icon" href="/favicon.ico" />')
-	).toBe(true);
+	expect(htmlContent).toContain('<link rel="icon" href="/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-absolute/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(htmlContent.includes('<link rel="icon" href="/favicon.ico" />')).toBe(
-		true
-	);
+	expect(htmlContent).toContain('<link rel="icon" href="/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-publicpath/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-publicpath/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path and public path", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes('<link rel="icon" href="/assets/favicon.ico" />')
-	).toBe(true);
+	expect(htmlContent).toContain('<link rel="icon" href="/assets/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-subdir-publicpath/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-subdir-publicpath/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path and public path", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes('<link rel="icon" href="/assets/favicon.ico" />')
-	).toBe(true);
+	expect(htmlContent).toContain('<link rel="icon" href="/assets/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-subdir/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative-subdir/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path in subdirectory", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes('<link rel="icon" href="/favicon.ico" />')
-	).toBe(true);
+	expect(htmlContent).toContain('<link rel="icon" href="/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-favicon-relative/index.js
@@ -7,7 +7,5 @@ it("html favicon with absolute path", () => {
 
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(htmlContent.includes('<link rel="icon" href="/favicon.ico" />')).toBe(
-		true
-	);
+	expect(htmlContent).toContain('<link rel="icon" href="/favicon.ico">');
 });

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-meta/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-meta/index.js
@@ -4,10 +4,6 @@ const path = require("path");
 it("html meta", () => {
 	const htmlPath = path.join(__dirname, "./index.html");
 	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
-	expect(
-		htmlContent.includes(
-			'<meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport" />'
-		)
-	).toBe(true);
-	expect(htmlContent.includes('<meta a="b" name="test" />')).toBe(true);
+	expect(htmlContent).toContain('<meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport">');
+	expect(htmlContent).toContain('<meta a="b" name="test">');
 });

--- a/packages/rspack-test-tools/tests/diagnosticsCases/builtins/html_syntax_error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/builtins/html_syntax_error/stats.err
@@ -1,13 +1,6 @@
-ERROR in × HTML parsing error: Start tag seen without seeing a doctype first, expected "<!DOCTYPE html>"
-   ╭─[1:0]
- 1 │ <head>
-   · ──────
- 2 │   </something>
-   ╰────
-
 ERROR in × HTML parsing error: Stray end tag "something"
    ╭─[2:2]
- 1 │ <head>
+ 1 │ <!DOCTYPE html><head>
  2 │   </something>
    ·   ────────────
    ╰────

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -4593,7 +4593,11 @@ export const HtmlRspackPlugin: {
         templateContent?: string | undefined;
         templateParameters?: Record<string, string> | undefined;
         inject?: boolean | "head" | "body" | undefined;
-        scriptLoading?: "module" | "blocking" | "defer" | undefined;
+        base?: string | {
+            target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
+            href?: string | undefined;
+        } | undefined;
+        scriptLoading?: "module" | "blocking" | "defer" | "systemjs-module" | undefined;
         excludeChunks?: string[] | undefined;
         sri?: "sha256" | "sha384" | "sha512" | undefined;
         minify?: boolean | undefined;
@@ -4611,7 +4615,11 @@ export const HtmlRspackPlugin: {
             templateContent?: string | undefined;
             templateParameters?: Record<string, string> | undefined;
             inject?: boolean | "head" | "body" | undefined;
-            scriptLoading?: "module" | "blocking" | "defer" | undefined;
+            base?: string | {
+                target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
+                href?: string | undefined;
+            } | undefined;
+            scriptLoading?: "module" | "blocking" | "defer" | "systemjs-module" | undefined;
             excludeChunks?: string[] | undefined;
             sri?: "sha256" | "sha384" | "sha512" | undefined;
             minify?: boolean | undefined;
@@ -4636,7 +4644,17 @@ const htmlRspackPluginOptions: z.ZodObject<{
     templateParameters: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodString>>;
     inject: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["head", "body"]>, z.ZodBoolean]>>;
     publicPath: z.ZodOptional<z.ZodString>;
-    scriptLoading: z.ZodOptional<z.ZodEnum<["blocking", "defer", "module"]>>;
+    base: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
+        href: z.ZodOptional<z.ZodString>;
+        target: z.ZodOptional<z.ZodEnum<["_self", "_blank", "_parent", "_top"]>>;
+    }, "strict", z.ZodTypeAny, {
+        target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
+        href?: string | undefined;
+    }, {
+        target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
+        href?: string | undefined;
+    }>]>>;
+    scriptLoading: z.ZodOptional<z.ZodEnum<["blocking", "defer", "module", "systemjs-module"]>>;
     chunks: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     excludeChunks: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     sri: z.ZodOptional<z.ZodEnum<["sha256", "sha384", "sha512"]>>;
@@ -4654,7 +4672,11 @@ const htmlRspackPluginOptions: z.ZodObject<{
     templateContent?: string | undefined;
     templateParameters?: Record<string, string> | undefined;
     inject?: boolean | "head" | "body" | undefined;
-    scriptLoading?: "module" | "blocking" | "defer" | undefined;
+    base?: string | {
+        target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
+        href?: string | undefined;
+    } | undefined;
+    scriptLoading?: "module" | "blocking" | "defer" | "systemjs-module" | undefined;
     excludeChunks?: string[] | undefined;
     sri?: "sha256" | "sha384" | "sha512" | undefined;
     minify?: boolean | undefined;
@@ -4670,7 +4692,11 @@ const htmlRspackPluginOptions: z.ZodObject<{
     templateContent?: string | undefined;
     templateParameters?: Record<string, string> | undefined;
     inject?: boolean | "head" | "body" | undefined;
-    scriptLoading?: "module" | "blocking" | "defer" | undefined;
+    base?: string | {
+        target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
+        href?: string | undefined;
+    } | undefined;
+    scriptLoading?: "module" | "blocking" | "defer" | "systemjs-module" | undefined;
     excludeChunks?: string[] | undefined;
     sri?: "sha256" | "sha384" | "sha512" | undefined;
     minify?: boolean | undefined;

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -4587,13 +4587,14 @@ export const HtmlRspackPlugin: {
     new (c?: {
         filename?: string | undefined;
         publicPath?: string | undefined;
+        hash?: boolean | undefined;
         chunks?: string[] | undefined;
         template?: string | undefined;
         templateContent?: string | undefined;
         templateParameters?: Record<string, string> | undefined;
         inject?: boolean | "head" | "body" | undefined;
         scriptLoading?: "module" | "blocking" | "defer" | undefined;
-        excludedChunks?: string[] | undefined;
+        excludeChunks?: string[] | undefined;
         sri?: "sha256" | "sha384" | "sha512" | undefined;
         minify?: boolean | undefined;
         title?: string | undefined;
@@ -4604,13 +4605,14 @@ export const HtmlRspackPlugin: {
         _args: [c?: {
             filename?: string | undefined;
             publicPath?: string | undefined;
+            hash?: boolean | undefined;
             chunks?: string[] | undefined;
             template?: string | undefined;
             templateContent?: string | undefined;
             templateParameters?: Record<string, string> | undefined;
             inject?: boolean | "head" | "body" | undefined;
             scriptLoading?: "module" | "blocking" | "defer" | undefined;
-            excludedChunks?: string[] | undefined;
+            excludeChunks?: string[] | undefined;
             sri?: "sha256" | "sha384" | "sha512" | undefined;
             minify?: boolean | undefined;
             title?: string | undefined;
@@ -4636,22 +4638,24 @@ const htmlRspackPluginOptions: z.ZodObject<{
     publicPath: z.ZodOptional<z.ZodString>;
     scriptLoading: z.ZodOptional<z.ZodEnum<["blocking", "defer", "module"]>>;
     chunks: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-    excludedChunks: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
+    excludeChunks: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
     sri: z.ZodOptional<z.ZodEnum<["sha256", "sha384", "sha512"]>>;
     minify: z.ZodOptional<z.ZodBoolean>;
     title: z.ZodOptional<z.ZodString>;
     favicon: z.ZodOptional<z.ZodString>;
     meta: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodString>]>>>;
+    hash: z.ZodOptional<z.ZodBoolean>;
 }, "strict", z.ZodTypeAny, {
     filename?: string | undefined;
     publicPath?: string | undefined;
+    hash?: boolean | undefined;
     chunks?: string[] | undefined;
     template?: string | undefined;
     templateContent?: string | undefined;
     templateParameters?: Record<string, string> | undefined;
     inject?: boolean | "head" | "body" | undefined;
     scriptLoading?: "module" | "blocking" | "defer" | undefined;
-    excludedChunks?: string[] | undefined;
+    excludeChunks?: string[] | undefined;
     sri?: "sha256" | "sha384" | "sha512" | undefined;
     minify?: boolean | undefined;
     title?: string | undefined;
@@ -4660,13 +4664,14 @@ const htmlRspackPluginOptions: z.ZodObject<{
 }, {
     filename?: string | undefined;
     publicPath?: string | undefined;
+    hash?: boolean | undefined;
     chunks?: string[] | undefined;
     template?: string | undefined;
     templateContent?: string | undefined;
     templateParameters?: Record<string, string> | undefined;
     inject?: boolean | "head" | "body" | undefined;
     scriptLoading?: "module" | "blocking" | "defer" | undefined;
-    excludedChunks?: string[] | undefined;
+    excludeChunks?: string[] | undefined;
     sri?: "sha256" | "sha384" | "sha512" | undefined;
     minify?: boolean | undefined;
     title?: string | undefined;

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -16,12 +16,13 @@ const htmlRspackPluginOptions = z.strictObject({
 	publicPath: z.string().optional(),
 	scriptLoading: z.enum(["blocking", "defer", "module"]).optional(),
 	chunks: z.string().array().optional(),
-	excludedChunks: z.string().array().optional(),
+	excludeChunks: z.string().array().optional(),
 	sri: z.enum(["sha256", "sha384", "sha512"]).optional(),
 	minify: z.boolean().optional(),
 	title: z.string().optional(),
 	favicon: z.string().optional(),
-	meta: z.record(z.string().or(z.record(z.string()))).optional()
+	meta: z.record(z.string().or(z.record(z.string()))).optional(),
+	hash: z.boolean().optional()
 });
 export type HtmlRspackPluginOptions = z.infer<typeof htmlRspackPluginOptions>;
 export const HtmlRspackPlugin = create(

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -14,7 +14,18 @@ const htmlRspackPluginOptions = z.strictObject({
 	templateParameters: z.record(z.string()).optional(),
 	inject: z.enum(["head", "body"]).or(z.boolean()).optional(),
 	publicPath: z.string().optional(),
-	scriptLoading: z.enum(["blocking", "defer", "module"]).optional(),
+	base: z
+		.string()
+		.or(
+			z.strictObject({
+				href: z.string().optional(),
+				target: z.enum(["_self", "_blank", "_parent", "_top"]).optional()
+			})
+		)
+		.optional(),
+	scriptLoading: z
+		.enum(["blocking", "defer", "module", "systemjs-module"])
+		.optional(),
 	chunks: z.string().array().optional(),
 	excludeChunks: z.string().array().optional(),
 	sri: z.enum(["sha256", "sha384", "sha512"]).optional(),
@@ -54,11 +65,13 @@ export const HtmlRspackPlugin = create(
 				: configInject === false
 					? "false"
 					: configInject;
+		const base = typeof c.base === "string" ? { href: c.base } : c.base;
 		return {
 			...c,
 			meta,
 			scriptLoading,
-			inject
+			inject,
+			base
 		};
 	}
 );

--- a/tests/plugin-test/html-plugin/basic.test.js
+++ b/tests/plugin-test/html-plugin/basic.test.js
@@ -139,49 +139,47 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: url encodes the file name
-  // it("properly encodes file names in emitted URIs", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "foo/very fancy+name.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin()],
-  //     },
-  //     [
-  //       /<script defer src="foo\/very%20fancy%2Bname.js"><\/script>[\s]*<\/head>/,
-  //     ],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("properly encodes file names in emitted URIs", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "foo/very fancy+name.js",
+        },
+        plugins: [new HtmlWebpackPlugin()],
+      },
+      [
+        /<script defer src="foo\/very%20fancy%2Bname.js"><\/script>[\s]*<\/head>/,
+      ],
+      null,
+      done,
+    );
+  });
 
-  // TODO: url encodes the file name
-  // itUnixOnly(
-  //   "properly encodes file names in emitted URIs but keeps the querystring",
-  //   (done) => {
-  //     testHtmlPlugin(
-  //       {
-  //         mode: "production",
-  //         entry: path.join(__dirname, "fixtures/index.js"),
-  //         output: {
-  //           path: OUTPUT_DIR,
-  //           filename:
-  //             "fo:o/very fancy+file-name.js?path=/home?value=abc&value=def#zzz",
-  //         },
-  //         plugins: [new HtmlWebpackPlugin()],
-  //       },
-  //       [
-  //         '<script defer src="fo%3Ao/very%20fancy%2Bfile-name.js?path=/home?value=abc&value=def#zzz">',
-  //       ],
-  //       null,
-  //       done,
-  //     );
-  //   },
-  // );
+  itUnixOnly(
+    "properly encodes file names in emitted URIs but keeps the querystring",
+    (done) => {
+      testHtmlPlugin(
+        {
+          mode: "production",
+          entry: path.join(__dirname, "fixtures/index.js"),
+          output: {
+            path: OUTPUT_DIR,
+            filename:
+              "fo:o/very fancy+file-name.js?path=/home?value=abc&value=def#zzz",
+          },
+          plugins: [new HtmlWebpackPlugin()],
+        },
+        [
+          '<script defer src="fo%3Ao/very%20fancy%2Bfile-name.js?path=/home?value=abc&value=def#zzz">',
+        ],
+        null,
+        done,
+      );
+    },
+  );
 
   it("generates a default index.html file with multiple entry points", (done) => {
     testHtmlPlugin(
@@ -519,32 +517,31 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: Support excludeChunks
-  // it("allows you to inject a specified asset into a given html file", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: {
-  //         util: path.join(__dirname, "fixtures/util.js"),
-  //         app: path.join(__dirname, "fixtures/index.js"),
-  //       },
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "[name]_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           inject: true,
-  //           excludeChunks: ["util"],
-  //           template: path.join(__dirname, "fixtures/plain.html"),
-  //         }),
-  //       ],
-  //     },
-  //     ['<script defer src="app_bundle.js"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("allows you to inject a specified asset into a given html file", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: {
+          util: path.join(__dirname, "fixtures/util.js"),
+          app: path.join(__dirname, "fixtures/index.js"),
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: "[name]_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            inject: true,
+            excludeChunks: ["util"],
+            template: path.join(__dirname, "fixtures/plain.html"),
+          }),
+        ],
+      },
+      ['<script defer src="app_bundle.js"'],
+      null,
+      done,
+    );
+  });
 
 
   // TODO: ejs template params `<%= webpackConfig.output.publicPath %>`
@@ -643,8 +640,6 @@ describe("HtmlWebpackPlugin", () => {
         },
         plugins: [new HtmlWebpackPlugin()],
       },
-      // DIFF: ['<script defer src="index_bundle.js"']
-      // `prodution` use html-minify-terser to convert `defer` to `defer`
       ['<script defer src="index_bundle.js"'],
       null,
       done,
@@ -688,41 +683,39 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: support hash config
-  // it("allows to append hashes to the assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin({ hash: true })],
-  //     },
-  //     ['<script defer src="index_bundle.js?%hash%"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("allows to append hashes to the assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [new HtmlWebpackPlugin({ hash: true })],
+      },
+      ['<script defer src="index_bundle.js?%hash%"'],
+      null,
+      done,
+    );
+  });
 
-  // TODO: support hash config
-  // it("allows to append hashes to the assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin({ hash: true, inject: true })],
-  //     },
-  //     ['<script defer src="index_bundle.js?%hash%"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("allows to append hashes to the assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [new HtmlWebpackPlugin({ hash: true, inject: true })],
+      },
+      ['<script defer src="index_bundle.js?%hash%"'],
+      null,
+      done,
+    );
+  });
 
   it("should work with the css extract plugin", (done) => {
     testHtmlPlugin(
@@ -809,159 +802,154 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: support hash config
-  // it("should allow to add cache hashes to with the css assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //         publicPath: "/some/",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           hash: true,
-  //           filename: path.resolve(OUTPUT_DIR, "subfolder", "test.html"),
-  //         }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     ['<link href="/some/styles.css?%hash%"'],
-  //     path.join("subfolder", "test.html"),
-  //     done,
-  //   );
-  // });
+  it("should allow to add cache hashes to with the css assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+          publicPath: "/some/",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            hash: true,
+            filename: path.resolve(OUTPUT_DIR, "subfolder", "test.html"),
+          }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      ['<link href="/some/styles.css?%hash%"'],
+      path.join("subfolder", "test.html"),
+      done,
+    );
+  });
 
-  // TODO: support hash config
-  // it("should allow to add cache hashes to with the css assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //         publicPath: "/some",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({ hash: true }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     ['<link href="/some/styles.css?%hash%"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should allow to add cache hashes to with the css assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+          publicPath: "/some",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({ hash: true }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      ['<link href="/some/styles.css?%hash%"'],
+      null,
+      done,
+    );
+  });
 
-  // TODO: support hash config
-  // it("should allow to add cache hashes to with the css assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //         publicPath: "some/",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({ hash: true }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     ['<link href="some/styles.css?%hash%"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should allow to add cache hashes to with the css assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+          publicPath: "some/",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({ hash: true }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      ['<link href="some/styles.css?%hash%"'],
+      null,
+      done,
+    );
+  });
 
-  // TODO: support hash config
-  // it("should allow to add cache hashes to with the css assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({ hash: true }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     ['<link href="styles.css?%hash%"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should allow to add cache hashes to with the css assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({ hash: true }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      ['<link href="styles.css?%hash%"'],
+      null,
+      done,
+    );
+  });
 
-  // TODO: support hash config
-  // it("should allow to add cache hashes to with the css assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           hash: true,
-  //           filename: path.resolve(OUTPUT_DIR, "subfolder", "test.html"),
-  //         }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     ['<link href="../styles.css?%hash%"'],
-  //     path.join("subfolder", "test.html"),
-  //     done,
-  //   );
-  // });
+  it("should allow to add cache hashes to with the css assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            hash: true,
+            filename: path.resolve(OUTPUT_DIR, "subfolder", "test.html"),
+          }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      ['<link href="../styles.css?%hash%"'],
+      path.join("subfolder", "test.html"),
+      done,
+    );
+  });
 
   it("should inject css files when using the extract text plugin", (done) => {
     testHtmlPlugin(
@@ -991,34 +979,33 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: support hash config
-  // it("should allow to add cache hashes to with injected css assets", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({ hash: true, inject: true }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     ['<link href="styles.css?%hash%"'],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should allow to add cache hashes to with injected css assets", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({ hash: true, inject: true }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      ['<link href="styles.css?%hash%"'],
+      null,
+      done,
+    );
+  });
 
   // TODO: support xhtml and minify config
   // it("should output xhtml link stylesheet tag", (done) => {

--- a/tests/plugin-test/html-plugin/basic.test.js
+++ b/tests/plugin-test/html-plugin/basic.test.js
@@ -594,8 +594,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      // DIFF ["<body></body>"],
-      [/<body>\s*<\/body>/],
+      ["<body></body>"],
       null,
       done,
     );
@@ -739,7 +738,7 @@ describe("HtmlWebpackPlugin", () => {
           new MiniCssExtractPlugin({ filename: "styles.css" }),
         ],
       },
-      ['<link href="styles.css" rel="stylesheet" />'],
+      ['<link href="styles.css" rel="stylesheet">'],
       null,
       done,
     );
@@ -1392,47 +1391,47 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // it("will replace [contenthash] in the filename with a content hash of 32 hex characters", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: {
-  //         index: path.join(__dirname, "fixtures/index.js"),
-  //       },
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "[name]_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({ filename: "index.[contenthash].html" }),
-  //       ],
-  //     },
-  //     [],
-  //     /index\.[a-f0-9]{20}\.html/,
-  //     done,
-  //   );
-  // });
+  it("will replace [contenthash] in the filename with a content hash of 32 hex characters", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: {
+          index: path.join(__dirname, "fixtures/index.js"),
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: "[name]_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({ filename: "index.[contenthash].html" }),
+        ],
+      },
+      [],
+      /index\.[a-f0-9]{16}\.html/,
+      done,
+    );
+  });
 
-  // it("will replace [templatehash] in the filename with a content hash of 32 hex characters", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: {
-  //         index: path.join(__dirname, "fixtures/index.js"),
-  //       },
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "[name]_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({ filename: "index.[templatehash].html" }),
-  //       ],
-  //     },
-  //     [],
-  //     /index\.[a-f0-9]{20}\.html/,
-  //     done,
-  //   );
-  // });
+  it("will replace [templatehash] in the filename with a content hash of 32 hex characters", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: {
+          index: path.join(__dirname, "fixtures/index.js"),
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: "[name]_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({ filename: "index.[templatehash].html" }),
+        ],
+      },
+      [],
+      /index\.[a-f0-9]{16}\.html/,
+      done,
+    );
+  });
 
   it("allows you to use an absolute output filename", (done) => {
     testHtmlPlugin(
@@ -1514,23 +1513,22 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: win32 path sep "..\\../assets/index_bundle.js"
-  // it('will try to use a relative name if the filename and the script defer are in a subdirectory', (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "assets/index_bundle.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin({ filename: "assets/demo/test.html" })],
-  //     },
-  //     ['<script defer src="../../assets/index_bundle.js"'],
-  //     "assets/demo/test.html",
-  //     done,
-  //   );
-  // });
+  it('will try to use a relative name if the filename and the script defer are in a subdirectory', (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "assets/index_bundle.js",
+        },
+        plugins: [new HtmlWebpackPlugin({ filename: "assets/demo/test.html" })],
+      },
+      ['<script defer src="../../assets/index_bundle.js"'],
+      "assets/demo/test.html",
+      done,
+    );
+  });
 
   it("allows you write multiple HTML files", (done) => {
     testHtmlPlugin(
@@ -1569,39 +1567,38 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: empty html
-  // it("should inject js css files even if the html file is incomplete", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/theme.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       module: {
-  //         rules: [
-  //           {
-  //             test: /\.css$/,
-  //             use: [MiniCssExtractPlugin.loader, "css-loader"],
-  //           },
-  //         ],
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           template: path.join(__dirname, "fixtures/empty_html.html"),
-  //         }),
-  //         new MiniCssExtractPlugin({ filename: "styles.css" }),
-  //       ],
-  //     },
-  //     [
-  //       '<link href="styles.css"',
-  //       '<script defer src="index_bundle.js"',
-  //     ],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should inject js css files even if the html file is incomplete", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/theme.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        module: {
+          rules: [
+            {
+              test: /\.css$/,
+              use: [MiniCssExtractPlugin.loader, "css-loader"],
+            },
+          ],
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            template: path.join(__dirname, "fixtures/empty_html.html"),
+          }),
+          new MiniCssExtractPlugin({ filename: "styles.css" }),
+        ],
+      },
+      [
+        '<link href="styles.css"',
+        '<script defer src="index_bundle.js"',
+      ],
+      null,
+      done,
+    );
+  });
 
   // TODO: ejs template params `<%= webpackConfig.output.publicPath %>`
   // it("exposes the webpack configuration to templates", (done) => {
@@ -2534,58 +2531,56 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="[^"]+\.ico" \/>/],
+      [/<link rel="icon" href="[^"]+\.ico">/],
       null,
       done,
     );
   });
 
-  // TODO: support base config
-  // it("adds a base tag with attributes", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           base: {
-  //             href: "http://example.com/page.html",
-  //             target: "_blank",
-  //           },
-  //         }),
-  //       ],
-  //     },
-  //     [/<base href="http:\/\/example\.com\/page\.html" target="_blank">/],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("adds a base tag with attributes", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            base: {
+              href: "http://example.com/page.html",
+              target: "_blank",
+            },
+          }),
+        ],
+      },
+      [/<base href="http:\/\/example\.com\/page\.html" target="_blank">/],
+      null,
+      done,
+    );
+  });
 
-  // TODO: support base config
-  // it("adds a base tag short syntax", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           base: "http://example.com/page.html",
-  //         }),
-  //       ],
-  //     },
-  //     [/<base href="http:\/\/example\.com\/page\.html">/],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("adds a base tag short syntax", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            base: "http://example.com/page.html",
+          }),
+        ],
+      },
+      [/<base href="http:\/\/example\.com\/page\.html">/],
+      null,
+      done,
+    );
+  });
 
   it("adds a meta tag", (done) => {
     testHtmlPlugin(
@@ -2609,14 +2604,14 @@ describe("HtmlWebpackPlugin", () => {
         ],
       },
       [
-        /<meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport" \/>/,
+        /<meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport">/,
       ],
       null,
       done,
     );
   });
 
-  // TODO: multiple meta in default.html
+  // Deprecated: will be removed in next major release of html-webpack-plugin, https://github.com/jantimon/html-webpack-plugin/blob/main/index.js#L222
   // it("avoid duplicate meta tags for default template", (done) => {
   //   testHtmlPlugin(
   //     {
@@ -2655,7 +2650,7 @@ describe("HtmlWebpackPlugin", () => {
         ],
       },
       [
-        /<meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport" \/>/,
+        /<meta content="width=device-width,initial-scale=1,shrink-to-fit=no" name="viewport">/,
       ],
       null,
       done,
@@ -2678,7 +2673,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="\/some\/+[^"]+\.ico" \/>/],
+      [/<link rel="icon" href="\/some\/+[^"]+\.ico">/],
       null,
       done,
     );
@@ -2700,7 +2695,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="\/some\/+[^"]+\.ico" \/>/],
+      [/<link rel="icon" href="\/some\/+[^"]+\.ico">/],
       null,
       done,
     );
@@ -2722,13 +2717,13 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="some\/+[^"]+\.ico" \/>/],
+      [/<link rel="icon" href="some\/+[^"]+\.ico">/],
       null,
       done,
     );
   });
 
-  it("adds a favicon with publicPath undefined", (done) => {
+  it("adds a favicon with publicPath undefined root", (done) => {
     testHtmlPlugin(
       {
         mode: "production",
@@ -2743,34 +2738,33 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="[^"]+\.ico" \/>/],
+      [/<link rel="icon" href="[^"]+\.ico">/],
       null,
       done,
     );
   });
 
-  // TODO: favicon with public path undefined
-  // it("adds a favicon with publicPath undefined", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           favicon: path.join(__dirname, "fixtures/favicon.ico"),
-  //           filename: path.resolve(OUTPUT_DIR, "subfolder", "test.html"),
-  //         }),
-  //       ],
-  //     },
-  //     [/<link rel="icon" href="\.\.\/[^"]+\.ico" \/>/],
-  //     path.join("subfolder", "test.html"),
-  //     done,
-  //   );
-  // });
+  it("adds a favicon with publicPath undefined subfolder", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            favicon: path.join(__dirname, "fixtures/favicon.ico"),
+            filename: path.resolve(OUTPUT_DIR, "subfolder", "test.html"),
+          }),
+        ],
+      },
+      [/<link rel="icon" href="\.\.\/[^"]+\.ico">/],
+      path.join("subfolder", "test.html"),
+      done,
+    );
+  });
 
   it("adds a favicon with a publicPath set to /[hash]/ and replaces the hash", (done) => {
     testHtmlPlugin(
@@ -2788,7 +2782,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="\/[a-z0-9]{20}\/favicon\.ico" \/>/],
+      [/<link rel="icon" href="\/[a-z0-9]{20}\/favicon\.ico">/],
       null,
       done,
     );
@@ -2810,7 +2804,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="[a-z0-9]{20}\/favicon\.ico" \/>/],
+      [/<link rel="icon" href="[a-z0-9]{20}\/favicon\.ico">/],
       null,
       done,
     );
@@ -2832,7 +2826,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<link rel="icon" href="[^"]+\.ico" \/>/],
+      [/<link rel="icon" href="[^"]+\.ico">/],
       null,
       done,
     );
@@ -3208,27 +3202,26 @@ describe("HtmlWebpackPlugin", () => {
   //   );
   // });
 
-  // TODO: support tempty templateContent
-  // it("should not treat templateContent set to an empty string as missing", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: { app: path.join(__dirname, "fixtures/index.js") },
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "app_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           templateContent: "",
-  //         }),
-  //       ],
-  //     },
-  //     [/^<head><script defer src="app_bundle\.js"><\/script><\/head>$/],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should not treat templateContent set to an empty string as missing", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: { app: path.join(__dirname, "fixtures/index.js") },
+        output: {
+          path: OUTPUT_DIR,
+          filename: "app_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            templateContent: "",
+          }),
+        ],
+      },
+      [/<head><script defer src="app_bundle\.js"><\/script><\/head>/],
+      null,
+      done,
+    );
+  });
 
   it("allows you to inject the assets into the body of the given spaced closing tag template", (done) => {
     testHtmlPlugin(
@@ -3276,23 +3269,22 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: html minify when production
-  // it("should minify by default when mode is production", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin()],
-  //     },
-  //     [/<!doctype html><html><head><meta charset="utf-8">/],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should minify by default when mode is production", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [new HtmlWebpackPlugin()],
+      },
+      [/<!doctype html><html><head><meta charset="utf-8">/],
+      null,
+      done,
+    );
+  });
 
   it("should not minify by default when mode is development", (done) => {
     testHtmlPlugin(
@@ -3311,41 +3303,39 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: minify correctly
-  // it("should minify in production if options.minify is true", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "development",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin({ minify: true })],
-  //     },
-  //     [/<!doctype html><html><head><meta charset="utf-8">/],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should minify in production if options.minify is true", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "development",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [new HtmlWebpackPlugin({ minify: true })],
+      },
+      [/<!doctype html><html><head><meta charset="utf-8">/],
+      null,
+      done,
+    );
+  });
 
-  // TODO: minify correctly
-  // it("should minify in development if options.minify is true", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "development",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [new HtmlWebpackPlugin({ minify: true })],
-  //     },
-  //     [/<!doctype html><html><head><meta charset="utf-8">/],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it("should minify in development if options.minify is true", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "development",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [new HtmlWebpackPlugin({ minify: true })],
+      },
+      [/<!doctype html><html><head><meta charset="utf-8">/],
+      null,
+      done,
+    );
+  });
 
   it("should not minify in production if options.minify is false", (done) => {
     testHtmlPlugin(
@@ -3420,7 +3410,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<script defer .+\s+<body>/],
+      [/<script defer .+<body>/],
       null,
       done,
     );
@@ -3441,35 +3431,34 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<script type="module" src="index_bundle.js"><\/script>.+\s+<body>/],
+      [/<script type="module" src="index_bundle.js"><\/script>.+<body>/],
       null,
       done,
     );
   });
 
-  // TODO: support scriptLoading=systemjs-module
-  // it('should allow to inject scripts with a type="systemjs-module" attribute', (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: path.join(__dirname, "fixtures/index.js"),
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "index_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           scriptLoading: "systemjs-module",
-  //         }),
-  //       ],
-  //     },
-  //     [
-  //       /<script type="systemjs-module" src="index_bundle.js"><\/script>.+\s+<body>/,
-  //     ],
-  //     null,
-  //     done,
-  //   );
-  // });
+  it('should allow to inject scripts with a type="systemjs-module" attribute', (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: path.join(__dirname, "fixtures/index.js"),
+        output: {
+          path: OUTPUT_DIR,
+          filename: "index_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            scriptLoading: "systemjs-module",
+          }),
+        ],
+      },
+      [
+        /<script type="systemjs-module" src="index_bundle.js"><\/script>.+<body>/,
+      ],
+      null,
+      done,
+    );
+  });
 
   it('should allow to inject scripts with a defer attribute to the body', (done) => {
     testHtmlPlugin(
@@ -3487,7 +3476,7 @@ describe("HtmlWebpackPlugin", () => {
           }),
         ],
       },
-      [/<body>.*\s+<script defer/],
+      [/<body>.*<script defer/],
       null,
       done,
     );
@@ -3523,7 +3512,7 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: doctype
+  // TODO: swc allow self closing 
   // it("should keep closing slashes from the template", (done) => {
   //   testHtmlPlugin(
   //     {
@@ -3581,7 +3570,7 @@ describe("HtmlWebpackPlugin", () => {
         ],
       },
       [
-        '<script defer src="index_bundle.js"></script><link href="styles.css" rel="stylesheet" /></head>',
+        '<script defer src="index_bundle.js"></script><link href="styles.css" rel="stylesheet"></head>',
       ],
       null,
       done,
@@ -3655,7 +3644,7 @@ describe("HtmlWebpackPlugin", () => {
         ],
       },
       [
-        '<script defer src="index_bundle.js"></script><link href="styles.css" rel="stylesheet" /></head>',
+        '<script defer src="index_bundle.js"></script><link href="styles.css" rel="stylesheet"></head>',
       ],
       null,
       done,

--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -74,7 +74,7 @@ type HtmlRspackPluginOptions = {
   publicPath?: string;
   scriptLoading?: 'blocking' | 'defer' | 'module';
   chunks?: string[];
-  excludedChunks?: string[];
+  excludeChunks?: string[];
   sri?: 'sha256' | 'sha384' | 'sha512';
   minify?: boolean;
   favicon?: string;
@@ -162,7 +162,7 @@ type HtmlRspackPluginOptions = {
       description: 'Allows you to add only some chunks.',
     },
     {
-      name: '`excludedChunks`',
+      name: '`excludeChunks`',
       type: '`string[]|undefined`',
       default: 'undefined',
       description: 'Allows you to skip some chunks.',

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -74,7 +74,7 @@ type HtmlRspackPluginOptions = {
   publicPath?: string;
   scriptLoading?: 'blocking' | 'defer' | 'module';
   chunks?: string[];
-  excludedChunks?: string[];
+  excludeChunks?: string[];
   sri?: 'sha256' | 'sha384' | 'sha512';
   minify?: boolean;
   favicon?: string;
@@ -160,7 +160,7 @@ type HtmlRspackPluginOptions = {
       description: '配置需要注入的 chunk，默认注入所有 chunk',
     },
     {
-      name: '`excludedChunks`',
+      name: '`excludeChunks`',
       type: '`string[]|undefined`',
       default: 'undefined',
       description: '配置需要跳过注入的 chunk',


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- [Feat] Support `hash` to append compilation hash
- [Feat] Support `base` to inject base tag
- [Feat] Support `scriptLoading=systemjs-module`
- [Feat] Support `[templatehash]` in filename template, same as `[contenthash]`
- [Breaking] Rename `excludedChunks` to `excludeChunks`, aligned with html-webpack-plugin
- [Breaking] Minify html by default when `mode=production`
- [Fix] No doctype parsing error
- [Fix] Win32 relateive path
- [Fix] Relative favicon path
- [Fix] Wrong `&` escaping in `script.src` and `link.href`
- [Test] Passed html-webpack-plugin basic cases from 45 to 85

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
