### PR TITLE
fix(node-stuff): use more conventional shim method

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -31,7 +31,7 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
         "node-module" => {
           // `ExternalModuleDependency` extends `CachedConstDependency` in webpack.
           // We need to create two separate dependencies in Rspack.
-          let external_dep = ExternalModuleDependency::new(
+          let external_url_dep = ExternalModuleDependency::new(
             "url".to_string(),
             vec![(
               "fileURLToPath".to_string(),
@@ -40,18 +40,27 @@ impl JavascriptParserPlugin for NodeStuffPlugin {
             None,
           );
 
+          let external_path_dep = ExternalModuleDependency::new(
+            "path".to_string(),
+            vec![("dirname".to_string(), "__webpack_dirname__".to_string())],
+            None,
+          );
+
           let const_dep = CachedConstDependency::new(
             ident.span.real_lo(),
             ident.span.real_hi(),
             DIR_NAME.into(),
-            "__webpack_fileURLToPath__(import.meta.url + '/..').slice(0, -1)"
+            "__webpack_dirname__(__webpack_fileURLToPath__(import.meta.url))"
               .to_string()
               .into(),
           );
 
           parser
             .presentational_dependencies
-            .push(Box::new(external_dep));
+            .push(Box::new(external_url_dep));
+          parser
+            .presentational_dependencies
+            .push(Box::new(external_path_dep));
           parser.presentational_dependencies.push(Box::new(const_dep));
           return Some(true);
         }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

In previous implementation, when there's a `.` in the path, the `__webpack_fileURLToPath__(temp + '/..').slice(0, -1)
` will change like this:

```txt
file:///Users/abc/.pnpm/index.js

-- after __webpack_fileURLToPath__(temp + '/..') -->

/Users/abc/.pnpm/index.js/..

-- after slice(0, -1) -->

/Users/abc/.pnpm/index.js/.
```

Use the commonly used and battle tested way, also used by tsup https://github.com/egoist/tsup/blob/49c11c3073ce977a01c84e7848fc070d5de0a652/assets/esm_shims.js.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
