### PR TITLE
fix: lightningCss default target use browserslist set

### DIFF
--- a/packages/rspack/src/builtin-plugin/LightningCssMiminizerRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/LightningCssMiminizerRspackPlugin.ts
@@ -2,6 +2,7 @@ import {
 	BuiltinPluginName,
 	type RawLightningCssMinimizerRspackPluginOptions
 } from "@rspack/binding";
+import browserslist from 'browserslist';
 
 import {
 	type Drafts,
@@ -37,7 +38,7 @@ export const LightningCssMinimizerRspackPlugin = create(
 	): RawLightningCssMinimizerRspackPluginOptions => {
 		const { include, exclude, draft, nonStandard, pseudoClasses } =
 			options?.minimizerOptions ?? {};
-		const targets = options?.minimizerOptions?.targets ?? "fully supports es6"; // last not support es module chrome version
+		const targets = options?.minimizerOptions?.targets ?? browserslist(null);
 		return {
 			test: options?.test,
 			include: options?.include,

--- a/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -77,7 +77,7 @@ Below are the configurations supported, `targets` configuration is plain browser
 
 :::info
 
-1. The default `targets` is set to `"fully supports es6"` to ensure that minification does not introduce advanced syntax that could cause browser incompatibility (minification might turn lower-level syntax into advanced syntax because it is shorter).
+1. The default `targets` are configured using [browserslist](https://github.com/browserslist/browserslist) . If configuration is not found, browserslist will use defaults: `> 0.5%, last 2 versions, Firefox ESR, not dead`。
 2. The `exclude` option is configured with all features by default. We usually do syntax degradation in [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader) or other loaders, so this plugin excludes all features by default to avoid syntax downgrading during the minimize process.
 
 We recommend and encourage users to configure their own `targets` to achieve the best minification results.

--- a/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -77,7 +77,7 @@ document.body.className = styles.a;
 
 :::info
 
-1. 默认 `targets` 为 `"fully supports es6"`，以保证压缩后不会出现高级语法导致浏览器不兼容（压缩过程中可能会出现由于高级语法更短而将低级语法转为高级语法）。
+1. 默认 `targets` 是通过 [browserslist](https://github.com/browserslist/browserslist) 配置的。如果没有找到配置，browserslist 会使用默认值： `> 0.5%, last 2 versions, Firefox ESR, not dead`。
 2. `exclude` 选项默认配置了所有的 features。我们通常会在[builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader) 或其他 loaders 中进行语法降级，所以此插件默认 exclude 所有的 features，避免在 minimize 过程中进行语法降级。
 
 我们建议并鼓励用户配置自己所需的 `targets`，以获得最好的压缩效果。


### PR DESCRIPTION
一些流行的库都是使用 browerslist 来配置 target, 例如 [Babel](https://github.com/babel/babel/tree/master/packages/babel-preset-env)、[postcss-preset-env](https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env)。

当前，rspack. LightningCssMinimizerRspackPlugin target  选项的默认值是”fully supports es6“，与 postcss-preset-env 默认 target 配置存在不一致。这种不一致，可能会让同时使用 postcss-loader 和 rspack.LightningCssMinimizerRspackPlugin 项目存在潜在问题。

因此，期望将 rspack. LightningCssMinimizerRspackPlugin  的 minimizerOptions 配置中的 target, 默认值也由 browerslist 指定。

此 PR 可能会引入破坏性更改，原因是项目未显示配置 target ，同时未使用 browserslist 的项目，target 默认值的兼容性会低于原先的 ”fully supports es6“。

- [ ] Tests updated (or not required).
- [x ] Documentation updated (or not required).
