### PR TITLE
refactor: add JSDoc to improve Rspack configuration.entry|context|mode types

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -89,11 +89,8 @@ interface AmdConfig extends BaseModuleConfig {
     type: "amd";
 }
 
-// @public (undocumented)
-export type AmdContainer = z.infer<typeof amdContainer>;
-
-// @public (undocumented)
-const amdContainer: z.ZodString;
+// @public
+export type AmdContainer = string;
 
 // @public (undocumented)
 export const applyRspackOptionsBaseDefaults: (options: RspackOptionsNormalized) => void;
@@ -361,32 +358,11 @@ const assetResourceGeneratorOptions: z.ZodObject<{
 // @public (undocumented)
 export type Assets = Record<string, Source>;
 
-// @public (undocumented)
-export type AsyncChunks = z.infer<typeof asyncChunks>;
+// @public
+export type AsyncChunks = boolean;
 
-// @public (undocumented)
-const asyncChunks: z.ZodBoolean;
-
-// @public (undocumented)
-export type AuxiliaryComment = z.infer<typeof auxiliaryComment>;
-
-// @public (undocumented)
-const auxiliaryComment: z.ZodUnion<[z.ZodString, z.ZodObject<{
-    amd: z.ZodOptional<z.ZodString>;
-    commonjs: z.ZodOptional<z.ZodString>;
-    commonjs2: z.ZodOptional<z.ZodString>;
-    root: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    commonjs2?: string | undefined;
-    root?: string | undefined;
-}, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    commonjs2?: string | undefined;
-    root?: string | undefined;
-}>]>;
+// @public
+export type AuxiliaryComment = string | LibraryCustomUmdCommentObject;
 
 // @public (undocumented)
 export type Bail = z.infer<typeof bail>;
@@ -541,9 +517,9 @@ const baseRuleSetRule: z.ZodObject<{
     sideEffects: z.ZodOptional<z.ZodBoolean>;
     enforce: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"pre">, z.ZodLiteral<"post">]>>;
 }, "strict", z.ZodTypeAny, {
+    layer?: string | undefined;
     options?: string | Record<string, any> | undefined;
     type?: string | undefined;
-    layer?: string | undefined;
     test?: RuleSetCondition | undefined;
     enforce?: "pre" | "post" | undefined;
     sideEffects?: boolean | undefined;
@@ -577,9 +553,9 @@ const baseRuleSetRule: z.ZodObject<{
     generator?: Record<string, any> | undefined;
     resolve?: t.ResolveOptions | undefined;
 }, {
+    layer?: string | undefined;
     options?: string | Record<string, any> | undefined;
     type?: string | undefined;
-    layer?: string | undefined;
     test?: RuleSetCondition | undefined;
     enforce?: "pre" | "post" | undefined;
     sideEffects?: boolean | undefined;
@@ -614,11 +590,8 @@ const baseRuleSetRule: z.ZodObject<{
     resolve?: t.ResolveOptions | undefined;
 }>;
 
-// @public (undocumented)
-export type BaseUri = z.infer<typeof baseUri>;
-
-// @public (undocumented)
-const baseUri: z.ZodString;
+// @public
+export type BaseUri = string;
 
 // @public (undocumented)
 type BigIntStatsCallback = (err: NodeJS.ErrnoException | null, stats?: IBigIntStats) => void;
@@ -822,11 +795,8 @@ export class ChunkGroup {
     get origins(): ReadonlyArray<JsChunkGroupOrigin>;
 }
 
-// @public (undocumented)
-export type ChunkLoading = z.infer<typeof chunkLoading>;
-
-// @public (undocumented)
-const chunkLoading: z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>;
+// @public
+export type ChunkLoading = false | ChunkLoadingType;
 
 // @public (undocumented)
 export type ChunkLoadingGlobal = z.infer<typeof chunkLoadingGlobal>;
@@ -834,11 +804,8 @@ export type ChunkLoadingGlobal = z.infer<typeof chunkLoadingGlobal>;
 // @public (undocumented)
 const chunkLoadingGlobal: z.ZodString;
 
-// @public (undocumented)
-export type ChunkLoadingType = z.infer<typeof chunkLoadingType>;
-
-// @public (undocumented)
-const chunkLoadingType: z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>;
+// @public
+export type ChunkLoadingType = string | "jsonp" | "import-scripts" | "require" | "async-node" | "import";
 
 // @public (undocumented)
 export type Clean = z.infer<typeof clean>;
@@ -1328,24 +1295,8 @@ class ContainerPlugin extends RspackBuiltinPlugin {
     _options: {
         name: string;
         shareScope: string;
-        library: {
-            type: string;
-            name?: string | string[] | {
-                commonjs?: string | undefined;
-                amd?: string | undefined;
-                root?: string | string[] | undefined;
-            } | undefined;
-            amdContainer?: string | undefined;
-            auxiliaryComment?: string | {
-                commonjs?: string | undefined;
-                amd?: string | undefined;
-                commonjs2?: string | undefined;
-                root?: string | undefined;
-            } | undefined;
-            export?: string | string[] | undefined;
-            umdNamedDefine?: boolean | undefined;
-        };
-        runtime: string | false | undefined;
+        library: LibraryOptions;
+        runtime: EntryRuntime | undefined;
         filename: string | undefined;
         exposes: [string, {
             import: string[];
@@ -1394,11 +1345,8 @@ export type ContainerReferencePluginOptions = {
     enhanced?: boolean;
 };
 
-// @public (undocumented)
-export type Context = z.infer<typeof context>;
-
-// @public (undocumented)
-const context: z.ZodEffects<z.ZodString, string, string>;
+// @public
+export type Context = string;
 
 // @public (undocumented)
 type ContextInfo = {
@@ -1693,11 +1641,8 @@ export const DefinePlugin: {
 // @public (undocumented)
 export type DefinePluginOptions = Record<string, CodeValue>;
 
-// @public (undocumented)
-export type Dependencies = z.infer<typeof dependencies>;
-
-// @public (undocumented)
-const dependencies: z.ZodArray<z.ZodString, "many">;
+// @public
+export type Dependencies = Name[];
 
 // @public (undocumented)
 class DependenciesBlock {
@@ -1926,413 +1871,8 @@ const EnableWasmLoadingPlugin: {
 // @public (undocumented)
 type EncodingOption = ObjectEncodingOptions | BufferEncoding | undefined | null;
 
-// @public (undocumented)
-export type Entry = z.infer<typeof entry>;
-
-// @public (undocumented)
-const entry: z.ZodUnion<[z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodFunction<z.ZodTuple<[], z.ZodUnknown>, z.ZodUnion<[z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodPromise<z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>>]>>]>;
+// @public
+export type Entry = EntryStatic | EntryDynamic;
 
 // @public (undocumented)
 interface Entry_2 {
@@ -2343,151 +1883,23 @@ interface Entry_2 {
 // @public (undocumented)
 type EntryData = binding.JsEntryData;
 
-// @public (undocumented)
-export type EntryDependOn = z.infer<typeof entryDependOn>;
+// @public
+export type EntryDependOn = string | string[];
 
 // @public (undocumented)
-const entryDependOn: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-
-// @public (undocumented)
-export type EntryDescription = z.infer<typeof entryDescription>;
-
-// @public (undocumented)
-const entryDescription: z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>;
+export type EntryDescription = {
+    import: EntryItem;
+    runtime?: EntryRuntime;
+    publicPath?: PublicPath;
+    baseUri?: BaseUri;
+    chunkLoading?: ChunkLoading;
+    asyncChunks?: AsyncChunks;
+    wasmLoading?: WasmLoading;
+    filename?: EntryFilename;
+    library?: LibraryOptions;
+    dependOn?: EntryDependOn;
+    layer?: Layer;
+};
 
 // @public (undocumented)
 export interface EntryDescriptionNormalized {
@@ -2513,437 +1925,23 @@ export interface EntryDescriptionNormalized {
     runtime?: EntryRuntime;
 }
 
-// @public (undocumented)
-export type EntryDynamic = z.infer<typeof entryDynamic>;
-
-// @public (undocumented)
-const entryDynamic: z.ZodFunction<z.ZodTuple<[], z.ZodUnknown>, z.ZodUnion<[z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodPromise<z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>>]>>;
+// @public
+export type EntryDynamic = () => EntryStatic | Promise<EntryStatic>;
 
 // @public (undocumented)
 export type EntryDynamicNormalized = () => Promise<EntryStaticNormalized>;
 
-// @public (undocumented)
-export type EntryFilename = z.infer<typeof entryFilename>;
+// @public
+export type EntryFilename = Filename;
 
-// @public (undocumented)
-const entryFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
-
-// @public (undocumented)
-export type EntryItem = z.infer<typeof entryItem>;
-
-// @public (undocumented)
-const entryItem: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+// @public
+export type EntryItem = string | string[];
 
 // @public (undocumented)
 export type EntryNormalized = EntryDynamicNormalized | EntryStaticNormalized;
 
 // @public (undocumented)
-export type EntryObject = z.infer<typeof entryObject>;
-
-// @public (undocumented)
-const entryObject: z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>;
+export type EntryObject = Record<string, EntryItem | EntryDescription>;
 
 // @public (undocumented)
 export class EntryOptionPlugin {
@@ -2989,151 +1987,11 @@ class Entrypoint extends ChunkGroup {
     getRuntimeChunk(): Readonly<Chunk | null>;
 }
 
-// @public (undocumented)
-export type EntryRuntime = z.infer<typeof entryRuntime>;
+// @public
+export type EntryRuntime = false | string;
 
-// @public (undocumented)
-const entryRuntime: z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>;
-
-// @public (undocumented)
-export type EntryStatic = z.infer<typeof entryStatic>;
-
-// @public (undocumented)
-const entryStatic: z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-    runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    baseUri: z.ZodOptional<z.ZodString>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    library: z.ZodOptional<z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>>;
-    dependOn: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
-}, "strict", z.ZodTypeAny, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}, {
-    import: string | string[];
-    filename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    layer?: string | null | undefined;
-    runtime?: string | false | undefined;
-    baseUri?: string | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    dependOn?: string | string[] | undefined;
-}>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>;
+// @public
+export type EntryStatic = EntryObject | EntryUnnamed;
 
 // @public (undocumented)
 export interface EntryStaticNormalized {
@@ -3142,10 +2000,7 @@ export interface EntryStaticNormalized {
 }
 
 // @public (undocumented)
-export type EntryUnnamed = z.infer<typeof entryUnnamed>;
-
-// @public (undocumented)
-const entryUnnamed: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+export type EntryUnnamed = EntryItem;
 
 // @public (undocumented)
 export type Environment = z.infer<typeof environment>;
@@ -3667,10 +2522,7 @@ type ExtraPluginHookData = {
 };
 
 // @public (undocumented)
-export type Falsy = z.infer<typeof falsy>;
-
-// @public (undocumented)
-const falsy: z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>;
+export type Falsy = false | "" | 0 | null | undefined;
 
 // @public (undocumented)
 const FetchCompileAsyncWasmPlugin: {
@@ -3684,16 +2536,10 @@ const FetchCompileAsyncWasmPlugin: {
 };
 
 // @public (undocumented)
-export type Filename = z.infer<typeof filename>;
+export type Filename = FilenameTemplate | ((pathData: PathData, assetInfo?: JsAssetInfo) => string);
 
 // @public (undocumented)
-const filename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
-
-// @public (undocumented)
-export type FilenameTemplate = z.infer<typeof filenameTemplate>;
-
-// @public (undocumented)
-const filenameTemplate: z.ZodString;
+export type FilenameTemplate = string;
 
 // @public (undocumented)
 interface FileSystemInfoEntry {
@@ -5100,11 +3946,8 @@ type KnownStatsProfile = {
     building: number;
 };
 
-// @public (undocumented)
-export type Layer = z.infer<typeof layer>;
-
-// @public (undocumented)
-const layer: z.ZodUnion<[z.ZodString, z.ZodNull]>;
+// @public
+export type Layer = string | null;
 
 // @public (undocumented)
 export type LazyCompilationOptions = z.infer<typeof lazyCompilationOptions>;
@@ -5210,8 +4053,8 @@ const lazyCompilationOptions: z.ZodObject<{
     imports?: boolean | undefined;
 }>;
 
-// @public (undocumented)
-export type Library = z.infer<typeof library_2>;
+// @public
+export type Library = LibraryName | LibraryOptions | undefined;
 
 // @public (undocumented)
 export const library: Library_2;
@@ -5223,226 +4066,38 @@ interface Library_2 {
 }
 
 // @public (undocumented)
-const library_2: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    amd: z.ZodOptional<z.ZodString>;
-    commonjs: z.ZodOptional<z.ZodString>;
-    root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-}, "strict", z.ZodTypeAny, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    root?: string | string[] | undefined;
-}, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    root?: string | string[] | undefined;
-}>]>, z.ZodObject<{
-    amdContainer: z.ZodOptional<z.ZodString>;
-    auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-        amd: z.ZodOptional<z.ZodString>;
-        commonjs: z.ZodOptional<z.ZodString>;
-        commonjs2: z.ZodOptional<z.ZodString>;
-        root: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    }, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    }>]>>;
-    export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        amd: z.ZodOptional<z.ZodString>;
-        commonjs: z.ZodOptional<z.ZodString>;
-        root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    }, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    }>]>>;
-    type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-    umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    type: string;
-    name?: string | string[] | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    } | undefined;
-    amdContainer?: string | undefined;
-    auxiliaryComment?: string | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    } | undefined;
-    export?: string | string[] | undefined;
-    umdNamedDefine?: boolean | undefined;
-}, {
-    type: string;
-    name?: string | string[] | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    } | undefined;
-    amdContainer?: string | undefined;
-    auxiliaryComment?: string | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    } | undefined;
-    export?: string | string[] | undefined;
-    umdNamedDefine?: boolean | undefined;
-}>]>>;
+export type LibraryCustomUmdCommentObject = {
+    amd?: string;
+    commonjs?: string;
+    commonjs2?: string;
+    root?: string;
+};
 
 // @public (undocumented)
-export type LibraryCustomUmdCommentObject = z.infer<typeof libraryCustomUmdCommentObject>;
+export type LibraryCustomUmdObject = {
+    amd?: string;
+    commonjs?: string;
+    root?: string | string[];
+};
 
-// @public (undocumented)
-const libraryCustomUmdCommentObject: z.ZodObject<{
-    amd: z.ZodOptional<z.ZodString>;
-    commonjs: z.ZodOptional<z.ZodString>;
-    commonjs2: z.ZodOptional<z.ZodString>;
-    root: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    commonjs2?: string | undefined;
-    root?: string | undefined;
-}, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    commonjs2?: string | undefined;
-    root?: string | undefined;
-}>;
+// @public
+export type LibraryExport = string | string[];
 
-// @public (undocumented)
-export type LibraryCustomUmdObject = z.infer<typeof libraryCustomUmdObject>;
+// @public
+export type LibraryName = string | string[] | LibraryCustomUmdObject;
 
-// @public (undocumented)
-const libraryCustomUmdObject: z.ZodObject<{
-    amd: z.ZodOptional<z.ZodString>;
-    commonjs: z.ZodOptional<z.ZodString>;
-    root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-}, "strict", z.ZodTypeAny, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    root?: string | string[] | undefined;
-}, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    root?: string | string[] | undefined;
-}>;
+// @public
+export type LibraryOptions = {
+    amdContainer?: AmdContainer;
+    auxiliaryComment?: AuxiliaryComment;
+    export?: LibraryExport;
+    name?: LibraryName;
+    type: LibraryType;
+    umdNamedDefine?: UmdNamedDefine;
+};
 
-// @public (undocumented)
-export type LibraryExport = z.infer<typeof libraryExport>;
-
-// @public (undocumented)
-const libraryExport: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-
-// @public (undocumented)
-export type LibraryName = z.infer<typeof libraryName>;
-
-// @public (undocumented)
-const libraryName: z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-    amd: z.ZodOptional<z.ZodString>;
-    commonjs: z.ZodOptional<z.ZodString>;
-    root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-}, "strict", z.ZodTypeAny, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    root?: string | string[] | undefined;
-}, {
-    commonjs?: string | undefined;
-    amd?: string | undefined;
-    root?: string | string[] | undefined;
-}>]>;
-
-// @public (undocumented)
-export type LibraryOptions = z.infer<typeof libraryOptions>;
-
-// @public (undocumented)
-const libraryOptions: z.ZodObject<{
-    amdContainer: z.ZodOptional<z.ZodString>;
-    auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-        amd: z.ZodOptional<z.ZodString>;
-        commonjs: z.ZodOptional<z.ZodString>;
-        commonjs2: z.ZodOptional<z.ZodString>;
-        root: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    }, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    }>]>>;
-    export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        amd: z.ZodOptional<z.ZodString>;
-        commonjs: z.ZodOptional<z.ZodString>;
-        root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    }, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    }>]>>;
-    type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-    umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    type: string;
-    name?: string | string[] | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    } | undefined;
-    amdContainer?: string | undefined;
-    auxiliaryComment?: string | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    } | undefined;
-    export?: string | string[] | undefined;
-    umdNamedDefine?: boolean | undefined;
-}, {
-    type: string;
-    name?: string | string[] | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    } | undefined;
-    amdContainer?: string | undefined;
-    auxiliaryComment?: string | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    } | undefined;
-    export?: string | string[] | undefined;
-    umdNamedDefine?: boolean | undefined;
-}>;
-
-// @public (undocumented)
-export type LibraryType = z.infer<typeof libraryType>;
-
-// @public (undocumented)
-const libraryType: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
+// @public
+export type LibraryType = string | "var" | "module" | "assign" | "assign-properties" | "this" | "window" | "self" | "global" | "commonjs" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd" | "amd-require" | "umd" | "umd2" | "jsonp" | "system";
 
 // @public (undocumented)
 export type LightningcssFeatureOptions = {
@@ -5867,11 +4522,8 @@ const matchObject: (obj: MatchObject, str: string) => boolean;
 // @public (undocumented)
 const matchPart: (str: string, test: Matcher) => boolean;
 
-// @public (undocumented)
-export type Mode = z.infer<typeof mode>;
-
-// @public (undocumented)
-const mode: z.ZodEnum<["development", "production", "none"]>;
+// @public
+export type Mode = "development" | "production" | "none";
 
 // @public (undocumented)
 export class Module {
@@ -6952,11 +5604,8 @@ class MultiWatching {
     watchings: Watching[];
 }
 
-// @public (undocumented)
-export type Name = z.infer<typeof name_2>;
-
-// @public (undocumented)
-const name_2: z.ZodString;
+// @public
+export type Name = string;
 
 // @public (undocumented)
 export const node: Node_3;
@@ -8017,8 +6666,8 @@ const output: z.ZodObject<{
         optionalChaining?: boolean | undefined;
         templateLiteral?: boolean | undefined;
     } | undefined;
-    path?: string | undefined;
     chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+    path?: string | undefined;
     auxiliaryComment?: string | {
         commonjs?: string | undefined;
         amd?: string | undefined;
@@ -8112,8 +6761,8 @@ const output: z.ZodObject<{
         optionalChaining?: boolean | undefined;
         templateLiteral?: boolean | undefined;
     } | undefined;
-    path?: string | undefined;
     chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+    path?: string | undefined;
     auxiliaryComment?: string | {
         commonjs?: string | undefined;
         amd?: string | undefined;
@@ -9292,11 +7941,8 @@ interface PseudoClasses {
     hover?: string;
 }
 
-// @public (undocumented)
-export type PublicPath = z.infer<typeof publicPath>;
-
-// @public (undocumented)
-const publicPath: z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<JsPathData, z.ZodTypeDef, JsPathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>;
+// @public
+export type PublicPath = "auto" | Filename;
 
 // @public (undocumented)
 type Purge = (files?: string | string[] | Set<string>) => void;
@@ -9775,42 +8421,6 @@ declare namespace rspackExports {
         IgnoreWarningsNormalized,
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
-        FilenameTemplate,
-        Filename,
-        Name,
-        Dependencies,
-        Context,
-        Mode,
-        Falsy,
-        PublicPath,
-        BaseUri,
-        ChunkLoadingType,
-        ChunkLoading,
-        AsyncChunks,
-        WasmLoadingType,
-        WasmLoading,
-        ScriptType,
-        LibraryCustomUmdObject,
-        LibraryName,
-        LibraryCustomUmdCommentObject,
-        AmdContainer,
-        AuxiliaryComment,
-        LibraryExport,
-        LibraryType,
-        UmdNamedDefine,
-        LibraryOptions,
-        Library,
-        Layer,
-        EntryFilename,
-        EntryRuntime,
-        EntryItem,
-        EntryDependOn,
-        EntryDescription,
-        EntryUnnamed,
-        EntryObject,
-        EntryStatic,
-        EntryDynamic,
-        Entry,
         Path,
         Pathinfo,
         AssetModuleFilename,
@@ -9926,6 +8536,42 @@ declare namespace rspackExports {
         rspackOptions,
         RspackOptions,
         Configuration,
+        FilenameTemplate,
+        Filename,
+        Name,
+        Dependencies,
+        Context,
+        Mode,
+        Falsy,
+        PublicPath,
+        BaseUri,
+        ChunkLoadingType,
+        ChunkLoading,
+        AsyncChunks,
+        WasmLoadingType,
+        WasmLoading,
+        ScriptType,
+        LibraryCustomUmdObject,
+        LibraryName,
+        LibraryCustomUmdCommentObject,
+        AmdContainer,
+        AuxiliaryComment,
+        LibraryExport,
+        LibraryType,
+        UmdNamedDefine,
+        LibraryOptions,
+        Library,
+        Layer,
+        EntryFilename,
+        EntryRuntime,
+        EntryItem,
+        EntryDependOn,
+        EntryDescription,
+        EntryUnnamed,
+        EntryObject,
+        EntryStatic,
+        EntryDynamic,
+        Entry,
         ResolveAlias,
         ResolveTsConfig,
         ResolveOptions,
@@ -10598,8 +9244,8 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        path?: string | undefined;
         chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
             amd?: string | undefined;
@@ -10693,8 +9339,8 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        path?: string | undefined;
         chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
             amd?: string | undefined;
@@ -12933,8 +11579,8 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        path?: string | undefined;
         chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
             amd?: string | undefined;
@@ -13061,7 +11707,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "jsonp" | "import" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
         context?: string | undefined;
         dependencyType?: string | undefined;
         request?: string | undefined;
@@ -13075,7 +11721,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "jsonp" | "import" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
         context?: string | undefined;
         dependencyType?: string | undefined;
         request?: string | undefined;
@@ -13083,7 +11729,7 @@ export const rspackOptions: z.ZodObject<{
             issuer: string;
         } | undefined;
     }, ...args_1: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
-    externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "jsonp" | "import" | "module-import" | "script" | "node-commonjs" | undefined;
+    externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
         web?: boolean | undefined;
@@ -13515,8 +12161,8 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        path?: string | undefined;
         chunkFilename?: string | ((args_0: JsPathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
             amd?: string | undefined;
@@ -13643,7 +12289,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "jsonp" | "import" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
         context?: string | undefined;
         dependencyType?: string | undefined;
         request?: string | undefined;
@@ -13657,7 +12303,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "jsonp" | "import" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
         context?: string | undefined;
         dependencyType?: string | undefined;
         request?: string | undefined;
@@ -13665,7 +12311,7 @@ export const rspackOptions: z.ZodObject<{
             issuer: string;
         } | undefined;
     }, ...args_1: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
-    externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "jsonp" | "import" | "module-import" | "script" | "node-commonjs" | undefined;
+    externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
         web?: boolean | undefined;
@@ -14207,10 +12853,7 @@ enum RuntimeModuleStage {
 type RuntimePlugins = string[];
 
 // @public (undocumented)
-export type ScriptType = z.infer<typeof scriptType>;
-
-// @public (undocumented)
-const scriptType: z.ZodUnion<[z.ZodEnum<["text/javascript", "module"]>, z.ZodLiteral<false>]>;
+export type ScriptType = false | "text/javascript" | "module";
 
 // @public (undocumented)
 export type Shared = (SharedItem | SharedObject)[] | SharedObject;
@@ -15178,6 +13821,42 @@ interface SystemjsConfig {
 
 declare namespace t {
     export {
+        FilenameTemplate,
+        Filename,
+        Name,
+        Dependencies,
+        Context,
+        Mode,
+        Falsy,
+        PublicPath,
+        BaseUri,
+        ChunkLoadingType,
+        ChunkLoading,
+        AsyncChunks,
+        WasmLoadingType,
+        WasmLoading,
+        ScriptType,
+        LibraryCustomUmdObject,
+        LibraryName,
+        LibraryCustomUmdCommentObject,
+        AmdContainer,
+        AuxiliaryComment,
+        LibraryExport,
+        LibraryType,
+        UmdNamedDefine,
+        LibraryOptions,
+        Library,
+        Layer,
+        EntryFilename,
+        EntryRuntime,
+        EntryItem,
+        EntryDependOn,
+        EntryDescription,
+        EntryUnnamed,
+        EntryObject,
+        EntryStatic,
+        EntryDynamic,
+        Entry,
         ResolveAlias,
         ResolveTsConfig,
         ResolveOptions,
@@ -15431,11 +14110,8 @@ interface UmdConfig extends BaseModuleConfig {
     type: "umd";
 }
 
-// @public (undocumented)
-export type UmdNamedDefine = z.infer<typeof umdNamedDefine>;
-
-// @public (undocumented)
-const umdNamedDefine: z.ZodBoolean;
+// @public
+export type UmdNamedDefine = boolean;
 
 // @public (undocumented)
 export type UniqueName = z.infer<typeof uniqueName>;
@@ -15466,17 +14142,11 @@ interface Wasm {
 // @public (undocumented)
 export const wasm: Wasm;
 
-// @public (undocumented)
-export type WasmLoading = z.infer<typeof wasmLoading>;
+// @public
+export type WasmLoading = false | WasmLoadingType;
 
-// @public (undocumented)
-const wasmLoading: z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>;
-
-// @public (undocumented)
-export type WasmLoadingType = z.infer<typeof wasmLoadingType>;
-
-// @public (undocumented)
-const wasmLoadingType: z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>;
+// @public
+export type WasmLoadingType = string | "fetch-streaming" | "fetch" | "async-node";
 
 // @public (undocumented)
 export type Watch = z.infer<typeof watch>;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1,3 +1,224 @@
+import type { JsAssetInfo } from "@rspack/binding";
+import type { PathData } from "../Compilation";
+
+export type FilenameTemplate = string;
+
+export type Filename =
+	| FilenameTemplate
+	| ((pathData: PathData, assetInfo?: JsAssetInfo) => string);
+
+//#region Name
+/** Name of the configuration. Used when loading multiple configurations. */
+export type Name = string;
+//#endregion
+
+//#region Dependencies
+/** A list of name defining all sibling configurations it depends on. Dependent configurations need to be compiled first. */
+export type Dependencies = Name[];
+//#endregion
+
+//#region Context
+/**
+ * The context configuration is used to set the base directory for Rspack builds.
+ * @default process.cwd()
+ * */
+export type Context = string;
+//#endregion
+
+//#region Mode
+/**
+ * The mode configuration is used to set the build mode of Rspack to enable the default optimization strategy.
+ * @default 'production'
+ * */
+export type Mode = "development" | "production" | "none";
+//#endregion
+
+//#region Falsy
+export type Falsy = false | "" | 0 | null | undefined;
+//#endregion
+
+//#region Entry
+/** The publicPath of the resource referenced by this entry. */
+export type PublicPath = "auto" | Filename;
+
+/** The baseURI of the resource referenced by this entry. */
+export type BaseUri = string;
+
+/** How this entry load other chunks. */
+export type ChunkLoadingType =
+	| string
+	| "jsonp"
+	| "import-scripts"
+	| "require"
+	| "async-node"
+	| "import";
+
+/** How this entry load other chunks. */
+export type ChunkLoading = false | ChunkLoadingType;
+
+/** Whether to create a load-on-demand asynchronous chunk for entry. */
+export type AsyncChunks = boolean;
+
+/** Option to set the method of loading WebAssembly Modules. */
+export type WasmLoadingType =
+	| string
+	| "fetch-streaming"
+	| "fetch"
+	| "async-node";
+
+/** Option to set the method of loading WebAssembly Modules. */
+export type WasmLoading = false | WasmLoadingType;
+
+export type ScriptType = false | "text/javascript" | "module";
+
+export type LibraryCustomUmdObject = {
+	amd?: string;
+	commonjs?: string;
+	root?: string | string[];
+};
+
+/** Specify a name for the library. */
+export type LibraryName = string | string[] | LibraryCustomUmdObject;
+
+export type LibraryCustomUmdCommentObject = {
+	amd?: string;
+	commonjs?: string;
+	commonjs2?: string;
+	root?: string;
+};
+
+/** Use a container(defined in global space) for calling define/require functions in an AMD module. */
+export type AmdContainer = string;
+
+/** Add a comment in the UMD wrapper. */
+export type AuxiliaryComment = string | LibraryCustomUmdCommentObject;
+
+/** Specify which export should be exposed as a library. */
+export type LibraryExport = string | string[];
+
+/** Configure how the library will be exposed. */
+export type LibraryType =
+	| string
+	| "var"
+	| "module"
+	| "assign"
+	| "assign-properties"
+	| "this"
+	| "window"
+	| "self"
+	| "global"
+	| "commonjs"
+	| "commonjs2"
+	| "commonjs-module"
+	| "commonjs-static"
+	| "amd"
+	| "amd-require"
+	| "umd"
+	| "umd2"
+	| "jsonp"
+	| "system";
+
+/** When using output.library.type: "umd", setting output.library.umdNamedDefine to true will name the AMD module of the UMD build. */
+export type UmdNamedDefine = boolean;
+
+/** Options for library.  */
+export type LibraryOptions = {
+	/** Use a container(defined in global space) for calling define/require functions in an AMD module. */
+	amdContainer?: AmdContainer;
+
+	/** Add a comment in the UMD wrapper. */
+	auxiliaryComment?: AuxiliaryComment;
+
+	/** Specify which export should be exposed as a library. */
+	export?: LibraryExport;
+
+	/** Specify a name for the library. */
+	name?: LibraryName;
+
+	/** Configure how the library will be exposed. */
+	type: LibraryType;
+
+	/**
+	 * When using output.library.type: "umd", setting output.library.umdNamedDefine to true will name the AMD module of the UMD build.
+	 * Otherwise, an anonymous define is used.
+	 * */
+	umdNamedDefine?: UmdNamedDefine;
+};
+
+/** Options for library. */
+export type Library = LibraryName | LibraryOptions | undefined;
+
+/** The layer of this entry. */
+export type Layer = string | null;
+
+/** The filename of the entry chunk. */
+export type EntryFilename = Filename;
+
+/** The name of the runtime chunk. */
+export type EntryRuntime = false | string;
+
+/** The path to the entry module. */
+export type EntryItem = string | string[];
+
+/** The entry that the current entry depends on. With dependOn option you can share the modules from one entry chunk to another. */
+export type EntryDependOn = string | string[];
+
+export type EntryDescription = {
+	/**
+	 * The path to the entry module.
+	 * @default './src/index.js'
+	 * */
+	import: EntryItem;
+
+	/**
+	 * The name of the runtime chunk.
+	 * When runtime is set, a new runtime chunk will be created.
+	 * You can also set it to false to avoid a new runtime chunk.
+	 * */
+	runtime?: EntryRuntime;
+
+	/** The publicPath of the resource referenced by this entry. */
+	publicPath?: PublicPath;
+
+	/** The baseURI of the resource referenced by this entry. */
+	baseUri?: BaseUri;
+
+	/** How this entry load other chunks. */
+	chunkLoading?: ChunkLoading;
+
+	/** Whether to create a load-on-demand asynchronous chunk for this entry. */
+	asyncChunks?: AsyncChunks;
+
+	/** Option to set the method of loading WebAssembly Modules. */
+	wasmLoading?: WasmLoading;
+
+	/** The filename of the entry chunk. */
+	filename?: EntryFilename;
+
+	/** The format of the chunk generated by this entry as a library. */
+	library?: LibraryOptions;
+
+	/** The entry that the current entry depends on. With dependOn option you can share the modules from one entry chunk to another. */
+	dependOn?: EntryDependOn;
+
+	/** The layer of this entry, make the corresponding configuration take effect through layer matching in SplitChunks, Rules, Stats, and Externals. */
+	layer?: Layer;
+};
+
+export type EntryUnnamed = EntryItem;
+
+export type EntryObject = Record<string, EntryItem | EntryDescription>;
+
+/** A static entry.  */
+export type EntryStatic = EntryObject | EntryUnnamed;
+
+/** A Function returning entry options. */
+export type EntryDynamic = () => EntryStatic | Promise<EntryStatic>;
+
+/** The entry options for building */
+export type Entry = EntryStatic | EntryDynamic;
+//#endregion
+
 //#region Resolve
 /**
  * Path alias

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -11,25 +11,21 @@ import type * as t from "./types";
 
 export type * from "./types";
 
-const filenameTemplate = z.string();
-export type FilenameTemplate = z.infer<typeof filenameTemplate>;
+const filenameTemplate = z.string() satisfies z.ZodType<t.FilenameTemplate>;
 
 const filename = filenameTemplate.or(
 	z
 		.function()
 		.args(z.custom<PathData>(), z.custom<JsAssetInfo>().optional())
 		.returns(z.string())
-);
-export type Filename = z.infer<typeof filename>;
+) satisfies z.ZodType<t.Filename>;
 
 //#region Name
-const name = z.string();
-export type Name = z.infer<typeof name>;
+const name = z.string() satisfies z.ZodType<t.Name>;
 //#endregion
 
 //#region Dependencies
-const dependencies = z.array(name);
-export type Dependencies = z.infer<typeof dependencies>;
+const dependencies = z.array(name) satisfies z.ZodType<t.Dependencies>;
 //#endregion
 
 //#region Context
@@ -38,13 +34,15 @@ const context = z.string().refine(
 	val => ({
 		message: `The provided value ${JSON.stringify(val)} must be an absolute path.`
 	})
-);
-export type Context = z.infer<typeof context>;
+) satisfies z.ZodType<t.Context>;
 //#endregion
 
 //#region Mode
-const mode = z.enum(["development", "production", "none"]);
-export type Mode = z.infer<typeof mode>;
+const mode = z.enum([
+	"development",
+	"production",
+	"none"
+]) satisfies z.ZodType<t.Mode>;
 //#endregion
 
 //#region Falsy
@@ -54,71 +52,65 @@ const falsy = z.union([
 	z.literal(""),
 	z.null(),
 	z.undefined()
-]);
-
-export type Falsy = z.infer<typeof falsy>;
+]) satisfies z.ZodType<t.Falsy>;
 //#endregion
 
 //#region Entry
-const publicPath = z.literal("auto").or(filename);
-export type PublicPath = z.infer<typeof publicPath>;
+const publicPath = z
+	.literal("auto")
+	.or(filename) satisfies z.ZodType<t.PublicPath>;
 
-const baseUri = z.string();
-export type BaseUri = z.infer<typeof baseUri>;
+const baseUri = z.string() satisfies z.ZodType<t.BaseUri>;
 
 const chunkLoadingType = z
 	.enum(["jsonp", "import-scripts", "require", "async-node", "import"])
-	.or(z.string());
-export type ChunkLoadingType = z.infer<typeof chunkLoadingType>;
+	.or(z.string()) satisfies z.ZodType<t.ChunkLoadingType>;
 
-const chunkLoading = z.literal(false).or(chunkLoadingType);
-export type ChunkLoading = z.infer<typeof chunkLoading>;
+const chunkLoading = z
+	.literal(false)
+	.or(chunkLoadingType) satisfies z.ZodType<t.ChunkLoading>;
 
-const asyncChunks = z.boolean();
-export type AsyncChunks = z.infer<typeof asyncChunks>;
+const asyncChunks = z.boolean() satisfies z.ZodType<t.AsyncChunks>;
 
 const wasmLoadingType = z
 	.enum(["fetch-streaming", "fetch", "async-node"])
-	.or(z.string());
-export type WasmLoadingType = z.infer<typeof wasmLoadingType>;
+	.or(z.string()) satisfies z.ZodType<t.WasmLoadingType>;
 
-const wasmLoading = z.literal(false).or(wasmLoadingType);
-export type WasmLoading = z.infer<typeof wasmLoading>;
+const wasmLoading = z
+	.literal(false)
+	.or(wasmLoadingType) satisfies z.ZodType<t.WasmLoading>;
 
-const scriptType = z.enum(["text/javascript", "module"]).or(z.literal(false));
-export type ScriptType = z.infer<typeof scriptType>;
+const scriptType = z
+	.enum(["text/javascript", "module"])
+	.or(z.literal(false)) satisfies z.ZodType<t.ScriptType>;
 
 const libraryCustomUmdObject = z.strictObject({
 	amd: z.string().optional(),
 	commonjs: z.string().optional(),
 	root: z.string().or(z.array(z.string())).optional()
-});
-export type LibraryCustomUmdObject = z.infer<typeof libraryCustomUmdObject>;
+}) satisfies z.ZodType<t.LibraryCustomUmdObject>;
 
 const libraryName = z
 	.string()
 	.or(z.array(z.string()))
-	.or(libraryCustomUmdObject);
-export type LibraryName = z.infer<typeof libraryName>;
+	.or(libraryCustomUmdObject) satisfies z.ZodType<t.LibraryName>;
 
 const libraryCustomUmdCommentObject = z.strictObject({
 	amd: z.string().optional(),
 	commonjs: z.string().optional(),
 	commonjs2: z.string().optional(),
 	root: z.string().optional()
-});
-export type LibraryCustomUmdCommentObject = z.infer<
-	typeof libraryCustomUmdCommentObject
->;
+}) satisfies z.ZodType<t.LibraryCustomUmdCommentObject>;
 
-const amdContainer = z.string();
-export type AmdContainer = z.infer<typeof amdContainer>;
+const amdContainer = z.string() satisfies z.ZodType<t.AmdContainer>;
 
-const auxiliaryComment = z.string().or(libraryCustomUmdCommentObject);
-export type AuxiliaryComment = z.infer<typeof auxiliaryComment>;
+const auxiliaryComment = z
+	.string()
+	.or(libraryCustomUmdCommentObject) satisfies z.ZodType<t.AuxiliaryComment>;
 
-const libraryExport = z.string().or(z.array(z.string()));
-export type LibraryExport = z.infer<typeof libraryExport>;
+const libraryExport = z
+	.string()
+	.or(z.array(z.string())) satisfies z.ZodType<t.LibraryExport>;
 
 const libraryType = z
 	.enum([
@@ -141,11 +133,9 @@ const libraryType = z
 		"jsonp",
 		"system"
 	])
-	.or(z.string());
-export type LibraryType = z.infer<typeof libraryType>;
+	.or(z.string()) satisfies z.ZodType<t.LibraryType>;
 
-const umdNamedDefine = z.boolean();
-export type UmdNamedDefine = z.infer<typeof umdNamedDefine>;
+const umdNamedDefine = z.boolean() satisfies z.ZodType<t.UmdNamedDefine>;
 
 const libraryOptions = z.strictObject({
 	amdContainer: amdContainer.optional(),
@@ -154,26 +144,27 @@ const libraryOptions = z.strictObject({
 	name: libraryName.optional(),
 	type: libraryType,
 	umdNamedDefine: umdNamedDefine.optional()
-});
-export type LibraryOptions = z.infer<typeof libraryOptions>;
+}) satisfies z.ZodType<t.LibraryOptions>;
 
-const library = libraryName.or(libraryOptions).optional();
-export type Library = z.infer<typeof library>;
+const library = libraryName
+	.or(libraryOptions)
+	.optional() satisfies z.ZodType<t.Library>;
 
-const layer = z.string().or(z.null());
-export type Layer = z.infer<typeof layer>;
+const layer = z.string().or(z.null()) satisfies z.ZodType<t.Layer>;
 
-const entryFilename = filename;
-export type EntryFilename = z.infer<typeof entryFilename>;
+const entryFilename = filename satisfies z.ZodType<t.EntryFilename>;
 
-const entryRuntime = z.literal(false).or(z.string());
-export type EntryRuntime = z.infer<typeof entryRuntime>;
+const entryRuntime = z
+	.literal(false)
+	.or(z.string()) satisfies z.ZodType<t.EntryRuntime>;
 
-const entryItem = z.string().or(z.array(z.string()));
-export type EntryItem = z.infer<typeof entryItem>;
+const entryItem = z
+	.string()
+	.or(z.array(z.string())) satisfies z.ZodType<t.EntryItem>;
 
-const entryDependOn = z.string().or(z.array(z.string()));
-export type EntryDependOn = z.infer<typeof entryDependOn>;
+const entryDependOn = z
+	.string()
+	.or(z.array(z.string())) satisfies z.ZodType<t.EntryDependOn>;
 
 const entryDescription = z.strictObject({
 	import: entryItem,
@@ -187,25 +178,25 @@ const entryDescription = z.strictObject({
 	library: libraryOptions.optional(),
 	dependOn: entryDependOn.optional(),
 	layer: layer.optional()
-});
-export type EntryDescription = z.infer<typeof entryDescription>;
+}) satisfies z.ZodType<t.EntryDescription>;
 
-const entryUnnamed = entryItem;
-export type EntryUnnamed = z.infer<typeof entryUnnamed>;
+const entryUnnamed = entryItem satisfies z.ZodType<t.EntryUnnamed>;
 
-const entryObject = z.record(entryItem.or(entryDescription));
-export type EntryObject = z.infer<typeof entryObject>;
+const entryObject = z.record(
+	entryItem.or(entryDescription)
+) satisfies z.ZodType<t.EntryObject>;
 
-const entryStatic = entryObject.or(entryUnnamed);
-export type EntryStatic = z.infer<typeof entryStatic>;
+const entryStatic = entryObject.or(
+	entryUnnamed
+) satisfies z.ZodType<t.EntryStatic>;
 
 const entryDynamic = z
 	.function()
-	.returns(entryStatic.or(z.promise(entryStatic)));
-export type EntryDynamic = z.infer<typeof entryDynamic>;
+	.returns(
+		entryStatic.or(z.promise(entryStatic))
+	) satisfies z.ZodType<t.EntryDynamic>;
 
-const entry = entryStatic.or(entryDynamic);
-export type Entry = z.infer<typeof entry>;
+const entry = entryStatic.or(entryDynamic) satisfies z.ZodType<t.Entry>;
 //#endregion
 
 //#region Output


### PR DESCRIPTION
…context] types.

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->
Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.entry
- Add type & JSDoc for config.context
- Add type & JSDoc for config.dependencies
- Add type & JSDoc for config.mode

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
