### PR TITLE
fix: avoid import external module re-assigin in concatenation

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -755,6 +755,7 @@ impl Module for ConcatenatedModule {
             }
           }
 
+          // Handle the name passed through by namespace_export_symbol
           if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {
             if namespace_export_symbol.starts_with(NAMESPACE_OBJECT_EXPORT)
               && namespace_export_symbol.len() > NAMESPACE_OBJECT_EXPORT.len()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -755,6 +755,20 @@ impl Module for ConcatenatedModule {
             }
           }
 
+          if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {
+            if namespace_export_symbol.starts_with(NAMESPACE_OBJECT_EXPORT)
+              && namespace_export_symbol.len() > NAMESPACE_OBJECT_EXPORT.len()
+            {
+              let name =
+                Atom::from(namespace_export_symbol[NAMESPACE_OBJECT_EXPORT.len()..].to_string());
+              all_used_names.insert(name.clone());
+              info
+                .internal_names
+                .insert(namespace_export_symbol.clone(), name.clone());
+              top_level_declarations.insert(name.clone());
+            }
+          }
+
           // Handle namespaceObjectName for concatenated type
           let namespace_object_name =
             if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -71,19 +71,6 @@ impl ExternalRequestValue {
   }
 }
 
-fn get_namespace_object_export_with_name<'a, 'b>(
-  concatenation_scope: Option<&'a mut ConcatenationScope>,
-  source: &'a str,
-) -> Cow<'b, str> {
-  if let Some(concatenation_scope) = concatenation_scope {
-    let namespace_export_with_name = format!("{}{}", NAMESPACE_OBJECT_EXPORT, source);
-    concatenation_scope.register_namespace_export(&namespace_export_with_name);
-    "".into()
-  } else {
-    "module.exports".into()
-  }
-}
-
 fn get_namespace_object_export(
   concatenation_scope: Option<&mut ConcatenationScope>,
   supports_const: bool,
@@ -301,9 +288,11 @@ impl ExternalModule {
                 .boxed(),
               );
 
-              if concatenation_scope.is_some() {
+              if let Some(concatenation_scope) = concatenation_scope {
                 let external_module_id = format!("__WEBPACK_EXTERNAL_MODULE_{}__", id);
-                get_namespace_object_export_with_name(concatenation_scope, &external_module_id);
+                let namespace_export_with_name =
+                  format!("{}{}", NAMESPACE_OBJECT_EXPORT, &external_module_id);
+                concatenation_scope.register_namespace_export(&namespace_export_with_name);
                 String::new()
               } else {
                 format!(

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -71,6 +71,19 @@ impl ExternalRequestValue {
   }
 }
 
+fn get_namespace_object_export_with_name<'a, 'b>(
+  concatenation_scope: Option<&'a mut ConcatenationScope>,
+  source: &'a str,
+) -> Cow<'b, str> {
+  if let Some(concatenation_scope) = concatenation_scope {
+    let namespace_export_with_name = format!("{}{}", NAMESPACE_OBJECT_EXPORT, source);
+    concatenation_scope.register_namespace_export(&namespace_export_with_name);
+    "".into()
+  } else {
+    "module.exports".into()
+  }
+}
+
 fn get_namespace_object_export(
   concatenation_scope: Option<&mut ConcatenationScope>,
   supports_const: bool,
@@ -287,13 +300,20 @@ impl ExternalModule {
                 )
                 .boxed(),
               );
-              format!(
-                r#"
-{} = __WEBPACK_EXTERNAL_MODULE_{}__;
-"#,
-                get_namespace_object_export(concatenation_scope, supports_const),
-                id.clone()
-              )
+
+              if concatenation_scope.is_some() {
+                let external_module_id = format!("__WEBPACK_EXTERNAL_MODULE_{}__", id);
+                get_namespace_object_export_with_name(concatenation_scope, &external_module_id);
+                String::new()
+              } else {
+                format!(
+                  r#"
+  {} = __WEBPACK_EXTERNAL_MODULE_{}__;
+  "#,
+                  get_namespace_object_export(concatenation_scope, supports_const),
+                  id.clone()
+                )
+              }
             } else {
               format!(
                 "{} = {};",

--- a/packages/rspack-test-tools/etc/api.md
+++ b/packages/rspack-test-tools/etc/api.md
@@ -1134,7 +1134,7 @@ export function parseModules(content: string, options?: {
 };
 
 // @public (undocumented)
-export function readConfigFile<T extends ECompilerType>(files: string[]): TCompilerOptions<T>[];
+export function readConfigFile<T extends ECompilerType>(files: string[], functionApply?: (config: (TCompilerOptions<T> | ((...args: unknown[]) => TCompilerOptions<T>))[]) => TCompilerOptions<T>[]): TCompilerOptions<T>[];
 
 // @public (undocumented)
 export function replaceModuleArgument(raw: string): string;

--- a/packages/rspack-test-tools/src/helper/read-config-file.ts
+++ b/packages/rspack-test-tools/src/helper/read-config-file.ts
@@ -3,9 +3,16 @@ import fs from "fs-extra";
 import type { ECompilerType, TCompilerOptions } from "../type";
 
 export function readConfigFile<T extends ECompilerType>(
-	files: string[]
+	files: string[],
+	functionApply?: (
+		config: (
+			| TCompilerOptions<T>
+			| ((...args: unknown[]) => TCompilerOptions<T>)
+		)[]
+	) => TCompilerOptions<T>[]
 ): TCompilerOptions<T>[] {
 	const existsFile = files.find(i => fs.existsSync(i));
 	const fileConfig = existsFile ? require(existsFile) : {};
-	return Array.isArray(fileConfig) ? fileConfig : [fileConfig];
+	const configArr = Array.isArray(fileConfig) ? fileConfig : [fileConfig];
+	return functionApply ? functionApply(configArr) : configArr;
 }

--- a/packages/rspack-test-tools/src/processor/multi.ts
+++ b/packages/rspack-test-tools/src/processor/multi.ts
@@ -92,7 +92,21 @@ export class MultiTaskProcessor<T extends ECompilerType>
 			this._multiOptions.configFiles
 		)
 			? readConfigFile(
-					this._multiOptions.configFiles!.map(i => context.getSource(i))
+					this._multiOptions.configFiles!.map(i => context.getSource(i)),
+					configs => {
+						return configs.flatMap(c => {
+							if (typeof c === "function") {
+								const options = {
+									testPath: context.getDist(),
+									env: undefined
+								};
+
+								return c(options.env, options) as TCompilerOptions<T>;
+							}
+
+							return c as TCompilerOptions<T>;
+						});
+					}
 				)
 			: [{}];
 

--- a/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/externals/m.mjs
+++ b/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/externals/m.mjs
@@ -1,0 +1,4 @@
+export const m1 = 11111;
+export const m2 = 22222;
+
+export const m1Add = () => m1++;

--- a/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/index.js
@@ -1,0 +1,3 @@
+import { m1, m2, m1Add } from "./externals/m.mjs";
+
+export { m1, m2, m1Add }

--- a/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/rspack.config.js
@@ -1,0 +1,23 @@
+const rspack = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	externals: [/\.\/externals\/.*/],
+	externalsType: "module",
+	output: {
+		module: true,
+		chunkFormat: "module",
+		filename: "[name].mjs",
+		library: {
+			type: "modern-module",
+		}
+	},
+	experiments: {
+		outputModule: true
+	},
+	plugins: [
+		new rspack.CopyRspackPlugin({
+      patterns: ["./externals/**/*"],
+    }),
+	]
+};

--- a/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/0-concatenation-tree-shaking/test.config.js
@@ -1,0 +1,1 @@
+exports.noTests = true;

--- a/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/consume.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/consume.js
@@ -1,0 +1,3 @@
+import { m1Add } from 'library'
+
+m1Add()

--- a/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/index.js
@@ -1,0 +1,7 @@
+import fs from "fs";
+import path from "path";
+
+it("static import from external module should be tree shaking friendly", () => {
+	const content = fs.readFileSync(path.resolve(__dirname, "consume.mjs"), "utf-8");
+	expect(content).not.toContain("22222");
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/rspack.config.js
@@ -1,0 +1,38 @@
+const { rspack } = require("@rspack/core");
+const path = require("path");
+
+/** @type {function(any, any): import("@rspack/core").Configuration[]} */
+module.exports = (env, { testPath }) => {
+	return {
+		entry: {
+			consume: "./consume.js",
+			main: "./index.js"
+		},
+		resolve: {
+			alias: {
+				library: path.resolve(testPath, "../0-concatenation-tree-shaking/main.mjs")
+			}
+		},
+		output: {
+			module: true,
+			chunkFormat: "module",
+			filename: "[name].mjs"
+		},
+		experiments: {
+			outputModule: true
+		},
+		optimization: {
+			minimize: true,
+			concatenateModules: true,
+		},
+		plugins: [
+			new rspack.SwcJsMinimizerRspackPlugin({
+				minimizerOptions: {
+					minify: false,
+					mangle: false
+				}
+			})
+		]
+};
+}
+

--- a/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/1-concatenation-tree-shaking/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../../dist").TConfigCaseConfig} */
+module.exports = {
+	findBundle: (i, options) => {
+		return ["main.mjs"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-export-char/rspack.config.js
@@ -29,8 +29,8 @@ module.exports = {
 				compilation.hooks.afterProcessAssets.tap("testcase", assets => {
 					const bundle = Object.values(assets)[0]._value
 					expect(bundle).toContain(`var __webpack_exports__cjsInterop = (foo_default());
-var __webpack_exports__defaultImport = external_external_module_namespaceObject["default"];
-var __webpack_exports__namedImport = external_external_module_namespaceObject.namedImport;`)
+var __webpack_exports__defaultImport = __WEBPACK_EXTERNAL_MODULE_external_module__["default"];
+var __webpack_exports__namedImport = __WEBPACK_EXTERNAL_MODULE_external_module__.namedImport;`)
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This PR will simplify `"module"` external type's runtime like below. When building a package with Rspack, it can be ensured that external modules can be tree shaken.

Changes summary:

1. only changed `"module"` external type.
2. variable name folding theoretically should not cause any potential problems, as there is currently no module remapping, it merely eliminates intermediate variables.
3. `MultiTaskProcessor` could handle function config.

```js
// --- before ---
import * as __WEBPACK_EXTERNAL_MODULE_react_alias__ from "react-alias";

;// CONCATENATED MODULE: external "react-alias"

const external_react_alias_namespaceObject = __WEBPACK_EXTERNAL_MODULE_react_alias__;

;// CONCATENATED MODULE: ./src/main.mjs

function main() {
    (0,external_react_alias_namespaceObject.createElement)('div');
}

// --- after ---
import * as __WEBPACK_EXTERNAL_MODULE_react_alias__ from "react-alias";

;// CONCATENATED MODULE: external "react-alias"

;// CONCATENATED MODULE: ./src/main.mjs

function main() {
    (0,__WEBPACK_EXTERNAL_MODULE_react_alias__.createElement)('div');
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
