### PR TITLE
chore: not allow run typecheck when run node bin/rspack for other project

### DIFF
--- a/packages/rspack-cli/tsconfig.json
+++ b/packages/rspack-cli/tsconfig.json
@@ -11,5 +11,8 @@
     {
       "path": "../rspack"
     }
-  ]
+  ],
+  "ts-node": {
+    "transpileOnly": true
+  }
 }


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
when use local build rspack bin to debug other projects, rspack will auto do typecheck which may fail 
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
