### PR TITLE
fix(create-rspack): should not replace plugin-react-refresh version

### DIFF
--- a/packages/create-rspack/index.js
+++ b/packages/create-rspack/index.js
@@ -89,6 +89,13 @@ function copyFolder(src, dst, targetDir) {
 		_gitignore: ".gitignore"
 	};
 
+	// replace workspace packages with version in package.json
+	const workspacePackages = [
+		"@rspack/cli",
+		"@rspack/core",
+		"@rspack/dev-server"
+	];
+
 	fs.mkdirSync(dst, { recursive: true });
 	for (const file of fs.readdirSync(src)) {
 		if (file === "node_modules") {
@@ -107,14 +114,14 @@ function copyFolder(src, dst, targetDir) {
 				const pkg = require(srcFile);
 				if (pkg.dependencies) {
 					for (const key of Object.keys(pkg.dependencies)) {
-						if (key.startsWith("@rspack/")) {
+						if (workspacePackages.includes(key)) {
 							pkg.dependencies[key] = version;
 						}
 					}
 				}
 				if (pkg.devDependencies) {
 					for (const key of Object.keys(pkg.devDependencies)) {
-						if (key.startsWith("@rspack/")) {
+						if (workspacePackages.includes(key)) {
 							pkg.devDependencies[key] = version;
 						}
 					}


### PR DESCRIPTION


## Summary

`create-rspack` should not replace the `plugin-react-refresh` version, this package has been moved to a separate repo and does not use the same version of `@rspack/core`.

Fix: 

<img width="1144" alt="Screenshot 2024-08-26 at 10 44 35" src="https://github.com/user-attachments/assets/337361b1-36ab-4253-b824-f2e2ad6ecdfb">


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
