### PR TITLE
test: not to display obsoleted snapshots when test with `-t`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "jest-cli": "29.7.0",
     "jest-environment-node": "29.7.0",
     "lint-staged": "^15.0.0",
-    "path-serializer": "0.0.6",
     "prettier": "3.2.5",
     "prettier-2": "npm:prettier@2.8.8",
     "rimraf": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "jest-cli": "29.7.0",
     "jest-environment-node": "29.7.0",
     "lint-staged": "^15.0.0",
+    "path-serializer": "0.0.6",
     "prettier": "3.2.5",
     "prettier-2": "npm:prettier@2.8.8",
     "rimraf": "3.0.2",

--- a/packages/rspack-test-tools/jest.config.js
+++ b/packages/rspack-test-tools/jest.config.js
@@ -9,7 +9,7 @@ const config = {
 		"@rspack/test-tools/setup-env"
 	],
 	reporters: [
-		["default", null],
+		["../../scripts/test/ignore-snapshot-default-reporter.cjs", null],
 		"../../scripts/test/ignore-snapshot-summary-reporter.cjs"
 	],
 	testTimeout: process.env.CI ? 60000 : 30000,

--- a/scripts/test/ignore-snapshot-default-reporter.cjs
+++ b/scripts/test/ignore-snapshot-default-reporter.cjs
@@ -1,0 +1,84 @@
+const { DefaultReporter } = require("@jest/reporters");
+const chalk = require.cache[require.resolve('@jest/reporters')].require("chalk");
+const jestUtil = require.cache[require.resolve('@jest/reporters')].require("jest-util");
+
+const ARROW = ' \u203A ';
+const DOT = ' \u2022 ';
+const FAIL_COLOR = chalk.bold.red;
+const SNAPSHOT_ADDED = chalk.bold.green;
+const SNAPSHOT_UPDATED = chalk.bold.green;
+const SNAPSHOT_OUTDATED = chalk.bold.yellow;
+function getSnapshotStatus(snapshot, afterUpdate) {
+  const statuses = [];
+  if (snapshot.added) {
+    statuses.push(
+      SNAPSHOT_ADDED(
+        `${ARROW + jestUtil().pluralize('snapshot', snapshot.added)
+        } written.`
+      )
+    );
+  }
+  if (snapshot.updated) {
+    statuses.push(
+      SNAPSHOT_UPDATED(
+        `${ARROW + jestUtil().pluralize('snapshot', snapshot.updated)
+        } updated.`
+      )
+    );
+  }
+  if (snapshot.unmatched) {
+    statuses.push(
+      FAIL_COLOR(
+        `${ARROW + jestUtil().pluralize('snapshot', snapshot.unmatched)
+        } failed.`
+      )
+    );
+  }
+  if (snapshot.unchecked) {
+    if (afterUpdate) {
+      statuses.push(
+        SNAPSHOT_UPDATED(
+          `${ARROW + jestUtil().pluralize('snapshot', snapshot.unchecked)
+          } removed.`
+        )
+      );
+      for (const key of snapshot.uncheckedKeys) {
+        statuses.push(`  ${DOT}${key}`);
+      }
+    } else {
+      statuses.push(
+        `${SNAPSHOT_OUTDATED(
+          `${ARROW + jestUtil().pluralize('snapshot', snapshot.unchecked)
+          } obsolete`
+        )}.`
+      );
+    }
+  }
+  if (snapshot.fileDeleted) {
+    statuses.push(SNAPSHOT_UPDATED(`${ARROW}snapshot file removed.`));
+  }
+  return statuses;
+}
+
+const isUpdate = process.argv.includes("-u") || process.argv.includes("--updateSnapshot");
+const isFiltering = process.argv.includes("-t") || process.argv.includes("--testNamePattern");
+const isVerbose = process.argv.includes("--verbose");
+
+if (!isVerbose && !isUpdate && isFiltering) {
+  class IgnoreSnapshotDefaultReporter extends DefaultReporter {
+    printTestFileFailureMessage(_testPath, _config, result) {
+      if (result.failureMessage) {
+        this.log(result.failureMessage);
+      }
+      const didUpdate = this._globalConfig.updateSnapshot === 'all';
+      const snapshotStatuses = getSnapshotStatus(
+        result.snapshot,
+        didUpdate
+      );
+      snapshotStatuses.forEach(this.log);
+    }
+  }
+  module.exports = IgnoreSnapshotDefaultReporter;
+} else {
+  module.exports = DefaultReporter;
+}

--- a/scripts/test/ignore-snapshot-summary-reporter.cjs
+++ b/scripts/test/ignore-snapshot-summary-reporter.cjs
@@ -1,7 +1,11 @@
 const { SummaryReporter } = require("@jest/reporters");
 const chalk = require.cache[require.resolve('@jest/reporters')].require("chalk");
 
-if (!process.argv.includes("--verbose") && (process.argv.includes("-t") || process.argv.some(i => i.includes("--testNamePattern")))) {
+const isUpdate = process.argv.includes("-u") || process.argv.includes("--updateSnapshot");
+const isFiltering = process.argv.includes("-t") || process.argv.includes("--testNamePattern");
+const isVerbose = process.argv.includes("--verbose");
+
+if (!isVerbose && !isUpdate && isFiltering) {
   class IgnoreSnapshotSummaryReporter extends SummaryReporter {
     _printSnapshotSummary(snapshots, globalConfig) {
       if (

--- a/tests/webpack-test/jest.config.js
+++ b/tests/webpack-test/jest.config.js
@@ -148,5 +148,9 @@ module.exports = {
 	"snapshotFormat": {
 		"escapeString": true,
 		"printBasicPrototype": true
-	}
+	},
+	"reporters": [
+		["../../scripts/test/ignore-snapshot-default-reporter.cjs", null],
+		"../../scripts/test/ignore-snapshot-summary-reporter.cjs"
+	],
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

There is no need to output all the obsoleted snapshots when test with `-t` which filters the test cases.

Before:

![image](https://github.com/user-attachments/assets/dc695761-21c6-44ad-a465-d0c52b2cf440)

After:
![image](https://github.com/user-attachments/assets/b8bd1228-8037-4a06-9b5f-fa7edf747b4c)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
