### PR TITLE
perf: lazy require `browserslist` package

### DIFF
--- a/packages/rspack/src/config/browserslistTargetHandler.ts
+++ b/packages/rspack/src/config/browserslistTargetHandler.ts
@@ -9,7 +9,6 @@
  */
 
 import path from "node:path";
-import browserslist from "browserslist";
 import type {
 	ApiTargetProperties,
 	EcmaTargetProperties,
@@ -43,6 +42,8 @@ const parse = (
 		return { configPath, env };
 	}
 
+	const browserslist = require("browserslist");
+
 	const config = browserslist.findConfig(context);
 
 	if (config && Object.keys(config).includes(input)) {
@@ -61,6 +62,7 @@ export const load = (
 	input: string | null | undefined,
 	context: string
 ): string[] | undefined => {
+	const browserslist = require("browserslist");
 	const { configPath, env, query } = parse(input, context);
 
 	// if a query is specified, then use it, else


### PR DESCRIPTION
## Summary

In most cases, Rspack does not need to require the `browserslist` package, it is only be used if `target` contains "browserslist".

Lazy require `browserslist` can make Rspack startup **17ms** faster.

- before:

<img width="974" alt="Screenshot 2024-09-24 at 17 20 31" src="https://github.com/user-attachments/assets/2619cb1c-965e-4457-9a73-078506c07530">

- after:

<img width="1089" alt="Screenshot 2024-09-24 at 17 20 44" src="https://github.com/user-attachments/assets/06d4329a-b733-4b0c-a017-122dd1d720b9">

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
