### PR TITLE
fix(dev-server): pin webpack-dev-server version

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -33,7 +33,7 @@
     "vue": "^3.4.21",
     "vue-loader": "^17.3.1",
     "css-loader": "^6.11.0",
-    "webpack-dev-server": "^5.0.4",
+    "webpack-dev-server": "5.0.4",
     "ws": "^8.16.0"
   }
 }

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -53,7 +53,7 @@
     "http-proxy-middleware": "^2.0.6",
     "mime-types": "^2.1.35",
     "webpack-dev-middleware": "^7.4.2",
-    "webpack-dev-server": "^5.0.4",
+    "webpack-dev-server": "5.0.4",
     "ws": "^8.16.0"
   },
   "peerDependencies": {

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -61,7 +61,7 @@
     "tsc-alias": "^1.8.8",
     "typescript": "5.0.2",
     "watchpack": "^2.4.0",
-    "webpack-dev-server": "^5.0.4",
+    "webpack-dev-server": "5.0.4",
     "webpack-sources": "3.2.3",
     "zod": "^3.23.8",
     "zod-validation-error": "3.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,7 +347,7 @@ importers:
         specifier: ^17.3.1
         version: 17.4.2(vue@3.4.21(typescript@5.0.2))(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
       webpack-dev-server:
-        specifier: ^5.0.4
+        specifier: 5.0.4
         version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
       ws:
         specifier: ^8.16.0
@@ -417,7 +417,7 @@ importers:
         specifier: ^2.4.0
         version: 2.4.1
       webpack-dev-server:
-        specifier: ^5.0.4
+        specifier: 5.0.4
         version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0)))
       webpack-sources:
         specifier: 3.2.3
@@ -517,7 +517,7 @@ importers:
         specifier: ^7.4.2
         version: 7.4.2(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
       webpack-dev-server:
-        specifier: ^5.0.4
+        specifier: 5.0.4
         version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
       ws:
         specifier: ^8.16.0
@@ -1178,7 +1178,7 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0
       webpack-dev-server:
-        specifier: ^5.0.4
+        specifier: 5.0.4
         version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0)))
 
 packages:
@@ -9251,15 +9251,6 @@ packages:
       webpack-dev-server:
         optional: true
 
-  webpack-dev-middleware@7.3.0:
-    resolution: {integrity: sha512-xD2qnNew+F6KwOGZR7kWdbIou/ud7cVqLEXeK1q0nHcNsX/u7ul/fSdlOTX4ntSL5FNFy7ZJJXbf0piF591JYw==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      webpack:
-        optional: true
-
   webpack-dev-middleware@7.4.2:
     resolution: {integrity: sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==}
     engines: {node: '>= 18.12.0'}
@@ -16725,7 +16716,7 @@ snapshots:
 
   launch-editor@2.6.1:
     dependencies:
-      picocolors: 1.0.0
+      picocolors: 1.0.1
       shell-quote: 1.8.1
 
   lazy-cache@1.0.4: {}
@@ -19648,7 +19639,7 @@ snapshots:
       webpack: 5.94.0(webpack-cli@5.1.4)
       webpack-merge: 5.9.0
 
-  webpack-dev-middleware@7.3.0(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0))):
+  webpack-dev-middleware@7.4.2(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
       colorette: 2.0.19
       memfs: 4.8.1
@@ -19659,7 +19650,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0))
 
-  webpack-dev-middleware@7.3.0(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))):
+  webpack-dev-middleware@7.4.2(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
       colorette: 2.0.19
       memfs: 4.8.1
@@ -19669,17 +19660,6 @@ snapshots:
       schema-utils: 4.2.0
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))
-
-  webpack-dev-middleware@7.3.0(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0))):
-    dependencies:
-      colorette: 2.0.19
-      memfs: 4.8.1
-      mime-types: 2.1.35
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-    optionalDependencies:
-      webpack: 5.94.0(webpack-cli@5.1.4(webpack@5.94.0))
 
   webpack-dev-middleware@7.4.2(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
@@ -19722,7 +19702,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.3.0(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0)))
+      webpack-dev-middleware: 7.4.2(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0)))
       ws: 8.17.1
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0))
@@ -19763,7 +19743,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.3.0(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0)))
+      webpack-dev-middleware: 7.4.2(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0)))
       ws: 8.17.1
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))
@@ -19804,7 +19784,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.3.0(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
+      webpack-dev-middleware: 7.4.2(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
       ws: 8.17.1
     optionalDependencies:
       webpack: 5.94.0(webpack-cli@5.1.4(webpack@5.94.0))

--- a/tests/webpack-test/package.json
+++ b/tests/webpack-test/package.json
@@ -53,7 +53,7 @@
     "util": "0.12.5",
     "uvu": "0.5.6",
     "webassembly-feature": "^1.3.0",
-    "webpack-dev-server": "^5.0.4"
+    "webpack-dev-server": "5.0.4"
   },
   "dependencies": {
     "@rspack/binding": "workspace:*",


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix #7782
rspack-dev-server use some internal api of webpack-dev-server, which cause it's easily broken if webpack-dev-server do some internal refactor
so the temporary solution is to pin the webpack-dev-server version
we need redesign rspack-dev-server implemention and shouldn't rely on internal api
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
