### PR TITLE
docs: add use case for `extensionAlias`

### DIFF
--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -87,8 +87,7 @@ Parse modules in order, e.g. `require('. /index')`, will try to parse `'. /index
 
 Define alias for the extension. e.g.
 
-```js
-// rspack.config.js
+```js title="rspack.config.js"
 module.exports = {
   resolve: {
     extensionAlias: {
@@ -98,7 +97,13 @@ module.exports = {
 };
 ```
 
-`require('./index.js')` will try to parse `'./index.ts'`, `./index.js`.
+This is particularly useful for TypeScript projects, as TypeScript recommends using the `.js` extension to reference TypeScript files.
+
+```ts title="index.ts"
+import { foo } from './foo.js'; // actually refers to `foo.ts`
+```
+
+Rspack will try to resolve `'./foo.ts'` and `./foo.js'` sequentially when resolving `import './foo.js'`.
 
 ## resolve.fallback
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -85,10 +85,9 @@ module.exports = {
 - **类型：** `Record<string, string[] | string>`
 - **默认值：** `{}`
 
-定义拓展名的别名，例如
+定义拓展名的别名，例如：
 
-```js
-// rspack.config.js
+```js title="rspack.config.js"
 module.exports = {
   resolve: {
     extensionAlias: {
@@ -98,7 +97,13 @@ module.exports = {
 };
 ```
 
-在 `require('./index.js')` 时，会依次尝试解析 `'./index.ts'`, `./index.js`。
+这对于 TypeScript 项目来说非常有用，因为 TypeScript 推荐使用 `.js` 扩展名来引用 TypeScript 文件。
+
+```ts title="index.ts"
+import { foo } from './foo.js'; // 实际引用的是 foo.ts
+```
+
+Rspack 在解析 `import './foo.js'` 时，会依次尝试解析 `'./foo.ts'` 和 `./foo.js`。
 
 ## resolve.fallback
 


### PR DESCRIPTION
## Summary

Add use case for `extensionAlias`, see:

- https://github.com/web-infra-dev/rsbuild/discussions/3529
- https://github.com/vercel/next.js/discussions/32237
- https://www.typescriptlang.org/docs/handbook/modules/theory.html

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
