### PR TITLE
fix: should set code generation hash to concatenated module

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1295,6 +1295,11 @@ impl Module for ConcatenatedModule {
           exports_final_names_map,
         ));
     }
+    code_generation_result.set_hash(
+      &compilation.options.output.hash_function,
+      &compilation.options.output.hash_digest,
+      &compilation.options.output.hash_salt,
+    );
     Ok(code_generation_result)
   }
 

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsAPI.test.js.snap
@@ -318,7 +318,7 @@ Object {
         "main.js",
       ],
       "filteredModules": undefined,
-      "hash": "eceae76a4802a119b192",
+      "hash": "9b2b751ee9c70405e371",
       "id": "909",
       "idHints": Array [],
       "initial": true,
@@ -685,7 +685,7 @@ Object {
   "errorsCount": 0,
   "filteredAssets": undefined,
   "filteredModules": undefined,
-  "hash": "b2ef257387e69373f7b0",
+  "hash": "345f9530d25377198050",
   "modules": Array [
     Object {
       "assets": Array [],

--- a/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/StatsOutput.test.js.snap
@@ -59,7 +59,7 @@ runtime modules 1.61 KiB
     [no exports]
     [used exports unknown]
   
-Rspack compiled successfully (2626c5e238d43a8c50f3)"
+Rspack compiled successfully (75a3437c65e54d5331bb)"
 `;
 
 exports[`statsOutput statsOutput/builtin-swc-loader-parse-error should print correct stats for 1`] = `

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/app.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/app.js
@@ -1,0 +1,3 @@
+export default async function App() {
+  return await import("./m1").then(({ m1 }) => m1());
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/m1.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/m1.js
@@ -1,0 +1,4 @@
+import { m2 } from "./mock-loader.js!./m2";
+export const m1 = function () {
+  return m2();
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/m2.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/m2.js
@@ -1,0 +1,3 @@
+export const m2 = function () {
+  throw new Error("should not run this function");
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/main.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/main.js
@@ -1,0 +1,5 @@
+import app from "./app";
+
+it("should run", async function () {
+  await app();
+});

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/mock-loader.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/mock-loader.js
@@ -1,0 +1,9 @@
+let mocked = false;
+module.exports = function () {
+  if (mocked) {
+    return `export const m2 = function () { return "content2" };`;
+  } else {
+    mocked = true;
+    return `export const m2 = function () { return "content1" };`;
+  }
+};

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/rspack.config.js
@@ -1,0 +1,47 @@
+let firstChunkAsset = null;
+
+class CheckAssetPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap("TestPlugin", compilation => {
+      compilation.hooks.afterProcessAssets.tap("TestPlugin", assets => {
+        const chunkAsset = Object.keys(assets).find(asset => asset.startsWith("chunk."));
+        if (!chunkAsset) {
+          throw new Error("chunk asset not found");
+        }
+        if (firstChunkAsset === null) {
+          firstChunkAsset = chunkAsset;
+        } else {
+          expect(firstChunkAsset).not.toEqual(chunkAsset);
+        }
+      });
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = [
+  {
+    mode: "production",
+    entry: "./main.js",
+    output: {
+      chunkFilename: "chunk.[chunkhash].js",
+    },
+    optimization: {
+      concatenateModules: true,
+      minimize: false
+    },
+    plugins: [new CheckAssetPlugin()]
+  },
+  {
+    mode: "production",
+    entry: "./main.js",
+    output: {
+      chunkFilename: "chunk.[chunkhash].js",
+    },
+    optimization: {
+      concatenateModules: true,
+      minimize: false
+    },
+    plugins: [new CheckAssetPlugin()]
+  }
+];

--- a/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/test.confg.js
+++ b/packages/rspack-test-tools/tests/configCases/concatenate-modules/chunk-hash/test.confg.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+  findBundle: function (i, options) {
+    return ["bundle0.js", "bundle1.js"];
+  },
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix https://github.com/web-infra-dev/rspack/issues/7937

Cause code generation hash of concatenated module is `None`, if contents its of inner modules change, the chunk hash will not change.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
