### PR TITLE
fix: make stage has_module_graph_change calculate incorrectly

### DIFF
--- a/crates/rspack_core/src/compiler/make/cutout/mod.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/mod.rs
@@ -144,9 +144,7 @@ impl Cutout {
 
     artifact.entry_dependencies = entry_dependencies;
 
-    self
-      .has_module_graph_change
-      .analyze_force_build_deps(&force_build_deps);
+    self.has_module_graph_change.analyze_artifact(artifact);
 
     force_build_deps
   }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

`has_module_graph_change` always evaluates to true when running `update_module_graph` multiple times during the make stage

``` rust
fn make(compilation: &Compilation, make_artifact: MakeArtifact) {
  // run multi times
  let make_artifact = update_module_graph(compilation, make_artifact, params);
  let make_artifact = update_module_graph(compilation, make_artifact, params);
  assert_eq!(make_artifact.has_module_graph_change, true);
}
```

This PR rewrite the `has_module_graph_change` calculate by check make_artifact.built_module change.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
