### PR TITLE
fix: replace deprecated fs.rmdir with recursive removal logic

### DIFF
--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -10,8 +10,8 @@
 
 import assert from "node:assert";
 import type { Abortable } from "node:events";
-import path from "node:path";
 import type { RmOptions } from "node:fs";
+import path from "node:path";
 
 import type { WatchOptions } from "../config";
 

--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -11,6 +11,7 @@
 import assert from "node:assert";
 import type { Abortable } from "node:events";
 import path from "node:path";
+import type { RmOptions } from "node:fs";
 
 import type { WatchOptions } from "../config";
 
@@ -96,9 +97,10 @@ export interface OutputFileSystem {
 			arg1?: (string | Buffer)[] | IDirent[]
 		) => void
 	) => void;
-	rmdir: (
+	rm: (
 		arg0: string,
-		arg1: (arg0?: null | NodeJS.ErrnoException) => void
+		arg1: RmOptions,
+		arg2: (arg0?: null | NodeJS.ErrnoException) => void
 	) => void;
 	unlink: (
 		arg0: string,
@@ -499,7 +501,7 @@ export function rmrf(
 				}
 				let count = files!.length;
 				if (count === 0) {
-					fs.rmdir(p, callback);
+					fs.rm(p, { recursive: true }, callback);
 				} else {
 					for (const file of files!) {
 						assert(typeof file === "string");
@@ -510,7 +512,7 @@ export function rmrf(
 							}
 							count--;
 							if (count === 0) {
-								fs.rmdir(p, callback);
+								fs.rm(p, { recursive: true }, callback);
 							}
 						});
 					}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This pull request addresses a deprecation warning in Node.js regarding the use of `fs.rmdir(path, { recursive: true })`. In future versions, this method will be removed.

To resolve this, I replaced `fs.rmdir` with `fs.rm(path, { recursive: true })` as recommended by the warning. This change maintains the functionality while adhering to future Node.js standards.
![image](https://github.com/user-attachments/assets/d15bfaab-66cb-48b7-865a-706b50c83414)


<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
