### PR TITLE
fix: overflow panic when shifting left value greater then 31

### DIFF
--- a/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-if-binary/index.js
+++ b/packages/rspack-test-tools/tests/normalCases/parsing/evaluate-if-binary/index.js
@@ -18,6 +18,8 @@ it("should handle bit operation", () => {
   if ((1 ^ 2) !== 3) require("fail");
   if ((1 << 1) !== 2) require("fail");
   if ((2 >> 1) !== 1) require("fail");
+  if ((2 >> 32) !== 2) require("fail");
+  if ((2 << 32) !== 2) require("fail");
 });
 
 it("should handle number operation", () => {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

panic when `1 << 32` in Rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
