### PR TITLE
docs: add `sources` JavaScript API

### DIFF
--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -269,15 +269,34 @@ isChild(): boolean;
 
 See [compiler hooks](/api/plugin-api/compiler-hooks) for more details.
 
-### rspack/webpack
+### rspack
 
-**Type:** `typeof rspack`
+- **Type:** `typeof rspack`
 
-Get the exports of @rspack/core to obtain the associated internal objects. This is usually very useful when Rspack is wrapped or there are multiple Rspack instances.
+Get the exports of @rspack/core to obtain the associated internal objects. This is especially useful when you cannot directly reference `@rspack/core` or there are multiple Rspack instances.
+
+A common example is accessing the [sources](/api/javascript-api/index#sources-object) object in a Rspack plugin:
+
+```js
+const { RawSource } = compiler.rspack.sources;
+const source = new RawSource('console.log("Hello, world!");');
+```
+
+### webpack
+
+- **Type:** `typeof rspack`
+
+Equivalent to `compiler.rspack`, this property is used for compatibility with webpack plugins.
+
+If the Rspack plugin you are developing needs to be webpack compatible, you can use this property instead of `compiler.rspack`.
+
+```js
+console.log(compiler.webpack === compiler.rspack); // true
+```
 
 ### name
 
-**Type:** `string`
+- **Type:** `string`
 
 Get the name:
 
@@ -294,37 +313,37 @@ Current project root directory:
 
 ### root
 
-**Type:** `Compiler`
+- **Type:** `Compiler`
 
 Get the root of the child compiler tree.
 
 ### options
 
-**Type:** `RspackOptionsNormalized`
+- **Type:** `RspackOptionsNormalized`
 
 Get the full options used by this compiler.
 
 ### watchMode
 
-**Type:** `boolean`
+- **Type:** `boolean`
 
 Whether started through `compiler.watch`.
 
 ### watching
 
-**Type:** `Watching`
+- **Type:** `Watching`
 
 Get the watching object, see [watch method](#watch) for more details.
 
 ### running
 
-**Type:** `boolean`
+- **Type:** `boolean`
 
 Whether the compilation is currently being executed.
 
 ### inputFileSystem
 
-**Type:** `InputFileSystem`
+- **Type:** `InputFileSystem`
 
 Get the proxy object used for reading from the file system, which has optimizations such as caching inside to reduce duplicate reading of the same file.
 
@@ -340,7 +359,7 @@ Get the proxy object used for reading from the file system, which has optimizati
 
 ### outputFileSystem
 
-**Type:** `OutputFileSystem`
+- **Type:** `OutputFileSystem`
 
 Get the proxy object used for writing to the file system, `fs` by default.
 
@@ -356,7 +375,7 @@ Get the proxy object used for writing to the file system, `fs` by default.
 
 ### watchFileSystem
 
-**Type:** `WatchFileSystem`
+- **Type:** `WatchFileSystem`
 
 Get the proxy object used for watching files or directories changes, which provides a `watch` method to start watching, and passes in the changed and removed items in the callback.
 
@@ -491,7 +510,7 @@ getInfrastructureLogger(name: string): Logger;
 
 #### compilers
 
-**Type:** `Compiler[]`
+- **Type:** `Compiler[]`
 
 Get all included compilers.
 
@@ -509,7 +528,7 @@ Get all included compilers.
 
 <Badge text="ReadOnly" type="info" />
 
-**Type:** `RspackOptionsNormalized[]`
+- **Type:** `RspackOptionsNormalized[]`
 
 Get all the [full options](/config/index) used by the compilers.
 
@@ -517,7 +536,7 @@ Get all the [full options](/config/index) used by the compilers.
 
 <Badge text="WriteOnly" type="info" />
 
-**Type:** `InputFileSystem`
+- **Type:** `InputFileSystem`
 
 Set the proxy object used for reading from the file system for each compiler.
 
@@ -535,7 +554,7 @@ Set the proxy object used for reading from the file system for each compiler.
 
 <Badge text="WriteOnly" type="info" />
 
-**Type:** `OutputFileSystem`
+- **Type:** `OutputFileSystem`
 
 Set the proxy object used for writing from the file system for each compiler.
 
@@ -553,7 +572,7 @@ Set the proxy object used for writing from the file system for each compiler.
 
 <Badge text="WriteOnly" type="info" />
 
-**Type:** `WatchFileSystem`
+- **Type:** `WatchFileSystem`
 
 Set the proxy object used for watching files or directories changes for each compiler.
 
@@ -569,6 +588,6 @@ Set the proxy object used for watching files or directories changes for each com
 
 #### running
 
-**Type:** `boolean`
+- **Type:** `boolean`
 
 Whether the compilation is currently being executed.

--- a/website/docs/en/api/javascript-api/index.mdx
+++ b/website/docs/en/api/javascript-api/index.mdx
@@ -15,7 +15,7 @@ Rspack provides a set of JavaScript APIs to be used in JavaScript runtimes like 
 The JavaScript API is useful in scenarios in which you need to customize the build or development process since all the reporting and error handling must be done manually and webpack only does the compiling part. For this reason the [`stats`](/config/stats) configuration options will not have any effect in the `rspack()` call.
 
 :::tip
-`@rspack/core` is designed based on Webpack's JavaScript API to ensure functional consistency and a similar user experience.
+`@rspack/core` is designed based on webpack's JavaScript API to ensure functional consistency and a similar user experience.
 :::
 
 ## Installation
@@ -262,3 +262,16 @@ compiler.run((err, stats) => {
   });
 });
 ```
+
+## `sources` object
+
+`@rspack/core` exports the [webpack-sources](https://github.com/webpack/webpack-sources) module through `sources`. It provides a set of classes for creating and manipulating source code fragments and source maps. When developing Rspack plugins, you can use these classes to handle and manipulate source code.
+
+```js
+import { sources } from '@rspack/core';
+
+const { RawSource } = sources;
+const source = new RawSource('console.log("Hello, world!");');
+```
+
+For detailed usage, please refer to the [webpack-sources](https://github.com/webpack/webpack-sources) documentation.

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -269,15 +269,34 @@ isChild(): boolean;
 
 详见 [Compiler 钩子](/api/plugin-api/compiler-hooks)
 
-### rspack/webpack
+### rspack
 
-**类型：** `typeof rspack`
+- **类型：** `typeof rspack`
 
-获取当前的 `@rspack/core` 的导出，以此来获取关联的内部对象。这通常在 Rspack 被封装或者存在多个 Rspack 实例时很有用。
+获取当前的 `@rspack/core` 的导出，以此来获取关联的内部对象。当你无法直接引用 `@rspack/core`，或者存在多个 Rspack 实例时很有用。
+
+一个常见的例子是在 Rspack 插件中获取 [sources](/api/javascript-api/index#sources-对象) 对象：
+
+```js
+const { RawSource } = compiler.rspack.sources;
+const source = new RawSource('console.log("Hello, world!");');
+```
+
+### webpack
+
+- **类型：** `typeof rspack`
+
+等同于 `compiler.rspack`，该属性用于兼容 webpack 插件。
+
+如果你开发的 Rspack 插件需要兼容 webpack，可以使用该属性代替 `compiler.rspack`。
+
+```js
+console.log(compiler.webpack === compiler.rspack); // true
+```
 
 ### name
 
-**类型：** `string`
+- **类型：** `string`
 
 获取名称：
 
@@ -294,37 +313,37 @@ isChild(): boolean;
 
 ### root
 
-**类型：** `Compiler`
+- **类型：** `Compiler`
 
 获取根 Compiler 实例。
 
 ### options
 
-**类型：** `RspackOptionsNormalized`
+- **类型：** `RspackOptionsNormalized`
 
 获取根 Compiler 所使用的完整[构建配置](/config/index)。
 
 ### watchMode
 
-**类型：** `boolean`
+- **类型：** `boolean`
 
 是否通过 watch 启动。
 
 ### watching
 
-**类型：** `Watching`
+- **类型：** `Watching`
 
 获取 watch 启动下的监听控制对象，详见 [watch 方法](#watch)
 
 ### running
 
-**类型：** `boolean`
+- **类型：** `boolean`
 
 当前是否正在执行构建流程。
 
 ### inputFileSystem
 
-**类型：** `InputFileSystem`
+- **类型：** `InputFileSystem`
 
 获取用于从文件系统读取的代理对象，其内部有缓存等优化，以降低对同一文件的重复读取。
 
@@ -340,7 +359,7 @@ isChild(): boolean;
 
 ### outputFileSystem
 
-**类型：** `OutputFileSystem`
+- **类型：** `OutputFileSystem`
 
 获取用于输出到文件系统的代理对象，默认使用 `fs`。
 
@@ -356,7 +375,7 @@ isChild(): boolean;
 
 ### watchFileSystem
 
-**类型：** `WatchFileSystem`
+- **类型：** `WatchFileSystem`
 
 获取用于持续监听文件/目录变化的代理对象，提供一个 `watch` 方法来启动监听，并在回调中传入变更和移除的项目。
 
@@ -491,7 +510,7 @@ getInfrastructureLogger(name: string): Logger;
 
 #### compilers
 
-**类型：** `Compiler[]`
+- **类型：** `Compiler[]`
 
 获取包含的所有 Compiler 实例。
 
@@ -509,7 +528,7 @@ getInfrastructureLogger(name: string): Logger;
 
 <Badge text="只读" type="info" />
 
-**类型：** `RspackOptionsNormalized[]`
+- **类型：** `RspackOptionsNormalized[]`
 
 获取各个 Compiler 所使用的完整[构建配置](/config/index)。
 
@@ -517,7 +536,7 @@ getInfrastructureLogger(name: string): Logger;
 
 <Badge text="只写" type="info" />
 
-**类型：** `InputFileSystem`
+- **类型：** `InputFileSystem`
 
 为各个 Compiler 设置用于从文件系统读取的代理对象。
 
@@ -535,7 +554,7 @@ getInfrastructureLogger(name: string): Logger;
 
 <Badge text="只写" type="info" />
 
-**类型：** `OutputFileSystem`
+- **类型：** `OutputFileSystem`
 
 为各个 Compiler 设置用于输出到文件系统的代理对象。
 
@@ -553,7 +572,7 @@ getInfrastructureLogger(name: string): Logger;
 
 <Badge text="只写" type="info" />
 
-**类型：** `WatchFileSystem`
+- **类型：** `WatchFileSystem`
 
 为各个 Compiler 设置用于持续监听文件/目录变化的代理对象。
 
@@ -569,6 +588,6 @@ getInfrastructureLogger(name: string): Logger;
 
 #### running
 
-**类型：** `boolean`
+- **类型：** `boolean`
 
 当前是否正在执行构建流程。

--- a/website/docs/zh/api/javascript-api/index.mdx
+++ b/website/docs/zh/api/javascript-api/index.mdx
@@ -15,7 +15,7 @@ Rspack 提供了一组 JavaScript API，可在 Node.js 或 Bun 等 JavaScript �
 当你需要自定义构建或开发流程时，JavaScript API 非常有用，因为此时所有的报告和错误处理都必须自行实现，Rspack 仅仅负责编译的部分。所以 [`stats`](/config/stats) 配置选项不会在 `rspack()` 调用中生效。
 
 :::tip 提示
-`@rspack/core` 是基于 Webpack JavaScript API 设计的，旨在提供一致的功能和相似的使用体验。
+`@rspack/core` 是基于 webpack 的 JavaScript API 设计的，旨在提供一致的功能和相似的使用体验。
 :::
 
 ## 安装
@@ -262,3 +262,16 @@ compiler.run((err, stats) => {
   });
 });
 ```
+
+## `sources` 对象
+
+`@rspack/core` 通过 `sources` 导出了 [webpack-sources](https://github.com/webpack/webpack-sources) 模块。它提供了一组 class，用于创建和操作源代码片段和源码映射。在开发 Rspack 插件时，你可以使用这些 class 来处理和操作源代码。
+
+```js
+import { sources } from '@rspack/core';
+
+const { RawSource } = sources;
+const source = new RawSource('console.log("Hello, world!");');
+```
+
+详细用法请参考 [webpack-sources](https://github.com/webpack/webpack-sources) 文档。


### PR DESCRIPTION
## Summary

The `compiler.webpack.sources` is a commonly used API and we should document it.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
