### PR TITLE
fix: should resolve aliased loader module with query

### DIFF
--- a/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   BoxLoader, Context, Loader, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, ResolveResult,
-  Resolver, RunnerContext, BUILTIN_LOADER_PREFIX,
+  Resolver, Resource, RunnerContext, BUILTIN_LOADER_PREFIX,
 };
 use rspack_error::{error, Result};
 use rspack_hook::plugin_hook;
@@ -104,19 +104,30 @@ pub(crate) async fn resolve_loader(
 
   match resolve_result {
     ResolveResult::Resource(resource) => {
-      let path = resource.path.as_str();
+      let Resource {
+        path,
+        query,
+        description_data,
+        ..
+      } = resource;
+
       let r#type = if path.ends_with(".mjs") {
         Some("module")
       } else if path.ends_with(".cjs") {
         Some("commonjs")
       } else {
-        resource
-          .description_data
+        description_data
           .as_ref()
           .and_then(|data| data.json().get("type").and_then(|t| t.as_str()))
       };
-      // TODO: Should move this logic to `resolver`, since `resolve.alias` may contain query or fragment too.
-      let resource = resource.path.as_str().to_owned() + rest.unwrap_or_default();
+      // favor explicit loader query over aliased query, see webpack issue-3320
+      let resource = if let Some(rest) = rest
+        && !rest.is_empty()
+      {
+        format!("{path}{rest}")
+      } else {
+        format!("{path}{query}")
+      };
       let ident = if let Some(ty) = r#type {
         format!("{ty}|{resource}")
       } else {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -620,8 +620,10 @@ pub struct FuncUseCtx {
 #[derive(Debug, Clone)]
 pub struct ModuleRuleUseLoader {
   /// Loader identifier with query and fragments
+  /// Loader ident or query will be appended if it exists.
   pub loader: String,
   /// Loader options
+  /// This only exists if the loader is a built-in loader.
   pub options: Option<String>,
 }
 

--- a/tests/webpack-test/configCases/loaders/issue-3320/index.js
+++ b/tests/webpack-test/configCases/loaders/issue-3320/index.js
@@ -1,9 +1,8 @@
-// Webpack supports this, but Rspack does not support `resolve.alias` with a custom query and fragment
-// it.skip("should resolve aliased loader module with query", function() {
-// 	var foo = require('./a');
+it("should resolve aliased loader module with query", function() {
+	var foo = require('./a');
 
-// 	expect(foo).toBe("someMessage");
-// });
+	expect(foo).toBe("someMessage");
+});
 
 it("should favor explicit loader query over aliased query (options in rule)", function() {
 	var foo = require('./b');


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support resolving loader alias with query.

With configs:
```js
resolveLoader: {
  alias: {
    "some-loader": "any-loader?foo=someMessage"
  }
}
```

**Previously**

Loader requests to `"some-loader"` will be resolved to `"any-loader"`, but leaves its query as empty if nothing is passed to `"some-loader"` in the first place.

**Currently**

If any module requested for `"some-loader"`, `"any-loader"` with query written in `resolve.alias` will be passed in as an option when explicit options are not provided to `"some-loader"`. If there's nothing provided by alias value, then queries provided to `"some-loader"` will be used instead. Check out the test for detail.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
