### PR TITLE
feat: introduce RemoveDuplicateModulesPlugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,6 +3547,7 @@ dependencies = [
  "rspack_plugin_no_emit_on_errors",
  "rspack_plugin_progress",
  "rspack_plugin_real_content_hash",
+ "rspack_plugin_remove_duplicate_modules",
  "rspack_plugin_remove_empty_chunks",
  "rspack_plugin_runtime",
  "rspack_plugin_runtime_chunk",
@@ -4403,6 +4404,17 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hash",
+ "rspack_hook",
+ "rustc-hash 1.1.0",
+ "tracing",
+]
+
+[[package]]
+name = "rspack_plugin_remove_duplicate_modules"
+version = "0.1.0"
+dependencies = [
+ "rspack_core",
+ "rspack_error",
  "rspack_hook",
  "rustc-hash 1.1.0",
  "tracing",

--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -263,6 +263,7 @@ export enum BuiltinPluginName {
   WebWorkerTemplatePlugin = 'WebWorkerTemplatePlugin',
   MergeDuplicateChunksPlugin = 'MergeDuplicateChunksPlugin',
   SplitChunksPlugin = 'SplitChunksPlugin',
+  RemoveDuplicateModulesPlugin = 'RemoveDuplicateModulesPlugin',
   ShareRuntimePlugin = 'ShareRuntimePlugin',
   ContainerPlugin = 'ContainerPlugin',
   ContainerReferencePlugin = 'ContainerReferencePlugin',

--- a/crates/rspack_binding_options/Cargo.toml
+++ b/crates/rspack_binding_options/Cargo.toml
@@ -13,67 +13,68 @@ plugin  = ["rspack_loader_swc/plugin"]
 ignored = ["tracing"]
 
 [dependencies]
-async-trait                           = { workspace = true }
-cow-utils                             = { workspace = true }
-derivative                            = { workspace = true }
-glob                                  = { workspace = true }
-napi                                  = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
-napi-derive                           = { workspace = true }
-rspack_binding_values                 = { version = "0.1.0", path = "../rspack_binding_values" }
-rspack_collections                    = { version = "0.1.0", path = "../rspack_collections" }
-rspack_core                           = { version = "0.1.0", path = "../rspack_core" }
-rspack_error                          = { version = "0.1.0", path = "../rspack_error" }
-rspack_hook                           = { version = "0.1.0", path = "../rspack_hook" }
-rspack_ids                            = { version = "0.1.0", path = "../rspack_ids" }
-rspack_loader_lightningcss            = { version = "0.1.0", path = "../rspack_loader_lightningcss" }
-rspack_loader_preact_refresh          = { version = "0.1.0", path = "../rspack_loader_preact_refresh" }
-rspack_loader_react_refresh           = { version = "0.1.0", path = "../rspack_loader_react_refresh" }
-rspack_loader_runner                  = { version = "0.1.0", path = "../rspack_loader_runner" }
-rspack_loader_swc                     = { version = "0.1.0", path = "../rspack_loader_swc" }
-rspack_loader_testing                 = { version = "0.1.0", path = "../rspack_loader_testing" }
-rspack_napi                           = { version = "0.1.0", path = "../rspack_napi" }
-rspack_napi_macros                    = { version = "0.1.0", path = "../rspack_napi_macros" }
-rspack_paths                          = { version = "0.1.0", path = "../rspack_paths" }
-rspack_plugin_asset                   = { version = "0.1.0", path = "../rspack_plugin_asset" }
-rspack_plugin_banner                  = { version = "0.1.0", path = "../rspack_plugin_banner" }
-rspack_plugin_context_replacement     = { version = "0.1.0", path = "../rspack_plugin_context_replacement" }
-rspack_plugin_copy                    = { version = "0.1.0", path = "../rspack_plugin_copy" }
-rspack_plugin_css                     = { version = "0.1.0", path = "../rspack_plugin_css" }
-rspack_plugin_devtool                 = { version = "0.1.0", path = "../rspack_plugin_devtool" }
-rspack_plugin_dynamic_entry           = { version = "0.1.0", path = "../rspack_plugin_dynamic_entry" }
-rspack_plugin_ensure_chunk_conditions = { version = "0.1.0", path = "../rspack_plugin_ensure_chunk_conditions" }
-rspack_plugin_entry                   = { version = "0.1.0", path = "../rspack_plugin_entry" }
-rspack_plugin_externals               = { version = "0.1.0", path = "../rspack_plugin_externals" }
-rspack_plugin_extract_css             = { version = "0.1.0", path = "../rspack_plugin_extract_css" }
-rspack_plugin_hmr                     = { version = "0.1.0", path = "../rspack_plugin_hmr" }
-rspack_plugin_html                    = { version = "0.1.0", path = "../rspack_plugin_html" }
-rspack_plugin_ignore                  = { version = "0.1.0", path = "../rspack_plugin_ignore" }
-rspack_plugin_javascript              = { version = "0.1.0", path = "../rspack_plugin_javascript" }
-rspack_plugin_json                    = { version = "0.1.0", path = "../rspack_plugin_json" }
-rspack_plugin_lazy_compilation        = { version = "0.1.0", path = "../rspack_plugin_lazy_compilation" }
-rspack_plugin_library                 = { version = "0.1.0", path = "../rspack_plugin_library" }
-rspack_plugin_lightning_css_minimizer = { version = "0.1.0", path = "../rspack_plugin_lightning_css_minimizer" }
-rspack_plugin_limit_chunk_count       = { version = "0.1.0", path = "../rspack_plugin_limit_chunk_count" }
-rspack_plugin_merge_duplicate_chunks  = { version = "0.1.0", path = "../rspack_plugin_merge_duplicate_chunks" }
-rspack_plugin_mf                      = { version = "0.1.0", path = "../rspack_plugin_mf" }
-rspack_plugin_no_emit_on_errors       = { version = "0.1.0", path = "../rspack_plugin_no_emit_on_errors" }
-rspack_plugin_progress                = { version = "0.1.0", path = "../rspack_plugin_progress" }
-rspack_plugin_real_content_hash       = { version = "0.1.0", path = "../rspack_plugin_real_content_hash" }
-rspack_plugin_remove_empty_chunks     = { version = "0.1.0", path = "../rspack_plugin_remove_empty_chunks" }
-rspack_plugin_runtime                 = { version = "0.1.0", path = "../rspack_plugin_runtime" }
-rspack_plugin_runtime_chunk           = { version = "0.1.0", path = "../rspack_plugin_runtime_chunk" }
-rspack_plugin_schemes                 = { version = "0.1.0", path = "../rspack_plugin_schemes" }
-rspack_plugin_size_limits             = { version = "0.1.0", path = "../rspack_plugin_size_limits" }
-rspack_plugin_split_chunks            = { version = "0.1.0", path = "../rspack_plugin_split_chunks" }
-rspack_plugin_swc_js_minimizer        = { version = "0.1.0", path = "../rspack_plugin_swc_js_minimizer" }
-rspack_plugin_warn_sensitive_module   = { version = "0.1.0", path = "../rspack_plugin_warn_sensitive_module" }
-rspack_plugin_wasm                    = { version = "0.1.0", path = "../rspack_plugin_wasm" }
-rspack_plugin_web_worker_template     = { version = "0.1.0", path = "../rspack_plugin_web_worker_template" }
-rspack_plugin_worker                  = { version = "0.1.0", path = "../rspack_plugin_worker" }
-rspack_regex                          = { version = "0.1.0", path = "../rspack_regex" }
-rustc-hash                            = { workspace = true }
-serde                                 = { workspace = true, features = ["derive"] }
-serde_json                            = { workspace = true }
-swc_core                              = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                 = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
-tracing                               = { workspace = true }
+async-trait                            = { workspace = true }
+cow-utils                              = { workspace = true }
+derivative                             = { workspace = true }
+glob                                   = { workspace = true }
+napi                                   = { workspace = true, features = ["async", "tokio_rt", "serde-json", "anyhow"] }
+napi-derive                            = { workspace = true }
+rspack_binding_values                  = { version = "0.1.0", path = "../rspack_binding_values" }
+rspack_collections                     = { version = "0.1.0", path = "../rspack_collections" }
+rspack_core                            = { version = "0.1.0", path = "../rspack_core" }
+rspack_error                           = { version = "0.1.0", path = "../rspack_error" }
+rspack_hook                            = { version = "0.1.0", path = "../rspack_hook" }
+rspack_ids                             = { version = "0.1.0", path = "../rspack_ids" }
+rspack_loader_lightningcss             = { version = "0.1.0", path = "../rspack_loader_lightningcss" }
+rspack_loader_preact_refresh           = { version = "0.1.0", path = "../rspack_loader_preact_refresh" }
+rspack_loader_react_refresh            = { version = "0.1.0", path = "../rspack_loader_react_refresh" }
+rspack_loader_runner                   = { version = "0.1.0", path = "../rspack_loader_runner" }
+rspack_loader_swc                      = { version = "0.1.0", path = "../rspack_loader_swc" }
+rspack_loader_testing                  = { version = "0.1.0", path = "../rspack_loader_testing" }
+rspack_napi                            = { version = "0.1.0", path = "../rspack_napi" }
+rspack_napi_macros                     = { version = "0.1.0", path = "../rspack_napi_macros" }
+rspack_paths                           = { version = "0.1.0", path = "../rspack_paths" }
+rspack_plugin_asset                    = { version = "0.1.0", path = "../rspack_plugin_asset" }
+rspack_plugin_banner                   = { version = "0.1.0", path = "../rspack_plugin_banner" }
+rspack_plugin_context_replacement      = { version = "0.1.0", path = "../rspack_plugin_context_replacement" }
+rspack_plugin_copy                     = { version = "0.1.0", path = "../rspack_plugin_copy" }
+rspack_plugin_css                      = { version = "0.1.0", path = "../rspack_plugin_css" }
+rspack_plugin_devtool                  = { version = "0.1.0", path = "../rspack_plugin_devtool" }
+rspack_plugin_dynamic_entry            = { version = "0.1.0", path = "../rspack_plugin_dynamic_entry" }
+rspack_plugin_ensure_chunk_conditions  = { version = "0.1.0", path = "../rspack_plugin_ensure_chunk_conditions" }
+rspack_plugin_entry                    = { version = "0.1.0", path = "../rspack_plugin_entry" }
+rspack_plugin_externals                = { version = "0.1.0", path = "../rspack_plugin_externals" }
+rspack_plugin_extract_css              = { version = "0.1.0", path = "../rspack_plugin_extract_css" }
+rspack_plugin_hmr                      = { version = "0.1.0", path = "../rspack_plugin_hmr" }
+rspack_plugin_html                     = { version = "0.1.0", path = "../rspack_plugin_html" }
+rspack_plugin_ignore                   = { version = "0.1.0", path = "../rspack_plugin_ignore" }
+rspack_plugin_javascript               = { version = "0.1.0", path = "../rspack_plugin_javascript" }
+rspack_plugin_json                     = { version = "0.1.0", path = "../rspack_plugin_json" }
+rspack_plugin_lazy_compilation         = { version = "0.1.0", path = "../rspack_plugin_lazy_compilation" }
+rspack_plugin_library                  = { version = "0.1.0", path = "../rspack_plugin_library" }
+rspack_plugin_lightning_css_minimizer  = { version = "0.1.0", path = "../rspack_plugin_lightning_css_minimizer" }
+rspack_plugin_limit_chunk_count        = { version = "0.1.0", path = "../rspack_plugin_limit_chunk_count" }
+rspack_plugin_merge_duplicate_chunks   = { version = "0.1.0", path = "../rspack_plugin_merge_duplicate_chunks" }
+rspack_plugin_mf                       = { version = "0.1.0", path = "../rspack_plugin_mf" }
+rspack_plugin_no_emit_on_errors        = { version = "0.1.0", path = "../rspack_plugin_no_emit_on_errors" }
+rspack_plugin_progress                 = { version = "0.1.0", path = "../rspack_plugin_progress" }
+rspack_plugin_real_content_hash        = { version = "0.1.0", path = "../rspack_plugin_real_content_hash" }
+rspack_plugin_remove_duplicate_modules = { version = "0.1.0", path = "../rspack_plugin_remove_duplicate_modules" }
+rspack_plugin_remove_empty_chunks      = { version = "0.1.0", path = "../rspack_plugin_remove_empty_chunks" }
+rspack_plugin_runtime                  = { version = "0.1.0", path = "../rspack_plugin_runtime" }
+rspack_plugin_runtime_chunk            = { version = "0.1.0", path = "../rspack_plugin_runtime_chunk" }
+rspack_plugin_schemes                  = { version = "0.1.0", path = "../rspack_plugin_schemes" }
+rspack_plugin_size_limits              = { version = "0.1.0", path = "../rspack_plugin_size_limits" }
+rspack_plugin_split_chunks             = { version = "0.1.0", path = "../rspack_plugin_split_chunks" }
+rspack_plugin_swc_js_minimizer         = { version = "0.1.0", path = "../rspack_plugin_swc_js_minimizer" }
+rspack_plugin_warn_sensitive_module    = { version = "0.1.0", path = "../rspack_plugin_warn_sensitive_module" }
+rspack_plugin_wasm                     = { version = "0.1.0", path = "../rspack_plugin_wasm" }
+rspack_plugin_web_worker_template      = { version = "0.1.0", path = "../rspack_plugin_web_worker_template" }
+rspack_plugin_worker                   = { version = "0.1.0", path = "../rspack_plugin_worker" }
+rspack_regex                           = { version = "0.1.0", path = "../rspack_regex" }
+rustc-hash                             = { workspace = true }
+serde                                  = { workspace = true, features = ["derive"] }
+serde_json                             = { workspace = true }
+swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "parking_lot"] }
+tracing                                = { workspace = true }

--- a/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/mod.rs
@@ -60,6 +60,7 @@ use rspack_plugin_mf::{
 use rspack_plugin_no_emit_on_errors::NoEmitOnErrorsPlugin;
 use rspack_plugin_progress::ProgressPlugin;
 use rspack_plugin_real_content_hash::RealContentHashPlugin;
+use rspack_plugin_remove_duplicate_modules::RemoveDuplicateModulesPlugin;
 use rspack_plugin_remove_empty_chunks::RemoveEmptyChunksPlugin;
 use rspack_plugin_runtime::{
   enable_chunk_loading_plugin, ArrayPushCallbackChunkFormatPlugin, BundlerInfoPlugin,
@@ -126,6 +127,7 @@ pub enum BuiltinPluginName {
   WebWorkerTemplatePlugin,
   MergeDuplicateChunksPlugin,
   SplitChunksPlugin,
+  RemoveDuplicateModulesPlugin,
   ShareRuntimePlugin,
   ContainerPlugin,
   ContainerReferencePlugin,
@@ -299,6 +301,9 @@ impl BuiltinPlugin {
         use rspack_plugin_split_chunks::SplitChunksPlugin;
         let options = downcast_into::<RawSplitChunksOptions>(self.options)?.into();
         plugins.push(SplitChunksPlugin::new(options).boxed());
+      }
+      BuiltinPluginName::RemoveDuplicateModulesPlugin => {
+        plugins.push(RemoveDuplicateModulesPlugin::default().boxed());
       }
       BuiltinPluginName::ShareRuntimePlugin => {
         plugins.push(ShareRuntimePlugin::new(downcast_into::<bool>(self.options)?).boxed())

--- a/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
+++ b/crates/rspack_plugin_remove_duplicate_modules/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+edition = "2021"
+name    = "rspack_plugin_remove_duplicate_modules"
+version = "0.1.0"
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-shear]
+ignored = ["tracing"]
+
+[dependencies]
+rspack_core  = { version = "0.1.0", path = "../rspack_core" }
+rspack_error = { version = "0.1.0", path = "../rspack_error" }
+rspack_hook  = { version = "0.1.0", path = "../rspack_hook" }
+rustc-hash   = { workspace = true }
+tracing      = { workspace = true }

--- a/crates/rspack_plugin_remove_duplicate_modules/LICENSE
+++ b/crates/rspack_plugin_remove_duplicate_modules/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2022-present Bytedance, Inc. and its affiliates.
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
+++ b/crates/rspack_plugin_remove_duplicate_modules/src/lib.rs
@@ -1,0 +1,86 @@
+use std::sync::Arc;
+
+use rspack_core::{
+  Chunk, ChunkUkey, Compilation, CompilationOptimizeChunks, ModuleIdentifier, Plugin,
+};
+use rspack_error::Result;
+use rspack_hook::{plugin, plugin_hook};
+use rustc_hash::FxHashMap;
+
+#[derive(Debug)]
+#[plugin]
+pub struct RemoveDuplicateModulesPlugin {}
+
+impl std::default::Default for RemoveDuplicateModulesPlugin {
+  fn default() -> Self {
+    Self {
+      inner: Arc::new(RemoveDuplicateModulesPluginInner {}),
+    }
+  }
+}
+
+#[plugin_hook(CompilationOptimizeChunks for RemoveDuplicateModulesPlugin)]
+fn optimize_chunks(&self, compilation: &mut Compilation) -> Result<Option<bool>> {
+  let module_graph = compilation.get_module_graph();
+  let chunk_graph = &compilation.chunk_graph;
+
+  let mut chunk_map: FxHashMap<Vec<ChunkUkey>, Vec<ModuleIdentifier>> = FxHashMap::default();
+
+  for identifier in module_graph.modules().keys() {
+    let chunks = chunk_graph.get_module_chunks(*identifier);
+    let mut sorted_chunks = chunks.iter().copied().collect::<Vec<_>>();
+    sorted_chunks.sort();
+    chunk_map
+      .entry(sorted_chunks)
+      .or_default()
+      .push(*identifier);
+  }
+
+  for (chunks, modules) in chunk_map {
+    if chunks.len() <= 1 {
+      continue;
+    }
+
+    // split chunks from original chunks and create new chunk
+    let mut new_chunk = Chunk::new(None, rspack_core::ChunkKind::Normal);
+    new_chunk.chunk_reason = Some("modules are shared across multiple chunks".into());
+    let new_chunk_ukey = new_chunk.ukey;
+    compilation.chunk_graph.add_chunk(new_chunk_ukey);
+
+    for chunk_ukey in &chunks {
+      let origin = compilation.chunk_by_ukey.expect_get_mut(chunk_ukey);
+      origin.split(&mut new_chunk, &mut compilation.chunk_group_by_ukey);
+    }
+
+    compilation.chunk_by_ukey.add(new_chunk);
+
+    for m in modules {
+      for chunk_ukey in &chunks {
+        compilation
+          .chunk_graph
+          .disconnect_chunk_and_module(chunk_ukey, m);
+      }
+
+      compilation
+        .chunk_graph
+        .connect_chunk_and_module(new_chunk_ukey, m);
+    }
+  }
+
+  Ok(None)
+}
+
+impl Plugin for RemoveDuplicateModulesPlugin {
+  fn apply(
+    &self,
+    ctx: rspack_core::PluginContext<&mut rspack_core::ApplyContext>,
+    _options: &rspack_core::CompilerOptions,
+  ) -> rspack_error::Result<()> {
+    ctx
+      .context
+      .compilation_hooks
+      .optimize_chunks
+      .tap(optimize_chunks::new(self));
+    Ok(())
+  }
+}

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1782,6 +1782,8 @@ interface Experiments_2 {
         register: typeof registerGlobalTrace;
         cleanup: typeof cleanupGlobalTrace;
     };
+    // (undocumented)
+    RemoveDuplicateModulesPlugin: typeof RemoveDuplicateModulesPlugin;
 }
 
 // @public (undocumented)
@@ -4379,6 +4381,17 @@ export type RemotesItems = RemotesItem[];
 // @public (undocumented)
 export type RemotesObject = {
     [k: string]: RemotesConfig | RemotesItem | RemotesItems;
+};
+
+// @public (undocumented)
+const RemoveDuplicateModulesPlugin: {
+    new (): {
+        name: BuiltinPluginName;
+        _args: [];
+        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
+        raw(compiler: Compiler_2): BuiltinPlugin;
+        apply(compiler: Compiler_2): void;
+    };
 };
 
 // @public

--- a/packages/rspack/src/builtin-plugin/RemoveDuplicateModulesPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RemoveDuplicateModulesPlugin.ts
@@ -1,0 +1,10 @@
+import { BuiltinPluginName } from "@rspack/binding";
+
+import { create } from "./base";
+
+export const RemoveDuplicateModulesPlugin = create(
+	BuiltinPluginName.RemoveDuplicateModulesPlugin,
+	() => {
+		return {};
+	}
+);

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -58,6 +58,8 @@ export * from "./SizeLimitsPlugin";
 export * from "./SourceMapDevToolPlugin";
 export * from "./SplitChunksPlugin";
 export * from "./LightningCssMinimizerRspackPlugin";
+export * from "./RemoveDuplicateModulesPlugin";
+export * from "./LightningCssMinimizerRspackPlugin";
 export * from "./SwcJsMinimizerPlugin";
 export * from "./WarnCaseSensitiveModulesPlugin";
 export * from "./WebWorkerTemplatePlugin";

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -170,6 +170,8 @@ export const webworker: Webworker = { WebWorkerTemplatePlugin };
 import { LimitChunkCountPlugin } from "./builtin-plugin";
 import { RuntimeChunkPlugin } from "./builtin-plugin";
 import { SplitChunksPlugin } from "./builtin-plugin";
+import { RemoveDuplicateModulesPlugin } from "./builtin-plugin";
+
 interface Optimize {
 	LimitChunkCountPlugin: typeof LimitChunkCountPlugin;
 	RuntimeChunkPlugin: typeof RuntimeChunkPlugin;
@@ -285,11 +287,13 @@ interface Experiments {
 		register: typeof registerGlobalTrace;
 		cleanup: typeof cleanupGlobalTrace;
 	};
+	RemoveDuplicateModulesPlugin: typeof RemoveDuplicateModulesPlugin;
 }
 
 export const experiments: Experiments = {
 	globalTrace: {
 		register: registerGlobalTrace,
 		cleanup: cleanupGlobalTrace
-	}
+	},
+	RemoveDuplicateModulesPlugin
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Introduce RemoveDuplicateModulesPlugin.

This plugin can help you remove duplicated modules without SplitChunksPlugin. Some projects may meet problem that rebuild costs too much time, and SplitChunksPlugin is one of the reasons. But without SplitChunksPlugin there are many duplicated modules, so this plugin comes out.

You can use this in development to speed up your rebuild time, and disable splitChunks.

```javascript
const rspack = require('@rspack/core')
module.exports = {
  optimization: { splitChunks: false },
  plugins: [new rspack.experiments.RemoveDuplicateModulesPlugin()]
}
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
