### PR TITLE
chore(infra/biome): enable noGlobalEval

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -48,9 +48,6 @@
 			"performance": {
 				"noDelete": "off"
 			},
-			"security": {
-				"noGlobalEval": "off"
-			},
 			"suspicious": {
 				"noFallthroughSwitchClause": "off",
 				"noConfusingVoidType": "off",

--- a/packages/rspack/src/loader-runner/loadLoader.ts
+++ b/packages/rspack/src/loader-runner/loadLoader.ts
@@ -31,9 +31,7 @@ export default function loadLoader(
 		try {
 			if (url === undefined) url = require("node:url");
 			const loaderUrl = url!.pathToFileURL(loader.path);
-			const modulePromise = eval(
-				`import(${JSON.stringify(loaderUrl.toString())})`
-			);
+			const modulePromise = import(JSON.stringify(loaderUrl.toString()));
 			modulePromise.then((module: LoaderModule) => {
 				handleResult(loader, module, callback);
 			}, callback);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Related to #7182 

I don't know if this is the right thing to do. Why use `eval`? Is there any special situation?
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
