### PR TITLE
fix(make): isolated module clean incomplete

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/clean_isolated_module.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/clean_isolated_module.rs
@@ -31,8 +31,6 @@ impl CleanIsolatedModule {
   }
 
   pub fn fix_artifact(self, artifact: &mut MakeArtifact) {
-    let module_graph = artifact.get_module_graph_mut();
-    let mut need_remove_modules = IdentifierSet::default();
     let mut queue = VecDeque::from(
       self
         .need_check_isolated_module_ids
@@ -40,6 +38,7 @@ impl CleanIsolatedModule {
         .collect::<Vec<_>>(),
     );
     while let Some(module_identifier) = queue.pop_front() {
+      let module_graph = artifact.get_module_graph();
       let Some(mgm) = module_graph.module_graph_module_by_identifier(&module_identifier) else {
         tracing::trace!("Module is cleaned: {}", module_identifier);
         continue;
@@ -53,9 +52,8 @@ impl CleanIsolatedModule {
         // clean child module
         queue.push_back(*connection.module_identifier());
       }
+      artifact.revoke_module(&module_identifier);
       tracing::trace!("Module is cleaned: {}", module_identifier);
-      need_remove_modules.insert(module_identifier);
     }
-    artifact.revoke_modules(need_remove_modules);
   }
 }

--- a/crates/rspack_core/src/compiler/make/cutout/mod.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/mod.rs
@@ -125,7 +125,9 @@ impl Cutout {
     }
 
     // do revoke module and collect deps
-    force_build_deps.extend(artifact.revoke_modules(force_build_modules));
+    for id in force_build_modules {
+      force_build_deps.extend(artifact.revoke_module(&id));
+    }
 
     let mut module_graph = artifact.get_module_graph_mut();
     for dep_id in remove_entry_deps {

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/__snapshots__/web/0.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case clean_isolated_module: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/__snapshots__/web/1.snap.txt
@@ -1,0 +1,56 @@
+# Case clean_isolated_module: Step 1
+
+## Changed Files
+- a.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 45
+- Update: main.LAST_HASH.hot-update.js, size: 526
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":["./b.js","./c.js"]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./a.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["webpackHotUpdate"]('main', {
+"./a.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
+});
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ("a");
+
+
+}),
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = function () {
+	return "CURRENT_HASH";
+};
+
+})();
+
+}
+);
+```

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/a.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/a.js
@@ -1,0 +1,5 @@
+import b from './b';
+
+export default b + "a";
+---
+export default "a";

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/b.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/b.js
@@ -1,0 +1,3 @@
+import c from "./c";
+
+export default c + "b";

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/c.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/index.js
@@ -1,0 +1,10 @@
+import value from "./a";
+
+it("should make clean isolated module works", done => {
+	expect(value).toBe("cba");
+	module.hot.accept("./a", () => {
+		expect(value).toBe("a");
+		done();
+	});
+	NEXT(require("../../update")(done));
+});

--- a/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/make/clean_isolated_module/rspack.config.js
@@ -1,0 +1,34 @@
+const plugin = {
+	name: "PLUGIN",
+	apply(compiler) {
+		let isFirst = true;
+		compiler.hooks.compilation.tap("PLUGIN", compilation => {
+			compilation.hooks.finishModules.tap("PLUGIN", modules => {
+				let hasModuleB = false;
+				let hasModuleC = false;
+				for (const m of modules) {
+					if (m.identifier().endsWith("b.js")) {
+						hasModuleB = true;
+					}
+					if (m.identifier().endsWith("c.js")) {
+						hasModuleC = true;
+					}
+				}
+				if (isFirst) {
+					isFirst = false;
+					expect(hasModuleB).toBe(true);
+					expect(hasModuleC).toBe(true);
+				} else {
+					expect(hasModuleB).toBe(false);
+					expect(hasModuleC).toBe(false);
+				}
+			});
+		});
+	}
+};
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	plugins: [plugin]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

Fix the step of clean isolated module in `cutout` will only clean one layer module.

There are a example:
1. if we have a module graph `a` -> `b` -> `c`
2. Edit module `a` so that it does not depend on module `b`

Before this PR the module_graph will only remove module `b`, because of call `revoke_modules` after module isolated check.


<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
