### PR TITLE
feat(html): support function filename and `[name]` in filename

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1291,7 +1291,7 @@ export interface RawHtmlRspackPluginBaseOptions {
 
 export interface RawHtmlRspackPluginOptions {
   /** emitted file name in output path */
-  filename?: string
+  filename?: string[]
   /** template html file */
   template?: string
   templateFn?: (data: string) => Promise<string>

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_html.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_html.rs
@@ -16,7 +16,7 @@ use rspack_plugin_html::sri::HtmlSriHashFunction;
 pub type RawHtmlScriptLoading = String;
 pub type RawHtmlInject = String;
 pub type RawHtmlSriHashFunction = String;
-pub type RawHtmlFilename = String;
+pub type RawHtmlFilename = Vec<String>;
 
 type RawTemplateRenderFn = ThreadsafeFunction<String, String>;
 
@@ -27,7 +27,7 @@ type RawTemplateParameter =
 #[napi(object, object_to_js = false)]
 pub struct RawHtmlRspackPluginOptions {
   /// emitted file name in output path
-  #[napi(ts_type = "string")]
+  #[napi(ts_type = "string[]")]
   pub filename: Option<RawHtmlFilename>,
   /// template html file
   pub template: Option<String>,
@@ -70,7 +70,9 @@ impl From<RawHtmlRspackPluginOptions> for HtmlRspackPluginOptions {
     });
 
     HtmlRspackPluginOptions {
-      filename: value.filename.unwrap_or_else(|| String::from("index.html")),
+      filename: value
+        .filename
+        .unwrap_or_else(|| vec![String::from("index.html")]),
       template: value.template,
       template_fn: value.template_fn.map(|func| TemplateRenderFn {
         inner: Box::new(move |data| {

--- a/crates/rspack_plugin_html/src/config.rs
+++ b/crates/rspack_plugin_html/src/config.rs
@@ -119,7 +119,7 @@ impl std::fmt::Debug for TemplateRenderFn {
 pub struct HtmlRspackPluginOptions {
   /// emitted file name in output path
   #[serde(default = "default_filename")]
-  pub filename: String,
+  pub filename: Vec<String>,
   /// template html file
   pub template: Option<String>,
   #[serde(skip)]
@@ -152,8 +152,8 @@ pub struct HtmlRspackPluginOptions {
   pub base: Option<HtmlRspackPluginBaseOptions>,
 }
 
-fn default_filename() -> String {
-  String::from("index.html")
+fn default_filename() -> Vec<String> {
+  vec![String::from("index.html")]
 }
 
 fn default_script_loading() -> HtmlScriptLoading {

--- a/crates/rspack_plugin_html/src/template.rs
+++ b/crates/rspack_plugin_html/src/template.rs
@@ -108,6 +108,7 @@ impl HtmlTemplate {
 
   pub async fn create_parameters(
     &mut self,
+    filename: &str,
     config: &HtmlRspackPluginOptions,
     head_tags: &Vec<HtmlPluginTag>,
     body_tags: &Vec<HtmlPluginTag>,
@@ -145,7 +146,7 @@ impl HtmlTemplate {
               Mode::None => "none",
             },
             "output": {
-              "publicPath": config.get_public_path(compilation, &config.filename),
+              "publicPath": config.get_public_path(compilation, filename),
             "crossOriginLoading": match &compilation.options.output.cross_origin_loading {
                 CrossOriginLoading::Disable => "false",
                 CrossOriginLoading::Enable(value) => value,

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -4619,7 +4619,7 @@ const hotUpdateMainFilename: z.ZodString;
 // @public (undocumented)
 export const HtmlRspackPlugin: {
     new (c?: {
-        filename?: string | undefined;
+        filename?: string | ((args_0: string, ...args_1: unknown[]) => string) | undefined;
         publicPath?: string | undefined;
         hash?: boolean | undefined;
         chunks?: string[] | undefined;
@@ -4641,7 +4641,7 @@ export const HtmlRspackPlugin: {
     } | undefined): {
         name: BuiltinPluginName;
         _args: [c?: {
-            filename?: string | undefined;
+            filename?: string | ((args_0: string, ...args_1: unknown[]) => string) | undefined;
             publicPath?: string | undefined;
             hash?: boolean | undefined;
             chunks?: string[] | undefined;
@@ -4696,7 +4696,7 @@ export type HtmlRspackPluginOptions = z.infer<typeof htmlRspackPluginOptions>;
 
 // @public (undocumented)
 const htmlRspackPluginOptions: z.ZodObject<{
-    filename: z.ZodOptional<z.ZodString>;
+    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodString>]>>;
     template: z.ZodOptional<z.ZodEffects<z.ZodString, string, string>>;
     templateContent: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodRecord<z.ZodString, z.ZodAny>], z.ZodUnknown>, z.ZodUnion<[z.ZodString, z.ZodPromise<z.ZodString>]>>]>>;
     templateParameters: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodString>, z.ZodBoolean]>, z.ZodFunction<z.ZodTuple<[z.ZodRecord<z.ZodString, z.ZodAny>], z.ZodUnknown>, z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodAny>, z.ZodPromise<z.ZodRecord<z.ZodString, z.ZodAny>>]>>]>>;
@@ -4722,7 +4722,7 @@ const htmlRspackPluginOptions: z.ZodObject<{
     meta: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodString>]>>>;
     hash: z.ZodOptional<z.ZodBoolean>;
 }, "strict", z.ZodTypeAny, {
-    filename?: string | undefined;
+    filename?: string | ((args_0: string, ...args_1: unknown[]) => string) | undefined;
     publicPath?: string | undefined;
     hash?: boolean | undefined;
     chunks?: string[] | undefined;
@@ -4742,7 +4742,7 @@ const htmlRspackPluginOptions: z.ZodObject<{
     favicon?: string | undefined;
     meta?: Record<string, string | Record<string, string>> | undefined;
 }, {
-    filename?: string | undefined;
+    filename?: string | ((args_0: string, ...args_1: unknown[]) => string) | undefined;
     publicPath?: string | undefined;
     hash?: boolean | undefined;
     chunks?: string[] | undefined;

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -39,8 +39,13 @@ const templateParamFunction = z
 		z.record(z.string(), z.any()).or(z.promise(z.record(z.string(), z.any())))
 	);
 
+const templateFilenameFunction = z
+	.function()
+	.args(z.string())
+	.returns(z.string());
+
 const htmlRspackPluginOptions = z.strictObject({
-	filename: z.string().optional(),
+	filename: z.string().or(templateFilenameFunction).optional(),
 	template: z
 		.string()
 		.refine(
@@ -214,8 +219,46 @@ const HtmlRspackPluginImpl = create(
 			templateParameters = rawTemplateParameters;
 		}
 
+		const addedFilename: Set<string> = new Set();
+		let filenames: string[] | undefined = undefined;
+		if (typeof c.filename === "string") {
+			filenames = [];
+			if (c.filename.includes("[name]")) {
+				if (typeof this.options.entry === "object") {
+					for (const entryName of Object.keys(this.options.entry)) {
+						const filename = c.filename.replace(/\[name\]/g, entryName);
+						if (!addedFilename.has(filename)) {
+							filenames.push(filename);
+							addedFilename.add(filename);
+						}
+					}
+				} else {
+					throw new Error(
+						"HtmlRspackPlugin: filename with `[name]` does not support function entry"
+					);
+				}
+			} else {
+				filenames.push(c.filename);
+			}
+		} else if (typeof c.filename === "function") {
+			filenames = [];
+			if (typeof this.options.entry === "object") {
+				for (const entryName of Object.keys(this.options.entry)) {
+					const filename = c.filename(entryName);
+					if (!addedFilename.has(filename)) {
+						filenames.push(filename);
+						addedFilename.add(filename);
+					}
+				}
+			} else {
+				throw new Error(
+					"HtmlRspackPlugin: function filename does not support function entry"
+				);
+			}
+		}
+
 		return {
-			filename: c.filename,
+			filename: filenames,
 			template: c.template,
 			hash: c.hash,
 			title: c.title,

--- a/tests/plugin-test/html-plugin/basic.test.js
+++ b/tests/plugin-test/html-plugin/basic.test.js
@@ -337,53 +337,51 @@ describe("HtmlWebpackPlugin", () => {
     );
   });
 
-  // TODO: support function filename
-  // it("allows to use a function to map entry names to filenames", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: {
-  //         app: path.join(__dirname, "fixtures/index.js"),
-  //       },
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "[name]_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           filename: (entry) => `${entry}.html`,
-  //         }),
-  //       ],
-  //     },
-  //     ['<script defer src="app_bundle.js'],
-  //     "app.html",
-  //     done,
-  //   );
-  // });
+  it("allows to use a function to map entry names to filenames", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: {
+          app: path.join(__dirname, "fixtures/index.js"),
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: "[name]_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            filename: (entry) => `${entry}.html`,
+          }),
+        ],
+      },
+      ['<script defer src="app_bundle.js'],
+      "app.html",
+      done,
+    );
+  });
 
-  // TODO: support filename template
-  // it("allows to use [name] for file names", (done) => {
-  //   testHtmlPlugin(
-  //     {
-  //       mode: "production",
-  //       entry: {
-  //         app: path.join(__dirname, "fixtures/index.js"),
-  //       },
-  //       output: {
-  //         path: OUTPUT_DIR,
-  //         filename: "[name]_bundle.js",
-  //       },
-  //       plugins: [
-  //         new HtmlWebpackPlugin({
-  //           filename: "[name].html",
-  //         }),
-  //       ],
-  //     },
-  //     ['<script defer src="app_bundle.js'],
-  //     "app.html",
-  //     done,
-  //   );
-  // });
+  it("allows to use [name] for file names", (done) => {
+    testHtmlPlugin(
+      {
+        mode: "production",
+        entry: {
+          app: path.join(__dirname, "fixtures/index.js"),
+        },
+        output: {
+          path: OUTPUT_DIR,
+          filename: "[name]_bundle.js",
+        },
+        plugins: [
+          new HtmlWebpackPlugin({
+            filename: "[name].html",
+          }),
+        ],
+      },
+      ['<script defer src="app_bundle.js'],
+      "app.html",
+      done,
+    );
+  });
 
   it("picks up src/index.ejs by default", (done) => {
     testHtmlPlugin(


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

- Support function filename
- Support filename with `[name]`

The filenames will be calculated from entries on JS side, then send them to Rust side. So dynamic entry is not supported.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
