### PR TITLE
fix: rslib link should be its github repo

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -100,7 +100,7 @@ If you need to migrate from an existing project to Rspack or Rsbuild, you can re
 There are already some Rspack-based toolchains in the community:
 
 - If you want to build a static site, you can try [Rspress](https://rspress.dev).
-- If you want to build a library or UI component, you can try [Rslib](https://rspress.dev).
+- If you want to build a library or UI component, you can try [Rslib](https://github.com/web-infra-dev/rslib).
 - If you want to analyze the build process and build artifacts, you can try [Rsdoctor](https://rsdoctor.dev).
 - If you're looking for a full-stack React framework, you can try [Modern.js](https://modernjs.dev/en/).
 - If you want a fast and production-ready setup that works in a monorepo, you can try [Nx](https://nx.dev).

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -105,7 +105,7 @@ npm init -y
 社区中已经有一些基于 Rspack 的工具链：
 
 - 如果你需要开发一个静态站点（如文档站），可以尝试 [Rspress](https://rspress.dev)。
-- 如果你需要开发一个工具库或组件库，可以尝试 [Rslib](https://rspress.dev)。
+- 如果你需要开发一个工具库或组件库，可以尝试 [Rslib](https://github.com/web-infra-dev/rslib)。
 - 如果你需要分析构建过程和构建产物，可以尝试 [Rsdoctor](https://rsdoctor.dev)。
 - 如果你需要一个 React 全栈框架来构建 Web 应用，可以尝试 [Modern.js](https://modernjs.dev/)。
 - 如果你需要在 Monorepo 中使用 Rspack，打造快速、可扩展的构建系统，可以尝试 [Nx](https://nx.dev)。


### PR DESCRIPTION
## Summary
Rslib 的链接应该是它的 github 主页

## Checklist
- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
