### PR TITLE
fix(dev-server): prebundle webpack-dev-server and pin webpack-dev-middleware

### DIFF
--- a/packages/rspack-dev-server/etc/api.md
+++ b/packages/rspack-dev-server/etc/api.md
@@ -6,30 +6,247 @@
 
 /// <reference types="node" />
 
-import { Compiler } from '@rspack/core';
+import * as bonjour_service from 'bonjour-service';
+import * as chokidar from 'chokidar';
+import { Compiler as Compiler_2 } from '@rspack/core';
 import { DevServer as Configuration } from '@rspack/core';
-import type { FSWatcher } from 'chokidar';
-import { MultiCompiler } from '@rspack/core';
-import type { Server } from 'node:http';
-import type { Socket } from 'node:net';
-import WebpackDevServer from 'webpack-dev-server';
+import * as connect_history_api_fallback from 'connect-history-api-fallback';
+import * as express from 'express';
+import * as express_serve_static_core from 'express-serve-static-core';
+import type { FSWatcher as FSWatcher_2 } from 'chokidar';
+import * as http from 'http';
+import * as http_proxy_middleware from 'http-proxy-middleware';
+import * as https from 'https';
+import { MultiCompiler as MultiCompiler_2 } from '@rspack/core';
+import * as net from 'net';
+import * as serve_index from 'serve-index';
+import * as serve_static from 'serve-static';
+import type { Server as Server_2 } from 'node:http';
+import type { Socket as Socket_2 } from 'node:net';
+import * as sockjs from 'sockjs';
+import * as webpack from 'webpack';
+import * as webpack_dev_middleware from 'webpack-dev-middleware';
+import * as ws from 'ws';
+
+// @public (undocumented)
+type ByPass = (
+req: Request_2,
+res: Response_2,
+proxyConfig: ProxyConfigArrayItem,
+) => any;
+
+// @public (undocumented)
+type ClientConfiguration = {
+    logging?: "none" | "error" | "warn" | "info" | "log" | "verbose" | undefined;
+    overlay?:
+    | boolean
+    | {
+        warnings?: OverlayMessageOptions | undefined;
+        errors?: OverlayMessageOptions | undefined;
+        runtimeErrors?: OverlayMessageOptions | undefined;
+    }
+    | undefined;
+    progress?: boolean | undefined;
+    reconnect?: number | boolean | undefined;
+    webSocketTransport?: string | undefined;
+    webSocketURL?: string | WebSocketURL | undefined;
+};
+
+// @public (undocumented)
+type ClientConnection = (
+| ws.WebSocket
+| (sockjs.Connection & {
+    send: ws.WebSocket["send"];
+    terminate: ws.WebSocket["terminate"];
+    ping: ws.WebSocket["ping"];
+})
+) & {
+    isAlive?: boolean;
+};
+
+// @public (undocumented)
+type Compiler = webpack.Compiler;
 
 export { Configuration }
+
+// @public (undocumented)
+type Configuration_2 = {
+    ipc?: string | boolean | undefined;
+    host?: string | undefined;
+    port?: Port | undefined;
+    hot?: boolean | "only" | undefined;
+    liveReload?: boolean | undefined;
+    devMiddleware?:
+    | DevMiddlewareOptions<
+    express.Request<
+    express_serve_static_core.ParamsDictionary,
+    any,
+    any,
+    qs.ParsedQs,
+    Record<string, any>
+    >,
+    express.Response<any, Record<string, any>>
+    >
+    | undefined;
+    compress?: boolean | undefined;
+    allowedHosts?: string | string[] | undefined;
+    historyApiFallback?:
+    | boolean
+    | connect_history_api_fallback.Options
+    | undefined;
+    bonjour?:
+    | boolean
+    | Record<string, never>
+    | bonjour_service.Service
+    | undefined;
+    watchFiles?:
+    | string
+    | string[]
+    | WatchFiles
+    | (string | WatchFiles)[]
+    | undefined;
+    static?: string | boolean | Static | (string | Static)[] | undefined;
+    https?: boolean | ServerOptions | undefined;
+    http2?: boolean | undefined;
+    server?: string | ServerConfiguration | undefined;
+    webSocketServer?: string | boolean | WebSocketServerConfiguration | undefined;
+    proxy?: ProxyConfigArray | undefined;
+    open?: string | boolean | Open | (string | Open)[] | undefined;
+    setupExitSignals?: boolean | undefined;
+    client?: boolean | ClientConfiguration | undefined;
+    headers?:
+    | Headers_2
+    | ((
+    req: Request_2,
+    res: Response_2,
+    context: DevMiddlewareContext<Request_2, Response_2>,
+    ) => Headers_2)
+    | undefined;
+    onListening?: ((devServer: Server) => void) | undefined;
+    setupMiddlewares?:
+    | ((middlewares: Middleware[], devServer: Server) => Middleware[])
+    | undefined;
+};
+
+// @public (undocumented)
+type DevMiddlewareContext<
+T extends express.Request<
+express_serve_static_core.ParamsDictionary,
+any,
+any,
+qs.ParsedQs,
+Record<string, any>
+>,
+U extends express.Response<any, Record<string, any>>,
+> = webpack_dev_middleware.Context<T, U>;
+
+// @public (undocumented)
+type DevMiddlewareOptions<
+T extends express.Request<
+express_serve_static_core.ParamsDictionary,
+any,
+any,
+qs.ParsedQs,
+Record<string, any>
+>,
+U extends express.Response<any, Record<string, any>>,
+> = webpack_dev_middleware.Options<T, U>;
+
+// @public (undocumented)
+type ExpressErrorRequestHandler = express.ErrorRequestHandler;
+
+// @public (undocumented)
+type ExpressRequestHandler = express.RequestHandler;
+
+// @public (undocumented)
+type FSWatcher = chokidar.FSWatcher;
+
+// @public (undocumented)
+type Headers_2 =
+| Array<{
+    key: string;
+    value: string;
+}>
+| Record<string, string | string[]>;
+
+// @public (undocumented)
+type Host = "local-ip" | "local-ipv4" | "local-ipv6" | string;
+
+// @public (undocumented)
+type HttpProxyMiddlewareOptions = http_proxy_middleware.Options;
+
+// @public (undocumented)
+type HttpProxyMiddlewareOptionsFilter = http_proxy_middleware.Filter;
+
+// @public (undocumented)
+type Middleware =
+| {
+    name?: string;
+    path?: string;
+    middleware: ExpressRequestHandler | ExpressErrorRequestHandler;
+}
+| ExpressRequestHandler
+| ExpressErrorRequestHandler;
+
+// @public (undocumented)
+type MultiCompiler = webpack.MultiCompiler;
+
+// @public (undocumented)
+type NextFunction = express.NextFunction;
+
+// @public (undocumented)
+type Open = {
+    app?: string | string[] | OpenApp | undefined;
+    target?: string | string[] | undefined;
+};
+
+// @public (undocumented)
+type OpenApp = {
+    name?: string | undefined;
+    arguments?: string[] | undefined;
+};
+
+// @public (undocumented)
+type OverlayMessageOptions = boolean | ((error: Error) => void);
+
+// @public (undocumented)
+type Port = number | string | "auto";
+
+// @public (undocumented)
+type ProxyConfigArray = (
+| ProxyConfigArrayItem
+| ((
+req?: Request_2 | undefined,
+res?: Response_2 | undefined,
+next?: NextFunction | undefined,
+) => ProxyConfigArrayItem)
+)[];
+
+// @public (undocumented)
+type ProxyConfigArrayItem = {
+    path?: HttpProxyMiddlewareOptionsFilter | undefined;
+    context?: HttpProxyMiddlewareOptionsFilter | undefined;
+} & {
+    bypass?: ByPass;
+} & HttpProxyMiddlewareOptions;
+
+// @public (undocumented)
+type Request_2 = express.Request;
 
 // @public (undocumented)
 interface ResolvedDevServer extends Configuration {
     // (undocumented)
     allowedHosts: "auto" | string[] | "all";
     // (undocumented)
-    bonjour: false | Record<string, never> | WebpackDevServer.BonjourOptions;
+    bonjour: false | Record<string, never> | Server.BonjourOptions;
     // (undocumented)
-    client: WebpackDevServer.ClientConfiguration;
+    client: Server.ClientConfiguration;
     // (undocumented)
     compress: boolean;
     // (undocumented)
     devMiddleware: Configuration["devMiddleware"];
     // (undocumented)
-    historyApiFallback: false | WebpackDevServer.ConnectHistoryApiFallbackOptions;
+    historyApiFallback: false | Server.ConnectHistoryApiFallbackOptions;
     // (undocumented)
     host?: string;
     // (undocumented)
@@ -41,41 +258,1306 @@ interface ResolvedDevServer extends Configuration {
     // (undocumented)
     magicHtml: boolean;
     // (undocumented)
-    open: WebpackDevServer.Open[];
+    open: Server.Open[];
     // (undocumented)
     port: number | string;
     // (undocumented)
-    proxy: WebpackDevServer.ProxyConfigArray;
+    proxy: Server.ProxyConfigArray;
     // (undocumented)
-    server: WebpackDevServer.ServerConfiguration;
+    server: Server.ServerConfiguration;
     // (undocumented)
     setupExitSignals: boolean;
     // (undocumented)
-    static: false | Array<WebpackDevServer.NormalizedStatic>;
+    static: false | Array<Server.NormalizedStatic>;
     // (undocumented)
-    watchFiles: WebpackDevServer.WatchFiles[];
+    watchFiles: Server.WatchFiles[];
     // (undocumented)
-    webSocketServer: false | WebpackDevServer.WebSocketServerConfiguration;
+    webSocketServer: false | Server.WebSocketServerConfiguration;
 }
 
 // @public (undocumented)
-export class RspackDevServer extends WebpackDevServer {
-    constructor(options: Configuration, compiler: Compiler | MultiCompiler);
-    compiler: Compiler | MultiCompiler;
+type Response_2 = express.Response;
+
+// @public (undocumented)
+export class RspackDevServer extends Server {
+    constructor(options: Configuration, compiler: Compiler_2 | MultiCompiler_2);
+    compiler: Compiler_2 | MultiCompiler_2;
     // (undocumented)
     initialize(): Promise<void>;
     options: ResolvedDevServer;
     // (undocumented)
-    server: Server;
+    server: Server_2;
     // (undocumented)
-    sockets: Socket[];
+    sockets: Socket_2[];
     // (undocumented)
-    staticWatchers: FSWatcher[];
+    staticWatchers: FSWatcher_2[];
     // (undocumented)
     static version: string;
     // (undocumented)
-    webSocketServer: WebpackDevServer.WebSocketServerImplementation | undefined;
+    webSocketServer: Server.WebSocketServerImplementation | undefined;
 }
+
+// @public (undocumented)
+class Server {
+    constructor(
+    options:
+    | webpack.Compiler
+    | webpack.MultiCompiler
+    | Configuration_2
+    | undefined,
+    compiler: Compiler | MultiCompiler | Configuration_2,
+    );
+    app: express.Application | undefined;
+    // (undocumented)
+    compiler: webpack.Compiler | webpack.MultiCompiler;
+    // (undocumented)
+    static findCacheDir(): string;
+    // (undocumented)
+    static findIp(gateway: string): string | undefined;
+    // (undocumented)
+    static getFreePort(port: Port, host: string): Promise<number | string>;
+    // (undocumented)
+    static getHostname(hostname: Host): Promise<string>;
+    // (undocumented)
+    static internalIP(family: "v4" | "v6"): Promise<string | undefined>;
+    // (undocumented)
+    static internalIPSync(family: "v4" | "v6"): string | undefined;
+    // (undocumented)
+    invalidate(
+    callback?: webpack_dev_middleware.Callback | undefined,
+    ): void;
+    // (undocumented)
+    static isAbsoluteURL(URL: string): boolean;
+    logger: ReturnType<Compiler["getInfrastructureLogger"]>;
+    // (undocumented)
+    middleware:
+    | webpack_dev_middleware.API<
+    express.Request<
+    express_serve_static_core.ParamsDictionary,
+    any,
+    any,
+    qs.ParsedQs,
+    Record<string, any>
+    >,
+    express.Response<any, Record<string, any>>
+    >
+    | null
+    | undefined;
+    // (undocumented)
+    options: Configuration_2;
+    // (undocumented)
+    static get schema(): {
+        title: string;
+        type: string;
+        definitions: {
+            AllowedHosts: {
+                anyOf: (
+                | {
+                    type: string;
+                    minItems: number;
+                    items: {
+                        $ref: string;
+                    };
+                    enum?: undefined;
+                    $ref?: undefined;
+                }
+                | {
+                    enum: string[];
+                    type?: undefined;
+                    minItems?: undefined;
+                    items?: undefined;
+                    $ref?: undefined;
+                }
+                | {
+                    $ref: string;
+                    type?: undefined;
+                    minItems?: undefined;
+                    items?: undefined;
+                    enum?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            AllowedHostsItem: {
+                type: string;
+                minLength: number;
+            };
+            Bonjour: {
+                anyOf: (
+                | {
+                    type: string;
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    description?: undefined;
+                    link?: undefined;
+                }
+                | {
+                    type: string /** @typedef {import("express").ErrorRequestHandler} ExpressErrorRequestHandler */;
+                    description: string;
+                    link: string;
+                    cli?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            Client: {
+                description: string;
+                link: string;
+                anyOf: (
+                | {
+                    enum: boolean[];
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    type?: undefined;
+                    additionalProperties?: undefined;
+                    properties?: undefined;
+                }
+                | {
+                    type: string;
+                    additionalProperties: boolean;
+                    properties: {
+                        logging: {
+                            $ref: string;
+                        };
+                        overlay: {
+                            $ref: string;
+                        };
+                        progress: {
+                            $ref: string;
+                        };
+                        reconnect: {
+                            $ref: string;
+                        };
+                        webSocketTransport: {
+                            $ref: string;
+                        };
+                        webSocketURL: {
+                            $ref: string;
+                        };
+                    };
+                    enum?: undefined;
+                    cli?: undefined;
+                }
+                )[];
+            };
+            ClientLogging: {
+                enum: string[];
+                description: string;
+                link: string;
+            };
+            ClientOverlay: {
+                anyOf: (
+                | {
+                    description: string;
+                    link: string;
+                    type: string;
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    additionalProperties?: undefined;
+                    properties?: undefined;
+                }
+                | {
+                    type: string;
+                    additionalProperties: boolean;
+                    properties: {
+                        errors: {
+                            anyOf: (
+                            | {
+                                description: string;
+                                type: string;
+                                cli: {
+                                    negatedDescription: string;
+                                };
+                                instanceof?: undefined;
+                            }
+                            | {
+                                instanceof: string;
+                                description: string;
+                                type?: undefined;
+                                cli?: undefined;
+                            }
+                            )[];
+                        };
+                        warnings: {
+                            anyOf: (
+                            | {
+                                description: string;
+                                type: string;
+                                cli: {
+                                    negatedDescription: string;
+                                };
+                                instanceof?: undefined;
+                            }
+                            | {
+                                instanceof: string /**
+                                * @typedef {import("ws").WebSocketServer | import("sockjs").Server & { close: import("ws").WebSocketServer["close"] }} WebSocketServer
+                                */;
+                                description: string;
+                                type?: undefined;
+                                cli?: undefined;
+                            }
+                            )[];
+                        };
+                        runtimeErrors: {
+                            anyOf: (
+                            | {
+                                description: string;
+                                type: string;
+                                cli: {
+                                    negatedDescription: string;
+                                };
+                                instanceof?: undefined;
+                            }
+                            | {
+                                instanceof: string;
+                                description: string;
+                                type?: undefined;
+                                cli?: undefined;
+                            }
+                            )[];
+                        };
+                        trustedTypesPolicyName: {
+                            description: string;
+                            type: string;
+                        };
+                    };
+                    description?: undefined;
+                    link?: undefined;
+                    cli?: undefined;
+                }
+                )[];
+            };
+            ClientProgress: {
+                description: string;
+                link: string;
+                type: string;
+                cli: {
+                    negatedDescription: string;
+                };
+            };
+            ClientReconnect: {
+                description: string;
+                link: string;
+                anyOf: (
+                | {
+                    type: string;
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    minimum?: undefined;
+                }
+                | {
+                    type: string;
+                    minimum: number;
+                    cli?: undefined;
+                }
+                )[];
+            };
+            ClientWebSocketTransport: {
+                anyOf: {
+                    $ref: string;
+                }[];
+                description: string;
+                link: string;
+            };
+            ClientWebSocketTransportEnum: {
+                enum: string[];
+            };
+            ClientWebSocketTransportString: {
+                type: string;
+                minLength: number;
+            };
+            ClientWebSocketURL: {
+                description: string;
+                link: string;
+                anyOf: (
+                | {
+                    type: string;
+                    minLength: number;
+                    additionalProperties?: undefined;
+                    properties?: undefined;
+                }
+                | {
+                    type: string;
+                    additionalProperties: boolean;
+                    properties: {
+                        hostname: {
+                            description: string;
+                            type: string;
+                            minLength: number;
+                        };
+                        pathname: {
+                            description: string;
+                            type: string;
+                        };
+                        password: {
+                            description: string;
+                            type: string;
+                        };
+                        port: {
+                            description: string;
+                            anyOf: (
+                            | {
+                                type: string;
+                                minLength?: undefined;
+                            }
+                            | {
+                                type: string;
+                                minLength: number;
+                            }
+                            )[];
+                        };
+                        protocol: {
+                            description: string;
+                            anyOf: (
+                            | {
+                                enum: string[];
+                                type?: undefined;
+                                minLength?: undefined;
+                            }
+                            | {
+                                type: string;
+                                minLength: number;
+                                enum?: undefined;
+                            }
+                            )[];
+                        };
+                        username: {
+                            description: string;
+                            type: string;
+                        };
+                    };
+                    minLength?: undefined;
+                }
+                )[];
+            };
+            Compress: {
+                type: string;
+                description: string;
+                link: string;
+                cli: {
+                    negatedDescription: string;
+                };
+            };
+            DevMiddleware: {
+                description: string;
+                link: string;
+                type: string;
+                additionalProperties: boolean;
+            };
+            HeaderObject: {
+                type: string;
+                additionalProperties: boolean;
+                properties: {
+                    key: {
+                        description: string;
+                        type: string;
+                    };
+                    value: {
+                        description: string;
+                        type: string;
+                    };
+                };
+                cli: {
+                    exclude: boolean;
+                };
+            };
+            Headers: {
+                anyOf: (
+                | {
+                    type: string;
+                    items: {
+                        $ref: string;
+                    };
+                    minItems: number;
+                    instanceof?: undefined;
+                }
+                | {
+                    type: string;
+                    items?: undefined;
+                    minItems?: undefined;
+                    instanceof?: undefined;
+                }
+                | {
+                    instanceof: string;
+                    type?: undefined;
+                    items?: undefined;
+                    minItems?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            HistoryApiFallback: {
+                anyOf: (
+                | {
+                    type: string;
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    description?: undefined;
+                    link?: undefined;
+                }
+                | {
+                    type: string;
+                    description: string;
+                    link: string;
+                    cli?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            Host: {
+                description: string;
+                link: string;
+                anyOf: (
+                | {
+                    enum: string[];
+                    type?: undefined;
+                    minLength?: undefined;
+                }
+                | {
+                    type: string;
+                    minLength: number;
+                    enum?: undefined;
+                }
+                )[];
+            };
+            Hot: {
+                anyOf: (
+                | {
+                    type: string;
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    enum?: undefined;
+                }
+                | {
+                    enum: string[];
+                    type?: undefined;
+                    cli?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            IPC: {
+                anyOf: (
+                | {
+                    type: string;
+                    minLength: number;
+                    enum?: undefined;
+                }
+                | {
+                    type: string;
+                    enum: boolean[];
+                    minLength?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            LiveReload: {
+                type: string;
+                description: string;
+                cli: {
+                    negatedDescription: string;
+                };
+                link: string;
+            };
+            OnListening: {
+                instanceof: string;
+                description: string;
+                link: string;
+            };
+            Open: {
+                anyOf: (
+                | {
+                    type: string;
+                    items: {
+                        anyOf: {
+                            $ref: string;
+                        }[];
+                    };
+                    $ref?: undefined;
+                }
+                | {
+                    $ref: string;
+                    type?: undefined;
+                    items?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            OpenBoolean: {
+                type: string;
+                cli: {
+                    negatedDescription: string;
+                };
+            };
+            OpenObject: {
+                type: string;
+                additionalProperties: boolean;
+                properties: {
+                    target: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                type: string;
+                            };
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                    app: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            additionalProperties: boolean;
+                            properties: {
+                                name: {
+                                    anyOf: (
+                                    | {
+                                        type: string;
+                                        items: {
+                                            type: string;
+                                            minLength: number;
+                                        };
+                                        minItems: number;
+                                        minLength?: undefined;
+                                    }
+                                    | {
+                                        type: string;
+                                        minLength: number;
+                                        items?: undefined;
+                                        minItems?: undefined;
+                                    }
+                                    )[];
+                                };
+                                arguments: {
+                                    items: {
+                                        type: string;
+                                        minLength: number;
+                                    };
+                                };
+                            };
+                            minLength?: undefined;
+                            description?: undefined;
+                            cli?: undefined;
+                        }
+                        | {
+                            type: string;
+                            minLength: number;
+                            description: string;
+                            cli: {
+                                exclude: boolean;
+                            };
+                            additionalProperties?: undefined;
+                            properties?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                };
+            };
+            OpenString: {
+                type: string;
+                minLength: number;
+            };
+            Port: {
+                anyOf: (
+                | {
+                    type: string;
+                    minimum: number;
+                    maximum: number;
+                    minLength?: undefined;
+                    enum?: undefined;
+                }
+                | {
+                    type: string;
+                    minLength: number;
+                    minimum?: undefined;
+                    maximum?: undefined;
+                    enum?: undefined;
+                }
+                | {
+                    enum: string[];
+                    type?: undefined;
+                    minimum?: undefined;
+                    maximum?: undefined;
+                    minLength?: undefined;
+                }
+                )[];
+                description: string;
+                link: string /** @type {WebSocketURL} */;
+            };
+            Proxy: {
+                type: string;
+                items: {
+                    anyOf: (
+                    | {
+                        type: string;
+                        instanceof?: undefined;
+                    }
+                    | {
+                        instanceof: string;
+                        type?: undefined;
+                    }
+                    )[];
+                };
+                description: string;
+                link: string;
+            };
+            Server: {
+                anyOf: {
+                    $ref: string;
+                }[];
+                link: string;
+                description: string;
+            };
+            ServerType: {
+                enum: string[];
+            };
+            ServerEnum: {
+                enum: string[];
+                cli: {
+                    exclude: boolean;
+                };
+            };
+            ServerString: {
+                type: string;
+                minLength: number;
+                cli: {
+                    exclude: boolean;
+                };
+            };
+            ServerObject: {
+                type: string;
+                properties: {
+                    type: {
+                        anyOf: {
+                            $ref: string;
+                        }[];
+                    };
+                    options: {
+                        $ref: string;
+                    };
+                };
+                additionalProperties: boolean;
+            };
+            ServerOptions: {
+                type: string;
+                additionalProperties: boolean;
+                properties: {
+                    passphrase: {
+                        type: string;
+                        description: string;
+                    };
+                    requestCert: {
+                        type: string;
+                        description: string;
+                        cli: {
+                            negatedDescription: string;
+                        };
+                    };
+                    ca: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                anyOf: (
+                                | {
+                                    type: string;
+                                    instanceof?: undefined;
+                                }
+                                | {
+                                    instanceof: string;
+                                    type?: undefined;
+                                }
+                                )[];
+                            };
+                            instanceof?: undefined;
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                            instanceof?: undefined;
+                        }
+                        | {
+                            instanceof: string;
+                            type?: undefined;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                    cert: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                anyOf: (
+                                | {
+                                    type: string;
+                                    instanceof?: undefined;
+                                }
+                                | {
+                                    instanceof: string;
+                                    type?: undefined;
+                                }
+                                )[];
+                            };
+                            instanceof?: undefined;
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                            instanceof?: undefined;
+                        }
+                        | {
+                            instanceof: string;
+                            type?: undefined;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                    crl: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                anyOf: (
+                                | {
+                                    type: string;
+                                    instanceof?: undefined;
+                                }
+                                | {
+                                    instanceof: string;
+                                    type?: undefined;
+                                }
+                                )[];
+                            };
+                            instanceof?: undefined;
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                            instanceof?: undefined;
+                        }
+                        | {
+                            instanceof: string;
+                            type?: undefined;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                    key: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                anyOf: (
+                                | {
+                                    type: string;
+                                    instanceof?: undefined;
+                                    additionalProperties?: undefined;
+                                }
+                                | {
+                                    instanceof: string;
+                                    type?: undefined;
+                                    additionalProperties?: undefined;
+                                }
+                                | {
+                                    type: string;
+                                    additionalProperties: boolean;
+                                    instanceof?: undefined;
+                                }
+                                )[];
+                            };
+                            instanceof?: undefined;
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                            instanceof?: undefined;
+                        }
+                        | {
+                            instanceof: string;
+                            type?: undefined;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                    pfx: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                anyOf: (
+                                | {
+                                    type: string;
+                                    instanceof?: undefined;
+                                    additionalProperties?: undefined;
+                                }
+                                | {
+                                    instanceof: string;
+                                    type?: undefined;
+                                    additionalProperties?: undefined;
+                                }
+                                | {
+                                    type: string;
+                                    additionalProperties: boolean;
+                                    instanceof?: undefined;
+                                }
+                                )[];
+                            };
+                            instanceof?: undefined;
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                            instanceof?: undefined;
+                        }
+                        | {
+                            instanceof: string;
+                            type?: undefined;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                };
+            };
+            SetupExitSignals: {
+                type: string;
+                description: string;
+                link: string;
+                cli: {
+                    exclude: boolean;
+                };
+            };
+            SetupMiddlewares: {
+                instanceof: string;
+                description: string;
+                link: string;
+            };
+            Static: {
+                anyOf: (
+                | {
+                    type: string;
+                    items: {
+                        anyOf: {
+                            $ref: string;
+                        }[];
+                    };
+                    cli?: undefined;
+                    $ref?: undefined;
+                }
+                | {
+                    type: string;
+                    cli: {
+                        negatedDescription: string;
+                    };
+                    items?: undefined;
+                    $ref?: undefined;
+                }
+                | {
+                    $ref: string;
+                    type?: undefined;
+                    items?: undefined;
+                    cli?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            StaticObject: {
+                type: string;
+                additionalProperties: boolean;
+                properties: {
+                    directory: {
+                        type: string;
+                        minLength: number;
+                        description: string;
+                        link: string;
+                    };
+                    staticOptions: {
+                        type: string;
+                        link: string;
+                        additionalProperties: boolean;
+                    };
+                    publicPath: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                type: string;
+                            };
+                            minItems: number;
+                        }
+                        | {
+                            type: string;
+                            items?: undefined;
+                            minItems?: undefined;
+                        }
+                        )[];
+                        description: string;
+                        link: string;
+                    };
+                    serveIndex: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            cli: {
+                                negatedDescription: string;
+                            };
+                            additionalProperties?: undefined;
+                        }
+                        | {
+                            type: string;
+                            additionalProperties: boolean;
+                            cli?: undefined;
+                        }
+                        )[];
+                        description: string;
+                        link: string;
+                    };
+                    watch: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            cli: {
+                                negatedDescription: string;
+                            };
+                            description?: undefined;
+                            link?: undefined;
+                        }
+                        | {
+                            type: string;
+                            description: string;
+                            link: string;
+                            cli?: undefined;
+                        }
+                        )[];
+                        description: string;
+                        link: string;
+                    };
+                };
+            };
+            StaticString: {
+                type: string;
+                minLength: number;
+            };
+            WatchFiles: {
+                anyOf: (
+                | {
+                    type: string;
+                    items: {
+                        anyOf: {
+                            $ref: string;
+                        }[];
+                    };
+                    $ref?: undefined;
+                }
+                | {
+                    $ref: string;
+                    type?: undefined;
+                    items?: undefined;
+                }
+                )[];
+                description: string;
+                link: string;
+            };
+            WatchFilesObject: {
+                cli: {
+                    exclude: boolean;
+                };
+                type: string;
+                properties: {
+                    paths: {
+                        anyOf: (
+                        | {
+                            type: string;
+                            items: {
+                                type: string;
+                                minLength: number;
+                            };
+                            minLength?: undefined;
+                        }
+                        | {
+                            type: string;
+                            minLength: number;
+                            items?: undefined;
+                        }
+                        )[];
+                        description: string;
+                    };
+                    options: {
+                        type: string;
+                        description: string;
+                        link: string;
+                        additionalProperties: boolean;
+                    };
+                };
+                additionalProperties: boolean;
+            };
+            WatchFilesString: {
+                type: string;
+                minLength: number;
+            };
+            WebSocketServer: {
+                anyOf: {
+                    $ref: string;
+                }[];
+                description: string;
+                link: string;
+            };
+            WebSocketServerType: {
+                enum: string[];
+            };
+            WebSocketServerEnum: {
+                anyOf: (
+                | {
+                    enum: boolean[];
+                    cli: {
+                        negatedDescription: string;
+                        exclude?: undefined;
+                    };
+                }
+                | {
+                    enum: string[];
+                    cli: {
+                        exclude: boolean;
+                        negatedDescription?: undefined;
+                    };
+                }
+                )[];
+            };
+            WebSocketServerFunction: {
+                instanceof: string;
+            };
+            WebSocketServerObject: {
+                type: string;
+                properties: {
+                    type: {
+                        anyOf: {
+                            $ref: string;
+                        }[];
+                    };
+                    options: {
+                        type: string;
+                        additionalProperties: boolean;
+                        cli: {
+                            exclude: boolean;
+                        };
+                    };
+                };
+                additionalProperties: boolean;
+            };
+            WebSocketServerString: {
+                type: string;
+                minLength: number;
+                cli: {
+                    exclude: boolean;
+                };
+            };
+        };
+        additionalProperties: boolean;
+        properties: {
+            allowedHosts: {
+                $ref: string;
+            };
+            bonjour: {
+                $ref: string;
+            };
+            client: {
+                $ref: string;
+            };
+            compress: {
+                $ref: string;
+            };
+            devMiddleware: {
+                $ref: string;
+            };
+            headers: {
+                $ref: string;
+            };
+            historyApiFallback: {
+                $ref: string;
+            };
+            host: {
+                $ref: string;
+            };
+            hot: {
+                $ref: string;
+            };
+            ipc: {
+                $ref: string;
+            };
+            liveReload: {
+                $ref: string;
+            };
+            onListening: {
+                $ref: string;
+            };
+            open: {
+                $ref: string;
+            };
+            port: {
+                $ref: string;
+            };
+            proxy: {
+                $ref: string;
+            };
+            server: {
+                $ref: string;
+            };
+            setupExitSignals: {
+                $ref: string;
+            };
+            setupMiddlewares: {
+                $ref: string;
+            };
+            static: {
+                $ref: string;
+            };
+            watchFiles: {
+                $ref: string;
+            };
+            webSocketServer: {
+                $ref: string;
+            };
+        };
+    };
+    // (undocumented)
+    sendMessage(
+    clients: ClientConnection[],
+    type: string,
+    data?: any,
+    params?: any,
+    ): void;
+    server: http.Server | undefined | null;
+    sockets: Socket[];
+    // (undocumented)
+    start(): Promise<void>;
+    // (undocumented)
+    startCallback(callback?: ((err?: Error) => void) | undefined): void;
+    staticWatchers: FSWatcher[];
+    // (undocumented)
+    stop(): Promise<void>;
+    // (undocumented)
+    stopCallback(callback?: ((err?: Error) => void) | undefined): void;
+    // (undocumented)
+    watchFiles(
+    watchPath: string | string[],
+    watchOptions?: chokidar.WatchOptions | undefined,
+    ): void;
+    webSocketServer: WebSocketServerImplementation | undefined | null;
+}
+
+// @public (undocumented)
+namespace Server {
+        { DEFAULT_STATS, type Schema, type Compiler, type MultiCompiler, type WebpackConfiguration, type StatsOptions, type StatsCompilation, type Stats, type MultiStats, type NetworkInterfaceInfo, type NextFunction, type ExpressRequestHandler, type ExpressErrorRequestHandler, type WatchOptions, type FSWatcher, type ConnectHistoryApiFallbackOptions, type Bonjour, type BonjourOptions, type RequestHandler, type HttpProxyMiddlewareOptions, type HttpProxyMiddlewareOptionsFilter, type ServeIndexOptions, type ServeStaticOptions, type IPv4, type IPv6, type Socket, type IncomingMessage, type ServerResponse, type OpenOptions, type ServerOptions, type Request, type Response, type DevMiddlewareOptions, type DevMiddlewareContext, type Host, type Port, type WatchFiles, type Static, type NormalizedStatic, type ServerConfiguration, type WebSocketServerConfiguration, type ClientConnection, type WebSocketServer, type WebSocketServerImplementation, type ByPass, type ProxyConfigArrayItem, type ProxyConfigArray, type OpenApp, type Open, type NormalizedOpen, type WebSocketURL, type OverlayMessageOptions, type ClientConfiguration, type Headers, type Middleware, type Configuration };
+}
+
+// @public (undocumented)
+type ServerConfiguration = {
+    type?: string | undefined;
+    options?: ServerOptions | undefined;
+};
+
+// @public (undocumented)
+type ServerOptions = https.ServerOptions & {
+    spdy?: {
+        plain?: boolean | undefined;
+        ssl?: boolean | undefined;
+        "x-forwarded-for"?: string | undefined;
+        protocol?: string | undefined;
+        protocols?: string[] | undefined;
+    };
+};
+
+// @public (undocumented)
+type Socket = net.Socket;
+
+// @public (undocumented)
+type Static = {
+    directory?: string | undefined;
+    publicPath?: string | string[] | undefined;
+    serveIndex?: boolean | serve_index.Options | undefined;
+    staticOptions?:
+    | serve_static.ServeStaticOptions<
+    http.ServerResponse<http.IncomingMessage>
+    >
+    | undefined;
+    watch?:
+    | boolean
+    | (chokidar.WatchOptions & {
+        aggregateTimeout?: number | undefined;
+        ignored?: WatchOptions["ignored"];
+        poll?: number | boolean | undefined;
+    })
+    | undefined;
+};
+
+// @public (undocumented)
+type WatchFiles = {
+    paths: string | string[];
+    options?:
+    | (chokidar.WatchOptions & {
+        aggregateTimeout?: number | undefined;
+        ignored?: WatchOptions["ignored"];
+        poll?: number | boolean | undefined;
+    })
+    | undefined;
+};
+
+// @public (undocumented)
+type WatchOptions = chokidar.WatchOptions;
+
+// @public (undocumented)
+type WebSocketServer =
+| ws.WebSocketServer
+| (sockjs.Server & {
+    close: ws.WebSocketServer["close"];
+});
+
+// @public (undocumented)
+type WebSocketServerConfiguration = {
+    type?: string | Function | undefined;
+    options?: Record<string, any> | undefined;
+};
+
+// @public (undocumented)
+type WebSocketServerImplementation = {
+    implementation: WebSocketServer;
+    clients: ClientConnection[];
+};
+
+// @public (undocumented)
+type WebSocketURL = {
+    hostname?: string | undefined;
+    password?: string | undefined;
+    pathname?: string | undefined;
+    port?: string | number | undefined;
+    protocol?: string | undefined;
+    username?: string | undefined;
+};
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "prepare": "prebundle",
-    "build": "tsc -b ./tsconfig.build.json",
+    "build": "tsc -b ./tsconfig.build.json && tsc-alias -p tsconfig.build.json",
     "dev": "tsc -b -w ./tsconfig.build.json",
     "test": "rimraf .test-temp && cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --colors",
     "api-extractor": "api-extractor run --verbose",

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -47,7 +47,8 @@
     "jest-serializer-path": "^0.1.15",
     "prebundle": "^1.1.0",
     "typescript": "5.0.2",
-    "webpack-dev-server": "5.0.4"
+    "webpack-dev-server": "5.0.4",
+    "tsc-alias": "^1.8.8"
   },
   "dependencies": {
     "chokidar": "^3.6.0",

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -43,6 +43,8 @@
     "@types/connect-history-api-fallback": "1.5.4",
     "@types/express": "4.17.21",
     "@types/mime-types": "2.1.4",
+    "@types/express-serve-static-core": "4.19.5",
+    "@types/serve-static": "1.15.7",
     "@types/ws": "8.5.10",
     "jest-serializer-path": "^0.1.15",
     "prebundle": "^1.1.0",

--- a/packages/rspack-dev-server/package.json
+++ b/packages/rspack-dev-server/package.json
@@ -18,8 +18,9 @@
     "./package.json": "./package.json"
   },
   "scripts": {
+    "prepare": "prebundle",
     "build": "tsc -b ./tsconfig.build.json",
-    "dev": "tsc -w -b ./tsconfig.build.json",
+    "dev": "tsc -b -w ./tsconfig.build.json",
     "test": "rimraf .test-temp && cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --colors",
     "api-extractor": "api-extractor run --verbose",
     "api-extractor:ci": "api-extractor run --verbose || diff temp/api.md etc/api.md"
@@ -44,7 +45,9 @@
     "@types/mime-types": "2.1.4",
     "@types/ws": "8.5.10",
     "jest-serializer-path": "^0.1.15",
-    "typescript": "5.0.2"
+    "prebundle": "^1.1.0",
+    "typescript": "5.0.2",
+    "webpack-dev-server": "5.0.4"
   },
   "dependencies": {
     "chokidar": "^3.6.0",
@@ -52,9 +55,23 @@
     "express": "^4.19.2",
     "http-proxy-middleware": "^2.0.6",
     "mime-types": "^2.1.35",
-    "webpack-dev-middleware": "^7.4.2",
-    "webpack-dev-server": "5.0.4",
-    "ws": "^8.16.0"
+    "ws": "^8.16.0",
+    "webpack-dev-middleware": "7.4.2",
+    "ansi-html-community": "^0.0.8",
+    "bonjour-service": "^1.2.1",
+    "colorette": "2.0.19",
+    "compression": "^1.7.4",
+    "graceful-fs": "4.2.10",
+    "html-entities": "^2.4.0",
+    "ipaddr.js": "^2.1.0",
+    "launch-editor": "^2.6.1",
+    "open": "^10.0.3",
+    "p-retry": "^6.2.0",
+    "schema-utils": "^4.2.0",
+    "selfsigned": "^2.4.1",
+    "serve-index": "^1.9.1",
+    "sockjs": "^0.3.24",
+    "spdy": "^4.0.2"
   },
   "peerDependencies": {
     "@rspack/core": "*"

--- a/packages/rspack-dev-server/prebundle.config.mjs
+++ b/packages/rspack-dev-server/prebundle.config.mjs
@@ -1,10 +1,32 @@
 // @ts-check
-
+import fs from 'node:fs';
+import {join} from 'node:path';
+function replaceFileContent(filePath, replaceFn) {
+  const content = fs.readFileSync(filePath, 'utf-8');
+  const newContent = replaceFn(content);
+  if (newContent !== content) {
+    fs.writeFileSync(filePath, newContent);
+  }
+}
 /** @type {import('prebundle').Config} */
 export default {
   dependencies: [{
     name: 'webpack-dev-server',
     ignoreDts: true,
+    // this is a trick to avoid ncc compiling the dynamic import syntax
+    // https://github.com/vercel/ncc/issues/935
+    beforeBundle(task) {
+      replaceFileContent(
+          join(task.depPath, 'lib/Server.js'),
+          (content) => content.replaceAll('await import', 'await __import'));
+    },
+    afterBundle(task) {
+      replaceFileContent(
+          join(task.distPath, 'index.js'),
+          (content) =>
+              `${content.replaceAll('await __import', 'await import')}`,
+      );
+    },
     externals: {
       // the following externals are from webpack-dev-server's dependencies
       // https://github.com/webpack/webpack-dev-server/blob/master/package.json#L48

--- a/packages/rspack-dev-server/prebundle.config.mjs
+++ b/packages/rspack-dev-server/prebundle.config.mjs
@@ -1,0 +1,36 @@
+// @ts-check
+
+/** @type {import('prebundle').Config} */
+export default {
+  dependencies: [{
+    name: 'webpack-dev-server',
+    ignoreDts: true,
+    externals: {
+      // the following externals are from webpack-dev-server's dependencies
+      // https://github.com/webpack/webpack-dev-server/blob/master/package.json#L48
+      'ansi-html-community': 'ansi-html-community',
+      'bonjour-service': 'bonjour-service',
+      chokidar: 'chokidar',
+      colorette: 'colorette',
+      compression: 'compression',
+      'connect-history-api-fallback': 'connect-history-api-fallback',
+      express: 'express',
+      'graceful-fs': 'graceful-fs',
+      'html-entities': 'html-entities',
+      'http-proxy-middleware': 'http-proxy-middleware',
+      'ipaddr.js': 'ipaddr.js',
+      'launch-editor': 'launch-editor',
+      open: 'open',
+      'p-retry': 'p-retry',
+      'schema-utils': 'schema-utils',
+      selfsigned: 'selfsigned',
+      'serve-index': 'serve-index',
+      sockjs: 'sockjs',
+      spdy: 'spdy',
+      'webpack-dev-middleware': 'webpack-dev-middleware',
+      ws: 'ws',
+      webpack: 'webpack',
+      'webpack-cli': 'webpack-cli'
+    }
+  }]
+};

--- a/packages/rspack-dev-server/prebundle.config.mjs
+++ b/packages/rspack-dev-server/prebundle.config.mjs
@@ -12,7 +12,7 @@ function replaceFileContent(filePath, replaceFn) {
 export default {
   dependencies: [{
     name: 'webpack-dev-server',
-    ignoreDts: true,
+    ignoreDts: false,
     // this is a trick to avoid ncc compiling the dynamic import syntax
     // https://github.com/vercel/ncc/issues/935
     beforeBundle(task) {
@@ -52,7 +52,9 @@ export default {
       'webpack-dev-middleware': 'webpack-dev-middleware',
       ws: 'ws',
       webpack: 'webpack',
-      'webpack-cli': 'webpack-cli'
+      'webpack-cli': 'webpack-cli',
+      'serve-static': 'serve-static',
+      'express-serve-static-core': 'express-serve-static-core'
     }
   }]
 };

--- a/packages/rspack-dev-server/src/server.ts
+++ b/packages/rspack-dev-server/src/server.ts
@@ -76,12 +76,13 @@ export class RspackDevServer extends WebpackDevServer {
 			case "string":
 				// could be 'sockjs', 'ws', or a path that should be required
 				if (clientTransport === "sockjs") {
+					// ts-alias doesn't support alias require.resolve so we have to do it manually
 					clientImplementation = require.resolve(
-						"webpack-dev-server/client/clients/SockJSClient"
+						"../compiled/webpack-dev-server/client/clients/SockJSClient"
 					);
 				} else if (clientTransport === "ws") {
 					clientImplementation = require.resolve(
-						"webpack-dev-server/client/clients/WebSocketClient"
+						"../compiled/webpack-dev-server/client/clients/WebSocketClient"
 					);
 				} else {
 					try {

--- a/packages/rspack-dev-server/tsconfig.json
+++ b/packages/rspack-dev-server/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "webpack-dev-server": [
+        "../compiled/webpack-dev-server"
+      ]
+    }
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,9 +580,15 @@ importers:
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
+      '@types/express-serve-static-core':
+        specifier: 4.19.5
+        version: 4.19.5
       '@types/mime-types':
         specifier: 2.1.4
         version: 2.1.4
+      '@types/serve-static':
+        specifier: 1.15.7
+        version: 1.15.7
       '@types/ws':
         specifier: 8.5.10
         version: 8.5.10
@@ -3620,8 +3626,8 @@ packages:
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
 
-  '@types/express-serve-static-core@4.19.0':
-    resolution: {integrity: sha512-bGyep3JqPCRry1wq+O5n7oiBgGWmeIJXPjXXCo8EK0u8duZGSYar7cGqd3ML2JUsLGeB7fmc06KYo9fLGWqPvQ==}
+  '@types/express-serve-static-core@4.19.5':
+    resolution: {integrity: sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==}
 
   '@types/express@4.17.21':
     resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
@@ -12969,7 +12975,7 @@ snapshots:
 
   '@types/connect-history-api-fallback@1.5.4':
     dependencies:
-      '@types/express-serve-static-core': 4.19.0
+      '@types/express-serve-static-core': 4.19.5
       '@types/node': 20.12.6
 
   '@types/connect@3.4.38':
@@ -12990,7 +12996,7 @@ snapshots:
 
   '@types/estree@1.0.5': {}
 
-  '@types/express-serve-static-core@4.19.0':
+  '@types/express-serve-static-core@4.19.5':
     dependencies:
       '@types/node': 20.12.7
       '@types/qs': 6.9.14
@@ -13000,7 +13006,7 @@ snapshots:
   '@types/express@4.17.21':
     dependencies:
       '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.0
+      '@types/express-serve-static-core': 4.19.5
       '@types/qs': 6.9.14
       '@types/serve-static': 1.15.7
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -498,27 +498,69 @@ importers:
 
   packages/rspack-dev-server:
     dependencies:
+      ansi-html-community:
+        specifier: ^0.0.8
+        version: 0.0.8
+      bonjour-service:
+        specifier: ^1.2.1
+        version: 1.2.1
       chokidar:
         specifier: ^3.6.0
         version: 3.6.0
+      colorette:
+        specifier: 2.0.19
+        version: 2.0.19
+      compression:
+        specifier: ^1.7.4
+        version: 1.7.4
       connect-history-api-fallback:
         specifier: ^2.0.0
         version: 2.0.0
       express:
         specifier: ^4.19.2
         version: 4.19.2
+      graceful-fs:
+        specifier: 4.2.10
+        version: 4.2.10
+      html-entities:
+        specifier: ^2.4.0
+        version: 2.5.2
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.6(@types/express@4.17.21)
+      ipaddr.js:
+        specifier: ^2.1.0
+        version: 2.1.0
+      launch-editor:
+        specifier: ^2.6.1
+        version: 2.6.1
       mime-types:
         specifier: ^2.1.35
         version: 2.1.35
+      open:
+        specifier: ^10.0.3
+        version: 10.1.0
+      p-retry:
+        specifier: ^6.2.0
+        version: 6.2.0
+      schema-utils:
+        specifier: ^4.2.0
+        version: 4.2.0
+      selfsigned:
+        specifier: ^2.4.1
+        version: 2.4.1
+      serve-index:
+        specifier: ^1.9.1
+        version: 1.9.1
+      sockjs:
+        specifier: ^0.3.24
+        version: 0.3.24
+      spdy:
+        specifier: ^4.0.2
+        version: 4.0.2
       webpack-dev-middleware:
-        specifier: ^7.4.2
+        specifier: 7.4.2
         version: 7.4.2(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
-      webpack-dev-server:
-        specifier: 5.0.4
-        version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
       ws:
         specifier: ^8.16.0
         version: 8.17.1
@@ -547,9 +589,15 @@ importers:
       jest-serializer-path:
         specifier: ^0.1.15
         version: 0.1.15
+      prebundle:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.0.2)
       typescript:
         specifier: 5.0.2
         version: 5.0.2
+      webpack-dev-server:
+        specifier: 5.0.4
+        version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(webpack-cli@5.1.4(webpack@5.94.0)))
 
   packages/rspack-test-tools:
     dependencies:
@@ -986,7 +1034,7 @@ importers:
         version: 3.36.1
       css-loader:
         specifier: ^6.11.0
-        version: 6.11.0(@rspack/core@1.0.0)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 6.11.0(@rspack/core@1.0.1)(webpack@5.94.0(webpack-cli@5.1.4))
       date-fns:
         specifier: ^2.29.3
         version: 2.30.0
@@ -2841,19 +2889,14 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.0.0':
-    resolution: {integrity: sha512-ZHQk9YK+swlTG48kJTgzFUW9T26KjhLXRok5la7t2AMoiuHyhGHHgC5iQfPJLZ62XzcJ/rfqs2rwakl97151jQ==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.0.0-rc.0':
     resolution: {integrity: sha512-4S/+q8HN69ErWUjGDePExqiNuKIEGYKEoT+91+Wz55jQV4NY1mNGRojKVKjZkz7MvbPEZ1howtpDcHuUE2+QhQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.0.0':
-    resolution: {integrity: sha512-qhTXm9wUhv2lBjsqqfCu59RchH1/2jursdPAmTqGc7zMReZdZvtJs2Ri6Ma1M48BLLu+7fS4fbL8Rw1g78TOOQ==}
-    cpu: [x64]
+  '@rspack/binding-darwin-arm64@1.0.1':
+    resolution: {integrity: sha512-oJ4ex0USLoOR5nFt0uQFinG6bDCSbCqwobepjA0qk33kuXdJyJw5LAwDW0Mfw3up+/ngEhySOZtQIv6PDeSFqQ==}
+    cpu: [arm64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.0.0-rc.0':
@@ -2861,18 +2904,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.0.0':
-    resolution: {integrity: sha512-yKnlsWgvydJRxDBGGKC+cyDeoSzIvOzuVqCloy5oAFAGOMXMY6bznxrkE6/olGZncdeLEpnJzZmXSuF1dYc8ow==}
-    cpu: [arm64]
-    os: [linux]
+  '@rspack/binding-darwin-x64@1.0.1':
+    resolution: {integrity: sha512-v5rfOUVGIQ25WAOSbzBHv42Qsz/DaC7bqjc7mEb1jO8a4Y9y0fO7Nw2/bgLRg1di2y+Q2M9CBgPf9TDt8T1jOg==}
+    cpu: [x64]
+    os: [darwin]
 
   '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
     resolution: {integrity: sha512-gqURooSNYGlwvgLE1xu8rz68E4Mfa2MONGTNMkre5aIYX2ZOd/MKGaB/R062Oj/78BIHmIGWcoz5GnBxBwToyw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.0.0':
-    resolution: {integrity: sha512-dKFmlqlF4FELT/AX02hSwX8aRawjH5zAliQzYnvgrqcEyCKE60vKacGJQ3ZeRyru6dh5MlbUNW4H1+TDT+cDVA==}
+  '@rspack/binding-linux-arm64-gnu@1.0.1':
+    resolution: {integrity: sha512-kCh94gOTms2N9A9oAaVpxqOn6l9Lr/oWGSQS9Zc4f0cyHmThYYMyPX76kLdL1WR/UpzrihQ3L9RfMU1FHMfjow==}
     cpu: [arm64]
     os: [linux]
 
@@ -2881,9 +2924,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.0.0':
-    resolution: {integrity: sha512-fRk9i8aE4FiwW7+LkNyw+5vfFzJ8BZ2seAL9V5U2iwYwYibzFJsukg3h3Uh+IsGm30/7+ZRENtGwybQiMruL4g==}
-    cpu: [x64]
+  '@rspack/binding-linux-arm64-musl@1.0.1':
+    resolution: {integrity: sha512-GCp5TxYSESzstqoZKBR0dFm8bh1F9aWsVnypcKndE3PCEPsptGwWvGZKl2QLZm87d/FL21eysAjFX4KQ1NNy+Q==}
+    cpu: [arm64]
     os: [linux]
 
   '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
@@ -2891,8 +2934,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.0.0':
-    resolution: {integrity: sha512-qcTJC8o3KvLwsnrJJcuBjfzSrjEbACMiCB4RtbFNecXDtI+Nputx1CO1SlUrINC25/44ILketf0/hsdBQHk60g==}
+  '@rspack/binding-linux-x64-gnu@1.0.1':
+    resolution: {integrity: sha512-kvwDRsXHp9HRWRqSqsFn+tEk8Uc2wPuGPzHo6pHaEKUu8S5czQmPuF5W0UtK7OluR+eec/6RfCy18WclGQx8Vg==}
     cpu: [x64]
     os: [linux]
 
@@ -2901,19 +2944,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@1.0.0':
-    resolution: {integrity: sha512-gqtakP0Yl2aj+Q/Giwgt31hz8eOZpo2s+sJlkMJGVdIF4dejB31a8vbj/VNGeSN1tDRiLI4cyqa5eQU//t26aQ==}
-    cpu: [arm64]
-    os: [win32]
+  '@rspack/binding-linux-x64-musl@1.0.1':
+    resolution: {integrity: sha512-Di64N+wOxiWFH5xTg8NJpPGe2Syv/wkHYlA8mVo6nPvfTIPdyzybrjYl7TX9YHUnCXPKSIaEVuQM3FppuSvK1w==}
+    cpu: [x64]
+    os: [linux]
 
   '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
     resolution: {integrity: sha512-ob510ObXoIBAMjPE8iBwvhWQ8Hd4v7bJSgImUBhSGExYI+z8b/gl8tNg8y1fttLtNO8j05rj9QFsGcZmv89Zsg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.0.0':
-    resolution: {integrity: sha512-nLfGu5DjdzwawzZ7zK69vZX5aL1Gt9+Ovfz4RlngDq/D5ZzqCnNWw93cqKADgFRWS4qK9vOD9RXNNnkyWB2SEw==}
-    cpu: [ia32]
+  '@rspack/binding-win32-arm64-msvc@1.0.1':
+    resolution: {integrity: sha512-UChXLKqND90LwBjoPZgD9P9ZYKmp9+y51n7kgNtDX2Hi/wsnFOZHUK2kpiSH9W69vE+c3pGFf0NIJ/scLdeUZw==}
+    cpu: [arm64]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.0.0-rc.0':
@@ -2921,9 +2964,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.0.0':
-    resolution: {integrity: sha512-H9PqjgtZMw5aP+eXdFo7bgSP/Ycwn3oW81uI9qFqOOQ90W+o3T9ItghHBf2/ksc5GHibd208EwOBNxbKwjZDSQ==}
-    cpu: [x64]
+  '@rspack/binding-win32-ia32-msvc@1.0.1':
+    resolution: {integrity: sha512-at+/S2t5yaADOV8s27S1nSsQc1Y5BxAb/y9lRvxKJJgshewsoOTNMQ1PFcy8pNDOF4Dvn/xiiCctqpZUjrT+jw==}
+    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
@@ -2931,14 +2974,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.0.0':
-    resolution: {integrity: sha512-eLyqSEM1h/exJYn98k+9MRktP8AYDB13x5oVn8hoxVucuhk0TubFqQSX8h9SQcZp1O3j/Z8eWWwOaNPe3JU40Q==}
+  '@rspack/binding-win32-x64-msvc@1.0.1':
+    resolution: {integrity: sha512-PpKDYqFSUypbATkSx7N0j521T6shYjiOEl44VI+99AkZVt7gQnS/LWXWrRYuZrueO2klPm+LUBACBJUKPWNYNg==}
+    cpu: [x64]
+    os: [win32]
 
   '@rspack/binding@1.0.0-rc.0':
     resolution: {integrity: sha512-mx0x4ho0ndHpOnSjAEOoQZohTqJLYOl4hLEvQLEnXIPTdMjZtpiLUyuyKtzv6DrXDV5La3bsZuzbcdMyqkSWpg==}
 
-  '@rspack/core@1.0.0':
-    resolution: {integrity: sha512-F4RA9uOLLvD1oTKa96Gcly+Sro1qaqPNENadFyiPwepa7DrwexQa/ym6CQKbvKMOYGKlVSFDPUmgFAirz35ETg==}
+  '@rspack/binding@1.0.1':
+    resolution: {integrity: sha512-bf5uTyen6Y1NYbHERA3oLX/IGx6T9C2PyKH+cia9Ik5A4hUwkOYamIAQIIC29VEPs06W1DccPLmGRZd3gjA7pA==}
+
+  '@rspack/core@1.0.0-rc.0':
+    resolution: {integrity: sha512-sxS6QfVm7FbuKIYai8CyxMv5WH3MVdQmowVEqIZ/Fa8+PX17/sO5dg8tAFYAEzpCe/4dC93eYh9APr3Vc4ditQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2946,8 +2994,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.0.0-rc.0':
-    resolution: {integrity: sha512-sxS6QfVm7FbuKIYai8CyxMv5WH3MVdQmowVEqIZ/Fa8+PX17/sO5dg8tAFYAEzpCe/4dC93eYh9APr3Vc4ditQ==}
+  '@rspack/core@1.0.1':
+    resolution: {integrity: sha512-z09J/6oJA5y7iclPe+4INg13J5OEWgBw6PdGAOExdcj0DvCicbTGR7QVx1vSrMRbi8oxWk10J3nosOs0zf1bRQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -9747,7 +9795,7 @@ snapshots:
   '@babel/code-frame@7.24.7':
     dependencies:
       '@babel/highlight': 7.24.7
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/compat-data@7.24.4': {}
 
@@ -10014,14 +10062,14 @@ snapshots:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/highlight@7.24.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   '@babel/parser@7.23.0':
     dependencies:
@@ -11685,71 +11733,58 @@ snapshots:
       '@microsoft/api-extractor': 7.43.1(@types/node@20.12.7)
       typescript: 5.0.2
 
-  '@rspack/binding-darwin-arm64@1.0.0':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.0.0':
+  '@rspack/binding-darwin-arm64@1.0.1':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.0.0':
+  '@rspack/binding-darwin-x64@1.0.1':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.0.0':
+  '@rspack/binding-linux-arm64-gnu@1.0.1':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.0.0':
+  '@rspack/binding-linux-arm64-musl@1.0.1':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.0.0':
+  '@rspack/binding-linux-x64-gnu@1.0.1':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.0.0':
+  '@rspack/binding-linux-x64-musl@1.0.1':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.0.0':
+  '@rspack/binding-win32-arm64-msvc@1.0.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.0.0':
+  '@rspack/binding-win32-ia32-msvc@1.0.1':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding@1.0.0':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.0
-      '@rspack/binding-darwin-x64': 1.0.0
-      '@rspack/binding-linux-arm64-gnu': 1.0.0
-      '@rspack/binding-linux-arm64-musl': 1.0.0
-      '@rspack/binding-linux-x64-gnu': 1.0.0
-      '@rspack/binding-linux-x64-musl': 1.0.0
-      '@rspack/binding-win32-arm64-msvc': 1.0.0
-      '@rspack/binding-win32-ia32-msvc': 1.0.0
-      '@rspack/binding-win32-x64-msvc': 1.0.0
+  '@rspack/binding-win32-x64-msvc@1.0.1':
     optional: true
 
   '@rspack/binding@1.0.0-rc.0':
@@ -11764,12 +11799,17 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.0-rc.0
       '@rspack/binding-win32-x64-msvc': 1.0.0-rc.0
 
-  '@rspack/core@1.0.0':
-    dependencies:
-      '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.0
-      '@rspack/lite-tapable': 1.0.0
-      caniuse-lite: 1.0.30001654
+  '@rspack/binding@1.0.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.0.1
+      '@rspack/binding-darwin-x64': 1.0.1
+      '@rspack/binding-linux-arm64-gnu': 1.0.1
+      '@rspack/binding-linux-arm64-musl': 1.0.1
+      '@rspack/binding-linux-x64-gnu': 1.0.1
+      '@rspack/binding-linux-x64-musl': 1.0.1
+      '@rspack/binding-win32-arm64-msvc': 1.0.1
+      '@rspack/binding-win32-ia32-msvc': 1.0.1
+      '@rspack/binding-win32-x64-msvc': 1.0.1
     optional: true
 
   '@rspack/core@1.0.0-rc.0(@swc/helpers@0.5.12)':
@@ -11780,6 +11820,14 @@ snapshots:
       caniuse-lite: 1.0.30001654
     optionalDependencies:
       '@swc/helpers': 0.5.12
+
+  '@rspack/core@1.0.1':
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': 1.0.1
+      '@rspack/lite-tapable': 1.0.0
+      caniuse-lite: 1.0.30001654
+    optional: true
 
   '@rspack/lite-tapable@1.0.0': {}
 
@@ -13391,9 +13439,9 @@ snapshots:
     dependencies:
       ajv: 6.12.6
 
-  ajv-formats@2.1.1(ajv@8.12.0):
+  ajv-formats@2.1.1(ajv@8.13.0):
     optionalDependencies:
-      ajv: 8.12.0
+      ajv: 8.13.0
 
   ajv-formats@3.0.1(ajv@8.13.0):
     optionalDependencies:
@@ -13403,9 +13451,9 @@ snapshots:
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.12.0):
+  ajv-keywords@5.1.0(ajv@8.13.0):
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.13.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -14498,7 +14546,7 @@ snapshots:
       semver: 7.6.2
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0))
 
-  css-loader@6.11.0(@rspack/core@1.0.0)(webpack@5.94.0(webpack-cli@5.1.4)):
+  css-loader@6.11.0(@rspack/core@1.0.1)(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -14509,7 +14557,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.0
     optionalDependencies:
-      '@rspack/core': 1.0.0
+      '@rspack/core': 1.0.1
       webpack: 5.94.0(webpack-cli@5.1.4)
 
   css-loader@6.11.0(@rspack/core@packages+rspack)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))):
@@ -18444,9 +18492,9 @@ snapshots:
   schema-utils@4.2.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
-      ajv-keywords: 5.1.0(ajv@8.12.0)
+      ajv: 8.13.0
+      ajv-formats: 2.1.1(ajv@8.13.0)
+      ajv-keywords: 5.1.0(ajv@8.13.0)
 
   scroll-into-view-if-needed@2.2.20:
     dependencies:
@@ -18929,7 +18977,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   swc-loader@0.2.6(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -592,6 +592,9 @@ importers:
       prebundle:
         specifier: ^1.1.0
         version: 1.1.0(typescript@5.0.2)
+      tsc-alias:
+        specifier: ^1.8.8
+        version: 1.8.8
       typescript:
         specifier: 5.0.2
         version: 5.0.2
@@ -1034,7 +1037,7 @@ importers:
         version: 3.36.1
       css-loader:
         specifier: ^6.11.0
-        version: 6.11.0(@rspack/core@1.0.1)(webpack@5.94.0(webpack-cli@5.1.4))
+        version: 6.11.0(@rspack/core@1.0.2)(webpack@5.94.0(webpack-cli@5.1.4))
       date-fns:
         specifier: ^2.29.3
         version: 2.30.0
@@ -2894,8 +2897,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.0.1':
-    resolution: {integrity: sha512-oJ4ex0USLoOR5nFt0uQFinG6bDCSbCqwobepjA0qk33kuXdJyJw5LAwDW0Mfw3up+/ngEhySOZtQIv6PDeSFqQ==}
+  '@rspack/binding-darwin-arm64@1.0.2':
+    resolution: {integrity: sha512-akRTzBjErSY2+med5AUidBkeVsZ5d+5x7d1MK1ZuirQY/OEOeM9qSASnF43jFY1BDmAl2kgrwGvizPWqPtVjYw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2904,8 +2907,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.0.1':
-    resolution: {integrity: sha512-v5rfOUVGIQ25WAOSbzBHv42Qsz/DaC7bqjc7mEb1jO8a4Y9y0fO7Nw2/bgLRg1di2y+Q2M9CBgPf9TDt8T1jOg==}
+  '@rspack/binding-darwin-x64@1.0.2':
+    resolution: {integrity: sha512-qnBRkmqslBoLHIv/gKlzKk6iLkC2G5Qg+O+zUQgTZ6Qepnn+CV0lwevfMlyaLbAE7g3X+525cVx4hHFGjj0wOA==}
     cpu: [x64]
     os: [darwin]
 
@@ -2914,8 +2917,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.0.1':
-    resolution: {integrity: sha512-kCh94gOTms2N9A9oAaVpxqOn6l9Lr/oWGSQS9Zc4f0cyHmThYYMyPX76kLdL1WR/UpzrihQ3L9RfMU1FHMfjow==}
+  '@rspack/binding-linux-arm64-gnu@1.0.2':
+    resolution: {integrity: sha512-EH/RA5FQN4PpqNJWYYemaaIgVTv2R7b/nmxKUIjLGTAT4jYOpJW8pYmBDpwHgjkOsTMIbgdwIYw0fw/vdWATrQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2924,8 +2927,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.0.1':
-    resolution: {integrity: sha512-GCp5TxYSESzstqoZKBR0dFm8bh1F9aWsVnypcKndE3PCEPsptGwWvGZKl2QLZm87d/FL21eysAjFX4KQ1NNy+Q==}
+  '@rspack/binding-linux-arm64-musl@1.0.2':
+    resolution: {integrity: sha512-jO/uemUF7ObUr2gUFYKEhuZtpc5fd400YEHAWHgcM0yUQi4+rWvyvMXQ+Hsy37nbWz5tsxiL9m/vuZr3r7NLCA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2934,8 +2937,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.0.1':
-    resolution: {integrity: sha512-kvwDRsXHp9HRWRqSqsFn+tEk8Uc2wPuGPzHo6pHaEKUu8S5czQmPuF5W0UtK7OluR+eec/6RfCy18WclGQx8Vg==}
+  '@rspack/binding-linux-x64-gnu@1.0.2':
+    resolution: {integrity: sha512-8/5zImJcz2K1ayja8982PUffdemkvIKP2LLnF7gsourhUV4GAUwCugR5c5prQ1o9wtt5p6er1c+M39AdzamFdA==}
     cpu: [x64]
     os: [linux]
 
@@ -2944,8 +2947,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.0.1':
-    resolution: {integrity: sha512-Di64N+wOxiWFH5xTg8NJpPGe2Syv/wkHYlA8mVo6nPvfTIPdyzybrjYl7TX9YHUnCXPKSIaEVuQM3FppuSvK1w==}
+  '@rspack/binding-linux-x64-musl@1.0.2':
+    resolution: {integrity: sha512-HoRHhM5uiqIOH+xB7Xktzjlf2RgpaTzJ29ul/m2sP/7OeWS2xnKe0uOLqI1CsftfsAZtPhS2AMqEiVFSE9WsPg==}
     cpu: [x64]
     os: [linux]
 
@@ -2954,8 +2957,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.0.1':
-    resolution: {integrity: sha512-UChXLKqND90LwBjoPZgD9P9ZYKmp9+y51n7kgNtDX2Hi/wsnFOZHUK2kpiSH9W69vE+c3pGFf0NIJ/scLdeUZw==}
+  '@rspack/binding-win32-arm64-msvc@1.0.2':
+    resolution: {integrity: sha512-mIB5McOrRVdBoE7mcGeA8VUzWfr5hSAP8s31IjCevKXxQDLy8bKwB02Gf/cE/R9DR/ngseEJbEDvAXXeBx7quw==}
     cpu: [arm64]
     os: [win32]
 
@@ -2964,8 +2967,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.0.1':
-    resolution: {integrity: sha512-at+/S2t5yaADOV8s27S1nSsQc1Y5BxAb/y9lRvxKJJgshewsoOTNMQ1PFcy8pNDOF4Dvn/xiiCctqpZUjrT+jw==}
+  '@rspack/binding-win32-ia32-msvc@1.0.2':
+    resolution: {integrity: sha512-3nFTUoN+6OmZ5W816t85+r3OgRrs27iF7RWRw9rqttXMpdAZuh78GSKIY/fDw7PJbt06GDi43QuJDw3KMG+ekQ==}
     cpu: [ia32]
     os: [win32]
 
@@ -2974,16 +2977,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.0.1':
-    resolution: {integrity: sha512-PpKDYqFSUypbATkSx7N0j521T6shYjiOEl44VI+99AkZVt7gQnS/LWXWrRYuZrueO2klPm+LUBACBJUKPWNYNg==}
+  '@rspack/binding-win32-x64-msvc@1.0.2':
+    resolution: {integrity: sha512-6phTrDps31Z2ZghcpUZFPiRuKj5N/yKxuZzZbbBCHYx47a5dlkKkDJhwgS2mMapg4qwnW5yW444dQ8rY2GPazw==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@1.0.0-rc.0':
     resolution: {integrity: sha512-mx0x4ho0ndHpOnSjAEOoQZohTqJLYOl4hLEvQLEnXIPTdMjZtpiLUyuyKtzv6DrXDV5La3bsZuzbcdMyqkSWpg==}
 
-  '@rspack/binding@1.0.1':
-    resolution: {integrity: sha512-bf5uTyen6Y1NYbHERA3oLX/IGx6T9C2PyKH+cia9Ik5A4hUwkOYamIAQIIC29VEPs06W1DccPLmGRZd3gjA7pA==}
+  '@rspack/binding@1.0.2':
+    resolution: {integrity: sha512-ZqYCCaG2mDaFotV1p2bFYS5o+xQrlEg57mm7jBKCiG7AQqOPl57z6B2tLOFNsJ+J0tYvmU8pFONWPvA6PINjDA==}
 
   '@rspack/core@1.0.0-rc.0':
     resolution: {integrity: sha512-sxS6QfVm7FbuKIYai8CyxMv5WH3MVdQmowVEqIZ/Fa8+PX17/sO5dg8tAFYAEzpCe/4dC93eYh9APr3Vc4ditQ==}
@@ -2994,8 +2997,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.0.1':
-    resolution: {integrity: sha512-z09J/6oJA5y7iclPe+4INg13J5OEWgBw6PdGAOExdcj0DvCicbTGR7QVx1vSrMRbi8oxWk10J3nosOs0zf1bRQ==}
+  '@rspack/core@1.0.2':
+    resolution: {integrity: sha512-6HkXdBSNCMhtxxjTVslANEbqbdU5RtablbD/Ll5Th1lEAfKauXwEu7VHpwWJ+r9E3gOect+7T5zjECDMf4FdmQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -11736,55 +11739,55 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.0.1':
+  '@rspack/binding-darwin-arm64@1.0.2':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.0.1':
+  '@rspack/binding-darwin-x64@1.0.2':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.0.1':
+  '@rspack/binding-linux-arm64-gnu@1.0.2':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.0.1':
+  '@rspack/binding-linux-arm64-musl@1.0.2':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.0.1':
+  '@rspack/binding-linux-x64-gnu@1.0.2':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.0.1':
+  '@rspack/binding-linux-x64-musl@1.0.2':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.0.1':
+  '@rspack/binding-win32-arm64-msvc@1.0.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.0.1':
+  '@rspack/binding-win32-ia32-msvc@1.0.2':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.0.1':
+  '@rspack/binding-win32-x64-msvc@1.0.2':
     optional: true
 
   '@rspack/binding@1.0.0-rc.0':
@@ -11799,17 +11802,17 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.0-rc.0
       '@rspack/binding-win32-x64-msvc': 1.0.0-rc.0
 
-  '@rspack/binding@1.0.1':
+  '@rspack/binding@1.0.2':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.1
-      '@rspack/binding-darwin-x64': 1.0.1
-      '@rspack/binding-linux-arm64-gnu': 1.0.1
-      '@rspack/binding-linux-arm64-musl': 1.0.1
-      '@rspack/binding-linux-x64-gnu': 1.0.1
-      '@rspack/binding-linux-x64-musl': 1.0.1
-      '@rspack/binding-win32-arm64-msvc': 1.0.1
-      '@rspack/binding-win32-ia32-msvc': 1.0.1
-      '@rspack/binding-win32-x64-msvc': 1.0.1
+      '@rspack/binding-darwin-arm64': 1.0.2
+      '@rspack/binding-darwin-x64': 1.0.2
+      '@rspack/binding-linux-arm64-gnu': 1.0.2
+      '@rspack/binding-linux-arm64-musl': 1.0.2
+      '@rspack/binding-linux-x64-gnu': 1.0.2
+      '@rspack/binding-linux-x64-musl': 1.0.2
+      '@rspack/binding-win32-arm64-msvc': 1.0.2
+      '@rspack/binding-win32-ia32-msvc': 1.0.2
+      '@rspack/binding-win32-x64-msvc': 1.0.2
     optional: true
 
   '@rspack/core@1.0.0-rc.0(@swc/helpers@0.5.12)':
@@ -11821,10 +11824,10 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.12
 
-  '@rspack/core@1.0.1':
+  '@rspack/core@1.0.2':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.1
+      '@rspack/binding': 1.0.2
       '@rspack/lite-tapable': 1.0.0
       caniuse-lite: 1.0.30001654
     optional: true
@@ -14546,7 +14549,7 @@ snapshots:
       semver: 7.6.2
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.1))(webpack-cli@5.1.4(webpack@5.94.0))
 
-  css-loader@6.11.0(@rspack/core@1.0.1)(webpack@5.94.0(webpack-cli@5.1.4)):
+  css-loader@6.11.0(@rspack/core@1.0.2)(webpack@5.94.0(webpack-cli@5.1.4)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -14557,7 +14560,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.0
     optionalDependencies:
-      '@rspack/core': 1.0.1
+      '@rspack/core': 1.0.2
       webpack: 5.94.0(webpack-cli@5.1.4)
 
   css-loader@6.11.0(@rspack/core@packages+rspack)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.8))(webpack-cli@5.1.4(webpack@5.94.0))):


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
related to #7782 and #7676

new published webpack-dev-server and webpack-dev-middleware can easily break rspack-cli cause there're no tests in webpack-dev-server & webpack-dev-middle repo and rspack-dev-server use some internal apis of these two packages.

so we need to pin webpack-dev-server  & webpack-dev-middleware version to avoid accidentally breaking, 
but since webpack-dev-middleware is indirect dependency of webpack-dev-server, there're no easy way to pin it without bundling webpack-dev-server.

This pr is  a temporarily solution, and the long term solutions is refactor rspack-dev-server implementation and maybe add tests in webpack-dev-server and webpack-dev-middleware about rspack compatibility
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
