### PR TITLE
fix: `Path` pitfall for loader type

### DIFF
--- a/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
@@ -111,15 +111,19 @@ pub(crate) async fn resolve_loader(
         ..
       } = resource;
 
-      let r#type = if path.ends_with(".mjs") {
-        Some("module")
-      } else if path.ends_with(".cjs") {
-        Some("commonjs")
-      } else {
-        description_data
-          .as_ref()
-          .and_then(|data| data.json().get("type").and_then(|t| t.as_str()))
-      };
+      let r#type = path
+        .extension()
+        .and_then(|extension| match extension {
+          "mjs" => Some("module"),
+          "cjs" => Some("commonjs"),
+          _ => None,
+        })
+        .or_else(|| {
+          description_data
+            .as_ref()
+            .and_then(|data| data.json().get("type").and_then(|t| t.as_str()))
+        });
+
       // favor explicit loader query over aliased query, see webpack issue-3320
       let resource = if let Some(rest) = rest
         && !rest.is_empty()

--- a/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
@@ -110,20 +110,20 @@ pub(crate) async fn resolve_loader(
         description_data,
         ..
       } = resource;
+      // Pitfall: `PathBuf::ends_with` is different from `str::ends_with`
+      // So we need to convert `PathBuf` to `&str`
+      // Use `str::ends_with` instead of `PathBuf::ends_with` to avoid unnecessary allocation
+      let path = path.as_str();
 
-      let r#type = path
-        .extension()
-        .and_then(|extension| match extension {
-          "mjs" => Some("module"),
-          "cjs" => Some("commonjs"),
-          _ => None,
-        })
-        .or_else(|| {
-          description_data
-            .as_ref()
-            .and_then(|data| data.json().get("type").and_then(|t| t.as_str()))
-        });
-
+      let r#type = if path.ends_with(".mjs") {
+        Some("module")
+      } else if path.ends_with(".cjs") {
+        Some("commonjs")
+      } else {
+        description_data
+          .as_ref()
+          .and_then(|data| data.json().get("type").and_then(|t| t.as_str()))
+      };
       // favor explicit loader query over aliased query, see webpack issue-3320
       let resource = if let Some(rest) = rest
         && !rest.is_empty()

--- a/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
@@ -112,7 +112,7 @@ pub(crate) async fn resolve_loader(
       } = resource;
       // Pitfall: `PathBuf::ends_with` is different from `str::ends_with`
       // So we need to convert `PathBuf` to `&str`
-      // Use `str::ends_with` instead of `PathBuf::ends_with` to avoid unnecessary allocation
+      // Use `str::ends_with` instead of `PathBuf::extension` to avoid unnecessary allocation
       let path = path.as_str();
 
       let r#type = if path.ends_with(".mjs") {

--- a/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
@@ -110,9 +110,9 @@ pub(crate) async fn resolve_loader(
         description_data,
         ..
       } = resource;
-      // Pitfall: `PathBuf::ends_with` is different from `str::ends_with`
+      // Pitfall: `Path::ends_with` is different from `str::ends_with`
       // So we need to convert `PathBuf` to `&str`
-      // Use `str::ends_with` instead of `PathBuf::extension` to avoid unnecessary allocation
+      // Use `str::ends_with` instead of `Path::extension` to avoid unnecessary allocation
       let path = path.as_str();
 
       let r#type = if path.ends_with(".mjs") {

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -105,7 +105,9 @@ function createLoaderObject(
 				obj.ident = ident;
 			}
 
-			obj.type = value.type;
+			// CHANGE: `rspack_core` returns empty string for `undefined` type.
+			// Comply to webpack test case: tests/webpack-test/cases/loaders/cjs-loader-type/index.js
+			obj.type = value.type === "" ? undefined : value.type;
 			if (obj.options === null) obj.query = "";
 			else if (obj.options === undefined) obj.query = "";
 			else if (typeof obj.options === "string") obj.query = `?${obj.options}`;

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/index.js
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/index.js
@@ -1,0 +1,15 @@
+it("should pass package.json type to loader", function () {
+	expect(require("cjs/loader.js!")).toBe("commonjs");
+	expect(require("./loader.js!")).toBe("undefined");
+});
+
+it("should pass 'commonjs' type to loader for .cjs", function () {
+	expect(require("cjs/loader.cjs!")).toBe("commonjs");
+	expect(require("./loader.cjs!")).toBe("commonjs");
+	// ORIGINAL WEBPACK COMMENT: TODO need fix in v8 https://github.com/nodejs/node/issues/35889
+	// ORIGINAL WEBPACK COMMENT: TODO otherwise this test case cause segment fault
+	// Turned on this as rspack checks extensions for loader type.
+	// So this will not fall into dynamic import which causes segment fault.
+	// See: crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+	expect(require("esm/loader.cjs!")).toBe("commonjs");
+});

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/loader.cjs
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/loader.cjs
@@ -1,0 +1,4 @@
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader() {
+	return `module.exports = "${this.loaders[this.loaderIndex].type}";`;
+};

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/loader.js
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/loader.js
@@ -1,0 +1,4 @@
+/** @type {import("../../../../").LoaderDefinition} */
+module.exports = function loader() {
+	return `module.exports = "${this.loaders[this.loaderIndex].type}";`;
+};

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/cjs/loader.cjs
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/cjs/loader.cjs
@@ -1,0 +1,4 @@
+/** @type {import("../../../../../../").LoaderDefinition} */
+module.exports = function loader() {
+	return `module.exports = "${this.loaders[this.loaderIndex].type}";`;
+};

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/cjs/loader.js
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/cjs/loader.js
@@ -1,0 +1,4 @@
+/** @type {import("../../../../../../").LoaderDefinition} */
+module.exports = function loader() {
+	return `module.exports = "${this.loaders[this.loaderIndex].type}";`;
+};

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/cjs/package.json
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/cjs/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cjs-package",
+  "type": "commonjs"
+}

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/esm/loader.cjs
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/esm/loader.cjs
@@ -1,0 +1,4 @@
+/** @type {import("../../../../../../").LoaderDefinition} */
+module.exports = function loader() {
+	return `module.exports = "${this.loaders[this.loaderIndex].type}";`;
+};

--- a/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/esm/package.json
+++ b/tests/webpack-test/cases/loaders/cjs-loader-type/node_modules/esm/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "esm-package",
+  "type": "module"
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

There's an pitfall for [`Path::ends_with`](https://doc.rust-lang.org/std/path/struct.PathBuf.html#method.ends_with). It only matches by components. We need to either convert to `&str` or use `Path::extension`.

Use `Path::as_str` to match extensions instead of `Path::extension` for performance. The second one analyzes `components` first.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
