### PR TITLE
perf: warn case sensitive plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,9 +3824,11 @@ dependencies = [
 name = "rspack_plugin_warn_sensitive_module"
 version = "0.1.0"
 dependencies = [
+ "rspack_collections",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
+ "rustc-hash 1.1.0",
  "tracing",
 ]
 

--- a/crates/rspack_plugin_warn_sensitive_module/Cargo.toml
+++ b/crates/rspack_plugin_warn_sensitive_module/Cargo.toml
@@ -5,11 +5,14 @@ license     = "MIT"
 name        = "rspack_plugin_warn_sensitive_module"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.1.0"
+
 [dependencies]
-rspack_core  = { version = "0.1.0", path = "../rspack_core" }
-rspack_error = { version = "0.1.0", path = "../rspack_error" }
-rspack_hook  = { version = "0.1.0", path = "../rspack_hook" }
-tracing      = { workspace = true }
+rspack_collections = { path = "../rspack_collections" }
+rspack_core        = { version = "0.1.0", path = "../rspack_core" }
+rspack_error       = { version = "0.1.0", path = "../rspack_error" }
+rspack_hook        = { version = "0.1.0", path = "../rspack_hook" }
+rustc-hash         = { workspace = true }
+tracing            = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]

--- a/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
+++ b/crates/rspack_plugin_warn_sensitive_module/src/lib.rs
@@ -1,13 +1,15 @@
 // https://github.com/webpack/webpack/blob/main/lib/WarnCaseSensitiveModulesPlugin.js
 
-use std::collections::HashMap;
+use std::{collections::HashMap, hash::BuildHasherDefault};
 
+use rspack_collections::{Identifier, IdentifierSet};
 use rspack_core::{
-  ApplyContext, Compilation, CompilationSeal, CompilerOptions, Logger, Module, ModuleGraph, Plugin,
+  ApplyContext, Compilation, CompilationSeal, CompilerOptions, Logger, ModuleGraph, Plugin,
   PluginContext,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
+use rustc_hash::{FxHashMap, FxHasher};
 
 #[plugin]
 #[derive(Debug, Default)]
@@ -16,15 +18,15 @@ pub struct WarnCaseSensitiveModulesPlugin;
 impl WarnCaseSensitiveModulesPlugin {
   pub fn create_sensitive_modules_warning(
     &self,
-    modules: &Vec<&dyn Module>,
+    modules: Vec<Identifier>,
     graph: &ModuleGraph,
   ) -> String {
     let mut message =
       String::from("There are multiple modules with names that only differ in casing.\n");
 
     for m in modules {
-      if let Some(boxed_m) = graph.module_by_identifier(&m.identifier()) {
-        let mut module_msg = format!("  - {}\n", m.identifier());
+      if let Some(boxed_m) = graph.module_by_identifier(&m) {
+        let mut module_msg = format!("  - {}\n", m);
         graph
           .get_incoming_connections(&boxed_m.identifier())
           .iter()
@@ -48,8 +50,11 @@ async fn seal(&self, compilation: &mut Compilation) -> Result<()> {
   let start = logger.time("check case sensitive modules");
   let mut diagnostics: Vec<Diagnostic> = vec![];
   let module_graph = compilation.get_module_graph();
-  let mut module_without_case_map: HashMap<String, HashMap<String, &Box<dyn Module>>> =
-    HashMap::new();
+  let mut not_conflect: FxHashMap<String, Identifier> = HashMap::with_capacity_and_hasher(
+    module_graph.modules().len(),
+    BuildHasherDefault::<FxHasher>::default(),
+  );
+  let mut conflict: FxHashMap<String, IdentifierSet> = FxHashMap::default();
 
   for module in module_graph.modules().values() {
     // Ignore `data:` URLs, because it's not a real path
@@ -63,25 +68,31 @@ async fn seal(&self, compilation: &mut Compilation) -> Result<()> {
       }
     }
 
-    let identifier = module.identifier().to_string();
+    let identifier = module.identifier();
     let lower_identifier = identifier.to_lowercase();
-    let lower_map = module_without_case_map.entry(lower_identifier).or_default();
-    lower_map.insert(identifier, module);
+    if let Some(prev_identifier) = not_conflect.remove(&lower_identifier) {
+      conflict.insert(
+        lower_identifier,
+        IdentifierSet::from_iter([prev_identifier, identifier]),
+      );
+    } else if let Some(set) = conflict.get_mut(&lower_identifier) {
+      set.insert(identifier);
+    } else {
+      not_conflect.insert(lower_identifier, identifier);
+    }
   }
 
   // sort by module identifier, guarantee the warning order
-  let mut case_map_vec = module_without_case_map.into_iter().collect::<Vec<_>>();
-  case_map_vec.sort_by(|a, b| a.0.cmp(&b.0));
+  let mut case_map_vec = conflict.into_iter().collect::<Vec<_>>();
+  case_map_vec.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-  for (_, lower_map) in case_map_vec {
-    if lower_map.values().len() > 1 {
-      let mut case_modules = lower_map.values().map(|m| m.as_ref()).collect::<Vec<_>>();
-      case_modules.sort_by_key(|m| m.identifier());
-      diagnostics.push(Diagnostic::warn(
-        "Sensitive Modules Warn".to_string(),
-        self.create_sensitive_modules_warning(&case_modules, &compilation.get_module_graph()),
-      ));
-    }
+  for (_, set) in case_map_vec {
+    let mut case_modules = set.iter().copied().collect::<Vec<_>>();
+    case_modules.sort_unstable();
+    diagnostics.push(Diagnostic::warn(
+      "Sensitive Modules Warn".to_string(),
+      self.create_sensitive_modules_warning(case_modules, &compilation.get_module_graph()),
+    ));
   }
 
   compilation.extend_diagnostics(diagnostics);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

For [9000](https://github.com/rspack-contrib/rspack-incremental-bench/tree/2966a89339890c414dcf265fb862a23033d4e5e2/cases/9000) case (without case sensitive path, which is the common case in development), 8ms -> 4ms

And now this plugin will increase 1ms per 2000 modules, which is acceptable for now, we can consider to move it as production only plugin by default when it becomes the bottleneck

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
