### PR TITLE
feat: cache unaffected for cgm code gen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,6 +856,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "rayon",
 ]
 
 [[package]]

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1626,7 +1626,7 @@ export interface RawResolveTsconfigOptions {
 }
 
 export interface RawRspackFuture {
-
+  newIncremental: boolean
 }
 
 export interface RawRuleSetCondition {

--- a/crates/rspack_binding_options/src/options/raw_experiments.rs
+++ b/crates/rspack_binding_options/src/options/raw_experiments.rs
@@ -4,7 +4,9 @@ use rspack_core::RspackFuture;
 #[allow(clippy::empty_structs_with_brackets)]
 #[derive(Debug, Default)]
 #[napi(object)]
-pub struct RawRspackFuture {}
+pub struct RawRspackFuture {
+  pub new_incremental: bool,
+}
 
 #[derive(Debug, Default)]
 #[napi(object)]
@@ -15,7 +17,9 @@ pub struct RawExperiments {
 }
 
 impl From<RawRspackFuture> for RspackFuture {
-  fn from(_value: RawRspackFuture) -> Self {
-    Self {}
+  fn from(value: RawRspackFuture) -> Self {
+    Self {
+      new_incremental: value.new_incremental,
+    }
   }
 }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -10,7 +10,7 @@ anymap = { workspace = true }
 async-recursion = { workspace = true }
 async-trait = { workspace = true }
 bitflags = { workspace = true }
-dashmap = { workspace = true }
+dashmap = { workspace = true, features = ["rayon"] }
 derivative = { workspace = true }
 dyn-clone = "1.0.17"
 either = "1"

--- a/crates/rspack_core/src/chunk_graph/mod.rs
+++ b/crates/rspack_core/src/chunk_graph/mod.rs
@@ -12,8 +12,6 @@ pub use chunk_graph_module::ChunkGraphModule;
 
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGraph {
-  pub split_point_module_identifier_to_chunk_ukey: IdentifierMap<ChunkUkey>,
-
   /// If a module is imported dynamically, it will be assigned to a unique ChunkGroup
   pub(crate) block_to_chunk_group_ukey: HashMap<AsyncDependenciesBlockIdentifier, ChunkGroupUkey>,
 

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1064,7 +1064,7 @@ impl Compilation {
     if self.options.new_incremental_enabled() {
       self
         .unaffected_modules_cache
-        .compute_affected_modules_with_module_graph(&self);
+        .compute_affected_modules_with_module_graph(self);
     }
 
     let start = logger.time("finish modules");

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -73,6 +73,7 @@ where
         self.loader_resolver_factory.clone(),
         Some(records),
         self.old_cache.clone(),
+        self.unaffected_modules_cache.clone(),
         Some(ModuleExecutor::default()),
         modified_files,
         removed_files,
@@ -98,6 +99,9 @@ where
 
         // reuse module executor
         new_compilation.module_executor = std::mem::take(&mut self.compilation.module_executor);
+
+        new_compilation.code_generation_results =
+          std::mem::take(&mut self.compilation.code_generation_results);
       }
 
       // FOR BINDING SAFETY:

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -126,10 +126,10 @@ mod t {
   use rspack_util::source_map::SourceMapKind;
 
   use crate::{
-    compiler::make::cutout::has_module_graph_change::ModuleDeps, AsContextDependency, BuildInfo,
-    BuildMeta, CodeGenerationResult, Compilation, ConcatenationScope, Context, DependenciesBlock,
-    Dependency, DependencyId, DependencyTemplate, ExportsInfo, FactoryMeta, Module,
-    ModuleDependency, ModuleGraph, ModuleGraphModule, ModuleGraphPartial, ModuleIdentifier,
+    compiler::make::cutout::has_module_graph_change::ModuleDeps, AffectType, AsContextDependency,
+    BuildInfo, BuildMeta, CodeGenerationResult, Compilation, ConcatenationScope, Context,
+    DependenciesBlock, Dependency, DependencyId, DependencyTemplate, ExportsInfo, FactoryMeta,
+    Module, ModuleDependency, ModuleGraph, ModuleGraphModule, ModuleGraphPartial, ModuleIdentifier,
     ModuleType, RuntimeSpec, SourceType,
   };
 
@@ -165,6 +165,10 @@ mod t {
         .iter()
         .map(|id| (*id).to_string().into())
         .collect_vec()
+    }
+
+    fn could_affect_referencing_module(&self) -> AffectType {
+      AffectType::True
     }
   }
 

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -12,6 +12,7 @@ use super::MakeArtifact;
 use crate::{
   module_graph::{ModuleGraph, ModuleGraphPartial},
   old_cache::Cache as OldCache,
+  unaffected_cache::UnaffectedModulesCache,
   utils::task_loop::{run_task_loop, Task},
   BuildDependency, Compilation, CompilerOptions, DependencyType, Module, ModuleFactory,
   ModuleProfile, NormalModuleSource, ResolverFactory, SharedPluginDriver,
@@ -24,6 +25,7 @@ pub struct MakeTaskContext {
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
   pub old_cache: Arc<OldCache>,
+  pub unaffected_modules_cache: Arc<UnaffectedModulesCache>,
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
 
   pub artifact: MakeArtifact,
@@ -37,6 +39,7 @@ impl MakeTaskContext {
       resolver_factory: compilation.resolver_factory.clone(),
       loader_resolver_factory: compilation.loader_resolver_factory.clone(),
       old_cache: compilation.old_cache.clone(),
+      unaffected_modules_cache: compilation.unaffected_modules_cache.clone(),
       dependency_factories: compilation.dependency_factories.clone(),
       artifact,
     }
@@ -61,6 +64,7 @@ impl MakeTaskContext {
       self.loader_resolver_factory.clone(),
       None,
       self.old_cache.clone(),
+      self.unaffected_modules_cache.clone(),
       None,
       Default::default(),
       Default::default(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -18,6 +18,7 @@ pub use self::compilation::*;
 pub use self::hmr::{collect_changed_modules, CompilationRecords};
 pub use self::module_executor::{ExecuteModuleId, ExecutedRuntimeModule, ModuleExecutor};
 use crate::old_cache::Cache as OldCache;
+use crate::unaffected_cache::UnaffectedModulesCache;
 use crate::{
   fast_set, BoxPlugin, CompilerOptions, Logger, PluginDriver, ResolverFactory, SharedPluginDriver,
 };
@@ -63,6 +64,7 @@ where
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
   pub emitted_asset_versions: HashMap<String, String>,
+  unaffected_modules_cache: Arc<UnaffectedModulesCache>,
 }
 
 impl<T> Compiler<T>
@@ -90,6 +92,7 @@ where
       .unwrap_or_else(|| Arc::new(ResolverFactory::new(options.resolve_loader.clone())));
     let (plugin_driver, options) = PluginDriver::new(options, plugins, resolver_factory.clone());
     let old_cache = Arc::new(OldCache::new(options.clone()));
+    let unaffected_modules_cache = Arc::new(UnaffectedModulesCache::default());
     let module_executor = ModuleExecutor::default();
     Self {
       options: options.clone(),
@@ -100,6 +103,7 @@ where
         loader_resolver_factory.clone(),
         None,
         old_cache.clone(),
+        unaffected_modules_cache.clone(),
         Some(module_executor),
         Default::default(),
         Default::default(),
@@ -110,6 +114,7 @@ where
       loader_resolver_factory,
       old_cache,
       emitted_asset_versions: Default::default(),
+      unaffected_modules_cache,
     }
   }
 
@@ -135,6 +140,7 @@ where
         self.loader_resolver_factory.clone(),
         None,
         self.old_cache.clone(),
+        self.unaffected_modules_cache.clone(),
         Some(module_executor),
         Default::default(),
         Default::default(),

--- a/crates/rspack_core/src/dependency/context_element_dependency.rs
+++ b/crates/rspack_core/src/dependency/context_element_dependency.rs
@@ -3,6 +3,7 @@ use rspack_paths::Utf8Path;
 use rspack_util::json_stringify;
 use swc_core::ecma::atoms::Atom;
 
+use super::AffectType;
 use crate::{
   create_exports_object_referenced, AsContextDependency, AsDependencyTemplate, Context,
   ImportAttributes, ModuleLayer,
@@ -86,6 +87,10 @@ impl Dependency for ContextElementDependency {
     } else {
       create_exports_object_referenced()
     }
+  }
+
+  fn could_affect_referencing_module(&self) -> AffectType {
+    AffectType::True
   }
 }
 

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -18,6 +18,13 @@ use crate::ModuleLayer;
 use crate::RuntimeSpec;
 use crate::{ConnectionState, Context, ErrorSpan, ModuleGraph, UsedByExports};
 
+#[derive(Debug, Clone, Copy)]
+pub enum AffectType {
+  True,
+  False,
+  Transitive,
+}
+
 pub trait Dependency:
   AsDependencyTemplate
   + AsContextDependency
@@ -99,6 +106,8 @@ pub trait Dependency:
   ) -> Vec<ExtendedReferencedExport> {
     create_exports_object_referenced()
   }
+
+  fn could_affect_referencing_module(&self) -> AffectType;
 }
 
 impl dyn Dependency + '_ {

--- a/crates/rspack_core/src/dependency/entry.rs
+++ b/crates/rspack_core/src/dependency/entry.rs
@@ -1,3 +1,4 @@
+use super::AffectType;
 use crate::{
   AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
   DependencyType, ModuleDependency, ModuleLayer,
@@ -52,6 +53,10 @@ impl Dependency for EntryDependency {
 
   fn get_layer(&self) -> Option<&ModuleLayer> {
     self.layer.as_ref()
+  }
+
+  fn could_affect_referencing_module(&self) -> AffectType {
+    AffectType::True
   }
 }
 

--- a/crates/rspack_core/src/dependency/loader_import.rs
+++ b/crates/rspack_core/src/dependency/loader_import.rs
@@ -1,3 +1,4 @@
+use super::AffectType;
 use crate::{
   AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
   DependencyType, ModuleDependency,
@@ -34,6 +35,10 @@ impl Dependency for LoaderImportDependency {
 
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::LoaderImport
+  }
+
+  fn could_affect_referencing_module(&self) -> AffectType {
+    AffectType::True
   }
 }
 

--- a/crates/rspack_core/src/dependency/static_exports_dependency.rs
+++ b/crates/rspack_core/src/dependency/static_exports_dependency.rs
@@ -1,5 +1,6 @@
 use swc_core::ecma::atoms::Atom;
 
+use super::AffectType;
 use crate::{
   AsContextDependency, AsDependencyTemplate, AsModuleDependency, Dependency, DependencyId,
   DependencyType, ExportNameOrSpec, ExportsOfExportsSpec, ExportsSpec, ModuleGraph,
@@ -51,6 +52,10 @@ impl Dependency for StaticExportsDependency {
       can_mangle: Some(self.can_mangle),
       ..Default::default()
     })
+  }
+
+  fn could_affect_referencing_module(&self) -> AffectType {
+    AffectType::True
   }
 }
 

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -9,6 +9,7 @@
 use std::{fmt, sync::Arc};
 mod dependencies_block;
 pub mod diagnostics;
+mod unaffected_cache;
 pub use dependencies_block::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, DependenciesBlock,
 };

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -237,6 +237,7 @@ impl<'a> ModuleGraph<'a> {
     res
   }
 
+  #[tracing::instrument(skip_all, fields(module = ?module_id))]
   pub fn get_incoming_connections_by_origin_module(
     &self,
     module_id: &ModuleIdentifier,

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -40,4 +40,8 @@ impl CompilerOptions {
   pub fn is_incremental_rebuild_emit_asset_enabled(&self) -> bool {
     self.experiments.incremental_rebuild.emit_asset
   }
+
+  pub fn new_incremental_enabled(&self) -> bool {
+    self.experiments.rspack_future.new_incremental
+  }
 }

--- a/crates/rspack_core/src/options/experiments.rs
+++ b/crates/rspack_core/src/options/experiments.rs
@@ -23,7 +23,9 @@ impl IncrementalRebuildMakeState {
 
 #[allow(clippy::empty_structs_with_brackets)]
 #[derive(Debug, Default)]
-pub struct RspackFuture {}
+pub struct RspackFuture {
+  pub new_incremental: bool,
+}
 
 #[derive(Debug, Default)]
 pub struct Experiments {

--- a/crates/rspack_core/src/unaffected_cache/mod.rs
+++ b/crates/rspack_core/src/unaffected_cache/mod.rs
@@ -1,0 +1,360 @@
+use std::{
+  hash::{BuildHasherDefault, Hash, Hasher},
+  sync::Mutex,
+};
+
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use rspack_collections::{IdentifierDashMap, IdentifierHasher, IdentifierMap, IdentifierSet};
+use rspack_util::fx_hash::FxIndexSet;
+use rustc_hash::FxHasher;
+
+use crate::{
+  AffectType, ChunkGraph, Compilation, Module, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
+};
+
+#[derive(Debug, Default)]
+pub struct UnaffectedModulesCache {
+  module_to_cache: IdentifierDashMap<UnaffectedModuleCache>,
+  affected_modules_with_module_graph: Mutex<IdentifierSet>,
+  affected_modules_with_chunk_graph: Mutex<IdentifierSet>,
+}
+
+#[derive(Debug)]
+struct UnaffectedModuleCache {
+  module_graph_invalidate_key: u64,
+  with_chunk_graph_cache: Option<UnaffectedModuleWithChunkGraphCache>,
+}
+
+#[derive(Debug)]
+struct UnaffectedModuleWithChunkGraphCache {
+  chunk_graph_invalidate_key: u64,
+}
+
+impl UnaffectedModulesCache {
+  // fn iter(
+  //   &self,
+  // ) -> dashmap::iter::Iter<
+  //   ModuleIdentifier,
+  //   UnaffectedModuleCache,
+  //   BuildHasherDefault<IdentifierHasher>,
+  // > {
+  //   self.module_to_cache.iter()
+  // }
+
+  fn par_iter(
+    &self,
+  ) -> dashmap::rayon::map::Iter<
+    ModuleIdentifier,
+    UnaffectedModuleCache,
+    BuildHasherDefault<IdentifierHasher>,
+  > {
+    self.module_to_cache.par_iter()
+  }
+
+  #[tracing::instrument(skip_all, fields(module = ?key))]
+  fn remove_cache(&self, key: &ModuleIdentifier) {
+    self.module_to_cache.remove(key);
+  }
+
+  #[tracing::instrument(skip_all, fields(module = ?key))]
+  fn insert_cache(&self, key: ModuleIdentifier, value: UnaffectedModuleCache) {
+    self.module_to_cache.insert(key, value);
+  }
+
+  #[tracing::instrument(skip_all, fields(module = ?key))]
+  fn affect_cache(&self, key: &ModuleIdentifier) -> Option<()> {
+    let mut cache = self.module_to_cache.get_mut(key)?;
+    cache.with_chunk_graph_cache = None;
+    // remove other cache...
+    Some(())
+  }
+
+  #[tracing::instrument(skip_all, fields(module = ?key))]
+  fn insert_chunk_graph_cache(
+    &self,
+    key: &ModuleIdentifier,
+    value: UnaffectedModuleWithChunkGraphCache,
+  ) -> Option<()> {
+    let mut cache = self.module_to_cache.get_mut(key)?;
+    cache.with_chunk_graph_cache = Some(value);
+    Some(())
+  }
+
+  #[tracing::instrument(skip_all)]
+  pub fn compute_affected_modules_with_module_graph(&self, compilation: &Compilation) {
+    let mg = compilation.get_module_graph();
+    let modules = IdentifierSet::from_iter(mg.modules().keys().copied());
+    let mut affected_modules = self
+      .affected_modules_with_module_graph
+      .lock()
+      .expect("failed to lock");
+    *affected_modules = compute_affected_modules_with_module_graph(compilation, modules);
+  }
+
+  #[tracing::instrument(skip_all)]
+  pub fn get_affected_modules_with_module_graph(&self) -> &Mutex<IdentifierSet> {
+    &self.affected_modules_with_module_graph
+  }
+
+  #[tracing::instrument(skip_all)]
+  pub fn compute_affected_modules_with_chunk_graph(&self, compilation: &Compilation) {
+    let mut affected_modules = self
+      .affected_modules_with_chunk_graph
+      .lock()
+      .expect("failed to lock");
+    *affected_modules = compute_affected_modules_with_chunk_graph(compilation);
+  }
+
+  #[tracing::instrument(skip_all)]
+  pub fn get_affected_modules_with_chunk_graph(&self) -> &Mutex<IdentifierSet> {
+    &self.affected_modules_with_chunk_graph
+  }
+}
+
+impl UnaffectedModuleCache {
+  fn new(module_graph_invalidate_key: u64) -> Self {
+    Self {
+      module_graph_invalidate_key,
+      with_chunk_graph_cache: None,
+    }
+  }
+
+  #[tracing::instrument(skip_all, fields(module = ?module.identifier()))]
+  fn create_module_graph_invalidate_key(module_graph: &ModuleGraph, module: &dyn Module) -> u64 {
+    let mut hasher = FxHasher::default();
+    module
+      .build_info()
+      .expect("should have build_info after build")
+      .hash
+      .as_ref()
+      .hash(&mut hasher);
+    for connection_id in module_graph
+      .get_ordered_connections(&module.identifier())
+      .expect("should have module")
+    {
+      let connection = module_graph
+        .connection_by_connection_id(connection_id)
+        .expect("should have connection");
+      connection.dependency_id.hash(&mut hasher);
+    }
+    hasher.finish()
+  }
+}
+
+impl UnaffectedModuleWithChunkGraphCache {
+  #[tracing::instrument(skip_all, fields(module = ?module.identifier()))]
+  fn create_chunk_graph_invalidate_key(
+    chunk_graph: &ChunkGraph,
+    module_graph: &ModuleGraph,
+    compilation: &Compilation,
+    module: &dyn Module,
+  ) -> u64 {
+    let module_identifier = module.identifier();
+    let mut hasher = FxHasher::default();
+    chunk_graph
+      .get_module_id(module_identifier)
+      .hash(&mut hasher);
+    let module_ids = FxIndexSet::from_iter(
+      module_graph
+        .get_ordered_connections(&module_identifier)
+        .expect("should have module")
+        .into_iter()
+        .filter_map(|c| {
+          let connection = module_graph
+            .connection_by_connection_id(c)
+            .expect("should have connection");
+          chunk_graph.get_module_id(*connection.module_identifier())
+        }),
+    );
+    for module_id in module_ids {
+      module_id.hash(&mut hasher);
+    }
+    for block_id in module.get_blocks() {
+      let Some(chunk_group) =
+        chunk_graph.get_block_chunk_group(block_id, &compilation.chunk_group_by_ukey)
+      else {
+        continue;
+      };
+      for chunk in &chunk_group.chunks {
+        let chunk = compilation.chunk_by_ukey.expect_get(chunk);
+        chunk.id.as_ref().hash(&mut hasher);
+      }
+    }
+    hasher.finish()
+  }
+}
+
+fn compute_affected_modules_with_module_graph(
+  compilation: &Compilation,
+  modules: IdentifierSet,
+) -> IdentifierSet {
+  fn reduce_affect_type(
+    module_graph: &ModuleGraph,
+    connections: &[ModuleGraphConnection],
+  ) -> AffectType {
+    let mut affected = AffectType::False;
+    for connection in connections {
+      let Some(dependency) = module_graph.dependency_by_id(&connection.dependency_id) else {
+        continue;
+      };
+      match dependency.could_affect_referencing_module() {
+        AffectType::True => affected = AffectType::True,
+        AffectType::False => continue,
+        AffectType::Transitive => return AffectType::Transitive,
+      }
+    }
+    affected
+  }
+
+  enum ModulesCacheIterResult {
+    Delete(ModuleIdentifier),
+    Unaffected(ModuleIdentifier),
+    Affected(ModuleIdentifier, u64),
+  }
+
+  let module_graph = compilation.get_module_graph();
+  let modules_cache = compilation.unaffected_modules_cache.clone();
+  let mut modules_without_cache = modules;
+  let results: Vec<ModulesCacheIterResult> = modules_cache
+    .par_iter()
+    .map(|item| {
+      let (module_identifier, cache) = item.pair();
+      if modules_without_cache.contains(module_identifier) {
+        let module = module_graph
+          .module_by_identifier(module_identifier)
+          .expect("should have module");
+        let invalidate_key =
+          UnaffectedModuleCache::create_module_graph_invalidate_key(&module_graph, module.as_ref());
+        if cache.module_graph_invalidate_key != invalidate_key {
+          ModulesCacheIterResult::Affected(*module_identifier, invalidate_key)
+        } else {
+          ModulesCacheIterResult::Unaffected(*module_identifier)
+        }
+      } else {
+        ModulesCacheIterResult::Delete(*module_identifier)
+      }
+    })
+    .collect();
+  let mut affected_modules_cache = IdentifierMap::default();
+  for result in results {
+    match result {
+      ModulesCacheIterResult::Delete(m) => {
+        modules_cache.remove_cache(&m);
+      }
+      ModulesCacheIterResult::Unaffected(m) => {
+        modules_without_cache.remove(&m);
+      }
+      ModulesCacheIterResult::Affected(m, invalidate_key) => {
+        modules_without_cache.remove(&m);
+        affected_modules_cache.insert(m, invalidate_key);
+      }
+    }
+  }
+  let more_affected_modules: Vec<_> = modules_without_cache
+    .into_par_iter()
+    .map(|module_identifier| {
+      let module = module_graph
+        .module_by_identifier(&module_identifier)
+        .expect("should have module");
+      let invalidate_key =
+        UnaffectedModuleCache::create_module_graph_invalidate_key(&module_graph, module.as_ref());
+      (module_identifier, invalidate_key)
+    })
+    .collect();
+  affected_modules_cache.extend(more_affected_modules);
+  let mut direct_affected_modules = IdentifierSet::default();
+  let mut transitive_affected_modules = IdentifierSet::default();
+  let mut all_affected_modules = IdentifierSet::from_iter(affected_modules_cache.keys().copied());
+  for (&module_identifier, &invalidate_key) in affected_modules_cache.iter() {
+    modules_cache.insert_cache(
+      module_identifier,
+      UnaffectedModuleCache::new(invalidate_key),
+    );
+    for (referencing_module, connections) in
+      module_graph.get_incoming_connections_by_origin_module(&module_identifier)
+    {
+      let Some(referencing_module) = referencing_module else {
+        continue;
+      };
+      if all_affected_modules.contains(&referencing_module) {
+        continue;
+      }
+      match reduce_affect_type(&module_graph, &connections) {
+        AffectType::False => continue,
+        AffectType::True => {
+          direct_affected_modules.insert(referencing_module);
+        }
+        AffectType::Transitive => {
+          transitive_affected_modules.insert(referencing_module);
+        }
+      };
+      modules_cache.affect_cache(&referencing_module);
+    }
+  }
+  while !transitive_affected_modules.is_empty() {
+    let transitive_affected_modules_current = std::mem::take(&mut transitive_affected_modules);
+    all_affected_modules.extend(transitive_affected_modules_current.iter().copied());
+    for &module_identifier in transitive_affected_modules_current.iter() {
+      for (referencing_module, connections) in
+        module_graph.get_incoming_connections_by_origin_module(&module_identifier)
+      {
+        let Some(referencing_module) = referencing_module else {
+          continue;
+        };
+        if all_affected_modules.contains(&referencing_module) {
+          continue;
+        }
+        match reduce_affect_type(&module_graph, &connections) {
+          AffectType::False => continue,
+          AffectType::True => {
+            direct_affected_modules.insert(referencing_module);
+          }
+          AffectType::Transitive => {
+            transitive_affected_modules.insert(referencing_module);
+          }
+        };
+        modules_cache.affect_cache(&referencing_module);
+      }
+    }
+  }
+  all_affected_modules.extend(direct_affected_modules);
+  all_affected_modules
+}
+
+fn compute_affected_modules_with_chunk_graph(compilation: &Compilation) -> IdentifierSet {
+  let modules_cache = compilation.unaffected_modules_cache.clone();
+  let module_graph = compilation.get_module_graph();
+  let affected_modules: IdentifierMap<u64> = modules_cache
+    .par_iter()
+    .filter_map(|item| {
+      let (module_identifier, cache) = item.pair();
+      let module = module_graph
+        .module_by_identifier(module_identifier)
+        .expect("should have module");
+      let invalidate_key = UnaffectedModuleWithChunkGraphCache::create_chunk_graph_invalidate_key(
+        &compilation.chunk_graph,
+        &module_graph,
+        compilation,
+        module.as_ref(),
+      );
+      if let Some(module_graph_cache) = &cache.with_chunk_graph_cache {
+        if module_graph_cache.chunk_graph_invalidate_key != invalidate_key {
+          Some((*module_identifier, invalidate_key))
+        } else {
+          None
+        }
+      } else {
+        Some((*module_identifier, invalidate_key))
+      }
+    })
+    .collect();
+  for (module_identifier, invalidate_key) in affected_modules.iter() {
+    modules_cache.insert_chunk_graph_cache(
+      module_identifier,
+      UnaffectedModuleWithChunkGraphCache {
+        chunk_graph_invalidate_key: *invalidate_key,
+      },
+    );
+  }
+  IdentifierSet::from_iter(affected_modules.keys().copied())
+}

--- a/crates/rspack_core/src/unaffected_cache/mod.rs
+++ b/crates/rspack_core/src/unaffected_cache/mod.rs
@@ -270,9 +270,7 @@ fn compute_affected_modules_with_module_graph(
           .get_incoming_connections_by_origin_module(&module_identifier)
           .into_iter()
           .filter_map(|(referencing_module, connections)| {
-            let Some(referencing_module) = referencing_module else {
-              return None;
-            };
+            let referencing_module = referencing_module?;
             if all_affected_modules.contains(&referencing_module) {
               return None;
             }

--- a/crates/rspack_plugin_css/src/dependency/compose.rs
+++ b/crates/rspack_plugin_css/src/dependency/compose.rs
@@ -36,6 +36,10 @@ impl Dependency for CssComposeDependency {
   fn span(&self) -> Option<ErrorSpan> {
     Some(self.span)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for CssComposeDependency {

--- a/crates/rspack_plugin_css/src/dependency/export.rs
+++ b/crates/rspack_plugin_css/src/dependency/export.rs
@@ -50,6 +50,10 @@ impl Dependency for CssExportDependency {
       ..Default::default()
     })
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl DependencyTemplate for CssExportDependency {

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -41,6 +41,10 @@ impl Dependency for CssImportDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for CssImportDependency {

--- a/crates/rspack_plugin_css/src/dependency/local_ident.rs
+++ b/crates/rspack_plugin_css/src/dependency/local_ident.rs
@@ -57,6 +57,10 @@ impl Dependency for CssLocalIdentDependency {
       ..Default::default()
     })
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl DependencyTemplate for CssLocalIdentDependency {

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -77,6 +77,10 @@ impl Dependency for CssUrlDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for CssUrlDependency {

--- a/crates/rspack_plugin_extract_css/src/css_dependency.rs
+++ b/crates/rspack_plugin_extract_css/src/css_dependency.rs
@@ -2,8 +2,8 @@ use std::path::PathBuf;
 
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  AsContextDependency, AsDependencyTemplate, ConnectionState, Dependency, DependencyCategory,
-  DependencyId, ModuleDependency, ModuleGraph,
+  AffectType, AsContextDependency, AsDependencyTemplate, ConnectionState, Dependency,
+  DependencyCategory, DependencyId, ModuleDependency, ModuleGraph,
 };
 use rustc_hash::FxHashSet;
 
@@ -116,6 +116,10 @@ impl Dependency for CssDependency {
 
   fn get_layer(&self) -> Option<&rspack_core::ModuleLayer> {
     self.layer.as_ref()
+  }
+
+  fn could_affect_referencing_module(&self) -> AffectType {
+    AffectType::Transitive
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -335,6 +335,10 @@ impl Dependency for CommonJsExportRequireDependency {
       })
       .collect_vec()
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::Transitive
+  }
 }
 
 impl DependencyTemplate for CommonJsExportRequireDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_exports_dependency.rs
@@ -95,6 +95,10 @@ impl Dependency for CommonJsExportsDependency {
       ..Default::default()
     })
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl AsModuleDependency for CommonJsExportsDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -84,6 +84,10 @@ impl Dependency for CommonJsFullRequireDependency {
     }
     vec![ExtendedReferencedExport::Array(self.names.clone())]
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for CommonJsFullRequireDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -53,6 +53,10 @@ impl Dependency for CommonJsRequireDependency {
       .clone()
       .map(|range| ErrorSpan::new(range.start, range.end))
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for CommonJsRequireDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -62,6 +62,10 @@ impl Dependency for CommonJsSelfReferenceDependency {
       vec![ExtendedReferencedExport::Array(self.names.clone())]
     }
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for CommonJsSelfReferenceDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/module_decorator_dependency.rs
@@ -116,4 +116,8 @@ impl Dependency for ModuleDecoratorDependency {
       create_no_exports_referenced()
     }
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -28,6 +28,10 @@ impl Dependency for RequireHeaderDependency {
   fn loc(&self) -> Option<String> {
     Some(self.range.to_string())
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl AsModuleDependency for RequireHeaderDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_resolve_dependency.rs
@@ -60,6 +60,10 @@ impl Dependency for RequireResolveDependency {
   ) -> Vec<ExtendedReferencedExport> {
     vec![]
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for RequireResolveDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/common_js_require_context_dependency.rs
@@ -58,6 +58,10 @@ impl Dependency for CommonJsRequireContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ContextDependency for CommonJsRequireContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_context_dependency.rs
@@ -58,6 +58,10 @@ impl Dependency for ImportContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ContextDependency for ImportContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/import_meta_context_dependency.rs
@@ -53,6 +53,10 @@ impl Dependency for ImportMetaContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ContextDependency for ImportMetaContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/context/require_context_dependency.rs
@@ -53,6 +53,10 @@ impl Dependency for RequireContextDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ContextDependency for RequireContextDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_expression_dependency.rs
@@ -85,12 +85,17 @@ impl Dependency for HarmonyExportExpressionDependency {
       exclude_exports: None,
     })
   }
+
   fn get_module_evaluation_side_effects_state(
     &self,
     _module_graph: &rspack_core::ModuleGraph,
     _module_chain: &mut IdentifierSet,
   ) -> rspack_core::ConnectionState {
     rspack_core::ConnectionState::Bool(false)
+  }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_header_dependency.rs
@@ -36,6 +36,10 @@ impl Dependency for HarmonyExportHeaderDependency {
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::EsmExportHeader
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl DependencyTemplate for HarmonyExportHeaderDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -1337,6 +1337,10 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
       }
     }
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::Transitive
+  }
 }
 
 impl ModuleDependency for HarmonyExportImportedSpecifierDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_specifier_dependency.rs
@@ -64,6 +64,10 @@ impl Dependency for HarmonyExportSpecifierDependency {
   ) -> rspack_core::ConnectionState {
     rspack_core::ConnectionState::Bool(false)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl AsModuleDependency for HarmonyExportSpecifierDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -425,6 +425,10 @@ impl Dependency for HarmonyImportSideEffectDependency {
   ) -> Vec<ExtendedReferencedExport> {
     vec![]
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for HarmonyImportSideEffectDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -335,6 +335,10 @@ impl Dependency for HarmonyImportSpecifierDependency {
     }
     self.get_referenced_exports_in_destructuring(Some(&ids))
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for HarmonyImportSpecifierDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -120,6 +120,10 @@ impl Dependency for ImportDependency {
   ) -> Vec<rspack_core::ExtendedReferencedExport> {
     create_import_dependency_referenced_exports(&self.id, &self.referenced_exports, module_graph)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ImportDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -78,6 +78,10 @@ impl Dependency for ImportEagerDependency {
   ) -> Vec<rspack_core::ExtendedReferencedExport> {
     create_import_dependency_referenced_exports(&self.id, &self.referenced_exports, module_graph)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ImportEagerDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -61,6 +61,10 @@ impl Dependency for ProvideDependency {
       vec![ExtendedReferencedExport::Array(self.ids.clone())]
     }
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ProvideDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_accept.rs
@@ -42,6 +42,10 @@ impl Dependency for ImportMetaHotAcceptDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ImportMetaHotAcceptDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/import_meta_hot_decline.rs
@@ -42,6 +42,10 @@ impl Dependency for ImportMetaHotDeclineDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ImportMetaHotDeclineDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_accept.rs
@@ -42,6 +42,10 @@ impl Dependency for ModuleHotAcceptDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ModuleHotAcceptDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/hmr/module_hot_decline.rs
@@ -42,6 +42,10 @@ impl Dependency for ModuleHotDeclineDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ModuleHotDeclineDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -41,6 +41,10 @@ impl Dependency for WebpackIsIncludedDependency {
   ) -> Vec<ExtendedReferencedExport> {
     vec![]
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for WebpackIsIncludedDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -72,6 +72,10 @@ impl Dependency for PureExpressionDependency {
   ) -> ConnectionState {
     ConnectionState::Bool(false)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl AsModuleDependency for PureExpressionDependency {}

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -59,6 +59,10 @@ impl Dependency for URLDependency {
   fn span(&self) -> Option<ErrorSpan> {
     self.span
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for URLDependency {

--- a/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/worker/mod.rs
@@ -59,6 +59,10 @@ impl Dependency for WorkerDependency {
   ) -> Vec<ExtendedReferencedExport> {
     vec![]
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for WorkerDependency {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -11,9 +11,8 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
+use rspack_util::queue::Queue;
 use swc_core::ecma::atoms::Atom;
-
-use crate::utils::queue::Queue;
 
 struct FlagDependencyExportsProxy<'a> {
   mg: &'a mut ModuleGraph<'a>,

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -11,10 +11,8 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
-use rspack_util::swc::join_atom;
+use rspack_util::{queue::Queue, swc::join_atom};
 use rustc_hash::FxHashMap as HashMap;
-
-use crate::utils::queue::Queue;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum ModuleOrAsyncDependenciesBlock {

--- a/crates/rspack_plugin_javascript/src/utils/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/mod.rs
@@ -1,7 +1,6 @@
 pub mod eval;
 pub mod mangle_exports;
 pub mod object_properties;
-pub(crate) mod queue;
 
 use rspack_core::{ErrorSpan, ModuleType};
 use rspack_error::{DiagnosticKind, TraceableError};

--- a/crates/rspack_plugin_json/src/json_exports_dependency.rs
+++ b/crates/rspack_plugin_json/src/json_exports_dependency.rs
@@ -32,6 +32,10 @@ impl Dependency for JsonExportsDependency {
       ..Default::default()
     })
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::False
+  }
 }
 
 impl AsModuleDependency for JsonExportsDependency {}

--- a/crates/rspack_plugin_lazy_compilation/src/dependency.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/dependency.rs
@@ -47,4 +47,8 @@ impl Dependency for LazyCompilationDependency {
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::LazyImport
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::Transitive
+  }
 }

--- a/crates/rspack_plugin_mf/src/container/container_entry_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_dependency.rs
@@ -50,6 +50,10 @@ impl Dependency for ContainerEntryDependency {
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::Transitive
+  }
 }
 
 impl ModuleDependency for ContainerEntryDependency {

--- a/crates/rspack_plugin_mf/src/container/container_exposed_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/container_exposed_dependency.rs
@@ -39,6 +39,10 @@ impl Dependency for ContainerExposedDependency {
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ContainerExposedDependency {

--- a/crates/rspack_plugin_mf/src/container/fallback_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_dependency.rs
@@ -37,6 +37,10 @@ impl Dependency for FallbackDependency {
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::Transitive
+  }
 }
 
 impl ModuleDependency for FallbackDependency {

--- a/crates/rspack_plugin_mf/src/container/fallback_item_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_item_dependency.rs
@@ -30,6 +30,10 @@ impl Dependency for FallbackItemDependency {
   fn dependency_type(&self) -> &DependencyType {
     &DependencyType::RemoteToFallbackItem
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for FallbackItemDependency {

--- a/crates/rspack_plugin_mf/src/container/remote_to_external_dependency.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_to_external_dependency.rs
@@ -30,6 +30,10 @@ impl Dependency for RemoteToExternalDependency {
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for RemoteToExternalDependency {

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_fallback_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_fallback_dependency.rs
@@ -30,6 +30,10 @@ impl Dependency for ConsumeSharedFallbackDependency {
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ConsumeSharedFallbackDependency {

--- a/crates/rspack_plugin_mf/src/sharing/provide_for_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_for_shared_dependency.rs
@@ -30,6 +30,10 @@ impl Dependency for ProvideForSharedDependency {
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for ProvideForSharedDependency {

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
@@ -71,6 +71,10 @@ impl Dependency for ProvideSharedDependency {
   fn resource_identifier(&self) -> Option<&str> {
     Some(&self.resource_identifier)
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::Transitive
+  }
 }
 
 impl ModuleDependency for ProvideSharedDependency {

--- a/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
+++ b/crates/rspack_plugin_wasm/src/dependency/wasm_import_dependency.rs
@@ -59,6 +59,10 @@ impl Dependency for WasmImportDependency {
   ) -> Vec<ExtendedReferencedExport> {
     vec![ExtendedReferencedExport::Array(vec![self.name.clone()])]
   }
+
+  fn could_affect_referencing_module(&self) -> rspack_core::AffectType {
+    rspack_core::AffectType::True
+  }
 }
 
 impl ModuleDependency for WasmImportDependency {

--- a/crates/rspack_util/src/lib.rs
+++ b/crates/rspack_util/src/lib.rs
@@ -12,6 +12,7 @@ pub mod identifier;
 pub mod infallible;
 pub mod number_hash;
 pub mod path;
+pub mod queue;
 pub mod size;
 pub mod source_map;
 pub mod swc;

--- a/crates/rspack_util/src/queue.rs
+++ b/crates/rspack_util/src/queue.rs
@@ -2,27 +2,27 @@ use std::{collections::VecDeque, hash::Hash};
 
 use rustc_hash::FxHashSet as HashSet;
 
-pub(crate) struct Queue<T: Hash + PartialEq + Eq + Clone> {
+pub struct Queue<T: Hash + PartialEq + Eq + Clone> {
   q: VecDeque<T>,
   set: HashSet<T>,
 }
 
 impl<T: Hash + PartialEq + Eq + Clone> Queue<T> {
-  pub(crate) fn new() -> Self {
+  pub fn new() -> Self {
     Self {
       q: VecDeque::default(),
       set: HashSet::default(),
     }
   }
 
-  pub(crate) fn enqueue(&mut self, item: T) {
+  pub fn enqueue(&mut self, item: T) {
     if !self.set.contains(&item) {
       self.q.push_back(item.clone());
       self.set.insert(item);
     }
   }
 
-  pub(crate) fn dequeue(&mut self) -> Option<T> {
+  pub fn dequeue(&mut self) -> Option<T> {
     if let Some(item) = self.q.pop_front() {
       self.set.remove(&item);
       return Some(item);

--- a/crates/rspack_util/src/queue.rs
+++ b/crates/rspack_util/src/queue.rs
@@ -7,6 +7,12 @@ pub struct Queue<T: Hash + PartialEq + Eq + Clone> {
   set: HashSet<T>,
 }
 
+impl<T: Hash + PartialEq + Eq + Clone> Default for Queue<T> {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
 impl<T: Hash + PartialEq + Eq + Clone> Queue<T> {
   pub fn new() -> Self {
     Self {

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -27,6 +27,7 @@ Object {
         "force": true,
         "version": "$version$",
       },
+      "newIncremental": false,
     },
     "topLevelAwait": true,
   },

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -3480,18 +3480,21 @@ const experiments_2: z.ZodObject<{
             version?: string | undefined;
             bundler?: string | undefined;
         }>>;
+        newIncremental: z.ZodOptional<z.ZodBoolean>;
     }, "strict", z.ZodTypeAny, {
         bundlerInfo?: {
             force?: boolean | ("version" | "uniqueId")[] | undefined;
             version?: string | undefined;
             bundler?: string | undefined;
         } | undefined;
+        newIncremental?: boolean | undefined;
     }, {
         bundlerInfo?: {
             force?: boolean | ("version" | "uniqueId")[] | undefined;
             version?: string | undefined;
             bundler?: string | undefined;
         } | undefined;
+        newIncremental?: boolean | undefined;
     }>>;
 }, "strict", z.ZodTypeAny, {
     css?: boolean | undefined;
@@ -3525,6 +3528,7 @@ const experiments_2: z.ZodObject<{
             version?: string | undefined;
             bundler?: string | undefined;
         } | undefined;
+        newIncremental?: boolean | undefined;
     } | undefined;
 }, {
     css?: boolean | undefined;
@@ -3558,6 +3562,7 @@ const experiments_2: z.ZodObject<{
             version?: string | undefined;
             bundler?: string | undefined;
         } | undefined;
+        newIncremental?: boolean | undefined;
     } | undefined;
 }>;
 
@@ -10224,18 +10229,21 @@ const rspackFutureOptions: z.ZodObject<{
         version?: string | undefined;
         bundler?: string | undefined;
     }>>;
+    newIncremental: z.ZodOptional<z.ZodBoolean>;
 }, "strict", z.ZodTypeAny, {
     bundlerInfo?: {
         force?: boolean | ("version" | "uniqueId")[] | undefined;
         version?: string | undefined;
         bundler?: string | undefined;
     } | undefined;
+    newIncremental?: boolean | undefined;
 }, {
     bundlerInfo?: {
         force?: boolean | ("version" | "uniqueId")[] | undefined;
         version?: string | undefined;
         bundler?: string | undefined;
     } | undefined;
+    newIncremental?: boolean | undefined;
 }>;
 
 // @public (undocumented)
@@ -11158,18 +11166,21 @@ export const rspackOptions: z.ZodObject<{
                 version?: string | undefined;
                 bundler?: string | undefined;
             }>>;
+            newIncremental: z.ZodOptional<z.ZodBoolean>;
         }, "strict", z.ZodTypeAny, {
             bundlerInfo?: {
                 force?: boolean | ("version" | "uniqueId")[] | undefined;
                 version?: string | undefined;
                 bundler?: string | undefined;
             } | undefined;
+            newIncremental?: boolean | undefined;
         }, {
             bundlerInfo?: {
                 force?: boolean | ("version" | "uniqueId")[] | undefined;
                 version?: string | undefined;
                 bundler?: string | undefined;
             } | undefined;
+            newIncremental?: boolean | undefined;
         }>>;
     }, "strict", z.ZodTypeAny, {
         css?: boolean | undefined;
@@ -11203,6 +11214,7 @@ export const rspackOptions: z.ZodObject<{
                 version?: string | undefined;
                 bundler?: string | undefined;
             } | undefined;
+            newIncremental?: boolean | undefined;
         } | undefined;
     }, {
         css?: boolean | undefined;
@@ -11236,6 +11248,7 @@ export const rspackOptions: z.ZodObject<{
                 version?: string | undefined;
                 bundler?: string | undefined;
             } | undefined;
+            newIncremental?: boolean | undefined;
         } | undefined;
     }>>;
     externals: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
@@ -13267,6 +13280,7 @@ export const rspackOptions: z.ZodObject<{
                 version?: string | undefined;
                 bundler?: string | undefined;
             } | undefined;
+            newIncremental?: boolean | undefined;
         } | undefined;
     } | undefined;
     externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
@@ -13840,6 +13854,7 @@ export const rspackOptions: z.ZodObject<{
                 version?: string | undefined;
                 bundler?: string | undefined;
             } | undefined;
+            newIncremental?: boolean | undefined;
         } | undefined;
     } | undefined;
     externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -897,9 +897,11 @@ function getRawExperiments(
 }
 
 function getRawRspackFutureOptions(
-	_future: RspackFutureOptions
+	future: RspackFutureOptions
 ): RawRspackFuture {
-	return {};
+	return {
+		newIncremental: future.newIncremental!
+	};
 }
 
 function getRawNode(node: Node): RawOptions["node"] {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -204,6 +204,9 @@ const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
 	// IGNORE(experiments.rspackFuture): Rspack specific configuration
 	D(experiments, "rspackFuture", {});
 	// rspackFuture.bundlerInfo default value is applied after applyDefaults
+	if (typeof experiments.rspackFuture === "object") {
+		D(experiments.rspackFuture, "newIncremental", false);
+	}
 };
 
 const applybundlerInfoDefaults = (

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1325,7 +1325,8 @@ const rspackFutureOptions = z.strictObject({
 				.or(z.array(z.enum(["version", "uniqueId"])))
 				.optional()
 		})
-		.optional()
+		.optional(),
+	newIncremental: z.boolean().optional()
 });
 export type RspackFutureOptions = z.infer<typeof rspackFutureOptions>;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

add `experiments.rspackFuture.newIncremental` for cache unaffected, we need more test to stabilize it, and this is not intend to let users aware this options for now.

- In 9000 case, codegen phase is ~200ns after enable this, before is 10ms, most of time is spend on cache key compare and cache read

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
