### PR TITLE
fix: use topological order when SideEffectsFlagPlugin optimize incoming connections

### DIFF
--- a/crates/rspack_core/src/exports_info.rs
+++ b/crates/rspack_core/src/exports_info.rs
@@ -1590,7 +1590,7 @@ pub struct ResolvedExportInfoTarget {
   pub module: ModuleIdentifier,
   pub export: Option<Vec<Atom>>,
   /// using dependency id to retrieve Connection
-  connection: DependencyId,
+  pub connection: DependencyId,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1034,7 +1034,11 @@ impl<'a> ModuleGraph<'a> {
       .insert(dep_id, DependencyExtraMeta { ids });
   }
 
-  pub fn update_module(&mut self, dep_id: &DependencyId, module_id: &ModuleIdentifier) {
+  pub fn update_module(
+    &mut self,
+    dep_id: &DependencyId,
+    module_id: &ModuleIdentifier,
+  ) -> Option<ConnectionId> {
     let connection_id = *self
       .connection_id_by_dependency_id(dep_id)
       .expect("should have connection id");
@@ -1042,7 +1046,7 @@ impl<'a> ModuleGraph<'a> {
       .connection_by_connection_id_mut(&connection_id)
       .expect("should have connection");
     if connection.module_identifier() == module_id {
-      return;
+      return None;
     }
 
     // clone connection
@@ -1097,6 +1101,7 @@ impl<'a> ModuleGraph<'a> {
       mgm.add_incoming_connection(new_connection_id);
       mgm.remove_incoming_connection(&connection_id);
     }
+    Some(new_connection_id)
   }
 
   pub fn get_exports_info(&self, module_identifier: &ModuleIdentifier) -> ExportsInfo {

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -736,7 +736,7 @@ fn optimize_incoming_connections(
       compilation,
     );
   }
-  // It is possiable to add additional new connections when optimizing module's incoming connections
+  // It is possible to add additional new connections when optimizing module's incoming connections
   while let Some(connections) = new_connections.remove(&module_identifier) {
     for new_connection_id in connections {
       optimize_incoming_connection(

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -1,9 +1,10 @@
-use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::LazyLock;
 
+use rspack_collections::IdentifierMap;
 use rspack_collections::IdentifierSet;
+use rspack_core::ConnectionId;
 use rspack_core::{
   BoxModule, Compilation, CompilationOptimizeDependencies, ConnectionState, FactoryMeta,
   ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, NormalModuleCreateData,
@@ -13,10 +14,9 @@ use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::AssertUtf8;
 use rspack_paths::Utf8Path;
+use rustc_hash::FxHashSet;
 use sugar_path::SugarPath;
 use swc_core::common::comments::Comments;
-// use rspack_core::Plugin;
-// use rspack_error::Result;
 use swc_core::common::{comments, Span, Spanned, SyntaxContext, GLOBALS};
 use swc_core::ecma::ast::*;
 use swc_core::ecma::utils::{ExprCtx, ExprExt};
@@ -656,121 +656,26 @@ async fn nmf_module(
 
 #[plugin_hook(CompilationOptimizeDependencies for SideEffectsFlagPlugin)]
 fn optimize_dependencies(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
-  let entries = compilation.entry_modules();
-  let level_order_module_identifier =
-    get_level_order_module_ids(&compilation.get_module_graph(), entries);
-  for module_identifier in level_order_module_identifier {
-    let module_graph = compilation.get_module_graph();
-    let mut module_chain = IdentifierSet::default();
-    // dbg!(&module_identifier);
-    let Some(module) = module_graph.module_by_identifier(&module_identifier) else {
-      continue;
-    };
-    let side_effects_state =
-      module.get_side_effects_connection_state(&module_graph, &mut module_chain);
-    if side_effects_state != rspack_core::ConnectionState::Bool(false) {
-      continue;
-    }
-    let cur_exports_info = module_graph.get_exports_info(&module_identifier);
-
-    let incoming_connections = module_graph
-      .module_graph_module_by_identifier(&module_identifier)
-      .map(|mgm| mgm.incoming_connections().clone())
-      .unwrap_or_default();
-    for con_id in incoming_connections {
-      let mut module_graph = compilation.get_module_graph_mut();
-      let con = module_graph
-        .connection_by_connection_id(&con_id)
-        .expect("should have connection");
-      let Some(dep) = module_graph.dependency_by_id(&con.dependency_id) else {
-        continue;
-      };
-      let dep_id = *dep.id();
-      let is_reexport = dep
-        .downcast_ref::<HarmonyExportImportedSpecifierDependency>()
-        .is_some();
-      let is_valid_import_specifier_dep = dep
-        .downcast_ref::<HarmonyImportSpecifierDependency>()
-        .map(|import_specifier_dep| !import_specifier_dep.namespace_object_as_context)
-        .unwrap_or_default();
-      if !is_reexport && !is_valid_import_specifier_dep {
-        continue;
-      }
-      if let Some(name) = dep
-        .downcast_ref::<HarmonyExportImportedSpecifierDependency>()
-        .and_then(|dep| dep.name.clone())
-      {
-        let export_info = module_graph.get_export_info(
-          con
-            .original_module_identifier
-            .expect("should have original_module_identifier"),
-          &name,
-        );
-        export_info.move_target(
-          &mut module_graph,
-          Arc::new(|target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
-            mg.module_by_identifier(&target.module)
-              .expect("should have module")
-              .get_side_effects_connection_state(mg, &mut IdentifierSet::default())
-              == ConnectionState::Bool(false)
-          }),
-          Arc::new(
-            move |target: &ResolvedExportInfoTarget, mg: &mut ModuleGraph| {
-              mg.update_module(&dep_id, &target.module);
-              // TODO: Explain https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/SideEffectsFlagPlugin.js#L303-L306
-              let ids = dep_id.get_ids(mg);
-              let processed_ids = target
-                .export
-                .as_ref()
-                .map(|item| {
-                  let mut ret = Vec::from_iter(item.iter().cloned());
-                  ret.extend_from_slice(ids.get(1..).unwrap_or_default());
-                  ret
-                })
-                .unwrap_or_else(|| ids.get(1..).unwrap_or_default().to_vec());
-              dep_id.set_ids(processed_ids, mg);
-              mg.connection_by_dependency(&dep_id).map(|_| dep_id)
-            },
-          ),
-        );
-        continue;
-      }
-
-      let ids = dep_id.get_ids(&module_graph);
-
-      if !ids.is_empty() {
-        let export_info = cur_exports_info.get_export_info(&mut module_graph, &ids[0]);
-
-        let target = export_info.get_target(
-          &module_graph,
-          Some(Arc::new(
-            |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
-              mg.module_by_identifier(&target.module)
-                .expect("should have module graph")
-                .get_side_effects_connection_state(mg, &mut IdentifierSet::default())
-                == ConnectionState::Bool(false)
-            },
-          )),
-        );
-        let Some(target) = target else {
-          continue;
-        };
-
-        // dbg!(&mg.connection_by_dependency(&dep_id));
-        module_graph.update_module(&dep_id, &target.module);
-        // TODO: Explain https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/SideEffectsFlagPlugin.js#L303-L306
-        let processed_ids = target
-          .export
-          .map(|mut item| {
-            item.extend_from_slice(&ids[1..]);
-            item
-          })
-          .unwrap_or_else(|| ids[1..].to_vec());
-
-        // dbg!(&mg.connection_by_dependency(&dep_id));
-        dep_id.set_ids(processed_ids, &mut module_graph);
-      }
-    }
+  let mut modules: IdentifierSet = if compilation.options.new_incremental_enabled() {
+    compilation
+      .unaffected_modules_cache
+      .get_affected_modules_with_module_graph()
+      .lock()
+      .expect("should lock")
+      .iter()
+      .copied()
+      .collect()
+  } else {
+    compilation
+      .get_module_graph()
+      .modules()
+      .keys()
+      .copied()
+      .collect()
+  };
+  let mut new_connections = Default::default();
+  for module in modules.clone() {
+    optimize_incoming_connections(module, &mut modules, &mut new_connections, compilation);
   }
   Ok(None)
 }
@@ -799,31 +704,193 @@ impl Plugin for SideEffectsFlagPlugin {
   }
 }
 
-fn get_level_order_module_ids(mg: &ModuleGraph, entries: IdentifierSet) -> Vec<ModuleIdentifier> {
-  let mut res = vec![];
-  let mut visited = IdentifierSet::default();
-  for entry in entries {
-    let mut q = VecDeque::from_iter([entry]);
-    while let Some(mi) = q.pop_front() {
-      if visited.contains(&mi) {
-        continue;
-      } else {
-        visited.insert(mi);
-        res.push(mi);
-      }
-      for con in mg.get_outgoing_connections(&mi) {
-        let mi = *con.module_identifier();
-        q.push_back(mi);
-      }
+#[tracing::instrument(skip_all, fields(module = ?module_identifier))]
+fn optimize_incoming_connections(
+  module_identifier: ModuleIdentifier,
+  to_be_optimized: &mut IdentifierSet,
+  new_connections: &mut IdentifierMap<FxHashSet<ConnectionId>>,
+  compilation: &mut Compilation,
+) {
+  if !to_be_optimized.remove(&module_identifier) {
+    return;
+  }
+  let module_graph = compilation.get_module_graph();
+  let Some(module) = module_graph.module_by_identifier(&module_identifier) else {
+    return;
+  };
+  let side_effects_state =
+    module.get_side_effects_connection_state(&module_graph, &mut IdentifierSet::default());
+  if side_effects_state != rspack_core::ConnectionState::Bool(false) {
+    return;
+  }
+  let incoming_connections = module_graph
+    .module_graph_module_by_identifier(&module_identifier)
+    .map(|mgm| mgm.incoming_connections().clone())
+    .unwrap_or_default();
+  for &connection_id in &incoming_connections {
+    optimize_incoming_connection(
+      connection_id,
+      module_identifier,
+      to_be_optimized,
+      new_connections,
+      compilation,
+    );
+  }
+  // It is possiable to add additional new connections when optimizing module's incoming connections
+  while let Some(connections) = new_connections.remove(&module_identifier) {
+    for new_connection_id in connections {
+      optimize_incoming_connection(
+        new_connection_id,
+        module_identifier,
+        to_be_optimized,
+        new_connections,
+        compilation,
+      );
     }
   }
+}
 
-  res.sort_by(|a, b| {
-    let ad = mg.get_depth(a);
-    let bd = mg.get_depth(b);
-    ad.cmp(&bd)
-  });
-  res
+fn optimize_incoming_connection(
+  connection_id: ConnectionId,
+  module_identifier: ModuleIdentifier,
+  to_be_optimized: &mut IdentifierSet,
+  new_connections: &mut IdentifierMap<FxHashSet<ConnectionId>>,
+  compilation: &mut Compilation,
+) {
+  let module_graph = compilation.get_module_graph();
+  let connection = module_graph
+    .connection_by_connection_id(&connection_id)
+    .expect("should have connection");
+  let Some(dep) = module_graph.dependency_by_id(&connection.dependency_id) else {
+    return;
+  };
+  let is_reexport = dep
+    .downcast_ref::<HarmonyExportImportedSpecifierDependency>()
+    .is_some();
+  let is_valid_import_specifier_dep = dep
+    .downcast_ref::<HarmonyImportSpecifierDependency>()
+    .map(|import_specifier_dep| !import_specifier_dep.namespace_object_as_context)
+    .unwrap_or_default();
+  if !is_reexport && !is_valid_import_specifier_dep {
+    return;
+  }
+  let Some(origin_module) = connection.original_module_identifier else {
+    return;
+  };
+  // For the best optimization results, connection.origin_module must optimize before connection.module
+  // See: https://github.com/webpack/webpack/pull/17595
+  optimize_incoming_connections(origin_module, to_be_optimized, new_connections, compilation);
+  do_optimize_incoming_connection(
+    connection_id,
+    module_identifier,
+    origin_module,
+    new_connections,
+    compilation,
+  );
+}
+
+#[tracing::instrument(skip_all, fields(origin = ?origin_module, module = ?module_identifier))]
+fn do_optimize_incoming_connection(
+  connection_id: ConnectionId,
+  module_identifier: ModuleIdentifier,
+  origin_module: ModuleIdentifier,
+  new_connections: &mut IdentifierMap<FxHashSet<ConnectionId>>,
+  compilation: &mut Compilation,
+) {
+  if let Some(connections) = new_connections.get_mut(&module_identifier) {
+    connections.remove(&connection_id);
+  }
+  let mut module_graph = compilation.get_module_graph_mut();
+  let connection = module_graph
+    .connection_by_connection_id(&connection_id)
+    .expect("should have connection");
+  let dep_id = connection.dependency_id;
+  let dep = module_graph
+    .dependency_by_id(&dep_id)
+    .expect("should have dep");
+  if let Some(name) = dep
+    .downcast_ref::<HarmonyExportImportedSpecifierDependency>()
+    .and_then(|dep| dep.name.clone())
+  {
+    let export_info = module_graph.get_export_info(origin_module, &name);
+    let target = export_info.move_target(
+      &mut module_graph,
+      Arc::new(|target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
+        mg.module_by_identifier(&target.module)
+          .expect("should have module")
+          .get_side_effects_connection_state(mg, &mut IdentifierSet::default())
+          == ConnectionState::Bool(false)
+      }),
+      Arc::new(
+        move |target: &ResolvedExportInfoTarget, mg: &mut ModuleGraph| {
+          mg.update_module(&dep_id, &target.module)?;
+          // TODO: Explain https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/SideEffectsFlagPlugin.js#L303-L306
+          let ids = dep_id.get_ids(mg);
+          let processed_ids = target
+            .export
+            .as_ref()
+            .map(|item| {
+              let mut ret = Vec::from_iter(item.iter().cloned());
+              ret.extend_from_slice(ids.get(1..).unwrap_or_default());
+              ret
+            })
+            .unwrap_or_else(|| ids.get(1..).unwrap_or_default().to_vec());
+          dep_id.set_ids(processed_ids, mg);
+          Some(dep_id)
+        },
+      ),
+    );
+    if let Some(ResolvedExportInfoTarget {
+      connection, module, ..
+    }) = target
+      && let Some(&connection_id) = compilation
+        .get_module_graph()
+        .connection_id_by_dependency_id(&connection)
+    {
+      new_connections
+        .entry(module)
+        .or_default()
+        .insert(connection_id);
+    };
+    return;
+  }
+
+  let ids = dep_id.get_ids(&module_graph);
+  if !ids.is_empty() {
+    let cur_exports_info = module_graph.get_exports_info(&module_identifier);
+    let export_info = cur_exports_info.get_export_info(&mut module_graph, &ids[0]);
+
+    let target = export_info.get_target(
+      &module_graph,
+      Some(Arc::new(
+        |target: &ResolvedExportInfoTarget, mg: &ModuleGraph| {
+          mg.module_by_identifier(&target.module)
+            .expect("should have module graph")
+            .get_side_effects_connection_state(mg, &mut IdentifierSet::default())
+            == ConnectionState::Bool(false)
+        },
+      )),
+    );
+    let Some(target) = target else {
+      return;
+    };
+    let Some(connection_id) = module_graph.update_module(&dep_id, &target.module) else {
+      return;
+    };
+    new_connections
+      .entry(target.module)
+      .or_default()
+      .insert(connection_id);
+    // TODO: Explain https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/SideEffectsFlagPlugin.js#L303-L306
+    let processed_ids = target
+      .export
+      .map(|mut item| {
+        item.extend_from_slice(&ids[1..]);
+        item
+      })
+      .unwrap_or_else(|| ids[1..].to_vec());
+    dep_id.set_ids(processed_ids, &mut module_graph);
+  }
 }
 
 #[cfg(test)]

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/index.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/index.js
@@ -1,0 +1,9 @@
+import { b } from "dep";
+
+b.c();
+
+import { modules } from "dep/trackModules.js";
+
+it("should not contain side-effect-free modules", () => {
+	expect(modules).toEqual(["c"]);
+});

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/a.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/a.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("a");
+export * as b from "./b.js";

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/b.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/b.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("b");
+export * from "./c.js";

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/c.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/c.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("c");
+export function c() {}

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/index.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/index.js
@@ -1,0 +1,3 @@
+import { track } from "./trackModules.js";
+track("index");
+export * from "./a.js"

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/package.json
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "dep",
+  "version": "1.0.0",
+  "type": "module",
+  "sideEffects": false
+}

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/trackModules.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/node_modules/dep/trackModules.js
@@ -1,0 +1,4 @@
+export const modules = [];
+export function track(name) {
+	modules.push(name);
+}

--- a/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/webpack.config.js
+++ b/tests/webpack-test/configCases/side-effects/side-effects-unsorted-modules/webpack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("../../../../").Configuration} */
+
+class ReorderModulesPlugin {
+	constructor() {}
+
+	apply(compiler) {
+		compiler.hooks.compilation.tap("ReorderModulesPlugin", compilation => {
+			compilation.hooks.seal.tap("ReorderModulesPlugin", () => {
+				const sortedModules = Array.from(compilation.modules).sort((a, _b) =>
+					a.request.includes("b.js") ? -1 : 1
+				);
+				compilation.modules = new Set(sortedModules);
+			});
+		});
+	}
+}
+
+module.exports = {
+	// We don't support modify the order of compilation.modules, but it's always unsorted
+	// plugins: [new ReorderModulesPlugin()],
+	optimization: {
+		sideEffects: true
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- use topological order for SideEffectsFlagPlugin when optimize incoming connections
- apply affected modules for SideEffectsFlagPlugin
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
