### PR TITLE
fix(rspack-test-tools): corret script `testu`

### DIFF
--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -19,7 +19,7 @@
     "dev:viewer": "rspack serve",
     "dev": "tsc -b -w",
     "test": "sh -c 'run-s \"test:* -- $*\"' sh",
-    "testu": "sh -c 'run-s \"test:* -u -- $*\"' sh",
+    "testu": "sh -c 'run-s \"test:* -- -u $*\"' sh",
     "test:base": "cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --logHeapUsage --colors --config ./jest.config.js --passWithNoTests",
     "test:hot": "cross-env RSPACK_HOT_TEST=true NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --logHeapUsage --colors --config ./jest.config.hot.js --passWithNoTests",
     "test:diff": "cross-env RSPACK_DIFF=true NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --logHeapUsage --colors --config ./jest.config.diff.js --passWithNoTests",


### PR DESCRIPTION
## Summary

`sh -c 'run-s \"test:* -u -- $*\"' sh` should be `sh -c 'run-s \"test:* -- -u $*\"' sh`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
