### PR TITLE
refactor: use trait for dependencyConditionFn for better cacheable

### DIFF
--- a/crates/rspack_core/src/dependency/mod.rs
+++ b/crates/rspack_core/src/dependency/mod.rs
@@ -137,16 +137,19 @@ impl From<Vec<ReferencedExport>> for ExportsReferencedType {
   }
 }
 
-pub type DependencyConditionFn = Arc<
-  dyn Fn(&ModuleGraphConnection, Option<&RuntimeSpec>, &ModuleGraph) -> ConnectionState
-    + Send
-    + Sync,
->;
+pub trait DependencyConditionFn: Sync + Send {
+  fn get_connection_state(
+    &self,
+    conn: &ModuleGraphConnection,
+    runtime: Option<&RuntimeSpec>,
+    module_graph: &ModuleGraph,
+  ) -> ConnectionState;
+}
 
 #[derive(Clone)]
 pub enum DependencyCondition {
   False,
-  Fn(DependencyConditionFn),
+  Fn(Arc<dyn DependencyConditionFn>),
 }
 
 impl std::fmt::Debug for DependencyCondition {

--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -17,6 +17,7 @@ use rustc_hash::FxHashSet as HashSet;
 use serde::Serialize;
 
 use crate::Compilation;
+use crate::DependencyConditionFn;
 use crate::{
   property_access, ConnectionState, DependencyCondition, DependencyId, ModuleGraph,
   ModuleIdentifier, Nullable, RuntimeSpec,
@@ -1794,31 +1795,46 @@ pub enum UsedByExports {
   Bool(bool),
 }
 
+#[derive(Clone)]
+pub struct UsedByExportsDependencyCondition {
+  dependency_id: DependencyId,
+  used_by_exports: HashSet<Atom>,
+}
+
+impl DependencyConditionFn for UsedByExportsDependencyCondition {
+  fn get_connection_state(
+    &self,
+    _conn: &crate::ModuleGraphConnection,
+    runtime: Option<&RuntimeSpec>,
+    mg: &ModuleGraph,
+  ) -> ConnectionState {
+    let module_identifier = mg
+      .get_parent_module(&self.dependency_id)
+      .expect("should have parent module");
+    let exports_info = mg.get_exports_info(module_identifier);
+    for export_name in self.used_by_exports.iter() {
+      if exports_info.get_used(mg, UsedName::Str(export_name.clone()), runtime)
+        != UsageState::Unused
+      {
+        return ConnectionState::Bool(true);
+      }
+    }
+    ConnectionState::Bool(false)
+  }
+}
+
 // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/InnerGraph.js#L319-L338
 pub fn get_dependency_used_by_exports_condition(
   dependency_id: DependencyId,
   used_by_exports: Option<&UsedByExports>,
 ) -> Option<DependencyCondition> {
   match used_by_exports {
-    Some(UsedByExports::Set(used_by_exports)) => {
-      let used_by_exports = Arc::new(used_by_exports.clone());
-      Some(DependencyCondition::Fn(Arc::new(
-        move |_, runtime, module_graph: &ModuleGraph| {
-          let module_identifier = module_graph
-            .get_parent_module(&dependency_id)
-            .expect("should have parent module");
-          let exports_info = module_graph.get_exports_info(module_identifier);
-          for export_name in used_by_exports.iter() {
-            if exports_info.get_used(module_graph, UsedName::Str(export_name.clone()), runtime)
-              != UsageState::Unused
-            {
-              return ConnectionState::Bool(true);
-            }
-          }
-          ConnectionState::Bool(false)
-        },
-      )))
-    }
+    Some(UsedByExports::Set(used_by_exports)) => Some(DependencyCondition::Fn(Arc::new(
+      UsedByExportsDependencyCondition {
+        dependency_id,
+        used_by_exports: used_by_exports.clone(),
+      },
+    ))),
     Some(UsedByExports::Bool(bool)) => {
       if *bool {
         None

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1210,7 +1210,7 @@ impl<'a> ModuleGraph<'a> {
       .expect("should have condition");
     match condition {
       DependencyCondition::False => ConnectionState::Bool(false),
-      DependencyCondition::Fn(f) => f(connection, runtime, self),
+      DependencyCondition::Fn(f) => f.get_connection_state(connection, runtime, self),
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -7,9 +7,9 @@ use rspack_core::{
   create_exports_object_referenced, create_no_exports_referenced, filter_runtime, get_exports_type,
   process_export_info, property_access, property_name, string_of_used_name, AsContextDependency,
   Compilation, ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
-  DependencyCondition, DependencyId, DependencyTemplate, DependencyType, ErrorSpan, ExportInfo,
-  ExportInfoProvided, ExportNameOrSpec, ExportPresenceMode, ExportSpec, ExportsInfo,
-  ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
+  DependencyCondition, DependencyConditionFn, DependencyId, DependencyTemplate, DependencyType,
+  ErrorSpan, ExportInfo, ExportInfoProvided, ExportNameOrSpec, ExportPresenceMode, ExportSpec,
+  ExportsInfo, ExportsOfExportsSpec, ExportsSpec, ExportsType, ExtendedReferencedExport,
   HarmonyExportInitFragment, ImportAttributes, InitFragmentExt, InitFragmentKey, InitFragmentStage,
   JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleIdentifier, NormalInitFragment,
   RealDependencyLocation, RuntimeCondition, RuntimeGlobals, RuntimeSpec, Template, TemplateContext,
@@ -1343,6 +1343,34 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
   }
 }
 
+struct HarmonyExportImportedSpecifierDependencyCondition(DependencyId);
+
+impl DependencyConditionFn for HarmonyExportImportedSpecifierDependencyCondition {
+  fn get_connection_state(
+    &self,
+    _conn: &rspack_core::ModuleGraphConnection,
+    runtime: Option<&RuntimeSpec>,
+    module_graph: &ModuleGraph,
+  ) -> ConnectionState {
+    let dep = module_graph
+      .dependency_by_id(&self.0)
+      .expect("should have dependency");
+    let down_casted_dep = dep
+      .downcast_ref::<HarmonyExportImportedSpecifierDependency>()
+      .expect("should be HarmonyExportImportedSpecifierDependency");
+    let mode = down_casted_dep.get_mode(
+      down_casted_dep.name.clone(),
+      module_graph,
+      &down_casted_dep.id,
+      runtime,
+    );
+    ConnectionState::Bool(!matches!(
+      mode.ty,
+      ExportModeType::Unused | ExportModeType::EmptyStar
+    ))
+  }
+}
+
 impl ModuleDependency for HarmonyExportImportedSpecifierDependency {
   fn request(&self) -> &str {
     &self.request
@@ -1367,24 +1395,7 @@ impl ModuleDependency for HarmonyExportImportedSpecifierDependency {
   fn get_condition(&self) -> Option<DependencyCondition> {
     let id = self.id;
     Some(DependencyCondition::Fn(Arc::new(
-      move |_mc, runtime, module_graph: &ModuleGraph| {
-        let dep = module_graph
-          .dependency_by_id(&id)
-          .expect("should have dependency");
-        let down_casted_dep = dep
-          .downcast_ref::<HarmonyExportImportedSpecifierDependency>()
-          .expect("should be HarmonyExportImportedSpecifierDependency");
-        let mode = down_casted_dep.get_mode(
-          down_casted_dep.name.clone(),
-          module_graph,
-          &down_casted_dep.id,
-          runtime,
-        );
-        ConnectionState::Bool(!matches!(
-          mode.ty,
-          ExportModeType::Unused | ExportModeType::EmptyStar
-        ))
-      },
+      HarmonyExportImportedSpecifierDependencyCondition(id),
     )))
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

As we will support persistent cache soon, dependencyConditionFn is Arc<dyn Fn> which cannot be cached, use another trait object for better cacheable

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
