### PR TITLE
test(plugin-test): support for reference Rspack source modules

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -895,6 +895,12 @@ importers:
       '@rspack/core':
         specifier: workspace:*
         version: link:../../packages/rspack
+      '@swc/core':
+        specifier: 1.4.0
+        version: 1.4.0(@swc/helpers@0.5.12)
+      '@swc/jest':
+        specifier: ^0.2.36
+        version: 0.2.36(@swc/core@1.4.0(@swc/helpers@0.5.12))
       css-loader:
         specifier: ^6.11.0
         version: 6.11.0(@rspack/core@packages+rspack)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.12))(webpack-cli@5.1.4(webpack@5.94.0)))
@@ -2303,6 +2309,10 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/create-cache-key-function@29.7.0':
+    resolution: {integrity: sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/environment@29.7.0':
     resolution: {integrity: sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3405,6 +3415,12 @@ packages:
 
   '@swc/helpers@0.5.8':
     resolution: {integrity: sha512-lruDGw3pnfM3wmZHeW7JuhkGQaJjPyiKjxeGhdmfoOT53Ic9qb5JLDNaK2HUdl1zLDeX28H221UvKjfdvSLVMg==}
+
+  '@swc/jest@0.2.36':
+    resolution: {integrity: sha512-8X80dp81ugxs4a11z1ka43FPhP+/e+mJNXJSxiNYk8gIX/jPBtY4gQTrKu/KIoco8bzKuPI5lUxjfLiGsfvnlw==}
+    engines: {npm: '>= 7.0.0'}
+    peerDependencies:
+      '@swc/core': '*'
 
   '@swc/plugin-remove-console@3.0.1':
     resolution: {integrity: sha512-uTOFWOhCe4xZspwbyR/QKSRm5xaE/BSQqjOXbvo9I3bBsPmwfUfSUHI4457NkF8w+2CAar+cN8IJBd6XTl01CA==}
@@ -6859,6 +6875,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -11410,6 +11429,10 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/create-cache-key-function@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -12644,6 +12667,13 @@ snapshots:
   '@swc/helpers@0.5.8':
     dependencies:
       tslib: 2.6.2
+
+  '@swc/jest@0.2.36(@swc/core@1.4.0(@swc/helpers@0.5.12))':
+    dependencies:
+      '@jest/create-cache-key-function': 29.7.0
+      '@swc/core': 1.4.0(@swc/helpers@0.5.12)
+      '@swc/counter': 0.1.3
+      jsonc-parser: 3.3.1
 
   '@swc/plugin-remove-console@3.0.1':
     dependencies:
@@ -17419,6 +17449,8 @@ snapshots:
       minimist: 1.2.8
 
   json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:

--- a/tests/plugin-test/css-extract/HMR.test.js
+++ b/tests/plugin-test/css-extract/HMR.test.js
@@ -4,8 +4,8 @@
 /* eslint-env browser */
 /* eslint-disable no-console */
 
-const hotModuleReplacement = require("../../../packages/rspack/dist/cssExtractHmr").cssReload;
-const hotLoader = require("../../../packages/rspack/dist/cssExtractLoader").hotLoader;
+const hotModuleReplacement = require("../../../packages/rspack/src/runtime/cssExtractHmr").cssReload;
+const hotLoader = require("../../../packages/rspack/src/builtin-plugin/css-extract/loader").hotLoader;
 
 function getLoadEvent() {
 	const event = document.createEvent("Event");

--- a/tests/plugin-test/css-extract/__snapshots__/HMR.test.js.snap
+++ b/tests/plugin-test/css-extract/__snapshots__/HMR.test.js.snap
@@ -6,7 +6,7 @@ exports[`HMR hotLoader works for locals 1`] = `
       (function() {
         var localsJsonString = \\"{\\\\\\"foo\\\\\\":\\\\\\"bar\\\\\\"}\\";
         // 1
-        var cssReload = require(\\"../../../packages/rspack/dist/cssExtractHmr.js\\").cssReload(module.id, {});
+        var cssReload = require(\\"../../../packages/rspack/src/builtin-plugin/css-extract/cssExtractHmr.js\\").cssReload(module.id, {});
         // only invalidate when locals change
         if (
           module.hot.data &&
@@ -32,7 +32,7 @@ exports[`HMR hotLoader works for non-locals 1`] = `
       (function() {
         var localsJsonString = undefined;
         // 1
-        var cssReload = require(\\"../../../packages/rspack/dist/cssExtractHmr.js\\").cssReload(module.id, {});
+        var cssReload = require(\\"../../../packages/rspack/src/builtin-plugin/css-extract/cssExtractHmr.js\\").cssReload(module.id, {});
         // only invalidate when locals change
         if (
           module.hot.data &&

--- a/tests/plugin-test/css-extract/normalizeUrl.test.js
+++ b/tests/plugin-test/css-extract/normalizeUrl.test.js
@@ -1,4 +1,4 @@
-const { normalizeUrl } = require("../../../packages/rspack/dist/cssExtractHmr");
+const { normalizeUrl } = require("../../../packages/rspack/src/runtime/cssExtractHmr");
 const dataUrls = require("./fixtures/json/data-urls.json");
 
 describe("normalize-url", () => {

--- a/tests/plugin-test/css-extract/stringifyLocal.test.js
+++ b/tests/plugin-test/css-extract/stringifyLocal.test.js
@@ -1,9 +1,8 @@
-// const {
-// 	stringifyLocal
-// } = require("../../../packages/rspack/dist/builtin-plugin/css-extract/utils");
+const {
+	stringifyLocal
+} = require("../../../packages/rspack/src/builtin-plugin/css-extract/utils");
 
-// TODO: should require from src instead of dist
-describe.skip("stringifyLocal", () => {
+describe("stringifyLocal", () => {
 	it(`primitive`, async () => {
 		const testObj = "classA";
 

--- a/tests/plugin-test/jest.config.js
+++ b/tests/plugin-test/jest.config.js
@@ -7,8 +7,12 @@ const root = path.resolve(__dirname, "../");
 const config = {
 	testEnvironment: "../../scripts/test/patch-node-env.cjs",
 	testMatch: [
-		"<rootDir>/**/*.test.js"
+		"<rootDir>/**/*.test.js",
+		"<rootDir>/**/*.test.ts"
 	],
+	transform: {
+    '^.+\\.ts?$': '@swc/jest',
+  },
 	testTimeout: process.env.CI ? 60000 : 30000,
 	prettierPath: require.resolve("prettier-2"),
 	cache: false,

--- a/tests/plugin-test/package.json
+++ b/tests/plugin-test/package.json
@@ -5,11 +5,14 @@
   "license": "MIT",
   "main": "./dist/index.d.ts",
   "scripts": {
-    "test": "cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --logHeapUsage"
+    "test": "cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --logHeapUsage",
+    "testu": "cross-env NO_COLOR=1 node --expose-gc --max-old-space-size=8192 --experimental-vm-modules ../../node_modules/jest-cli/bin/jest --logHeapUsage --updateSnapshot"
   },
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
     "@rspack/core": "workspace:*",
+    "@swc/core": "1.4.0",
+    "@swc/jest": "^0.2.36",
     "css-loader": "^6.11.0",
     "file-loader": "^6.2.0",
     "html-loader": "2.1.1",


### PR DESCRIPTION
## Summary

Introduce `@swc/jest` to allow `plugin-test` cases to reference Rspack source modules.

Fix a TODO introduced by https://github.com/web-infra-dev/rspack/pull/8072.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
