### PR TITLE
perf: improve performance of eval-source-map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,6 +1170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1411,6 +1420,16 @@ name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "halfbrown"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8588661a8607108a5ca69cab034063441a0413a0b041c13618a7dd348021ef6f"
+dependencies = [
+ "hashbrown 0.14.5",
+ "serde",
+]
 
 [[package]]
 name = "handlebars"
@@ -1769,12 +1788,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
 name = "lexical-sort"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c09e4591611e231daf4d4c685a66cb0410cc1e502027a20ae55f2bb9e997207a"
 dependencies = [
  "any_ascii",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2867,6 +2950,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,6 +3626,7 @@ dependencies = [
  "rayon",
  "regex",
  "rspack_base64",
+ "rspack_collections",
  "rspack_core",
  "rspack_error",
  "rspack_hash",
@@ -3530,7 +3634,7 @@ dependencies = [
  "rspack_plugin_javascript",
  "rspack_util",
  "rustc-hash 1.1.0",
- "serde_json",
+ "simd-json",
  "tracing",
 ]
 
@@ -4402,6 +4506,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cadb29c57caadc51ff8346233b5cec1d240b68ce55cf1afc764818791876987"
 dependencies = [
  "outref 0.1.0",
+]
+
+[[package]]
+name = "simd-json"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "570c430b3d902ea083097e853263ae782dfe40857d93db019a12356c8e8143fa"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "lexical-core",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
 ]
 
 [[package]]
@@ -6357,6 +6477,18 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-trait"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad8db98c1e677797df21ba03fca7d3bf9bec3ca38db930954e4fe6e1ea27eb4"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vergen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ rustc-hash         = { version = "1.1.0" }
 schemars           = { version = "0.8.16" }
 serde              = { version = "1.0.197" }
 serde_json         = { version = "1.0.115" }
+simd-json          = { version = "0.13.10" }
 stacker            = { version = "0.1.15" }
 sugar_path         = { version = "1.2.0", features = ["cached_current_dir"] }
 syn                = { version = "2.0.58" }

--- a/crates/rspack_plugin_devtool/Cargo.toml
+++ b/crates/rspack_plugin_devtool/Cargo.toml
@@ -17,6 +17,7 @@ pathdiff                 = { workspace = true }
 rayon                    = { workspace = true }
 regex                    = { workspace = true }
 rspack_base64            = { version = "0.1.0", path = "../rspack_base64" }
+rspack_collections       = { version = "0.1.0", path = "../rspack_collections" }
 rspack_core              = { version = "0.1.0", path = "../rspack_core" }
 rspack_error             = { version = "0.1.0", path = "../rspack_error" }
 rspack_hash              = { version = "0.1.0", path = "../rspack_hash" }
@@ -24,7 +25,7 @@ rspack_hook              = { version = "0.1.0", path = "../rspack_hook" }
 rspack_plugin_javascript = { version = "0.1.0", path = "../rspack_plugin_javascript" }
 rspack_util              = { version = "0.1.0", path = "../rspack_util" }
 rustc-hash               = { workspace = true }
-serde_json               = { workspace = true }
+simd-json                = { workspace = true }
 tracing                  = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_dev_tool_module_plugin.rs
@@ -1,8 +1,9 @@
-use std::hash::Hash;
 use std::sync::LazyLock;
+use std::{borrow::Cow, hash::Hash};
 
 use dashmap::DashMap;
 use derivative::Derivative;
+use rspack_collections::UkeySet;
 use rspack_core::{
   rspack_sources::{BoxSource, RawSource, Source, SourceExt},
   ApplyContext, BoxModule, ChunkInitFragments, ChunkUkey, Compilation, CompilationParams,
@@ -15,8 +16,6 @@ use rspack_plugin_javascript::{
   JavascriptModulesChunkHash, JavascriptModulesInlineInRuntimeBailout,
   JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
 };
-use rustc_hash::FxHashSet as HashSet;
-use serde_json::json;
 
 use crate::{
   module_filename_helpers::ModuleFilenameHelpers, ModuleFilenameTemplate, ModuleOrSource,
@@ -138,7 +137,11 @@ fn eval_devtool_plugin_render_module_content(
     );
     // TODO: Implement support for the trustedTypes option.
     // This will depend on the additionalModuleRuntimeRequirements hook.
-    RawSource::from(format!("eval({});", json!(format!("{source}{footer}")))).boxed()
+    RawSource::from(format!(
+      "eval({});",
+      simd_json::to_string(&format!("{source}{footer}")).expect("failed to parse string")
+    ))
+    .boxed()
   };
 
   self.cache.insert(origin_source, source.clone());
@@ -184,36 +187,50 @@ impl Plugin for EvalDevToolModulePlugin {
   }
 }
 
-// https://tc39.es/ecma262/#sec-encodeuri-uri
-fn encode_uri(uri: &str) -> String {
-  encode(uri, ";/?:@&=+$,#")
-}
-
-static ALWAYS_UNESCAPED: LazyLock<HashSet<char>> = LazyLock::new(|| {
-  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!*'()"
+// https://tc39.es/ecma262/#sec-encode
+// UNESCAPED is combined by ALWAYS_UNESCAPED and ";/?:@&=+$,#"
+static UNESCAPED: LazyLock<UkeySet<u32>> = LazyLock::new(|| {
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~!*'();/?:@&=+$,#"
     .chars()
+    .map(|c| c as u32)
     .collect()
 });
 
 // https://tc39.es/ecma262/#sec-encode
-fn encode(string: &str, extra_unescaped: &str) -> String {
+fn encode_uri(string: &str) -> Cow<str> {
   // Let R be the empty String.
-  let mut r = String::new();
+  let mut r = Cow::Borrowed(string);
   // Let alwaysUnescaped be the string-concatenation of the ASCII word characters and "-.!~*'()".
-  let always_unescaped = ALWAYS_UNESCAPED.clone();
-  // Let unescapedSet be the string-concatenation of alwaysUnescaped and extraUnescaped.
-  let unescaped_set: HashSet<char> = always_unescaped
-    .union(&extra_unescaped.chars().collect::<HashSet<_>>())
-    .cloned()
-    .collect();
-  for c in string.chars() {
-    if unescaped_set.contains(&c) {
-      r.push(c);
+  for (byte_idx, c) in string.char_indices() {
+    if UNESCAPED.contains(&(c as u32)) {
+      match r {
+        Cow::Borrowed(_) => {
+          continue;
+        }
+        Cow::Owned(mut inner) => {
+          inner.push(c);
+          r = Cow::Owned(inner);
+        }
+      }
     } else {
-      let mut b = [0u8; 4];
-      let octets = c.encode_utf8(&mut b).as_bytes().to_vec();
-      for octet in octets {
-        r.push_str(&format!("%{:02X}", octet));
+      match r {
+        Cow::Borrowed(_) => {
+          let mut s = string[0..byte_idx].to_string();
+          let mut b = [0u8; 4];
+          let octets = c.encode_utf8(&mut b).as_bytes().to_vec();
+          for octet in octets {
+            s.push_str(&format!("%{:02X}", octet));
+          }
+          r = Cow::Owned(s);
+        }
+        Cow::Owned(mut inner) => {
+          let mut b = [0u8; 4];
+          let octets = c.encode_utf8(&mut b).as_bytes().to_vec();
+          for octet in octets {
+            inner.push_str(&format!("%{:02X}", octet));
+          }
+          r = Cow::Owned(inner);
+        }
       }
     }
   }

--- a/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/eval_source_map_dev_tool_plugin.rs
@@ -16,7 +16,6 @@ use rspack_plugin_javascript::{
   JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
 };
 use rspack_util::identifier::make_paths_absolute;
-use serde_json::json;
 
 use crate::{
   module_filename_helpers::ModuleFilenameHelpers, ModuleFilenameTemplate, ModuleOrSource,
@@ -174,7 +173,11 @@ fn eval_source_map_devtool_plugin_render_module_content(
       let base64 = rspack_base64::encode_to_string(&map_buffer);
       let footer =
         format!("\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,{base64}");
-      RawSource::from(format!("eval({});", json!(format!("{source}{footer}")))).boxed()
+      RawSource::from(format!(
+        "eval({});",
+        simd_json::to_string(&format!("{source}{footer}")).expect("should convert to string")
+      ))
+      .boxed()
     };
     self.cache.insert(origin_source, source.clone());
     render_source.source = source;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

using simd_json to convert string to json string, the improvement is small, but better than current, especially if the number of modules is super large.

encoding url always allocate new string, but in most cases there is no replacement at all, so using Cow to avoid unnessary allocation here.

here is the improvement I saw with my MacBook Pro M1, using this [repo](https://github.com/rspack-contrib/rspack-incremental-bench), CASE=9000

## Before
![image](https://github.com/user-attachments/assets/7a75e09a-44ce-4031-917a-ce851f627680)

## After
![image](https://github.com/user-attachments/assets/79a5b8d5-701a-4c9d-898a-52cd9d7236bb)




<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
