### PR TITLE
feat: support `compilation.addRuntimeModule`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,5 +42,6 @@
     "tokio",
     "ukey",
     "Ukey"
-  ]
+  ],
+  "rust-analyzer.checkOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,6 +42,5 @@
     "tokio",
     "ukey",
     "Ukey"
-  ],
-  "rust-analyzer.checkOnSave": true
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3027,6 +3027,7 @@ dependencies = [
  "rspack_error",
  "rspack_napi",
  "rspack_plugin_html",
+ "rspack_plugin_runtime",
  "rspack_regex",
  "rspack_util",
  "rustc-hash 1.1.0",
@@ -3811,6 +3812,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "cow-utils",
+ "derivative",
  "indexmap 2.2.6",
  "itertools 0.13.0",
  "rspack_collections",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -3,8 +3,8 @@
 
 /* -- banner.d.ts -- */
 export type JsFilename =
-  | string
-  | ((pathData: JsPathData, assetInfo?: JsAssetInfo) => string);
+	| string
+	| ((pathData: JsPathData, assetInfo?: JsAssetInfo) => string);
 
 export type LocalJsFilename = JsFilename;
 
@@ -282,6 +282,8 @@ export function cleanupGlobalTrace(): void
 export interface ContextInfo {
   issuer: string
 }
+
+export function formatDiagnostic(diagnostic: JsDiagnostic): ExternalObject<'Diagnostic'>
 
 export interface JsAddingRuntimeModule {
   name: string

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -3,8 +3,8 @@
 
 /* -- banner.d.ts -- */
 export type JsFilename =
-	| string
-	| ((pathData: JsPathData, assetInfo?: JsAssetInfo) => string);
+  | string
+  | ((pathData: JsPathData, assetInfo?: JsAssetInfo) => string);
 
 export type LocalJsFilename = JsFilename;
 
@@ -117,6 +117,7 @@ export class JsCompilation {
   rebuildModule(moduleIdentifiers: Array<string>, f: (...args: any[]) => any): void
   importModule(request: string, layer: string | undefined | null, publicPath: JsFilename | undefined | null, baseUri: string | undefined | null, originalModule: string | undefined | null, originalModuleContext: string | undefined | null, callback: (...args: any[]) => any): void
   get entries(): JsEntries
+  addRuntimeModule(chunkUkey: number, runtimeModule: JsAddingRuntimeModule): void
 }
 
 export class JsEntries {
@@ -282,7 +283,13 @@ export interface ContextInfo {
   issuer: string
 }
 
-export function formatDiagnostic(diagnostic: JsDiagnostic): ExternalObject<'Diagnostic'>
+export interface JsAddingRuntimeModule {
+  name: string
+  generator: () => String
+  cacheable: boolean
+  isolate: boolean
+  stage: number
+}
 
 export interface JsAdditionalTreeRuntimeRequirementsArg {
   chunk: JsChunk

--- a/crates/rspack_binding_values/Cargo.toml
+++ b/crates/rspack_binding_values/Cargo.toml
@@ -6,18 +6,19 @@ name        = "rspack_binding_values"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.1.0"
 [dependencies]
-cow-utils          = { workspace = true }
-futures            = { workspace = true }
-heck               = { workspace = true }
-napi               = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
-napi-derive        = { workspace = true }
-rspack_collections = { version = "0.1.0", path = "../rspack_collections" }
-rspack_core        = { version = "0.1.0", path = "../rspack_core" }
-rspack_error       = { version = "0.1.0", path = "../rspack_error" }
-rspack_napi        = { version = "0.1.0", path = "../rspack_napi" }
-rspack_plugin_html = { version = "0.1.0", path = "../rspack_plugin_html" }
-rspack_regex       = { version = "0.1.0", path = "../rspack_regex" }
-rspack_util        = { version = "0.1.0", path = "../rspack_util" }
-rustc-hash         = { workspace = true }
-serde              = { workspace = true }
-serde_json         = { workspace = true }
+cow-utils             = { workspace = true }
+futures               = { workspace = true }
+heck                  = { workspace = true }
+napi                  = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
+napi-derive           = { workspace = true }
+rspack_collections    = { version = "0.1.0", path = "../rspack_collections" }
+rspack_core           = { version = "0.1.0", path = "../rspack_core" }
+rspack_error          = { version = "0.1.0", path = "../rspack_error" }
+rspack_napi           = { version = "0.1.0", path = "../rspack_napi" }
+rspack_plugin_html    = { version = "0.1.0", path = "../rspack_plugin_html" }
+rspack_plugin_runtime = { version = "0.1.0", path = "../rspack_plugin_runtime" }
+rspack_regex          = { version = "0.1.0", path = "../rspack_regex" }
+rspack_util           = { version = "0.1.0", path = "../rspack_util" }
+rustc-hash            = { workspace = true }
+serde                 = { workspace = true }
+serde_json            = { workspace = true }

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -14,17 +14,20 @@ use rspack_core::get_chunk_from_ukey;
 use rspack_core::get_chunk_group_from_ukey;
 use rspack_core::rspack_sources::BoxSource;
 use rspack_core::AssetInfo;
+use rspack_core::ChunkUkey;
 use rspack_core::CompilationId;
 use rspack_core::ModuleIdentifier;
 use rspack_error::Diagnostic;
 use rspack_napi::napi::bindgen_prelude::*;
 use rspack_napi::NapiResultExt;
 use rspack_napi::Ref;
+use rspack_plugin_runtime::RuntimeModuleFromJs;
 use sys::napi_env;
 
 use super::module::ToJsModule;
 use super::{JsFilename, PathWithInfo};
 use crate::utils::callbackify;
+use crate::JsAddingRuntimeModule;
 use crate::JsStatsOptimizationBailout;
 use crate::LocalJsFilename;
 use crate::ModuleDTOWrapper;
@@ -531,6 +534,21 @@ impl JsCompilation {
   #[napi(getter)]
   pub fn entries(&'static mut self) -> JsEntries {
     JsEntries::new(self.0)
+  }
+
+  #[napi]
+  pub fn add_runtime_module(
+    &'static mut self,
+    chunk_ukey: u32,
+    runtime_module: JsAddingRuntimeModule,
+  ) -> napi::Result<()> {
+    self
+      .0
+      .add_runtime_module(
+        &ChunkUkey::from(chunk_ukey),
+        Box::new(RuntimeModuleFromJs::from(runtime_module)),
+      )
+      .map_err(|e| Error::new(napi::Status::GenericFailure, format!("{e}")))
   }
 }
 

--- a/crates/rspack_binding_values/src/runtime.rs
+++ b/crates/rspack_binding_values/src/runtime.rs
@@ -172,31 +172,3 @@ impl JsRuntimeRequirementInTreeResult {
     runtime_requirements
   }
 }
-
-#[napi(object)]
-pub struct JsRuntimeRequirementInTreeArg {
-  pub chunk: JsChunk,
-  pub runtime_requirements: JsRuntimeGlobals,
-}
-
-#[derive(Debug)]
-#[napi(object)]
-pub struct JsRuntimeRequirementInTreeResult {
-  pub runtime_requirements: JsRuntimeGlobals,
-}
-
-impl JsRuntimeRequirementInTreeResult {
-  pub fn as_runtime_globals(&self) -> RuntimeGlobals {
-    let mut runtime_requirements = RuntimeGlobals::default();
-
-    for item in self.runtime_requirements.value.iter() {
-      let name = item.to_snake_case().to_uppercase();
-
-      if let Some(item) = RUNTIME_GLOBAL_MAP.1.get(&name) {
-        runtime_requirements.extend(*item);
-      }
-    }
-
-    runtime_requirements
-  }
-}

--- a/crates/rspack_binding_values/src/runtime.rs
+++ b/crates/rspack_binding_values/src/runtime.rs
@@ -172,3 +172,31 @@ impl JsRuntimeRequirementInTreeResult {
     runtime_requirements
   }
 }
+
+#[napi(object)]
+pub struct JsRuntimeRequirementInTreeArg {
+  pub chunk: JsChunk,
+  pub runtime_requirements: JsRuntimeGlobals,
+}
+
+#[derive(Debug)]
+#[napi(object)]
+pub struct JsRuntimeRequirementInTreeResult {
+  pub runtime_requirements: JsRuntimeGlobals,
+}
+
+impl JsRuntimeRequirementInTreeResult {
+  pub fn as_runtime_globals(&self) -> RuntimeGlobals {
+    let mut runtime_requirements = RuntimeGlobals::default();
+
+    for item in self.runtime_requirements.value.iter() {
+      let name = item.to_snake_case().to_uppercase();
+
+      if let Some(item) = RUNTIME_GLOBAL_MAP.1.get(&name) {
+        runtime_requirements.extend(*item);
+      }
+    }
+
+    runtime_requirements
+  }
+}

--- a/crates/rspack_core/src/runtime_module.rs
+++ b/crates/rspack_core/src/runtime_module.rs
@@ -41,12 +41,30 @@ pub trait CustomSourceRuntimeModule {
 
 pub type BoxRuntimeModule = Box<dyn RuntimeModule>;
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum RuntimeModuleStage {
   Normal,  // Runtime modules without any dependencies to other runtime modules
   Basic,   // Runtime modules with simple dependencies on other runtime modules
   Attach,  // Runtime modules which attach to handlers of other runtime modules
   Trigger, // Runtime modules which trigger actions on bootstrap
+}
+
+impl Default for RuntimeModuleStage {
+  fn default() -> Self {
+    Self::Normal
+  }
+}
+
+impl From<u32> for RuntimeModuleStage {
+  fn from(stage: u32) -> Self {
+    match stage {
+      0 => RuntimeModuleStage::Normal,
+      5 => RuntimeModuleStage::Basic,
+      10 => RuntimeModuleStage::Attach,
+      20 => RuntimeModuleStage::Trigger,
+      _ => RuntimeModuleStage::Normal,
+    }
+  }
 }
 
 pub trait RuntimeModuleExt {

--- a/crates/rspack_plugin_runtime/Cargo.toml
+++ b/crates/rspack_plugin_runtime/Cargo.toml
@@ -10,6 +10,7 @@ version     = "0.1.0"
 [dependencies]
 async-trait              = { workspace = true }
 cow-utils                = { workspace = true }
+derivative               = { workspace = true }
 indexmap                 = { workspace = true }
 itertools                = { workspace = true }
 rspack_collections       = { version = "0.1.0", path = "../rspack_collections" }

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -29,6 +29,8 @@ mod chunk_prefetch_preload;
 pub use chunk_prefetch_preload::ChunkPrefetchPreloadPlugin;
 mod bundler_info;
 pub use bundler_info::{BundlerInfoForceMode, BundlerInfoPlugin};
+mod runtime_module_from_js;
+pub use runtime_module_from_js::RuntimeModuleFromJs;
 
 pub fn enable_chunk_loading_plugin(loading_type: ChunkLoadingType, plugins: &mut Vec<BoxPlugin>) {
   match loading_type {

--- a/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use derivative::Derivative;
+use rspack_collections::Identifier;
+use rspack_core::{
+  impl_runtime_module,
+  rspack_sources::{BoxSource, RawSource, SourceExt},
+  Compilation, RuntimeModule, RuntimeModuleStage,
+};
+
+type GenerateFn = Arc<dyn Fn() -> rspack_error::Result<String> + Send + Sync>;
+
+#[impl_runtime_module]
+#[derive(Derivative)]
+#[derivative(Debug)]
+pub struct RuntimeModuleFromJs {
+  pub name: String,
+  #[derivative(Debug = "ignore")]
+  pub generator: GenerateFn,
+  pub cacheable: bool,
+  pub isolate: bool,
+  pub stage: RuntimeModuleStage,
+}
+
+impl RuntimeModule for RuntimeModuleFromJs {
+  fn name(&self) -> Identifier {
+    Identifier::from(format!("webpack/runtime/{}", self.name))
+  }
+
+  fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
+    let res = (&self.generator)()?;
+    Ok(RawSource::from(res).boxed())
+  }
+
+  fn cacheable(&self) -> bool {
+    self.cacheable
+  }
+
+  fn should_isolate(&self) -> bool {
+    self.isolate
+  }
+
+  fn stage(&self) -> RuntimeModuleStage {
+    self.stage.clone()
+  }
+}

--- a/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module_from_js.rs
@@ -28,7 +28,7 @@ impl RuntimeModule for RuntimeModuleFromJs {
   }
 
   fn generate(&self, _: &Compilation) -> rspack_error::Result<BoxSource> {
-    let res = (&self.generator)()?;
+    let res = (self.generator)()?;
     Ok(RawSource::from(res).boxed())
   }
 

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/index.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/index.js
@@ -1,0 +1,3 @@
+it("should inject runtime according to isolate scope", async function () {
+  expect(__webpack_require__.mock()).toBe("isolated");
+});

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/rspack.config.js
@@ -1,0 +1,65 @@
+const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
+
+class IsolateRuntimeModule extends RuntimeModule {
+  constructor(chunk) {
+    super("mock-isolate");
+  }
+
+  generate(compilation) {
+    return `
+      __webpack_require__.mock = function() {
+        return someGlobalValue;
+      };
+    `;
+  }
+}
+
+class NonIsolateRuntimeModule extends RuntimeModule {
+  constructor(chunk) {
+    super("mock-non-isolate");
+  }
+
+  shouldIsolate() {
+    return false;
+  }
+
+  generate(compilation) {
+    return `
+      var someGlobalValue = "isolated";
+    `;
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: "./index.js",
+  mode: "development",
+  devtool: false,
+  optimization: {
+    minimize: false,
+    sideEffects: false,
+    concatenateModules: false,
+    usedExports: false,
+    innerGraph: false,
+    providedExports: false
+  },
+  plugins: [
+    compiler => {
+      compiler.hooks.thisCompilation.tap(
+        "MockRuntimePlugin",
+        (compilation) => {
+          compilation.hooks.runtimeRequirementInTree.tap("MockRuntimePlugin", (chunk, set) => {
+            compilation.addRuntimeModule(
+              chunk,
+              new NonIsolateRuntimeModule()
+            );
+            compilation.addRuntimeModule(
+              chunk,
+              new IsolateRuntimeModule()
+            );
+          })
+        }
+      );
+    }
+  ],
+};

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/index.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/index.js
@@ -1,0 +1,9 @@
+it("should inject trigger runtime module after normal runtime module", async function () {
+  expect(__webpack_require__.mockNormal).toBe("normal");
+  expect(__webpack_require__.mockTrigger).toBe("trigger");
+  const fs = require("fs");
+  const content = fs.readFileSync(__filename, 'utf-8');
+  const triggerIndex = content.indexOf(`__webpack_require__.mockTrigger = "trigger"`);
+  const normalIndex = content.indexOf(`__webpack_require__.mockNormal = "normal"`);
+  expect(normalIndex).toBeLessThan(triggerIndex);
+});

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/rspack.config.js
@@ -1,0 +1,57 @@
+const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
+
+class MockNormalRuntimeModule extends RuntimeModule {
+  constructor(chunk) {
+    super("mock-normal", RuntimeModule.STAGE_NORMAL);
+  }
+
+  generate(compilation) {
+    return `__webpack_require__.mockNormal = "normal";`;
+  }
+}
+
+class MockTriggerRuntimeModule extends RuntimeModule {
+  constructor(chunk) {
+    super("mock-trigger", RuntimeModule.STAGE_TRIGGER);
+  }
+
+  generate(compilation) {
+    return `__webpack_require__.mockTrigger = "trigger";`;
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: "./index.js",
+  mode: "development",
+  devtool: false,
+  optimization: {
+    minimize: false,
+    sideEffects: false,
+    concatenateModules: false,
+    usedExports: false,
+    innerGraph: false,
+    providedExports: false
+  },
+  plugins: [
+    compiler => {
+      compiler.hooks.thisCompilation.tap(
+        "MockRuntimePlugin",
+        (compilation) => {
+          compilation.hooks.runtimeRequirementInTree.tap("MockRuntimePlugin", (chunk, set) => {
+            set.add(RuntimeGlobals.publicPath);
+            set.add(RuntimeGlobals.getChunkScriptFilename);
+            compilation.addRuntimeModule(
+              chunk,
+              new MockTriggerRuntimeModule()
+            );
+            compilation.addRuntimeModule(
+              chunk,
+              new MockNormalRuntimeModule()
+            );
+          })
+        }
+      );
+    }
+  ],
+};

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/a.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/a.js
@@ -1,0 +1,2 @@
+import(/* webpackChunkName: "chunk-b" */'./b');
+export default "a";

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/b.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/b.js
@@ -1,0 +1,2 @@
+import(/* webpackChunkName: "chunk-c" */'./c');
+export default "b";

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/c.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/index.js
@@ -1,0 +1,6 @@
+import(/* webpackChunkName: "chunk-a" */'./a');
+
+it("should inject mock runtime module", async function () {
+  expect(typeof __webpack_require__.mock).toBe("function");
+  expect(__webpack_require__.mock("chunk-a")).toBe("chunk-a.bundle0.js");
+});

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
@@ -1,0 +1,59 @@
+const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
+
+class MockRuntimeModule extends RuntimeModule {
+  constructor(chunk) {
+    super("mock");
+    this.chunk = chunk;
+  }
+
+  generate(compilation) {
+    const chunkIdToName = this.chunk.getChunkMaps(false).name;
+    const chunkNameToId = Object.fromEntries(
+      Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
+        chunkName,
+        chunkId,
+      ]),
+    );
+
+    return `
+      __webpack_require__.mock = function(chunkId) {
+        chunkId = (${JSON.stringify(
+      chunkNameToId,
+    )})[chunkId]||chunkId;
+        return ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);
+      };
+    `;
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: "./index.js",
+  mode: "development",
+  devtool: false,
+  optimization: {
+    minimize: false,
+    sideEffects: false,
+    concatenateModules: false,
+    usedExports: false,
+    innerGraph: false,
+    providedExports: false
+  },
+  plugins: [
+    compiler => {
+      compiler.hooks.thisCompilation.tap(
+        "MockRuntimePlugin",
+        (compilation) => {
+          compilation.hooks.runtimeRequirementInTree.tap("MockRuntimePlugin", (chunk, set) => {
+            set.add(RuntimeGlobals.publicPath);
+            set.add(RuntimeGlobals.getChunkScriptFilename);
+            compilation.addRuntimeModule(
+              chunk,
+              new MockRuntimeModule(chunk)
+            );
+          })
+        }
+      );
+    }
+  ],
+};

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -26,6 +26,7 @@ import fs from 'graceful-fs';
 import { fs as fs_2 } from 'fs';
 import { HookMap } from '@rspack/lite-tapable';
 import { inspect } from 'node:util';
+import type { JsAddingRuntimeModule } from '@rspack/binding';
 import { JsAfterEmitData } from '@rspack/binding';
 import { JsAfterTemplateExecutionData } from '@rspack/binding';
 import { JsAlterAssetTagGroupsData } from '@rspack/binding';
@@ -1042,6 +1043,8 @@ export class Compilation {
     __internal__setAssetSource(filename: string, source: Source): void;
     // @internal
     __internal_getInner(): binding.JsCompilation;
+    // (undocumented)
+    addRuntimeModule(chunk: Chunk, runtimeModule: RuntimeModule): void;
     get assets(): Record<string, Source>;
     // (undocumented)
     buildDependencies: {
@@ -1165,7 +1168,10 @@ export class Compilation {
         Chunk,
         Set<string>
         ], void>;
-        runtimeModule: RuntimeModule;
+        runtimeModule: liteTapable.SyncHook<[
+        JsRuntimeModule,
+        Chunk
+        ], void>;
         seal: liteTapable.SyncHook<[], void>;
         afterSeal: liteTapable.AsyncSeriesHook<[], void>;
     }>;
@@ -10021,6 +10027,7 @@ declare namespace rspackExports {
         StatsError,
         StatsModule,
         Stats,
+        RuntimeModule,
         ModuleFilenameHelpers,
         Template,
         WebpackError,
@@ -14457,10 +14464,47 @@ export const RuntimeGlobals: {
 };
 
 // @public (undocumented)
-type RuntimeModule = liteTapable.SyncHook<[
-JsRuntimeModule,
-Chunk
-], void>;
+export class RuntimeModule {
+    constructor(name: string, stage?: RuntimeModuleStage);
+    // (undocumented)
+    static __to_binding(compilation: Compilation, module: RuntimeModule): JsAddingRuntimeModule;
+    // (undocumented)
+    depedentHash: boolean;
+    // (undocumented)
+    fullHash: boolean;
+    // (undocumented)
+    generate(compilation: Compilation): string;
+    // (undocumented)
+    identifier(): string;
+    // (undocumented)
+    get name(): string;
+    // (undocumented)
+    readableIdentifier(): string;
+    // (undocumented)
+    shouldIsolate(): boolean;
+    // (undocumented)
+    get stage(): RuntimeModuleStage;
+    // (undocumented)
+    static STAGE_ATTACH: RuntimeModuleStage;
+    // (undocumented)
+    static STAGE_BASIC: RuntimeModuleStage;
+    // (undocumented)
+    static STAGE_NORMAL: RuntimeModuleStage;
+    // (undocumented)
+    static STAGE_TRIGGER: RuntimeModuleStage;
+}
+
+// @public (undocumented)
+enum RuntimeModuleStage {
+    // (undocumented)
+    ATTACH = 10,
+    // (undocumented)
+    BASIC = 5,
+    // (undocumented)
+    NORMAL = 0,
+    // (undocumented)
+    TRIGGER = 20
+}
 
 // @public (undocumented)
 type RuntimePlugins = string[];

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -897,6 +897,12 @@ export class Chunk {
     // (undocumented)
     getAllReferencedChunks(): Iterable<Chunk>;
     // (undocumented)
+    getChunkMaps(realHash: boolean): {
+        hash: Record<string | number, string>;
+        contentHash: Record<string | number, Record<string, string>>;
+        name: Record<string | number, string>;
+    };
+    // (undocumented)
     get groupsIterable(): Iterable<ChunkGroup>;
     // (undocumented)
     hash?: Readonly<string>;

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -1168,10 +1168,7 @@ export class Compilation {
         Chunk,
         Set<string>
         ], void>;
-        runtimeModule: liteTapable.SyncHook<[
-        JsRuntimeModule,
-        Chunk
-        ], void>;
+        runtimeModule: liteTapable.SyncHook<[JsRuntimeModule, Chunk], void>;
         seal: liteTapable.SyncHook<[], void>;
         afterSeal: liteTapable.AsyncSeriesHook<[], void>;
     }>;
@@ -14469,7 +14466,7 @@ export class RuntimeModule {
     // (undocumented)
     static __to_binding(compilation: Compilation, module: RuntimeModule): JsAddingRuntimeModule;
     // (undocumented)
-    depedentHash: boolean;
+    dependentHash: boolean;
     // (undocumented)
     fullHash: boolean;
     // (undocumented)

--- a/packages/rspack/src/Chunk.ts
+++ b/packages/rspack/src/Chunk.ts
@@ -96,6 +96,39 @@ export class Chunk {
 		return new Set(chunk_groups);
 	}
 
+	getChunkMaps(realHash: boolean) {
+		const chunkHashMap: Record<string | number, string> = {};
+		const chunkContentHashMap: Record<
+			string | number,
+			Record<string, string>
+		> = {};
+		const chunkNameMap: Record<string | number, string> = {};
+
+		for (const chunk of this.getAllAsyncChunks()) {
+			const id = chunk.id;
+			if (!id) continue;
+			const chunkHash = realHash ? chunk.hash : chunk.renderedHash;
+			if (chunkHash) {
+				chunkHashMap[id] = chunkHash;
+			}
+			for (const key of Object.keys(chunk.contentHash)) {
+				if (!chunkContentHashMap[key]) {
+					chunkContentHashMap[key] = {};
+				}
+				chunkContentHashMap[key][id] = chunk.contentHash[key];
+			}
+			if (chunk.name) {
+				chunkNameMap[id] = chunk.name;
+			}
+		}
+
+		return {
+			hash: chunkHashMap,
+			contentHash: chunkContentHashMap,
+			name: chunkNameMap
+		};
+	}
+
 	getAllAsyncChunks(): Iterable<Chunk> {
 		return new Set(
 			__chunk_inner_get_all_async_chunks(

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -598,7 +598,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 				? assetInfoUpdateOrFunction
 				: typeof assetInfoUpdateOrFunction === "function"
 					? jsAssetInfo =>
-						JsAssetInfo.__to_binding(assetInfoUpdateOrFunction(jsAssetInfo))
+							JsAssetInfo.__to_binding(assetInfoUpdateOrFunction(jsAssetInfo))
 					: JsAssetInfo.__to_binding(assetInfoUpdateOrFunction)
 		);
 	}
@@ -1160,8 +1160,8 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		return this.#inner;
 	}
 
-	seal() { }
-	unseal() { }
+	seal() {}
+	unseal() {}
 
 	static PROCESS_ASSETS_STAGE_ADDITIONAL = -2000;
 	static PROCESS_ASSETS_STAGE_PRE_PROCESS = -1000;

--- a/packages/rspack/src/RuntimeModule.ts
+++ b/packages/rspack/src/RuntimeModule.ts
@@ -22,7 +22,7 @@ export class RuntimeModule {
 			name: module.name,
 			stage: module.stage,
 			generator: () => module.generate(compilation),
-			cacheable: module.fullHash || module.dependentHash,
+			cacheable: !(module.fullHash || module.dependentHash),
 			isolate: module.shouldIsolate()
 		};
 	}

--- a/packages/rspack/src/RuntimeModule.ts
+++ b/packages/rspack/src/RuntimeModule.ts
@@ -22,7 +22,7 @@ export class RuntimeModule {
 			name: module.name,
 			stage: module.stage,
 			generator: () => module.generate(compilation),
-			cacheable: module.fullHash || module.depedentHash,
+			cacheable: module.fullHash || module.dependentHash,
 			isolate: module.shouldIsolate()
 		};
 	}
@@ -30,7 +30,7 @@ export class RuntimeModule {
 	private _name: string;
 	private _stage: RuntimeModuleStage;
 	public fullHash = false;
-	public depedentHash = false;
+	public dependentHash = false;
 	constructor(name: string, stage = RuntimeModuleStage.NORMAL) {
 		this._name = name;
 		this._stage = stage;

--- a/packages/rspack/src/RuntimeModule.ts
+++ b/packages/rspack/src/RuntimeModule.ts
@@ -1,0 +1,64 @@
+import type { JsAddingRuntimeModule } from "@rspack/binding";
+import type { Compilation } from "./Compilation";
+
+export enum RuntimeModuleStage {
+	NORMAL = 0,
+	BASIC = 5,
+	ATTACH = 10,
+	TRIGGER = 20
+}
+
+export class RuntimeModule {
+	static STAGE_NORMAL = RuntimeModuleStage.NORMAL;
+	static STAGE_BASIC = RuntimeModuleStage.BASIC;
+	static STAGE_ATTACH = RuntimeModuleStage.ATTACH;
+	static STAGE_TRIGGER = RuntimeModuleStage.TRIGGER;
+
+	static __to_binding(
+		compilation: Compilation,
+		module: RuntimeModule
+	): JsAddingRuntimeModule {
+		return {
+			name: module.name,
+			stage: module.stage,
+			generator: () => module.generate(compilation),
+			cacheable: module.fullHash || module.depedentHash,
+			isolate: module.shouldIsolate()
+		};
+	}
+
+	private _name: string;
+	private _stage: RuntimeModuleStage;
+	public fullHash = false;
+	public depedentHash = false;
+	constructor(name: string, stage = RuntimeModuleStage.NORMAL) {
+		this._name = name;
+		this._stage = stage;
+	}
+
+	get name(): string {
+		return this._name;
+	}
+
+	get stage(): RuntimeModuleStage {
+		return this._stage;
+	}
+
+	identifier() {
+		return `webpack/runtime/${this._name}`;
+	}
+
+	readableIdentifier() {
+		return `webpack/runtime/${this._name}`;
+	}
+
+	shouldIsolate(): boolean {
+		return true;
+	}
+
+	generate(compilation: Compilation): string {
+		throw new Error(
+			`Should implement "generate" method of runtime module "${this.name}"`
+		);
+	}
+}

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -40,6 +40,7 @@ export type {
 	StatsModule
 } from "./Stats";
 export { Stats } from "./Stats";
+export { RuntimeModule } from "./RuntimeModule";
 
 // API extractor not working with some re-exports, see: https://github.com/microsoft/fluentui/issues/20694
 import * as ModuleFilenameHelpers from "./lib/ModuleFilenameHelpers";


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support `compilation.addRuntimeModule` to add custom runtime module:

```js
const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");

class CustomRuntimeModule extends RuntimeModule {
  constructor(chunk) {
    // set name and stage of this runtime module
    super("module-name", RuntimeModule.STAGE_NORMAL);
  }

  shouldIsolate() {
    // if false, will not be wrapped by IIFE
    return true;
  }

  generate(compilation) {
    return `
      // content of this runtime module
      __webpack_require__.xxx = xxx;
    `;
  }
}

module.exports = {
  // ...
  plugins: [
    compiler => {
      compiler.hooks.thisCompilation.tap("CustomRuntimePlugin", (compilation) => {
          compilation.hooks.runtimeRequirementInTree.tap("CustomRuntimePlugin", (chunk, set) => {
            // add dependent runtime globals
            set.add(RuntimeGlobals.publicPath);
            // add custom runtime module
            const m = new CustomRuntimeModule();
            // set fullHash or dependentHash to tell rspack this module is not cacheable
            m.fullHash = true;
            compilation.addRuntimeModule(chunk, m);
          })
        }
      );
    }
  ],
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
