### PR TITLE
feat: support `compilation.builtModules`

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -81,6 +81,7 @@ export class JsCompilation {
   getAsset(name: string): JsAsset | null
   getAssetSource(name: string): JsCompatSource | null
   get modules(): Array<ModuleDTO>
+  get builtModules(): Array<ModuleDTO>
   getOptimizationBailout(): Array<JsStatsOptimizationBailout>
   getChunks(): Array<JsChunk>
   getNamedChunkKeys(): Array<string>
@@ -1880,7 +1881,7 @@ export interface RawTrustedTypes {
  * Author Donny/강동윤
  * Copyright (c)
  */
-export function registerGlobalTrace(filter: string, layer: "chrome" | "logger" | "console", output: string): void
+export function registerGlobalTrace(filter: string, layer: "chrome" | "logger"| "console", output: string): void
 
 export enum RegisterJsTapKind {
   CompilerThisCompilation = 0,

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -154,7 +154,7 @@ impl JsCompilation {
       .0
       .built_modules
       .iter()
-      .map(|module_id| ModuleDTOWrapper::new(module_id.clone(), self.0))
+      .map(|module_id| ModuleDTOWrapper::new(*module_id, self.0))
       .collect::<Vec<_>>()
   }
 

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -148,6 +148,16 @@ impl JsCompilation {
       .collect::<Vec<_>>()
   }
 
+  #[napi(getter, ts_return_type = "Array<ModuleDTO>")]
+  pub fn built_modules(&'static self) -> Vec<ModuleDTOWrapper> {
+    self
+      .0
+      .built_modules
+      .iter()
+      .map(|module_id| ModuleDTOWrapper::new(module_id.clone(), self.0))
+      .collect::<Vec<_>>()
+  }
+
   #[napi]
   pub fn get_optimization_bailout(&self) -> Vec<JsStatsOptimizationBailout> {
     self

--- a/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/0/foo.js
+++ b/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/0/foo.js
@@ -1,0 +1,1 @@
+export const v = 'foo'

--- a/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/0/index.js
@@ -1,0 +1,5 @@
+import { v } from "./foo";
+
+v;
+
+it("should run", function () { });

--- a/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/1/foo.js
+++ b/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/1/foo.js
@@ -1,0 +1,1 @@
+export const v = 'fooo'

--- a/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/compilation/built-modules/rspack.config.js
@@ -1,0 +1,21 @@
+let firstRun = true;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	plugins: [{
+		apply(compiler) {
+			compiler.hooks.compilation.tap("test", (compilation) => {
+				compilation.hooks.seal.tap("test", () => {
+					const builtModules = Array.from(compilation.builtModules).map(m => m.rawRequest);
+					builtModules.sort();
+					if (firstRun) {
+						expect(builtModules).toEqual(["./foo", "./index.js"]);
+						firstRun = false;
+					} else {
+						expect(builtModules).toEqual(["./foo"]);
+					}
+				});
+			});
+		}
+	}]
+};

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -1061,6 +1061,8 @@ export class Compilation {
         addAll: (deps: Iterable<string>) => void;
     };
     // (undocumented)
+    get builtModules(): ReadonlySet<Module>;
+    // (undocumented)
     children: Compilation[];
     // (undocumented)
     childrenCounters: Record<string, number>;

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -431,6 +431,14 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		);
 	}
 
+	get builtModules(): ReadonlySet<Module> {
+		return new Set(
+			this.#inner.builtModules.map(module =>
+				Module.__from_binding(module, this)
+			)
+		);
+	}
+
 	get chunks(): ReadonlySet<Chunk> {
 		return memoizeValue(() => new Set(this.__internal__getChunks()));
 	}

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -669,6 +669,22 @@ List of all modules, with the structure as follows:
   </CollapsePanel>
 </Collapse>
 
+### builtModules
+
+**Type:** `ReadonlySet<Module>`
+
+List of built modules that were not be cached, with the structure as follows:
+
+<Collapse>
+  <CollapsePanel
+    className="collapse-code-panel"
+    header="Module.ts"
+    key="Module"
+  >
+    <ModuleType />
+  </CollapsePanel>
+</Collapse>
+
 ### chunks
 
 **Type:** `ReadonlySet<Chunk>`

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -666,6 +666,22 @@ getCache(name: string): CacheFacade;
   </CollapsePanel>
 </Collapse>
 
+### builtModules
+
+**类型：** `ReadonlySet<Module>`
+
+获取未缓存被构建的模块，其结构如下：
+
+<Collapse>
+  <CollapsePanel
+    className="collapse-code-panel"
+    header="Module.ts"
+    key="Module"
+  >
+    <ModuleType />
+  </CollapsePanel>
+</Collapse>
+
 ### chunks
 
 **类型：** `ReadonlySet<Chunk>`


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Support `compilation.builtModules`, these modules will be collected after calling finishModules hook and then eslint-rspack-plugin can use it to implement [`lintDirtyModulesOnly`](https://github.com/rspack-contrib/eslint-rspack-plugin/pull/5).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
