### PR TITLE
fix: should create an empty codegen result for module that has failure in codegen

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1730,21 +1730,19 @@ impl ConcatenatedModule {
         Ok(res) => Program::Module(res),
         Err(err) => {
           let span: ErrorSpan = err.span().into();
-          self
-            .diagnostics
-            .lock()
-            .expect("should have diagnostics")
-            .append(&mut map_box_diagnostics_to_module_parse_diagnostics(vec![
-              rspack_error::TraceableError::from_source_file(
-                &fm,
-                span.start as usize,
-                span.end as usize,
-                "JavaScript parsing error".to_string(),
-                err.kind().msg().to_string(),
-              )
-              .with_kind(DiagnosticKind::JavaScript),
-            ]));
-          return Ok(ModuleInfo::Concatenated(module_info));
+
+          // return empty error as we already push error to compilation.diagnostics
+          return Err(
+            rspack_error::TraceableError::from_source_file(
+              &fm,
+              span.start as usize,
+              span.end as usize,
+              "JavaScript parsing error:\n".to_string(),
+              err.kind().msg().to_string(),
+            )
+            .with_kind(DiagnosticKind::JavaScript)
+            .into(),
+          );
         }
       };
       let mut ast = Ast::new(program, cm, Some(comments));

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/foo.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/foo.js
@@ -1,0 +1,2 @@
+console.log(DEFINE_VAR)
+export default 1

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/index.js
@@ -1,0 +1,3 @@
+import v from './foo'
+
+console.log(v)

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/rspack.config.js
@@ -1,0 +1,13 @@
+const rspack = require('@rspack/core')
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+	plugins: [
+		new rspack.DefinePlugin({
+			DEFINE_VAR: '1 2 3'
+		})
+	],
+	optimization: {
+		concatenateModules: true
+	}
+}

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-parse-failed/concatenate_parse_module/stats.err
@@ -1,0 +1,8 @@
+ERROR in ./index.js + 1 modules
+  × JavaScript parsing error:
+  │ : Expected ',', got 'numeric literal (2, 2)'
+   ╭─[1:14]
+ 1 │ console.log(1 2 3)
+   ·               ─
+ 2 │ /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (1);
+   ╰────


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix #7382

When `code_generation` returns an `Err`, we should push this error to diagnostics and keep a empty `CodegenerateResult` like webpack
Parse error in concatenatedModule should be added to compilation diagnostics.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
