### PR TITLE
fix: allow `null` and `undefined` in EnvironmentPlugin

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -3276,10 +3276,10 @@ const environment: z.ZodObject<{
 
 // @public (undocumented)
 export class EnvironmentPlugin {
-    constructor(...keys: string[] | [Record<string, string> | string]);
+    constructor(...keys: string[] | [Record<string, string | undefined | null> | string | string[]]);
     apply(compiler: Compiler): void;
     // (undocumented)
-    defaultValues: Record<string, string>;
+    defaultValues: Record<string, string | undefined | null>;
     // (undocumented)
     keys: string[];
 }

--- a/packages/rspack/src/lib/EnvironmentPlugin.ts
+++ b/packages/rspack/src/lib/EnvironmentPlugin.ts
@@ -18,15 +18,19 @@ type CodeValue = any;
 
 class EnvironmentPlugin {
 	keys: string[];
-	defaultValues: Record<string, string>;
+	defaultValues: Record<string, string | undefined | null>;
 
-	constructor(...keys: string[] | [Record<string, string> | string]) {
+	constructor(
+		...keys:
+			| string[]
+			| [Record<string, string | undefined | null> | string | string[]]
+	) {
 		if (keys.length === 1 && Array.isArray(keys[0])) {
 			this.keys = keys[0];
 			this.defaultValues = {};
 		} else if (keys.length === 1 && keys[0] && typeof keys[0] === "object") {
 			this.keys = Object.keys(keys[0]);
-			this.defaultValues = keys[0];
+			this.defaultValues = keys[0] as Record<string, string | undefined | null>;
 		} else {
 			this.keys = keys as string[];
 			this.defaultValues = {};
@@ -49,7 +53,7 @@ class EnvironmentPlugin {
 			if (value === undefined) {
 				compiler.hooks.thisCompilation.tap("EnvironmentPlugin", compilation => {
 					const error = new WebpackError(
-						`EnvironmentPlugin - ${key} environment variable is undefined.\n\nYou can pass an object with default values to suppress this warning.\nSee https://webpack.js.org/plugins/environment-plugin for example.`
+						`EnvironmentPlugin - ${key} environment variable is undefined.\n\nYou can pass an object with default values to suppress this warning.\nSee https://rspack.dev/plugins/webpack/environment-plugin for example.`
 					);
 
 					error.name = "EnvVariableNotDefinedError";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Currently, using `EnvironmentPlugin` from `@rspack/core` will have TS error:

```ts
    new EnvironmentPlugin({
      FOO: null, // Type 'null' is not assignable to type 'string | undefined'.ts(2345)
    })
```

But using `null` as the default value is allowed. Quoted from Rspack website:

> Default values of null and undefined behave differently. Use undefined for variables that must be provided during bundling, or null if they are optional.
> https://rspack.dev/plugins/webpack/environment-plugin

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
