### PR TITLE
fix: should not panic when passing `test` option to SourceMapDevToolPlugin

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/plugins/source-map-dev-tool-plugin/rspack.config.js
@@ -14,6 +14,7 @@ module.exports = {
 	},
 	plugins: [
 		new rspack.SourceMapDevToolPlugin({
+			test: /\.js/,
 			filename: "[file].map",
 			sourceRoot: path.join(__dirname, "folder") + "/"
 		}),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
Passing the `test` option to `SourceMapDevToolPlugin` now results in the following error:

Panic occurred at runtime. Please file an issue on GitHub with the backtrace below: https://github.com/web-infra-dev/rspack/issues
Message:  Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks.
Location: crates/rspack_binding_options/src/options/raw_devtool.rs:99
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
