### PR TITLE
feat(core): integrate rspack_resolver with input_filesystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "dunce"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
@@ -3133,9 +3133,11 @@ dependencies = [
 name = "rspack_fs"
 version = "0.1.0"
 dependencies = [
+ "dunce",
  "futures",
  "rspack_error",
  "rspack_paths",
+ "rspack_resolver",
  "tokio",
 ]
 
@@ -3240,6 +3242,7 @@ dependencies = [
  "regex",
  "rspack_collections",
  "rspack_error",
+ "rspack_fs",
  "rspack_paths",
  "rspack_sources",
  "rspack_util",
@@ -3346,6 +3349,7 @@ dependencies = [
  "rspack_collections",
  "rspack_core",
  "rspack_error",
+ "rspack_fs",
  "rspack_fs_node",
  "rspack_hash",
  "rspack_hook",
@@ -3967,9 +3971,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e53e65a19bc1b2f784acaa4c481968778cf2f26db564beb70956822abd3293"
+checksum = "51106b568dee8123f549ed5163818d4efa74fbca567a4bb88222b4f45e8b074d"
 dependencies = [
  "cfg-if",
  "dashmap 6.0.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,7 +3137,6 @@ dependencies = [
  "futures",
  "rspack_error",
  "rspack_paths",
- "rspack_resolver",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ proc-macro2        = { version = "1.0.79" }
 quote              = { version = "1.0.35" }
 rayon              = { version = "1.10.0" }
 regex              = { version = "1.10.4" }
+rspack_resolver    = { version = "0.3.3", features = ["package_json_raw_json_api"] }
 rspack_sources     = { version = "=0.3.2" }
 rustc-hash         = { version = "1.1.0" }
 serde              = { version = "1.0.197" }

--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -20,6 +20,7 @@ rspack_binding_values    = { version = "0.1.0", path = "../rspack_binding_values
 rspack_collections       = { version = "0.1.0", path = "../rspack_collections" }
 rspack_core              = { version = "0.1.0", path = "../rspack_core" }
 rspack_error             = { version = "0.1.0", path = "../rspack_error" }
+rspack_fs                = { version = "0.1.0", path = "../rspack_fs" }
 rspack_fs_node           = { version = "0.1.0", path = "../rspack_fs_node" }
 rspack_hash              = { version = "0.1.0", path = "../rspack_hash" }
 rspack_hook              = { version = "0.1.0", path = "../rspack_hook" }

--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -67,10 +67,11 @@ impl Rspack {
     let rspack = rspack_core::Compiler::new(
       compiler_options,
       plugins,
-      Box::new(
+      Some(Box::new(
         AsyncNodeWritableFileSystem::new(output_filesystem)
           .map_err(|e| Error::from_reason(format!("Failed to create writable filesystem: {e}",)))?,
-      ),
+      )),
+      None,
       Some(resolver_factory),
       Some(loader_resolver_factory),
     );

--- a/crates/node_binding/src/resolver_factory.rs
+++ b/crates/node_binding/src/resolver_factory.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use napi_derive::napi;
 use rspack_core::{Resolve, ResolverFactory};
+use rspack_fs::{NativeFileSystem, ReadableFileSystem};
 
 use crate::{
   raw_resolve::{
@@ -14,23 +15,30 @@ use crate::{
 pub struct JsResolverFactory {
   pub(crate) resolver_factory: Option<Arc<ResolverFactory>>,
   pub(crate) loader_resolver_factory: Option<Arc<ResolverFactory>>,
+  pub(crate) input_filesystem: Arc<dyn ReadableFileSystem>,
 }
 
 #[napi]
 impl JsResolverFactory {
   #[napi(constructor)]
   pub fn new() -> napi::Result<Self> {
+    let input_filesystem = Arc::new(NativeFileSystem {});
     Ok(Self {
       resolver_factory: None,
       loader_resolver_factory: None,
+      input_filesystem,
     })
   }
 
   pub fn get_resolver_factory(&mut self, resolve_options: Resolve) -> Arc<ResolverFactory> {
     match &self.resolver_factory {
       Some(resolver_factory) => resolver_factory.clone(),
+
       None => {
-        let resolver_factory = Arc::new(ResolverFactory::new(resolve_options));
+        let resolver_factory = Arc::new(ResolverFactory::new(
+          resolve_options,
+          self.input_filesystem.clone(),
+        ));
         self.resolver_factory = Some(resolver_factory.clone());
         resolver_factory
       }
@@ -41,7 +49,10 @@ impl JsResolverFactory {
     match &self.loader_resolver_factory {
       Some(resolver_factory) => resolver_factory.clone(),
       None => {
-        let resolver_factory = Arc::new(ResolverFactory::new(resolve_options));
+        let resolver_factory = Arc::new(ResolverFactory::new(
+          resolve_options,
+          self.input_filesystem.clone(),
+        ));
         self.loader_resolver_factory = Some(resolver_factory.clone());
         resolver_factory
       }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -31,7 +31,7 @@ regex = { workspace = true }
 rspack_ast = { version = "0.1.0", path = "../rspack_ast" }
 rspack_collections = { version = "0.1.0", path = "../rspack_collections" }
 rspack_error = { version = "0.1.0", path = "../rspack_error" }
-rspack_fs = { version = "0.1.0", path = "../rspack_fs", features = ["async", "rspack-error"] }
+rspack_fs = { version = "0.1.0", path = "../rspack_fs" }
 rspack_futures = { version = "0.1.0", path = "../rspack_futures" }
 rspack_hash = { version = "0.1.0", path = "../rspack_hash" }
 rspack_hook = { version = "0.1.0", path = "../rspack_hook" }
@@ -39,7 +39,7 @@ rspack_loader_runner = { version = "0.1.0", path = "../rspack_loader_runner" }
 rspack_macros = { version = "0.1.0", path = "../rspack_macros" }
 rspack_paths = { version = "0.1.0", path = "../rspack_paths" }
 rspack_regex = { version = "0.1.0", path = "../rspack_regex" }
-rspack_resolver = { version = "0.3.1", features = ["package_json_raw_json_api"] }
+rspack_resolver = { workspace = true }
 rspack_sources = { workspace = true }
 rspack_util = { version = "0.1.0", path = "../rspack_util" }
 rustc-hash = { workspace = true }

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use dashmap::DashSet;
+use derivative::Derivative;
 use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -14,6 +15,7 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierDashMap, IdentifierMap, IdentifierSet, UkeySet,
 };
 use rspack_error::{error, Diagnostic, Result, Severity};
+use rspack_fs::ReadableFileSystem;
 use rspack_futures::FuturesResults;
 use rspack_hash::{RspackHash, RspackHashDigest};
 use rspack_hook::define_hook;
@@ -129,8 +131,8 @@ impl Default for CompilationId {
 type ValueCacheVersions = HashMap<String, String>;
 
 static COMPILATION_ID: AtomicU32 = AtomicU32::new(0);
-
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct Compilation {
   /// get_compilation_hooks(compilation.id)
   id: CompilationId,
@@ -191,6 +193,8 @@ pub struct Compilation {
   pub modified_files: HashSet<PathBuf>,
   pub removed_files: HashSet<PathBuf>,
   make_artifact: MakeArtifact,
+  #[derivative(Debug = "ignore")]
+  pub input_filesystem: Arc<dyn ReadableFileSystem>,
 }
 
 impl Compilation {
@@ -226,6 +230,7 @@ impl Compilation {
     module_executor: Option<ModuleExecutor>,
     modified_files: HashSet<PathBuf>,
     removed_files: HashSet<PathBuf>,
+    input_filesystem: Arc<dyn ReadableFileSystem>,
   ) -> Self {
     Self {
       id: CompilationId::new(),
@@ -280,6 +285,7 @@ impl Compilation {
       make_artifact: Default::default(),
       modified_files,
       removed_files,
+      input_filesystem,
     }
   }
 

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -73,6 +73,7 @@ impl Compiler {
         Some(ModuleExecutor::default()),
         modified_files,
         removed_files,
+        self.input_filesystem.clone(),
       );
 
       if let Some(state) = self.options.get_incremental_rebuild_make_state() {

--- a/crates/rspack_core/src/compiler/make/repair/add.rs
+++ b/crates/rspack_core/src/compiler/make/repair/add.rs
@@ -77,6 +77,7 @@ impl Task<MakeTaskContext> for AddTask {
       resolver_factory: context.resolver_factory.clone(),
       compiler_options: context.compiler_options.clone(),
       plugin_driver: context.plugin_driver.clone(),
+      fs: context.fs.clone(),
     })])
   }
 }

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -6,6 +6,7 @@ pub mod process_dependencies;
 use std::sync::Arc;
 
 use rspack_error::Result;
+use rspack_fs::ReadableFileSystem;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::MakeArtifact;
@@ -21,6 +22,7 @@ use crate::{
 pub struct MakeTaskContext {
   // compilation info
   pub plugin_driver: SharedPluginDriver,
+  pub fs: Arc<dyn ReadableFileSystem>,
   pub compiler_options: Arc<CompilerOptions>,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
@@ -41,6 +43,7 @@ impl MakeTaskContext {
       old_cache: compilation.old_cache.clone(),
       unaffected_modules_cache: compilation.unaffected_modules_cache.clone(),
       dependency_factories: compilation.dependency_factories.clone(),
+      fs: compilation.input_filesystem.clone(),
       artifact,
     }
   }
@@ -68,6 +71,7 @@ impl MakeTaskContext {
       None,
       Default::default(),
       Default::default(),
+      self.fs.clone(),
     );
     compilation.dependency_factories = self.dependency_factories.clone();
     compilation.swap_make_artifact(&mut self.artifact);

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -6,7 +6,9 @@ use std::sync::Arc;
 
 use derivative::Derivative;
 use rspack_error::Result;
-use rspack_fs::AsyncWritableFileSystem;
+use rspack_fs::{
+  AsyncNativeFileSystem, AsyncWritableFileSystem, NativeFileSystem, ReadableFileSystem,
+};
 use rspack_futures::FuturesResults;
 use rspack_hook::define_hook;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
@@ -55,6 +57,8 @@ pub struct Compiler {
   pub options: Arc<CompilerOptions>,
   #[derivative(Debug = "ignore")]
   pub output_filesystem: Box<dyn AsyncWritableFileSystem + Send + Sync>,
+  #[derivative(Debug = "ignore")]
+  pub input_filesystem: Arc<dyn ReadableFileSystem>,
   pub compilation: Compilation,
   pub plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
@@ -71,7 +75,9 @@ impl Compiler {
   pub fn new(
     options: CompilerOptions,
     plugins: Vec<BoxPlugin>,
-    output_filesystem: Box<dyn AsyncWritableFileSystem + Send + Sync>,
+    output_filesystem: Option<Box<dyn AsyncWritableFileSystem + Send + Sync>>,
+    // only supports passing input_filesystem in rust api, no support for js api
+    input_filesystem: Option<Arc<dyn ReadableFileSystem + Send + Sync>>,
     // no need to pass resolve_factory in rust api
     resolver_factory: Option<Arc<ResolverFactory>>,
     loader_resolver_factory: Option<Arc<ResolverFactory>>,
@@ -82,14 +88,26 @@ impl Compiler {
         debug_info.with_context(options.context.to_string());
       }
     }
-    let resolver_factory =
-      resolver_factory.unwrap_or_else(|| Arc::new(ResolverFactory::new(options.resolve.clone())));
-    let loader_resolver_factory = loader_resolver_factory
-      .unwrap_or_else(|| Arc::new(ResolverFactory::new(options.resolve_loader.clone())));
+    let input_filesystem = input_filesystem.unwrap_or_else(|| Arc::new(NativeFileSystem {}));
+
+    let resolver_factory = resolver_factory.unwrap_or_else(|| {
+      Arc::new(ResolverFactory::new(
+        options.resolve.clone(),
+        input_filesystem.clone(),
+      ))
+    });
+    let loader_resolver_factory = loader_resolver_factory.unwrap_or_else(|| {
+      Arc::new(ResolverFactory::new(
+        options.resolve_loader.clone(),
+        input_filesystem.clone(),
+      ))
+    });
     let (plugin_driver, options) = PluginDriver::new(options, plugins, resolver_factory.clone());
     let old_cache = Arc::new(OldCache::new(options.clone()));
     let unaffected_modules_cache = Arc::new(UnaffectedModulesCache::default());
     let module_executor = ModuleExecutor::default();
+    let output_filesystem = output_filesystem.unwrap_or_else(|| Box::new(AsyncNativeFileSystem {}));
+
     Self {
       options: options.clone(),
       compilation: Compilation::new(
@@ -103,6 +121,7 @@ impl Compiler {
         Some(module_executor),
         Default::default(),
         Default::default(),
+        input_filesystem.clone(),
       ),
       output_filesystem,
       plugin_driver,
@@ -111,6 +130,7 @@ impl Compiler {
       old_cache,
       emitted_asset_versions: Default::default(),
       unaffected_modules_cache,
+      input_filesystem,
     }
   }
 
@@ -140,6 +160,7 @@ impl Compiler {
         Some(module_executor),
         Default::default(),
         Default::default(),
+        self.input_filesystem.clone(),
       ),
     );
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1,5 +1,4 @@
-use std::borrow::Cow;
-use std::iter;
+use std::{borrow::Cow, iter};
 
 use rspack_collections::{Identifiable, Identifier};
 use rspack_error::{error, impl_empty_diagnosable_trait, Diagnostic, Result};

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -1,12 +1,14 @@
 use std::fmt::Display;
 use std::hash::Hash;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::{any::Any, borrow::Cow, fmt::Debug};
 
 use async_trait::async_trait;
 use json::JsonValue;
 use rspack_collections::{Identifiable, Identifier, IdentifierSet};
 use rspack_error::{Diagnosable, Diagnostic, Result};
+use rspack_fs::ReadableFileSystem;
 use rspack_hash::RspackHashDigest;
 use rspack_sources::Source;
 use rspack_util::atom::Atom;
@@ -28,6 +30,7 @@ pub struct BuildContext<'a> {
   pub runner_context: RunnerContext,
   pub plugin_driver: SharedPluginDriver,
   pub compiler_options: &'a CompilerOptions,
+  pub fs: Arc<dyn ReadableFileSystem>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -228,7 +228,6 @@ impl NormalModule {
       build_info: None,
       build_meta: None,
       parsed: false,
-
       source_map_kind: SourceMapKind::empty(),
       last_successful_build_meta: BuildMeta::default(),
     }
@@ -415,6 +414,7 @@ impl Module for NormalModule {
       self.resource_data.clone(),
       Some(plugin.clone()),
       build_context.runner_context,
+      build_context.fs.clone(),
     )
     .await;
     let (mut loader_result, ds) = match loader_result {

--- a/crates/rspack_core/src/resolver/boxfs.rs
+++ b/crates/rspack_core/src/resolver/boxfs.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use rspack_fs::ReadableFileSystem;
+use rspack_resolver::{FileMetadata, FileSystem as ResolverFileSystem};
+
+#[derive(Clone)]
+pub struct BoxFS(Arc<dyn ReadableFileSystem>);
+
+impl BoxFS {
+  pub fn new(fs: Arc<dyn ReadableFileSystem>) -> Self {
+    Self(fs)
+  }
+}
+impl ResolverFileSystem for BoxFS {
+  fn read_to_string(&self, path: &std::path::Path) -> std::io::Result<String> {
+    self.0.read_to_string(path)
+  }
+
+  fn metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {
+    self.0.metadata(path)
+  }
+
+  fn symlink_metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {
+    self.0.symlink_metadata(path)
+  }
+
+  fn canonicalize(&self, path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
+    self.0.canonicalize(path)
+  }
+}

--- a/crates/rspack_core/src/resolver/boxfs.rs
+++ b/crates/rspack_core/src/resolver/boxfs.rs
@@ -19,11 +19,11 @@ impl ResolverFileSystem for BoxFS {
   }
 
   fn metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {
-    self.0.metadata(path)
+    self.0.metadata(path).map(FileMetadata::from)
   }
 
   fn symlink_metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {
-    self.0.symlink_metadata(path)
+    self.0.symlink_metadata(path).map(FileMetadata::from)
   }
 
   fn canonicalize(&self, path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {

--- a/crates/rspack_core/src/resolver/boxfs.rs
+++ b/crates/rspack_core/src/resolver/boxfs.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{io, sync::Arc};
 
 use rspack_fs::ReadableFileSystem;
 use rspack_resolver::{FileMetadata, FileSystem as ResolverFileSystem};
@@ -13,7 +13,9 @@ impl BoxFS {
 }
 impl ResolverFileSystem for BoxFS {
   fn read_to_string(&self, path: &std::path::Path) -> std::io::Result<String> {
-    self.0.read_to_string(path)
+    self.0.read(path).and_then(|x| {
+      String::from_utf8(x).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
+    })
   }
 
   fn metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {

--- a/crates/rspack_core/src/resolver/factory.rs
+++ b/crates/rspack_core/src/resolver/factory.rs
@@ -1,6 +1,7 @@
 use std::{hash::BuildHasherDefault, sync::Arc};
 
 use dashmap::DashMap;
+use rspack_fs::ReadableFileSystem;
 use rustc_hash::FxHasher;
 
 use super::resolver_impl::Resolver;
@@ -23,21 +24,15 @@ pub struct ResolverFactory {
   resolvers: DashMap<ResolveOptionsWithDependencyType, Arc<Resolver>, BuildHasherDefault<FxHasher>>,
 }
 
-impl Default for ResolverFactory {
-  fn default() -> Self {
-    Self::new(Resolve::default())
-  }
-}
-
 impl ResolverFactory {
   pub fn clear_cache(&self) {
     self.resolver.clear_cache();
   }
 
-  pub fn new(options: Resolve) -> Self {
+  pub fn new(options: Resolve, fs: Arc<dyn ReadableFileSystem>) -> Self {
     Self {
       base_options: options.clone(),
-      resolver: Resolver::new(options),
+      resolver: Resolver::new(options, fs),
       resolvers: Default::default(),
     }
   }

--- a/crates/rspack_core/src/resolver/mod.rs
+++ b/crates/rspack_core/src/resolver/mod.rs
@@ -1,3 +1,4 @@
+mod boxfs;
 mod factory;
 mod resolver_impl;
 use std::borrow::Borrow;

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -5,17 +5,12 @@ license     = "MIT"
 name        = "rspack_fs"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.1.0"
-[features]
-async        = ["dep:futures", "dep:tokio"]
-default      = ["native"]
-native       = []
-rspack-error = ["dep:rspack_error"]
-
-
+[dependencies]
+dunce           = { version = "1.0.5" }
+rspack_resolver = { workspace = true }
 [dependencies.rspack_error]
-optional = true
-path     = "../rspack_error"
-version  = "0.1.0"
+path    = "../rspack_error"
+version = "0.1.0"
 
 
 [dependencies.rspack_paths]
@@ -23,10 +18,8 @@ path    = "../rspack_paths"
 version = "0.1.0"
 
 [dependencies.futures]
-optional  = true
 workspace = true
 
 [dependencies.tokio]
 features  = ["fs"]
-optional  = true
 workspace = true

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -6,8 +6,7 @@ name        = "rspack_fs"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.1.0"
 [dependencies]
-dunce           = { version = "1.0.5" }
-rspack_resolver = { workspace = true }
+dunce = { version = "1.0.5" }
 [dependencies.rspack_error]
 path    = "../rspack_error"
 version = "0.1.0"

--- a/crates/rspack_fs/src/error.rs
+++ b/crates/rspack_fs/src/error.rs
@@ -1,12 +1,10 @@
 use std::fmt::Display;
 
-#[cfg(feature = "rspack-error")]
 use rspack_error::{
   miette::{self, Diagnostic},
   thiserror::{self, Error},
 };
 
-#[cfg(feature = "rspack-error")]
 #[derive(Debug, Error, Diagnostic)]
 #[error("Rspack FS Error: {0}")]
 struct FsError(#[source] std::io::Error);
@@ -23,7 +21,6 @@ impl From<std::io::Error> for Error {
   }
 }
 
-#[cfg(feature = "rspack-error")]
 impl From<Error> for rspack_error::Error {
   fn from(value: Error) -> Self {
     match value {

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -1,19 +1,10 @@
+pub mod r#async;
 mod macros;
-
-cfg_async! {
-  pub mod r#async;
-  pub use r#async::{AsyncFileSystem, AsyncReadableFileSystem, AsyncWritableFileSystem};
-}
+mod native;
+pub use r#async::{AsyncFileSystem, AsyncReadableFileSystem, AsyncWritableFileSystem};
 pub mod sync;
 pub use sync::{FileSystem, ReadableFileSystem, WritableFileSystem};
-
 mod error;
 pub use error::{Error, Result};
-
-cfg_native! {
-  mod native;
-  pub use native::{NativeFileSystem};
-
-  #[cfg(feature = "async")]
-  pub use native::AsyncNativeFileSystem;
-}
+pub use native::AsyncNativeFileSystem;
+pub use native::NativeFileSystem;

--- a/crates/rspack_fs/src/native.rs
+++ b/crates/rspack_fs/src/native.rs
@@ -1,10 +1,10 @@
 use std::{
-  fs, io,
+  fs::{self, Metadata},
+  io,
   path::{Path, PathBuf},
 };
 
 use rspack_paths::Utf8Path;
-use rspack_resolver::FileMetadata;
 
 use super::{
   sync::{ReadableFileSystem, WritableFileSystem},
@@ -32,12 +32,12 @@ impl ReadableFileSystem for NativeFileSystem {
     fs::read(path)
   }
 
-  fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    fs::metadata(path).map(FileMetadata::from)
+  fn metadata(&self, path: &Path) -> io::Result<Metadata> {
+    fs::metadata(path)
   }
 
-  fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata> {
-    fs::symlink_metadata(path).map(FileMetadata::from)
+  fn symlink_metadata(&self, path: &Path) -> io::Result<Metadata> {
+    fs::symlink_metadata(path)
   }
 
   fn canonicalize(&self, path: &Path) -> io::Result<PathBuf> {

--- a/crates/rspack_fs/src/native.rs
+++ b/crates/rspack_fs/src/native.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use rspack_paths::Utf8Path;
-use rspack_resolver::{FileMetadata, FileSystem as ResolverFileSystem};
+use rspack_resolver::FileMetadata;
 
 use super::{
   sync::{ReadableFileSystem, WritableFileSystem},
@@ -27,10 +27,9 @@ impl WritableFileSystem for NativeFileSystem {
   }
 }
 
-impl ReadableFileSystem for NativeFileSystem {}
-impl ResolverFileSystem for NativeFileSystem {
-  fn read_to_string(&self, path: &Path) -> io::Result<String> {
-    fs::read_to_string(path)
+impl ReadableFileSystem for NativeFileSystem {
+  fn read(&self, path: &Path) -> io::Result<Vec<u8>> {
+    fs::read(path)
   }
 
   fn metadata(&self, path: &Path) -> io::Result<FileMetadata> {

--- a/crates/rspack_fs/src/sync.rs
+++ b/crates/rspack_fs/src/sync.rs
@@ -1,3 +1,7 @@
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
 use rspack_paths::Utf8Path;
 pub use rspack_resolver::FileMetadata;
 pub use rspack_resolver::FileSystem as ResolverFileSystem;
@@ -26,7 +30,19 @@ pub trait WritableFileSystem {
   fn write(&self, file: &Utf8Path, data: &[u8]) -> Result<()>;
 }
 
-pub trait ReadableFileSystem: ResolverFileSystem + Send + Sync {}
+pub trait ReadableFileSystem: Send + Sync {
+  /// See [std::fs::read]
+  fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
+
+  /// See [std::fs::metadata]
+  fn metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+
+  /// See [std::fs::symlink_metadata]
+  fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+
+  /// See [std::fs::canonicalize]
+  fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
+}
 
 /// Readable and writable file system representation.
 pub trait FileSystem: ReadableFileSystem + WritableFileSystem {}

--- a/crates/rspack_fs/src/sync.rs
+++ b/crates/rspack_fs/src/sync.rs
@@ -1,5 +1,8 @@
 use rspack_paths::Utf8Path;
+pub use rspack_resolver::FileMetadata;
+pub use rspack_resolver::FileSystem as ResolverFileSystem;
 
+// pubResolverFileSystem
 use super::Result;
 
 pub trait WritableFileSystem {
@@ -23,12 +26,7 @@ pub trait WritableFileSystem {
   fn write(&self, file: &Utf8Path, data: &[u8]) -> Result<()>;
 }
 
-pub trait ReadableFileSystem {
-  /// Read the entire contents of a file into a bytes vector.
-  ///
-  /// Error: This function will return an error if path does not already exist.
-  fn read(&self, file: &Utf8Path) -> Result<Vec<u8>>;
-}
+pub trait ReadableFileSystem: ResolverFileSystem + Send + Sync {}
 
 /// Readable and writable file system representation.
 pub trait FileSystem: ReadableFileSystem + WritableFileSystem {}

--- a/crates/rspack_fs/src/sync.rs
+++ b/crates/rspack_fs/src/sync.rs
@@ -1,10 +1,9 @@
+use std::fs::Metadata;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 
 use rspack_paths::Utf8Path;
-pub use rspack_resolver::FileMetadata;
-pub use rspack_resolver::FileSystem as ResolverFileSystem;
 
 // pubResolverFileSystem
 use super::Result;
@@ -35,10 +34,10 @@ pub trait ReadableFileSystem: Send + Sync {
   fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
 
   /// See [std::fs::metadata]
-  fn metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+  fn metadata(&self, path: &Path) -> io::Result<Metadata>;
 
   /// See [std::fs::symlink_metadata]
-  fn symlink_metadata(&self, path: &Path) -> io::Result<FileMetadata>;
+  fn symlink_metadata(&self, path: &Path) -> io::Result<Metadata>;
 
   /// See [std::fs::canonicalize]
   fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;

--- a/crates/rspack_fs_node/Cargo.toml
+++ b/crates/rspack_fs_node/Cargo.toml
@@ -8,15 +8,12 @@ version     = "0.1.0"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
-[features]
-async   = ["rspack_fs/async"]
-default = ["async"]
 
 [dependencies]
 futures      = { workspace = true }
 napi         = { workspace = true, features = ["napi4", "tokio_rt"] }
 napi-derive  = { workspace = true }
-rspack_fs    = { version = "0.1.0", path = "../rspack_fs", default-features = false, features = ["rspack-error"] }
+rspack_fs    = { version = "0.1.0", path = "../rspack_fs" }
 rspack_napi  = { version = "0.1.0", path = "../rspack_napi" }
 rspack_paths = { version = "0.1.0", path = "../rspack_paths" }
 

--- a/crates/rspack_fs_node/src/lib.rs
+++ b/crates/rspack_fs_node/src/lib.rs
@@ -1,20 +1,13 @@
 #![allow(clippy::unwrap_in_result)]
 
-use rspack_fs::cfg_async;
-
-cfg_async! {
-  mod r#async;
-  pub use r#async::AsyncNodeWritableFileSystem;
-}
+mod r#async;
+pub use r#async::AsyncNodeWritableFileSystem;
 mod sync;
 pub use sync::NodeWritableFileSystem;
 
 mod node;
 pub use node::NodeFS;
-
-cfg_async! {
-  pub use node::ThreadsafeNodeFS;
-}
+pub use node::ThreadsafeNodeFS;
 
 #[cfg(node)]
 mod node_test {

--- a/crates/rspack_fs_node/src/node.rs
+++ b/crates/rspack_fs_node/src/node.rs
@@ -1,6 +1,5 @@
 use napi::{bindgen_prelude::Buffer, Env, JsFunction, Ref};
 use napi_derive::napi;
-use rspack_fs::cfg_async;
 
 pub(crate) struct JsFunctionRef {
   env: Env,
@@ -55,21 +54,19 @@ pub(crate) struct NodeFSRef {
   pub(crate) mkdirp: JsFunctionRef,
 }
 
-cfg_async! {
-  use napi::Either;
-  use rspack_napi::threadsafe_function::ThreadsafeFunction;
+use napi::Either;
+use rspack_napi::threadsafe_function::ThreadsafeFunction;
 
-  #[napi(object, object_to_js = false, js_name = "ThreadsafeNodeFS")]
-  pub struct ThreadsafeNodeFS {
-    #[napi(ts_type = "(name: string, content: Buffer) => Promise<void> | void")]
-    pub write_file: ThreadsafeFunction<(String, Buffer), ()>,
-    #[napi(ts_type = "(name: string) => Promise<void> | void")]
-    pub remove_file: ThreadsafeFunction<String, ()>,
-    #[napi(ts_type = "(name: string) => Promise<void> | void")]
-    pub mkdir: ThreadsafeFunction<String, ()>,
-    #[napi(ts_type = "(name: string) => Promise<string | void> | string | void")]
-    pub mkdirp: ThreadsafeFunction<String, Either<String, ()>>,
-    #[napi(ts_type = "(name: string) => Promise<string | void> | string | void")]
-    pub remove_dir_all: ThreadsafeFunction<String, Either<String, ()>>,
-  }
+#[napi(object, object_to_js = false, js_name = "ThreadsafeNodeFS")]
+pub struct ThreadsafeNodeFS {
+  #[napi(ts_type = "(name: string, content: Buffer) => Promise<void> | void")]
+  pub write_file: ThreadsafeFunction<(String, Buffer), ()>,
+  #[napi(ts_type = "(name: string) => Promise<void> | void")]
+  pub remove_file: ThreadsafeFunction<String, ()>,
+  #[napi(ts_type = "(name: string) => Promise<void> | void")]
+  pub mkdir: ThreadsafeFunction<String, ()>,
+  #[napi(ts_type = "(name: string) => Promise<string | void> | string | void")]
+  pub mkdirp: ThreadsafeFunction<String, Either<String, ()>>,
+  #[napi(ts_type = "(name: string) => Promise<string | void> | string | void")]
+  pub remove_dir_all: ThreadsafeFunction<String, Either<String, ()>>,
 }

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -16,6 +16,7 @@ once_cell          = { workspace = true }
 regex              = { workspace = true }
 rspack_collections = { version = "0.1.0", path = "../rspack_collections" }
 rspack_error       = { version = "0.1.0", path = "../rspack_error" }
+rspack_fs          = { version = "0.1.0", path = "../rspack_fs" }
 rspack_paths       = { version = "0.1.0", path = "../rspack_paths" }
 rspack_sources     = { workspace = true }
 rspack_util        = { version = "0.1.0", path = "../rspack_util" }

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -237,6 +237,7 @@ mod test {
   use once_cell::sync::OnceCell;
   use rspack_collections::{Identifiable, Identifier};
   use rspack_error::Result;
+  use rspack_fs::NativeFileSystem;
 
   use super::{run_loaders, Loader, LoaderContext, ResourceData};
   use crate::{content::Content, plugin::LoaderRunnerPlugin, AdditionalData};
@@ -419,6 +420,7 @@ mod test {
       rs.clone(),
       Some(Arc::new(TestContentPlugin)),
       (),
+      Arc::new(NativeFileSystem {})
     )
     .await
     .err()
@@ -436,6 +438,7 @@ mod test {
       rs.clone(),
       Some(Arc::new(TestContentPlugin)),
       (),
+      Arc::new(NativeFileSystem {})
     )
     .await
     .err()
@@ -515,6 +518,7 @@ mod test {
       rs,
       Some(Arc::new(TestContentPlugin)),
       (),
+      Arc::new(NativeFileSystem {}),
     )
     .await
     .unwrap();
@@ -577,6 +581,7 @@ mod test {
       rs,
       Some(Arc::new(TestContentPlugin)),
       (),
+      Arc::new(NativeFileSystem {})
     )
     .await
     .err()

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -4,6 +4,7 @@ use rspack_error::{error, IntoTWithDiagnosticArray, Result, TWithDiagnosticArray
 use rspack_fs::ReadableFileSystem;
 use rspack_sources::SourceMap;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use tokio::task::spawn_blocking;
 
 use crate::{
   content::{AdditionalData, Content, ResourceData},
@@ -41,9 +42,12 @@ async fn process_resource<Context: Send>(
     if let Some(resource_path) = resource_data.resource_path.as_deref()
       && !resource_path.as_str().is_empty()
     {
-      let result = fs
-        .read(resource_path.as_std_path())
-        .map_err(|e| error!("{e}, failed to read {resource_path}"))?;
+      let resource_path_owned = resource_path.to_owned();
+      // use spawn_blocking to avoid block,see https://docs.rs/tokio/latest/src/tokio/fs/read.rs.html#48
+      let result = spawn_blocking(move || fs.read(resource_path_owned.as_std_path()))
+        .await
+        .map_err(|e| error!("{e}, spawn task failed"))?;
+      let result = result.map_err(|e| error!("{e}, failed to read {resource_path}"))?;
       loader_context.content = Some(Content::from(result));
     } else if !resource_data.get_scheme().is_none() {
       let resource = &resource_data.resource;

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -42,7 +42,7 @@ async fn process_resource<Context: Send>(
       && !resource_path.as_str().is_empty()
     {
       let result = fs
-        .read_to_string(resource_path.as_std_path())
+        .read(resource_path.as_std_path())
         .map_err(|e| error!("{e}, failed to read {resource_path}"))?;
       loader_context.content = Some(Content::from(result));
     } else if !resource_data.get_scheme().is_none() {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -642,6 +642,7 @@ impl ModuleConcatenationPlugin {
           },
           plugin_driver: compilation.plugin_driver.clone(),
           compiler_options: &compilation.options,
+          fs: compilation.input_filesystem.clone(),
         },
         Some(compilation),
       )


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
> [!CAUTION]
> since the performance regression is not acceptable for inputFilesystem binding, won't  export input filesystem to js side now


related to #7478 
This PR support input_filesystem api in rust side and bridge with resolver's filesystem: this will not introduce performance regression
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
