### PR TITLE
feat!: support `optimization.emitOnErrors`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3677,7 +3677,6 @@ dependencies = [
 name = "rspack_plugin_no_emit_on_errors"
 version = "0.1.0"
 dependencies = [
- "rspack_collections",
  "rspack_core",
  "rspack_error",
  "rspack_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "rspack_plugin_limit_chunk_count",
  "rspack_plugin_merge_duplicate_chunks",
  "rspack_plugin_mf",
+ "rspack_plugin_no_emit_on_errors",
  "rspack_plugin_progress",
  "rspack_plugin_real_content_hash",
  "rspack_plugin_remove_empty_chunks",
@@ -3669,6 +3670,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "rspack_plugin_no_emit_on_errors"
+version = "0.1.0"
+dependencies = [
+ "rspack_collections",
+ "rspack_core",
+ "rspack_error",
+ "rspack_hook",
  "tracing",
 ]
 

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -263,6 +263,7 @@ export enum BuiltinPluginName {
   APIPlugin = 'APIPlugin',
   RuntimeChunkPlugin = 'RuntimeChunkPlugin',
   SizeLimitsPlugin = 'SizeLimitsPlugin',
+  NoEmitOnErrorsPlugin = 'NoEmitOnErrorsPlugin',
   HttpExternalsRspackPlugin = 'HttpExternalsRspackPlugin',
   CopyRspackPlugin = 'CopyRspackPlugin',
   HtmlRspackPlugin = 'HtmlRspackPlugin',

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -53,6 +53,7 @@ rspack_plugin_lightning_css_minimizer = { version = "0.1.0", path = "../rspack_p
 rspack_plugin_limit_chunk_count       = { version = "0.1.0", path = "../rspack_plugin_limit_chunk_count" }
 rspack_plugin_merge_duplicate_chunks  = { version = "0.1.0", path = "../rspack_plugin_merge_duplicate_chunks" }
 rspack_plugin_mf                      = { version = "0.1.0", path = "../rspack_plugin_mf" }
+rspack_plugin_no_emit_on_errors       = { version = "0.1.0", path = "../rspack_plugin_no_emit_on_errors" }
 rspack_plugin_progress                = { version = "0.1.0", path = "../rspack_plugin_progress" }
 rspack_plugin_real_content_hash       = { version = "0.1.0", path = "../rspack_plugin_real_content_hash" }
 rspack_plugin_remove_empty_chunks     = { version = "0.1.0", path = "../rspack_plugin_remove_empty_chunks" }

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -56,6 +56,7 @@ use rspack_plugin_mf::{
   ConsumeSharedPlugin, ContainerPlugin, ContainerReferencePlugin, ModuleFederationRuntimePlugin,
   ProvideSharedPlugin, ShareRuntimePlugin,
 };
+use rspack_plugin_no_emit_on_errors::NoEmitOnErrorsPlugin;
 use rspack_plugin_progress::ProgressPlugin;
 use rspack_plugin_real_content_hash::RealContentHashPlugin;
 use rspack_plugin_remove_empty_chunks::RemoveEmptyChunksPlugin;
@@ -160,6 +161,7 @@ pub enum BuiltinPluginName {
   APIPlugin,
   RuntimeChunkPlugin,
   SizeLimitsPlugin,
+  NoEmitOnErrorsPlugin,
 
   // rspack specific plugins
   // naming format follow XxxRspackPlugin
@@ -501,6 +503,9 @@ impl BuiltinPlugin {
             options.imports,
           ),
         ) as Box<dyn Plugin>)
+      }
+      BuiltinPluginName::NoEmitOnErrorsPlugin => {
+        plugins.push(NoEmitOnErrorsPlugin::new().boxed());
       }
     }
     Ok(())

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -505,7 +505,7 @@ impl BuiltinPlugin {
         ) as Box<dyn Plugin>)
       }
       BuiltinPluginName::NoEmitOnErrorsPlugin => {
-        plugins.push(NoEmitOnErrorsPlugin::new().boxed());
+        plugins.push(NoEmitOnErrorsPlugin::default().boxed());
       }
     }
     Ok(())

--- a/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
+++ b/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
@@ -8,11 +8,10 @@ version     = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rspack_collections = { version = "0.1.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.1.0", path = "../rspack_core" }
-rspack_error       = { version = "0.1.0", path = "../rspack_error" }
-rspack_hook        = { version = "0.1.0", path = "../rspack_hook" }
-tracing            = { workspace = true }
+rspack_core  = { version = "0.1.0", path = "../rspack_core" }
+rspack_error = { version = "0.1.0", path = "../rspack_error" }
+rspack_hook  = { version = "0.1.0", path = "../rspack_hook" }
+tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
+++ b/crates/rspack_plugin_no_emit_on_errors/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+description = "rspack no emit on errors plugin"
+edition     = "2021"
+license     = "MIT"
+name        = "rspack_plugin_no_emit_on_errors"
+repository  = "https://github.com/web-infra-dev/rspack"
+version     = "0.1.0"
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rspack_collections = { version = "0.1.0", path = "../rspack_collections" }
+rspack_core        = { version = "0.1.0", path = "../rspack_core" }
+rspack_error       = { version = "0.1.0", path = "../rspack_error" }
+rspack_hook        = { version = "0.1.0", path = "../rspack_hook" }
+tracing            = { workspace = true }
+
+[package.metadata.cargo-shear]
+ignored = ["tracing"]

--- a/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
+++ b/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
@@ -1,0 +1,41 @@
+use std::fmt::Debug;
+
+use rspack_core::{
+  ApplyContext, Compilation, CompilerOptions, CompilerShouldEmit, Plugin, PluginContext,
+};
+use rspack_error::Result;
+use rspack_hook::{plugin, plugin_hook};
+
+#[plugin]
+#[derive(Debug)]
+pub struct NoEmitOnErrorsPlugin {}
+
+impl NoEmitOnErrorsPlugin {
+  pub fn new() -> Self {
+    Self::new_inner()
+  }
+}
+
+#[plugin_hook(CompilerShouldEmit for NoEmitOnErrorsPlugin)]
+async fn should_emit(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+  Ok(Some(compilation.get_errors().next().is_none()))
+}
+
+impl Plugin for NoEmitOnErrorsPlugin {
+  fn name(&self) -> &'static str {
+    "NoEmitOnErrorsPlugin"
+  }
+
+  fn apply(
+    &self,
+    ctx: PluginContext<&mut ApplyContext>,
+    _options: &mut CompilerOptions,
+  ) -> Result<()> {
+    ctx
+      .context
+      .compiler_hooks
+      .should_emit
+      .tap(should_emit::new(self));
+    Ok(())
+  }
+}

--- a/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
+++ b/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
@@ -18,7 +18,11 @@ impl NoEmitOnErrorsPlugin {
 
 #[plugin_hook(CompilerShouldEmit for NoEmitOnErrorsPlugin)]
 async fn should_emit(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
-  Ok(Some(compilation.get_errors().next().is_none()))
+  if compilation.get_errors().next().is_some() {
+    Ok(Some(false))
+  } else {
+    Ok(None)
+  }
 }
 
 impl Plugin for NoEmitOnErrorsPlugin {

--- a/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
+++ b/crates/rspack_plugin_no_emit_on_errors/src/lib.rs
@@ -10,8 +10,8 @@ use rspack_hook::{plugin, plugin_hook};
 #[derive(Debug)]
 pub struct NoEmitOnErrorsPlugin {}
 
-impl NoEmitOnErrorsPlugin {
-  pub fn new() -> Self {
+impl Default for NoEmitOnErrorsPlugin {
+  fn default() -> Self {
     Self::new_inner()
   }
 }

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -236,6 +236,7 @@ Object {
   "optimization": Object {
     "chunkIds": "natural",
     "concatenateModules": false,
+    "emitOnErrors": true,
     "innerGraph": false,
     "mangleExports": false,
     "mergeDuplicateChunks": true,

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -85,7 +85,7 @@ Rspack x.x.x compiled successfully in X s"
 `;
 
 exports[`statsOutput statsOutput/css-concat-error should print correct stats for 1`] = `
-"asset main.js 49 bytes [emitted] (name: main)
+"assets by status 49 bytes [cached] 1 asset
 
 ERROR in × Module not found: Can't resolve './src' in 'Xdir/css-concat-error'
 
@@ -380,7 +380,7 @@ exports[`statsOutput statsOutput/reasons should print correct stats for 1`] = `
 `;
 
 exports[`statsOutput statsOutput/resolve-overflow-error should print correct stats for 1`] = `
-"asset main.js 348 bytes [emitted] (name: main)
+"assets by status 348 bytes [cached] 1 asset
 ./index.js 51 bytes [built] [code generated] [1 error]
 
 ERROR in ./index.js 1:0-34

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-1/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-1/rspack.config.js
@@ -19,7 +19,4 @@ class Plugin {
 module.exports = {
 	context: __dirname,
 	plugins: [new Plugin()],
-	optimization: {
-		emitOnErrors: true
-	}
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-1/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-1/rspack.config.js
@@ -18,5 +18,8 @@ class Plugin {
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	context: __dirname,
-	plugins: [new Plugin()]
+	plugins: [new Plugin()],
+	optimization: {
+		emitOnErrors: true
+	}
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/rspack.config.js
@@ -34,5 +34,8 @@ class Plugin {
 
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
-	plugins: [new Plugin()]
+	plugins: [new Plugin()],
+	optimization: {
+		emitOnErrors: true
+	},
 };

--- a/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/hooks/should-emit-2/rspack.config.js
@@ -35,7 +35,4 @@ class Plugin {
 /**@type {import("@rspack/core").Configuration}*/
 module.exports = {
 	plugins: [new Plugin()],
-	optimization: {
-		emitOnErrors: true
-	},
 };

--- a/packages/rspack-test-tools/tests/defaultsCases/mode/production.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/mode/production.js
@@ -13,10 +13,12 @@ module.exports = {
 		@@ ... @@
 		-     "chunkIds": "natural",
 		-     "concatenateModules": false,
+		-     "emitOnErrors": true,
 		-     "innerGraph": false,
 		-     "mangleExports": false,
 		+     "chunkIds": "deterministic",
 		+     "concatenateModules": true,
+		+     "emitOnErrors": false,
 		+     "innerGraph": true,
 		+     "mangleExports": true,
 		@@ ... @@

--- a/packages/rspack-test-tools/tests/defaultsCases/mode/undefined.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/mode/undefined.js
@@ -13,10 +13,12 @@ module.exports = {
 		@@ ... @@
 		-     "chunkIds": "natural",
 		-     "concatenateModules": false,
+		-     "emitOnErrors": true,
 		-     "innerGraph": false,
 		-     "mangleExports": false,
 		+     "chunkIds": "deterministic",
 		+     "concatenateModules": true,
+		+     "emitOnErrors": false,
 		+     "innerGraph": true,
 		+     "mangleExports": true,
 		@@ ... @@

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -7237,6 +7237,17 @@ type NodeTemplatePluginOptions = {
 };
 
 // @public (undocumented)
+export const NoEmitOnErrorsPlugin: {
+    new (): {
+        name: BuiltinPluginName;
+        _args: [];
+        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
+    };
+};
+
+// @public (undocumented)
 interface NonStandard {
     deepSelectorCombinator?: boolean;
 }
@@ -7517,6 +7528,7 @@ const optimization: z.ZodObject<{
     usedExports: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["global"]>, z.ZodBoolean]>>;
     mangleExports: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["size", "deterministic"]>, z.ZodBoolean]>>;
     nodeEnv: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>>;
+    emitOnErrors: z.ZodOptional<z.ZodBoolean>;
 }, "strict", z.ZodTypeAny, {
     moduleIds?: "named" | "natural" | "deterministic" | undefined;
     chunkIds?: "named" | "natural" | "deterministic" | undefined;
@@ -7582,6 +7594,7 @@ const optimization: z.ZodObject<{
     innerGraph?: boolean | undefined;
     mangleExports?: boolean | "deterministic" | "size" | undefined;
     nodeEnv?: string | false | undefined;
+    emitOnErrors?: boolean | undefined;
 }, {
     moduleIds?: "named" | "natural" | "deterministic" | undefined;
     chunkIds?: "named" | "natural" | "deterministic" | undefined;
@@ -7647,6 +7660,7 @@ const optimization: z.ZodObject<{
     innerGraph?: boolean | undefined;
     mangleExports?: boolean | "deterministic" | "size" | undefined;
     nodeEnv?: string | false | undefined;
+    emitOnErrors?: boolean | undefined;
 }>;
 
 // @public (undocumented)
@@ -9700,6 +9714,7 @@ declare namespace rspackExports {
         DynamicEntryPlugin,
         ExternalsPlugin,
         HotModuleReplacementPlugin,
+        NoEmitOnErrorsPlugin,
         EnvironmentPlugin,
         LoaderOptionsPlugin,
         LoaderTargetPlugin,
@@ -11625,6 +11640,7 @@ export const rspackOptions: z.ZodObject<{
         usedExports: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["global"]>, z.ZodBoolean]>>;
         mangleExports: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["size", "deterministic"]>, z.ZodBoolean]>>;
         nodeEnv: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>>;
+        emitOnErrors: z.ZodOptional<z.ZodBoolean>;
     }, "strict", z.ZodTypeAny, {
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
         chunkIds?: "named" | "natural" | "deterministic" | undefined;
@@ -11690,6 +11706,7 @@ export const rspackOptions: z.ZodObject<{
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "deterministic" | "size" | undefined;
         nodeEnv?: string | false | undefined;
+        emitOnErrors?: boolean | undefined;
     }, {
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
         chunkIds?: "named" | "natural" | "deterministic" | undefined;
@@ -11755,6 +11772,7 @@ export const rspackOptions: z.ZodObject<{
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "deterministic" | "size" | undefined;
         nodeEnv?: string | false | undefined;
+        emitOnErrors?: boolean | undefined;
     }>>;
     resolve: z.ZodOptional<z.ZodType<ResolveOptions, z.ZodTypeDef, ResolveOptions>>;
     resolveLoader: z.ZodOptional<z.ZodType<ResolveOptions, z.ZodTypeDef, ResolveOptions>>;
@@ -13215,6 +13233,7 @@ export const rspackOptions: z.ZodObject<{
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "deterministic" | "size" | undefined;
         nodeEnv?: string | false | undefined;
+        emitOnErrors?: boolean | undefined;
     } | undefined;
     resolveLoader?: ResolveOptions | undefined;
     plugins?: (false | "" | 0 | RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
@@ -13787,6 +13806,7 @@ export const rspackOptions: z.ZodObject<{
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "deterministic" | "size" | undefined;
         nodeEnv?: string | false | undefined;
+        emitOnErrors?: boolean | undefined;
     } | undefined;
     resolveLoader?: ResolveOptions | undefined;
     plugins?: (false | "" | 0 | RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;

--- a/packages/rspack/src/builtin-plugin/NoEmitOnErrorsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/NoEmitOnErrorsPlugin.ts
@@ -1,0 +1,8 @@
+import { BuiltinPluginName } from "@rspack/binding";
+
+import { create } from "./base";
+
+export const NoEmitOnErrorsPlugin = create(
+	BuiltinPluginName.NoEmitOnErrorsPlugin,
+	() => undefined
+);

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -63,3 +63,4 @@ export * from "./WarnCaseSensitiveModulesPlugin";
 export * from "./WebWorkerTemplatePlugin";
 export * from "./WorkerPlugin";
 export * from "./FetchCompileAsyncWasmPlugin";
+export * from "./NoEmitOnErrorsPlugin";

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -937,6 +937,7 @@ const applyOptimizationDefaults = (
 	D(optimization, "providedExports", true);
 	D(optimization, "usedExports", production);
 	D(optimization, "innerGraph", production);
+	D(optimization, "emitOnErrors", !production);
 	D(optimization, "runtimeChunk", false);
 	D(optimization, "realContentHash", production);
 	D(optimization, "minimize", production);

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1308,7 +1308,8 @@ const optimization = z.strictObject({
 	innerGraph: z.boolean().optional(),
 	usedExports: z.enum(["global"]).or(z.boolean()).optional(),
 	mangleExports: z.enum(["size", "deterministic"]).or(z.boolean()).optional(),
-	nodeEnv: z.union([z.string(), z.literal(false)]).optional()
+	nodeEnv: z.union([z.string(), z.literal(false)]).optional(),
+	emitOnErrors: z.boolean().optional()
 });
 export type Optimization = z.infer<typeof optimization>;
 //#endregion

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -98,6 +98,7 @@ export { EntryPlugin } from "./builtin-plugin";
 export { DynamicEntryPlugin } from "./builtin-plugin";
 export { ExternalsPlugin } from "./builtin-plugin";
 export { HotModuleReplacementPlugin } from "./builtin-plugin";
+export { NoEmitOnErrorsPlugin } from "./builtin-plugin";
 export { EnvironmentPlugin } from "./lib/EnvironmentPlugin";
 export { LoaderOptionsPlugin } from "./lib/LoaderOptionsPlugin";
 export { LoaderTargetPlugin } from "./lib/LoaderTargetPlugin";

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -54,6 +54,7 @@ import {
 	NamedModuleIdsPlugin,
 	NaturalChunkIdsPlugin,
 	NaturalModuleIdsPlugin,
+	NoEmitOnErrorsPlugin,
 	NodeTargetPlugin,
 	RealContentHashPlugin,
 	RemoveEmptyChunksPlugin,
@@ -173,6 +174,10 @@ export class RspackOptionsApply {
 			.runtimeChunk as OptimizationRuntimeChunkNormalized;
 		if (runtimeChunk) {
 			new RuntimeChunkPlugin(runtimeChunk).apply(compiler);
+		}
+
+		if (!options.optimization.emitOnErrors) {
+			new NoEmitOnErrorsPlugin().apply(compiler);
 		}
 
 		if (options.devtool) {

--- a/tests/webpack-test/TestCases.template.js
+++ b/tests/webpack-test/TestCases.template.js
@@ -119,7 +119,7 @@ const describeCases = config => {
 										usedExports: true,
 										mangleExports: true,
 										// CHANGE: rspack does not support `emitOnErrors` yet.
-										// emitOnErrors: true,
+										emitOnErrors: true,
 										concatenateModules:
 											!!testConfig?.optimization?.concatenateModules,
 										innerGraph: true,

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -756,7 +756,7 @@ Rspack x.x.x compiled successfully in X.23"
 `;
 
 exports[`StatsTestCases should print correct stats for module-trace-disabled-in-error 1`] = `
-"asset main.js 1.58 KiB [emitted] (name: main)
+"assets by status 1.58 KiB [cached] 1 asset
 modules with errors 53 bytes [errors]
   ./not-existing.js 26 bytes [built] [code generated] [1 error]
   ./parse-error.js 27 bytes [built] [code generated] [1 error]
@@ -789,7 +789,7 @@ Rspack x.x.x compiled with 2 errors in X.23"
 `;
 
 exports[`StatsTestCases should print correct stats for module-trace-enabled-in-error 1`] = `
-"asset main.js 1.58 KiB [emitted] (name: main)
+"assets by status 1.58 KiB [cached] 1 asset
 modules with errors 53 bytes [errors]
   ./not-existing.js 26 bytes [built] [code generated] [1 error]
   ./parse-error.js 27 bytes [built] [code generated] [1 error]
@@ -904,7 +904,7 @@ Rspack x.x.x compiled successfully in X.23"
 `;
 
 exports[`StatsTestCases should print correct stats for parse-error 1`] = `
-"asset main.js 1.41 KiB [emitted] (name: main)
+"assets by status 1.41 KiB [cached] 1 asset
 orphan modules 30 bytes [orphan] 2 modules
 cacheable modules 85 bytes
   ./index.js + 1 modules 30 bytes [code generated]

--- a/tests/webpack-test/checkArrayExpectation.js
+++ b/tests/webpack-test/checkArrayExpectation.js
@@ -113,7 +113,6 @@ module.exports = function checkArrayExpectation(
 			if (Array.isArray(expected[i])) {
 				for (let j = 0; j < expected[i].length; j++) {
 					if (!check(expected[i][j], array[i])) {
-						console.log(array);
 						return (
 							done(
 								new Error(

--- a/website/components/PluginSupportStatusTable.tsx
+++ b/website/components/PluginSupportStatusTable.tsx
@@ -103,7 +103,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'NoEmitOnErrorsPlugin',
-    status: SupportStatus.NotSupported,
+    status: SupportStatus.FullySupported,
   },
   {
     name: 'NormalModuleReplacementPlugin',

--- a/website/docs/en/config/optimization.mdx
+++ b/website/docs/en/config/optimization.mdx
@@ -351,3 +351,15 @@ module.exports = {
 :::tip
 When [mode](/config/mode) is set to `'none'`, `optimization.nodeEnv` defaults to `false`.
 :::
+
+## optimization.emitOnErrors
+
+<PropertyType
+  type="boolean"
+  defaultValueList={[
+    { defaultValue: 'false', mode: 'production' },
+    { defaultValue: 'true', mode: 'development' },
+  ]}
+/>
+
+Use the `optimization.emitOnErrors` to emit assets whenever there are errors while compiling. This ensures that erroring assets are emitted. Critical errors are emitted into the generated code and will cause errors at runtime.

--- a/website/docs/en/plugins/webpack/_meta.json
+++ b/website/docs/en/plugins/webpack/_meta.json
@@ -21,5 +21,6 @@
   "limit-chunk-count-plugin",
   "normal-module-replacement-plugin",
   "javascript-modules-plugin",
-  "internal-plugins"
+  "internal-plugins",
+  "no-emit-on-errors-plugin"
 ]

--- a/website/docs/en/plugins/webpack/no-emit-on-errors-plugin.mdx
+++ b/website/docs/en/plugins/webpack/no-emit-on-errors-plugin.mdx
@@ -1,0 +1,11 @@
+import { ApiMeta } from '@components/ApiMeta.tsx';
+
+# NoEmitOnErrorsPlugin
+
+<ApiMeta addedVersion={'1.0.0'} />
+
+This plugin is used to prevent the assets emitting when there are compilation errors. [`optimization.emitOnErrors`](/config/optimization#optimizationemitonerrors) uses this plugin.
+
+```js
+new rspack.NoEmitOnErrorsPlugin();
+```

--- a/website/docs/zh/config/optimization.mdx
+++ b/website/docs/zh/config/optimization.mdx
@@ -345,3 +345,15 @@ module.exports = {
 :::tip
 当 [mode](/config/mode) 被设置为 `'none'` 时，`optimization.nodeEnv` 默认为 `false`。
 :::
+
+## optimization.emitOnErrors
+
+<PropertyType
+  type="boolean"
+  defaultValueList={[
+    { defaultValue: 'false', mode: 'production' },
+    { defaultValue: 'true', mode: 'development' },
+  ]}
+/>
+
+开启 optimization.emitOnErrors 时，即使编译过程中发生错误也会生成产物。关键错误会被注入到产物代码中，运行它们时会抛出错误。

--- a/website/docs/zh/plugins/webpack/_meta.json
+++ b/website/docs/zh/plugins/webpack/_meta.json
@@ -21,5 +21,6 @@
   "limit-chunk-count-plugin",
   "normal-module-replacement-plugin",
   "javascript-modules-plugin",
-  "internal-plugins"
+  "internal-plugins",
+  "no-emit-on-errors-plugin"
 ]

--- a/website/docs/zh/plugins/webpack/no-emit-on-errors-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/no-emit-on-errors-plugin.mdx
@@ -1,0 +1,11 @@
+import { ApiMeta } from '@components/ApiMeta.tsx';
+
+# NoEmitOnErrorsPlugin
+
+<ApiMeta addedVersion={'1.0.0'} />
+
+此插件用来在编译错误时阻止产物生成，[`optimization.emitOnErrors`](/config/optimization#optimizationemitonerrors) 底层使用了该插件。
+
+```js
+new rspack.NoEmitOnErrorsPlugin();
+```

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -101,6 +101,7 @@ ngtools
 noimport
 nosources
 nwjs
+optimizationemitonerrors
 optionsrspackexperiments
 outputdevtoolfallbackmodulefilenametemplate
 outputdevtoolmodulefilenametemplate


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Add NoEmitOnErrorsPlugin to support `optimization.emitOnErrors`
- [Breaking] Enable this plugin when mode=`production`(means not to emit assets when error occurs in production mode)



## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
