### PR TITLE
fix: add `in_function_scope` for getters and setters

### DIFF
--- a/packages/rspack-test-tools/tests/normalCases/parsing/harmony-import-specifier/a.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/harmony-import-specifier/a.js
@@ -1,0 +1,1 @@
+export class Texture {}

--- a/packages/rspack-test-tools/tests/normalCases/parsing/harmony-import-specifier/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/harmony-import-specifier/index.js
@@ -1,0 +1,16 @@
+import { Texture as e } from "./a.js";
+
+it("should not parse when logical and with `false && unknown = false`", function () {
+  var index_es_e = {};
+  var index_es_Ce = {
+    get exports() {
+		  return index_es_e;
+    },
+    set exports(e) {
+    	index_es_e = e;
+    }
+  };
+  console.log.bind(null, e);
+  index_es_Ce.exports = 1;
+  expect(index_es_Ce.exports).toBe(1)
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Closes https://github.com/web-infra-dev/rspack/issues/7722

Currently, the variables used in bodies of getters/setters will be replaced, if the names of some import specifiers are same as them.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
