### PR TITLE
refactor: add JSDoc & types to improve Rspack configuration.output types.

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -288,11 +288,8 @@ const assetInlineGeneratorOptions: z.ZodObject<{
     }, ...args_1: unknown[]) => string) | undefined;
 }>;
 
-// @public (undocumented)
-export type AssetModuleFilename = z.infer<typeof assetModuleFilename>;
-
-// @public (undocumented)
-const assetModuleFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
+// @public
+export type AssetModuleFilename = Filename;
 
 // @public (undocumented)
 export type AssetParserDataUrl = z.infer<typeof assetParserDataUrl>;
@@ -748,17 +745,11 @@ export class Chunk {
     runtime: ReadonlySet<string>;
 }
 
-// @public (undocumented)
-export type ChunkFilename = z.infer<typeof chunkFilename>;
+// @public
+export type ChunkFilename = Filename;
 
-// @public (undocumented)
-const chunkFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
-
-// @public (undocumented)
-export type ChunkFormat = z.infer<typeof chunkFormat>;
-
-// @public (undocumented)
-const chunkFormat: z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>;
+// @public
+export type ChunkFormat = string | false;
 
 // @public (undocumented)
 class ChunkGraph {
@@ -803,20 +794,14 @@ export class ChunkGroup {
 // @public
 export type ChunkLoading = false | ChunkLoadingType;
 
-// @public (undocumented)
-export type ChunkLoadingGlobal = z.infer<typeof chunkLoadingGlobal>;
-
-// @public (undocumented)
-const chunkLoadingGlobal: z.ZodString;
+// @public
+export type ChunkLoadingGlobal = string;
 
 // @public
 export type ChunkLoadingType = string | "jsonp" | "import-scripts" | "require" | "async-node" | "import";
 
-// @public (undocumented)
-export type Clean = z.infer<typeof clean>;
-
-// @public (undocumented)
-const clean: z.ZodBoolean;
+// @public
+export type Clean = boolean;
 
 // @public (undocumented)
 class CodeGenerationResult {
@@ -1449,11 +1434,8 @@ type CreateData = Partial<JsCreateData>;
 // @public (undocumented)
 type CreateStatsOptionsContext = KnownCreateStatsOptionsContext & Record<string, any>;
 
-// @public (undocumented)
-export type CrossOriginLoading = z.infer<typeof crossOriginLoading>;
-
-// @public (undocumented)
-const crossOriginLoading: z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["anonymous", "use-credentials"]>]>;
+// @public
+export type CrossOriginLoading = false | "anonymous" | "use-credentials";
 
 // @public (undocumented)
 export type CssAutoGeneratorOptions = z.infer<typeof cssAutoGeneratorOptions>;
@@ -1488,11 +1470,8 @@ const cssAutoParserOptions: z.ZodObject<{
     namedExports?: boolean | undefined;
 }>;
 
-// @public (undocumented)
-export type CssChunkFilename = z.infer<typeof cssChunkFilename>;
-
-// @public (undocumented)
-const cssChunkFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
+// @public
+export type CssChunkFilename = Filename;
 
 // @public (undocumented)
 export interface CssExtractRspackLoaderOptions {
@@ -1543,11 +1522,8 @@ export interface CssExtractRspackPluginOptions {
     runtime?: boolean;
 }
 
-// @public (undocumented)
-export type CssFilename = z.infer<typeof cssFilename>;
-
-// @public (undocumented)
-const cssFilename: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>;
+// @public
+export type CssFilename = Filename;
 
 // @public (undocumented)
 export type CssGeneratorEsModule = z.infer<typeof cssGeneratorEsModule>;
@@ -1692,23 +1668,14 @@ export type DevTool = z.infer<typeof devTool>;
 // @public (undocumented)
 const devTool: z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["eval", "cheap-source-map", "cheap-module-source-map", "source-map", "inline-cheap-source-map", "inline-cheap-module-source-map", "inline-source-map", "inline-nosources-cheap-source-map", "inline-nosources-cheap-module-source-map", "inline-nosources-source-map", "nosources-cheap-source-map", "nosources-cheap-module-source-map", "nosources-source-map", "hidden-nosources-cheap-source-map", "hidden-nosources-cheap-module-source-map", "hidden-nosources-source-map", "hidden-cheap-source-map", "hidden-cheap-module-source-map", "hidden-source-map", "eval-cheap-source-map", "eval-cheap-module-source-map", "eval-source-map", "eval-nosources-cheap-source-map", "eval-nosources-cheap-module-source-map", "eval-nosources-source-map"]>]>;
 
-// @public (undocumented)
-export type DevtoolFallbackModuleFilenameTemplate = z.infer<typeof devtoolFallbackModuleFilenameTemplate>;
+// @public
+export type DevtoolFallbackModuleFilenameTemplate = DevtoolModuleFilenameTemplate;
 
-// @public (undocumented)
-const devtoolFallbackModuleFilenameTemplate: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodAny], null>, z.ZodAny>]>;
+// @public
+export type DevtoolModuleFilenameTemplate = string | ((info: any) => any);
 
-// @public (undocumented)
-export type DevtoolModuleFilenameTemplate = z.infer<typeof devtoolModuleFilenameTemplate>;
-
-// @public (undocumented)
-const devtoolModuleFilenameTemplate: z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodAny], null>, z.ZodAny>]>;
-
-// @public (undocumented)
-export type DevtoolNamespace = z.infer<typeof devtoolNamespace>;
-
-// @public (undocumented)
-const devtoolNamespace: z.ZodString;
+// @public
+export type DevtoolNamespace = string;
 
 // @public (undocumented)
 interface Diagnostic {
@@ -1841,23 +1808,14 @@ const EnableChunkLoadingPlugin: {
     };
 };
 
-// @public (undocumented)
-export type EnabledChunkLoadingTypes = z.infer<typeof enabledChunkLoadingTypes>;
+// @public
+export type EnabledChunkLoadingTypes = string[];
 
-// @public (undocumented)
-const enabledChunkLoadingTypes: z.ZodArray<z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>, "many">;
+// @public
+export type EnabledLibraryTypes = string[];
 
-// @public (undocumented)
-export type EnabledLibraryTypes = z.infer<typeof enabledLibraryTypes>;
-
-// @public (undocumented)
-const enabledLibraryTypes: z.ZodArray<z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>, "many">;
-
-// @public (undocumented)
-export type EnabledWasmLoadingTypes = z.infer<typeof enabledWasmLoadingTypes>;
-
-// @public (undocumented)
-const enabledWasmLoadingTypes: z.ZodArray<z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>, "many">;
+// @public
+export type EnabledWasmLoadingTypes = string[];
 
 // @public (undocumented)
 class EnableLibraryPlugin extends RspackBuiltinPlugin {
@@ -2017,56 +1975,23 @@ export interface EntryStaticNormalized {
 // @public (undocumented)
 export type EntryUnnamed = EntryItem;
 
-// @public (undocumented)
-export type Environment = z.infer<typeof environment>;
-
-// @public (undocumented)
-const environment: z.ZodObject<{
-    arrowFunction: z.ZodOptional<z.ZodBoolean>;
-    asyncFunction: z.ZodOptional<z.ZodBoolean>;
-    bigIntLiteral: z.ZodOptional<z.ZodBoolean>;
-    const: z.ZodOptional<z.ZodBoolean>;
-    destructuring: z.ZodOptional<z.ZodBoolean>;
-    document: z.ZodOptional<z.ZodBoolean>;
-    dynamicImport: z.ZodOptional<z.ZodBoolean>;
-    dynamicImportInWorker: z.ZodOptional<z.ZodBoolean>;
-    forOf: z.ZodOptional<z.ZodBoolean>;
-    globalThis: z.ZodOptional<z.ZodBoolean>;
-    module: z.ZodOptional<z.ZodBoolean>;
-    nodePrefixForCoreModules: z.ZodOptional<z.ZodBoolean>;
-    optionalChaining: z.ZodOptional<z.ZodBoolean>;
-    templateLiteral: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    module?: boolean | undefined;
-    arrowFunction?: boolean | undefined;
-    asyncFunction?: boolean | undefined;
-    bigIntLiteral?: boolean | undefined;
-    const?: boolean | undefined;
-    destructuring?: boolean | undefined;
-    document?: boolean | undefined;
-    dynamicImport?: boolean | undefined;
-    dynamicImportInWorker?: boolean | undefined;
-    forOf?: boolean | undefined;
-    globalThis?: boolean | undefined;
-    nodePrefixForCoreModules?: boolean | undefined;
-    optionalChaining?: boolean | undefined;
-    templateLiteral?: boolean | undefined;
-}, {
-    module?: boolean | undefined;
-    arrowFunction?: boolean | undefined;
-    asyncFunction?: boolean | undefined;
-    bigIntLiteral?: boolean | undefined;
-    const?: boolean | undefined;
-    destructuring?: boolean | undefined;
-    document?: boolean | undefined;
-    dynamicImport?: boolean | undefined;
-    dynamicImportInWorker?: boolean | undefined;
-    forOf?: boolean | undefined;
-    globalThis?: boolean | undefined;
-    nodePrefixForCoreModules?: boolean | undefined;
-    optionalChaining?: boolean | undefined;
-    templateLiteral?: boolean | undefined;
-}>;
+// @public
+export type Environment = {
+    arrowFunction?: boolean;
+    asyncFunction?: boolean;
+    bigIntLiteral?: boolean;
+    const?: boolean;
+    destructuring?: boolean;
+    document?: boolean;
+    dynamicImport?: boolean;
+    dynamicImportInWorker?: boolean;
+    forOf?: boolean;
+    globalThis?: boolean;
+    module?: boolean;
+    nodePrefixForCoreModules?: boolean;
+    optionalChaining?: boolean;
+    templateLiteral?: boolean;
+};
 
 // @public (undocumented)
 export class EnvironmentPlugin {
@@ -3072,11 +2997,8 @@ export const getRawOptions: (options: RspackOptionsNormalized, compiler: Compile
 // @public (undocumented)
 export function getRawResolve(resolve: Resolve): RawOptions["resolve"];
 
-// @public (undocumented)
-export type GlobalObject = z.infer<typeof globalObject>;
-
-// @public (undocumented)
-const globalObject: z.ZodString;
+// @public
+export type GlobalObject = string;
 
 // @public
 interface GlobalPassOption {
@@ -3126,29 +3048,17 @@ interface HashableObject {
 // @public (undocumented)
 type HashConstructor = typeof Hash_2;
 
-// @public (undocumented)
-export type HashDigest = z.infer<typeof hashDigest>;
+// @public
+export type HashDigest = string;
 
-// @public (undocumented)
-const hashDigest: z.ZodString;
+// @public
+export type HashDigestLength = number;
 
-// @public (undocumented)
-export type HashDigestLength = z.infer<typeof hashDigestLength>;
+// @public
+export type HashFunction = "md4" | "xxhash64";
 
-// @public (undocumented)
-const hashDigestLength: z.ZodNumber;
-
-// @public (undocumented)
-export type HashFunction = z.infer<typeof hashFunction>;
-
-// @public (undocumented)
-const hashFunction: z.ZodEnum<["md4", "xxhash64"]>;
-
-// @public (undocumented)
-export type HashSalt = z.infer<typeof hashSalt>;
-
-// @public (undocumented)
-const hashSalt: z.ZodString;
+// @public
+export type HashSalt = string;
 
 // @public (undocumented)
 type Hooks = Readonly<{
@@ -3179,23 +3089,14 @@ export class HotModuleReplacementPlugin extends RspackBuiltinPlugin {
     raw(compiler: Compiler): BuiltinPlugin;
 }
 
-// @public (undocumented)
-export type HotUpdateChunkFilename = z.infer<typeof hotUpdateChunkFilename>;
+// @public
+export type HotUpdateChunkFilename = FilenameTemplate;
 
-// @public (undocumented)
-const hotUpdateChunkFilename: z.ZodString;
+// @public
+export type HotUpdateGlobal = string;
 
-// @public (undocumented)
-export type HotUpdateGlobal = z.infer<typeof hotUpdateGlobal>;
-
-// @public (undocumented)
-const hotUpdateGlobal: z.ZodString;
-
-// @public (undocumented)
-export type HotUpdateMainFilename = z.infer<typeof hotUpdateMainFilename>;
-
-// @public (undocumented)
-const hotUpdateMainFilename: z.ZodString;
+// @public
+export type HotUpdateMainFilename = FilenameTemplate;
 
 // @public (undocumented)
 export const HtmlRspackPlugin: {
@@ -3311,23 +3212,14 @@ const ignoreWarnings: z.ZodArray<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, Reg
 // @public (undocumented)
 export type IgnoreWarningsNormalized = ((warning: Error, compilation: Compilation) => boolean)[];
 
-// @public (undocumented)
-export type Iife = z.infer<typeof iife>;
+// @public
+export type Iife = boolean;
 
-// @public (undocumented)
-const iife: z.ZodBoolean;
+// @public
+export type ImportFunctionName = string;
 
-// @public (undocumented)
-export type ImportFunctionName = z.infer<typeof importFunctionName>;
-
-// @public (undocumented)
-const importFunctionName: z.ZodString;
-
-// @public (undocumented)
-export type ImportMetaName = z.infer<typeof importMetaName>;
-
-// @public (undocumented)
-const importMetaName: z.ZodString;
+// @public
+export type ImportMetaName = string;
 
 // @public (undocumented)
 export type Incremental = z.infer<typeof incremental>;
@@ -6012,397 +5904,60 @@ type OptimizerConfig = {
 };
 
 // @public (undocumented)
-export type Output = z.infer<typeof output>;
-
-// @public (undocumented)
-const output: z.ZodObject<{
-    path: z.ZodOptional<z.ZodString>;
-    pathinfo: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"verbose">]>>;
-    clean: z.ZodOptional<z.ZodBoolean>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    chunkFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    crossOriginLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["anonymous", "use-credentials"]>]>>;
-    cssFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    cssHeadDataCompression: z.ZodOptional<z.ZodBoolean>;
-    cssChunkFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    hotUpdateMainFilename: z.ZodOptional<z.ZodString>;
-    hotUpdateChunkFilename: z.ZodOptional<z.ZodString>;
-    hotUpdateGlobal: z.ZodOptional<z.ZodString>;
-    assetModuleFilename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    uniqueName: z.ZodOptional<z.ZodString>;
-    chunkLoadingGlobal: z.ZodOptional<z.ZodString>;
-    enabledLibraryTypes: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>, "many">>;
-    library: z.ZodOptional<z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        amd: z.ZodOptional<z.ZodString>;
-        commonjs: z.ZodOptional<z.ZodString>;
-        root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    }, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    }>]>, z.ZodObject<{
-        amdContainer: z.ZodOptional<z.ZodString>;
-        auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            commonjs2: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        }>]>>;
-        export: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        name: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-            amd: z.ZodOptional<z.ZodString>;
-            commonjs: z.ZodOptional<z.ZodString>;
-            root: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }, {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        }>]>>;
-        type: z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>;
-        umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }, {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    }>]>>>;
-    libraryExport: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    libraryTarget: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["var", "module", "assign", "assign-properties", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system"]>, z.ZodString]>>;
-    umdNamedDefine: z.ZodOptional<z.ZodBoolean>;
-    auxiliaryComment: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodObject<{
-        amd: z.ZodOptional<z.ZodString>;
-        commonjs: z.ZodOptional<z.ZodString>;
-        commonjs2: z.ZodOptional<z.ZodString>;
-        root: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    }, {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    }>]>>;
-    module: z.ZodOptional<z.ZodBoolean>;
-    strictModuleExceptionHandling: z.ZodOptional<z.ZodBoolean>;
-    strictModuleErrorHandling: z.ZodOptional<z.ZodBoolean>;
-    globalObject: z.ZodOptional<z.ZodString>;
-    importFunctionName: z.ZodOptional<z.ZodString>;
-    importMetaName: z.ZodOptional<z.ZodString>;
-    iife: z.ZodOptional<z.ZodBoolean>;
-    wasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    enabledWasmLoadingTypes: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>, "many">>;
-    webassemblyModuleFilename: z.ZodOptional<z.ZodString>;
-    chunkFormat: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
-    chunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    enabledChunkLoadingTypes: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>, "many">>;
-    trustedTypes: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<true>, z.ZodString]>, z.ZodObject<{
-        policyName: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        policyName?: string | undefined;
-    }, {
-        policyName?: string | undefined;
-    }>]>>;
-    sourceMapFilename: z.ZodOptional<z.ZodString>;
-    hashDigest: z.ZodOptional<z.ZodString>;
-    hashDigestLength: z.ZodOptional<z.ZodNumber>;
-    hashFunction: z.ZodOptional<z.ZodEnum<["md4", "xxhash64"]>>;
-    hashSalt: z.ZodOptional<z.ZodString>;
-    asyncChunks: z.ZodOptional<z.ZodBoolean>;
-    workerChunkLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["jsonp", "import-scripts", "require", "async-node", "import"]>, z.ZodString]>]>>;
-    workerWasmLoading: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["fetch-streaming", "fetch", "async-node"]>, z.ZodString]>]>>;
-    workerPublicPath: z.ZodOptional<z.ZodString>;
-    scriptType: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["text/javascript", "module"]>, z.ZodLiteral<false>]>>;
-    devtoolNamespace: z.ZodOptional<z.ZodString>;
-    devtoolModuleFilenameTemplate: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodAny], null>, z.ZodAny>]>>;
-    devtoolFallbackModuleFilenameTemplate: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodAny], null>, z.ZodAny>]>>;
-    chunkLoadTimeout: z.ZodOptional<z.ZodNumber>;
-    charset: z.ZodOptional<z.ZodBoolean>;
-    environment: z.ZodOptional<z.ZodObject<{
-        arrowFunction: z.ZodOptional<z.ZodBoolean>;
-        asyncFunction: z.ZodOptional<z.ZodBoolean>;
-        bigIntLiteral: z.ZodOptional<z.ZodBoolean>;
-        const: z.ZodOptional<z.ZodBoolean>;
-        destructuring: z.ZodOptional<z.ZodBoolean>;
-        document: z.ZodOptional<z.ZodBoolean>;
-        dynamicImport: z.ZodOptional<z.ZodBoolean>;
-        dynamicImportInWorker: z.ZodOptional<z.ZodBoolean>;
-        forOf: z.ZodOptional<z.ZodBoolean>;
-        globalThis: z.ZodOptional<z.ZodBoolean>;
-        module: z.ZodOptional<z.ZodBoolean>;
-        nodePrefixForCoreModules: z.ZodOptional<z.ZodBoolean>;
-        optionalChaining: z.ZodOptional<z.ZodBoolean>;
-        templateLiteral: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        module?: boolean | undefined;
-        arrowFunction?: boolean | undefined;
-        asyncFunction?: boolean | undefined;
-        bigIntLiteral?: boolean | undefined;
-        const?: boolean | undefined;
-        destructuring?: boolean | undefined;
-        document?: boolean | undefined;
-        dynamicImport?: boolean | undefined;
-        dynamicImportInWorker?: boolean | undefined;
-        forOf?: boolean | undefined;
-        globalThis?: boolean | undefined;
-        nodePrefixForCoreModules?: boolean | undefined;
-        optionalChaining?: boolean | undefined;
-        templateLiteral?: boolean | undefined;
-    }, {
-        module?: boolean | undefined;
-        arrowFunction?: boolean | undefined;
-        asyncFunction?: boolean | undefined;
-        bigIntLiteral?: boolean | undefined;
-        const?: boolean | undefined;
-        destructuring?: boolean | undefined;
-        document?: boolean | undefined;
-        dynamicImport?: boolean | undefined;
-        dynamicImportInWorker?: boolean | undefined;
-        forOf?: boolean | undefined;
-        globalThis?: boolean | undefined;
-        nodePrefixForCoreModules?: boolean | undefined;
-        optionalChaining?: boolean | undefined;
-        templateLiteral?: boolean | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    module?: boolean | undefined;
-    filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    environment?: {
-        module?: boolean | undefined;
-        arrowFunction?: boolean | undefined;
-        asyncFunction?: boolean | undefined;
-        bigIntLiteral?: boolean | undefined;
-        const?: boolean | undefined;
-        destructuring?: boolean | undefined;
-        document?: boolean | undefined;
-        dynamicImport?: boolean | undefined;
-        dynamicImportInWorker?: boolean | undefined;
-        forOf?: boolean | undefined;
-        globalThis?: boolean | undefined;
-        nodePrefixForCoreModules?: boolean | undefined;
-        optionalChaining?: boolean | undefined;
-        templateLiteral?: boolean | undefined;
-    } | undefined;
-    chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    path?: string | undefined;
-    auxiliaryComment?: string | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    } | undefined;
-    umdNamedDefine?: boolean | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: string | string[] | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    } | {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    pathinfo?: boolean | "verbose" | undefined;
-    clean?: boolean | undefined;
-    crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-    cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    cssHeadDataCompression?: boolean | undefined;
-    cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    hotUpdateMainFilename?: string | undefined;
-    hotUpdateChunkFilename?: string | undefined;
-    hotUpdateGlobal?: string | undefined;
-    assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    uniqueName?: string | undefined;
-    chunkLoadingGlobal?: string | undefined;
-    enabledLibraryTypes?: string[] | undefined;
-    libraryExport?: string | string[] | undefined;
-    libraryTarget?: string | undefined;
-    strictModuleExceptionHandling?: boolean | undefined;
-    strictModuleErrorHandling?: boolean | undefined;
-    globalObject?: string | undefined;
-    importFunctionName?: string | undefined;
-    importMetaName?: string | undefined;
-    iife?: boolean | undefined;
-    enabledWasmLoadingTypes?: string[] | undefined;
-    webassemblyModuleFilename?: string | undefined;
-    chunkFormat?: string | false | undefined;
-    enabledChunkLoadingTypes?: string[] | undefined;
-    trustedTypes?: string | true | {
-        policyName?: string | undefined;
-    } | undefined;
-    sourceMapFilename?: string | undefined;
-    hashDigest?: string | undefined;
-    hashDigestLength?: number | undefined;
-    hashFunction?: "xxhash64" | "md4" | undefined;
-    hashSalt?: string | undefined;
-    workerChunkLoading?: string | false | undefined;
-    workerWasmLoading?: string | false | undefined;
-    workerPublicPath?: string | undefined;
-    scriptType?: false | "module" | "text/javascript" | undefined;
-    devtoolNamespace?: string | undefined;
-    devtoolModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-    devtoolFallbackModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-    chunkLoadTimeout?: number | undefined;
-    charset?: boolean | undefined;
-}, {
-    module?: boolean | undefined;
-    filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    environment?: {
-        module?: boolean | undefined;
-        arrowFunction?: boolean | undefined;
-        asyncFunction?: boolean | undefined;
-        bigIntLiteral?: boolean | undefined;
-        const?: boolean | undefined;
-        destructuring?: boolean | undefined;
-        document?: boolean | undefined;
-        dynamicImport?: boolean | undefined;
-        dynamicImportInWorker?: boolean | undefined;
-        forOf?: boolean | undefined;
-        globalThis?: boolean | undefined;
-        nodePrefixForCoreModules?: boolean | undefined;
-        optionalChaining?: boolean | undefined;
-        templateLiteral?: boolean | undefined;
-    } | undefined;
-    chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    path?: string | undefined;
-    auxiliaryComment?: string | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        commonjs2?: string | undefined;
-        root?: string | undefined;
-    } | undefined;
-    umdNamedDefine?: boolean | undefined;
-    chunkLoading?: string | false | undefined;
-    asyncChunks?: boolean | undefined;
-    wasmLoading?: string | false | undefined;
-    library?: string | string[] | {
-        commonjs?: string | undefined;
-        amd?: string | undefined;
-        root?: string | string[] | undefined;
-    } | {
-        type: string;
-        name?: string | string[] | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            root?: string | string[] | undefined;
-        } | undefined;
-        amdContainer?: string | undefined;
-        auxiliaryComment?: string | {
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-            root?: string | undefined;
-        } | undefined;
-        export?: string | string[] | undefined;
-        umdNamedDefine?: boolean | undefined;
-    } | undefined;
-    pathinfo?: boolean | "verbose" | undefined;
-    clean?: boolean | undefined;
-    crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-    cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    cssHeadDataCompression?: boolean | undefined;
-    cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    hotUpdateMainFilename?: string | undefined;
-    hotUpdateChunkFilename?: string | undefined;
-    hotUpdateGlobal?: string | undefined;
-    assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    uniqueName?: string | undefined;
-    chunkLoadingGlobal?: string | undefined;
-    enabledLibraryTypes?: string[] | undefined;
-    libraryExport?: string | string[] | undefined;
-    libraryTarget?: string | undefined;
-    strictModuleExceptionHandling?: boolean | undefined;
-    strictModuleErrorHandling?: boolean | undefined;
-    globalObject?: string | undefined;
-    importFunctionName?: string | undefined;
-    importMetaName?: string | undefined;
-    iife?: boolean | undefined;
-    enabledWasmLoadingTypes?: string[] | undefined;
-    webassemblyModuleFilename?: string | undefined;
-    chunkFormat?: string | false | undefined;
-    enabledChunkLoadingTypes?: string[] | undefined;
-    trustedTypes?: string | true | {
-        policyName?: string | undefined;
-    } | undefined;
-    sourceMapFilename?: string | undefined;
-    hashDigest?: string | undefined;
-    hashDigestLength?: number | undefined;
-    hashFunction?: "xxhash64" | "md4" | undefined;
-    hashSalt?: string | undefined;
-    workerChunkLoading?: string | false | undefined;
-    workerWasmLoading?: string | false | undefined;
-    workerPublicPath?: string | undefined;
-    scriptType?: false | "module" | "text/javascript" | undefined;
-    devtoolNamespace?: string | undefined;
-    devtoolModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-    devtoolFallbackModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-    chunkLoadTimeout?: number | undefined;
-    charset?: boolean | undefined;
-}>;
+export type Output = {
+    path?: Path;
+    pathinfo?: Pathinfo;
+    clean?: Clean;
+    publicPath?: PublicPath;
+    filename?: Filename;
+    chunkFilename?: ChunkFilename;
+    crossOriginLoading?: CrossOriginLoading;
+    cssFilename?: CssFilename;
+    cssHeadDataCompression?: boolean;
+    cssChunkFilename?: CssChunkFilename;
+    hotUpdateMainFilename?: HotUpdateMainFilename;
+    hotUpdateChunkFilename?: HotUpdateChunkFilename;
+    hotUpdateGlobal?: HotUpdateGlobal;
+    assetModuleFilename?: AssetModuleFilename;
+    uniqueName?: UniqueName;
+    chunkLoadingGlobal?: ChunkLoadingGlobal;
+    enabledLibraryTypes?: EnabledLibraryTypes;
+    library?: Library;
+    libraryExport?: LibraryExport;
+    libraryTarget?: LibraryType;
+    umdNamedDefine?: UmdNamedDefine;
+    auxiliaryComment?: AuxiliaryComment;
+    module?: OutputModule;
+    strictModuleExceptionHandling?: StrictModuleExceptionHandling;
+    strictModuleErrorHandling?: StrictModuleErrorHandling;
+    globalObject?: GlobalObject;
+    importFunctionName?: ImportFunctionName;
+    importMetaName?: ImportMetaName;
+    iife?: Iife;
+    wasmLoading?: WasmLoading;
+    enabledWasmLoadingTypes?: EnabledWasmLoadingTypes;
+    webassemblyModuleFilename?: WebassemblyModuleFilename;
+    chunkFormat?: ChunkFormat;
+    chunkLoading?: ChunkLoading;
+    enabledChunkLoadingTypes?: EnabledChunkLoadingTypes;
+    trustedTypes?: true | string | TrustedTypes;
+    sourceMapFilename?: SourceMapFilename;
+    hashDigest?: HashDigest;
+    hashDigestLength?: HashDigestLength;
+    hashFunction?: HashFunction;
+    hashSalt?: HashSalt;
+    asyncChunks?: AsyncChunks;
+    workerChunkLoading?: ChunkLoading;
+    workerWasmLoading?: WasmLoading;
+    workerPublicPath?: WorkerPublicPath;
+    scriptType?: ScriptType;
+    devtoolNamespace?: DevtoolNamespace;
+    devtoolModuleFilenameTemplate?: DevtoolModuleFilenameTemplate;
+    devtoolFallbackModuleFilenameTemplate?: DevtoolFallbackModuleFilenameTemplate;
+    chunkLoadTimeout?: number;
+    charset?: boolean;
+    environment?: Environment;
+};
 
 // @public (undocumented)
 export interface OutputFileSystem {
@@ -6430,11 +5985,8 @@ export interface OutputFileSystem {
     writeFile: (arg0: string, arg1: string | Buffer, arg2: (arg0?: null | NodeJS.ErrnoException) => void) => void;
 }
 
-// @public (undocumented)
-export type OutputModule = z.infer<typeof outputModule>;
-
-// @public (undocumented)
-const outputModule: z.ZodBoolean;
+// @public
+export type OutputModule = boolean;
 
 // @public (undocumented)
 export interface OutputNormalized {
@@ -7492,22 +7044,16 @@ export type ParserOptionsByModuleTypeUnknown = z.infer<typeof parserOptionsByMod
 // @public (undocumented)
 const parserOptionsByModuleTypeUnknown: z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>;
 
-// @public (undocumented)
-export type Path = z.infer<typeof path>;
-
-// @public (undocumented)
-const path: z.ZodString;
+// @public
+export type Path = string;
 
 // @public (undocumented)
 type PathData = Omit<JsPathData, "chunk"> & {
     chunk?: Chunk | binding.JsChunkPathData;
 };
 
-// @public (undocumented)
-export type Pathinfo = z.infer<typeof pathinfo>;
-
-// @public (undocumented)
-const pathinfo: z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"verbose">]>;
+// @public
+export type Pathinfo = boolean | "verbose";
 
 // @public (undocumented)
 type PathLike = string | Buffer | URL;
@@ -8150,43 +7696,6 @@ declare namespace rspackExports {
         IgnoreWarningsNormalized,
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
-        Path,
-        Pathinfo,
-        AssetModuleFilename,
-        WebassemblyModuleFilename,
-        ChunkFilename,
-        CrossOriginLoading,
-        CssFilename,
-        CssChunkFilename,
-        HotUpdateChunkFilename,
-        HotUpdateMainFilename,
-        HotUpdateGlobal,
-        UniqueName,
-        ChunkLoadingGlobal,
-        EnabledLibraryTypes,
-        Clean,
-        OutputModule,
-        StrictModuleExceptionHandling,
-        StrictModuleErrorHandling,
-        GlobalObject,
-        EnabledWasmLoadingTypes,
-        ImportFunctionName,
-        ImportMetaName,
-        Iife,
-        EnabledChunkLoadingTypes,
-        ChunkFormat,
-        WorkerPublicPath,
-        TrustedTypes,
-        HashDigest,
-        HashDigestLength,
-        HashFunction,
-        HashSalt,
-        SourceMapFilename,
-        DevtoolNamespace,
-        DevtoolModuleFilenameTemplate,
-        DevtoolFallbackModuleFilenameTemplate,
-        Environment,
-        Output,
         RuleSetCondition,
         RuleSetConditions,
         RuleSetLogicalConditions,
@@ -8290,6 +7799,43 @@ declare namespace rspackExports {
         EntryStatic,
         EntryDynamic,
         Entry,
+        Path,
+        Pathinfo,
+        AssetModuleFilename,
+        WebassemblyModuleFilename,
+        ChunkFilename,
+        CrossOriginLoading,
+        CssFilename,
+        CssChunkFilename,
+        HotUpdateChunkFilename,
+        HotUpdateMainFilename,
+        HotUpdateGlobal,
+        UniqueName,
+        ChunkLoadingGlobal,
+        EnabledLibraryTypes,
+        Clean,
+        OutputModule,
+        StrictModuleExceptionHandling,
+        StrictModuleErrorHandling,
+        GlobalObject,
+        EnabledWasmLoadingTypes,
+        ImportFunctionName,
+        ImportMetaName,
+        Iife,
+        EnabledChunkLoadingTypes,
+        ChunkFormat,
+        WorkerPublicPath,
+        TrustedTypes,
+        HashDigest,
+        HashDigestLength,
+        HashFunction,
+        HashSalt,
+        SourceMapFilename,
+        DevtoolNamespace,
+        DevtoolModuleFilenameTemplate,
+        DevtoolFallbackModuleFilenameTemplate,
+        Environment,
+        Output,
         ResolveAlias,
         ResolveTsConfig,
         ResolveOptions,
@@ -9857,7 +9403,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -9877,7 +9423,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -9901,14 +9447,14 @@ export const rspackOptions: z.ZodObject<{
                 maxInitialSize: z.ZodOptional<z.ZodNumber>;
                 automaticNameDelimiter: z.ZodOptional<z.ZodString>;
             }, "strict", z.ZodTypeAny, {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             }, {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -9918,7 +9464,7 @@ export const rspackOptions: z.ZodObject<{
             hidePathInfo: z.ZodOptional<z.ZodBoolean>;
         }, "strict", z.ZodTypeAny, {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -9934,7 +9480,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -9951,7 +9497,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -9961,7 +9507,7 @@ export const rspackOptions: z.ZodObject<{
             hidePathInfo?: boolean | undefined;
         }, {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -9977,7 +9523,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -9994,7 +9540,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -10034,7 +9580,7 @@ export const rspackOptions: z.ZodObject<{
     }, "strict", z.ZodTypeAny, {
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -10050,7 +9596,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -10067,7 +9613,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -10100,7 +9646,7 @@ export const rspackOptions: z.ZodObject<{
     }, {
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -10116,7 +9662,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -10133,7 +9679,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -11698,7 +11244,7 @@ export const rspackOptions: z.ZodObject<{
     optimization?: {
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -11714,7 +11260,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -11731,7 +11277,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -12296,7 +11842,7 @@ export const rspackOptions: z.ZodObject<{
     optimization?: {
         splitChunks?: false | {
             name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -12312,7 +11858,7 @@ export const rspackOptions: z.ZodObject<{
                 filename?: string | undefined;
                 name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
                 test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
@@ -12329,7 +11875,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "async" | "all" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -12888,11 +12434,8 @@ export interface SourceMapDevToolPluginOptions extends Omit<RawSourceMapDevToolP
     test?: Rules_2;
 }
 
-// @public (undocumented)
-export type SourceMapFilename = z.infer<typeof sourceMapFilename>;
-
-// @public (undocumented)
-const sourceMapFilename: z.ZodString;
+// @public
+export type SourceMapFilename = string;
 
 export { sources }
 
@@ -13545,17 +13088,11 @@ type StatSyncOptions = {
     throwIfNoEntry?: boolean;
 };
 
-// @public (undocumented)
-export type StrictModuleErrorHandling = z.infer<typeof strictModuleErrorHandling>;
+// @public
+export type StrictModuleErrorHandling = boolean;
 
-// @public (undocumented)
-const strictModuleErrorHandling: z.ZodBoolean;
-
-// @public (undocumented)
-export type StrictModuleExceptionHandling = z.infer<typeof strictModuleExceptionHandling>;
-
-// @public (undocumented)
-const strictModuleExceptionHandling: z.ZodBoolean;
+// @public
+export type StrictModuleExceptionHandling = boolean;
 
 // @public (undocumented)
 type StringCallback = (err: NodeJS.ErrnoException | null, data?: string) => void;
@@ -13747,6 +13284,43 @@ declare namespace t {
         EntryStatic,
         EntryDynamic,
         Entry,
+        Path,
+        Pathinfo,
+        AssetModuleFilename,
+        WebassemblyModuleFilename,
+        ChunkFilename,
+        CrossOriginLoading,
+        CssFilename,
+        CssChunkFilename,
+        HotUpdateChunkFilename,
+        HotUpdateMainFilename,
+        HotUpdateGlobal,
+        UniqueName,
+        ChunkLoadingGlobal,
+        EnabledLibraryTypes,
+        Clean,
+        OutputModule,
+        StrictModuleExceptionHandling,
+        StrictModuleErrorHandling,
+        GlobalObject,
+        EnabledWasmLoadingTypes,
+        ImportFunctionName,
+        ImportMetaName,
+        Iife,
+        EnabledChunkLoadingTypes,
+        ChunkFormat,
+        WorkerPublicPath,
+        TrustedTypes,
+        HashDigest,
+        HashDigestLength,
+        HashFunction,
+        HashSalt,
+        SourceMapFilename,
+        DevtoolNamespace,
+        DevtoolModuleFilenameTemplate,
+        DevtoolFallbackModuleFilenameTemplate,
+        Environment,
+        Output,
         ResolveAlias,
         ResolveTsConfig,
         ResolveOptions,
@@ -13990,17 +13564,10 @@ type ToSnakeCaseProperties<T> = {
     [K in keyof T as K extends string ? ToSnakeCase<K> : K]: T[K];
 };
 
-// @public (undocumented)
-export type TrustedTypes = z.infer<typeof trustedTypes>;
-
-// @public (undocumented)
-const trustedTypes: z.ZodObject<{
-    policyName: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    policyName?: string | undefined;
-}, {
-    policyName?: string | undefined;
-}>;
+// @public
+export type TrustedTypes = {
+    policyName?: string;
+};
 
 // @public (undocumented)
 interface UmdConfig extends BaseModuleConfig {
@@ -14015,11 +13582,8 @@ interface UmdConfig extends BaseModuleConfig {
 // @public
 export type UmdNamedDefine = boolean;
 
-// @public (undocumented)
-export type UniqueName = z.infer<typeof uniqueName>;
-
-// @public (undocumented)
-const uniqueName: z.ZodString;
+// @public
+export type UniqueName = string;
 
 // @public (undocumented)
 export const util: {
@@ -14282,11 +13846,8 @@ interface Web {
 // @public (undocumented)
 export const web: Web;
 
-// @public (undocumented)
-export type WebassemblyModuleFilename = z.infer<typeof webassemblyModuleFilename>;
-
-// @public (undocumented)
-const webassemblyModuleFilename: z.ZodString;
+// @public
+export type WebassemblyModuleFilename = string;
 
 // @public (undocumented)
 export type WebpackCompiler = any;
@@ -14343,11 +13904,8 @@ const WebWorkerTemplatePlugin: {
     };
 };
 
-// @public (undocumented)
-export type WorkerPublicPath = z.infer<typeof workerPublicPath>;
-
-// @public (undocumented)
-const workerPublicPath: z.ZodString;
+// @public
+export type WorkerPublicPath = string;
 
 // @public (undocumented)
 namespace z {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -222,6 +222,420 @@ export type EntryDynamic = () => EntryStatic | Promise<EntryStatic>;
 export type Entry = EntryStatic | EntryDynamic;
 //#endregion
 
+//#region Output
+/** The output directory as an absolute path. */
+export type Path = string;
+
+/** Tells Rspack to include comments in bundles with information about the contained modules. */
+export type Pathinfo = boolean | "verbose";
+
+/** Before generating the products, delete all files in the output directory. */
+export type AssetModuleFilename = Filename;
+
+/** Specifies the filename of WebAssembly modules. */
+export type WebassemblyModuleFilename = string;
+
+/** This option determines the name of non-initial chunk files. */
+export type ChunkFilename = Filename;
+
+/** Allows you to set the [crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script)  */
+export type CrossOriginLoading = false | "anonymous" | "use-credentials";
+
+/** This option determines the name of CSS output files on disk. */
+export type CssFilename = Filename;
+
+/** This option determines the name of non-initial CSS output files on disk. */
+export type CssChunkFilename = Filename;
+
+/** Customize the filenames of hot update chunks. */
+export type HotUpdateChunkFilename = FilenameTemplate;
+
+/** Customize the main hot update filename. */
+export type HotUpdateMainFilename = FilenameTemplate;
+
+/** Which uses JSONP for loading hot updates. */
+export type HotUpdateGlobal = string;
+
+/** A unique name of the Rspack build */
+export type UniqueName = string;
+
+/** The global variable is used by Rspack for loading chunks. */
+export type ChunkLoadingGlobal = string;
+
+/** List of library types enabled for use by entry points. */
+export type EnabledLibraryTypes = string[];
+
+/** Whether delete all files in the output directory. */
+export type Clean = boolean;
+
+/** Output JavaScript files as module type. */
+export type OutputModule = boolean;
+
+/** Tell Rspack to remove a module from the module instance cache (require.cache) if it throws an exception when it is required. */
+export type StrictModuleExceptionHandling = boolean;
+
+/** Handle error in module loading as per EcmaScript Modules spec at a performance cost. */
+export type StrictModuleErrorHandling = boolean;
+
+/** Indicates what global object will be used to mount the library. */
+export type GlobalObject = string;
+
+/** List of wasm loading types enabled for use by entry points. */
+export type EnabledWasmLoadingTypes = string[];
+
+/** The name of the native import() function. */
+export type ImportFunctionName = string;
+
+/** The name of the native import.meta object. */
+export type ImportMetaName = string;
+
+/** Tells Rspack to add IIFE wrapper around emitted code. */
+export type Iife = boolean;
+
+/** List of chunk loading types enabled for use by entry points. */
+export type EnabledChunkLoadingTypes = string[];
+
+/** The format of chunks */
+export type ChunkFormat = string | false;
+
+/** Set a public path for Worker. */
+export type WorkerPublicPath = string;
+
+/** Controls [Trusted Types](https://web.dev/articles/trusted-types) compatibility. */
+export type TrustedTypes = {
+	policyName?: string;
+};
+
+/** The encoding to use when generating the hash. */
+export type HashDigest = string;
+
+/** The prefix length of the hash digest to use. */
+export type HashDigestLength = number;
+
+/** The hashing algorithm to use. */
+export type HashFunction = "md4" | "xxhash64";
+
+/** An optional salt to update the hash. */
+export type HashSalt = string;
+
+/** Configure how source maps are named. */
+export type SourceMapFilename = string;
+
+/** This option determines the module's namespace */
+export type DevtoolNamespace = string;
+
+/** This option is only used when devtool uses an option that requires module names. */
+export type DevtoolModuleFilenameTemplate = string | ((info: any) => any);
+
+/** A fallback is used when the template string or function above yields duplicates. */
+export type DevtoolFallbackModuleFilenameTemplate =
+	DevtoolModuleFilenameTemplate;
+
+/** Tell Rspack what kind of ES-features may be used in the generated runtime-code. */
+export type Environment = {
+	/** The environment supports arrow functions ('() => { ... }'). */
+	arrowFunction?: boolean;
+
+	/** The environment supports async function and await ('async function () { await ... }'). */
+	asyncFunction?: boolean;
+
+	/** The environment supports BigInt as literal (123n). */
+	bigIntLiteral?: boolean;
+
+	/** The environment supports const and let for variable declarations. */
+	const?: boolean;
+
+	/** The environment supports destructuring ('{ a, b } = obj'). */
+	destructuring?: boolean;
+
+	/** The environment supports 'document' variable. */
+	document?: boolean;
+
+	/** The environment supports an async import() function to import EcmaScript modules. */
+	dynamicImport?: boolean;
+
+	/** The environment supports an async import() when creating a worker, only for web targets at the moment. */
+	dynamicImportInWorker?: boolean;
+
+	/** The environment supports 'for of' iteration ('for (const x of array) { ... }'). */
+	forOf?: boolean;
+
+	/** The environment supports 'globalThis'. */
+	globalThis?: boolean;
+
+	/** The environment supports ECMAScript Module syntax to import ECMAScript modules (import ... from '...'). */
+	module?: boolean;
+
+	/**
+	 * Determines if the node: prefix is generated for core module imports in environments that support it.
+	 * This is only applicable to Webpack runtime code.
+	 * */
+	nodePrefixForCoreModules?: boolean;
+
+	/** The environment supports optional chaining ('obj?.a' or 'obj?.()'). */
+	optionalChaining?: boolean;
+
+	/** The environment supports template literals. */
+	templateLiteral?: boolean;
+};
+
+export type Output = {
+	/**
+	 * The output directory as an absolute path.
+	 * @default path.resolve(process.cwd(), 'dist')
+	 * */
+	path?: Path;
+
+	/**
+	 * Tells Rspack to include comments in bundles with information about the contained modules.
+	 * @default true
+	 */
+	pathinfo?: Pathinfo;
+
+	/**
+	 * Before generating the products, whether delete all files in the output directory.
+	 * @default false
+	 * */
+	clean?: Clean;
+
+	/** This option determines the URL prefix of the referenced resource, such as: image, file, etc. */
+	publicPath?: PublicPath;
+
+	/** This option determines the name of each output bundle. */
+	filename?: Filename;
+
+	/** This option determines the name of non-initial chunk files. */
+	chunkFilename?: ChunkFilename;
+
+	/** Allows you to set the [crossorigin attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) for dynamically loaded chunks. */
+	crossOriginLoading?: CrossOriginLoading;
+
+	/** This option determines the name of CSS output files on disk. */
+	cssFilename?: CssFilename;
+
+	/**
+	 * Rspack adds some metadata in CSS to parse CSS modules, and this configuration determines whether to compress these metadata.
+	 *
+	 * The value is `true` in production mode.
+	 * The value is `false` in development mode.
+	 * */
+	cssHeadDataCompression?: boolean;
+
+	/** This option determines the name of non-initial CSS output files on disk. */
+	cssChunkFilename?: CssChunkFilename;
+
+	/**
+	 * Customize the main hot update filename. [fullhash] and [runtime] are available as placeholder.
+	 * @default '[runtime].[fullhash].hot-update.json'
+	 * */
+	hotUpdateMainFilename?: HotUpdateMainFilename;
+
+	/**
+	 * Customize the filenames of hot update chunks.
+	 * @default '[id].[fullhash].hot-update.js'
+	 * */
+	hotUpdateChunkFilename?: HotUpdateChunkFilename;
+
+	/**
+	 * Only used when target is set to 'web', which uses JSONP for loading hot updates.
+	 * @default 'webpackHotUpdate' + output.uniqueName
+	 * */
+	hotUpdateGlobal?: HotUpdateGlobal;
+
+	/**
+	 * This option determines the name of each asset modules.
+	 * @default '[hash][ext][query]'
+	 * */
+	assetModuleFilename?: AssetModuleFilename;
+
+	/** A unique name of the Rspack build to avoid multiple Rspack runtimes to conflict when using globals. */
+	uniqueName?: UniqueName;
+
+	/**
+	 * The global variable is used by Rspack for loading chunks.
+	 * Determined by output.uniqueName default.
+	 * */
+	chunkLoadingGlobal?: ChunkLoadingGlobal;
+
+	/**
+	 * List of library types enabled for use by entry points.
+	 * Determined by output.library and Entry default.
+	 * */
+	enabledLibraryTypes?: EnabledLibraryTypes;
+
+	/** Output a library exposing the exports of your entry point. */
+	library?: Library;
+
+	/**
+	 * Specify which export should be exposed as a library.
+	 * @deprecated We might drop support for this, so prefer to use output.library.export
+	 * */
+	libraryExport?: LibraryExport;
+
+	/**
+	 * Configure how the library will be exposed.
+	 * @deprecated Use output.library.type instead as we might drop support for output.libraryTarget in the future.
+	 * */
+	libraryTarget?: LibraryType;
+
+	/**
+	 * When using output.library.type: "umd", setting output.umdNamedDefine to true will name the AMD module of the UMD build.
+	 * @deprecated Use output.library.umdNamedDefine instead.
+	 */
+	umdNamedDefine?: UmdNamedDefine;
+
+	/**
+	 * Add a comment in the UMD wrapper.
+	 * @deprecated use output.library.auxiliaryComment instead.
+	 * */
+	auxiliaryComment?: AuxiliaryComment;
+
+	/**
+	 * Output JavaScript files as module type.
+	 * Disabled by default as it's an experimental feature. To use it, you must set experiments.outputModule to true.
+	 * @default false
+	 */
+	module?: OutputModule;
+
+	/** Tell Rspack to remove a module from the module instance cache (require.cache) if it throws an exception when it is required. */
+	strictModuleExceptionHandling?: StrictModuleExceptionHandling;
+
+	/**
+	 * Handle error in module loading as per EcmaScript Modules spec at a performance cost.
+	 * @default false
+	 * */
+	strictModuleErrorHandling?: StrictModuleErrorHandling;
+
+	/**
+	 * When targeting a library, especially when library.type is 'umd', this option indicates what global object will be used to mount the library.
+	 * @default 'self'
+	 */
+	globalObject?: GlobalObject;
+
+	/**
+	 * The name of the native import() function.
+	 * @default 'import'
+	 * */
+	importFunctionName?: ImportFunctionName;
+
+	/**
+	 * The name of the native import.meta object (can be exchanged for a polyfill).
+	 * @default 'import.meta'
+	 */
+	importMetaName?: ImportMetaName;
+
+	/**
+	 * Tells Rspack to add IIFE wrapper around emitted code.
+	 * @default true
+	 */
+	iife?: Iife;
+
+	/**
+	 * Option to set the method of loading WebAssembly Modules.
+	 * @default 'fetch'
+	 * */
+	wasmLoading?: WasmLoading;
+
+	/** List of wasm loading types enabled for use by entry points. */
+	enabledWasmLoadingTypes?: EnabledWasmLoadingTypes;
+
+	/**
+	 * Specifies the filename of WebAssembly modules.
+	 * @default '[hash].module.wasm'
+	 * */
+	webassemblyModuleFilename?: WebassemblyModuleFilename;
+
+	/** The format of chunks (formats included by default are 'array-push' (web/webworker), 'commonjs' (node.js), 'module' (ESM). */
+	chunkFormat?: ChunkFormat;
+
+	/** The method to load chunks (methods included by default are 'jsonp' (web), 'import' (ESM), 'importScripts' (webworker), 'require' (sync node.js), 'async-node' (async node.js) */
+	chunkLoading?: ChunkLoading;
+
+	/** List of chunk loading types enabled for use by entry points. */
+	enabledChunkLoadingTypes?: EnabledChunkLoadingTypes;
+
+	/** Controls [Trusted Types](https://web.dev/articles/trusted-types) compatibility. */
+	trustedTypes?: true | string | TrustedTypes;
+
+	/**
+	 * Configure how source maps are named.
+	 * Only takes effect when devtool is set to 'source-map', which writes an output file.
+	 * @default '[file].map[query]'
+	 * */
+	sourceMapFilename?: SourceMapFilename;
+
+	/** The encoding to use when generating the hash. */
+	hashDigest?: HashDigest;
+
+	/**
+	 * The prefix length of the hash digest to use.
+	 * @default 20
+	 * */
+	hashDigestLength?: HashDigestLength;
+
+	/**
+	 * The hashing algorithm to use.
+	 * @default 'md4'
+	 * */
+	hashFunction?: HashFunction;
+
+	/** An optional salt to update the hash. */
+	hashSalt?: HashSalt;
+
+	/**
+	 * Create async chunks that are loaded on demand.
+	 * @default true
+	 * */
+	asyncChunks?: AsyncChunks;
+
+	/**
+	 * The new option workerChunkLoading controls the chunk loading of workers.
+	 * @default false
+	 * */
+	workerChunkLoading?: ChunkLoading;
+
+	/**
+	 * Option to set the method of loading WebAssembly Modules in workers, defaults to the value of output.wasmLoading.
+	 * @default false
+	 * */
+	workerWasmLoading?: WasmLoading;
+
+	/** Set a public path for Worker, defaults to value of output.publicPath. */
+	workerPublicPath?: WorkerPublicPath;
+
+	/**
+	 * This option allows loading asynchronous chunks with a custom script type.
+	 * @default false
+	 * */
+	scriptType?: ScriptType;
+
+	/** This option determines the module's namespace used with the output.devtoolModuleFilenameTemplate */
+	devtoolNamespace?: DevtoolNamespace;
+
+	/** This option is only used when devtool uses an option that requires module names. */
+	devtoolModuleFilenameTemplate?: DevtoolModuleFilenameTemplate;
+
+	/** A fallback is used when the template string or function above yields duplicates. */
+	devtoolFallbackModuleFilenameTemplate?: DevtoolFallbackModuleFilenameTemplate;
+
+	/**
+	 * The Number of milliseconds before chunk request timed out.
+	 * @default 120000
+	 * */
+	chunkLoadTimeout?: number;
+
+	/**
+	 * Add charset="utf-8" to the HTML <script> tag.
+	 * @default true
+	 * */
+	charset?: boolean;
+
+	/** Tell Rspack what kind of ES-features may be used in the generated runtime-code. */
+	environment?: Environment;
+};
+
+//#endregion
+
 //#region Resolve
 /**
  * Path alias

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -199,127 +199,103 @@ const entry = entryStatic.or(entryDynamic) satisfies z.ZodType<t.Entry>;
 //#endregion
 
 //#region Output
-const path = z.string();
-export type Path = z.infer<typeof path>;
+const path = z.string() satisfies z.ZodType<t.Path>;
 
-const pathinfo = z.boolean().or(z.literal("verbose"));
-export type Pathinfo = z.infer<typeof pathinfo>;
+const pathinfo = z
+	.boolean()
+	.or(z.literal("verbose")) satisfies z.ZodType<t.Pathinfo>;
 
-const assetModuleFilename = filename;
-export type AssetModuleFilename = z.infer<typeof assetModuleFilename>;
+const assetModuleFilename = filename satisfies z.ZodType<t.AssetModuleFilename>;
 
-const webassemblyModuleFilename = z.string();
-export type WebassemblyModuleFilename = z.infer<
-	typeof webassemblyModuleFilename
->;
+const webassemblyModuleFilename =
+	z.string() satisfies z.ZodType<t.WebassemblyModuleFilename>;
 
-const chunkFilename = filename;
-export type ChunkFilename = z.infer<typeof chunkFilename>;
+const chunkFilename = filename satisfies z.ZodType<t.ChunkFilename>;
 
 const crossOriginLoading = z
 	.literal(false)
-	.or(z.enum(["anonymous", "use-credentials"]));
-export type CrossOriginLoading = z.infer<typeof crossOriginLoading>;
+	.or(
+		z.enum(["anonymous", "use-credentials"])
+	) satisfies z.ZodType<t.CrossOriginLoading>;
 
-const cssFilename = filename;
-export type CssFilename = z.infer<typeof cssFilename>;
+const cssFilename = filename satisfies z.ZodType<t.CssFilename>;
 
-const cssChunkFilename = filename;
-export type CssChunkFilename = z.infer<typeof cssChunkFilename>;
+const cssChunkFilename = filename satisfies z.ZodType<t.CssChunkFilename>;
 
-const hotUpdateChunkFilename = filenameTemplate;
-export type HotUpdateChunkFilename = z.infer<typeof hotUpdateChunkFilename>;
+const hotUpdateChunkFilename =
+	filenameTemplate satisfies z.ZodType<t.HotUpdateChunkFilename>;
 
-const hotUpdateMainFilename = filenameTemplate;
-export type HotUpdateMainFilename = z.infer<typeof hotUpdateMainFilename>;
+const hotUpdateMainFilename =
+	filenameTemplate satisfies z.ZodType<t.HotUpdateMainFilename>;
 
-const hotUpdateGlobal = z.string();
-export type HotUpdateGlobal = z.infer<typeof hotUpdateGlobal>;
+const hotUpdateGlobal = z.string() satisfies z.ZodType<t.HotUpdateGlobal>;
 
-const uniqueName = z.string();
-export type UniqueName = z.infer<typeof uniqueName>;
+const uniqueName = z.string() satisfies z.ZodType<t.UniqueName>;
 
-const chunkLoadingGlobal = z.string();
-export type ChunkLoadingGlobal = z.infer<typeof chunkLoadingGlobal>;
+const chunkLoadingGlobal = z.string() satisfies z.ZodType<t.ChunkLoadingGlobal>;
 
-const enabledLibraryTypes = z.array(libraryType);
-export type EnabledLibraryTypes = z.infer<typeof enabledLibraryTypes>;
+const enabledLibraryTypes = z.array(
+	libraryType
+) satisfies z.ZodType<t.EnabledLibraryTypes>;
 
-const clean = z.boolean();
-export type Clean = z.infer<typeof clean>;
+const clean = z.boolean() satisfies z.ZodType<t.Clean>;
 
-const outputModule = z.boolean();
-export type OutputModule = z.infer<typeof outputModule>;
+const outputModule = z.boolean() satisfies z.ZodType<t.OutputModule>;
 
-const strictModuleExceptionHandling = z.boolean();
-export type StrictModuleExceptionHandling = z.infer<
-	typeof strictModuleExceptionHandling
->;
+const strictModuleExceptionHandling =
+	z.boolean() satisfies z.ZodType<t.StrictModuleExceptionHandling>;
 
-const strictModuleErrorHandling = z.boolean();
-export type StrictModuleErrorHandling = z.infer<
-	typeof strictModuleErrorHandling
->;
+const strictModuleErrorHandling =
+	z.boolean() satisfies z.ZodType<t.StrictModuleErrorHandling>;
 
-const globalObject = z.string();
-export type GlobalObject = z.infer<typeof globalObject>;
+const globalObject = z.string() satisfies z.ZodType<t.GlobalObject>;
 
-const enabledWasmLoadingTypes = z.array(wasmLoadingType);
-export type EnabledWasmLoadingTypes = z.infer<typeof enabledWasmLoadingTypes>;
+const enabledWasmLoadingTypes = z.array(
+	wasmLoadingType
+) satisfies z.ZodType<t.EnabledWasmLoadingTypes>;
 
-const importFunctionName = z.string();
-export type ImportFunctionName = z.infer<typeof importFunctionName>;
+const importFunctionName = z.string() satisfies z.ZodType<t.ImportFunctionName>;
 
-const importMetaName = z.string();
-export type ImportMetaName = z.infer<typeof importMetaName>;
+const importMetaName = z.string() satisfies z.ZodType<t.ImportMetaName>;
 
-const iife = z.boolean();
-export type Iife = z.infer<typeof iife>;
+const iife = z.boolean() satisfies z.ZodType<t.Iife>;
 
-const enabledChunkLoadingTypes = z.array(chunkLoadingType);
-export type EnabledChunkLoadingTypes = z.infer<typeof enabledChunkLoadingTypes>;
+const enabledChunkLoadingTypes = z.array(
+	chunkLoadingType
+) satisfies z.ZodType<t.EnabledChunkLoadingTypes>;
 
-const chunkFormat = z.literal(false).or(z.string());
-export type ChunkFormat = z.infer<typeof chunkFormat>;
+const chunkFormat = z
+	.literal(false)
+	.or(z.string()) satisfies z.ZodType<t.ChunkFormat>;
 
-const workerPublicPath = z.string();
-export type WorkerPublicPath = z.infer<typeof workerPublicPath>;
+const workerPublicPath = z.string() satisfies z.ZodType<t.WorkerPublicPath>;
 
 const trustedTypes = z.strictObject({
 	policyName: z.string().optional()
-});
-export type TrustedTypes = z.infer<typeof trustedTypes>;
+}) satisfies z.ZodType<t.TrustedTypes>;
 
-const hashDigest = z.string();
-export type HashDigest = z.infer<typeof hashDigest>;
+const hashDigest = z.string() satisfies z.ZodType<t.HashDigest>;
 
-const hashDigestLength = z.number();
-export type HashDigestLength = z.infer<typeof hashDigestLength>;
+const hashDigestLength = z.number() satisfies z.ZodType<t.HashDigestLength>;
 
-const hashFunction = z.enum(["md4", "xxhash64"]);
-export type HashFunction = z.infer<typeof hashFunction>;
+const hashFunction = z.enum([
+	"md4",
+	"xxhash64"
+]) satisfies z.ZodType<t.HashFunction>;
 
-const hashSalt = z.string();
-export type HashSalt = z.infer<typeof hashSalt>;
+const hashSalt = z.string() satisfies z.ZodType<t.HashSalt>;
 
-const sourceMapFilename = z.string();
-export type SourceMapFilename = z.infer<typeof sourceMapFilename>;
+const sourceMapFilename = z.string() satisfies z.ZodType<t.SourceMapFilename>;
 
-const devtoolNamespace = z.string();
-export type DevtoolNamespace = z.infer<typeof devtoolNamespace>;
+const devtoolNamespace = z.string() satisfies z.ZodType<t.DevtoolNamespace>;
 
 const devtoolModuleFilenameTemplate = z.union([
 	z.string(),
 	z.function(z.tuple([z.any()]), z.any())
-]);
-export type DevtoolModuleFilenameTemplate = z.infer<
-	typeof devtoolModuleFilenameTemplate
->;
+]) satisfies z.ZodType<t.DevtoolModuleFilenameTemplate>;
 
-const devtoolFallbackModuleFilenameTemplate = devtoolModuleFilenameTemplate;
-export type DevtoolFallbackModuleFilenameTemplate = z.infer<
-	typeof devtoolFallbackModuleFilenameTemplate
->;
+const devtoolFallbackModuleFilenameTemplate =
+	devtoolModuleFilenameTemplate satisfies z.ZodType<t.DevtoolFallbackModuleFilenameTemplate>;
 
 const environment = z.strictObject({
 	arrowFunction: z.boolean().optional(),
@@ -336,8 +312,7 @@ const environment = z.strictObject({
 	nodePrefixForCoreModules: z.boolean().optional(),
 	optionalChaining: z.boolean().optional(),
 	templateLiteral: z.boolean().optional()
-});
-export type Environment = z.infer<typeof environment>;
+}) satisfies z.ZodType<t.Environment>;
 
 const output = z.strictObject({
 	path: path.optional(),
@@ -393,8 +368,7 @@ const output = z.strictObject({
 	chunkLoadTimeout: z.number().optional(),
 	charset: z.boolean().optional(),
 	environment: environment.optional()
-});
-export type Output = z.infer<typeof output>;
+}) satisfies z.ZodType<t.Output>;
 //#endregion
 
 //#region Resolve

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -355,6 +355,8 @@ module.exports = {
       const: true,
       // The environment supports destructuring ('{ a, b } = obj').
       destructuring: true,
+      // The environment supports 'document' variable.
+      document: true,
       // The environment supports an async import() function to import EcmaScript modules.
       dynamicImport: false,
       // The environment supports an async import() when creating a worker, only for web targets at the moment.
@@ -1652,6 +1654,12 @@ module.exports = {
   },
 };
 ```
+
+## output.strictModuleExceptionHandling
+
+- **Types:** boolean
+
+Tell Rspack to remove a module from the module instance cache (require.cache) if it throws an exception when it is required.
 
 ## output.trustedTypes
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -351,6 +351,8 @@ module.exports = {
       const: true,
       // The environment supports destructuring ('{ a, b } = obj').
       destructuring: true,
+      // The environment supports 'document' variable.
+      document: true,
       // The environment supports an async import() function to import EcmaScript modules.
       dynamicImport: false,
       // The environment supports an async import() when creating a worker, only for web targets at the moment.
@@ -1644,6 +1646,12 @@ module.exports = {
   },
 };
 ```
+
+## output.strictModuleExceptionHandling
+
+- **Types:** boolean
+
+告诉 Rspack 当 require 模块出现错误时，移除模块的缓存。
 
 ## output.trustedTypes
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.output

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
