### PR TITLE
test: add more test cases for asi with sequence expressions

### DIFF
--- a/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/asi/index.js
@@ -22,3 +22,12 @@ foo()
 
 debugger
 foo()
+
+export function a() {}
+function bb() {
+  a(), foo();
+}
+
+function d() {}
+export function c() {}
+d(), foo();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Added some case for asi.

The following case is also failed in webpack:
```js
import { foo } from "./a"

export const fooC = foo
d(), foo();
```

which transformed into:

```js
export const fooC = foo
d(), ;(0, xxx.foo)();
```

so as the case:

```js
export default (function Foo() {})
d(), foo();
```

which should be fixed on webpack side as well.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
