### PR TITLE
fix: remove the unnecessary logic for inserting semicolons

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/semicolon.rs
@@ -124,17 +124,7 @@ impl<'a> Visit for InsertedSemicolons<'a> {
     n.visit_children_with(self)
   }
 
-  fn visit_export_decl(&mut self, n: &swc_core::ecma::ast::ExportDecl) {
-    self.post_semi(&n.span);
-    n.visit_children_with(self)
-  }
-
   fn visit_named_export(&mut self, n: &swc_core::ecma::ast::NamedExport) {
-    self.post_semi(&n.span);
-    n.visit_children_with(self)
-  }
-
-  fn visit_export_default_decl(&mut self, n: &swc_core::ecma::ast::ExportDefaultDecl) {
     self.post_semi(&n.span);
     n.visit_children_with(self)
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #7611 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

1. We don't need to insert a semicolon for ExportDefaultDeclaration:
```js
export default function () {} // No need to insert a semicolon
export default class MyClass {}
```
2. For ExportDeclaration, when a semicolon needs to be inserted, the corresponding Visit will be triggered:
```js
export function foo() {} // No need to insert a semicolon
export const bar = 42 // It will call visit_var_decl to insert a semicolon
```

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
