### PR TITLE
chore: remove `Compilation.updateAsset` comment

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -562,8 +562,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 	/**
 	 * Update an existing asset. Trying to update an asset that doesn't exist will throw an error.
-	 *
-	 * FIXME: *AssetInfo* may be undefined in update fn for webpack impl, but still not implemented in rspack
 	 */
 	updateAsset(
 		filename: string,


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Webpack uses a separate `Compilation.assetInfo` to store `AssetInfo`. An empty object will be passed to the first argument `assetInfoUpdateOrFunction` if it's a `function`. [Ref](https://github.com/webpack/webpack/blob/6be4065ade1e252c1d8dcba4af0f43e32af1bdc1/lib/Compilation.js#L4348).

Rspack will always store a default `AssetInfo` if nothing is provided. This makes these two implementation(webpack and rspack) almost the same(both results in nullish values per request). So here I removed the comment.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
