### PR TITLE
chore(workflow): remove rangeStrategy from renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -122,7 +122,6 @@
         "typescript",
         "pnpm"
       ],
-      "rangeStrategy": "bump",
       // bump major in a separate PR
       "matchUpdateTypes": ["patch", "minor"]
     },
@@ -134,7 +133,6 @@
       "matchDepTypes": [
         "dependencies"
       ],
-      "rangeStrategy": "bump",
       // bump major in a separate PR
       "matchUpdateTypes": ["patch", "minor"]
     },


### PR DESCRIPTION

## Summary

Fix: 

> The renovate configuration file contains some invalid settings
Message: packageRules[7]: packageRules cannot combine both matchUpdateTypes and rangeStrategy

Ref: https://github.com/renovatebot/renovate/discussions/10165

resolve https://github.com/web-infra-dev/rspack/issues/6172

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
