### PR TITLE
fix(core): improve error report when load builtin:swc-loader and buitin:lightningcss-loader

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -114,7 +114,10 @@ impl Task<MakeTaskContext> for FactorizeTask {
         }
         // Wrap source code if available
         if let Some(s) = self.original_module_source {
-          e = e.with_source_code(s.source().to_string());
+          let has_source_code = e.source_code().is_some();
+          if !has_source_code {
+            e = e.with_source_code(s.source().to_string());
+          }
         }
         // Bail out if `options.bail` set to `true`,
         // which means 'Fail out on the first error instead of tolerating it.'

--- a/crates/rspack_core/src/diagnostics.rs
+++ b/crates/rspack_core/src/diagnostics.rs
@@ -20,7 +20,7 @@ pub struct EmptyDependency(Box<dyn Diagnostic + Send + Sync>);
 impl EmptyDependency {
   pub fn new(span: ErrorSpan) -> Self {
     Self(
-      TraceableError::from_empty_file(
+      TraceableError::from_lazy_file(
         span.start as usize,
         span.end as usize,
         "Empty dependency".to_string(),

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -313,7 +313,7 @@ fn map_resolver_error(
 
   let span = args.span.unwrap_or_default();
   let message = format!("Can't resolve '{request}' in '{context}'");
-  TraceableError::from_empty_file(
+  TraceableError::from_lazy_file(
     span.start as usize,
     span.end as usize,
     "Module not found".to_string(),

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -1,4 +1,3 @@
-use std::sync::LazyLock;
 use std::{fmt::Display, sync::Arc};
 
 use miette::{Diagnostic, LabeledSpan, MietteDiagnostic, Severity, SourceCode, SourceSpan};
@@ -6,9 +5,6 @@ use swc_core::common::SourceFile;
 use thiserror::Error;
 
 use crate::RspackSeverity;
-
-#[allow(clippy::rc_buffer)]
-static EMPTY_STRING: LazyLock<Arc<String>> = LazyLock::new(|| Arc::new("".to_string()));
 
 #[derive(Debug, Error)]
 #[error(transparent)]
@@ -53,7 +49,7 @@ pub struct TraceableError {
   message: String,
   severity: Severity,
   #[allow(clippy::rc_buffer)]
-  src: Arc<String>,
+  src: Option<Arc<String>>,
   label: SourceSpan,
   help: Option<String>,
   url: Option<String>,
@@ -82,7 +78,7 @@ impl Diagnostic for TraceableError {
   }
 
   fn source_code(&self) -> Option<&dyn SourceCode> {
-    Some(&self.src)
+    self.src.as_ref().map(|s| &**s as &dyn SourceCode)
   }
 
   fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
@@ -131,7 +127,7 @@ impl TraceableError {
     title: String,
     message: String,
   ) -> Self {
-    Self::from_arc_string(source_file.src.clone(), start, end, title, message)
+    Self::from_arc_string(Some(source_file.src.clone()), start, end, title, message)
   }
 
   pub fn from_file(
@@ -141,15 +137,15 @@ impl TraceableError {
     title: String,
     message: String,
   ) -> Self {
-    Self::from_arc_string(Arc::new(file_src), start, end, title, message)
+    Self::from_arc_string(Some(Arc::new(file_src)), start, end, title, message)
   }
-
-  pub fn from_empty_file(start: usize, end: usize, title: String, message: String) -> Self {
-    Self::from_arc_string(EMPTY_STRING.clone(), start, end, title, message)
+  // lazy set source_file if we can't know the source content in advance
+  pub fn from_lazy_file(start: usize, end: usize, title: String, message: String) -> Self {
+    Self::from_arc_string(None, start, end, title, message)
   }
 
   pub fn from_arc_string(
-    src: Arc<String>,
+    src: Option<Arc<String>>,
     start: usize,
     end: usize,
     title: String,

--- a/crates/rspack_loader_lightningcss/src/config.rs
+++ b/crates/rspack_loader_lightningcss/src/config.rs
@@ -51,7 +51,7 @@ pub struct RawConfig {
 }
 
 impl TryFrom<RawConfig> for Config {
-  type Error = rspack_error::Error;
+  type Error = rspack_error::miette::Report;
   fn try_from(value: RawConfig) -> Result<Self, Self::Error> {
     Ok(Self {
       minify: value.minify,

--- a/crates/rspack_plugin_css/src/utils.rs
+++ b/crates/rspack_plugin_css/src/utils.rs
@@ -376,7 +376,7 @@ pub fn css_parsing_traceable_error(
   severity: RspackSeverity,
 ) -> TraceableError {
   TraceableError::from_arc_string(
-    source_code,
+    Some(source_code),
     start as usize,
     end as usize,
     match severity {

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/index.css
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/index.css
@@ -1,0 +1,3 @@
+body {
+    color: red;
+}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/rspack.config.js
@@ -1,0 +1,29 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+   context: __dirname,
+   entry: {
+    main: './index.js'
+   },
+   experiments: {
+     css: true
+   },
+   module: {
+     rules: [
+        {
+            test: /\.css$/,
+            use: [
+                {
+                    loader: "builtin:lightningcss-loader",
+                    /** @type {import("@rspack/core").LightningcssLoaderOptions} */
+                    options: {
+                        unusedSymbols: ['unused'],
+                        targets: '> 0.2%',
+                        draft: 'xx'
+                    }
+                }
+            ],
+            type: "css/auto"
+        },
+     ]
+   }
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-lightningcss-loader/stats.err
@@ -1,0 +1,10 @@
+ERROR in ./index.js 1:0-21
+  × Could not parse builtin:lightningcss-loader options
+   ╭─[8:14]
+ 6 │     "> 0.2%"
+ 7 │   ],
+ 8 │   "draft": "xx"
+   ·               ▲
+   ·               ╰── invalid type: string "xx", expected struct Draft at line 8 column 15
+ 9 │ }
+   ╰────

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/rspack.config.js
@@ -1,0 +1,22 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+   module: {
+     rules: [
+        {
+            test: /\.js$/,
+            use: [
+                {
+                    loader: "builtin:swc-loader",
+                    options: {
+                        jsc: {
+                            parser2: {
+                                syntax: "ecmascript"
+                            }
+                        },
+                    }
+                }
+            ]
+        }
+     ]
+   }
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/stats.err
@@ -1,0 +1,10 @@
+ERROR in × failed to parse builtin:swc-loader options
+   ╭─[3:12]
+ 1 │ {
+ 2 │   "jsc": {
+ 3 │     "parser2": {
+   ·             ▲
+   ·             ╰── unknown field `parser2`, expected one of `assumptions`, `parser`, `transform`, `externalHelpers`, `target`, `loose`, `keepClassNames`, `baseUrl`, `paths`, `minify`, `experimental`, `lints`, `preserveAllComments`, `output` at line 3 column 13
+ 4 │       "syntax": "ecmascript"
+ 5 │     }
+   ╰────

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -257,7 +257,12 @@ function createRawModuleRuleUsesImpl(
 		let isBuiltin = false;
 		if (use.loader.startsWith(BUILTIN_LOADER_PREFIX)) {
 			o = getBuiltinLoaderOptions(use.loader, use.options, options);
-			o = isNil(o) ? undefined : typeof o === "string" ? o : JSON.stringify(o);
+			// keep json with indent so miette can show pretty error
+			o = isNil(o)
+				? undefined
+				: typeof o === "string"
+					? o
+					: JSON.stringify(o, null, 2);
 			isBuiltin = true;
 		}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
improve error report of serde deserialize error
* before
![image](https://github.com/user-attachments/assets/d46c56ec-27cf-412f-abda-273ec7259fbd)

* after 
![img_v3_02e5_3513c308-b8f6-4407-a9d4-39492a68382g](https://github.com/user-attachments/assets/bff217a5-f66a-4bc3-8b6d-009e05cb7bd2)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
