### PR TITLE
test: disable unstable test case of rspack-cli

### DIFF
--- a/packages/rspack-cli/tests/build/issue-6359/index.test.ts
+++ b/packages/rspack-cli/tests/build/issue-6359/index.test.ts
@@ -8,7 +8,8 @@ it("should not have `process.env.WEBPACK_SERVE` set on build mode", async () => 
 	expect(mainJs).toContain("WEBPACK_SERVE=<EMPTY>");
 });
 
-it("should have `process.env.WEBPACK_SERVE` set on serve mode", async () => {
+// TODO: this test is not stable on CI, need to fix it
+it.skip("should have `process.env.WEBPACK_SERVE` set on serve mode", async () => {
 	await runWatch(__dirname, ["serve"], { killString: /rspack compiled/i });
 	// wait 1s to make sure the assets have been generated
 	await new Promise(resolve => setTimeout(resolve, 1000));


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

This test case is not stable on CI. Disable it now and will delve into it in the future

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
