### PR TITLE
fix(external_module): use "const" if supported when concatenation

### DIFF
--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -71,10 +71,17 @@ impl ExternalRequestValue {
   }
 }
 
-fn get_namespace_object_export(concatenation_scope: Option<&mut ConcatenationScope>) -> Cow<str> {
+fn get_namespace_object_export(
+  concatenation_scope: Option<&mut ConcatenationScope>,
+  supports_const: bool,
+) -> Cow<str> {
   if let Some(concatenation_scope) = concatenation_scope {
     concatenation_scope.register_namespace_export(NAMESPACE_OBJECT_EXPORT);
-    format!("var {NAMESPACE_OBJECT_EXPORT}").into()
+    format!(
+      "{} {NAMESPACE_OBJECT_EXPORT}",
+      if supports_const { "const" } else { "var" }
+    )
+    .into()
   } else {
     "module.exports".into()
   }
@@ -188,21 +195,22 @@ impl ExternalModule {
   ) -> Result<(BoxSource, ChunkInitFragments, RuntimeGlobals)> {
     let mut chunk_init_fragments: ChunkInitFragments = Default::default();
     let mut runtime_requirements: RuntimeGlobals = Default::default();
+    let supports_const = compilation.options.output.environment.supports_const();
 
     let source = match self.external_type.as_str() {
       "this" if let Some(request) = request => format!(
         "{} = (function() {{ return {}; }}());",
-        get_namespace_object_export(concatenation_scope),
+        get_namespace_object_export(concatenation_scope, supports_const),
         get_source_for_global_variable_external(request, external_type)
       ),
       "window" | "self" if let Some(request) = request => format!(
         "{} = {};",
-        get_namespace_object_export(concatenation_scope),
+        get_namespace_object_export(concatenation_scope, supports_const),
         get_source_for_global_variable_external(request, external_type)
       ),
       "global" if let Some(request) = request => format!(
         "{} = {};",
-        get_namespace_object_export(concatenation_scope),
+        get_namespace_object_export(concatenation_scope, supports_const),
         get_source_for_global_variable_external(request, &compilation.options.output.global_object)
       ),
       "commonjs" | "commonjs2" | "commonjs-module" | "commonjs-static"
@@ -210,7 +218,7 @@ impl ExternalModule {
       {
         format!(
           "{} = {};",
-          get_namespace_object_export(concatenation_scope),
+          get_namespace_object_export(concatenation_scope, supports_const),
           get_source_for_commonjs(request)
         )
       }
@@ -229,14 +237,14 @@ impl ExternalModule {
           );
           format!(
             "{} = __WEBPACK_EXTERNAL_createRequire({}.url)({});",
-            get_namespace_object_export(concatenation_scope),
+            get_namespace_object_export(concatenation_scope, supports_const),
             compilation.options.output.import_meta_name,
             json_stringify(request.primary())
           )
         } else {
           format!(
             "{} = {};",
-            get_namespace_object_export(concatenation_scope),
+            get_namespace_object_export(concatenation_scope, supports_const),
             get_source_for_commonjs(request)
           )
         }
@@ -249,7 +257,7 @@ impl ExternalModule {
           .unwrap_or_default();
         format!(
           "{} = __WEBPACK_EXTERNAL_MODULE_{}__;",
-          get_namespace_object_export(concatenation_scope),
+          get_namespace_object_export(concatenation_scope, supports_const),
           to_identifier(id)
         )
       }
@@ -258,7 +266,7 @@ impl ExternalModule {
           "import" => {
             format!(
               "{} = {};",
-              get_namespace_object_export(concatenation_scope),
+              get_namespace_object_export(concatenation_scope, supports_const),
               get_source_for_import(request, compilation)
             )
           }
@@ -283,13 +291,13 @@ impl ExternalModule {
                 r#"
 {} = __WEBPACK_EXTERNAL_MODULE_{}__;
 "#,
-                get_namespace_object_export(concatenation_scope),
+                get_namespace_object_export(concatenation_scope, supports_const),
                 id.clone()
               )
             } else {
               format!(
                 "{} = {};",
-                get_namespace_object_export(concatenation_scope),
+                get_namespace_object_export(concatenation_scope, supports_const),
                 get_source_for_import(request, compilation)
               )
             }
@@ -302,7 +310,7 @@ impl ExternalModule {
       }
       "var" | "promise" | "const" | "let" | "assign" if let Some(request) = request => format!(
         "{} = {};",
-        get_namespace_object_export(concatenation_scope),
+        get_namespace_object_export(concatenation_scope, supports_const),
         get_source_for_default_case(false, request)
       ),
       "script" if let Some(request) = request => {
@@ -325,7 +333,7 @@ if(typeof {global} !== "undefined") return resolve();
 }}, {global_str});
 }}).then(function() {{ return {global}; }});
 "#,
-          export = get_namespace_object_export(concatenation_scope),
+          export = get_namespace_object_export(concatenation_scope, supports_const),
           global = url_and_global.global,
           global_str =
             serde_json::to_string(url_and_global.global).map_err(|e| error!(e.to_string()))?,

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/request/output.snap.txt
@@ -82,7 +82,7 @@ var a_default = /*#__PURE__*/__webpack_require__.n(a);
 var c = __webpack_require__("../../normalModuleFactory​#afterResolve/request/c.js");
 var c_default = /*#__PURE__*/__webpack_require__.n(c);
 ;// CONCATENATED MODULE: external "fs"
-var external_fs_namespaceObject = require("fs");
+const external_fs_namespaceObject = require("fs");
 var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ../../normalModuleFactory​#afterResolve/request/request.js
 

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#afterResolve/resource/output.snap.txt
@@ -82,7 +82,7 @@ var a_default = /*#__PURE__*/__webpack_require__.n(a);
 var b = __webpack_require__("../../normalModuleFactory​#afterResolve/resource/b.js");
 var b_default = /*#__PURE__*/__webpack_require__.n(b);
 ;// CONCATENATED MODULE: external "fs"
-var external_fs_namespaceObject = require("fs");
+const external_fs_namespaceObject = require("fs");
 var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ../../normalModuleFactory​#afterResolve/resource/resource.js
 

--- a/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
+++ b/packages/rspack-test-tools/tests/hookCases/normalModuleFactory#resolve/resource/output.snap.txt
@@ -82,7 +82,7 @@ var a_default = /*#__PURE__*/__webpack_require__.n(a);
 var b = __webpack_require__("../../normalModuleFactory​#resolve/resource/b.js");
 var b_default = /*#__PURE__*/__webpack_require__.n(b);
 ;// CONCATENATED MODULE: external "fs"
-var external_fs_namespaceObject = require("fs");
+const external_fs_namespaceObject = require("fs");
 var external_fs_default = /*#__PURE__*/__webpack_require__.n(external_fs_namespaceObject);
 ;// CONCATENATED MODULE: ../../normalModuleFactory​#resolve/resource/resource.js
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Align with https://github.com/webpack/webpack/blob/039e8c96338ee98cf37d5035cdd30073a96b4ec5/lib/ExternalModule.js#L878. No coveraged test found in webpack.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
