### PR TITLE
refactor: add JSDoc to improve BannerPlugin options types

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -395,44 +395,20 @@ export type Bail = z.infer<typeof bail>;
 const bail: z.ZodBoolean;
 
 // @public (undocumented)
+type BannerContent = string | BannerFunction;
+
+// @public (undocumented)
+type BannerFunction = (args: {
+    hash: string;
+    chunk: JsChunk;
+    filename: string;
+}) => string;
+
+// @public (undocumented)
 export const BannerPlugin: {
-    new (args: string | ((args_0: {
-        filename: string;
-        hash: string;
-        chunk: JsChunk;
-    }, ...args_1: unknown[]) => string) | {
-        banner: string | ((args_0: {
-            filename: string;
-            hash: string;
-            chunk: JsChunk;
-        }, ...args_1: unknown[]) => string);
-        entryOnly?: boolean | undefined;
-        exclude?: string | RegExp | (string | RegExp)[] | undefined;
-        include?: string | RegExp | (string | RegExp)[] | undefined;
-        raw?: boolean | undefined;
-        footer?: boolean | undefined;
-        stage?: number | undefined;
-        test?: string | RegExp | (string | RegExp)[] | undefined;
-    }): {
+    new (args: BannerPluginArgument): {
         name: BuiltinPluginName;
-        _args: [args: string | ((args_0: {
-            filename: string;
-            hash: string;
-            chunk: JsChunk;
-        }, ...args_1: unknown[]) => string) | {
-            banner: string | ((args_0: {
-                filename: string;
-                hash: string;
-                chunk: JsChunk;
-            }, ...args_1: unknown[]) => string);
-            entryOnly?: boolean | undefined;
-            exclude?: string | RegExp | (string | RegExp)[] | undefined;
-            include?: string | RegExp | (string | RegExp)[] | undefined;
-            raw?: boolean | undefined;
-            footer?: boolean | undefined;
-            stage?: number | undefined;
-            test?: string | RegExp | (string | RegExp)[] | undefined;
-        }];
+        _args: [args: BannerPluginArgument];
         affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
         raw(compiler: Compiler_2): BuiltinPlugin;
         apply(compiler: Compiler_2): void;
@@ -440,69 +416,19 @@ export const BannerPlugin: {
 };
 
 // @public (undocumented)
-export type BannerPluginArgument = z.infer<typeof bannerPluginArgument>;
+export type BannerPluginArgument = BannerContent | BannerPluginOptions;
 
 // @public (undocumented)
-const bannerPluginArgument: z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-    hash: z.ZodString;
-    chunk: z.ZodType<JsChunk, z.ZodTypeDef, JsChunk>;
-    filename: z.ZodString;
-}, "strip", z.ZodTypeAny, {
-    filename: string;
-    hash: string;
-    chunk: JsChunk;
-}, {
-    filename: string;
-    hash: string;
-    chunk: JsChunk;
-}>], z.ZodUnknown>, z.ZodString>]>, z.ZodObject<{
-    banner: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-        hash: z.ZodString;
-        chunk: z.ZodType<JsChunk, z.ZodTypeDef, JsChunk>;
-        filename: z.ZodString;
-    }, "strip", z.ZodTypeAny, {
-        filename: string;
-        hash: string;
-        chunk: JsChunk;
-    }, {
-        filename: string;
-        hash: string;
-        chunk: JsChunk;
-    }>], z.ZodUnknown>, z.ZodString>]>;
-    entryOnly: z.ZodOptional<z.ZodBoolean>;
-    exclude: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, "many">]>>;
-    include: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, "many">]>>;
-    raw: z.ZodOptional<z.ZodBoolean>;
-    footer: z.ZodOptional<z.ZodBoolean>;
-    stage: z.ZodOptional<z.ZodNumber>;
-    test: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, "many">]>>;
-}, "strict", z.ZodTypeAny, {
-    banner: string | ((args_0: {
-        filename: string;
-        hash: string;
-        chunk: JsChunk;
-    }, ...args_1: unknown[]) => string);
-    entryOnly?: boolean | undefined;
-    exclude?: string | RegExp | (string | RegExp)[] | undefined;
-    include?: string | RegExp | (string | RegExp)[] | undefined;
-    raw?: boolean | undefined;
-    footer?: boolean | undefined;
-    stage?: number | undefined;
-    test?: string | RegExp | (string | RegExp)[] | undefined;
-}, {
-    banner: string | ((args_0: {
-        filename: string;
-        hash: string;
-        chunk: JsChunk;
-    }, ...args_1: unknown[]) => string);
-    entryOnly?: boolean | undefined;
-    exclude?: string | RegExp | (string | RegExp)[] | undefined;
-    include?: string | RegExp | (string | RegExp)[] | undefined;
-    raw?: boolean | undefined;
-    footer?: boolean | undefined;
-    stage?: number | undefined;
-    test?: string | RegExp | (string | RegExp)[] | undefined;
-}>]>;
+type BannerPluginOptions = {
+    banner: BannerContent;
+    entryOnly?: boolean;
+    exclude?: Rules;
+    include?: Rules;
+    raw?: boolean;
+    footer?: boolean;
+    stage?: number;
+    test?: Rules;
+};
 
 // @public (undocumented)
 abstract class BaseCache {
@@ -698,13 +624,13 @@ const baseRuleSetRule: z.ZodObject<{
 }, "strict", z.ZodTypeAny, {
     options?: string | Record<string, any> | undefined;
     type?: string | undefined;
-    exclude?: RuleSetCondition | undefined;
-    include?: RuleSetCondition | undefined;
-    test?: RuleSetCondition | undefined;
     layer?: string | undefined;
+    test?: RuleSetCondition | undefined;
     enforce?: "pre" | "post" | undefined;
     sideEffects?: boolean | undefined;
     loader?: string | undefined;
+    exclude?: RuleSetCondition | undefined;
+    include?: RuleSetCondition | undefined;
     issuer?: RuleSetCondition | undefined;
     issuerLayer?: RuleSetCondition | undefined;
     dependency?: RuleSetCondition | undefined;
@@ -734,13 +660,13 @@ const baseRuleSetRule: z.ZodObject<{
 }, {
     options?: string | Record<string, any> | undefined;
     type?: string | undefined;
-    exclude?: RuleSetCondition | undefined;
-    include?: RuleSetCondition | undefined;
-    test?: RuleSetCondition | undefined;
     layer?: string | undefined;
+    test?: RuleSetCondition | undefined;
     enforce?: "pre" | "post" | undefined;
     sideEffects?: boolean | undefined;
     loader?: string | undefined;
+    exclude?: RuleSetCondition | undefined;
+    include?: RuleSetCondition | undefined;
     issuer?: RuleSetCondition | undefined;
     issuerLayer?: RuleSetCondition | undefined;
     dependency?: RuleSetCondition | undefined;
@@ -4734,8 +4660,8 @@ export const HtmlRspackPlugin: {
     new (c?: {
         filename?: string | undefined;
         publicPath?: string | undefined;
-        hash?: boolean | undefined;
         chunks?: string[] | undefined;
+        hash?: boolean | undefined;
         base?: string | {
             target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
             href?: string | undefined;
@@ -4756,8 +4682,8 @@ export const HtmlRspackPlugin: {
         _args: [c?: {
             filename?: string | undefined;
             publicPath?: string | undefined;
-            hash?: boolean | undefined;
             chunks?: string[] | undefined;
+            hash?: boolean | undefined;
             base?: string | {
                 target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
                 href?: string | undefined;
@@ -4837,8 +4763,8 @@ const htmlRspackPluginOptions: z.ZodObject<{
 }, "strict", z.ZodTypeAny, {
     filename?: string | undefined;
     publicPath?: string | undefined;
-    hash?: boolean | undefined;
     chunks?: string[] | undefined;
+    hash?: boolean | undefined;
     base?: string | {
         target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
         href?: string | undefined;
@@ -4857,8 +4783,8 @@ const htmlRspackPluginOptions: z.ZodObject<{
 }, {
     filename?: string | undefined;
     publicPath?: string | undefined;
-    hash?: boolean | undefined;
     chunks?: string[] | undefined;
+    hash?: boolean | undefined;
     base?: string | {
         target?: "_self" | "_blank" | "_parent" | "_top" | undefined;
         href?: string | undefined;
@@ -7656,9 +7582,9 @@ const optimization: z.ZodObject<{
         }, "strict", z.ZodTypeAny, {
             filename?: string | undefined;
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+            priority?: number | undefined;
             type?: string | RegExp | undefined;
             test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
             enforce?: boolean | undefined;
             reuseExistingChunk?: boolean | undefined;
             idHint?: string | undefined;
@@ -7676,9 +7602,9 @@ const optimization: z.ZodObject<{
         }, {
             filename?: string | undefined;
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+            priority?: number | undefined;
             type?: string | RegExp | undefined;
             test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
             enforce?: boolean | undefined;
             reuseExistingChunk?: boolean | undefined;
             idHint?: string | undefined;
@@ -7733,9 +7659,9 @@ const optimization: z.ZodObject<{
         cacheGroups?: Record<string, false | {
             filename?: string | undefined;
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+            priority?: number | undefined;
             type?: string | RegExp | undefined;
             test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
             enforce?: boolean | undefined;
             reuseExistingChunk?: boolean | undefined;
             idHint?: string | undefined;
@@ -7776,9 +7702,9 @@ const optimization: z.ZodObject<{
         cacheGroups?: Record<string, false | {
             filename?: string | undefined;
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+            priority?: number | undefined;
             type?: string | RegExp | undefined;
             test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
             enforce?: boolean | undefined;
             reuseExistingChunk?: boolean | undefined;
             idHint?: string | undefined;
@@ -7855,9 +7781,9 @@ const optimization: z.ZodObject<{
         cacheGroups?: Record<string, false | {
             filename?: string | undefined;
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+            priority?: number | undefined;
             type?: string | RegExp | undefined;
             test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
             enforce?: boolean | undefined;
             reuseExistingChunk?: boolean | undefined;
             idHint?: string | undefined;
@@ -7921,9 +7847,9 @@ const optimization: z.ZodObject<{
         cacheGroups?: Record<string, false | {
             filename?: string | undefined;
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+            priority?: number | undefined;
             type?: string | RegExp | undefined;
             test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
             enforce?: boolean | undefined;
             reuseExistingChunk?: boolean | undefined;
             idHint?: string | undefined;
@@ -8022,9 +7948,9 @@ const optimizationSplitChunksCacheGroup: z.ZodObject<{
 }, "strict", z.ZodTypeAny, {
     filename?: string | undefined;
     name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+    priority?: number | undefined;
     type?: string | RegExp | undefined;
     test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-    priority?: number | undefined;
     enforce?: boolean | undefined;
     reuseExistingChunk?: boolean | undefined;
     idHint?: string | undefined;
@@ -8042,9 +7968,9 @@ const optimizationSplitChunksCacheGroup: z.ZodObject<{
 }, {
     filename?: string | undefined;
     name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+    priority?: number | undefined;
     type?: string | RegExp | undefined;
     test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-    priority?: number | undefined;
     enforce?: boolean | undefined;
     reuseExistingChunk?: boolean | undefined;
     idHint?: string | undefined;
@@ -8107,9 +8033,9 @@ const optimizationSplitChunksOptions: z.ZodObject<{
     }, "strict", z.ZodTypeAny, {
         filename?: string | undefined;
         name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+        priority?: number | undefined;
         type?: string | RegExp | undefined;
         test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
         enforce?: boolean | undefined;
         reuseExistingChunk?: boolean | undefined;
         idHint?: string | undefined;
@@ -8127,9 +8053,9 @@ const optimizationSplitChunksOptions: z.ZodObject<{
     }, {
         filename?: string | undefined;
         name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+        priority?: number | undefined;
         type?: string | RegExp | undefined;
         test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
         enforce?: boolean | undefined;
         reuseExistingChunk?: boolean | undefined;
         idHint?: string | undefined;
@@ -8184,9 +8110,9 @@ const optimizationSplitChunksOptions: z.ZodObject<{
     cacheGroups?: Record<string, false | {
         filename?: string | undefined;
         name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+        priority?: number | undefined;
         type?: string | RegExp | undefined;
         test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
         enforce?: boolean | undefined;
         reuseExistingChunk?: boolean | undefined;
         idHint?: string | undefined;
@@ -8227,9 +8153,9 @@ const optimizationSplitChunksOptions: z.ZodObject<{
     cacheGroups?: Record<string, false | {
         filename?: string | undefined;
         name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+        priority?: number | undefined;
         type?: string | RegExp | undefined;
         test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
         enforce?: boolean | undefined;
         reuseExistingChunk?: boolean | undefined;
         idHint?: string | undefined;
@@ -11759,7 +11685,6 @@ export const rspackOptions: z.ZodObject<{
     }, "strict", z.ZodTypeAny, {
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
-        hash?: boolean | undefined;
         all?: boolean | undefined;
         chunks?: boolean | undefined;
         usedExports?: boolean | undefined;
@@ -11774,6 +11699,7 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
+        hash?: boolean | undefined;
         version?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
@@ -11836,7 +11762,6 @@ export const rspackOptions: z.ZodObject<{
     }, {
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
-        hash?: boolean | undefined;
         all?: boolean | undefined;
         chunks?: boolean | undefined;
         usedExports?: boolean | undefined;
@@ -11851,6 +11776,7 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
+        hash?: boolean | undefined;
         version?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
@@ -11954,9 +11880,9 @@ export const rspackOptions: z.ZodObject<{
             }, "strict", z.ZodTypeAny, {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -11974,9 +11900,9 @@ export const rspackOptions: z.ZodObject<{
             }, {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -12031,9 +11957,9 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -12074,9 +12000,9 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -12153,9 +12079,9 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -12219,9 +12145,9 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -13590,7 +13516,6 @@ export const rspackOptions: z.ZodObject<{
     stats?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
-        hash?: boolean | undefined;
         all?: boolean | undefined;
         chunks?: boolean | undefined;
         usedExports?: boolean | undefined;
@@ -13605,6 +13530,7 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
+        hash?: boolean | undefined;
         version?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
@@ -13689,9 +13615,9 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -14172,7 +14098,6 @@ export const rspackOptions: z.ZodObject<{
     stats?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
-        hash?: boolean | undefined;
         all?: boolean | undefined;
         chunks?: boolean | undefined;
         usedExports?: boolean | undefined;
@@ -14187,6 +14112,7 @@ export const rspackOptions: z.ZodObject<{
         errors?: boolean | undefined;
         errorsCount?: boolean | undefined;
         colors?: boolean | undefined;
+        hash?: boolean | undefined;
         version?: boolean | undefined;
         reasons?: boolean | undefined;
         outputPath?: boolean | undefined;
@@ -14271,9 +14197,9 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
                 type?: string | RegExp | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
                 enforce?: boolean | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
@@ -14407,11 +14333,17 @@ export interface RspackPluginInstance {
 // @public (undocumented)
 export const rspackVersion: string;
 
-// @public
-type Rule = RegExp | string;
+// @public (undocumented)
+type Rule = string | RegExp;
 
 // @public
+type Rule_2 = RegExp | string;
+
+// @public (undocumented)
 type Rules = Rule[] | Rule;
+
+// @public
+type Rules_2 = Rule_2[] | Rule_2;
 
 // @public (undocumented)
 class RuleSetCompiler {
@@ -14817,11 +14749,11 @@ export const SourceMapDevToolPlugin: {
 // @public (undocumented)
 export interface SourceMapDevToolPluginOptions extends Omit<RawSourceMapDevToolPluginOptions, "test" | "include" | "exclude"> {
     // (undocumented)
-    exclude?: Rules;
+    exclude?: Rules_2;
     // (undocumented)
-    include?: Rules;
+    include?: Rules_2;
     // (undocumented)
-    test?: Rules;
+    test?: Rules_2;
 }
 
 // @public (undocumented)
@@ -15031,7 +14963,6 @@ const statsOptions: z.ZodObject<{
 }, "strict", z.ZodTypeAny, {
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
-    hash?: boolean | undefined;
     all?: boolean | undefined;
     chunks?: boolean | undefined;
     usedExports?: boolean | undefined;
@@ -15046,6 +14977,7 @@ const statsOptions: z.ZodObject<{
     errors?: boolean | undefined;
     errorsCount?: boolean | undefined;
     colors?: boolean | undefined;
+    hash?: boolean | undefined;
     version?: boolean | undefined;
     reasons?: boolean | undefined;
     outputPath?: boolean | undefined;
@@ -15108,7 +15040,6 @@ const statsOptions: z.ZodObject<{
 }, {
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
-    hash?: boolean | undefined;
     all?: boolean | undefined;
     chunks?: boolean | undefined;
     usedExports?: boolean | undefined;
@@ -15123,6 +15054,7 @@ const statsOptions: z.ZodObject<{
     errors?: boolean | undefined;
     errorsCount?: boolean | undefined;
     colors?: boolean | undefined;
+    hash?: boolean | undefined;
     version?: boolean | undefined;
     reasons?: boolean | undefined;
     outputPath?: boolean | undefined;
@@ -15298,7 +15230,6 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
 }, "strict", z.ZodTypeAny, {
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
-    hash?: boolean | undefined;
     all?: boolean | undefined;
     chunks?: boolean | undefined;
     usedExports?: boolean | undefined;
@@ -15313,6 +15244,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     errors?: boolean | undefined;
     errorsCount?: boolean | undefined;
     colors?: boolean | undefined;
+    hash?: boolean | undefined;
     version?: boolean | undefined;
     reasons?: boolean | undefined;
     outputPath?: boolean | undefined;
@@ -15375,7 +15307,6 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
 }, {
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
-    hash?: boolean | undefined;
     all?: boolean | undefined;
     chunks?: boolean | undefined;
     usedExports?: boolean | undefined;
@@ -15390,6 +15321,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     errors?: boolean | undefined;
     errorsCount?: boolean | undefined;
     colors?: boolean | undefined;
+    hash?: boolean | undefined;
     version?: boolean | undefined;
     reasons?: boolean | undefined;
     outputPath?: boolean | undefined;

--- a/packages/rspack/src/builtin-plugin/BannerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/BannerPlugin.ts
@@ -3,45 +3,48 @@ import {
 	type JsChunk,
 	type RawBannerPluginOptions
 } from "@rspack/binding";
-import { z } from "zod";
 
 import { create } from "./base";
 
-const rule = z.string().or(z.instanceof(RegExp));
-export type Rule = z.infer<typeof rule>;
+export type Rule = string | RegExp;
 
-const rules = rule.or(rule.array());
-export type Rules = z.infer<typeof rules>;
+export type Rules = Rule[] | Rule;
 
-const bannerFunction = z
-	.function()
-	.args(
-		z.object({
-			hash: z.string(),
-			chunk: z.custom<JsChunk>(),
-			filename: z.string()
-		})
-	)
-	.returns(z.string());
-export type BannerFunction = z.infer<typeof bannerFunction>;
+export type BannerFunction = (args: {
+	hash: string;
+	chunk: JsChunk;
+	filename: string;
+}) => string;
 
-const bannerContent = z.string().or(bannerFunction);
-export type BannerContent = z.infer<typeof bannerContent>;
+export type BannerContent = string | BannerFunction;
 
-const bannerPluginOptions = z.strictObject({
-	banner: bannerContent,
-	entryOnly: z.boolean().optional(),
-	exclude: rules.optional(),
-	include: rules.optional(),
-	raw: z.boolean().optional(),
-	footer: z.boolean().optional(),
-	stage: z.number().optional(),
-	test: rules.optional()
-});
-export type BannerPluginOptions = z.infer<typeof bannerPluginOptions>;
+export type BannerPluginOptions = {
+	/** Specifies the banner, it will be wrapped in a comment. */
+	banner: BannerContent;
 
-const bannerPluginArgument = bannerContent.or(bannerPluginOptions);
-export type BannerPluginArgument = z.infer<typeof bannerPluginArgument>;
+	/** If true, the banner will only be added to the entry chunks. */
+	entryOnly?: boolean;
+
+	/** Exclude all modules matching any of these conditions. */
+	exclude?: Rules;
+
+	/** Include all modules matching any of these conditions. */
+	include?: Rules;
+
+	/** If true, banner will not be wrapped in a comment. */
+	raw?: boolean;
+
+	/** If true, banner will be placed at the end of the output. */
+	footer?: boolean;
+
+	/** The stage of the compilation in which the banner should be injected. */
+	stage?: number;
+
+	/** Include all modules that pass test assertion. */
+	test?: Rules;
+};
+
+export type BannerPluginArgument = BannerContent | BannerPluginOptions;
 
 export const BannerPlugin = create(
 	BuiltinPluginName.BannerPlugin,

--- a/packages/rspack/src/builtin-plugin/BannerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/BannerPlugin.ts
@@ -37,7 +37,10 @@ export type BannerPluginOptions = {
 	/** If true, banner will be placed at the end of the output. */
 	footer?: boolean;
 
-	/** The stage of the compilation in which the banner should be injected. */
+/**
+ * The stage of the compilation in which the banner should be injected.
+ * @default PROCESS_ASSETS_STAGE_ADDITIONS (-100)
+ */
 	stage?: number;
 
 	/** Include all modules that pass test assertion. */

--- a/packages/rspack/src/builtin-plugin/BannerPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/BannerPlugin.ts
@@ -37,10 +37,10 @@ export type BannerPluginOptions = {
 	/** If true, banner will be placed at the end of the output. */
 	footer?: boolean;
 
-/**
- * The stage of the compilation in which the banner should be injected.
- * @default PROCESS_ASSETS_STAGE_ADDITIONS (-100)
- */
+	/**
+	 * The stage of the compilation in which the banner should be injected.
+	 * @default PROCESS_ASSETS_STAGE_ADDITIONS (-100)
+	 */
 	stage?: number;
 
 	/** Include all modules that pass test assertion. */

--- a/website/docs/en/plugins/webpack/banner-plugin.mdx
+++ b/website/docs/en/plugins/webpack/banner-plugin.mdx
@@ -13,8 +13,12 @@ Adds a banner to the top or bottom of each generated chunk.
 - **Type:**
 
 ```ts
-type BannerContent = string;
-type BannerRules = string | RegExp | Array<string | RegExp>;
+type BannerFunction = (args: {
+  hash: string;
+  chunk: JsChunk;
+  filename: string;
+}) => string;
+type BannerContent = string | BannerFunction;
 type BannerPluginOptions = {
   banner: BannerContent;
   entryOnly?: boolean;
@@ -52,7 +56,7 @@ type BannerPluginArgument = BannerContent | BannerPluginOptions;
   body={[
     {
       name: '`banner`',
-      type: '`string`',
+      type: '`BannerFunction|string`',
       default: 'undefined',
       description: 'Specifies the banner, it will be wrapped in a comment.',
     },

--- a/website/docs/zh/plugins/webpack/banner-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/banner-plugin.mdx
@@ -13,7 +13,12 @@ new rspack.BannerPlugin(options);
 - **类型：**
 
 ```ts
-type BannerContent = string;
+type BannerFunction = (args: {
+  hash: string;
+  chunk: JsChunk;
+  filename: string;
+}) => string;
+type BannerContent = string | BannerFunction;
 type BannerRules = string | RegExp | Array<string | RegExp>;
 type BannerPluginOptions = {
   banner: BannerContent;
@@ -52,7 +57,7 @@ type BannerPluginArgument = BannerContent | BannerPluginOptions;
   body={[
     {
       name: '`banner`',
-      type: '`string`',
+      type: '`BannerFunction|string`',
       default: 'undefined',
       description: '指定 banner 内容（会被包裹成注释）',
     },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Zod types system is not easy to understand by user. 

We tend use raw ts provider intellisense and jsDoc for user in ide, 

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
