### PR TITLE
refactor: import module hooks

### DIFF
--- a/crates/node_binding/src/lib.rs
+++ b/crates/node_binding/src/lib.rs
@@ -69,6 +69,7 @@ impl Rspack {
     let rspack = rspack_core::Compiler::new(
       compiler_options,
       plugins,
+      rspack_binding_options::buildtime_plugins::buildtime_plugins(),
       Some(Box::new(
         AsyncNodeWritableFileSystem::new(output_filesystem)
           .map_err(|e| Error::from_reason(format!("Failed to create writable filesystem: {e}",)))?,

--- a/crates/rspack_binding_options/src/lib.rs
+++ b/crates/rspack_binding_options/src/lib.rs
@@ -3,4 +3,5 @@
 mod options;
 mod plugins;
 pub use options::*;
+pub use plugins::buildtime_plugins;
 pub(crate) use plugins::*;

--- a/crates/rspack_binding_options/src/plugins/buildtime_plugins.rs
+++ b/crates/rspack_binding_options/src/plugins/buildtime_plugins.rs
@@ -1,15 +1,11 @@
-use rspack_core::{BoxPlugin, ChunkLoading, ChunkLoadingType, PluginExt};
-use rspack_plugin_javascript::JsPlugin;
-use rspack_plugin_runtime::{
-  CommonJsChunkLoadingPlugin, RuntimePlugin, StartupChunkDependenciesPlugin,
-};
+use rspack_core::{BoxPlugin, PluginExt};
+use rspack_plugin_javascript::{api_plugin::APIPlugin, JsPlugin};
+use rspack_plugin_runtime::RuntimePlugin;
 
 pub fn buildtime_plugins() -> Vec<BoxPlugin> {
   vec![
-    RuntimePlugin::default().boxed(),
     JsPlugin::default().boxed(),
-    // StartupChunkDependenciesPlugin::new(ChunkLoading::Enable(ChunkLoadingType::Require), false)
-    //   .boxed(),
-    // CommonJsChunkLoadingPlugin::new(false).boxed(),
+    RuntimePlugin::default().boxed(),
+    APIPlugin::default().boxed(),
   ]
 }

--- a/crates/rspack_binding_options/src/plugins/buildtime_plugins.rs
+++ b/crates/rspack_binding_options/src/plugins/buildtime_plugins.rs
@@ -1,0 +1,15 @@
+use rspack_core::{BoxPlugin, ChunkLoading, ChunkLoadingType, PluginExt};
+use rspack_plugin_javascript::JsPlugin;
+use rspack_plugin_runtime::{
+  CommonJsChunkLoadingPlugin, RuntimePlugin, StartupChunkDependenciesPlugin,
+};
+
+pub fn buildtime_plugins() -> Vec<BoxPlugin> {
+  vec![
+    RuntimePlugin::default().boxed(),
+    JsPlugin::default().boxed(),
+    // StartupChunkDependenciesPlugin::new(ChunkLoading::Enable(ChunkLoadingType::Require), false)
+    //   .boxed(),
+    // CommonJsChunkLoadingPlugin::new(false).boxed(),
+  ]
+}

--- a/crates/rspack_binding_options/src/plugins/mod.rs
+++ b/crates/rspack_binding_options/src/plugins/mod.rs
@@ -3,3 +3,4 @@ mod js_loader;
 
 pub use context_replacement::*;
 pub(super) use js_loader::{JsLoaderRspackPlugin, JsLoaderRunner};
+pub mod buildtime_plugins;

--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -161,6 +161,7 @@ pub struct Compilation {
   diagnostics: Vec<Diagnostic>,
   logging: CompilationLogging,
   pub plugin_driver: SharedPluginDriver,
+  pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
   pub named_chunks: HashMap<String, ChunkUkey>,
@@ -224,6 +225,7 @@ impl Compilation {
   pub fn new(
     options: Arc<CompilerOptions>,
     plugin_driver: SharedPluginDriver,
+    buildtime_plugin_driver: SharedPluginDriver,
     resolver_factory: Arc<ResolverFactory>,
     loader_resolver_factory: Arc<ResolverFactory>,
     records: Option<CompilationRecords>,
@@ -257,6 +259,7 @@ impl Compilation {
       diagnostics: Default::default(),
       logging: Default::default(),
       plugin_driver,
+      buildtime_plugin_driver,
       resolver_factory,
       loader_resolver_factory,
       named_chunks: Default::default(),

--- a/crates/rspack_core/src/compiler/hmr.rs
+++ b/crates/rspack_core/src/compiler/hmr.rs
@@ -65,6 +65,7 @@ impl Compiler {
       let mut new_compilation = Compilation::new(
         self.options.clone(),
         self.plugin_driver.clone(),
+        self.buildtime_plugin_driver.clone(),
         self.resolver_factory.clone(),
         self.loader_resolver_factory.clone(),
         Some(records),

--- a/crates/rspack_core/src/compiler/make/repair/mod.rs
+++ b/crates/rspack_core/src/compiler/make/repair/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 pub struct MakeTaskContext {
   // compilation info
   pub plugin_driver: SharedPluginDriver,
+  pub buildtime_plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
   pub compiler_options: Arc<CompilerOptions>,
   pub resolver_factory: Arc<ResolverFactory>,
@@ -37,6 +38,7 @@ impl MakeTaskContext {
   pub fn new(compilation: &Compilation, artifact: MakeArtifact) -> Self {
     Self {
       plugin_driver: compilation.plugin_driver.clone(),
+      buildtime_plugin_driver: compilation.buildtime_plugin_driver.clone(),
       compiler_options: compilation.options.clone(),
       resolver_factory: compilation.resolver_factory.clone(),
       loader_resolver_factory: compilation.loader_resolver_factory.clone(),
@@ -63,6 +65,7 @@ impl MakeTaskContext {
     let mut compilation = Compilation::new(
       self.compiler_options.clone(),
       self.plugin_driver.clone(),
+      self.buildtime_plugin_driver.clone(),
       self.resolver_factory.clone(),
       self.loader_resolver_factory.clone(),
       None,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -119,6 +119,7 @@ impl Compiler {
       compilation: Compilation::new(
         options,
         plugin_driver.clone(),
+        buildtime_plugin_driver.clone(),
         resolver_factory.clone(),
         loader_resolver_factory.clone(),
         None,
@@ -159,6 +160,7 @@ impl Compiler {
       Compilation::new(
         self.options.clone(),
         self.plugin_driver.clone(),
+        self.buildtime_plugin_driver.clone(),
         self.resolver_factory.clone(),
         self.loader_resolver_factory.clone(),
         None,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -61,6 +61,7 @@ pub struct Compiler {
   pub input_filesystem: Arc<dyn ReadableFileSystem>,
   pub compilation: Compilation,
   pub plugin_driver: SharedPluginDriver,
+  pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
   pub old_cache: Arc<OldCache>,
@@ -75,6 +76,7 @@ impl Compiler {
   pub fn new(
     options: CompilerOptions,
     plugins: Vec<BoxPlugin>,
+    buildtime_plugins: Vec<BoxPlugin>,
     output_filesystem: Option<Box<dyn AsyncWritableFileSystem + Send + Sync>>,
     // only supports passing input_filesystem in rust api, no support for js api
     input_filesystem: Option<Arc<dyn ReadableFileSystem + Send + Sync>>,
@@ -102,8 +104,11 @@ impl Compiler {
         input_filesystem.clone(),
       ))
     });
+
     let options = Arc::new(options);
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
+    let buildtime_plugin_driver =
+      PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
     let old_cache = Arc::new(OldCache::new(options.clone()));
     let unaffected_modules_cache = Arc::new(UnaffectedModulesCache::default());
     let module_executor = ModuleExecutor::default();
@@ -126,6 +131,7 @@ impl Compiler {
       ),
       output_filesystem,
       plugin_driver,
+      buildtime_plugin_driver,
       resolver_factory,
       loader_resolver_factory,
       old_cache,

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -55,11 +55,11 @@ impl Task<MakeTaskContext> for EntryTask {
               )
             })
             .clone(),
-          original_module_identifier: dep.original_module,
+          original_module_identifier: None,
           original_module_source: None,
           issuer: None,
           issuer_layer: None,
-          original_module_context: Some(Box::new(dep.context.clone())),
+          original_module_context: None,
           dependencies: vec![dep],
           resolve_options: None,
           options: context.compiler_options.clone(),

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -55,11 +55,11 @@ impl Task<MakeTaskContext> for EntryTask {
               )
             })
             .clone(),
-          original_module_identifier: None,
+          original_module_identifier: dep.original_module,
           original_module_source: None,
           issuer: None,
           issuer_layer: None,
-          original_module_context: None,
+          original_module_context: Some(Box::new(dep.context.clone())),
           dependencies: vec![dep],
           resolve_options: None,
           options: context.compiler_options.clone(),

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -73,15 +73,16 @@ impl Task<MakeTaskContext> for ExecuteTask {
     } = *self;
 
     let mut compilation = context.transform_to_temp_compilation();
+    let main_compilation_plugin_driver = compilation.plugin_driver.clone();
+    compilation.plugin_driver = compilation.buildtime_plugin_driver.clone();
 
     let id = EXECUTE_MODULE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     let mg = compilation.get_module_graph_mut();
-    let Some(entry_module_identifier) = mg.get_module_by_dependency_id(&entry_dep_id) else {
-      return Err(rspack_error::error!("entry module not found"));
-    };
-
-    let entry_module_identifier = entry_module_identifier.identifier();
+    let entry_module_identifier = mg
+      .get_module_by_dependency_id(&entry_dep_id)
+      .expect("should have module")
+      .identifier();
     let mut queue = vec![entry_module_identifier];
     let mut modules = IdentifierSet::default();
 
@@ -113,7 +114,7 @@ impl Task<MakeTaskContext> for ExecuteTask {
         name: Some("build time".into()),
         runtime: Some("runtime".into()),
         chunk_loading: Some(crate::ChunkLoading::Disable),
-        async_chunks: None,
+        async_chunks: Some(false),
         public_path,
         base_uri,
         filename: None,
@@ -214,8 +215,7 @@ impl Task<MakeTaskContext> for ExecuteTask {
     }
 
     let codegen_results = compilation.code_generation_results.clone();
-    let exports = compilation
-      .plugin_driver
+    let exports = main_compilation_plugin_driver
       .compilation_hooks
       .execute_module
       .call(

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -77,10 +77,11 @@ impl Task<MakeTaskContext> for ExecuteTask {
     let id = EXECUTE_MODULE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
 
     let mg = compilation.get_module_graph_mut();
-    let entry_module_identifier = mg
-      .get_module_by_dependency_id(&entry_dep_id)
-      .expect("should have module")
-      .identifier();
+    let Some(entry_module_identifier) = mg.get_module_by_dependency_id(&entry_dep_id) else {
+      return Err(rspack_error::error!("entry module not found"));
+    };
+
+    let entry_module_identifier = entry_module_identifier.identifier();
     let mut queue = vec![entry_module_identifier];
     let mut modules = IdentifierSet::default();
 

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -182,6 +182,7 @@ impl ModuleExecutor {
         let dep = LoaderImportDependency::new(
           request.clone(),
           original_module_context.unwrap_or(Context::from("")),
+          original_module_identifier,
         );
         let dep_id = *dep.id();
         v.insert(dep_id);

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -182,7 +182,6 @@ impl ModuleExecutor {
         let dep = LoaderImportDependency::new(
           request.clone(),
           original_module_context.unwrap_or(Context::from("")),
-          original_module_identifier,
         );
         let dep_id = *dep.id();
         v.insert(dep_id);

--- a/crates/rspack_core/src/dependency/loader_import.rs
+++ b/crates/rspack_core/src/dependency/loader_import.rs
@@ -1,23 +1,21 @@
 use super::AffectType;
 use crate::{
   AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ModuleDependency, ModuleIdentifier,
+  DependencyType, ModuleDependency,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct LoaderImportDependency {
   id: DependencyId,
-  pub context: Context,
-  pub original_module: Option<ModuleIdentifier>,
+  context: Context,
   request: String,
 }
 
 impl LoaderImportDependency {
-  pub fn new(request: String, context: Context, original_module: Option<ModuleIdentifier>) -> Self {
+  pub fn new(request: String, context: Context) -> Self {
     Self {
       request,
       context,
-      original_module,
       id: DependencyId::new(),
     }
   }
@@ -29,6 +27,10 @@ impl AsContextDependency for LoaderImportDependency {}
 impl Dependency for LoaderImportDependency {
   fn id(&self) -> &DependencyId {
     &self.id
+  }
+
+  fn get_context(&self) -> Option<&Context> {
+    Some(&self.context)
   }
 
   fn category(&self) -> &DependencyCategory {

--- a/crates/rspack_core/src/dependency/loader_import.rs
+++ b/crates/rspack_core/src/dependency/loader_import.rs
@@ -1,21 +1,23 @@
 use super::AffectType;
 use crate::{
   AsContextDependency, AsDependencyTemplate, Context, Dependency, DependencyCategory, DependencyId,
-  DependencyType, ModuleDependency,
+  DependencyType, ModuleDependency, ModuleIdentifier,
 };
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone)]
 pub struct LoaderImportDependency {
   id: DependencyId,
-  context: Context,
+  pub context: Context,
+  pub original_module: Option<ModuleIdentifier>,
   request: String,
 }
 
 impl LoaderImportDependency {
-  pub fn new(request: String, context: Context) -> Self {
+  pub fn new(request: String, context: Context, original_module: Option<ModuleIdentifier>) -> Self {
     Self {
       request,
       context,
+      original_module,
       id: DependencyId::new(),
     }
   }

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/a.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/a.js
@@ -1,0 +1,2 @@
+import(/* webpackChunkName: "chunk-b" */'./b');
+export default "a";

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/b.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/b.js
@@ -1,0 +1,2 @@
+import(/* webpackChunkName: "chunk-c" */'./c');
+export default "b";

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/c.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/c.js
@@ -1,0 +1,1 @@
+export default "c";

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/execute-module.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/execute-module.js
@@ -1,0 +1,1 @@
+export default 1

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/index.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/index.js
@@ -1,0 +1,9 @@
+import v from './imported-module'
+
+import(/* webpackChunkName: "chunk-a" */'./a');
+
+it("should inject mock runtime module", async function () {
+	expect(v).toBe(1)
+  expect(typeof __webpack_require__.mock).toBe("function");
+  expect(__webpack_require__.mock("chunk-a")).toBe("chunk-a.bundle0.js");
+});

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/loader.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/loader.js
@@ -1,0 +1,7 @@
+const path = require('path')
+
+module.exports = async function loader() {
+	const callback = this.async()
+	const result = await this.importModule(path.resolve(__dirname, './execute-module.js'))
+	callback(null, `export default ${result.default}`)
+}

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-with-import-module/rspack.config.js
@@ -1,0 +1,63 @@
+const { RuntimeModule, RuntimeGlobals } = require("@rspack/core");
+
+class MockRuntimeModule extends RuntimeModule {
+  constructor() {
+    super("mock");
+  }
+
+  generate(compilation) {
+    const chunkIdToName = this.chunk.getChunkMaps(false).name;
+    const chunkNameToId = Object.fromEntries(
+      Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [
+        chunkName,
+        chunkId,
+      ]),
+    );
+
+    return `
+      __webpack_require__.mock = function(chunkId) {
+        chunkId = (${JSON.stringify(
+      chunkNameToId,
+    )})[chunkId]||chunkId;
+        return ${RuntimeGlobals.publicPath} + ${RuntimeGlobals.getChunkScriptFilename}(chunkId);
+      };
+    `;
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: "./index.js",
+  mode: "development",
+  devtool: false,
+	module: {
+		rules: [
+			{ test: /imported-module\.js/, use: ['./loader']}
+		]
+	},
+  optimization: {
+    minimize: false,
+    sideEffects: false,
+    concatenateModules: false,
+    usedExports: false,
+    innerGraph: false,
+    providedExports: false
+  },
+  plugins: [
+    compiler => {
+      compiler.hooks.thisCompilation.tap(
+        "MockRuntimePlugin",
+        (compilation) => {
+          compilation.hooks.runtimeRequirementInTree.tap("MockRuntimePlugin", (chunk, set) => {
+            set.add(RuntimeGlobals.publicPath);
+            set.add(RuntimeGlobals.getChunkScriptFilename);
+            compilation.addRuntimeModule(
+              chunk,
+              new MockRuntimeModule(chunk)
+            );
+          })
+        }
+      );
+    }
+  ],
+};

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -784,10 +784,10 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		];
 
 		for (const item of proxyMethod) {
-			const proxyedMethod = new Proxy(errors[item.method as any], {
+			const proxiedMethod = new Proxy(errors[item.method as any], {
 				apply: item.handler as any
 			});
-			errors[item.method as any] = proxyedMethod;
+			errors[item.method as any] = proxiedMethod;
 		}
 		return errors;
 	}
@@ -877,10 +877,10 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		];
 
 		for (const item of proxyMethod) {
-			const proxyedMethod = new Proxy(warnings[item.method as any], {
+			const proxiedMethod = new Proxy(warnings[item.method as any], {
 				apply: item.handler as any
 			});
-			warnings[item.method as any] = proxyedMethod;
+			warnings[item.method as any] = proxiedMethod;
 		}
 		return warnings;
 	}

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -404,9 +404,10 @@ export async function runLoaders(
 	};
 	loaderContext.importModule = function importModule(
 		request,
-		options,
+		userOptions,
 		callback
 	) {
+		const options = userOptions ? userOptions : {};
 		if (!callback) {
 			return new Promise((resolve, reject) => {
 				compiler


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

import module should use different plugin_driver compare to main compilation, so that plugins won't operate incorrect compilation

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
