### PR TITLE
fix: remove HotUpdateChunk in chunks

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -64,6 +64,11 @@ impl ChunkGraph {
       .entry(chunk_ukey)
       .or_default();
   }
+
+  pub fn remove_chunk(&mut self, chunk_ukey: &ChunkUkey) {
+    self.chunk_graph_chunk_by_chunk_ukey.remove(chunk_ukey);
+  }
+
   pub fn add_chunk_wit_chunk_graph_chunk(&mut self, chunk_ukey: ChunkUkey, cgc: ChunkGraphChunk) {
     debug_assert!(!self
       .chunk_graph_chunk_by_chunk_ukey
@@ -255,6 +260,29 @@ impl ChunkGraph {
     let cgc = self.get_chunk_graph_chunk_mut(chunk);
     if !cgc.runtime_modules.contains(&module_identifier) {
       cgc.runtime_modules.push(module_identifier);
+    }
+  }
+
+  pub fn disconnect_chunk_and_runtime_module(
+    &mut self,
+    chunk: &ChunkUkey,
+    module_identifier: &ModuleIdentifier,
+  ) {
+    let cgm = self
+      .chunk_graph_module_by_module_identifier
+      .get_mut(module_identifier);
+    if let Some(cgm) = cgm {
+      cgm.runtime_in_chunks.remove(chunk);
+    }
+
+    let cgc = self.chunk_graph_chunk_by_chunk_ukey.get_mut(chunk);
+    if let Some(cgc) = cgc {
+      cgc.runtime_modules = cgc
+        .runtime_modules
+        .iter()
+        .copied()
+        .filter(|id| *id != *module_identifier)
+        .collect::<Vec<_>>();
     }
   }
 

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/__snapshots__/web/0.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/__snapshots__/web/0.snap.txt
@@ -1,0 +1,12 @@
+# Case chunks: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+
+## Manifest
+
+
+## Update

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/__snapshots__/web/1.snap.txt
@@ -1,0 +1,55 @@
+# Case chunks: Step 1
+
+## Changed Files
+- file.js
+
+## Asset Files
+- Bundle: bundle.js
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: main.LAST_HASH.hot-update.js, size: 526
+
+## Manifest
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./file.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["webpackHotUpdate"]('main', {
+"./file.js": (function (__unused_webpack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  "default": function() { return __WEBPACK_DEFAULT_EXPORT__; }
+});
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (2);
+
+}),
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = function () {
+	return "CURRENT_HASH";
+};
+
+})();
+
+}
+);
+```

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/file.js
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/file.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 2;

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/index.js
@@ -1,0 +1,11 @@
+import value from './file'
+
+it("should be pass", done => {
+    expect(value).toBe(1);
+    NEXT(require("../../update")(done, true, () => {
+        expect(value).toBe(2);
+        done();
+    }));
+});
+
+module.hot.accept("./file");

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/index.js
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/index.js
@@ -1,6 +1,6 @@
 import value from './file'
 
-it("should be pass", done => {
+it("should correctly handle hot module replacement", done => {
     expect(value).toBe(1);
     NEXT(require("../../update")(done, true, () => {
         expect(value).toBe(2);

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/rspack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+    plugins: [
+        compiler => {
+            compiler.hooks.compilation.tap("PLUGIN", compilation => {
+                compiler.hooks.afterCompile.tap("PLUGIN", () => {
+                    const stats = compilation.getStats();
+                    const { chunks } = stats.toJson({
+                        all: false,
+                        chunks: true
+                    });
+                    // Ensure that HotUpdateChunk is not added to chunks
+                    expect(chunks.length).toBe(1);
+                    expect(chunks[0].runtime[0]).toBe('main');
+                    expect(chunks[0].files[0]).toBe('bundle.js');
+                })
+            })
+        }
+    ]
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

1. In webpack, there is no need to add `HotUpdateChunk` to `compilation.chunks`, because `HotUpdateChunk` is no longer used after generating the manifest.

    However, in Rspack, we need to add `HotUpdateChunk` to `compilation.chunk_by_ukey` because during the manifest generation, `HotUpdateChunk` is passed to various plugins via the `ukey`. The plugins then use the `ukey` to query `compilation.chunk_by_ukey` to get the `HotUpdateChunk` instance.

    Therefore, in Rspack, after the manifest is generated, we need to manually remove the `HotUpdateChunk` from `compilation.chunks`.

2. In webpack, `compilation.chunkGraph` uses a `WeakMap` to maintain the relationship between `Chunk`s and `Module`s.
This means the lifecycle of these data is tied to the `Chunk`, and they are garbage-collected when the `Chunk` is.

    In Rspack, we need to manually clean up the data in `compilation.chunk_graph` after `HotUpdateChunk` is used.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
