### PR TITLE
fix(ci/preview-commit): remove predicate-quantifier

### DIFF
--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -21,10 +21,9 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
-          predicate-quantifier: "every"
           filters: |
             changed:
-              - "crates"
+              - "crates/**"
               - "packages/rspack/**"
               - "packages/rspack-cli/**"
 


### PR DESCRIPTION
## Summary

I noticed that `pkg-pr-new` has been consistently skipped because I mistakenly set the `predicate-quantifier` to `every`. This caused files to only be filtered if they met all conditions, which resulted in the intended files being excluded.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
