### PR TITLE
test(rspack-cli): enable rspack cli command serve basic test case

### DIFF
--- a/packages/rspack-cli/tests/serve/basic/serve-basic.test.ts
+++ b/packages/rspack-cli/tests/serve/basic/serve-basic.test.ts
@@ -1,10 +1,11 @@
 import { normalizeStderr, runWatch } from "../../utils/test-utils";
 
 describe("basic serve usage", () => {
-	it.skip("should work", async () => {
-		const { stderr } = await runWatch(__dirname, ["serve"]);
+	it("should work", async () => {
+		const { stderr } = await runWatch(__dirname, ["serve"], {
+			killString: /localhost/
+		});
 
-		// @todo current server implementation is too buggy to test
-		expect(normalizeStderr(stderr)).toBeTruthy;
+		expect(normalizeStderr(stderr)).toContain("Project is running at");
 	});
 });


### PR DESCRIPTION
## Summary
It seems that the basic test case for the `serve` command is being skipped due to timeout or other reasons. We could try to terminate the test as soon as the relevant log information appears to achieve the intended testing purpose.
https://github.com/web-infra-dev/rspack/blob/a08d70edd941c019d4cb073a0e7ec02d785e2fea/packages/rspack-cli/tests/serve/basic/serve-basic.test.ts#L4-L9

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
