### PR TITLE
fix(core): should external package.json from bundle

### DIFF
--- a/packages/rspack/tsup.config.ts
+++ b/packages/rspack/tsup.config.ts
@@ -26,7 +26,7 @@ export default defineConfig([
 	{
 		...commonConfig,
 		entry: ["./src/index.ts"],
-		external: ["./moduleFederationDefaultRuntime.js"]
+		external: ["./moduleFederationDefaultRuntime.js", /..\/package\.json/]
 	},
 	{
 		...commonConfig,

--- a/packages/rspack/tsup.config.ts
+++ b/packages/rspack/tsup.config.ts
@@ -1,7 +1,7 @@
 import { type Options, defineConfig } from "tsup";
 import prebundleConfig from "./prebundle.config.mjs";
 
-const aliasCompiledPlugin = {
+const aliasPlugin = {
 	name: "alias-compiled-plugin",
 	setup(build) {
 		const { dependencies } = prebundleConfig;
@@ -13,20 +13,25 @@ const aliasCompiledPlugin = {
 				external: true
 			}));
 		}
+
+		build.onResolve({ filter: /..\/package\.json/ }, () => ({
+			path: "../package.json",
+			external: true
+		}));
 	}
 };
 
 const commonConfig: Options = {
 	format: ["cjs"],
 	target: "node16",
-	esbuildPlugins: [aliasCompiledPlugin]
+	esbuildPlugins: [aliasPlugin]
 };
 
 export default defineConfig([
 	{
 		...commonConfig,
 		entry: ["./src/index.ts"],
-		external: ["./moduleFederationDefaultRuntime.js", /..\/package\.json/]
+		external: ["./moduleFederationDefaultRuntime.js"]
 	},
 	{
 		...commonConfig,


### PR DESCRIPTION
## Summary

Should external package.json from bundle, this ensures that the Rspack canary package can read the correct version.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
