### PR TITLE
perf: cache swc loader

### DIFF
--- a/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_options/src/plugins/js_loader/resolver.rs
@@ -45,8 +45,8 @@ pub fn serde_error_to_miette(
   miette!(labels = vec![span], "{msg}").with_source_code(content.clone())
 }
 
-static SWC_LOADER_CACHE: LazyLock<RwLock<FxHashMap<(Cow<str>, Arc<str>), Arc<SwcLoader>>>> =
-  LazyLock::new(|| RwLock::new(FxHashMap::default()));
+type SwcLoaderCache<'a> = LazyLock<RwLock<FxHashMap<(Cow<'a, str>, Arc<str>), Arc<SwcLoader>>>>;
+static SWC_LOADER_CACHE: SwcLoaderCache = LazyLock::new(|| RwLock::new(FxHashMap::default()));
 
 pub async fn get_builtin_loader(builtin: &str, options: Option<&str>) -> Result<BoxLoader> {
   let options: Arc<str> = options.unwrap_or("{}").into();


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

Assume: 
1. Creating an `SwcLoaderJsOptions` is costly
2. Most modules are created with same swc loader options

Cost:
1. `RwLock` and concurrent runtime.
Maybe there is a better cache strategy.

🙏 Help me run the benchmark.

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
