### PR TITLE
test: ignore snapshot obsolete warnings while using `-t`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "1.8.0",
+    "@jest/reporters": "29.7.0",
     "@microsoft/api-extractor": "^7.43.1",
     "@microsoft/api-extractor-model": "^7.28.14",
     "@rspack/cli": "workspace:*",

--- a/packages/rspack-test-tools/jest.config.js
+++ b/packages/rspack-test-tools/jest.config.js
@@ -8,6 +8,10 @@ const config = {
 		"@rspack/test-tools/setup-expect",
 		"@rspack/test-tools/setup-env"
 	],
+	reporters: [
+		["default", null],
+		"../../scripts/test/ignore-snapshot-summary-reporter.cjs"
+	],
 	testTimeout: process.env.CI ? 60000 : 30000,
 	prettierPath: require.resolve("prettier-2"),
 	testMatch: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@biomejs/biome':
         specifier: 1.8.0
         version: 1.8.0
+      '@jest/reporters':
+        specifier: 29.7.0
+        version: 29.7.0
       '@microsoft/api-extractor':
         specifier: ^7.43.1
         version: 7.43.1(@types/node@20.12.7)

--- a/scripts/test/ignore-snapshot-summary-reporter.cjs
+++ b/scripts/test/ignore-snapshot-summary-reporter.cjs
@@ -1,0 +1,21 @@
+const { SummaryReporter } = require("@jest/reporters");
+const chalk = require.cache[require.resolve('@jest/reporters')].require("chalk");
+
+if (!process.argv.includes("--verbose") && (process.argv.includes("-t") || process.argv.some(i => i.includes("--testNamePattern")))) {
+  class IgnoreSnapshotSummaryReporter extends SummaryReporter {
+    _printSnapshotSummary(snapshots, globalConfig) {
+      if (
+        snapshots.added ||
+        snapshots.filesRemoved ||
+        snapshots.unchecked ||
+        snapshots.unmatched ||
+        snapshots.updated
+      ) {
+        this.log(chalk.bold.yellow('Some snapshots are obsoleted, flush with `npm run test -- -u` if necessary.\n'));
+      }
+    }
+  }
+  module.exports = IgnoreSnapshotSummaryReporter;
+} else {
+  module.exports = SummaryReporter;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Ignore snapshot obsolete warnings while using `-t` to filter cases.

Before:

![image](https://github.com/user-attachments/assets/7a5b6a1c-1419-4734-819a-127716704793)

After:

![image](https://github.com/user-attachments/assets/15aed233-86a0-4016-aaa3-06bdcf930d79)

The warnings can be displayed by `--verbose` if necessary.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
