### PR TITLE
test(infra): improve e2e test stability

### DIFF
--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/index.js
@@ -1,4 +1,4 @@
-import "./index.css";
+import "./main";
 
 it("css recovery", done => {
 	NEXT(

--- a/packages/rspack-test-tools/tests/hotCases/css/recovery/main.js
+++ b/packages/rspack-test-tools/tests/hotCases/css/recovery/main.js
@@ -1,0 +1,1 @@
+import "./index.css";


### PR DESCRIPTION
## Summary

closes #7683 

It seems that the issue is caused by the CI attempting to perform a hot update on the `index.js` module, but the update fails because it is the entry module.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
