### PR TITLE
feat(create-rspack): configure Lightning CSS targets by default

### DIFF
--- a/packages/create-rspack/template-react-ts/rspack.config.ts
+++ b/packages/create-rspack/template-react-ts/rspack.config.ts
@@ -4,6 +4,9 @@ import * as RefreshPlugin from "@rspack/plugin-react-refresh";
 
 const isDev = process.env.NODE_ENV === "development";
 
+// Target browsers, see: https://github.com/browserslist/browserslist
+const targets = ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"];
+
 export default defineConfig({
 	context: __dirname,
 	entry: {
@@ -37,14 +40,7 @@ export default defineConfig({
 									}
 								}
 							},
-							env: {
-								targets: [
-									"chrome >= 87",
-									"edge >= 88",
-									"firefox >= 78",
-									"safari >= 14"
-								]
-							}
+							env: { targets }
 						}
 					}
 				]
@@ -52,15 +48,19 @@ export default defineConfig({
 		]
 	},
 	plugins: [
-		new rspack.DefinePlugin({
-			"process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV)
-		}),
-		new rspack.ProgressPlugin({}),
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
 		isDev ? new RefreshPlugin() : null
 	].filter(Boolean),
+	optimization: {
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin(),
+			new rspack.LightningCssMinimizerRspackPlugin({
+				minimizerOptions: { targets }
+			})
+		]
+	},
 	experiments: {
 		css: true
 	}

--- a/packages/create-rspack/template-react/rspack.config.mjs
+++ b/packages/create-rspack/template-react/rspack.config.mjs
@@ -7,6 +7,9 @@ import RefreshPlugin from "@rspack/plugin-react-refresh";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const isDev = process.env.NODE_ENV === "development";
 
+// Target browsers, see: https://github.com/browserslist/browserslist
+const targets = ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"];
+
 export default defineConfig({
 	context: __dirname,
 	entry: {
@@ -40,14 +43,7 @@ export default defineConfig({
 									}
 								}
 							},
-							env: {
-								targets: [
-									"chrome >= 87",
-									"edge >= 88",
-									"firefox >= 78",
-									"safari >= 14"
-								]
-							}
+							env: { targets }
 						}
 					}
 				]
@@ -55,15 +51,19 @@ export default defineConfig({
 		]
 	},
 	plugins: [
-		new rspack.DefinePlugin({
-			"process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV)
-		}),
-		new rspack.ProgressPlugin({}),
 		new rspack.HtmlRspackPlugin({
 			template: "./index.html"
 		}),
 		isDev ? new RefreshPlugin() : null
 	].filter(Boolean),
+	optimization: {
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin(),
+			new rspack.LightningCssMinimizerRspackPlugin({
+				minimizerOptions: { targets }
+			})
+		]
+	},
 	experiments: {
 		css: true
 	}

--- a/packages/create-rspack/template-vanilla-ts/rspack.config.ts
+++ b/packages/create-rspack/template-vanilla-ts/rspack.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
 
+// Target browsers, see: https://github.com/browserslist/browserslist
 const targets = ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"];
 
 export default defineConfig({
@@ -51,6 +52,14 @@ export default defineConfig({
 		]
 	},
 	plugins: [new rspack.HtmlRspackPlugin({ template: "./index.html" })],
+	optimization: {
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin(),
+			new rspack.LightningCssMinimizerRspackPlugin({
+				minimizerOptions: { targets }
+			})
+		]
+	},
 	experiments: {
 		css: true
 	}

--- a/packages/create-rspack/template-vanilla/rspack.config.mjs
+++ b/packages/create-rspack/template-vanilla/rspack.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "@rspack/cli";
 import { rspack } from "@rspack/core";
 
+// Target browsers, see: https://github.com/browserslist/browserslist
 const targets = ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"];
 
 export default defineConfig({
@@ -32,6 +33,14 @@ export default defineConfig({
 		]
 	},
 	plugins: [new rspack.HtmlRspackPlugin({ template: "./index.html" })],
+	optimization: {
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin(),
+			new rspack.LightningCssMinimizerRspackPlugin({
+				minimizerOptions: { targets }
+			})
+		]
+	},
 	experiments: {
 		css: true
 	}

--- a/packages/create-rspack/template-vue-ts/rspack.config.ts
+++ b/packages/create-rspack/template-vue-ts/rspack.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "@rspack/cli";
 import { type RspackPluginFunction, rspack } from "@rspack/core";
 import { VueLoaderPlugin } from "vue-loader";
 
+// Target browsers, see: https://github.com/browserslist/browserslist
+const targets = ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"];
+
 export default defineConfig({
 	context: __dirname,
 	entry: {
@@ -10,16 +13,6 @@ export default defineConfig({
 	resolve: {
 		extensions: ["...", ".ts", ".vue"]
 	},
-	plugins: [
-		new VueLoaderPlugin() as RspackPluginFunction,
-		new rspack.HtmlRspackPlugin({
-			template: "./index.html"
-		}),
-		new rspack.DefinePlugin({
-			__VUE_OPTIONS_API__: true,
-			__VUE_PROD_DEVTOOLS__: false
-		})
-	],
 	module: {
 		rules: [
 			{
@@ -41,14 +34,7 @@ export default defineConfig({
 									syntax: "typescript"
 								}
 							},
-							env: {
-								targets: [
-									"chrome >= 87",
-									"edge >= 88",
-									"firefox >= 78",
-									"safari >= 14"
-								]
-							}
+							env: { targets }
 						}
 					}
 				]
@@ -57,6 +43,24 @@ export default defineConfig({
 				test: /\.svg/,
 				type: "asset/resource"
 			}
+		]
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
+			__VUE_OPTIONS_API__: true,
+			__VUE_PROD_DEVTOOLS__: false
+		}),
+		new VueLoaderPlugin() as RspackPluginFunction
+	],
+	optimization: {
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin(),
+			new rspack.LightningCssMinimizerRspackPlugin({
+				minimizerOptions: { targets }
+			})
 		]
 	},
 	experiments: {

--- a/packages/create-rspack/template-vue/rspack.config.mjs
+++ b/packages/create-rspack/template-vue/rspack.config.mjs
@@ -6,6 +6,9 @@ import { VueLoaderPlugin } from "vue-loader";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Target browsers, see: https://github.com/browserslist/browserslist
+const targets = ["chrome >= 87", "edge >= 88", "firefox >= 78", "safari >= 14"];
+
 export default defineConfig({
 	context: __dirname,
 	entry: {
@@ -14,16 +17,6 @@ export default defineConfig({
 	resolve: {
 		extensions: ["...", ".ts", ".vue"]
 	},
-	plugins: [
-		new VueLoaderPlugin(),
-		new rspack.HtmlRspackPlugin({
-			template: "./index.html"
-		}),
-		new rspack.DefinePlugin({
-			__VUE_OPTIONS_API__: true,
-			__VUE_PROD_DEVTOOLS__: false
-		})
-	],
 	module: {
 		rules: [
 			{
@@ -44,14 +37,7 @@ export default defineConfig({
 									syntax: "typescript"
 								}
 							},
-							env: {
-								targets: [
-									"chrome >= 87",
-									"edge >= 88",
-									"firefox >= 78",
-									"safari >= 14"
-								]
-							}
+							env: { targets }
 						}
 					}
 				]
@@ -60,6 +46,24 @@ export default defineConfig({
 				test: /\.svg/,
 				type: "asset/resource"
 			}
+		]
+	},
+	plugins: [
+		new rspack.HtmlRspackPlugin({
+			template: "./index.html"
+		}),
+		new rspack.DefinePlugin({
+			__VUE_OPTIONS_API__: true,
+			__VUE_PROD_DEVTOOLS__: false
+		}),
+		new VueLoaderPlugin()
+	],
+	optimization: {
+		minimizer: [
+			new rspack.SwcJsMinimizerRspackPlugin(),
+			new rspack.LightningCssMinimizerRspackPlugin({
+				minimizerOptions: { targets }
+			})
 		]
 	},
 	experiments: {


### PR DESCRIPTION
## Summary

Configure Lightning CSS targets by default in the Rspack templates.

This is best practice and explicitly defines the scope of syntax reduction for Lightning CSS.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
