### PR TITLE
fix: should provide full error message with error name when `hideStack` is set to `true`

### DIFF
--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/index.js
@@ -1,0 +1,10 @@
+it("should include loader thrown error", () => {
+  let errored = false;
+	try {
+		require("./lib");
+	} catch (e) {
+    errored = true;
+		expect(e.message).toContain("Failed to load");
+	}
+  expect(errored).toBeTruthy()
+});

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/lib.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/lib.js
@@ -1,0 +1,1 @@
+export const lib = "lib";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/my-loader.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/my-loader.js
@@ -1,0 +1,4 @@
+module.exports = function (context) {
+  this.emitError(new Error("Failed to load"));
+	return ""
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/rspack.config.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: /lib\.js$/,
+				use: [
+					{
+						loader: "./my-loader.js"
+					}
+				]
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-error/stats.err
@@ -1,0 +1,9 @@
+ERROR in ./lib.js
+  × ModuleError: Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-error/my-loader.js)
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/index.js
@@ -1,0 +1,10 @@
+it("should include loader thrown error", () => {
+  let errored = false;
+	try {
+		require("./lib");
+	} catch (e) {
+    errored = true;
+		expect(e.message).toContain("Failed to load");
+	}
+  expect(errored).toBeTruthy()
+});

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/lib.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/lib.js
@@ -1,0 +1,1 @@
+export const lib = "lib";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js
@@ -1,0 +1,11 @@
+module.exports = function (context) {
+	let e;
+	e = new Error("Failed to load");
+	e.hideStack = true;
+  this.emitError(e);
+
+	e = new Error("Failed to load");
+	e.hideStack = true;
+	this.emitWarning(e);
+	return ""
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/rspack.config.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: /lib\.js$/,
+				use: [
+					{
+						loader: "./my-loader.js"
+					}
+				]
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/stats.err
@@ -1,0 +1,5 @@
+WARNING in ./lib.js
+  ⚠ ModuleWarning: Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js)
+
+ERROR in ./lib.js
+  × ModuleError: Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js)

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/index.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/index.js
@@ -1,0 +1,10 @@
+it("should include loader thrown error", () => {
+  let errored = false;
+	try {
+		require("./lib");
+	} catch (e) {
+    errored = true;
+		expect(e.message).toContain("Failed to load");
+	}
+  expect(errored).toBeTruthy()
+});

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/lib.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/lib.js
@@ -1,0 +1,1 @@
+export const lib = "lib";

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/my-loader.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/my-loader.js
@@ -1,0 +1,4 @@
+module.exports = function (context) {
+  this.emitWarning(new Error("Failed to load"));
+	return ""
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/rspack.config.js
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/rspack.config.js
@@ -1,0 +1,18 @@
+/**
+ * @type {import('@rspack/core').RspackOptions}
+ */
+module.exports = {
+	context: __dirname,
+	module: {
+		rules: [
+			{
+				test: /lib\.js$/,
+				use: [
+					{
+						loader: "./my-loader.js"
+					}
+				]
+			}
+		]
+	}
+};

--- a/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/module-build-failed/loader-emit-warning/stats.err
@@ -1,0 +1,9 @@
+WARNING in ./lib.js
+  ⚠ ModuleWarning: Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-warning/my-loader.js)
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx
+  │     at xxx

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -618,12 +618,10 @@ export async function runLoaders(
 		if (!(error instanceof Error)) {
 			error = new NonErrorEmittedError(error);
 		}
-		const hasStack = !!error.stack;
 		error.name = "ModuleError";
 		error.message = `${error.message} (from: ${stringifyLoaderObject(
 			loaderContext.loaders[loaderContext.loaderIndex]
 		)})`;
-		!hasStack && Error.captureStackTrace(error);
 		error = concatErrorMsgAndStack(error);
 		(error as RspackError).moduleIdentifier = this._module.identifier();
 		compiler._lastCompilation!.__internal__pushDiagnostic({
@@ -636,12 +634,10 @@ export async function runLoaders(
 		if (!(warning instanceof Error)) {
 			warning = new NonErrorEmittedError(warning);
 		}
-		const hasStack = !!warning.stack;
 		warning.name = "ModuleWarning";
 		warning.message = `${warning.message} (from: ${stringifyLoaderObject(
 			loaderContext.loaders[loaderContext.loaderIndex]
 		)})`;
-		hasStack && Error.captureStackTrace(warning);
 		warning = concatErrorMsgAndStack(warning);
 		(warning as RspackError).moduleIdentifier = this._module.identifier();
 		compiler._lastCompilation!.__internal__pushDiagnostic({

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -77,7 +77,17 @@ export function concatErrorMsgAndStack(
 	}
 	const hideStack = "hideStack" in err && err.hideStack;
 	if (!hideStack && "stack" in err) {
-		err.message = err.stack || err.message;
+		// This is intended to be different than webpack,
+		// here we want to treat the almost the same as `Error.stack` just without the stack.
+		// Webpack uses `Error.message`, however it does not contain the `Error.prototype.name`
+		// `xxx` -> `Error: xxx`. So they behave the same even if `hideStack` is set to `true`.
+		err.message = err.stack || err.toString();
+	} else {
+		// This is intended to be different than webpack,
+		// here we want to treat the almost the same as `Error.stack` just without the stack.
+		// Webpack uses `Error.message`, however it does not contain the `Error.prototype.name`
+		// `xxx` -> `Error: xxx`. So they behave the same even if `hideStack` is set to `true`.
+		err.message = err.toString();
 	}
 	// maybe `null`, use `undefined` to compatible with `Option<String>`
 	err.stack = err.stack || undefined;

--- a/tests/plugin-test/css-extract/cases/build-in-css-support/warnings.js
+++ b/tests/plugin-test/css-extract/cases/build-in-css-support/warnings.js
@@ -4,7 +4,7 @@
 // decide bailout on builtin css module
 
 module.exports = `WARNING in ./style.css
-  ⚠ use type 'css' and \`CssExtractRspackPlugin\` together, please set \`experiments.css\` to \`false\` or set \`{ type: "javascript/auto" }\` for rules with \`CssExtractRspackPlugin\` in your rspack config (now \`CssExtractRspackPlugin\` does nothing). 
+  ⚠ ModuleWarning: use type 'css' and \`CssExtractRspackPlugin\` together, please set \`experiments.css\` to \`false\` or set \`{ type: "javascript/auto" }\` for rules with \`CssExtractRspackPlugin\` in your rspack config (now \`CssExtractRspackPlugin\` does nothing). 
 
 WARNING in ./style.css
   ⚠ ModuleWarning: You can't use \`experiments.css\` (\`experiments.futureDefaults\` enable built-in CSS support by default) and \`css-loader\` together, please set \`experiments.css\` to \`false\` or set \`{ type: "javascript/auto" }\` for rules with \`css-loader\` in your webpack config (now css-loader does nothing). `;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

**Before**
```
WARNING in ./lib.js
  ⚠ Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js)

ERROR in ./lib.js
  × Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js)
```

**After**
```
WARNING in ./lib.js
  ⚠ ModuleWarning: Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js)

ERROR in ./lib.js
  × ModuleError: Failed to load (from: <PROJECT_ROOT>/tests/diagnosticsCases/module-build-failed/loader-emit-hide-stack/my-loader.js)
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
