### PR TITLE
fix: wrong `builtin:swc-loader` source maps if `inputSourceMap` is provided

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,9 +4769,9 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "0.283.0"
+version = "0.284.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb7fe4bd6a604528819c84fc9acc5d5ec1b3bd0d11d13ee5d8a77d49ff678fa"
+checksum = "833bb7f4073f08aec7144619a2cf682413b7a0cc8f21b7e76abd2fd02373685d"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4863,9 +4863,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.37.2"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46741b5a4ff3e821f6bb8d6c1289549272e71a5e0d163dbbae9e16e771d8da76"
+checksum = "70265894dfc70e4f01475d3fd11ddfcd25fae781d7352d1228168072ee6a0a40"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4895,9 +4895,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "0.16.0"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b47fac27c2e84e033bdea294ac12f575322c81c9d5d44f423e3f11ff239a86"
+checksum = "9859d605bfa3ba8323f37bc4f51839c0e21ea59b657f65865388b0adfeb0a413"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4948,9 +4948,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.100.7"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ff548cf185b9bb1ddaff5e5c74c1b79fb06b5f5e6f34a80d0faab211cb9972"
+checksum = "62adeea9d9da142eed5b068eadf67d6ed41bef898465f735c74f5e94f39aed5f"
 dependencies = [
  "swc",
  "swc_allocator",
@@ -5277,9 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.201.0"
+version = "0.203.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d75a42254926bad8b7fa9390767a18ac608d99cfd5a3be675e4739c2cf7db1b"
+checksum = "e13ee1a0975dc79d2cb23456bf45c7862b61f9a8890ade3025af8dc728e730db"
 dependencies = [
  "arrayvec",
  "indexmap 2.2.6",
@@ -5335,9 +5335,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "0.214.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85162c77f8c80b55e5aed3a5e5477b74a53ce9cca05dec6e3dabec1de0f49af"
+checksum = "e5c01c4097d54b6992d926474546472f10f1f94799a6eb9b70176fc33e778573"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -5377,9 +5377,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "0.236.0"
+version = "0.238.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d289a83ab829d076d6c2bf2cc0beea7fbf0480ac47a415401f683181a65f4856"
+checksum = "d6a33679b1611630ee41f8ee8b41b9587de4171819698d313f7f8ae2c699f41a"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -5483,9 +5483,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "0.187.0"
+version = "0.189.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc022be297cdc70d5e71720587c7e810401a958577d77830f3108411e73c466d"
+checksum = "2b5bddea322502ce309f77b76dcd7994ff700fbba7caf9d12eb6fb7ef98ecd1b"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -5510,9 +5510,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.205.0"
+version = "0.207.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17446e46b75654901d962251ec4d0063423ee81759a325ed82fcf073308d97ca"
+checksum = "fc9b6dcb79ac6f396988c13ce2f782116aeb92e8ee77656072d1146697f66022"
 dependencies = [
  "dashmap 5.5.3",
  "indexmap 2.2.6",
@@ -5535,9 +5535,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "0.178.0"
+version = "0.178.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7ddb3aae86f19eb9e41b0c62509d8e400c1dc79c0889df98f6df1ab893f3f"
+checksum = "b252ea08cfd11e434f4c625ec95493e06c8b000b50eb8e908d76f3325dd5dfa8"
 dependencies = [
  "either",
  "rustc-hash 1.1.0",
@@ -5580,9 +5580,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "0.195.1"
+version = "0.197.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f814b32ec83fde097df19e7346c429825390d156d0015f321f1f6434b6a06c0c"
+checksum = "19b5f73e9996c6f374c05ff724afea6e6b5de03253ef856c321ff47f23717b5e"
 dependencies = [
  "ryu-js",
  "serde",
@@ -5685,9 +5685,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "0.146.1"
+version = "0.148.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d32f3d3a03a287d7038f055200ba417d0476914e4df5d5330c46a29ee718acd"
+checksum = "706509020207c5e4dc17e9c6c3adcec901ec5e0d06314050643c3efce8be7fb7"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -5737,9 +5737,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "0.143.1"
+version = "0.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ed3ec02741044a5f528c3e390cfd9d46bb0954217ffee0bc5f7ff483bac794c"
+checksum = "f944d0cf2352767ddee5f65a02c73dadcd2050a75eab8bee45a30f80b318199f"
 dependencies = [
  "once_cell",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,11 +73,11 @@ napi-derive = { version = "2" }
 # Must be pinned with the same swc versions
 #rkyv                = { version = "=0.7.44" }                           # synced with swc wasm plugin
 swc_config          = { version = "=0.1.15" }
-swc_core            = { version = "=0.100.7", default-features = false }
-swc_ecma_minifier   = { version = "=0.201.0", default-features = false }
+swc_core            = { version = "=0.101.4", default-features = false }
+swc_ecma_minifier   = { version = "=0.203.1", default-features = false }
 swc_error_reporters = { version = "=0.21.0" }
-swc_html            = { version = "=0.146.1" }
-swc_html_minifier   = { version = "=0.143.1", default-features = false }
+swc_html            = { version = "=0.148.0" }
+swc_html_minifier   = { version = "=0.145.0", default-features = false }
 swc_node_comments   = { version = "=0.24.0" }
 
 

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/a.jsx
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/a.jsx
@@ -1,0 +1,17 @@
+export function a0() {
+  a2('*a0*')
+  return <view></view>
+}
+
+function A1() {
+  return <view>{'*a1*'}</view>
+}
+
+export function a2() {
+  return (
+    <view>
+      <A1 bar={'*a2*'} />
+    </view>
+  )
+}
+

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/index.js
@@ -1,0 +1,28 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+const checkMap = __non_webpack_require__("../../../../../dist/helper/util/checkSourceMap.js").default;
+
+import "./a"
+
+const source = fs.readFileSync(__filename + ".map", "utf-8");
+const map = JSON.parse(source);
+const output = fs.readFileSync(__filename, "utf-8");
+const input = fs.readFileSync(path.resolve(CONTEXT, "a.jsx"), "utf-8");
+
+it("should keep the original content with `devtool: \"cheap-module-source-map\"` enabled", () => {
+	expect(map.sources).toEqual([
+		"webpack:///./a.jsx",
+		"webpack:///./index.js",
+	]);
+	expect(map.sourcesContent[0]).toEqual(input)
+})
+it("should keep the mappings to the original content", async () => {
+	// does not checking columns for cheap source-map
+	const CHECK_COLUMN = false;
+	expect(await checkMap(output, source, {
+		"'*a0*'": "webpack:///a.jsx",
+		"'*a1*'": "webpack:///a.jsx",
+		"'*a2*'": "webpack:///a.jsx",
+	}, CHECK_COLUMN)).toBe(true)
+})
+

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/prev-loader.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/prev-loader.js
@@ -1,0 +1,45 @@
+/** @type {import("@rspack/core").LoaderDefinition} */
+module.exports = function() {
+	// Return the pre-transformed code and sourcemap
+	this.callback(null, `export function a0() {
+  a2('*a0*');
+  return /*#__PURE__*/React.createElement("view", null);
+}
+function A1() {
+  return /*#__PURE__*/React.createElement("view", null, '*a1*');
+}
+export function a2() {
+  return /*#__PURE__*/React.createElement("view", null, /*#__PURE__*/React.createElement(A1, {
+    bar: '*a2*'
+  }));
+}`, {
+  version: 3,
+  file: undefined,
+  names: [ 'a0', 'a2', 'React', 'createElement', 'A1', 'bar' ],
+  sourceRoot: undefined,
+  sources: [
+    this.resourcePath
+  ],
+  sourcesContent: [
+    'export function a0() {\n' +
+      "  a2('*a0*')\n" +
+      '  return <view></view>\n' +
+      '}\n' +
+      '\n' +
+      'function A1() {\n' +
+      "  return <view>{'*a1*'}</view>\n" +
+      '}\n' +
+      '\n' +
+      'export function a2() {\n' +
+      '  return (\n' +
+      '    <view>\n' +
+      "      <A1 bar={'*a2*'} />\n" +
+      '    </view>\n' +
+      '  )\n' +
+      '}\n' +
+      '\n'
+  ],
+  mappings: 'AAAA,OAAO,SAASA,EAAEA,CAAA,EAAG;EACnBC,EAAE,CAAC,MAAM,CAAC;EACV,oBAAOC,KAAA,CAAAC,aAAA,aAAY,CAAC;AACtB;AAEA,SAASC,EAAEA,CAAA,EAAG;EACZ,oBAAOF,KAAA,CAAAC,aAAA,eAAO,MAAa,CAAC;AAC9B;AAEA,OAAO,SAASF,EAAEA,CAAA,EAAG;EACnB,oBACEC,KAAA,CAAAC,aAAA,4BACED,KAAA,CAAAC,aAAA,CAACC,EAAE;IAACC,GAAG,EAAE;EAAO,CAAE,CACd,CAAC;AAEX',
+  ignoreList: []
+})
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-cheap-module/rspack.config.js
@@ -1,0 +1,31 @@
+const { DefinePlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: "cheap-module-source-map",
+	resolve: {
+		extensions: ["...", ".jsx"]
+	},
+	module: {
+		rules: [
+			{
+				test: /a\.jsx$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							sourceMap: true
+						}
+					},
+					"./prev-loader"
+				]
+			}
+		]
+	},
+	plugins: [
+		new DefinePlugin({
+			CONTEXT: JSON.stringify(__dirname)
+		})
+	]
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/a.jsx
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/a.jsx
@@ -1,0 +1,17 @@
+export function a0() {
+  a2('*a0*')
+  return <view></view>
+}
+
+function A1() {
+  return <view>{'*a1*'}</view>
+}
+
+export function a2() {
+  return (
+    <view>
+      <A1 bar={'*a2*'} />
+    </view>
+  )
+}
+

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/index.js
@@ -1,0 +1,27 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+const checkMap = __non_webpack_require__("../../../../../dist/helper/util/checkSourceMap.js").default;
+
+import "./a"
+
+const source = fs.readFileSync(__filename + ".map", "utf-8");
+const map = JSON.parse(source);
+const output = fs.readFileSync(__filename, "utf-8");
+const input = fs.readFileSync(path.resolve(CONTEXT, "a.jsx"), "utf-8");
+
+it("should keep the original content with `devtool: \"source-map\"` enabled", () => {
+	expect(map.sources).toEqual([
+		"webpack:///./a.jsx",
+		"webpack:///./index.js",
+	]);
+	expect(map.sourcesContent[0]).toEqual(input)
+})
+
+it("should keep the mappings to the original content", async () => {
+	expect(await checkMap(output, source, {
+		"'*a0*'": "webpack:///a.jsx",
+		"'*a1*'": "webpack:///a.jsx",
+		"'*a2*'": "webpack:///a.jsx",
+	})).toBe(true)
+})
+

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/prev-loader.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/prev-loader.js
@@ -1,0 +1,45 @@
+/** @type {import("@rspack/core").LoaderDefinition} */
+module.exports = function() {
+	// Return the pre-transformed code and sourcemap
+	this.callback(null, `export function a0() {
+  a2('*a0*');
+  return /*#__PURE__*/React.createElement("view", null);
+}
+function A1() {
+  return /*#__PURE__*/React.createElement("view", null, '*a1*');
+}
+export function a2() {
+  return /*#__PURE__*/React.createElement("view", null, /*#__PURE__*/React.createElement(A1, {
+    bar: '*a2*'
+  }));
+}`, {
+  version: 3,
+  file: undefined,
+  names: [ 'a0', 'a2', 'React', 'createElement', 'A1', 'bar' ],
+  sourceRoot: undefined,
+  sources: [
+    this.resourcePath
+  ],
+  sourcesContent: [
+    'export function a0() {\n' +
+      "  a2('*a0*')\n" +
+      '  return <view></view>\n' +
+      '}\n' +
+      '\n' +
+      'function A1() {\n' +
+      "  return <view>{'*a1*'}</view>\n" +
+      '}\n' +
+      '\n' +
+      'export function a2() {\n' +
+      '  return (\n' +
+      '    <view>\n' +
+      "      <A1 bar={'*a2*'} />\n" +
+      '    </view>\n' +
+      '  )\n' +
+      '}\n' +
+      '\n'
+  ],
+  mappings: 'AAAA,OAAO,SAASA,EAAEA,CAAA,EAAG;EACnBC,EAAE,CAAC,MAAM,CAAC;EACV,oBAAOC,KAAA,CAAAC,aAAA,aAAY,CAAC;AACtB;AAEA,SAASC,EAAEA,CAAA,EAAG;EACZ,oBAAOF,KAAA,CAAAC,aAAA,eAAO,MAAa,CAAC;AAC9B;AAEA,OAAO,SAASF,EAAEA,CAAA,EAAG;EACnB,oBACEC,KAAA,CAAAC,aAAA,4BACED,KAAA,CAAAC,aAAA,CAACC,EAAE;IAACC,GAAG,EAAE;EAAO,CAAE,CACd,CAAC;AAEX',
+  ignoreList: []
+})
+}

--- a/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtin-swc-loader/input-source-map-module/rspack.config.js
@@ -1,0 +1,31 @@
+const { DefinePlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	devtool: "source-map",
+	resolve: {
+		extensions: ["...", ".jsx"]
+	},
+	module: {
+		rules: [
+			{
+				test: /a\.jsx$/,
+				use: [
+					{
+						loader: "builtin:swc-loader",
+						options: {
+							sourceMap: true
+						}
+					},
+					"./prev-loader"
+				]
+			}
+		]
+	},
+	plugins: [
+		new DefinePlugin({
+			CONTEXT: JSON.stringify(__dirname)
+		})
+	]
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Synced upstream SWC source map fix.

> [!NOTE]
> Wasm plugins are not being broken as this upgrade does not contain a breaking AST change according to https://swc.rs/docs/plugin/selecting-swc-core

Added `inputSourceMap` test to avoid it being broken again.

closes https://github.com/web-infra-dev/rspack/issues/7636

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
