### PR TITLE
fix: generate params of runtime module

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-isolate/rspack.config.js
@@ -5,7 +5,7 @@ class IsolateRuntimeModule extends RuntimeModule {
     super("mock-isolate");
   }
 
-  generate(compilation) {
+  generate() {
     return `
       __webpack_require__.mock = function() {
         return someGlobalValue;
@@ -23,7 +23,7 @@ class NonIsolateRuntimeModule extends RuntimeModule {
     return false;
   }
 
-  generate(compilation) {
+  generate() {
     return `
       var someGlobalValue = "isolated";
     `;

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module-stage/rspack.config.js
@@ -5,7 +5,7 @@ class MockNormalRuntimeModule extends RuntimeModule {
     super("mock-normal", RuntimeModule.STAGE_NORMAL);
   }
 
-  generate(compilation) {
+  generate() {
     return `__webpack_require__.mockNormal = "normal";`;
   }
 }
@@ -15,7 +15,7 @@ class MockTriggerRuntimeModule extends RuntimeModule {
     super("mock-trigger", RuntimeModule.STAGE_TRIGGER);
   }
 
-  generate(compilation) {
+  generate() {
     return `__webpack_require__.mockTrigger = "trigger";`;
   }
 }

--- a/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/runtime/add-runtime-module/rspack.config.js
@@ -5,7 +5,7 @@ class MockRuntimeModule extends RuntimeModule {
     super("mock");
   }
 
-  generate(compilation) {
+  generate() {
     const chunkIdToName = this.chunk.getChunkMaps(false).name;
     const chunkNameToId = Object.fromEntries(
       Object.entries(chunkIdToName).map(([chunkId, chunkName]) => [

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -14639,7 +14639,7 @@ export class RuntimeModule {
     // (undocumented)
     fullHash: boolean;
     // (undocumented)
-    generate(compilation: Compilation): string;
+    generate(): string;
     // (undocumented)
     identifier(): string;
     // (undocumented)

--- a/packages/rspack/src/RuntimeModule.ts
+++ b/packages/rspack/src/RuntimeModule.ts
@@ -23,7 +23,7 @@ export class RuntimeModule {
 		return {
 			name: module.name,
 			stage: module.stage,
-			generator: () => module.generate(compilation),
+			generator: module.generate.bind(module),
 			cacheable: !(module.fullHash || module.dependentHash),
 			isolate: module.shouldIsolate()
 		};
@@ -67,7 +67,7 @@ export class RuntimeModule {
 		return true;
 	}
 
-	generate(compilation: Compilation): string {
+	generate(): string {
 		throw new Error(
 			`Should implement "generate" method of runtime module "${this.name}"`
 		);

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -439,7 +439,8 @@ module.exports = {
             super('custom');
           }
 
-          generate(compilation) {
+          generate() {
+            const compilation = this.compilation;
             return `
             __webpack_require__.mock = function() {
               // ...

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -616,7 +616,8 @@ module.exports = {
             super('custom');
           }
 
-          generate(compilation) {
+          generate() {
+            const compilation = this.compilation;
             return `
             __webpack_require__.mock = function(file) {
               return ${RuntimeGlobals.publicPath} + "/subpath/" + file;

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -439,7 +439,8 @@ module.exports = {
             super('custom', RuntimeModule.STAGE_NORMAL);
           }
 
-          generate(compilation) {
+          generate() {
+            const compilation = this.compilation;
             return `
             __webpack_require__.mock = function() {
               // ...

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -617,7 +617,8 @@ module.exports = {
             super('custom');
           }
 
-          generate(compilation) {
+          generate() {
+            const compilation = this.compilation;
             return `
             __webpack_require__.mock = function(file) {
               return ${RuntimeGlobals.publicPath} + "/subpath/" + file;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should get the `compilation` object through `this.compilation` in `RuntimeModule.generate`. Pass compilation as param is not aligned with webpack. This is a bug 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
