### PR TITLE
feat: add setters for errors and warnings in Compilation

### DIFF
--- a/packages/rspack-test-tools/tests/errorCases/error-test-set.js
+++ b/packages/rspack-test-tools/tests/errorCases/error-test-set.js
@@ -1,0 +1,35 @@
+/** @type {import('../..').TErrorCaseConfig} */
+module.exports = {
+	description: "Testing set errors",
+	options() {
+		return {
+			entry: "./resolve-fail-esm",
+			plugins: [
+				compiler => {
+					compiler.hooks.afterCompile.tap("set errors", compilation => {
+						compilation.errors = [new Error("error 1"), new Error("error 2")];
+					});
+				}
+			]
+		};
+	},
+	async check(diagnostics) {
+		expect(diagnostics).toMatchInlineSnapshot(`
+		Object {
+		  "errors": Array [
+		    Object {
+		      "message": "  × Error: error 1/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n",
+		      "moduleTrace": Array [],
+		      "stack": "Error: error 1/n    at Object.fn (<ROOT>/tests/errorCases/error-test-set.js<LINE_COL>)/n    at next (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsyncStageRange (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsync (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>",
+		    },
+		    Object {
+		      "message": "  × Error: error 2/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n",
+		      "moduleTrace": Array [],
+		      "stack": "Error: error 2/n    at Object.fn (<ROOT>/tests/errorCases/error-test-set.js<LINE_COL>)/n    at next (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsyncStageRange (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsync (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>",
+		    },
+		  ],
+		  "warnings": Array [],
+		}
+	`);
+	}
+};

--- a/packages/rspack-test-tools/tests/errorCases/warning-test-set.js
+++ b/packages/rspack-test-tools/tests/errorCases/warning-test-set.js
@@ -1,0 +1,38 @@
+/** @type {import('../..').TErrorCaseConfig} */
+module.exports = {
+	description: "Testing set warnings",
+	options() {
+		return {
+			entry: "./require.main.require",
+			plugins: [
+				compiler => {
+					compiler.hooks.afterCompile.tap("set warnings", compilation => {
+						compilation.warnings = [
+							new Error("warning 1"),
+							new Error("warning 2")
+						];
+					});
+				}
+			]
+		};
+	},
+	async check(diagnostics) {
+		expect(diagnostics).toMatchInlineSnapshot(`
+		Object {
+		  "errors": Array [],
+		  "warnings": Array [
+		    Object {
+		      "message": "  ⚠ Error: warning 1/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n",
+		      "moduleTrace": Array [],
+		      "stack": "Error: warning 1/n    at Object.fn (<ROOT>/tests/errorCases/warning-test-set.js<LINE_COL>)/n    at next (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsyncStageRange (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsync (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>",
+		    },
+		    Object {
+		      "message": "  ⚠ Error: warning 2/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n  │     at xxx/n",
+		      "moduleTrace": Array [],
+		      "stack": "Error: warning 2/n    at Object.fn (<ROOT>/tests/errorCases/warning-test-set.js<LINE_COL>)/n    at next (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsyncStageRange (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at AsyncSeriesHook.callAsync (<WORKSPACE>/node_modules/<PNPM_INNER>/@rspack/lite-tapable/dist/index.js<LINE_COL>)/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>/n    at <WORKSPACE>/packages/rspack/dist/index.js<LINE_COL>",
+		    },
+		  ],
+		}
+	`);
+	}
+};

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -636,6 +636,7 @@ export class Compilation {
     get entrypoints(): ReadonlyMap<string, Entrypoint>;
     // (undocumented)
     get errors(): RspackError[];
+    set errors(errors: RspackError[]);
     // (undocumented)
     fileDependencies: {
         [Symbol.iterator](): Generator<string, void, unknown>;
@@ -783,6 +784,7 @@ export class Compilation {
     updateAsset(filename: string, newSourceOrFunction: Source | ((source: Source) => Source), assetInfoUpdateOrFunction?: AssetInfo | ((assetInfo: AssetInfo) => AssetInfo)): void;
     // (undocumented)
     get warnings(): RspackError[];
+    set warnings(warnings: RspackError[]);
 }
 
 // @public (undocumented)

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -800,6 +800,18 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 		return errors;
 	}
 
+	set errors(errors: RspackError[]) {
+		const inner = this.#inner;
+		const length = inner.getErrors().length;
+		inner.spliceDiagnostic(
+			0,
+			length,
+			errors.map(error => {
+				return JsRspackDiagnostic.__to_binding(error, JsRspackSeverity.Error);
+			})
+		);
+	}
+
 	get warnings(): RspackError[] {
 		const inner = this.#inner;
 		type WarnType = Error | RspackError;
@@ -891,6 +903,18 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 			warnings[item.method as any] = proxiedMethod;
 		}
 		return warnings;
+	}
+
+	set warnings(warnings: RspackError[]) {
+		const inner = this.#inner;
+		const length = inner.getWarnings().length;
+		inner.spliceDiagnostic(
+			0,
+			length,
+			warnings.map(warning => {
+				return JsRspackDiagnostic.__to_binding(warning, JsRspackSeverity.Warn);
+			})
+		);
 	}
 
 	getPath(filename: Filename, data: PathData = {}) {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
close #8109 

Enhance compatibility with ts-loader: https://github.com/TypeStrong/ts-loader/blob/6a4e29c729fd6727c1c625fad3a65d509c2c37eb/src/after-compile.ts#L464-L466
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
