### PR TITLE
fix: `context` should be an absolute path

### DIFF
--- a/packages/rspack-test-tools/tests/Validation.test.js
+++ b/packages/rspack-test-tools/tests/Validation.test.js
@@ -1,0 +1,32 @@
+describe("Validation", () => {
+	const createTestCase = (name, config, fn) => {
+		it(`should fail validation for ${name}`, () => {
+			try {
+				const rspack = require("@rspack/core");
+				rspack(config);
+			} catch (err) {
+				if (err.name !== "ValidationError") throw err;
+
+				expect(err.message).toMatch(/^Configuration error:/);
+				fn(err.message);
+
+				return;
+			}
+
+			throw new Error("Validation didn't fail");
+		});
+	};
+
+	createTestCase(
+		"not absolute context",
+		{
+			context: "./"
+		},
+		message => {
+			expect(message).toMatchInlineSnapshot(`
+			"Configuration error:
+			- The provided value \\"./\\" must be an absolute path. at \\"context\\""
+		`);
+		}
+	);
+});

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -1528,7 +1528,7 @@ export type ContainerReferencePluginOptions = {
 export type Context = z.infer<typeof context>;
 
 // @public (undocumented)
-const context: z.ZodString;
+const context: z.ZodEffects<z.ZodString, string, string>;
 
 // @public (undocumented)
 type ContextInfo = {
@@ -11407,7 +11407,7 @@ export const rspackOptions: z.ZodObject<{
         stream?: NodeJS.WritableStream | undefined;
     }>>;
     cache: z.ZodOptional<z.ZodBoolean>;
-    context: z.ZodOptional<z.ZodString>;
+    context: z.ZodOptional<z.ZodEffects<z.ZodString, string, string>>;
     devtool: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["eval", "cheap-source-map", "cheap-module-source-map", "source-map", "inline-cheap-source-map", "inline-cheap-module-source-map", "inline-source-map", "inline-nosources-cheap-source-map", "inline-nosources-cheap-module-source-map", "inline-nosources-source-map", "nosources-cheap-source-map", "nosources-cheap-module-source-map", "nosources-source-map", "hidden-nosources-cheap-source-map", "hidden-nosources-cheap-module-source-map", "hidden-nosources-source-map", "hidden-cheap-source-map", "hidden-cheap-module-source-map", "hidden-source-map", "eval-cheap-source-map", "eval-cheap-module-source-map", "eval-source-map", "eval-nosources-cheap-source-map", "eval-nosources-cheap-module-source-map", "eval-nosources-source-map"]>]>>;
     node: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
         __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -9942,6 +9942,7 @@ declare namespace rspackExports {
         Watching,
         sources,
         config,
+        ValidationError,
         util,
         EntryOptionPlugin,
         OutputFileSystem,
@@ -15600,6 +15601,11 @@ export const util: {
     createHash: (algorithm: (string & {}) | "debug" | "xxhash64" | "md4" | "native-md4" | (new () => default_2)) => default_2;
     cleverMerge: <First, Second>(first: First, second: Second) => First | Second | (First & Second);
 };
+
+// @public (undocumented)
+export class ValidationError extends Error {
+    constructor(message: string);
+}
 
 // @public (undocumented)
 export const version: string;

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1,3 +1,4 @@
+import nodePath from "node:path";
 import type { JsAssetInfo, RawFuncUseCtx } from "@rspack/binding";
 import type * as webpackDevServer from "webpack-dev-server";
 import { z } from "zod";
@@ -29,7 +30,12 @@ export type Dependencies = z.infer<typeof dependencies>;
 //#endregion
 
 //#region Context
-const context = z.string();
+const context = z.string().refine(
+	val => nodePath.isAbsolute(val),
+	val => ({
+		message: `The provided value ${JSON.stringify(val)} must be an absolute path.`
+	})
+);
 export type Context = z.infer<typeof context>;
 //#endregion
 

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -76,6 +76,9 @@ export const config: Config = {
 
 export type * from "./config";
 
+import { ValidationError } from "./util/validate";
+export { ValidationError };
+
 import { cachedCleverMerge as cleverMerge } from "./util/cleverMerge";
 import { createHash } from "./util/createHash";
 export const util = { createHash, cleverMerge };

--- a/packages/rspack/src/util/validate.ts
+++ b/packages/rspack/src/util/validate.ts
@@ -1,6 +1,13 @@
 import type { z } from "zod";
 import { fromZodError } from "zod-validation-error";
 
+export class ValidationError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "ValidationError";
+	}
+}
+
 export function validate<T extends z.ZodType>(opts: any, schema: T) {
 	const res = schema.safeParse(opts);
 	if (!res.success) {
@@ -17,7 +24,7 @@ export function validate<T extends z.ZodType>(opts: any, schema: T) {
 		// `Configuration error$prefix$xxxx error$issue$yyy error$issue$zzz error`
 		const [prefix, reason] = validationErr.message.split(prefixSeparator);
 		const reasonItem = reason.split(issueSeparator);
-		const friendlyErr = new Error(
+		const friendlyErr = new ValidationError(
 			`${prefix}:\n${reasonItem.map(item => `- ${item}`).join("\n")}`
 		);
 		if (strategy === "loose") {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should validate if `context` is an absolute path.
Added `ValidationError` to align with schema-utils of webpack.
Exported `ValidationError` to support rsbuild detecting errors.

closes: #7393

Test template is ported from webpack [`Validation.test.js`](https://github.com/webpack/webpack/blob/b9d9a5d9ffd8d53899a4b198870377090558a32f/test/Validation.test.js).

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
