### PR TITLE
refactor: remove connection id

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -515,7 +515,7 @@ impl ChunkGraph {
       ) {
         for connection in module_graph.get_outgoing_connections(&module) {
           // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/ChunkGraph.js#L290
-          let active_state = connection.get_active_state(module_graph, None);
+          let active_state = connection.active_state(module_graph, None);
           match active_state {
             crate::ConnectionState::Bool(false) => {
               continue;

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -192,7 +192,7 @@ impl ChunkGraph {
         if visited_modules.contains(module_identifier) {
           continue;
         }
-        if connection.get_active_state(&mg, runtime).is_false() {
+        if connection.active_state(&mg, runtime).is_false() {
           continue;
         }
         visited_modules.insert(*module_identifier);

--- a/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/fix_issuers.rs
@@ -20,7 +20,7 @@ impl FixIssuers {
       .expect("should have module graph module");
     self
       .origin_module_issuers
-      .insert(*module_identifier, mgm.get_issuer().clone());
+      .insert(*module_identifier, mgm.issuer().clone());
   }
 
   pub fn fix_artifact(self, artifact: &mut MakeArtifact) {

--- a/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/has_module_graph_change.rs
@@ -28,7 +28,7 @@ impl ModuleDeps {
         .dependency_by_id(dep_id)
         .expect("should have dependency");
 
-      let Some(conn) = module_graph.connection_by_dependency(dep_id) else {
+      let Some(conn) = module_graph.connection_by_dependency_id(dep_id) else {
         continue;
       };
       let identifier = conn.module_identifier();

--- a/crates/rspack_core/src/compiler/make/cutout/mod.rs
+++ b/crates/rspack_core/src/compiler/make/cutout/mod.rs
@@ -132,12 +132,11 @@ impl Cutout {
     let mut module_graph = artifact.get_module_graph_mut();
     for dep_id in remove_entry_deps {
       // connection may have been deleted by revoke module
-      if let Some(con) = module_graph.connection_by_dependency(&dep_id) {
+      if let Some(con) = module_graph.connection_by_dependency_id(&dep_id) {
         self
           .clean_isolated_module
           .add_need_check_module(*con.module_identifier());
-        let con_id = con.id;
-        module_graph.revoke_connection(&con_id, true);
+        module_graph.revoke_connection(&dep_id, true);
       }
       force_build_deps.remove(&(dep_id, None));
     }

--- a/crates/rspack_core/src/compiler/make/repair/add.rs
+++ b/crates/rspack_core/src/compiler/make/repair/add.rs
@@ -29,7 +29,7 @@ impl Task<MakeTaskContext> for AddTask {
     if self.module.as_self_module().is_some() {
       let issuer = self
         .module_graph_module
-        .get_issuer()
+        .issuer()
         .identifier()
         .expect("self module should have issuer");
 

--- a/crates/rspack_core/src/compiler/module_executor/ctrl.rs
+++ b/crates/rspack_core/src/compiler/module_executor/ctrl.rs
@@ -259,9 +259,9 @@ impl Task<MakeTaskContext> for FinishModuleTask {
         .expect("should have mgm");
 
       let mut original_module_identifiers = HashSet::default();
-      for connection_id in mgm.incoming_connections() {
+      for dep_id in mgm.incoming_connections() {
         let connection = module_graph
-          .connection_by_connection_id(connection_id)
+          .connection_by_dependency_id(dep_id)
           .expect("should have connection");
         if let Some(original_module_identifier) = &connection.original_module_identifier {
           // skip self reference

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -39,13 +39,12 @@ use crate::{
   subtract_runtime_condition, to_identifier, AsyncDependenciesBlockIdentifier, BoxDependency,
   BuildContext, BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, BuildResult,
   ChunkInitFragments, CodeGenerationDataTopLevelDeclarations, CodeGenerationExportsFinalNames,
-  CodeGenerationResult, Compilation, ConcatenatedModuleIdent, ConcatenationScope, ConnectionId,
-  ConnectionState, Context, DependenciesBlock, DependencyId, DependencyTemplate, DependencyType,
-  ErrorSpan, ExportInfo, ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta,
-  IdentCollector, LibIdentOptions, Module, ModuleDependency, ModuleGraph, ModuleGraphConnection,
-  ModuleIdentifier, ModuleLayer, ModuleType, Resolve, RuntimeCondition, RuntimeGlobals,
-  RuntimeSpec, SourceType, SpanExt, Template, UsageState, UsedName, DEFAULT_EXPORT,
-  NAMESPACE_OBJECT_EXPORT,
+  CodeGenerationResult, Compilation, ConcatenatedModuleIdent, ConcatenationScope, ConnectionState,
+  Context, DependenciesBlock, DependencyId, DependencyTemplate, DependencyType, ErrorSpan,
+  ExportInfo, ExportInfoProvided, ExportsArgument, ExportsType, FactoryMeta, IdentCollector,
+  LibIdentOptions, Module, ModuleDependency, ModuleGraph, ModuleGraphConnection, ModuleIdentifier,
+  ModuleLayer, ModuleType, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec, SourceType,
+  SpanExt, Template, UsageState, UsedName, DEFAULT_EXPORT, NAMESPACE_OBJECT_EXPORT,
 };
 
 type ExportsDefinitionArgs = Vec<(String, String)>;
@@ -140,14 +139,14 @@ struct ConcatenationEntryConcatenated {
 
 #[derive(Debug)]
 struct ConcatenationEntryExternal {
-  connection: ConnectionId,
+  dependency: DependencyId,
   runtime_condition: RuntimeCondition,
 }
 
 impl ConcatenationEntryExternal {
   pub fn module(&self, mg: &ModuleGraph) -> ModuleIdentifier {
     let con = mg
-      .connection_by_connection_id(&self.connection)
+      .connection_by_dependency_id(&self.dependency)
       .expect("should have connection");
     *con.module_identifier()
   }
@@ -1580,11 +1579,8 @@ impl ConcatenatedModule {
           merge_runtime_condition(&last.runtime_condition, &runtime_condition, runtime);
         return;
       }
-      let con_id = mg
-        .connection_id_by_dependency_id(&con.dependency_id)
-        .expect("should have dep id");
       list.push(ConcatenationEntry::External(ConcatenationEntryExternal {
-        connection: *con_id,
+        dependency: con.dependency_id,
         runtime_condition,
       }));
     }

--- a/crates/rspack_core/src/module_graph/connection.rs
+++ b/crates/rspack_core/src/module_graph/connection.rs
@@ -1,41 +1,10 @@
 use std::hash::Hash;
-use std::sync::atomic::AtomicU32;
-use std::sync::atomic::Ordering::Relaxed;
 
 use crate::{DependencyId, ModuleGraph, ModuleIdentifier, RuntimeSpec};
 
-pub static CONNECTION_ID: AtomicU32 = AtomicU32::new(0);
-
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
-pub struct ConnectionId(u32);
-
-impl ConnectionId {
-  pub fn new() -> Self {
-    Self(CONNECTION_ID.fetch_add(1, Relaxed))
-  }
-}
-
-impl Default for ConnectionId {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-impl std::ops::Deref for ConnectionId {
-  type Target = u32;
-
-  fn deref(&self) -> &Self::Target {
-    &self.0
-  }
-}
-impl From<u32> for ConnectionId {
-  fn from(id: u32) -> Self {
-    Self(id)
-  }
-}
-
 #[derive(Debug, Clone, Eq)]
 pub struct ModuleGraphConnection {
-  pub id: ConnectionId,
+  pub dependency_id: DependencyId,
   /// The referencing module identifier
   pub original_module_identifier: Option<ModuleIdentifier>,
   pub resolved_original_module_identifier: Option<ModuleIdentifier>,
@@ -43,37 +12,34 @@ pub struct ModuleGraphConnection {
   /// The referenced module identifier
   module_identifier: ModuleIdentifier,
 
-  /// The referencing dependency id
-  pub dependency_id: DependencyId,
   pub active: bool,
   pub conditional: bool,
 }
 
 impl Hash for ModuleGraphConnection {
   fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-    self.id.hash(state);
+    self.dependency_id.hash(state);
   }
 }
 
 impl PartialEq for ModuleGraphConnection {
   fn eq(&self, other: &Self) -> bool {
-    self.id == other.id
+    self.dependency_id == other.dependency_id
   }
 }
 
 impl ModuleGraphConnection {
   pub fn new(
-    original_module_identifier: Option<ModuleIdentifier>,
     dependency_id: DependencyId,
+    original_module_identifier: Option<ModuleIdentifier>,
     module_identifier: ModuleIdentifier,
     active: bool,
     conditional: bool,
   ) -> Self {
     Self {
-      id: ConnectionId::new(),
+      dependency_id,
       original_module_identifier,
       module_identifier,
-      dependency_id,
       active,
       conditional,
       resolved_original_module_identifier: original_module_identifier,
@@ -105,7 +71,7 @@ impl ModuleGraphConnection {
     module_graph.get_condition_state(self, runtime).is_true()
   }
 
-  pub fn get_active_state(
+  pub fn active_state(
     &self,
     module_graph: &ModuleGraph,
     runtime: Option<&RuntimeSpec>,
@@ -148,21 +114,24 @@ impl ConnectionState {
   }
 }
 
-pub fn add_connection_states(a: ConnectionState, b: ConnectionState) -> ConnectionState {
-  if matches!(a, ConnectionState::Bool(true)) || matches!(b, ConnectionState::Bool(true)) {
-    return ConnectionState::Bool(true);
+impl std::ops::Add for ConnectionState {
+  type Output = Self;
+  fn add(self, other: Self) -> Self::Output {
+    if matches!(self, ConnectionState::Bool(true)) || matches!(other, ConnectionState::Bool(true)) {
+      return ConnectionState::Bool(true);
+    }
+    if matches!(self, ConnectionState::Bool(false)) {
+      return other;
+    }
+    if matches!(other, ConnectionState::Bool(false)) {
+      return self;
+    }
+    if matches!(self, ConnectionState::TransitiveOnly) {
+      return other;
+    }
+    if matches!(other, ConnectionState::TransitiveOnly) {
+      return self;
+    }
+    self
   }
-  if matches!(a, ConnectionState::Bool(false)) {
-    return b;
-  }
-  if matches!(b, ConnectionState::Bool(false)) {
-    return a;
-  }
-  if matches!(a, ConnectionState::TransitiveOnly) {
-    return b;
-  }
-  if matches!(b, ConnectionState::TransitiveOnly) {
-    return a;
-  }
-  a
 }

--- a/crates/rspack_core/src/module_graph/module.rs
+++ b/crates/rspack_core/src/module_graph/module.rs
@@ -1,16 +1,13 @@
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::ExportsInfo;
-use crate::{
-  module_graph::ConnectionId, ChunkGraph, DependencyId, ModuleIdentifier, ModuleIssuer,
-  ModuleProfile,
-};
+use crate::{ChunkGraph, DependencyId, ModuleIdentifier, ModuleIssuer, ModuleProfile};
 
 #[derive(Debug, Clone)]
 pub struct ModuleGraphModule {
   // edges from module to module
-  outgoing_connections: HashSet<ConnectionId>,
-  incoming_connections: HashSet<ConnectionId>,
+  outgoing_connections: HashSet<DependencyId>,
+  incoming_connections: HashSet<DependencyId>,
 
   issuer: ModuleIssuer,
 
@@ -50,35 +47,27 @@ impl ModuleGraphModule {
     c.unwrap_or_else(|| panic!("{} module id not found", self.module_identifier))
   }
 
-  pub fn add_incoming_connection(&mut self, connection_id: ConnectionId) {
-    self.incoming_connections.insert(connection_id);
+  pub fn add_incoming_connection(&mut self, dependency_id: DependencyId) {
+    self.incoming_connections.insert(dependency_id);
   }
 
-  pub fn remove_incoming_connection(&mut self, connection_id: &ConnectionId) {
-    self.incoming_connections.remove(connection_id);
+  pub fn remove_incoming_connection(&mut self, dependency_id: &DependencyId) {
+    self.incoming_connections.remove(dependency_id);
   }
 
-  pub fn add_outgoing_connection(&mut self, connection_id: ConnectionId) {
-    self.outgoing_connections.insert(connection_id);
+  pub fn add_outgoing_connection(&mut self, dependency_id: DependencyId) {
+    self.outgoing_connections.insert(dependency_id);
   }
 
-  pub fn remove_outgoing_connection(&mut self, connection_id: &ConnectionId) {
-    self.outgoing_connections.remove(connection_id);
+  pub fn remove_outgoing_connection(&mut self, dependency_id: &DependencyId) {
+    self.outgoing_connections.remove(dependency_id);
   }
 
-  pub fn incoming_connections(&self) -> &HashSet<ConnectionId> {
+  pub fn incoming_connections(&self) -> &HashSet<DependencyId> {
     &self.incoming_connections
   }
 
-  pub fn outgoing_connections(&self) -> &HashSet<ConnectionId> {
-    &self.outgoing_connections
-  }
-
-  pub fn get_incoming_connections_unordered(&self) -> &HashSet<ConnectionId> {
-    &self.incoming_connections
-  }
-
-  pub fn get_outgoing_connections_unordered(&self) -> &HashSet<ConnectionId> {
+  pub fn outgoing_connections(&self) -> &HashSet<DependencyId> {
     &self.outgoing_connections
   }
 
@@ -86,7 +75,7 @@ impl ModuleGraphModule {
     self.profile = Some(profile);
   }
 
-  pub fn get_profile(&self) -> Option<&ModuleProfile> {
+  pub fn profile(&self) -> Option<&ModuleProfile> {
     self.profile.as_deref()
   }
 
@@ -100,7 +89,7 @@ impl ModuleGraphModule {
     self.issuer = issuer;
   }
 
-  pub fn get_issuer(&self) -> &ModuleIssuer {
+  pub fn issuer(&self) -> &ModuleIssuer {
     &self.issuer
   }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -28,10 +28,10 @@ use rustc_hash::FxHasher;
 use serde_json::json;
 
 use crate::{
-  add_connection_states, contextify, diagnostics::ModuleBuildError, get_context,
-  impl_module_meta_info, module_update_hash, AsyncDependenciesBlockIdentifier, BoxLoader,
-  BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResult,
-  Compilation, ConcatenationScope, ConnectionState, Context, DependenciesBlock, DependencyId,
+  contextify, diagnostics::ModuleBuildError, get_context, impl_module_meta_info,
+  module_update_hash, AsyncDependenciesBlockIdentifier, BoxLoader, BoxModule, BuildContext,
+  BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResult, Compilation,
+  ConcatenationScope, ConnectionState, Context, DependenciesBlock, DependencyId,
   DependencyTemplate, FactoryMeta, GenerateContext, GeneratorOptions, LibIdentOptions, Module,
   ModuleDependency, ModuleGraph, ModuleIdentifier, ModuleLayer, ModuleType, OutputOptions,
   ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve, RspackLoaderRunnerPlugin,
@@ -721,7 +721,7 @@ impl Module for NormalModule {
             module_chain.remove(&self.identifier());
             return ConnectionState::Bool(true);
           } else if !matches!(state, ConnectionState::CircularConnection) {
-            current = add_connection_states(current, state);
+            current = current + state;
           }
         }
       }

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -785,7 +785,7 @@ impl Stats<'_> {
         .filter(|d| d.module_identifier().is_some_and(|id| id == identifier))
         .count() as u32;
 
-      let profile = if let Some(p) = mgm.get_profile()
+      let profile = if let Some(p) = mgm.profile()
         && let Some(factory) = p.factory.duration()
         && let Some(building) = p.building.duration()
       {
@@ -857,11 +857,11 @@ impl Stats<'_> {
 
     if options.reasons {
       let mut reasons: Vec<StatsModuleReason> = mgm
-        .get_incoming_connections_unordered()
+        .incoming_connections()
         .iter()
-        .filter_map(|connection_id| {
+        .filter_map(|dep_id| {
           // the connection is removed
-          let connection = module_graph.connection_by_connection_id(connection_id)?;
+          let connection = module_graph.connection_by_dependency_id(dep_id)?;
           let (module_name, module_id) = connection
             .original_module_identifier
             .and_then(|i| module_graph.module_by_identifier(&i))

--- a/crates/rspack_core/src/unaffected_cache/mod.rs
+++ b/crates/rspack_core/src/unaffected_cache/mod.rs
@@ -121,14 +121,11 @@ impl UnaffectedModuleCache {
       .hash
       .as_ref()
       .hash(&mut hasher);
-    for connection_id in module_graph
+    for dep_id in module_graph
       .get_ordered_connections(&module.identifier())
       .expect("should have module")
     {
-      let connection = module_graph
-        .connection_by_connection_id(connection_id)
-        .expect("should have connection");
-      connection.dependency_id.hash(&mut hasher);
+      dep_id.hash(&mut hasher);
     }
     hasher.finish()
   }
@@ -151,9 +148,9 @@ impl UnaffectedModuleWithChunkGraphCache {
       .get_ordered_connections(&module_identifier)
       .expect("should have module")
       .into_iter()
-      .filter_map(|c| {
+      .filter_map(|dep_id| {
         let connection = module_graph
-          .connection_by_connection_id(c)
+          .connection_by_dependency_id(dep_id)
           .expect("should have connection");
         chunk_graph.get_module_id(*connection.module_identifier())
       })

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_export_require_dependency.rs
@@ -179,7 +179,7 @@ impl Dependency for CommonJsExportRequireDependency {
       let Some(name) = self.names.first() else {
         unreachable!();
       };
-      let from = mg.connection_by_dependency(&self.id)?;
+      let from = mg.connection_by_dependency_id(&self.id)?;
       Some(ExportsSpec {
         exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
           name: name.to_owned(),
@@ -196,7 +196,7 @@ impl Dependency for CommonJsExportRequireDependency {
         ..Default::default()
       })
     } else if self.names.is_empty() {
-      let from = mg.connection_by_dependency(&self.id)?;
+      let from = mg.connection_by_dependency_id(&self.id)?;
       if let Some(reexport_info) = self.get_star_reexports(mg, None, from.module_identifier()) {
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::Array(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_export_imported_specifier_dependency.rs
@@ -619,7 +619,7 @@ impl HarmonyExportImportedSpecifierDependency {
             ));
             let runtime_condition = if self.weak() {
               RuntimeCondition::Boolean(false)
-            } else if let Some(connection) = mg.connection_by_dependency(self.id()) {
+            } else if let Some(connection) = mg.connection_by_dependency_id(self.id()) {
               filter_runtime(ctxt.runtime, |r| connection.is_target_active(mg, r))
             } else {
               RuntimeCondition::Boolean(true)
@@ -1092,7 +1092,7 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
         ..Default::default()
       }),
       ExportModeType::ReexportDynamicDefault => {
-        let from = mg.connection_by_dependency(self.id());
+        let from = mg.connection_by_dependency_id(self.id());
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
             name: mode.name.unwrap_or_default(),
@@ -1106,7 +1106,7 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
         })
       }
       ExportModeType::ReexportNamedDefault => {
-        let from = mg.connection_by_dependency(self.id());
+        let from = mg.connection_by_dependency_id(self.id());
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
             name: mode.name.unwrap_or_default(),
@@ -1120,7 +1120,7 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
         })
       }
       ExportModeType::ReexportNamespaceObject => {
-        let from = mg.connection_by_dependency(self.id());
+        let from = mg.connection_by_dependency_id(self.id());
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
             name: mode.name.unwrap_or_default(),
@@ -1134,7 +1134,7 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
         })
       }
       ExportModeType::ReexportFakeNamespaceObject => {
-        let from = mg.connection_by_dependency(self.id());
+        let from = mg.connection_by_dependency_id(self.id());
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::Array(vec![ExportNameOrSpec::ExportSpec(ExportSpec {
             name: mode.name.unwrap_or_default(),
@@ -1164,7 +1164,7 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
         ..Default::default()
       }),
       ExportModeType::NormalReexport => {
-        let from = mg.connection_by_dependency(self.id());
+        let from = mg.connection_by_dependency_id(self.id());
         Some(ExportsSpec {
           priority: Some(1),
           exports: ExportsOfExportsSpec::Array(
@@ -1191,7 +1191,7 @@ impl Dependency for HarmonyExportImportedSpecifierDependency {
         })
       }
       ExportModeType::DynamicReexport => {
-        let from = mg.connection_by_dependency(self.id());
+        let from = mg.connection_by_dependency_id(self.id());
         Some(ExportsSpec {
           exports: ExportsOfExportsSpec::True,
           from: from.cloned(),

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_dependency.rs
@@ -110,7 +110,7 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
   } = code_generatable_context;
   // Only available when module factorization is successful.
   let module_graph = compilation.get_module_graph();
-  let connection = module_graph.connection_by_dependency(module_dependency.id());
+  let connection = module_graph.connection_by_dependency_id(module_dependency.id());
   let is_target_active = if let Some(con) = connection {
     Some(con.is_target_active(&module_graph, *runtime))
   } else {
@@ -123,7 +123,8 @@ pub fn harmony_import_dependency_apply<T: ModuleDependency>(
 
   let runtime_condition = if module_dependency.weak() {
     RuntimeCondition::Boolean(false)
-  } else if let Some(connection) = module_graph.connection_by_dependency(module_dependency.id()) {
+  } else if let Some(connection) = module_graph.connection_by_dependency_id(module_dependency.id())
+  {
     filter_runtime(*runtime, |r| connection.is_target_active(&module_graph, r))
   } else {
     RuntimeCondition::Boolean(true)

--- a/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/harmony_import_specifier_dependency.rs
@@ -125,7 +125,7 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
     let module_graph = compilation.get_module_graph();
     // Only available when module factorization is successful.
     let reference_mgm = module_graph.module_graph_module_by_dependency_id(&self.id);
-    let connection = module_graph.connection_by_dependency(&self.id);
+    let connection = module_graph.connection_by_dependency_id(&self.id);
     let is_target_active = if let Some(con) = connection {
       con.is_target_active(&module_graph, *runtime)
     } else {
@@ -152,7 +152,7 @@ impl DependencyTemplate for HarmonyImportSpecifierDependency {
     let import_var = compilation.get_import_var(&self.id);
 
     let export_expr = if let Some(scope) = concatenation_scope
-      && let Some(con) = module_graph.connection_by_dependency(&self.id)
+      && let Some(con) = module_graph.connection_by_dependency_id(&self.id)
       && scope.is_module_in_scope(con.module_identifier())
     {
       if ids.is_empty() {

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -98,7 +98,7 @@ impl DependencyTemplate for ProvideDependency {
       ..
     } = code_generatable_context;
     let module_graph = compilation.get_module_graph();
-    let Some(con) = module_graph.connection_by_dependency(&self.id) else {
+    let Some(con) = module_graph.connection_by_dependency_id(&self.id) else {
       // not find connection, maybe because it's not resolved in make phase, and `bail` is false
       return;
     };

--- a/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/is_included_dependency.rs
@@ -67,7 +67,7 @@ impl DependencyTemplate for WebpackIsIncludedDependency {
 
     let included = compilation
       .get_module_graph()
-      .connection_by_dependency(&self.id)
+      .connection_by_dependency_id(&self.id)
       .map(|connection| {
         compilation
           .chunk_graph

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -145,14 +145,14 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       }
       for dep_id in dep_id_list.into_iter() {
         let module_graph = self.compilation.get_module_graph();
-        let connection = module_graph.connection_by_dependency(&dep_id);
+        let connection = module_graph.connection_by_dependency_id(&dep_id);
 
         let connection = if let Some(connection) = connection {
           connection
         } else {
           continue;
         };
-        let active_state = connection.get_active_state(&module_graph, runtime.as_ref());
+        let active_state = connection.active_state(&module_graph, runtime.as_ref());
 
         match active_state {
           ConnectionState::Bool(false) => {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -166,7 +166,7 @@ impl ModuleConcatenationPlugin {
       if !is_harmony_import_like {
         continue;
       }
-      let Some(con) = mg.connection_by_dependency(d) else {
+      let Some(con) = mg.connection_by_dependency_id(d) else {
         continue;
       };
       if !con.is_target_active(mg, runtime) {
@@ -271,10 +271,7 @@ impl ModuleConcatenationPlugin {
       return Some(problem);
     }
 
-    let get_incoming_connections_by_origin_module =
-      module_graph.get_incoming_connections_by_origin_module(module_id);
-
-    let incoming_connections = get_incoming_connections_by_origin_module;
+    let incoming_connections = module_graph.get_incoming_connections_by_origin_module(module_id);
 
     if let Some(incoming_connections_from_non_modules) = incoming_connections.get(&None) {
       let active_non_modules_connections = incoming_connections_from_non_modules
@@ -663,12 +660,9 @@ impl ModuleConcatenationPlugin {
       if m == &root_module_id {
         continue;
       }
-      module_graph.copy_outgoing_module_connections(m, &new_module.id(), |c, mg| {
-        let dep = mg
-          .dependency_by_id(&c.dependency_id)
-          .expect("should have dependency");
-        c.original_module_identifier.as_ref() == Some(m)
-          && !(is_harmony_dep_like(dep) && modules_set.contains(c.module_identifier()))
+      module_graph.copy_outgoing_module_connections(m, &new_module.id(), |con, dep| {
+        con.original_module_identifier.as_ref() == Some(m)
+          && !(is_harmony_dep_like(dep) && modules_set.contains(con.module_identifier()))
       });
       // TODO: optimize asset module https://github.com/webpack/webpack/pull/15515/files
       for chunk_ukey in chunk_graph.get_module_chunks(root_module_id).clone() {

--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -2,10 +2,11 @@ use std::hash::Hash;
 
 use rspack_core::rspack_sources::{ConcatSource, RawSource, SourceExt};
 use rspack_core::{
-  merge_runtime, to_identifier, ApplyContext, ChunkUkey, CodeGenerationExportsFinalNames,
-  Compilation, CompilationFinishModules, CompilationOptimizeChunkModules, CompilationParams,
-  CompilerCompilation, CompilerOptions, ConcatenatedModule, ConcatenatedModuleExportsDefinitions,
-  DependenciesBlock, Dependency, LibraryOptions, ModuleIdentifier, Plugin, PluginContext,
+  merge_runtime, to_identifier, ApplyContext, BoxDependency, ChunkUkey,
+  CodeGenerationExportsFinalNames, Compilation, CompilationFinishModules,
+  CompilationOptimizeChunkModules, CompilationParams, CompilerCompilation, CompilerOptions,
+  ConcatenatedModule, ConcatenatedModuleExportsDefinitions, DependenciesBlock, Dependency,
+  LibraryOptions, ModuleIdentifier, Plugin, PluginContext,
 };
 use rspack_error::{error_bail, Result};
 use rspack_hash::RspackHash;
@@ -236,7 +237,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
                   *block_id,
                   block_dep.clone(),
                   new_dep.clone(),
-                  import_dep_connection.id,
+                  import_dep_connection.dependency_id,
                 ));
               }
             }
@@ -249,7 +250,7 @@ async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
       let block = mg.block_by_id_mut(block_id).expect("should have block");
       let dep_id = dep.id();
       block.remove_dependency_id(*dep_id);
-      let boxed_dep = Box::new(new_dep.clone()) as Box<dyn rspack_core::Dependency>;
+      let boxed_dep = Box::new(new_dep.clone()) as BoxDependency;
       block.add_dependency_id(*new_dep.id());
       mg.add_dependency(boxed_dep);
       mg.revoke_connection(connection_id, true);

--- a/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
+++ b/tests/webpack-test/__snapshots__/StatsTestCases.basictest.js.snap
@@ -1589,9 +1589,6 @@ cacheable modules 967 bytes
       ./components/src/index.js 84 bytes [orphan] [built]
         [module unused]
         esm import ./components ./foo.js
-        esm import specifier ./components ./foo.js
-        esm import specifier ./components ./main.js
-        esm import specifier ./components ./main.js
         esm import ./components ./main.js
     code generated modules 186 bytes [code generated]
       ./components/src/CompAB/CompA.js 89 bytes [built] [code generated]
@@ -1604,8 +1601,6 @@ cacheable modules 967 bytes
       ./components/src/CompAB/utils.js 97 bytes [built] [code generated]
         esm import ./utils ./components/src/CompAB/CompA.js
         esm import specifier ./utils ./components/src/CompAB/CompA.js
-        esm import ./utils ./components/src/CompAB/CompB.js
-        esm import specifier ./utils ./components/src/CompAB/CompB.js
         esm import ./utils ./components/src/CompAB/CompB.js
         esm import specifier ./utils ./components/src/CompAB/CompB.js
   modules by path ./*.js 466 bytes
@@ -1634,7 +1629,6 @@ modules by path ./node_modules/pmodule/*.js 232 bytes
     [only some exports used: default]
     esm import pmodule ./index.js
     esm import specifier pmodule ./index.js
-    esm import specifier pmodule ./index.js
   ./node_modules/pmodule/c.js 28 bytes [orphan] [built]
     [only some exports used: z]
     esm import specifier pmodule ./index.js
@@ -1644,14 +1638,8 @@ modules by path ./node_modules/pmodule/*.js 232 bytes
     [module unused]
     esm export ./a ./node_modules/pmodule/index.js
     esm export import specifier ./a ./node_modules/pmodule/index.js
-    esm export ./a ./node_modules/pmodule/index.js
-    esm export import specifier ./a ./node_modules/pmodule/index.js
   ./node_modules/pmodule/b.js 69 bytes [orphan] [built]
     [module unused]
-    esm export ./b ./node_modules/pmodule/index.js
-    esm export import specifier ./b ./node_modules/pmodule/index.js
-    esm export import specifier ./b ./node_modules/pmodule/index.js
-    esm export import specifier ./b ./node_modules/pmodule/index.js
     esm export ./b ./node_modules/pmodule/index.js
     esm export import specifier ./b ./node_modules/pmodule/index.js
     esm export import specifier ./b ./node_modules/pmodule/index.js
@@ -1667,7 +1655,6 @@ modules by path ./*.js 213 bytes
     | ./node_modules/pmodule/index.js 75 bytes [orphan] [built]
     |   [only some exports used: default]
     |   esm import pmodule ./index.js
-    |   esm import specifier pmodule ./index.js
     |   esm import specifier pmodule ./index.js
     | ./node_modules/pmodule/c.js 28 bytes [orphan] [built]
     |   [only some exports used: z]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Currently we use `ModuleIdentifier` to access `Module` and `ModuleGraphModule`, but need to convert the dependency_id to the connection_id to access the `Connection`, which will cause additional performance loss.

``` rust
impl ModuleGraph {
    fn connection_by_dependency_id(&self, dep_id: &DependencyId) -> Option<Connection> {
        let con_id = self.dependency_id_to_connection_id.get(dep_id)?;
        self.connections.get(con_id)
    }
}
```

This PR will remove ConnectionId and use DependencyId to access Connection.

``` rust
impl ModuleGraph {
    fn connection_by_dependency_id(&self, dep_id: &DependencyId) -> Option<Connection> {
        self.connections.get(dep_id)
    }
}
```

NOTE: There are some inactive connections in the module graph that cannot be found from the dependency ID. This is useful when you need to print debug information, but it makes the module graph more cluttered. We will use some other methods to ensure these features.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
