### PR TITLE
refactor: add JSDoc to improve Rspack configuration.optimization types.

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -7550,13 +7550,7 @@ type PluginImportConfig = {
 type PluginImportOptions = PluginImportConfig[] | undefined;
 
 // @public (undocumented)
-export type Plugins = z.infer<typeof plugins>;
-
-// @public (undocumented)
-const plugins: z.ZodArray<z.ZodUnion<[z.ZodType<t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction, z.ZodTypeDef, t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">;
-
-// @public (undocumented)
-type Plugins_2 = Plugin_2[];
+export type Plugins = Plugin_2[];
 
 // @public (undocumented)
 type PrintedElement = {
@@ -8234,7 +8228,6 @@ declare namespace rspackExports {
         CacheOptions,
         StatsOptions,
         StatsValue,
-        Plugins,
         RspackFutureOptions,
         LazyCompilationOptions,
         Incremental,
@@ -8301,6 +8294,7 @@ declare namespace rspackExports {
         WebpackPluginInstance,
         WebpackPluginFunction,
         Plugin_2 as Plugin,
+        Plugins,
         OptimizationRuntimeChunk,
         OptimizationSplitChunksNameFunction,
         OptimizationSplitChunksCacheGroup,
@@ -13757,7 +13751,7 @@ declare namespace t {
         WebpackPluginInstance,
         WebpackPluginFunction,
         Plugin_2 as Plugin,
-        Plugins_2 as Plugins,
+        Plugins,
         OptimizationRuntimeChunk,
         OptimizationSplitChunksNameFunction,
         OptimizationSplitChunksCacheGroup,

--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -521,10 +521,8 @@ const baseRuleSetRule: z.ZodObject<{
     layer?: string | undefined;
     options?: string | Record<string, any> | undefined;
     type?: string | undefined;
-    test?: RuleSetCondition | undefined;
-    enforce?: "pre" | "post" | undefined;
-    sideEffects?: boolean | undefined;
     loader?: string | undefined;
+    test?: RuleSetCondition | undefined;
     exclude?: RuleSetCondition | undefined;
     include?: RuleSetCondition | undefined;
     issuer?: RuleSetCondition | undefined;
@@ -553,14 +551,14 @@ const baseRuleSetRule: z.ZodObject<{
     parser?: Record<string, any> | undefined;
     generator?: Record<string, any> | undefined;
     resolve?: t.ResolveOptions | undefined;
+    sideEffects?: boolean | undefined;
+    enforce?: "pre" | "post" | undefined;
 }, {
     layer?: string | undefined;
     options?: string | Record<string, any> | undefined;
     type?: string | undefined;
-    test?: RuleSetCondition | undefined;
-    enforce?: "pre" | "post" | undefined;
-    sideEffects?: boolean | undefined;
     loader?: string | undefined;
+    test?: RuleSetCondition | undefined;
     exclude?: RuleSetCondition | undefined;
     include?: RuleSetCondition | undefined;
     issuer?: RuleSetCondition | undefined;
@@ -589,6 +587,8 @@ const baseRuleSetRule: z.ZodObject<{
     parser?: Record<string, any> | undefined;
     generator?: Record<string, any> | undefined;
     resolve?: t.ResolveOptions | undefined;
+    sideEffects?: boolean | undefined;
+    enforce?: "pre" | "post" | undefined;
 }>;
 
 // @public
@@ -5905,382 +5905,33 @@ type ObjectEncodingOptions = {
 };
 
 // @public (undocumented)
-export type Optimization = z.infer<typeof optimization>;
+export type Optimization = {
+    moduleIds?: "named" | "natural" | "deterministic";
+    chunkIds?: "natural" | "named" | "deterministic";
+    minimize?: boolean;
+    minimizer?: Array<"..." | Plugin_2>;
+    mergeDuplicateChunks?: boolean;
+    splitChunks?: false | OptimizationSplitChunksOptions;
+    runtimeChunk?: OptimizationRuntimeChunk;
+    removeAvailableModules?: boolean;
+    removeEmptyChunks?: boolean;
+    realContentHash?: boolean;
+    sideEffects?: "flag" | boolean;
+    providedExports?: boolean;
+    concatenateModules?: boolean;
+    innerGraph?: boolean;
+    usedExports?: "global" | boolean;
+    mangleExports?: "size" | "deterministic" | boolean;
+    nodeEnv?: string | false;
+    emitOnErrors?: boolean;
+};
 
-// @public (undocumented)
-const optimization: z.ZodObject<{
-    moduleIds: z.ZodOptional<z.ZodEnum<["named", "natural", "deterministic"]>>;
-    chunkIds: z.ZodOptional<z.ZodEnum<["natural", "named", "deterministic"]>>;
-    minimize: z.ZodOptional<z.ZodBoolean>;
-    minimizer: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodLiteral<"...">, z.ZodUnion<[z.ZodType<RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction, z.ZodTypeDef, RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>]>, "many">>;
-    mergeDuplicateChunks: z.ZodOptional<z.ZodBoolean>;
-    splitChunks: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
-        chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-        defaultSizeTypes: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-        minChunks: z.ZodOptional<z.ZodNumber>;
-        usedExports: z.ZodOptional<z.ZodBoolean>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Module, z.ZodTypeDef, Module>>], z.ZodUnknown>, z.ZodUnknown>]>>;
-        minSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxAsyncSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxInitialSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxAsyncRequests: z.ZodOptional<z.ZodNumber>;
-        maxInitialRequests: z.ZodOptional<z.ZodNumber>;
-        automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-        cacheGroups: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
-            chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-            defaultSizeTypes: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-            minChunks: z.ZodOptional<z.ZodNumber>;
-            usedExports: z.ZodOptional<z.ZodBoolean>;
-            name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Module, z.ZodTypeDef, Module>>], z.ZodUnknown>, z.ZodUnknown>]>>;
-            minSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-            maxSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-            maxAsyncSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-            maxInitialSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-            maxAsyncRequests: z.ZodOptional<z.ZodNumber>;
-            maxInitialRequests: z.ZodOptional<z.ZodNumber>;
-            automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-            test: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodUnknown>]>>;
-            priority: z.ZodOptional<z.ZodNumber>;
-            enforce: z.ZodOptional<z.ZodBoolean>;
-            filename: z.ZodOptional<z.ZodString>;
-            reuseExistingChunk: z.ZodOptional<z.ZodBoolean>;
-            type: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>>;
-            idHint: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            filename?: string | undefined;
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
-            type?: string | RegExp | undefined;
-            test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            enforce?: boolean | undefined;
-            reuseExistingChunk?: boolean | undefined;
-            idHint?: string | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }, {
-            filename?: string | undefined;
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
-            type?: string | RegExp | undefined;
-            test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            enforce?: boolean | undefined;
-            reuseExistingChunk?: boolean | undefined;
-            idHint?: string | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }>]>>>;
-        fallbackCacheGroup: z.ZodOptional<z.ZodObject<{
-            chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-            minSize: z.ZodOptional<z.ZodNumber>;
-            maxSize: z.ZodOptional<z.ZodNumber>;
-            maxAsyncSize: z.ZodOptional<z.ZodNumber>;
-            maxInitialSize: z.ZodOptional<z.ZodNumber>;
-            automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            minSize?: number | undefined;
-            maxSize?: number | undefined;
-            maxAsyncSize?: number | undefined;
-            maxInitialSize?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }, {
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            minSize?: number | undefined;
-            maxSize?: number | undefined;
-            maxAsyncSize?: number | undefined;
-            maxInitialSize?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }>>;
-        hidePathInfo: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-        cacheGroups?: Record<string, false | {
-            filename?: string | undefined;
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
-            type?: string | RegExp | undefined;
-            test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            enforce?: boolean | undefined;
-            reuseExistingChunk?: boolean | undefined;
-            idHint?: string | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }> | undefined;
-        fallbackCacheGroup?: {
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            minSize?: number | undefined;
-            maxSize?: number | undefined;
-            maxAsyncSize?: number | undefined;
-            maxInitialSize?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        } | undefined;
-        hidePathInfo?: boolean | undefined;
-    }, {
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-        cacheGroups?: Record<string, false | {
-            filename?: string | undefined;
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
-            type?: string | RegExp | undefined;
-            test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            enforce?: boolean | undefined;
-            reuseExistingChunk?: boolean | undefined;
-            idHint?: string | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }> | undefined;
-        fallbackCacheGroup?: {
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            minSize?: number | undefined;
-            maxSize?: number | undefined;
-            maxAsyncSize?: number | undefined;
-            maxInitialSize?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        } | undefined;
-        hidePathInfo?: boolean | undefined;
-    }>]>>;
-    runtimeChunk: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["single", "multiple"]>, z.ZodBoolean]>, z.ZodObject<{
-        name: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-            name: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            name: string;
-        }, {
-            name: string;
-        }>], z.ZodUnknown>, z.ZodString>]>>;
-    }, "strict", z.ZodTypeAny, {
-        name?: string | ((args_0: {
-            name: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    }, {
-        name?: string | ((args_0: {
-            name: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    }>]>>;
-    removeAvailableModules: z.ZodOptional<z.ZodBoolean>;
-    removeEmptyChunks: z.ZodOptional<z.ZodBoolean>;
-    realContentHash: z.ZodOptional<z.ZodBoolean>;
-    sideEffects: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["flag"]>, z.ZodBoolean]>>;
-    providedExports: z.ZodOptional<z.ZodBoolean>;
-    concatenateModules: z.ZodOptional<z.ZodBoolean>;
-    innerGraph: z.ZodOptional<z.ZodBoolean>;
-    usedExports: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["global"]>, z.ZodBoolean]>>;
-    mangleExports: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["size", "deterministic"]>, z.ZodBoolean]>>;
-    nodeEnv: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>>;
-    emitOnErrors: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    moduleIds?: "named" | "natural" | "deterministic" | undefined;
-    chunkIds?: "named" | "natural" | "deterministic" | undefined;
-    minimize?: boolean | undefined;
-    minimizer?: (false | "" | 0 | RspackPluginInstance | "..." | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
-    mergeDuplicateChunks?: boolean | undefined;
-    usedExports?: boolean | "global" | undefined;
-    splitChunks?: false | {
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-        cacheGroups?: Record<string, false | {
-            filename?: string | undefined;
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
-            type?: string | RegExp | undefined;
-            test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            enforce?: boolean | undefined;
-            reuseExistingChunk?: boolean | undefined;
-            idHint?: string | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }> | undefined;
-        fallbackCacheGroup?: {
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            minSize?: number | undefined;
-            maxSize?: number | undefined;
-            maxAsyncSize?: number | undefined;
-            maxInitialSize?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        } | undefined;
-        hidePathInfo?: boolean | undefined;
-    } | undefined;
-    runtimeChunk?: boolean | "single" | "multiple" | {
-        name?: string | ((args_0: {
-            name: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    } | undefined;
-    removeAvailableModules?: boolean | undefined;
-    removeEmptyChunks?: boolean | undefined;
-    realContentHash?: boolean | undefined;
-    sideEffects?: boolean | "flag" | undefined;
-    providedExports?: boolean | undefined;
-    concatenateModules?: boolean | undefined;
-    innerGraph?: boolean | undefined;
-    mangleExports?: boolean | "size" | "deterministic" | undefined;
-    nodeEnv?: string | false | undefined;
-    emitOnErrors?: boolean | undefined;
-}, {
-    moduleIds?: "named" | "natural" | "deterministic" | undefined;
-    chunkIds?: "named" | "natural" | "deterministic" | undefined;
-    minimize?: boolean | undefined;
-    minimizer?: (false | "" | 0 | RspackPluginInstance | "..." | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
-    mergeDuplicateChunks?: boolean | undefined;
-    usedExports?: boolean | "global" | undefined;
-    splitChunks?: false | {
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-        cacheGroups?: Record<string, false | {
-            filename?: string | undefined;
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            priority?: number | undefined;
-            type?: string | RegExp | undefined;
-            test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-            enforce?: boolean | undefined;
-            reuseExistingChunk?: boolean | undefined;
-            idHint?: string | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        }> | undefined;
-        fallbackCacheGroup?: {
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-            minSize?: number | undefined;
-            maxSize?: number | undefined;
-            maxAsyncSize?: number | undefined;
-            maxInitialSize?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-        } | undefined;
-        hidePathInfo?: boolean | undefined;
-    } | undefined;
-    runtimeChunk?: boolean | "single" | "multiple" | {
-        name?: string | ((args_0: {
-            name: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    } | undefined;
-    removeAvailableModules?: boolean | undefined;
-    removeEmptyChunks?: boolean | undefined;
-    realContentHash?: boolean | undefined;
-    sideEffects?: boolean | "flag" | undefined;
-    providedExports?: boolean | undefined;
-    concatenateModules?: boolean | undefined;
-    innerGraph?: boolean | undefined;
-    mangleExports?: boolean | "size" | "deterministic" | undefined;
-    nodeEnv?: string | false | undefined;
-    emitOnErrors?: boolean | undefined;
-}>;
-
-// @public (undocumented)
-export type OptimizationRuntimeChunk = z.infer<typeof optimizationRuntimeChunk>;
-
-// @public (undocumented)
-const optimizationRuntimeChunk: z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["single", "multiple"]>, z.ZodBoolean]>, z.ZodObject<{
-    name: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-        name: z.ZodString;
-    }, "strict", z.ZodTypeAny, {
+// @public
+export type OptimizationRuntimeChunk = boolean | "single" | "multiple" | {
+    name?: string | ((value: {
         name: string;
-    }, {
-        name: string;
-    }>], z.ZodUnknown>, z.ZodString>]>>;
-}, "strict", z.ZodTypeAny, {
-    name?: string | ((args_0: {
-        name: string;
-    }, ...args_1: unknown[]) => string) | undefined;
-}, {
-    name?: string | ((args_0: {
-        name: string;
-    }, ...args_1: unknown[]) => string) | undefined;
-}>]>;
+    }) => string);
+};
 
 // @public (undocumented)
 export type OptimizationRuntimeChunkNormalized = false | {
@@ -6289,266 +5940,42 @@ export type OptimizationRuntimeChunkNormalized = false | {
     }) => string);
 };
 
-// @public (undocumented)
-export type OptimizationSplitChunksCacheGroup = z.infer<typeof optimizationSplitChunksCacheGroup>;
+// @public
+export type OptimizationSplitChunksCacheGroup = {
+    test?: string | RegExp | ((module: Module) => unknown);
+    priority?: number;
+    enforce?: boolean;
+    filename?: string;
+    reuseExistingChunk?: boolean;
+    type?: string | RegExp;
+    idHint?: string;
+} & SharedOptimizationSplitChunksCacheGroup;
 
 // @public (undocumented)
-const optimizationSplitChunksCacheGroup: z.ZodObject<{
-    chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-    defaultSizeTypes: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-    minChunks: z.ZodOptional<z.ZodNumber>;
-    usedExports: z.ZodOptional<z.ZodBoolean>;
-    name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Module, z.ZodTypeDef, Module>>], z.ZodUnknown>, z.ZodUnknown>]>>;
-    minSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxAsyncSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxInitialSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxAsyncRequests: z.ZodOptional<z.ZodNumber>;
-    maxInitialRequests: z.ZodOptional<z.ZodNumber>;
-    automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-    test: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodUnknown>]>>;
-    priority: z.ZodOptional<z.ZodNumber>;
-    enforce: z.ZodOptional<z.ZodBoolean>;
-    filename: z.ZodOptional<z.ZodString>;
-    reuseExistingChunk: z.ZodOptional<z.ZodBoolean>;
-    type: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>>;
-    idHint: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    filename?: string | undefined;
-    name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-    priority?: number | undefined;
-    type?: string | RegExp | undefined;
-    test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-    enforce?: boolean | undefined;
-    reuseExistingChunk?: boolean | undefined;
-    idHint?: string | undefined;
-    chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-    defaultSizeTypes?: string[] | undefined;
-    minChunks?: number | undefined;
-    usedExports?: boolean | undefined;
-    minSize?: number | Record<string, number> | undefined;
-    maxSize?: number | Record<string, number> | undefined;
-    maxAsyncSize?: number | Record<string, number> | undefined;
-    maxInitialSize?: number | Record<string, number> | undefined;
-    maxAsyncRequests?: number | undefined;
-    maxInitialRequests?: number | undefined;
-    automaticNameDelimiter?: string | undefined;
-}, {
-    filename?: string | undefined;
-    name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-    priority?: number | undefined;
-    type?: string | RegExp | undefined;
-    test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-    enforce?: boolean | undefined;
-    reuseExistingChunk?: boolean | undefined;
-    idHint?: string | undefined;
-    chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-    defaultSizeTypes?: string[] | undefined;
-    minChunks?: number | undefined;
-    usedExports?: boolean | undefined;
-    minSize?: number | Record<string, number> | undefined;
-    maxSize?: number | Record<string, number> | undefined;
-    maxAsyncSize?: number | Record<string, number> | undefined;
-    maxInitialSize?: number | Record<string, number> | undefined;
-    maxAsyncRequests?: number | undefined;
-    maxInitialRequests?: number | undefined;
-    automaticNameDelimiter?: string | undefined;
-}>;
+type OptimizationSplitChunksChunks = "initial" | "async" | "all" | RegExp | ((chunk: Chunk) => boolean);
 
 // @public (undocumented)
-export type OptimizationSplitChunksNameFunction = z.infer<typeof optimizationSplitChunksNameFunction>;
+type OptimizationSplitChunksName = string | false | OptimizationSplitChunksNameFunction;
 
 // @public (undocumented)
-const optimizationSplitChunksNameFunction: z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Module, z.ZodTypeDef, Module>>], z.ZodUnknown>, z.ZodUnknown>;
+export type OptimizationSplitChunksNameFunction = (module?: Module) => unknown;
 
-// @public (undocumented)
-export type OptimizationSplitChunksOptions = z.infer<typeof optimizationSplitChunksOptions>;
-
-// @public (undocumented)
-const optimizationSplitChunksOptions: z.ZodObject<{
-    chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-    defaultSizeTypes: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-    minChunks: z.ZodOptional<z.ZodNumber>;
-    usedExports: z.ZodOptional<z.ZodBoolean>;
-    name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Module, z.ZodTypeDef, Module>>], z.ZodUnknown>, z.ZodUnknown>]>>;
-    minSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxAsyncSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxInitialSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-    maxAsyncRequests: z.ZodOptional<z.ZodNumber>;
-    maxInitialRequests: z.ZodOptional<z.ZodNumber>;
-    automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-    cacheGroups: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
-        chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-        defaultSizeTypes: z.ZodOptional<z.ZodArray<z.ZodString, "many">>;
-        minChunks: z.ZodOptional<z.ZodNumber>;
-        usedExports: z.ZodOptional<z.ZodBoolean>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Module, z.ZodTypeDef, Module>>], z.ZodUnknown>, z.ZodUnknown>]>>;
-        minSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxAsyncSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxInitialSize: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodRecord<z.ZodString, z.ZodNumber>]>>;
-        maxAsyncRequests: z.ZodOptional<z.ZodNumber>;
-        maxInitialRequests: z.ZodOptional<z.ZodNumber>;
-        automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-        test: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodUnknown>]>>;
-        priority: z.ZodOptional<z.ZodNumber>;
-        enforce: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodString>;
-        reuseExistingChunk: z.ZodOptional<z.ZodBoolean>;
-        type: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>>;
-        idHint: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        filename?: string | undefined;
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
-        type?: string | RegExp | undefined;
-        test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        enforce?: boolean | undefined;
-        reuseExistingChunk?: boolean | undefined;
-        idHint?: string | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    }, {
-        filename?: string | undefined;
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
-        type?: string | RegExp | undefined;
-        test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        enforce?: boolean | undefined;
-        reuseExistingChunk?: boolean | undefined;
-        idHint?: string | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    }>]>>>;
-    fallbackCacheGroup: z.ZodOptional<z.ZodObject<{
-        chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
-        minSize: z.ZodOptional<z.ZodNumber>;
-        maxSize: z.ZodOptional<z.ZodNumber>;
-        maxAsyncSize: z.ZodOptional<z.ZodNumber>;
-        maxInitialSize: z.ZodOptional<z.ZodNumber>;
-        automaticNameDelimiter: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        minSize?: number | undefined;
-        maxSize?: number | undefined;
-        maxAsyncSize?: number | undefined;
-        maxInitialSize?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    }, {
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        minSize?: number | undefined;
-        maxSize?: number | undefined;
-        maxAsyncSize?: number | undefined;
-        maxInitialSize?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    }>>;
-    hidePathInfo: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-    chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-    defaultSizeTypes?: string[] | undefined;
-    minChunks?: number | undefined;
-    usedExports?: boolean | undefined;
-    minSize?: number | Record<string, number> | undefined;
-    maxSize?: number | Record<string, number> | undefined;
-    maxAsyncSize?: number | Record<string, number> | undefined;
-    maxInitialSize?: number | Record<string, number> | undefined;
-    maxAsyncRequests?: number | undefined;
-    maxInitialRequests?: number | undefined;
-    automaticNameDelimiter?: string | undefined;
-    cacheGroups?: Record<string, false | {
-        filename?: string | undefined;
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
-        type?: string | RegExp | undefined;
-        test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        enforce?: boolean | undefined;
-        reuseExistingChunk?: boolean | undefined;
-        idHint?: string | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    }> | undefined;
+// @public
+export type OptimizationSplitChunksOptions = {
+    cacheGroups?: Record<string, false | OptimizationSplitChunksCacheGroup>;
     fallbackCacheGroup?: {
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        minSize?: number | undefined;
-        maxSize?: number | undefined;
-        maxAsyncSize?: number | undefined;
-        maxInitialSize?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    } | undefined;
-    hidePathInfo?: boolean | undefined;
-}, {
-    name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-    chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-    defaultSizeTypes?: string[] | undefined;
-    minChunks?: number | undefined;
-    usedExports?: boolean | undefined;
-    minSize?: number | Record<string, number> | undefined;
-    maxSize?: number | Record<string, number> | undefined;
-    maxAsyncSize?: number | Record<string, number> | undefined;
-    maxInitialSize?: number | Record<string, number> | undefined;
-    maxAsyncRequests?: number | undefined;
-    maxInitialRequests?: number | undefined;
-    automaticNameDelimiter?: string | undefined;
-    cacheGroups?: Record<string, false | {
-        filename?: string | undefined;
-        name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-        priority?: number | undefined;
-        type?: string | RegExp | undefined;
-        test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
-        enforce?: boolean | undefined;
-        reuseExistingChunk?: boolean | undefined;
-        idHint?: string | undefined;
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        defaultSizeTypes?: string[] | undefined;
-        minChunks?: number | undefined;
-        usedExports?: boolean | undefined;
-        minSize?: number | Record<string, number> | undefined;
-        maxSize?: number | Record<string, number> | undefined;
-        maxAsyncSize?: number | Record<string, number> | undefined;
-        maxInitialSize?: number | Record<string, number> | undefined;
-        maxAsyncRequests?: number | undefined;
-        maxInitialRequests?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    }> | undefined;
-    fallbackCacheGroup?: {
-        chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-        minSize?: number | undefined;
-        maxSize?: number | undefined;
-        maxAsyncSize?: number | undefined;
-        maxInitialSize?: number | undefined;
-        automaticNameDelimiter?: string | undefined;
-    } | undefined;
-    hidePathInfo?: boolean | undefined;
-}>;
+        chunks?: OptimizationSplitChunksChunks;
+        minSize?: number;
+        maxSize?: number;
+        maxAsyncSize?: number;
+        maxInitialSize?: number;
+        automaticNameDelimiter?: string;
+    };
+    hidePathInfo?: boolean;
+} & SharedOptimizationSplitChunksCacheGroup;
+
+// @public (undocumented)
+type OptimizationSplitChunksSizes = number | Record<string, number>;
 
 // @public (undocumented)
 interface Optimize {
@@ -8102,6 +7529,10 @@ const performance_2: z.ZodUnion<[z.ZodObject<{
 type PitchLoaderDefinitionFunction<OptionsType = {}, ContextAdditions = {}> = (this: LoaderContext<OptionsType> & ContextAdditions, remainingRequest: string, previousRequest: string, data: object) => string | void | Buffer | Promise<string | Buffer>;
 
 // @public (undocumented)
+type Plugin_2 = RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | Falsy;
+export { Plugin_2 as Plugin }
+
+// @public (undocumented)
 type PluginImportConfig = {
     libraryName: string;
     libraryDirectory?: string;
@@ -8122,7 +7553,10 @@ type PluginImportOptions = PluginImportConfig[] | undefined;
 export type Plugins = z.infer<typeof plugins>;
 
 // @public (undocumented)
-const plugins: z.ZodArray<z.ZodUnion<[z.ZodType<RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction, z.ZodTypeDef, RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">;
+const plugins: z.ZodArray<z.ZodUnion<[z.ZodType<t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction, z.ZodTypeDef, t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">;
+
+// @public (undocumented)
+type Plugins_2 = Plugin_2[];
 
 // @public (undocumented)
 type PrintedElement = {
@@ -8800,17 +8234,7 @@ declare namespace rspackExports {
         CacheOptions,
         StatsOptions,
         StatsValue,
-        RspackPluginInstance,
-        RspackPluginFunction,
-        WebpackCompiler,
-        WebpackPluginInstance,
-        WebpackPluginFunction,
         Plugins,
-        OptimizationRuntimeChunk,
-        OptimizationSplitChunksNameFunction,
-        OptimizationSplitChunksCacheGroup,
-        OptimizationSplitChunksOptions,
-        Optimization,
         RspackFutureOptions,
         LazyCompilationOptions,
         Incremental,
@@ -8870,7 +8294,18 @@ declare namespace rspackExports {
         ExternalItemObjectUnknown,
         ExternalItemFunctionData,
         ExternalItem,
-        Externals
+        Externals,
+        RspackPluginInstance,
+        RspackPluginFunction,
+        WebpackCompiler,
+        WebpackPluginInstance,
+        WebpackPluginFunction,
+        Plugin_2 as Plugin,
+        OptimizationRuntimeChunk,
+        OptimizationSplitChunksNameFunction,
+        OptimizationSplitChunksCacheGroup,
+        OptimizationSplitChunksOptions,
+        Optimization
     }
 }
 
@@ -10220,11 +9655,9 @@ export const rspackOptions: z.ZodObject<{
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
         all?: boolean | undefined;
-        chunks?: boolean | undefined;
-        usedExports?: boolean | undefined;
-        providedExports?: boolean | undefined;
         preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
+        chunks?: boolean | undefined;
         modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
@@ -10249,6 +9682,8 @@ export const rspackOptions: z.ZodObject<{
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
+        usedExports?: boolean | undefined;
+        providedExports?: boolean | undefined;
         optimizationBailout?: boolean | undefined;
         groupModulesByType?: boolean | undefined;
         groupModulesByCacheStatus?: boolean | undefined;
@@ -10297,11 +9732,9 @@ export const rspackOptions: z.ZodObject<{
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
         all?: boolean | undefined;
-        chunks?: boolean | undefined;
-        usedExports?: boolean | undefined;
-        providedExports?: boolean | undefined;
         preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
+        chunks?: boolean | undefined;
         modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
@@ -10326,6 +9759,8 @@ export const rspackOptions: z.ZodObject<{
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
+        usedExports?: boolean | undefined;
+        providedExports?: boolean | undefined;
         optimizationBailout?: boolean | undefined;
         groupModulesByType?: boolean | undefined;
         groupModulesByCacheStatus?: boolean | undefined;
@@ -10376,7 +9811,7 @@ export const rspackOptions: z.ZodObject<{
         moduleIds: z.ZodOptional<z.ZodEnum<["named", "natural", "deterministic"]>>;
         chunkIds: z.ZodOptional<z.ZodEnum<["natural", "named", "deterministic"]>>;
         minimize: z.ZodOptional<z.ZodBoolean>;
-        minimizer: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodLiteral<"...">, z.ZodUnion<[z.ZodType<RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction, z.ZodTypeDef, RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>]>, "many">>;
+        minimizer: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodLiteral<"...">, z.ZodUnion<[z.ZodType<t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction, z.ZodTypeDef, t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>]>, "many">>;
         mergeDuplicateChunks: z.ZodOptional<z.ZodBoolean>;
         splitChunks: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
             chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
@@ -10416,16 +9851,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -10436,16 +9871,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -10460,16 +9895,16 @@ export const rspackOptions: z.ZodObject<{
                 maxInitialSize: z.ZodOptional<z.ZodNumber>;
                 automaticNameDelimiter: z.ZodOptional<z.ZodString>;
             }, "strict", z.ZodTypeAny, {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             }, {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
@@ -10477,12 +9912,12 @@ export const rspackOptions: z.ZodObject<{
             hidePathInfo: z.ZodOptional<z.ZodBoolean>;
         }, "strict", z.ZodTypeAny, {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
             minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
             minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             maxAsyncSize?: number | Record<string, number> | undefined;
             maxInitialSize?: number | Record<string, number> | undefined;
             maxAsyncRequests?: number | undefined;
@@ -10493,16 +9928,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -10510,9 +9945,9 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
@@ -10520,12 +9955,12 @@ export const rspackOptions: z.ZodObject<{
             hidePathInfo?: boolean | undefined;
         }, {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
             minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
             minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             maxAsyncSize?: number | Record<string, number> | undefined;
             maxInitialSize?: number | Record<string, number> | undefined;
             maxAsyncRequests?: number | undefined;
@@ -10536,16 +9971,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -10553,9 +9988,9 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
@@ -10591,20 +10026,14 @@ export const rspackOptions: z.ZodObject<{
         nodeEnv: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodLiteral<false>]>>;
         emitOnErrors: z.ZodOptional<z.ZodBoolean>;
     }, "strict", z.ZodTypeAny, {
-        moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | undefined;
-        minimize?: boolean | undefined;
-        minimizer?: (false | "" | 0 | RspackPluginInstance | "..." | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
-        mergeDuplicateChunks?: boolean | undefined;
-        usedExports?: boolean | "global" | undefined;
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
             minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
             minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             maxAsyncSize?: number | Record<string, number> | undefined;
             maxInitialSize?: number | Record<string, number> | undefined;
             maxAsyncRequests?: number | undefined;
@@ -10615,16 +10044,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -10632,15 +10061,23 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
         } | undefined;
+        usedExports?: boolean | "global" | undefined;
+        providedExports?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
+        moduleIds?: "named" | "natural" | "deterministic" | undefined;
+        chunkIds?: "named" | "natural" | "deterministic" | undefined;
+        minimize?: boolean | undefined;
+        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+        mergeDuplicateChunks?: boolean | undefined;
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
@@ -10649,28 +10086,20 @@ export const rspackOptions: z.ZodObject<{
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
         realContentHash?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
-        providedExports?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "size" | "deterministic" | undefined;
         nodeEnv?: string | false | undefined;
         emitOnErrors?: boolean | undefined;
     }, {
-        moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | undefined;
-        minimize?: boolean | undefined;
-        minimizer?: (false | "" | 0 | RspackPluginInstance | "..." | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
-        mergeDuplicateChunks?: boolean | undefined;
-        usedExports?: boolean | "global" | undefined;
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
             minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
             minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             maxAsyncSize?: number | Record<string, number> | undefined;
             maxInitialSize?: number | Record<string, number> | undefined;
             maxAsyncRequests?: number | undefined;
@@ -10681,16 +10110,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -10698,15 +10127,23 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
         } | undefined;
+        usedExports?: boolean | "global" | undefined;
+        providedExports?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
+        moduleIds?: "named" | "natural" | "deterministic" | undefined;
+        chunkIds?: "named" | "natural" | "deterministic" | undefined;
+        minimize?: boolean | undefined;
+        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+        mergeDuplicateChunks?: boolean | undefined;
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
@@ -10715,8 +10152,6 @@ export const rspackOptions: z.ZodObject<{
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
         realContentHash?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
-        providedExports?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "size" | "deterministic" | undefined;
@@ -10725,7 +10160,7 @@ export const rspackOptions: z.ZodObject<{
     }>>;
     resolve: z.ZodOptional<z.ZodType<t.ResolveOptions, z.ZodTypeDef, t.ResolveOptions>>;
     resolveLoader: z.ZodOptional<z.ZodType<t.ResolveOptions, z.ZodTypeDef, t.ResolveOptions>>;
-    plugins: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodType<RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction, z.ZodTypeDef, RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
+    plugins: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodType<t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction, z.ZodTypeDef, t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
     devServer: z.ZodOptional<z.ZodType<DevServer, z.ZodTypeDef, DevServer>>;
     module: z.ZodOptional<z.ZodObject<{
         defaultRules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<RuleSetRule, z.ZodTypeDef, RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
@@ -12179,11 +11614,9 @@ export const rspackOptions: z.ZodObject<{
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
         all?: boolean | undefined;
-        chunks?: boolean | undefined;
-        usedExports?: boolean | undefined;
-        providedExports?: boolean | undefined;
         preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
+        chunks?: boolean | undefined;
         modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
@@ -12208,6 +11641,8 @@ export const rspackOptions: z.ZodObject<{
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
+        usedExports?: boolean | undefined;
+        providedExports?: boolean | undefined;
         optimizationBailout?: boolean | undefined;
         groupModulesByType?: boolean | undefined;
         groupModulesByCacheStatus?: boolean | undefined;
@@ -12255,20 +11690,14 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     snapshot?: {} | undefined;
     optimization?: {
-        moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | undefined;
-        minimize?: boolean | undefined;
-        minimizer?: (false | "" | 0 | RspackPluginInstance | "..." | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
-        mergeDuplicateChunks?: boolean | undefined;
-        usedExports?: boolean | "global" | undefined;
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
             minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
             minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             maxAsyncSize?: number | Record<string, number> | undefined;
             maxInitialSize?: number | Record<string, number> | undefined;
             maxAsyncRequests?: number | undefined;
@@ -12279,16 +11708,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -12296,15 +11725,23 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
         } | undefined;
+        usedExports?: boolean | "global" | undefined;
+        providedExports?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
+        moduleIds?: "named" | "natural" | "deterministic" | undefined;
+        chunkIds?: "named" | "natural" | "deterministic" | undefined;
+        minimize?: boolean | undefined;
+        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+        mergeDuplicateChunks?: boolean | undefined;
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
@@ -12313,8 +11750,6 @@ export const rspackOptions: z.ZodObject<{
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
         realContentHash?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
-        providedExports?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "size" | "deterministic" | undefined;
@@ -12322,7 +11757,7 @@ export const rspackOptions: z.ZodObject<{
         emitOnErrors?: boolean | undefined;
     } | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
-    plugins?: (false | "" | 0 | RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
+    plugins?: (false | "" | 0 | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
     devServer?: DevServer | undefined;
     bail?: boolean | undefined;
 }, {
@@ -12777,11 +12212,9 @@ export const rspackOptions: z.ZodObject<{
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
         all?: boolean | undefined;
-        chunks?: boolean | undefined;
-        usedExports?: boolean | undefined;
-        providedExports?: boolean | undefined;
         preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
         assets?: boolean | undefined;
+        chunks?: boolean | undefined;
         modules?: boolean | undefined;
         entrypoints?: boolean | "auto" | undefined;
         chunkGroups?: boolean | undefined;
@@ -12806,6 +12239,8 @@ export const rspackOptions: z.ZodObject<{
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
+        usedExports?: boolean | undefined;
+        providedExports?: boolean | undefined;
         optimizationBailout?: boolean | undefined;
         groupModulesByType?: boolean | undefined;
         groupModulesByCacheStatus?: boolean | undefined;
@@ -12853,20 +12288,14 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     snapshot?: {} | undefined;
     optimization?: {
-        moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | undefined;
-        minimize?: boolean | undefined;
-        minimizer?: (false | "" | 0 | RspackPluginInstance | "..." | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
-        mergeDuplicateChunks?: boolean | undefined;
-        usedExports?: boolean | "global" | undefined;
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
             minChunks?: number | undefined;
-            usedExports?: boolean | undefined;
             minSize?: number | Record<string, number> | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             maxAsyncSize?: number | Record<string, number> | undefined;
             maxInitialSize?: number | Record<string, number> | undefined;
             maxAsyncRequests?: number | undefined;
@@ -12877,16 +12306,16 @@ export const rspackOptions: z.ZodObject<{
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
                 type?: string | RegExp | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
                 idHint?: string | undefined;
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 defaultSizeTypes?: string[] | undefined;
                 minChunks?: number | undefined;
-                usedExports?: boolean | undefined;
                 minSize?: number | Record<string, number> | undefined;
-                maxSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
                 maxInitialSize?: number | Record<string, number> | undefined;
                 maxAsyncRequests?: number | undefined;
@@ -12894,15 +12323,23 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "initial" | "all" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
-                minSize?: number | undefined;
+                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
+                minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
         } | undefined;
+        usedExports?: boolean | "global" | undefined;
+        providedExports?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
+        moduleIds?: "named" | "natural" | "deterministic" | undefined;
+        chunkIds?: "named" | "natural" | "deterministic" | undefined;
+        minimize?: boolean | undefined;
+        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+        mergeDuplicateChunks?: boolean | undefined;
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
@@ -12911,8 +12348,6 @@ export const rspackOptions: z.ZodObject<{
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
         realContentHash?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
-        providedExports?: boolean | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "size" | "deterministic" | undefined;
@@ -12920,7 +12355,7 @@ export const rspackOptions: z.ZodObject<{
         emitOnErrors?: boolean | undefined;
     } | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
-    plugins?: (false | "" | 0 | RspackPluginInstance | RspackPluginFunction | WebpackPluginInstance | WebpackPluginFunction | null | undefined)[] | undefined;
+    plugins?: (false | "" | 0 | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
     devServer?: DevServer | undefined;
     bail?: boolean | undefined;
 }>;
@@ -13313,6 +12748,22 @@ export type SharedObject = {
 };
 
 // @public (undocumented)
+type SharedOptimizationSplitChunksCacheGroup = {
+    chunks?: OptimizationSplitChunksChunks;
+    defaultSizeTypes?: string[];
+    minChunks?: number;
+    usedExports?: boolean;
+    name?: false | OptimizationSplitChunksName;
+    minSize?: OptimizationSplitChunksSizes;
+    maxSize?: OptimizationSplitChunksSizes;
+    maxAsyncSize?: OptimizationSplitChunksSizes;
+    maxInitialSize?: OptimizationSplitChunksSizes;
+    maxAsyncRequests?: number;
+    maxInitialRequests?: number;
+    automaticNameDelimiter?: string;
+};
+
+// @public (undocumented)
 class SharePlugin {
     constructor(options: SharePluginOptions);
     // (undocumented)
@@ -13639,11 +13090,9 @@ const statsOptions: z.ZodObject<{
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
     all?: boolean | undefined;
-    chunks?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
     preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
+    chunks?: boolean | undefined;
     modules?: boolean | undefined;
     entrypoints?: boolean | "auto" | undefined;
     chunkGroups?: boolean | undefined;
@@ -13668,6 +13117,8 @@ const statsOptions: z.ZodObject<{
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
+    usedExports?: boolean | undefined;
+    providedExports?: boolean | undefined;
     optimizationBailout?: boolean | undefined;
     groupModulesByType?: boolean | undefined;
     groupModulesByCacheStatus?: boolean | undefined;
@@ -13716,11 +13167,9 @@ const statsOptions: z.ZodObject<{
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
     all?: boolean | undefined;
-    chunks?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
     preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
+    chunks?: boolean | undefined;
     modules?: boolean | undefined;
     entrypoints?: boolean | "auto" | undefined;
     chunkGroups?: boolean | undefined;
@@ -13745,6 +13194,8 @@ const statsOptions: z.ZodObject<{
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
+    usedExports?: boolean | undefined;
+    providedExports?: boolean | undefined;
     optimizationBailout?: boolean | undefined;
     groupModulesByType?: boolean | undefined;
     groupModulesByCacheStatus?: boolean | undefined;
@@ -13906,11 +13357,9 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
     all?: boolean | undefined;
-    chunks?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
     preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
+    chunks?: boolean | undefined;
     modules?: boolean | undefined;
     entrypoints?: boolean | "auto" | undefined;
     chunkGroups?: boolean | undefined;
@@ -13935,6 +13384,8 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
+    usedExports?: boolean | undefined;
+    providedExports?: boolean | undefined;
     optimizationBailout?: boolean | undefined;
     groupModulesByType?: boolean | undefined;
     groupModulesByCacheStatus?: boolean | undefined;
@@ -13983,11 +13434,9 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     source?: boolean | undefined;
     publicPath?: boolean | undefined;
     all?: boolean | undefined;
-    chunks?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
     preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
     assets?: boolean | undefined;
+    chunks?: boolean | undefined;
     modules?: boolean | undefined;
     entrypoints?: boolean | "auto" | undefined;
     chunkGroups?: boolean | undefined;
@@ -14012,6 +13461,8 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
+    usedExports?: boolean | undefined;
+    providedExports?: boolean | undefined;
     optimizationBailout?: boolean | undefined;
     groupModulesByType?: boolean | undefined;
     groupModulesByCacheStatus?: boolean | undefined;
@@ -14299,7 +13750,19 @@ declare namespace t {
         ExternalItemObjectUnknown,
         ExternalItemFunctionData,
         ExternalItem,
-        Externals
+        Externals,
+        RspackPluginInstance,
+        RspackPluginFunction,
+        WebpackCompiler,
+        WebpackPluginInstance,
+        WebpackPluginFunction,
+        Plugin_2 as Plugin,
+        Plugins_2 as Plugins,
+        OptimizationRuntimeChunk,
+        OptimizationSplitChunksNameFunction,
+        OptimizationSplitChunksCacheGroup,
+        OptimizationSplitChunksOptions,
+        Optimization
     }
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -530,7 +530,7 @@ type SharedOptimizationSplitChunksCacheGroup = {
 	 * */
 	chunks?: OptimizationSplitChunksChunks;
 
-	// TODO: add JSDoc
+	/** Sets the size types which are used when a number is used for sizes. */
 	defaultSizeTypes?: string[];
 
 	/**
@@ -613,7 +613,7 @@ export type OptimizationSplitChunksCacheGroup = {
 	 * */
 	reuseExistingChunk?: boolean;
 
-	// TODO: add JSDoc
+	/** Allows to assign modules to a cache group by module type. */
 	type?: string | RegExp;
 
 	/** Sets the hint for chunk id. It will be added to chunk's filename. */
@@ -622,9 +622,14 @@ export type OptimizationSplitChunksCacheGroup = {
 
 /** Tell Rspack how to splitting chunks. */
 export type OptimizationSplitChunksOptions = {
+	/**
+	 * Options for module cache group
+	 * */
 	cacheGroups?: Record<string, false | OptimizationSplitChunksCacheGroup>;
 
-	// TODO: add JSDoc
+	/**
+	 * Options for modules not selected by any other group.
+	 */
 	fallbackCacheGroup?: {
 		chunks?: OptimizationSplitChunksChunks;
 		minSize?: number;
@@ -634,7 +639,12 @@ export type OptimizationSplitChunksOptions = {
 		automaticNameDelimiter?: string;
 	};
 
-	// TODO: add JSDoc
+	/**
+	 * Prevents exposing path info when creating names for parts splitted by maxSize.
+	 *
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
+	 * */
 	hidePathInfo?: boolean;
 } & SharedOptimizationSplitChunksCacheGroup;
 
@@ -651,8 +661,8 @@ export type Optimization = {
 
 	/**
 	 * Whether to minimize the bundle.
-	 * The value is `true` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
 	 */
 	minimize?: boolean;
 
@@ -696,16 +706,16 @@ export type Optimization = {
 	/**
 	 * Adds an additional hash compilation pass after the assets have been processed to get the correct asset content hashes.
 	 *
-	 * The value is `true` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
 	 */
 	realContentHash?: boolean;
 
 	/**
 	 * Tells Rspack to recognise the sideEffects flag in package.json or rules to skip over modules which are flagged to contain no side effects when exports are not used.
 	 *
-	 * The value is `true` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
 	 * */
 	sideEffects?: "flag" | boolean;
 
@@ -718,32 +728,32 @@ export type Optimization = {
 	/**
 	 * Tells Rspack to find segments of the module graph which can be safely concatenated into a single module.
 	 *
-	 * The value is `true` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
 	 */
 	concatenateModules?: boolean;
 
 	/**
 	 * Tells Rspack whether to perform a more detailed analysis of variable assignments.
 	 *
-	 * The value is `true` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
 	 */
 	innerGraph?: boolean;
 
 	/**
 	 * Tells Rspack to determine used exports for each module.
 	 *
-	 * The value is `true` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
 	 * */
 	usedExports?: "global" | boolean;
 
 	/**
 	 * Allows to control export mangling.
 	 *
-	 * The value is `isdeterministic` when production mode.
-	 * The value is `false` when development mode.
+	 * The value is `isdeterministic` in production mode.
+	 * The value is `false` in development mode.
 	 */
 	mangleExports?: "size" | "deterministic" | boolean;
 
@@ -756,8 +766,8 @@ export type Optimization = {
 	/**
 	 * Emit assets whenever there are errors while compiling.
 	 *
-	 * The value is `false` when production mode.
-	 * The value is `true` when development mode.
+	 * The value is `false` in production mode.
+	 * The value is `true` in development mode.
 	 * */
 	emitOnErrors?: boolean;
 };

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1167,8 +1167,8 @@ const plugin = z.union([
 	>(),
 	falsy
 ]) satisfies z.ZodType<t.Plugin>;
+
 const plugins = plugin.array() satisfies z.ZodType<t.Plugins>;
-export type Plugins = z.infer<typeof plugins>;
 //#endregion
 
 //#region Optimization

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -2,10 +2,8 @@ import nodePath from "node:path";
 import type { JsAssetInfo, RawFuncUseCtx } from "@rspack/binding";
 import type * as webpackDevServer from "webpack-dev-server";
 import { z } from "zod";
-
-import type { Compilation, Compiler } from "..";
 import { Chunk } from "../Chunk";
-import type { PathData } from "../Compilation";
+import type { Compilation, PathData } from "../Compilation";
 import { Module } from "../Module";
 import type * as t from "./types";
 
@@ -53,6 +51,7 @@ const falsy = z.union([
 	z.null(),
 	z.undefined()
 ]) satisfies z.ZodType<t.Falsy>;
+
 //#endregion
 
 //#region Entry
@@ -1159,36 +1158,16 @@ export type StatsValue = z.infer<typeof statsValue>;
 //#endregion
 
 //#region Plugins
-export interface RspackPluginInstance {
-	apply: (compiler: Compiler) => void;
-	[k: string]: any;
-}
-export type RspackPluginFunction = (this: Compiler, compiler: Compiler) => void;
-
-// The Compiler type of webpack is not exactly the same as Rspack.
-// It is allowed to use webpack plugins in in the Rspack config,
-// so we have defined a loose type here to adapt to webpack plugins.
-export type WebpackCompiler = any;
-
-export interface WebpackPluginInstance {
-	apply: (compiler: WebpackCompiler) => void;
-	[k: string]: any;
-}
-export type WebpackPluginFunction = (
-	this: WebpackCompiler,
-	compiler: WebpackCompiler
-) => void;
-
 const plugin = z.union([
 	z.custom<
-		| RspackPluginInstance
-		| RspackPluginFunction
-		| WebpackPluginInstance
-		| WebpackPluginFunction
+		| t.RspackPluginInstance
+		| t.RspackPluginFunction
+		| t.WebpackPluginInstance
+		| t.WebpackPluginFunction
 	>(),
 	falsy
-]);
-const plugins = plugin.array();
+]) satisfies z.ZodType<t.Plugin>;
+const plugins = plugin.array() satisfies z.ZodType<t.Plugins>;
 export type Plugins = z.infer<typeof plugins>;
 //#endregion
 
@@ -1208,18 +1187,13 @@ const optimizationRuntimeChunk = z
 				)
 				.optional()
 		})
-	);
-export type OptimizationRuntimeChunk = z.infer<typeof optimizationRuntimeChunk>;
+	) satisfies z.ZodType<t.OptimizationRuntimeChunk>;
 
 const optimizationSplitChunksNameFunction = z.function().args(
 	z.instanceof(Module).optional()
 	// FIXME: z.array(z.instanceof(Chunk)).optional(), z.string()
 	// FIXME: Chunk[],   															cacheChunkKey
-);
-
-export type OptimizationSplitChunksNameFunction = z.infer<
-	typeof optimizationSplitChunksNameFunction
->;
+) satisfies z.ZodType<t.OptimizationSplitChunksNameFunction>;
 
 const optimizationSplitChunksName = z
 	.string()
@@ -1267,10 +1241,7 @@ const optimizationSplitChunksCacheGroup = z.strictObject({
 	type: z.string().or(z.instanceof(RegExp)).optional(),
 	idHint: z.string().optional(),
 	...sharedOptimizationSplitChunksCacheGroup
-});
-export type OptimizationSplitChunksCacheGroup = z.infer<
-	typeof optimizationSplitChunksCacheGroup
->;
+}) satisfies z.ZodType<t.OptimizationSplitChunksCacheGroup>;
 
 const optimizationSplitChunksOptions = z.strictObject({
 	cacheGroups: z
@@ -1288,10 +1259,7 @@ const optimizationSplitChunksOptions = z.strictObject({
 		.optional(),
 	hidePathInfo: z.boolean().optional(),
 	...sharedOptimizationSplitChunksCacheGroup
-});
-export type OptimizationSplitChunksOptions = z.infer<
-	typeof optimizationSplitChunksOptions
->;
+}) satisfies z.ZodType<t.OptimizationSplitChunksOptions>;
 
 const optimization = z.strictObject({
 	moduleIds: z.enum(["named", "natural", "deterministic"]).optional(),
@@ -1312,8 +1280,7 @@ const optimization = z.strictObject({
 	mangleExports: z.enum(["size", "deterministic"]).or(z.boolean()).optional(),
 	nodeEnv: z.union([z.string(), z.literal(false)]).optional(),
 	emitOnErrors: z.boolean().optional()
-});
-export type Optimization = z.infer<typeof optimization>;
+}) satisfies z.ZodType<t.Optimization>;
 //#endregion
 
 //#region Experiments

--- a/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/en/plugins/webpack/split-chunks-plugin.mdx
@@ -273,6 +273,12 @@ chunk baz
       chunk shared-2 (exports only value2)
 ```
 
+### splitChunks.defaultSizeTypes
+
+- **Types:** `string[]`
+
+Sets the size types which are used when a number is used for sizes.
+
 ### splitChunks.cacheGroups
 
 Cache groups can inherit and/or override any options from `splitChunks.*`; but `test`, `priority` and `reuseExistingChunk` can only be configured on cache group level. To disable any of the default cache groups, set them to `false`.
@@ -358,3 +364,9 @@ cacheGroup: {
 In chunks Foo and Bar, the module B, due to the configuration of cacheGroup, will be split into a new chunk that only contains module B. This new chunk is identical in terms of the modules it contains with chunk Bar, so chunk Bar can be directly reused.
 
 If the setting of reuseExistingChunk is set to `false`, then the module B in chunks Bar and Foo will be moved to a new chunk, and chunk Bar, since it no longer contains any modules, will be deleted as an empty chunk.
+
+#### splitChunks.cacheGroups.\{cacheGroup\}.type
+
+- **Types:** `string | RegExp`
+
+Allows to assign modules to a cache group by module type.

--- a/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
@@ -263,6 +263,12 @@ chunk baz
       chunk shared-2 (exports only value2)
 ```
 
+### splitChunks.defaultSizeTypes
+
+- **类型:** `string[]`
+
+用来控制在计算文件大小时应该使用哪些大小类型
+
 ### splitChunks.cacheGroups
 
 缓存组可以继承和/或覆盖来自 `splitChunks.*` 的任何选项。但是 `test`、`priority` 和 `reuseExistingChunk` 只能在缓存组级别上进行配置。将它们设置为 `false` 以禁用任何默认缓存组。
@@ -348,3 +354,9 @@ cacheGroup: {
 由于 cacheGroup 的配置，在 chunk Foo 和 chunk Bar 中的 module B 会被拆分到一个新的 chunk 中，该 chunk 只包含 module B，这个新 chunk 和 chunk Bar 包含的 module 完全一样，因此可以直接复用 chunk Bar。
 
 如果设置 reuseExistingChunk 为 `false`，那么 chunk Bar 和 chunk Foo 中的 module B 会被移到新 chunk 中，chunk Bar 由于不包含任何 module，会作为空 chunk 被删除。
+
+#### splitChunks.cacheGroups.\{cacheGroup\}.type
+
+- **Types:** `string | RegExp`
+
+允许模块根据模块类型分配给 cache group


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.optimization

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
