### PR TITLE
docs(homepage): lazy load images

### DIFF
--- a/website/theme/components/Landingpage/BuiltWithRspack/index.tsx
+++ b/website/theme/components/Landingpage/BuiltWithRspack/index.tsx
@@ -62,7 +62,7 @@ const CompanyItem = ({ item }: { item: Company }) => {
   const { logo, name, url, text, width } = item;
   return (
     <Link className={styles.logo} href={url}>
-      <img src={logo} alt={name} style={{ width }} />
+      <img src={logo} alt={name} style={{ width }} loading="lazy" />
       {text !== undefined ? (
         <span className={styles.logoText}>{text}</span>
       ) : (

--- a/website/theme/components/Landingpage/FullyFeatured/index.tsx
+++ b/website/theme/components/Landingpage/FullyFeatured/index.tsx
@@ -125,6 +125,7 @@ const FullyFeatured = memo(() => {
                       src={icon}
                       alt={index.toString()}
                       className={styles.icon}
+                      loading="lazy"
                     />
                     <div className={styles.featureContent}>
                       <h2 className={styles.featureTitle}>{title}</h2>

--- a/website/theme/components/Landingpage/ToolStack/index.tsx
+++ b/website/theme/components/Landingpage/ToolStack/index.tsx
@@ -65,7 +65,12 @@ const ToolStack: React.FC = memo(() => {
           {tools.map(({ name, desc, logo, url }) => {
             return (
               <Link className={styles.tool} key={name} href={url}>
-                <img src={logo} alt={name} className={styles.logo} />
+                <img
+                  src={logo}
+                  alt={name}
+                  className={styles.logo}
+                  loading="lazy"
+                />
                 <h3 className={styles.toolTitle}>{name}</h3>
                 <p className={styles.toolDescription}>{desc}</p>
               </Link>


### PR DESCRIPTION
## Summary

Lazy load images for performance.

- before:

<img width="349" alt="Screenshot 2024-08-27 at 17 27 36" src="https://github.com/user-attachments/assets/7240b777-b13c-4b8a-a645-8fcd84d7c5d5">

- after:

<img width="335" alt="Screenshot 2024-08-27 at 17 29 59" src="https://github.com/user-attachments/assets/f64b0277-6f86-48ba-9c7c-bc57be4ec59e">

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#loading

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
