### PR TITLE
fix(mf2): initializeSharingInitTokens should be object

### DIFF
--- a/packages/rspack/src/container/default.runtime.js
+++ b/packages/rspack/src/container/default.runtime.js
@@ -41,7 +41,7 @@ module.exports = function () {
 			{};
 		const consumesLoadinginstalledModules = {};
 		const initializeSharingInitPromises = [];
-		const initializeSharingInitTokens = [];
+		const initializeSharingInitTokens = {};
 		const containerShareScope =
 			__webpack_require__.initializeExposesData?.shareScope;
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
initializeSharingInitTokens should be object
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
