### PR TITLE
fix: change javascript parser options to properly merge

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1403,20 +1403,20 @@ export interface RawInfo {
 }
 
 export interface RawJavascriptParserOptions {
-  dynamicImportMode: string
-  dynamicImportPreload: string
-  dynamicImportPrefetch: string
+  dynamicImportMode?: string
+  dynamicImportPreload?: string
+  dynamicImportPrefetch?: string
   dynamicImportFetchPriority?: string
-  url: string
-  exprContextCritical: boolean
-  wrappedContextCritical: boolean
+  url?: string
+  exprContextCritical?: boolean
+  wrappedContextCritical?: boolean
   exportsPresence?: string
   importExportsPresence?: string
   reexportExportsPresence?: string
-  strictExportPresence: boolean
-  worker: Array<string>
+  strictExportPresence?: boolean
+  worker?: Array<string>
   overrideStrict?: string
-  importMeta: boolean
+  importMeta?: boolean
 }
 
 export interface RawLazyCompilationOption {

--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -258,32 +258,38 @@ impl From<RawParserOptions> for ParserOptions {
 #[derive(Debug, Default)]
 #[napi(object)]
 pub struct RawJavascriptParserOptions {
-  pub dynamic_import_mode: String,
-  pub dynamic_import_preload: String,
-  pub dynamic_import_prefetch: String,
+  pub dynamic_import_mode: Option<String>,
+  pub dynamic_import_preload: Option<String>,
+  pub dynamic_import_prefetch: Option<String>,
   pub dynamic_import_fetch_priority: Option<String>,
-  pub url: String,
-  pub expr_context_critical: bool,
-  pub wrapped_context_critical: bool,
+  pub url: Option<String>,
+  pub expr_context_critical: Option<bool>,
+  pub wrapped_context_critical: Option<bool>,
   pub exports_presence: Option<String>,
   pub import_exports_presence: Option<String>,
   pub reexport_exports_presence: Option<String>,
-  pub strict_export_presence: bool,
-  pub worker: Vec<String>,
+  pub strict_export_presence: Option<bool>,
+  pub worker: Option<Vec<String>>,
   pub override_strict: Option<String>,
-  pub import_meta: bool,
+  pub import_meta: Option<bool>,
 }
 
 impl From<RawJavascriptParserOptions> for JavascriptParserOptions {
   fn from(value: RawJavascriptParserOptions) -> Self {
     Self {
-      dynamic_import_mode: DynamicImportMode::from(value.dynamic_import_mode.as_str()),
-      dynamic_import_preload: JavascriptParserOrder::from(value.dynamic_import_preload.as_str()),
-      dynamic_import_prefetch: JavascriptParserOrder::from(value.dynamic_import_prefetch.as_str()),
+      dynamic_import_mode: value
+        .dynamic_import_mode
+        .map(|v| DynamicImportMode::from(v.as_str())),
+      dynamic_import_preload: value
+        .dynamic_import_preload
+        .map(|v| JavascriptParserOrder::from(v.as_str())),
+      dynamic_import_prefetch: value
+        .dynamic_import_prefetch
+        .map(|v| JavascriptParserOrder::from(v.as_str())),
       dynamic_import_fetch_priority: value
         .dynamic_import_fetch_priority
         .map(|x| DynamicImportFetchPriority::from(x.as_str())),
-      url: JavascriptParserUrl::from(value.url.as_str()),
+      url: value.url.map(|v| JavascriptParserUrl::from(v.as_str())),
       expr_context_critical: value.expr_context_critical,
       wrapped_context_critical: value.wrapped_context_critical,
       exports_presence: value

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -221,20 +221,20 @@ impl From<&str> for OverrideStrict {
 
 #[derive(Debug, Clone, MergeFrom)]
 pub struct JavascriptParserOptions {
-  pub dynamic_import_mode: DynamicImportMode,
-  pub dynamic_import_preload: JavascriptParserOrder,
-  pub dynamic_import_prefetch: JavascriptParserOrder,
+  pub dynamic_import_mode: Option<DynamicImportMode>,
+  pub dynamic_import_preload: Option<JavascriptParserOrder>,
+  pub dynamic_import_prefetch: Option<JavascriptParserOrder>,
   pub dynamic_import_fetch_priority: Option<DynamicImportFetchPriority>,
-  pub url: JavascriptParserUrl,
-  pub expr_context_critical: bool,
-  pub wrapped_context_critical: bool,
+  pub url: Option<JavascriptParserUrl>,
+  pub expr_context_critical: Option<bool>,
+  pub wrapped_context_critical: Option<bool>,
   pub exports_presence: Option<ExportPresenceMode>,
   pub import_exports_presence: Option<ExportPresenceMode>,
   pub reexport_exports_presence: Option<ExportPresenceMode>,
-  pub strict_export_presence: bool,
-  pub worker: Vec<String>,
+  pub strict_export_presence: Option<bool>,
+  pub worker: Option<Vec<String>>,
   pub override_strict: Option<OverrideStrict>,
-  pub import_meta: bool,
+  pub import_meta: Option<bool>,
 }
 
 #[derive(Debug, Clone, MergeFrom)]

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -844,7 +844,7 @@ impl HarmonyExportImportedSpecifierDependency {
     options
       .reexport_exports_presence
       .or(options.exports_presence)
-      .unwrap_or(if options.strict_export_presence {
+      .unwrap_or(if let Some(true) = options.strict_export_presence {
         ExportPresenceMode::Error
       } else {
         ExportPresenceMode::Auto

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -102,7 +102,7 @@ impl HarmonyImportSpecifierDependency {
     options
       .import_exports_presence
       .or(options.exports_presence)
-      .unwrap_or(if options.strict_export_presence {
+      .unwrap_or(if let Some(true) = options.strict_export_presence {
         ExportPresenceMode::Error
       } else {
         ExportPresenceMode::Auto

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -31,10 +31,15 @@ impl JavascriptParserPlugin for ImportParserPlugin {
       return None;
     }
     let dynamic_import_mode = parser.javascript_options.dynamic_import_mode;
-    let dynamic_import_preload = parser.javascript_options.dynamic_import_preload.get_order();
+    let dynamic_import_preload = parser
+      .javascript_options
+      .dynamic_import_preload
+      .expect("should have dynamic_import_preload")
+      .get_order();
     let dynamic_import_prefetch = parser
       .javascript_options
       .dynamic_import_prefetch
+      .expect("should have dynamic_import_prefetch")
       .get_order();
     let dynamic_import_fetch_priority = parser.javascript_options.dynamic_import_fetch_priority;
 
@@ -55,7 +60,7 @@ impl JavascriptParserPlugin for ImportParserPlugin {
     let mode = magic_comment_options
       .get_webpack_mode()
       .map(|x| DynamicImportMode::from(x.as_str()))
-      .unwrap_or(dynamic_import_mode);
+      .unwrap_or(dynamic_import_mode.expect("should have dynamic_import_mode"));
     let chunk_name = magic_comment_options
       .get_webpack_chunk_name()
       .map(|x| x.to_owned());

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -84,7 +84,7 @@ pub fn create_context_dependency(
       }
     }
 
-    if parser.javascript_options.wrapped_context_critical {
+    if let Some(true) = parser.javascript_options.wrapped_context_critical {
       let range = param.range();
       let warn: Diagnostic = create_traceable_error(
         "Critical dependency".into(),
@@ -161,7 +161,7 @@ pub fn create_context_dependency(
       replaces.push((json_stringify(&postfix), postfix_range.0, postfix_range.1))
     }
 
-    if parser.javascript_options.wrapped_context_critical {
+    if let Some(true) = parser.javascript_options.wrapped_context_critical {
       let range = param.range();
       let warn: Diagnostic = create_traceable_error(
         "Critical dependency".into(),
@@ -191,7 +191,7 @@ pub fn create_context_dependency(
       critical,
     }
   } else {
-    if parser.javascript_options.expr_context_critical {
+    if let Some(true) = parser.javascript_options.expr_context_critical {
       let range = param.range();
       let warn: Diagnostic = create_traceable_error(
         "Critical dependency".into(),

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -295,7 +295,7 @@ impl<'parser> JavascriptParser<'parser> {
       plugins.push(Box::new(
         parser_plugin::ImportMetaContextDependencyParserPlugin,
       ));
-      if javascript_options.import_meta {
+      if let Some(true) = javascript_options.import_meta {
         plugins.push(Box::new(parser_plugin::ImportMetaPlugin));
       } else {
         plugins.push(Box::new(parser_plugin::ImportMetaDisabledPlugin));
@@ -341,13 +341,16 @@ impl<'parser> JavascriptParser<'parser> {
       )));
       plugins.push(Box::new(parser_plugin::ImportParserPlugin));
       let parse_url = javascript_options.url;
-      if !matches!(parse_url, JavascriptParserUrl::Disable) {
+      if !matches!(parse_url, Some(JavascriptParserUrl::Disable)) {
         plugins.push(Box::new(parser_plugin::URLPlugin {
-          relative: matches!(parse_url, JavascriptParserUrl::Relative),
+          relative: matches!(parse_url, Some(JavascriptParserUrl::Relative)),
         }));
       }
       plugins.push(Box::new(parser_plugin::WorkerPlugin::new(
-        &javascript_options.worker,
+        javascript_options
+          .worker
+          .as_ref()
+          .expect("should have worker"),
       )));
       plugins.push(Box::new(parser_plugin::OverrideStrictPlugin));
     }

--- a/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Defaults.test.js.snap
@@ -161,12 +161,8 @@ Object {
         "dynamicImportMode": "lazy",
         "dynamicImportPrefetch": false,
         "dynamicImportPreload": false,
-        "exportsPresence": undefined,
         "exprContextCritical": true,
-        "importExportsPresence": undefined,
         "importMeta": true,
-        "overrideStrict": undefined,
-        "reexportExportsPresence": undefined,
         "strictExportPresence": false,
         "url": true,
         "worker": Array [

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -655,19 +655,14 @@ function getRawJavascriptParserOptions(
 	parser: JavascriptParserOptions
 ): RawJavascriptParserOptions {
 	return {
-		dynamicImportMode: parser.dynamicImportMode ?? "lazy",
-		dynamicImportPreload: parser.dynamicImportPreload?.toString() ?? "false",
-		dynamicImportPrefetch: parser.dynamicImportPrefetch?.toString() ?? "false",
-		dynamicImportFetchPriority: parser.dynamicImportFetchPriority?.toString(),
-		importMeta: parser.importMeta ?? true,
-		url:
-			parser.url === false
-				? "false"
-				: parser.url === "relative"
-					? parser.url
-					: "true",
-		exprContextCritical: parser.exprContextCritical ?? true,
-		wrappedContextCritical: parser.wrappedContextCritical ?? false,
+		dynamicImportMode: parser.dynamicImportMode,
+		dynamicImportPreload: parser.dynamicImportPreload?.toString(),
+		dynamicImportPrefetch: parser.dynamicImportPrefetch?.toString(),
+		dynamicImportFetchPriority: parser.dynamicImportFetchPriority,
+		importMeta: parser.importMeta,
+		url: parser.url?.toString(),
+		exprContextCritical: parser.exprContextCritical,
+		wrappedContextCritical: parser.wrappedContextCritical,
 		exportsPresence:
 			parser.exportsPresence === false ? "false" : parser.exportsPresence,
 		importExportsPresence:
@@ -678,13 +673,13 @@ function getRawJavascriptParserOptions(
 			parser.reexportExportsPresence === false
 				? "false"
 				: parser.reexportExportsPresence,
-		strictExportPresence: parser.strictExportPresence ?? false,
+		strictExportPresence: parser.strictExportPresence,
 		worker:
 			typeof parser.worker === "boolean"
 				? parser.worker
 					? ["..."]
 					: []
-				: parser.worker ?? ["..."],
+				: parser.worker,
 		overrideStrict: parser.overrideStrict
 	};
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -242,12 +242,8 @@ const applyJavascriptParserOptionsDefaults = (
 	D(parserOptions, "url", true);
 	D(parserOptions, "exprContextCritical", true);
 	D(parserOptions, "wrappedContextCritical", false);
-	D(parserOptions, "exportsPresence", undefined);
-	D(parserOptions, "importExportsPresence", undefined);
-	D(parserOptions, "reexportExportsPresence", undefined);
 	D(parserOptions, "strictExportPresence", false);
 	D(parserOptions, "worker", ["..."]);
-	D(parserOptions, "overrideStrict", undefined);
 	D(parserOptions, "importMeta", true);
 };
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

After #7812, we should not return the default value in getRawJavascriptParserOptions, as it will break the merging logic.

I want to write test cases, but I found that the createParser hook of NormalModuleFactory is not yet supported.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
