### PR TITLE
fix: attach when add runtime module

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
@@ -1,9 +1,8 @@
 const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
 
 class MockRuntimeModule extends RuntimeModule {
-  constructor(chunk) {
+  constructor() {
     super("mock");
-    this.chunk = chunk;
   }
 
   generate(compilation) {

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -14505,6 +14505,14 @@ export class RuntimeModule {
     // (undocumented)
     static __to_binding(compilation: Compilation, module: RuntimeModule): JsAddingRuntimeModule;
     // (undocumented)
+    attach(compilation: Compilation, chunk: Chunk, chunkGraph: ChunkGraph): void;
+    // (undocumented)
+    protected chunk: Chunk | null;
+    // (undocumented)
+    protected chunkGraph: ChunkGraph | null;
+    // (undocumented)
+    protected compilation: Compilation | null;
+    // (undocumented)
     dependentHash: boolean;
     // (undocumented)
     fullHash: boolean;

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -1075,6 +1075,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	}
 
 	addRuntimeModule(chunk: Chunk, runtimeModule: RuntimeModule) {
+		runtimeModule.attach(this, chunk, this.chunkGraph);
 		this.#inner.addRuntimeModule(
 			chunk.__internal__innerUkey(),
 			RuntimeModule.__to_binding(this, runtimeModule)

--- a/packages/rspack/src/RuntimeModule.ts
+++ b/packages/rspack/src/RuntimeModule.ts
@@ -1,4 +1,6 @@
 import type { JsAddingRuntimeModule } from "@rspack/binding";
+import type { Chunk } from "./Chunk";
+import type { ChunkGraph } from "./ChunkGraph";
 import type { Compilation } from "./Compilation";
 
 export enum RuntimeModuleStage {
@@ -31,9 +33,18 @@ export class RuntimeModule {
 	private _stage: RuntimeModuleStage;
 	public fullHash = false;
 	public dependentHash = false;
+	protected chunk: Chunk | null = null;
+	protected compilation: Compilation | null = null;
+	protected chunkGraph: ChunkGraph | null = null;
 	constructor(name: string, stage = RuntimeModuleStage.NORMAL) {
 		this._name = name;
 		this._stage = stage;
+	}
+
+	attach(compilation: Compilation, chunk: Chunk, chunkGraph: ChunkGraph) {
+		this.compilation = compilation;
+		this.chunk = chunk;
+		this.chunkGraph = chunkGraph;
 	}
 
 	get name(): string {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Just attach `chunk`, `compilation` and `chunkGraph` to runtime module when added

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
