### PR TITLE
refactor: add JSDoc for configuration.module

### DIFF
--- a/packages/rspack/etc/api.md
+++ b/packages/rspack/etc/api.md
@@ -135,110 +135,22 @@ interface AssetEmittedInfo {
 }
 
 // @public (undocumented)
-export type AssetGeneratorDataUrl = z.infer<typeof assetGeneratorDataUrl>;
+export type AssetGeneratorDataUrl = AssetGeneratorDataUrlOptions | AssetGeneratorDataUrlFunction;
 
 // @public (undocumented)
-const assetGeneratorDataUrl: z.ZodUnion<[z.ZodObject<{
-    encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-    mimetype: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    mimetype?: string | undefined;
-    encoding?: false | "base64" | undefined;
-}, {
-    mimetype?: string | undefined;
-    encoding?: false | "base64" | undefined;
-}>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-    content: z.ZodString;
-    filename: z.ZodString;
-}, "strict", z.ZodTypeAny, {
+export type AssetGeneratorDataUrlFunction = (options: {
     filename: string;
     content: string;
-}, {
-    filename: string;
-    content: string;
-}>], z.ZodUnknown>, z.ZodString>]>;
+}) => string;
 
 // @public (undocumented)
-export type AssetGeneratorDataUrlFunction = z.infer<typeof assetGeneratorDataUrlFunction>;
+export type AssetGeneratorDataUrlOptions = {
+    encoding?: false | "base64";
+    mimetype?: string;
+};
 
-// @public (undocumented)
-const assetGeneratorDataUrlFunction: z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-    content: z.ZodString;
-    filename: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    filename: string;
-    content: string;
-}, {
-    filename: string;
-    content: string;
-}>], z.ZodUnknown>, z.ZodString>;
-
-// @public (undocumented)
-export type AssetGeneratorDataUrlOptions = z.infer<typeof assetGeneratorDataUrlOptions>;
-
-// @public (undocumented)
-const assetGeneratorDataUrlOptions: z.ZodObject<{
-    encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-    mimetype: z.ZodOptional<z.ZodString>;
-}, "strict", z.ZodTypeAny, {
-    mimetype?: string | undefined;
-    encoding?: false | "base64" | undefined;
-}, {
-    mimetype?: string | undefined;
-    encoding?: false | "base64" | undefined;
-}>;
-
-// @public (undocumented)
-export type AssetGeneratorOptions = z.infer<typeof assetGeneratorOptions>;
-
-// @public (undocumented)
-const assetGeneratorOptions: z.ZodObject<z.objectUtil.extendShape<{
-    dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-        encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-        mimetype: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    }, {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-        content: z.ZodString;
-        filename: z.ZodString;
-    }, "strict", z.ZodTypeAny, {
-        filename: string;
-        content: string;
-    }, {
-        filename: string;
-        content: string;
-    }>], z.ZodUnknown>, z.ZodString>]>>;
-}, {
-    emit: z.ZodOptional<z.ZodBoolean>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-}>, "strict", z.ZodTypeAny, {
-    filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    emit?: boolean | undefined;
-    dataUrl?: {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    } | ((args_0: {
-        filename: string;
-        content: string;
-    }, ...args_1: unknown[]) => string) | undefined;
-}, {
-    filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    emit?: boolean | undefined;
-    dataUrl?: {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    } | ((args_0: {
-        filename: string;
-        content: string;
-    }, ...args_1: unknown[]) => string) | undefined;
-}>;
+// @public
+export type AssetGeneratorOptions = AssetInlineGeneratorOptions_2 & AssetResourceGeneratorOptions;
 
 // @public (undocumented)
 export type AssetInfo = Partial<Omit<JsAssetInfo, "extras">> & Record<string, any>;
@@ -289,71 +201,32 @@ const assetInlineGeneratorOptions: z.ZodObject<{
 }>;
 
 // @public
+type AssetInlineGeneratorOptions_2 = {
+    dataUrl?: AssetGeneratorDataUrl;
+};
+
+// @public
 export type AssetModuleFilename = Filename;
 
-// @public (undocumented)
-export type AssetParserDataUrl = z.infer<typeof assetParserDataUrl>;
+// @public
+export type AssetParserDataUrl = AssetParserDataUrlOptions;
 
-// @public (undocumented)
-const assetParserDataUrl: z.ZodObject<{
-    maxSize: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
+// @public
+export type AssetParserDataUrlOptions = {
     maxSize?: number | undefined;
-}, {
-    maxSize?: number | undefined;
-}>;
+};
 
-// @public (undocumented)
-export type AssetParserDataUrlOptions = z.infer<typeof assetParserDataUrlOptions>;
+// @public
+export type AssetParserOptions = {
+    dataUrlCondition?: AssetParserDataUrlOptions;
+};
 
-// @public (undocumented)
-const assetParserDataUrlOptions: z.ZodObject<{
-    maxSize: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
-    maxSize?: number | undefined;
-}, {
-    maxSize?: number | undefined;
-}>;
-
-// @public (undocumented)
-export type AssetParserOptions = z.infer<typeof assetParserOptions>;
-
-// @public (undocumented)
-const assetParserOptions: z.ZodObject<{
-    dataUrlCondition: z.ZodOptional<z.ZodObject<{
-        maxSize: z.ZodOptional<z.ZodNumber>;
-    }, "strict", z.ZodTypeAny, {
-        maxSize?: number | undefined;
-    }, {
-        maxSize?: number | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    dataUrlCondition?: {
-        maxSize?: number | undefined;
-    } | undefined;
-}, {
-    dataUrlCondition?: {
-        maxSize?: number | undefined;
-    } | undefined;
-}>;
-
-// @public (undocumented)
-export type AssetResourceGeneratorOptions = z.infer<typeof assetResourceGeneratorOptions>;
-
-// @public (undocumented)
-const assetResourceGeneratorOptions: z.ZodObject<{
-    emit: z.ZodOptional<z.ZodBoolean>;
-    filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-    publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-}, "strict", z.ZodTypeAny, {
-    filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    emit?: boolean | undefined;
-}, {
-    filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-    emit?: boolean | undefined;
-}>;
+// @public
+export type AssetResourceGeneratorOptions = {
+    emit?: boolean;
+    filename?: Filename;
+    publicPath?: PublicPath;
+};
 
 // @public (undocumented)
 export type Assets = Record<string, Source>;
@@ -451,144 +324,6 @@ interface BaseResolveRequest {
     	// (undocumented)
     relativePath?: string;
 }
-
-// @public (undocumented)
-const baseRuleSetCondition: z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>;
-
-// @public (undocumented)
-const baseRuleSetRule: z.ZodObject<{
-    test: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    exclude: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    include: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    issuer: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    issuerLayer: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    dependency: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    resource: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    resourceFragment: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    resourceQuery: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    scheme: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    mimetype: z.ZodOptional<z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>;
-    descriptionData: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>>;
-    with: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodType<RuleSetCondition, z.ZodTypeDef, RuleSetCondition>>>;
-    type: z.ZodOptional<z.ZodString>;
-    layer: z.ZodOptional<z.ZodString>;
-    loader: z.ZodOptional<z.ZodString>;
-    options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-    use: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodObject<{
-        ident: z.ZodOptional<z.ZodString>;
-        loader: z.ZodString;
-        options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-    }, "strict", z.ZodTypeAny, {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    }, {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    }>]>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodObject<{
-        ident: z.ZodOptional<z.ZodString>;
-        loader: z.ZodString;
-        options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-    }, "strict", z.ZodTypeAny, {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    }, {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    }>]>, "many">]>, z.ZodFunction<z.ZodTuple<[z.ZodType<RawFuncUseCtx, z.ZodTypeDef, RawFuncUseCtx>], z.ZodUnknown>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodObject<{
-        ident: z.ZodOptional<z.ZodString>;
-        loader: z.ZodString;
-        options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-    }, "strict", z.ZodTypeAny, {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    }, {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    }>]>, "many">>]>>;
-    parser: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodAny>>;
-    generator: z.ZodOptional<z.ZodRecord<z.ZodString, z.ZodAny>>;
-    resolve: z.ZodOptional<z.ZodType<t.ResolveOptions, z.ZodTypeDef, t.ResolveOptions>>;
-    sideEffects: z.ZodOptional<z.ZodBoolean>;
-    enforce: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"pre">, z.ZodLiteral<"post">]>>;
-}, "strict", z.ZodTypeAny, {
-    type?: string | undefined;
-    resource?: RuleSetCondition | undefined;
-    layer?: string | undefined;
-    options?: string | Record<string, any> | undefined;
-    loader?: string | undefined;
-    test?: RuleSetCondition | undefined;
-    exclude?: RuleSetCondition | undefined;
-    include?: RuleSetCondition | undefined;
-    issuer?: RuleSetCondition | undefined;
-    issuerLayer?: RuleSetCondition | undefined;
-    dependency?: RuleSetCondition | undefined;
-    resourceFragment?: RuleSetCondition | undefined;
-    resourceQuery?: RuleSetCondition | undefined;
-    scheme?: RuleSetCondition | undefined;
-    mimetype?: RuleSetCondition | undefined;
-    descriptionData?: Record<string, RuleSetCondition> | undefined;
-    with?: Record<string, RuleSetCondition> | undefined;
-    use?: string | {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    } | (string | {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    })[] | ((args_0: RawFuncUseCtx, ...args_1: unknown[]) => (string | {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    })[]) | undefined;
-    parser?: Record<string, any> | undefined;
-    generator?: Record<string, any> | undefined;
-    resolve?: t.ResolveOptions | undefined;
-    sideEffects?: boolean | undefined;
-    enforce?: "pre" | "post" | undefined;
-}, {
-    type?: string | undefined;
-    resource?: RuleSetCondition | undefined;
-    layer?: string | undefined;
-    options?: string | Record<string, any> | undefined;
-    loader?: string | undefined;
-    test?: RuleSetCondition | undefined;
-    exclude?: RuleSetCondition | undefined;
-    include?: RuleSetCondition | undefined;
-    issuer?: RuleSetCondition | undefined;
-    issuerLayer?: RuleSetCondition | undefined;
-    dependency?: RuleSetCondition | undefined;
-    resourceFragment?: RuleSetCondition | undefined;
-    resourceQuery?: RuleSetCondition | undefined;
-    scheme?: RuleSetCondition | undefined;
-    mimetype?: RuleSetCondition | undefined;
-    descriptionData?: Record<string, RuleSetCondition> | undefined;
-    with?: Record<string, RuleSetCondition> | undefined;
-    use?: string | {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    } | (string | {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    })[] | ((args_0: RawFuncUseCtx, ...args_1: unknown[]) => (string | {
-        loader: string;
-        options?: string | Record<string, any> | undefined;
-        ident?: string | undefined;
-    })[]) | undefined;
-    parser?: Record<string, any> | undefined;
-    generator?: Record<string, any> | undefined;
-    resolve?: t.ResolveOptions | undefined;
-    sideEffects?: boolean | undefined;
-    enforce?: "pre" | "post" | undefined;
-}>;
 
 // @public
 export type BaseUri = string;
@@ -1437,38 +1172,18 @@ type CreateStatsOptionsContext = KnownCreateStatsOptionsContext & Record<string,
 // @public
 export type CrossOriginLoading = false | "anonymous" | "use-credentials";
 
-// @public (undocumented)
-export type CssAutoGeneratorOptions = z.infer<typeof cssAutoGeneratorOptions>;
+// @public
+export type CssAutoGeneratorOptions = {
+    exportsConvention?: CssGeneratorExportsConvention;
+    exportsOnly?: CssGeneratorExportsOnly;
+    localIdentName?: CssGeneratorLocalIdentName;
+    esModule?: CssGeneratorEsModule;
+};
 
-// @public (undocumented)
-const cssAutoGeneratorOptions: z.ZodObject<{
-    exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-    exportsOnly: z.ZodOptional<z.ZodBoolean>;
-    localIdentName: z.ZodOptional<z.ZodString>;
-    esModule: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    exportsOnly?: boolean | undefined;
-    esModule?: boolean | undefined;
-    exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-    localIdentName?: string | undefined;
-}, {
-    exportsOnly?: boolean | undefined;
-    esModule?: boolean | undefined;
-    exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-    localIdentName?: string | undefined;
-}>;
-
-// @public (undocumented)
-export type CssAutoParserOptions = z.infer<typeof cssAutoParserOptions>;
-
-// @public (undocumented)
-const cssAutoParserOptions: z.ZodObject<{
-    namedExports: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    namedExports?: boolean | undefined;
-}, {
-    namedExports?: boolean | undefined;
-}>;
+// @public
+export type CssAutoParserOptions = {
+    namedExports?: CssParserNamedExports;
+};
 
 // @public
 export type CssChunkFilename = Filename;
@@ -1526,94 +1241,38 @@ export interface CssExtractRspackPluginOptions {
 export type CssFilename = Filename;
 
 // @public (undocumented)
-export type CssGeneratorEsModule = z.infer<typeof cssGeneratorEsModule>;
+export type CssGeneratorEsModule = boolean;
 
 // @public (undocumented)
-const cssGeneratorEsModule: z.ZodBoolean;
+export type CssGeneratorExportsConvention = "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only";
 
 // @public (undocumented)
-export type CssGeneratorExportsConvention = z.infer<typeof cssGeneratorExportsConvention>;
+export type CssGeneratorExportsOnly = boolean;
 
 // @public (undocumented)
-const cssGeneratorExportsConvention: z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>;
+export type CssGeneratorLocalIdentName = string;
+
+// @public
+export type CssGeneratorOptions = {
+    exportsOnly?: CssGeneratorExportsOnly;
+    esModule?: CssGeneratorEsModule;
+};
+
+// @public
+export type CssModuleGeneratorOptions = CssAutoGeneratorOptions;
+
+// @public
+export type CssModuleParserOptions = {
+    namedExports?: CssParserNamedExports;
+};
 
 // @public (undocumented)
-export type CssGeneratorExportsOnly = z.infer<typeof cssGeneratorExportsOnly>;
+export type CssParserNamedExports = boolean;
 
-// @public (undocumented)
-const cssGeneratorExportsOnly: z.ZodBoolean;
-
-// @public (undocumented)
-export type CssGeneratorLocalIdentName = z.infer<typeof cssGeneratorLocalIdentName>;
-
-// @public (undocumented)
-const cssGeneratorLocalIdentName: z.ZodString;
-
-// @public (undocumented)
-export type CssGeneratorOptions = z.infer<typeof cssGeneratorOptions>;
-
-// @public (undocumented)
-const cssGeneratorOptions: z.ZodObject<{
-    exportsOnly: z.ZodOptional<z.ZodBoolean>;
-    esModule: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    exportsOnly?: boolean | undefined;
-    esModule?: boolean | undefined;
-}, {
-    exportsOnly?: boolean | undefined;
-    esModule?: boolean | undefined;
-}>;
-
-// @public (undocumented)
-export type CssModuleGeneratorOptions = z.infer<typeof cssModuleGeneratorOptions>;
-
-// @public (undocumented)
-const cssModuleGeneratorOptions: z.ZodObject<{
-    exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-    exportsOnly: z.ZodOptional<z.ZodBoolean>;
-    localIdentName: z.ZodOptional<z.ZodString>;
-    esModule: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    exportsOnly?: boolean | undefined;
-    esModule?: boolean | undefined;
-    exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-    localIdentName?: string | undefined;
-}, {
-    exportsOnly?: boolean | undefined;
-    esModule?: boolean | undefined;
-    exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-    localIdentName?: string | undefined;
-}>;
-
-// @public (undocumented)
-export type CssModuleParserOptions = z.infer<typeof cssModuleParserOptions>;
-
-// @public (undocumented)
-const cssModuleParserOptions: z.ZodObject<{
-    namedExports: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    namedExports?: boolean | undefined;
-}, {
-    namedExports?: boolean | undefined;
-}>;
-
-// @public (undocumented)
-export type CssParserNamedExports = z.infer<typeof cssParserNamedExports>;
-
-// @public (undocumented)
-const cssParserNamedExports: z.ZodBoolean;
-
-// @public (undocumented)
-export type CssParserOptions = z.infer<typeof cssParserOptions>;
-
-// @public (undocumented)
-const cssParserOptions: z.ZodObject<{
-    namedExports: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    namedExports?: boolean | undefined;
-}, {
-    namedExports?: boolean | undefined;
-}>;
+// @public
+export type CssParserOptions = {
+    namedExports?: CssParserNamedExports;
+};
 
 // @public (undocumented)
 export const DefinePlugin: {
@@ -2346,6 +2005,9 @@ export interface ExperimentsNormalized {
 }
 
 // @public (undocumented)
+type ExportsPresence = "error" | "warn" | "auto" | false;
+
+// @public (undocumented)
 export type Exposes = (ExposesItem | ExposesObject)[] | ExposesObject;
 
 // @public (undocumented)
@@ -2509,237 +2171,8 @@ export type FilterTypes = z.infer<typeof filterTypes>;
 // @public (undocumented)
 const filterTypes: z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>]>;
 
-// @public (undocumented)
-export type GeneratorOptionsByModuleType = z.infer<typeof generatorOptionsByModuleType>;
-
-// @public (undocumented)
-const generatorOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
-    asset: z.ZodOptional<z.ZodObject<z.objectUtil.extendShape<{
-        dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-            encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-            mimetype: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-            content: z.ZodString;
-            filename: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            filename: string;
-            content: string;
-        }, {
-            filename: string;
-            content: string;
-        }>], z.ZodUnknown>, z.ZodString>]>>;
-    }, {
-        emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-        publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    }>, "strict", z.ZodTypeAny, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    }, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    }>>;
-    "asset/inline": z.ZodOptional<z.ZodObject<{
-        dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-            encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-            mimetype: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-            content: z.ZodString;
-            filename: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            filename: string;
-            content: string;
-        }, {
-            filename: string;
-            content: string;
-        }>], z.ZodUnknown>, z.ZodString>]>>;
-    }, "strict", z.ZodTypeAny, {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    }, {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    }>>;
-    "asset/resource": z.ZodOptional<z.ZodObject<{
-        emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-        publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    }, "strict", z.ZodTypeAny, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    }, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    }>>;
-    css: z.ZodOptional<z.ZodObject<{
-        exportsOnly: z.ZodOptional<z.ZodBoolean>;
-        esModule: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    }, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    }>>;
-    "css/auto": z.ZodOptional<z.ZodObject<{
-        exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-        exportsOnly: z.ZodOptional<z.ZodBoolean>;
-        localIdentName: z.ZodOptional<z.ZodString>;
-        esModule: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }>>;
-    "css/module": z.ZodOptional<z.ZodObject<{
-        exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-        exportsOnly: z.ZodOptional<z.ZodBoolean>;
-        localIdentName: z.ZodOptional<z.ZodString>;
-        esModule: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    css?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    "css/module"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    asset?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/inline"?: {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/resource"?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    } | undefined;
-}, {
-    css?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    "css/module"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    asset?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/inline"?: {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/resource"?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    } | undefined;
-}>, z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>]>;
+// @public
+export type GeneratorOptionsByModuleType = GeneratorOptionsByModuleTypeKnown_2 | GeneratorOptionsByModuleTypeUnknown;
 
 // @public (undocumented)
 export type GeneratorOptionsByModuleTypeKnown = z.infer<typeof generatorOptionsByModuleTypeKnown>;
@@ -2974,10 +2407,17 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
 }>;
 
 // @public (undocumented)
-export type GeneratorOptionsByModuleTypeUnknown = z.infer<typeof generatorOptionsByModuleTypeUnknown>;
+type GeneratorOptionsByModuleTypeKnown_2 = {
+    asset?: AssetGeneratorOptions;
+    "asset/inline"?: AssetInlineGeneratorOptions_2;
+    "asset/resource"?: AssetResourceGeneratorOptions;
+    css?: CssGeneratorOptions;
+    "css/auto"?: CssAutoGeneratorOptions;
+    "css/module"?: CssModuleGeneratorOptions;
+};
 
 // @public (undocumented)
-const generatorOptionsByModuleTypeUnknown: z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>;
+export type GeneratorOptionsByModuleTypeUnknown = Record<string, Record<string, any>>;
 
 // @public (undocumented)
 type GetChildLogger = (name: string | (() => string)) => Logger;
@@ -3379,67 +2819,26 @@ class JavascriptModulesPlugin extends RspackBuiltinPlugin {
 }
 
 // @public (undocumented)
-export type JavascriptParserOptions = z.infer<typeof javascriptParserOptions>;
-
-// @public (undocumented)
-const javascriptParserOptions: z.ZodObject<{
-    dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-    dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-    dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-    dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-    importMeta: z.ZodOptional<z.ZodBoolean>;
-    url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-    exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-    wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-    exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-    importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-    reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-    strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-    worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-    overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-    requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-    requireDynamic: z.ZodOptional<z.ZodBoolean>;
-    requireResolve: z.ZodOptional<z.ZodBoolean>;
-    importDynamic: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    url?: boolean | "relative" | undefined;
-    dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-    dynamicImportPreload?: number | boolean | undefined;
-    dynamicImportPrefetch?: number | boolean | undefined;
-    dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-    importMeta?: boolean | undefined;
-    exprContextCritical?: boolean | undefined;
-    wrappedContextCritical?: boolean | undefined;
-    exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-    importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-    reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-    strictExportPresence?: boolean | undefined;
-    worker?: boolean | string[] | undefined;
-    overrideStrict?: "strict" | "non-strict" | undefined;
-    requireAsExpression?: boolean | undefined;
-    requireDynamic?: boolean | undefined;
-    requireResolve?: boolean | undefined;
-    importDynamic?: boolean | undefined;
-}, {
-    url?: boolean | "relative" | undefined;
-    dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-    dynamicImportPreload?: number | boolean | undefined;
-    dynamicImportPrefetch?: number | boolean | undefined;
-    dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-    importMeta?: boolean | undefined;
-    exprContextCritical?: boolean | undefined;
-    wrappedContextCritical?: boolean | undefined;
-    exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-    importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-    reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-    strictExportPresence?: boolean | undefined;
-    worker?: boolean | string[] | undefined;
-    overrideStrict?: "strict" | "non-strict" | undefined;
-    requireAsExpression?: boolean | undefined;
-    requireDynamic?: boolean | undefined;
-    requireResolve?: boolean | undefined;
-    importDynamic?: boolean | undefined;
-}>;
+export type JavascriptParserOptions = {
+    dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once";
+    dynamicImportPreload?: boolean | number;
+    dynamicImportPrefetch?: boolean | number;
+    dynamicImportFetchPriority?: "low" | "high" | "auto";
+    importMeta?: boolean;
+    url?: "relative" | boolean;
+    exprContextCritical?: boolean;
+    wrappedContextCritical?: boolean;
+    exportsPresence?: ExportsPresence;
+    importExportsPresence?: ExportsPresence;
+    reexportExportsPresence?: ExportsPresence;
+    strictExportPresence?: boolean;
+    worker?: string[] | boolean;
+    overrideStrict?: "strict" | "non-strict";
+    requireAsExpression?: boolean;
+    requireDynamic?: boolean;
+    requireResolve?: boolean;
+    importDynamic?: boolean;
+};
 
 // @public (undocumented)
 type JscTarget = "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "esnext";
@@ -4538,991 +3937,13 @@ declare namespace ModuleFilenameHelpers {
 export { ModuleFilenameHelpers }
 
 // @public (undocumented)
-export type ModuleOptions = z.infer<typeof moduleOptions>;
-
-// @public (undocumented)
-const moduleOptions: z.ZodObject<{
-    defaultRules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<RuleSetRule, z.ZodTypeDef, RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
-    rules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<RuleSetRule, z.ZodTypeDef, RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
-    parser: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-        asset: z.ZodOptional<z.ZodObject<{
-            dataUrlCondition: z.ZodOptional<z.ZodObject<{
-                maxSize: z.ZodOptional<z.ZodNumber>;
-            }, "strict", z.ZodTypeAny, {
-                maxSize?: number | undefined;
-            }, {
-                maxSize?: number | undefined;
-            }>>;
-        }, "strict", z.ZodTypeAny, {
-            dataUrlCondition?: {
-                maxSize?: number | undefined;
-            } | undefined;
-        }, {
-            dataUrlCondition?: {
-                maxSize?: number | undefined;
-            } | undefined;
-        }>>;
-        css: z.ZodOptional<z.ZodObject<{
-            namedExports: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            namedExports?: boolean | undefined;
-        }, {
-            namedExports?: boolean | undefined;
-        }>>;
-        "css/auto": z.ZodOptional<z.ZodObject<{
-            namedExports: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            namedExports?: boolean | undefined;
-        }, {
-            namedExports?: boolean | undefined;
-        }>>;
-        "css/module": z.ZodOptional<z.ZodObject<{
-            namedExports: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            namedExports?: boolean | undefined;
-        }, {
-            namedExports?: boolean | undefined;
-        }>>;
-        javascript: z.ZodOptional<z.ZodObject<{
-            dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-            dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-            importMeta: z.ZodOptional<z.ZodBoolean>;
-            url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-            exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-            wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-            exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-            worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-            overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-            requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-            requireDynamic: z.ZodOptional<z.ZodBoolean>;
-            requireResolve: z.ZodOptional<z.ZodBoolean>;
-            importDynamic: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }>>;
-        "javascript/auto": z.ZodOptional<z.ZodObject<{
-            dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-            dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-            importMeta: z.ZodOptional<z.ZodBoolean>;
-            url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-            exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-            wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-            exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-            worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-            overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-            requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-            requireDynamic: z.ZodOptional<z.ZodBoolean>;
-            requireResolve: z.ZodOptional<z.ZodBoolean>;
-            importDynamic: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }>>;
-        "javascript/dynamic": z.ZodOptional<z.ZodObject<{
-            dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-            dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-            importMeta: z.ZodOptional<z.ZodBoolean>;
-            url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-            exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-            wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-            exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-            worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-            overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-            requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-            requireDynamic: z.ZodOptional<z.ZodBoolean>;
-            requireResolve: z.ZodOptional<z.ZodBoolean>;
-            importDynamic: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }>>;
-        "javascript/esm": z.ZodOptional<z.ZodObject<{
-            dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-            dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-            dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-            importMeta: z.ZodOptional<z.ZodBoolean>;
-            url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-            exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-            wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-            exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-            strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-            worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-            overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-            requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-            requireDynamic: z.ZodOptional<z.ZodBoolean>;
-            requireResolve: z.ZodOptional<z.ZodBoolean>;
-            importDynamic: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }, {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        }>>;
-    }, "strict", z.ZodTypeAny, {
-        javascript?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        css?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/module"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        asset?: {
-            dataUrlCondition?: {
-                maxSize?: number | undefined;
-            } | undefined;
-        } | undefined;
-        "javascript/auto"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/dynamic"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/esm"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-    }, {
-        javascript?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        css?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/module"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        asset?: {
-            dataUrlCondition?: {
-                maxSize?: number | undefined;
-            } | undefined;
-        } | undefined;
-        "javascript/auto"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/dynamic"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/esm"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-    }>, z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>]>>;
-    generator: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-        asset: z.ZodOptional<z.ZodObject<z.objectUtil.extendShape<{
-            dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-                encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-                mimetype: z.ZodOptional<z.ZodString>;
-            }, "strict", z.ZodTypeAny, {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            }, {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-                content: z.ZodString;
-                filename: z.ZodString;
-            }, "strict", z.ZodTypeAny, {
-                filename: string;
-                content: string;
-            }, {
-                filename: string;
-                content: string;
-            }>], z.ZodUnknown>, z.ZodString>]>>;
-        }, {
-            emit: z.ZodOptional<z.ZodBoolean>;
-            filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-            publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-        }>, "strict", z.ZodTypeAny, {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        }, {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        }>>;
-        "asset/inline": z.ZodOptional<z.ZodObject<{
-            dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-                encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-                mimetype: z.ZodOptional<z.ZodString>;
-            }, "strict", z.ZodTypeAny, {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            }, {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-                content: z.ZodString;
-                filename: z.ZodString;
-            }, "strict", z.ZodTypeAny, {
-                filename: string;
-                content: string;
-            }, {
-                filename: string;
-                content: string;
-            }>], z.ZodUnknown>, z.ZodString>]>>;
-        }, "strict", z.ZodTypeAny, {
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        }, {
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        }>>;
-        "asset/resource": z.ZodOptional<z.ZodObject<{
-            emit: z.ZodOptional<z.ZodBoolean>;
-            filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-            publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-        }, "strict", z.ZodTypeAny, {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-        }, {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-        }>>;
-        css: z.ZodOptional<z.ZodObject<{
-            exportsOnly: z.ZodOptional<z.ZodBoolean>;
-            esModule: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-        }, {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-        }>>;
-        "css/auto": z.ZodOptional<z.ZodObject<{
-            exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-            exportsOnly: z.ZodOptional<z.ZodBoolean>;
-            localIdentName: z.ZodOptional<z.ZodString>;
-            esModule: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        }, {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        }>>;
-        "css/module": z.ZodOptional<z.ZodObject<{
-            exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-            exportsOnly: z.ZodOptional<z.ZodBoolean>;
-            localIdentName: z.ZodOptional<z.ZodString>;
-            esModule: z.ZodOptional<z.ZodBoolean>;
-        }, "strict", z.ZodTypeAny, {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        }, {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        }>>;
-    }, "strict", z.ZodTypeAny, {
-        css?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        "css/module"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        asset?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/inline"?: {
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/resource"?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-        } | undefined;
-    }, {
-        css?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        "css/module"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        asset?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/inline"?: {
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/resource"?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-        } | undefined;
-    }>, z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>]>>;
-    noParse: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">]>>;
-}, "strict", z.ZodTypeAny, {
-    parser?: {
-        javascript?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        css?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/module"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        asset?: {
-            dataUrlCondition?: {
-                maxSize?: number | undefined;
-            } | undefined;
-        } | undefined;
-        "javascript/auto"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/dynamic"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/esm"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-    } | Record<string, Record<string, any>> | undefined;
-    generator?: Record<string, Record<string, any>> | {
-        css?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        "css/module"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        asset?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/inline"?: {
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/resource"?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-        } | undefined;
-    } | undefined;
-    rules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-    defaultRules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-    noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-}, {
-    parser?: {
-        javascript?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        css?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        "css/module"?: {
-            namedExports?: boolean | undefined;
-        } | undefined;
-        asset?: {
-            dataUrlCondition?: {
-                maxSize?: number | undefined;
-            } | undefined;
-        } | undefined;
-        "javascript/auto"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/dynamic"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-        "javascript/esm"?: {
-            url?: boolean | "relative" | undefined;
-            dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-            dynamicImportPreload?: number | boolean | undefined;
-            dynamicImportPrefetch?: number | boolean | undefined;
-            dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-            importMeta?: boolean | undefined;
-            exprContextCritical?: boolean | undefined;
-            wrappedContextCritical?: boolean | undefined;
-            exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-            strictExportPresence?: boolean | undefined;
-            worker?: boolean | string[] | undefined;
-            overrideStrict?: "strict" | "non-strict" | undefined;
-            requireAsExpression?: boolean | undefined;
-            requireDynamic?: boolean | undefined;
-            requireResolve?: boolean | undefined;
-            importDynamic?: boolean | undefined;
-        } | undefined;
-    } | Record<string, Record<string, any>> | undefined;
-    generator?: Record<string, Record<string, any>> | {
-        css?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-        } | undefined;
-        "css/auto"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        "css/module"?: {
-            exportsOnly?: boolean | undefined;
-            esModule?: boolean | undefined;
-            exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-            localIdentName?: string | undefined;
-        } | undefined;
-        asset?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/inline"?: {
-            dataUrl?: {
-                mimetype?: string | undefined;
-                encoding?: false | "base64" | undefined;
-            } | ((args_0: {
-                filename: string;
-                content: string;
-            }, ...args_1: unknown[]) => string) | undefined;
-        } | undefined;
-        "asset/resource"?: {
-            filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-            emit?: boolean | undefined;
-        } | undefined;
-    } | undefined;
-    rules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-    defaultRules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-    noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
-}>;
+export type ModuleOptions = {
+    defaultRules?: RuleSetRules;
+    rules?: RuleSetRules;
+    parser?: ParserOptionsByModuleType;
+    generator?: GeneratorOptionsByModuleType;
+    noParse?: NoParseOption;
+};
 
 // @public (undocumented)
 export interface ModuleOptionsNormalized {
@@ -5748,11 +4169,11 @@ interface NonStandard {
     deepSelectorCombinator?: boolean;
 }
 
-// @public (undocumented)
-export type NoParseOption = z.infer<typeof noParseOption>;
+// @public
+export type NoParseOption = NoParseOptionSingle | NoParseOptionSingle[];
 
 // @public (undocumented)
-const noParseOption: z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">]>;
+type NoParseOptionSingle = string | RegExp | ((request: string) => boolean);
 
 // @public (undocumented)
 type NormalizedStatsOptions = KnownNormalizedStatsOptions & Omit<StatsOptions, keyof KnownNormalizedStatsOptions> & Record<string, any>;
@@ -6104,945 +4525,25 @@ interface ParsedIdentifier {
     request: string;
 }
 
-// @public (undocumented)
-export type ParserOptionsByModuleType = z.infer<typeof parserOptionsByModuleType>;
+// @public
+export type ParserOptionsByModuleType = ParserOptionsByModuleTypeKnown | ParserOptionsByModuleTypeUnknown;
 
-// @public (undocumented)
-const parserOptionsByModuleType: z.ZodUnion<[z.ZodObject<{
-    asset: z.ZodOptional<z.ZodObject<{
-        dataUrlCondition: z.ZodOptional<z.ZodObject<{
-            maxSize: z.ZodOptional<z.ZodNumber>;
-        }, "strict", z.ZodTypeAny, {
-            maxSize?: number | undefined;
-        }, {
-            maxSize?: number | undefined;
-        }>>;
-    }, "strict", z.ZodTypeAny, {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    }, {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    }>>;
-    css: z.ZodOptional<z.ZodObject<{
-        namedExports: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        namedExports?: boolean | undefined;
-    }, {
-        namedExports?: boolean | undefined;
-    }>>;
-    "css/auto": z.ZodOptional<z.ZodObject<{
-        namedExports: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        namedExports?: boolean | undefined;
-    }, {
-        namedExports?: boolean | undefined;
-    }>>;
-    "css/module": z.ZodOptional<z.ZodObject<{
-        namedExports: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        namedExports?: boolean | undefined;
-    }, {
-        namedExports?: boolean | undefined;
-    }>>;
-    javascript: z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-    "javascript/auto": z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-    "javascript/dynamic": z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-    "javascript/esm": z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    javascript?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    css?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/module"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    asset?: {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    } | undefined;
-    "javascript/auto"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/dynamic"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/esm"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-}, {
-    javascript?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    css?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/module"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    asset?: {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    } | undefined;
-    "javascript/auto"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/dynamic"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/esm"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-}>, z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>]>;
+// @public
+export type ParserOptionsByModuleTypeKnown = {
+    asset?: AssetParserOptions;
+    css?: CssParserOptions;
+    "css/auto"?: CssAutoParserOptions;
+    "css/module"?: CssModuleParserOptions;
+    javascript?: JavascriptParserOptions;
+    "javascript/auto"?: JavascriptParserOptions;
+    "javascript/dynamic"?: JavascriptParserOptions;
+    "javascript/esm"?: JavascriptParserOptions;
+};
 
-// @public (undocumented)
-export type ParserOptionsByModuleTypeKnown = z.infer<typeof parserOptionsByModuleTypeKnown>;
-
-// @public (undocumented)
-const parserOptionsByModuleTypeKnown: z.ZodObject<{
-    asset: z.ZodOptional<z.ZodObject<{
-        dataUrlCondition: z.ZodOptional<z.ZodObject<{
-            maxSize: z.ZodOptional<z.ZodNumber>;
-        }, "strict", z.ZodTypeAny, {
-            maxSize?: number | undefined;
-        }, {
-            maxSize?: number | undefined;
-        }>>;
-    }, "strict", z.ZodTypeAny, {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    }, {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    }>>;
-    css: z.ZodOptional<z.ZodObject<{
-        namedExports: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        namedExports?: boolean | undefined;
-    }, {
-        namedExports?: boolean | undefined;
-    }>>;
-    "css/auto": z.ZodOptional<z.ZodObject<{
-        namedExports: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        namedExports?: boolean | undefined;
-    }, {
-        namedExports?: boolean | undefined;
-    }>>;
-    "css/module": z.ZodOptional<z.ZodObject<{
-        namedExports: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        namedExports?: boolean | undefined;
-    }, {
-        namedExports?: boolean | undefined;
-    }>>;
-    javascript: z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-    "javascript/auto": z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-    "javascript/dynamic": z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-    "javascript/esm": z.ZodOptional<z.ZodObject<{
-        dynamicImportMode: z.ZodOptional<z.ZodEnum<["eager", "lazy", "weak", "lazy-once"]>>;
-        dynamicImportPreload: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportPrefetch: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodNumber]>>;
-        dynamicImportFetchPriority: z.ZodOptional<z.ZodEnum<["low", "high", "auto"]>>;
-        importMeta: z.ZodOptional<z.ZodBoolean>;
-        url: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"relative">, z.ZodBoolean]>>;
-        exprContextCritical: z.ZodOptional<z.ZodBoolean>;
-        wrappedContextCritical: z.ZodOptional<z.ZodBoolean>;
-        exportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        importExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        reexportExportsPresence: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warn", "auto"]>, z.ZodLiteral<false>]>>;
-        strictExportPresence: z.ZodOptional<z.ZodBoolean>;
-        worker: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodBoolean]>>;
-        overrideStrict: z.ZodOptional<z.ZodEnum<["strict", "non-strict"]>>;
-        requireAsExpression: z.ZodOptional<z.ZodBoolean>;
-        requireDynamic: z.ZodOptional<z.ZodBoolean>;
-        requireResolve: z.ZodOptional<z.ZodBoolean>;
-        importDynamic: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }, {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    javascript?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    css?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/module"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    asset?: {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    } | undefined;
-    "javascript/auto"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/dynamic"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/esm"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-}, {
-    javascript?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    css?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    "css/module"?: {
-        namedExports?: boolean | undefined;
-    } | undefined;
-    asset?: {
-        dataUrlCondition?: {
-            maxSize?: number | undefined;
-        } | undefined;
-    } | undefined;
-    "javascript/auto"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/dynamic"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-    "javascript/esm"?: {
-        url?: boolean | "relative" | undefined;
-        dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once" | undefined;
-        dynamicImportPreload?: number | boolean | undefined;
-        dynamicImportPrefetch?: number | boolean | undefined;
-        dynamicImportFetchPriority?: "auto" | "low" | "high" | undefined;
-        importMeta?: boolean | undefined;
-        exprContextCritical?: boolean | undefined;
-        wrappedContextCritical?: boolean | undefined;
-        exportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        importExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        reexportExportsPresence?: false | "auto" | "error" | "warn" | undefined;
-        strictExportPresence?: boolean | undefined;
-        worker?: boolean | string[] | undefined;
-        overrideStrict?: "strict" | "non-strict" | undefined;
-        requireAsExpression?: boolean | undefined;
-        requireDynamic?: boolean | undefined;
-        requireResolve?: boolean | undefined;
-        importDynamic?: boolean | undefined;
-    } | undefined;
-}>;
-
-// @public (undocumented)
-export type ParserOptionsByModuleTypeUnknown = z.infer<typeof parserOptionsByModuleTypeUnknown>;
-
-// @public (undocumented)
-const parserOptionsByModuleTypeUnknown: z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>;
+// @public
+export type ParserOptionsByModuleTypeUnknown = {
+    [x: string]: Record<string, any>;
+};
 
 // @public
 export type Path = string;
@@ -7696,45 +5197,8 @@ declare namespace rspackExports {
         IgnoreWarningsNormalized,
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
-        RuleSetCondition,
-        RuleSetConditions,
-        RuleSetLogicalConditions,
-        RuleSetLoader,
-        RuleSetLoaderOptions,
-        RuleSetLoaderWithOptions,
-        RuleSetUseItem,
-        RuleSetUse,
-        RuleSetRule,
-        RuleSetRules,
-        AssetParserDataUrlOptions,
-        AssetParserDataUrl,
-        AssetParserOptions,
-        CssParserNamedExports,
-        CssParserOptions,
-        CssAutoParserOptions,
-        CssModuleParserOptions,
-        JavascriptParserOptions,
-        ParserOptionsByModuleTypeKnown,
-        ParserOptionsByModuleTypeUnknown,
-        ParserOptionsByModuleType,
-        AssetGeneratorDataUrlOptions,
-        AssetGeneratorDataUrlFunction,
-        AssetGeneratorDataUrl,
         AssetInlineGeneratorOptions,
-        AssetResourceGeneratorOptions,
-        AssetGeneratorOptions,
-        CssGeneratorExportsConvention,
-        CssGeneratorExportsOnly,
-        CssGeneratorLocalIdentName,
-        CssGeneratorEsModule,
-        CssGeneratorOptions,
-        CssAutoGeneratorOptions,
-        CssModuleGeneratorOptions,
         GeneratorOptionsByModuleTypeKnown,
-        GeneratorOptionsByModuleTypeUnknown,
-        GeneratorOptionsByModuleType,
-        NoParseOption,
-        ModuleOptions,
         Target,
         externalsType,
         ExternalsPresets,
@@ -7840,6 +5304,43 @@ declare namespace rspackExports {
         ResolveTsConfig,
         ResolveOptions,
         Resolve,
+        RuleSetCondition,
+        RuleSetConditions,
+        RuleSetLogicalConditions,
+        RuleSetLoader,
+        RuleSetLoaderOptions,
+        RuleSetLoaderWithOptions,
+        RuleSetUseItem,
+        RuleSetUse,
+        RuleSetRule,
+        RuleSetRules,
+        AssetParserDataUrlOptions,
+        AssetParserDataUrl,
+        AssetParserOptions,
+        CssParserNamedExports,
+        CssParserOptions,
+        CssAutoParserOptions,
+        CssModuleParserOptions,
+        JavascriptParserOptions,
+        ParserOptionsByModuleTypeKnown,
+        ParserOptionsByModuleTypeUnknown,
+        ParserOptionsByModuleType,
+        AssetGeneratorDataUrlOptions,
+        AssetGeneratorDataUrlFunction,
+        AssetGeneratorDataUrl,
+        AssetResourceGeneratorOptions,
+        AssetGeneratorOptions,
+        CssGeneratorExportsConvention,
+        CssGeneratorExportsOnly,
+        CssGeneratorLocalIdentName,
+        CssGeneratorEsModule,
+        CssGeneratorOptions,
+        CssAutoGeneratorOptions,
+        CssModuleGeneratorOptions,
+        GeneratorOptionsByModuleTypeUnknown,
+        GeneratorOptionsByModuleType,
+        NoParseOption,
+        ModuleOptions,
         ExternalsType,
         ExternalItemValue,
         ExternalItemObjectUnknown,
@@ -9715,8 +7216,8 @@ export const rspackOptions: z.ZodObject<{
     plugins: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodType<t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction, z.ZodTypeDef, t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
     devServer: z.ZodOptional<z.ZodType<DevServer, z.ZodTypeDef, DevServer>>;
     module: z.ZodOptional<z.ZodObject<{
-        defaultRules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<RuleSetRule, z.ZodTypeDef, RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
-        rules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<RuleSetRule, z.ZodTypeDef, RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
+        defaultRules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<t.RuleSetRule, z.ZodTypeDef, t.RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
+        rules: z.ZodOptional<z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<t.RuleSetRule, z.ZodTypeDef, t.RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">>;
         parser: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
             asset: z.ZodOptional<z.ZodObject<{
                 dataUrlCondition: z.ZodOptional<z.ZodObject<{
@@ -10548,8 +8049,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
-        rules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     }, {
         parser?: {
@@ -10692,8 +8193,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
-        rules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     }>>;
     profile: z.ZodOptional<z.ZodBoolean>;
@@ -10858,8 +8359,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
-        rules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     } | undefined;
     name?: string | undefined;
@@ -11456,8 +8957,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
-        rules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
     } | undefined;
     name?: string | undefined;
@@ -12019,40 +9520,23 @@ class RuleSetCompiler {
 }
 
 // @public (undocumented)
-export type RuleSetCondition = z.infer<typeof baseRuleSetCondition> | RuleSetConditions | RuleSetLogicalConditions;
+export type RuleSetCondition = string | RegExp | ((value: string) => boolean) | RuleSetConditions | RuleSetLogicalConditions;
 
 // @public (undocumented)
 export type RuleSetConditions = RuleSetCondition[];
 
 // @public (undocumented)
-export type RuleSetLoader = z.infer<typeof ruleSetLoader>;
+export type RuleSetLoader = string;
 
 // @public (undocumented)
-const ruleSetLoader: z.ZodString;
+export type RuleSetLoaderOptions = string | Record<string, any>;
 
 // @public (undocumented)
-export type RuleSetLoaderOptions = z.infer<typeof ruleSetLoaderOptions>;
-
-// @public (undocumented)
-const ruleSetLoaderOptions: z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>;
-
-// @public (undocumented)
-export type RuleSetLoaderWithOptions = z.infer<typeof ruleSetLoaderWithOptions>;
-
-// @public (undocumented)
-const ruleSetLoaderWithOptions: z.ZodObject<{
-    ident: z.ZodOptional<z.ZodString>;
-    loader: z.ZodString;
-    options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-}, "strict", z.ZodTypeAny, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}>;
+export type RuleSetLoaderWithOptions = {
+    ident?: string;
+    loader: RuleSetLoader;
+    options?: RuleSetLoaderOptions;
+};
 
 // @public (undocumented)
 export type RuleSetLogicalConditions = {
@@ -12061,77 +9545,43 @@ export type RuleSetLogicalConditions = {
     not?: RuleSetCondition;
 };
 
-// @public (undocumented)
-export type RuleSetRule = z.infer<typeof baseRuleSetRule> & {
+// @public
+export type RuleSetRule = {
+    test?: RuleSetCondition;
+    exclude?: RuleSetCondition;
+    include?: RuleSetCondition;
+    issuer?: RuleSetCondition;
+    issuerLayer?: RuleSetCondition;
+    dependency?: RuleSetCondition;
+    resource?: RuleSetCondition;
+    resourceFragment?: RuleSetCondition;
+    resourceQuery?: RuleSetCondition;
+    mimetype?: RuleSetCondition;
+    scheme?: RuleSetCondition;
+    descriptionData?: Record<string, RuleSetCondition>;
+    with?: Record<string, RuleSetCondition>;
+    type?: string;
+    layer?: string;
+    loader?: RuleSetLoader;
+    options?: RuleSetLoaderOptions;
+    use?: RuleSetUse;
+    parser?: Record<string, any>;
+    generator?: Record<string, any>;
+    resolve?: ResolveOptions;
+    sideEffects?: boolean;
+    enforce?: "pre" | "post";
     oneOf?: RuleSetRule[];
     rules?: RuleSetRule[];
 };
 
-// @public (undocumented)
-export type RuleSetRules = z.infer<typeof ruleSetRules>;
+// @public
+export type RuleSetRules = ("..." | RuleSetRule | Falsy)[];
 
 // @public (undocumented)
-const ruleSetRules: z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodLiteral<"...">, z.ZodType<RuleSetRule, z.ZodTypeDef, RuleSetRule>]>, z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<0>, z.ZodLiteral<"">, z.ZodNull, z.ZodUndefined]>]>, "many">;
+export type RuleSetUse = RuleSetUseItem | RuleSetUseItem[] | ((data: RawFuncUseCtx) => RuleSetUseItem[]);
 
 // @public (undocumented)
-export type RuleSetUse = z.infer<typeof ruleSetUse>;
-
-// @public (undocumented)
-const ruleSetUse: z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodObject<{
-    ident: z.ZodOptional<z.ZodString>;
-    loader: z.ZodString;
-    options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-}, "strict", z.ZodTypeAny, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}>]>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodObject<{
-    ident: z.ZodOptional<z.ZodString>;
-    loader: z.ZodString;
-    options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-}, "strict", z.ZodTypeAny, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}>]>, "many">]>, z.ZodFunction<z.ZodTuple<[z.ZodType<RawFuncUseCtx, z.ZodTypeDef, RawFuncUseCtx>], z.ZodUnknown>, z.ZodArray<z.ZodUnion<[z.ZodString, z.ZodObject<{
-    ident: z.ZodOptional<z.ZodString>;
-    loader: z.ZodString;
-    options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-}, "strict", z.ZodTypeAny, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}>]>, "many">>]>;
-
-// @public (undocumented)
-export type RuleSetUseItem = z.infer<typeof ruleSetUseItem>;
-
-// @public (undocumented)
-const ruleSetUseItem: z.ZodUnion<[z.ZodString, z.ZodObject<{
-    ident: z.ZodOptional<z.ZodString>;
-    loader: z.ZodString;
-    options: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>]>>;
-}, "strict", z.ZodTypeAny, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}, {
-    loader: string;
-    options?: string | Record<string, any> | undefined;
-    ident?: string | undefined;
-}>]>;
+export type RuleSetUseItem = RuleSetLoader | RuleSetLoaderWithOptions;
 
 // @public (undocumented)
 const RuntimeChunkPlugin: {
@@ -13325,6 +10775,45 @@ declare namespace t {
         ResolveTsConfig,
         ResolveOptions,
         Resolve,
+        RuleSetCondition,
+        RuleSetConditions,
+        RuleSetLogicalConditions,
+        RuleSetLoader,
+        RuleSetLoaderOptions,
+        RuleSetLoaderWithOptions,
+        RuleSetUseItem,
+        RuleSetUse,
+        RuleSetRule,
+        RuleSetRules,
+        AssetParserDataUrlOptions,
+        AssetParserDataUrl,
+        AssetParserOptions,
+        CssParserNamedExports,
+        CssParserOptions,
+        CssAutoParserOptions,
+        CssModuleParserOptions,
+        JavascriptParserOptions,
+        ParserOptionsByModuleTypeKnown,
+        ParserOptionsByModuleTypeUnknown,
+        ParserOptionsByModuleType,
+        AssetGeneratorDataUrlOptions,
+        AssetGeneratorDataUrlFunction,
+        AssetGeneratorDataUrl,
+        AssetInlineGeneratorOptions_2 as AssetInlineGeneratorOptions,
+        AssetResourceGeneratorOptions,
+        AssetGeneratorOptions,
+        CssGeneratorExportsConvention,
+        CssGeneratorExportsOnly,
+        CssGeneratorLocalIdentName,
+        CssGeneratorEsModule,
+        CssGeneratorOptions,
+        CssAutoGeneratorOptions,
+        CssModuleGeneratorOptions,
+        GeneratorOptionsByModuleTypeKnown_2 as GeneratorOptionsByModuleTypeKnown,
+        GeneratorOptionsByModuleTypeUnknown,
+        GeneratorOptionsByModuleType,
+        NoParseOption,
+        ModuleOptions,
         ExternalsType,
         ExternalItemValue,
         ExternalItemObjectUnknown,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -825,6 +825,9 @@ export type RuleSetRule = {
 	/** Matches all modules that match this resource, and will match against Resource */
 	issuer?: RuleSetCondition;
 
+	/** Matches all modules that match this resource, and will match against layer of the module that issued the current module. */
+	issuerLayer?: RuleSetCondition;
+
 	/** Matches all modules that match this resource, and will match against the category of the dependency that introduced the current module */
 	dependency?: RuleSetCondition;
 
@@ -836,6 +839,9 @@ export type RuleSetRule = {
 
 	/** Matches all modules that match this resource against the Resource's query. */
 	resourceQuery?: RuleSetCondition;
+
+	/** Matches all modules that match this resource, and will match against the Resource's mimetype. */
+	mimetype?: RuleSetCondition;
 
 	/** Matches all modules that match this resource, and will match against the Resource's scheme. */
 	scheme?: RuleSetCondition;
@@ -881,7 +887,7 @@ export type RuleSetRule = {
 	/** Flag the module for side effects */
 	sideEffects?: boolean;
 
-	// TODO: add docs
+	/** Specify loader category.  */
 	enforce?: "pre" | "post";
 
 	/** A kind of Nested Rule, an array of Rules from which only the first matching Rule is used when the parent Rule matches. */
@@ -1007,7 +1013,7 @@ export type JavascriptParserOptions = {
 	/** Warn or error for conflicting re-exports */
 	reexportExportsPresence?: ExportsPresence;
 
-	// TODO: add docs
+	/** Emit errors instead of warnings when imported names don't exist in imported module. */
 	strictExportPresence?: boolean;
 
 	/** Provide custom syntax for Worker parsing, commonly used to support Worklet */

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1,4 +1,4 @@
-import type { JsAssetInfo } from "@rspack/binding";
+import type { JsAssetInfo, RawFuncUseCtx } from "@rspack/binding";
 import type { PathData } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { Module } from "../Module";
@@ -776,6 +776,444 @@ export type ResolveOptions = {
 export type Resolve = ResolveOptions;
 //#endregion
 
+//#region Module
+export type RuleSetCondition =
+	| string
+	| RegExp
+	| ((value: string) => boolean)
+	| RuleSetConditions
+	| RuleSetLogicalConditions;
+
+export type RuleSetConditions = RuleSetCondition[];
+
+export type RuleSetLogicalConditions = {
+	and?: RuleSetConditions;
+	or?: RuleSetConditions;
+	not?: RuleSetCondition;
+};
+
+export type RuleSetLoader = string;
+
+export type RuleSetLoaderOptions = string | Record<string, any>;
+
+export type RuleSetLoaderWithOptions = {
+	ident?: string;
+
+	loader: RuleSetLoader;
+
+	options?: RuleSetLoaderOptions;
+};
+
+export type RuleSetUseItem = RuleSetLoader | RuleSetLoaderWithOptions;
+
+export type RuleSetUse =
+	| RuleSetUseItem
+	| RuleSetUseItem[]
+	| ((data: RawFuncUseCtx) => RuleSetUseItem[]);
+
+/** Rule defines the conditions for matching a module and the behavior of handling those modules. */
+export type RuleSetRule = {
+	/** Matches all modules that match this resource, and will match against Resource. */
+	test?: RuleSetCondition;
+
+	/** Excludes all modules that match this condition and will match against the absolute path of the resource */
+	exclude?: RuleSetCondition;
+
+	/** Matches all modules that match this condition against the absolute path of the resource */
+	include?: RuleSetCondition;
+
+	/** Matches all modules that match this resource, and will match against Resource */
+	issuer?: RuleSetCondition;
+
+	/** Matches all modules that match this resource, and will match against the category of the dependency that introduced the current module */
+	dependency?: RuleSetCondition;
+
+	/** Matches all modules that match this resource, and will match against Resource */
+	resource?: RuleSetCondition;
+
+	/** Matches all modules that match this resource against the Resource's fragment. */
+	resourceFragment?: RuleSetCondition;
+
+	/** Matches all modules that match this resource against the Resource's query. */
+	resourceQuery?: RuleSetCondition;
+
+	/** Matches all modules that match this resource, and will match against the Resource's scheme. */
+	scheme?: RuleSetCondition;
+
+	/** Allows you to match values of properties in the description file, typically package.json, to determine which modules a rule should apply to. */
+	descriptionData?: Record<string, RuleSetCondition>;
+
+	/** Used in conjunction with [import attributes](https://github.com/tc39/proposal-import-attributes). */
+	with?: Record<string, RuleSetCondition>;
+
+	/** Used to mark the type of the matching module, which affects how the module is handled by Rspack's built-in processing. */
+	type?: string;
+
+	/** Used to mark the layer of the matching module. */
+	layer?: string;
+
+	/** A loader name */
+	loader?: RuleSetLoader;
+
+	/** A loader options */
+	options?: RuleSetLoaderOptions;
+
+	/** An array to pass the Loader package name and its options.  */
+	use?: RuleSetUse;
+
+	/**
+	 * Parser options for the specific modules that matched by the rule conditions
+	 * It will override the parser options in module.parser.
+	 * @default {}
+	 * */
+	parser?: Record<string, any>;
+
+	/**
+	 * Generator options for the specific modules that matched by the rule conditions
+	 * It will override the parser options in module.generator.
+	 * @default {}
+	 */
+	generator?: Record<string, any>;
+
+	/** Matches all modules that match this resource, and will match against Resource. */
+	resolve?: ResolveOptions;
+
+	/** Flag the module for side effects */
+	sideEffects?: boolean;
+
+	// TODO: add docs
+	enforce?: "pre" | "post";
+
+	/** A kind of Nested Rule, an array of Rules from which only the first matching Rule is used when the parent Rule matches. */
+	oneOf?: RuleSetRule[];
+
+	/** A kind of Nested Rule, an array of Rules that is also used when the parent Rule matches. */
+	rules?: RuleSetRule[];
+};
+
+/** A list of rules. */
+export type RuleSetRules = ("..." | RuleSetRule | Falsy)[];
+
+/**
+ * Options object for DataUrl condition.
+ * */
+export type AssetParserDataUrlOptions = {
+	maxSize?: number | undefined;
+};
+
+/**
+ * Options object for DataUrl condition.
+ * */
+export type AssetParserDataUrl = AssetParserDataUrlOptions;
+
+/** Options object for `asset` modules. */
+export type AssetParserOptions = {
+	/**
+	 * It be used only for Asset Module scenarios.
+	 * @default { maxSize: 8096 }
+	 * */
+	dataUrlCondition?: AssetParserDataUrlOptions;
+};
+
+export type CssParserNamedExports = boolean;
+
+/** Options object for `css` modules. */
+export type CssParserOptions = {
+	/**
+	 * Use ES modules named export for CSS exports.
+	 * @default true
+	 * */
+	namedExports?: CssParserNamedExports;
+};
+
+/** Options object for `css/auto` modules. */
+export type CssAutoParserOptions = {
+	/**
+	 * Use ES modules named export for CSS exports.
+	 * @default true
+	 * */
+	namedExports?: CssParserNamedExports;
+};
+
+/** Options object for `css/module` modules. */
+export type CssModuleParserOptions = {
+	/**
+	 * Use ES modules named export for CSS exports.
+	 * @default true
+	 * */
+	namedExports?: CssParserNamedExports;
+};
+
+type ExportsPresence = "error" | "warn" | "auto" | false;
+
+export type JavascriptParserOptions = {
+	/**
+	 * Specifies global mode for dynamic import.
+	 * @default 'lazy'
+	 * */
+	dynamicImportMode?: "eager" | "lazy" | "weak" | "lazy-once";
+
+	/**
+	 * Specifies global preload for dynamic import.
+	 * @default false
+	 * */
+	dynamicImportPreload?: boolean | number;
+
+	/**
+	 * Specifies global prefetch for dynamic import
+	 * @default false
+	 * */
+	dynamicImportPrefetch?: boolean | number;
+
+	/**
+	 * Specifies global fetchPriority for dynamic import
+	 * @default 'auto'
+	 */
+	dynamicImportFetchPriority?: "low" | "high" | "auto";
+
+	/**
+	 * Enable or disable evaluating import.meta.
+	 * @default true
+	 */
+	importMeta?: boolean;
+
+	/**
+	 * Enable parsing of new URL() syntax.
+	 * @default true
+	 * */
+	url?: "relative" | boolean;
+
+	/**
+	 * Enable warnings for full dynamic dependencies
+	 * @default true
+	 * */
+	exprContextCritical?: boolean;
+
+	/**
+	 * Enable warnings for partial dynamic dependencies
+	 * @default false
+	 * */
+	wrappedContextCritical?: boolean;
+
+	/**
+	 * Warn or error for using non-existent exports and conflicting re-exports.
+	 * @default 'auto'
+	 */
+	exportsPresence?: ExportsPresence;
+
+	/** Warn or error for using non-existent exports */
+	importExportsPresence?: ExportsPresence;
+
+	/** Warn or error for conflicting re-exports */
+	reexportExportsPresence?: ExportsPresence;
+
+	// TODO: add docs
+	strictExportPresence?: boolean;
+
+	/** Provide custom syntax for Worker parsing, commonly used to support Worklet */
+	worker?: string[] | boolean;
+
+	/** Override the module to strict or non-strict. */
+	overrideStrict?: "strict" | "non-strict";
+
+	// TODO: add docs
+	requireAsExpression?: boolean;
+
+	// TODO: add docs
+	requireDynamic?: boolean;
+
+	// TODO: add docs
+	requireResolve?: boolean;
+
+	// TODO: add docs
+	importDynamic?: boolean;
+};
+
+/** Configure all parsers' options in one place with module.parser. */
+export type ParserOptionsByModuleTypeKnown = {
+	/** Parser options for `asset` modules. */
+	asset?: AssetParserOptions;
+
+	/** Parser options for `css` modules. */
+	css?: CssParserOptions;
+
+	/** Parser options for `css/auto` modules. */
+	"css/auto"?: CssAutoParserOptions;
+
+	/** Parser options for `css/module` modules. */
+	"css/module"?: CssModuleParserOptions;
+
+	/** Parser options for `javascript` modules. */
+	javascript?: JavascriptParserOptions;
+
+	/** Parser options for `javascript/auto` modules. */
+	"javascript/auto"?: JavascriptParserOptions;
+
+	/** Parser options for `javascript/dynamic` modules. */
+	"javascript/dynamic"?: JavascriptParserOptions;
+
+	/** Parser options for `javascript/esm` modules. */
+	"javascript/esm"?: JavascriptParserOptions;
+};
+
+/** Configure all parsers' options in one place with module.parser. */
+export type ParserOptionsByModuleTypeUnknown = {
+	[x: string]: Record<string, any>;
+};
+
+/** Configure all parsers' options in one place with module.parser. */
+export type ParserOptionsByModuleType =
+	| ParserOptionsByModuleTypeKnown
+	| ParserOptionsByModuleTypeUnknown;
+
+export type AssetGeneratorDataUrlOptions = {
+	encoding?: false | "base64";
+	mimetype?: string;
+};
+
+export type AssetGeneratorDataUrlFunction = (options: {
+	filename: string;
+	content: string;
+}) => string;
+
+export type AssetGeneratorDataUrl =
+	| AssetGeneratorDataUrlOptions
+	| AssetGeneratorDataUrlFunction;
+
+/** Options for asset inline modules. */
+export type AssetInlineGeneratorOptions = {
+	/** Only for modules with module type 'asset' or 'asset/inline'. */
+	dataUrl?: AssetGeneratorDataUrl;
+};
+
+/** Options for asset modules. */
+export type AssetResourceGeneratorOptions = {
+	/**
+	 * Whether to output assets to disk.
+	 * @default true
+	 * */
+	emit?: boolean;
+
+	/** This option determines the name of each asset resource output bundle.*/
+	filename?: Filename;
+
+	/** This option determines the URL prefix of the referenced 'asset' or 'asset/resource'*/
+	publicPath?: PublicPath;
+};
+
+/** Generator options for asset modules. */
+export type AssetGeneratorOptions = AssetInlineGeneratorOptions &
+	AssetResourceGeneratorOptions;
+
+export type CssGeneratorExportsConvention =
+	| "as-is"
+	| "camel-case"
+	| "camel-case-only"
+	| "dashes"
+	| "dashes-only";
+
+export type CssGeneratorExportsOnly = boolean;
+
+export type CssGeneratorLocalIdentName = string;
+
+export type CssGeneratorEsModule = boolean;
+
+/** Generator options for css modules. */
+export type CssGeneratorOptions = {
+	/**
+	 * If true, only exports the identifier mappings from CSS into the output JavaScript files
+	 * If false, generate stylesheets and embed them in the template.
+	 */
+	exportsOnly?: CssGeneratorExportsOnly;
+
+	/** This configuration is available for improved ESM-CJS interoperability purposes. */
+	esModule?: CssGeneratorEsModule;
+};
+
+/** Generator options for css/auto modules. */
+export type CssAutoGeneratorOptions = {
+	/**
+	 * Customize how CSS export names are exported to javascript modules
+	 * @default 'as-is'
+	 * */
+	exportsConvention?: CssGeneratorExportsConvention;
+
+	/**
+	 * If true, only exports the identifier mappings from CSS into the output JavaScript files
+	 * If false, generate stylesheets and embed them in the template.
+	 */
+	exportsOnly?: CssGeneratorExportsOnly;
+
+	/** Customize the format of the local class names generated for CSS modules */
+	localIdentName?: CssGeneratorLocalIdentName;
+
+	/** This configuration is available for improved ESM-CJS interoperability purposes. */
+	esModule?: CssGeneratorEsModule;
+};
+
+/** Generator options for css/module modules. */
+export type CssModuleGeneratorOptions = CssAutoGeneratorOptions;
+
+export type GeneratorOptionsByModuleTypeKnown = {
+	/** Generator options for asset modules. */
+	asset?: AssetGeneratorOptions;
+
+	/** Generator options for asset/inline modules. */
+	"asset/inline"?: AssetInlineGeneratorOptions;
+
+	/** Generator options for asset/resource modules. */
+	"asset/resource"?: AssetResourceGeneratorOptions;
+
+	/** Generator options for css modules. */
+	css?: CssGeneratorOptions;
+
+	/** Generator options for css/auto modules. */
+	"css/auto"?: CssAutoGeneratorOptions;
+
+	/** Generator options for css/module modules. */
+	"css/module"?: CssModuleGeneratorOptions;
+};
+
+export type GeneratorOptionsByModuleTypeUnknown = Record<
+	string,
+	Record<string, any>
+>;
+
+/** Options for module.generator */
+export type GeneratorOptionsByModuleType =
+	| GeneratorOptionsByModuleTypeKnown
+	| GeneratorOptionsByModuleTypeUnknown;
+
+type NoParseOptionSingle = string | RegExp | ((request: string) => boolean);
+
+/** Options for module.noParse */
+export type NoParseOption = NoParseOptionSingle | NoParseOptionSingle[];
+
+export type ModuleOptions = {
+	/** Used to decide how to handle different types of modules in a project. */
+	defaultRules?: RuleSetRules;
+
+	/**
+	 * An array of rules that match the module's requests when it is created.
+	 * @default []
+	 * */
+	rules?: RuleSetRules;
+
+	/**
+	 * Configure all parsers' options in one place with module.parser.
+	 * @default {}
+	 * */
+	parser?: ParserOptionsByModuleType;
+
+	/** Configure all generators' options in one place with module.generator. */
+	generator?: GeneratorOptionsByModuleType;
+
+	/** Keep module mechanism of the matched modules as-is, such as module.exports, require, import. */
+	noParse?: NoParseOption;
+};
+
+//#endregion
+
 //#region ExternalsType
 /**
  * Specify the default type of externals.
@@ -877,6 +1315,8 @@ export type ExternalItem =
  * ```
  * */
 export type Externals = ExternalItem | ExternalItem[];
+//#endregion
+
 //#region Plugins
 export interface RspackPluginInstance {
 	apply: (compiler: Compiler) => void;

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -422,56 +422,42 @@ const baseRuleSetCondition = z
 	.or(z.string())
 	.or(z.function().args(z.string()).returns(z.boolean()));
 
-export type RuleSetCondition =
-	| z.infer<typeof baseRuleSetCondition>
-	| RuleSetConditions
-	| RuleSetLogicalConditions;
-
-const ruleSetCondition: z.ZodType<RuleSetCondition> = baseRuleSetCondition
+const ruleSetCondition: z.ZodType<t.RuleSetCondition> = baseRuleSetCondition
 	.or(z.lazy(() => ruleSetConditions))
 	.or(z.lazy(() => ruleSetLogicalConditions));
 
-export type RuleSetConditions = RuleSetCondition[];
-
-const ruleSetConditions: z.ZodType<RuleSetConditions> = z.lazy(() =>
+const ruleSetConditions: z.ZodType<t.RuleSetConditions> = z.lazy(() =>
 	z.array(ruleSetCondition)
 );
 
-export type RuleSetLogicalConditions = {
-	and?: RuleSetConditions;
-	or?: RuleSetConditions;
-	not?: RuleSetCondition;
-};
-
-const ruleSetLogicalConditions: z.ZodType<RuleSetLogicalConditions> =
+const ruleSetLogicalConditions: z.ZodType<t.RuleSetLogicalConditions> =
 	z.strictObject({
 		and: ruleSetConditions.optional(),
 		or: ruleSetConditions.optional(),
 		not: ruleSetCondition.optional()
 	});
 
-const ruleSetLoader = z.string();
-export type RuleSetLoader = z.infer<typeof ruleSetLoader>;
+const ruleSetLoader = z.string() satisfies z.ZodType<t.RuleSetLoader>;
 
-const ruleSetLoaderOptions = z.string().or(z.record(z.any()));
-export type RuleSetLoaderOptions = z.infer<typeof ruleSetLoaderOptions>;
+const ruleSetLoaderOptions = z
+	.string()
+	.or(z.record(z.any())) satisfies z.ZodType<t.RuleSetLoaderOptions>;
 
 const ruleSetLoaderWithOptions = z.strictObject({
 	ident: z.string().optional(),
 	loader: ruleSetLoader,
 	options: ruleSetLoaderOptions.optional()
-});
-export type RuleSetLoaderWithOptions = z.infer<typeof ruleSetLoaderWithOptions>;
+}) satisfies z.ZodType<t.RuleSetLoaderWithOptions>;
 
-const ruleSetUseItem = ruleSetLoader.or(ruleSetLoaderWithOptions);
-export type RuleSetUseItem = z.infer<typeof ruleSetUseItem>;
+const ruleSetUseItem = ruleSetLoader.or(
+	ruleSetLoaderWithOptions
+) satisfies z.ZodType<t.RuleSetUseItem>;
 
 const ruleSetUse = ruleSetUseItem
 	.or(ruleSetUseItem.array())
 	.or(
 		z.function().args(z.custom<RawFuncUseCtx>()).returns(ruleSetUseItem.array())
-	);
-export type RuleSetUse = z.infer<typeof ruleSetUse>;
+	) satisfies z.ZodType<t.RuleSetUse>;
 
 const baseRuleSetRule = z.strictObject({
 	test: ruleSetCondition.optional(),
@@ -497,53 +483,42 @@ const baseRuleSetRule = z.strictObject({
 	resolve: resolveOptions.optional(),
 	sideEffects: z.boolean().optional(),
 	enforce: z.literal("pre").or(z.literal("post")).optional()
-});
+}) satisfies z.ZodType<t.RuleSetRule>;
 
-export type RuleSetRule = z.infer<typeof baseRuleSetRule> & {
-	oneOf?: RuleSetRule[];
-	rules?: RuleSetRule[];
-};
-
-const ruleSetRule: z.ZodType<RuleSetRule> = baseRuleSetRule.extend({
+const ruleSetRule: z.ZodType<t.RuleSetRule> = baseRuleSetRule.extend({
 	oneOf: z.lazy(() => ruleSetRule.array()).optional(),
 	rules: z.lazy(() => ruleSetRule.array()).optional()
 });
 
-const ruleSetRules = z.array(z.literal("...").or(ruleSetRule).or(falsy));
-export type RuleSetRules = z.infer<typeof ruleSetRules>;
+const ruleSetRules = z.array(
+	z.literal("...").or(ruleSetRule).or(falsy)
+) satisfies z.ZodType<t.RuleSetRules>;
 
 const assetParserDataUrlOptions = z.strictObject({
 	maxSize: z.number().optional()
-});
-export type AssetParserDataUrlOptions = z.infer<
-	typeof assetParserDataUrlOptions
->;
+}) satisfies z.ZodType<t.AssetParserDataUrlOptions>;
 
-const assetParserDataUrl = assetParserDataUrlOptions;
-export type AssetParserDataUrl = z.infer<typeof assetParserDataUrl>;
+const assetParserDataUrl =
+	assetParserDataUrlOptions satisfies z.ZodType<t.AssetParserDataUrl>;
 
 const assetParserOptions = z.strictObject({
 	dataUrlCondition: assetParserDataUrl.optional()
-});
-export type AssetParserOptions = z.infer<typeof assetParserOptions>;
+}) satisfies z.ZodType<t.AssetParserOptions>;
 
-const cssParserNamedExports = z.boolean();
-export type CssParserNamedExports = z.infer<typeof cssParserNamedExports>;
+const cssParserNamedExports =
+	z.boolean() satisfies z.ZodType<t.CssParserNamedExports>;
 
 const cssParserOptions = z.strictObject({
 	namedExports: cssParserNamedExports.optional()
-});
-export type CssParserOptions = z.infer<typeof cssParserOptions>;
+}) satisfies z.ZodType<t.CssParserOptions>;
 
 const cssAutoParserOptions = z.strictObject({
 	namedExports: cssParserNamedExports.optional()
-});
-export type CssAutoParserOptions = z.infer<typeof cssAutoParserOptions>;
+}) satisfies z.ZodType<t.CssAutoParserOptions>;
 
 const cssModuleParserOptions = z.strictObject({
 	namedExports: cssParserNamedExports.optional()
-});
-export type CssModuleParserOptions = z.infer<typeof cssModuleParserOptions>;
+}) satisfies z.ZodType<t.CssModuleParserOptions>;
 
 const dynamicImportMode = z.enum(["eager", "lazy", "weak", "lazy-once"]);
 const dynamicImportPreload = z.union([z.boolean(), z.number()]);
@@ -588,8 +563,7 @@ const javascriptParserOptions = z.strictObject({
 	requireResolve: requireResolve.optional(),
 	importDynamic: importDynamic.optional()
 	// #endregion
-});
-export type JavascriptParserOptions = z.infer<typeof javascriptParserOptions>;
+}) satisfies z.ZodType<t.JavascriptParserOptions>;
 
 const parserOptionsByModuleTypeKnown = z.strictObject({
 	asset: assetParserOptions.optional(),
@@ -600,31 +574,20 @@ const parserOptionsByModuleTypeKnown = z.strictObject({
 	"javascript/auto": javascriptParserOptions.optional(),
 	"javascript/dynamic": javascriptParserOptions.optional(),
 	"javascript/esm": javascriptParserOptions.optional()
-});
+}) satisfies z.ZodType<t.ParserOptionsByModuleTypeKnown>;
 
-export type ParserOptionsByModuleTypeKnown = z.infer<
-	typeof parserOptionsByModuleTypeKnown
->;
-
-const parserOptionsByModuleTypeUnknown = z.record(z.record(z.any()));
-export type ParserOptionsByModuleTypeUnknown = z.infer<
-	typeof parserOptionsByModuleTypeUnknown
->;
+const parserOptionsByModuleTypeUnknown = z.record(
+	z.record(z.any())
+) satisfies z.ZodType<t.ParserOptionsByModuleTypeUnknown>;
 
 const parserOptionsByModuleType = parserOptionsByModuleTypeKnown.or(
 	parserOptionsByModuleTypeUnknown
-);
-export type ParserOptionsByModuleType = z.infer<
-	typeof parserOptionsByModuleType
->;
+) satisfies z.ZodType<t.ParserOptionsByModuleType>;
 
 const assetGeneratorDataUrlOptions = z.strictObject({
 	encoding: z.literal(false).or(z.literal("base64")).optional(),
 	mimetype: z.string().optional()
-});
-export type AssetGeneratorDataUrlOptions = z.infer<
-	typeof assetGeneratorDataUrlOptions
->;
+}) satisfies z.ZodType<t.AssetGeneratorDataUrlOptions>;
 
 const assetGeneratorDataUrlFunction = z
 	.function()
@@ -634,19 +597,15 @@ const assetGeneratorDataUrlFunction = z
 			filename: z.string()
 		})
 	)
-	.returns(z.string());
-export type AssetGeneratorDataUrlFunction = z.infer<
-	typeof assetGeneratorDataUrlFunction
->;
+	.returns(z.string()) satisfies z.ZodType<t.AssetGeneratorDataUrlFunction>;
 
 const assetGeneratorDataUrl = assetGeneratorDataUrlOptions.or(
 	assetGeneratorDataUrlFunction
-);
-export type AssetGeneratorDataUrl = z.infer<typeof assetGeneratorDataUrl>;
+) satisfies z.ZodType<t.AssetGeneratorDataUrl>;
 
 const assetInlineGeneratorOptions = z.strictObject({
 	dataUrl: assetGeneratorDataUrl.optional()
-});
+}) satisfies z.ZodType<t.AssetInlineGeneratorOptions>;
 export type AssetInlineGeneratorOptions = z.infer<
 	typeof assetInlineGeneratorOptions
 >;
@@ -655,15 +614,11 @@ const assetResourceGeneratorOptions = z.strictObject({
 	emit: z.boolean().optional(),
 	filename: filename.optional(),
 	publicPath: publicPath.optional()
-});
-export type AssetResourceGeneratorOptions = z.infer<
-	typeof assetResourceGeneratorOptions
->;
+}) satisfies z.ZodType<t.AssetResourceGeneratorOptions>;
 
 const assetGeneratorOptions = assetInlineGeneratorOptions.merge(
 	assetResourceGeneratorOptions
-);
-export type AssetGeneratorOptions = z.infer<typeof assetGeneratorOptions>;
+) satisfies z.ZodType<t.AssetGeneratorOptions>;
 
 const cssGeneratorExportsConvention = z.enum([
 	"as-is",
@@ -671,45 +626,35 @@ const cssGeneratorExportsConvention = z.enum([
 	"camel-case-only",
 	"dashes",
 	"dashes-only"
-]);
-export type CssGeneratorExportsConvention = z.infer<
-	typeof cssGeneratorExportsConvention
->;
+]) satisfies z.ZodType<t.CssGeneratorExportsConvention>;
 
-const cssGeneratorExportsOnly = z.boolean();
-export type CssGeneratorExportsOnly = z.infer<typeof cssGeneratorExportsOnly>;
+const cssGeneratorExportsOnly =
+	z.boolean() satisfies z.ZodType<t.CssGeneratorExportsOnly>;
 
-const cssGeneratorLocalIdentName = z.string();
-export type CssGeneratorLocalIdentName = z.infer<
-	typeof cssGeneratorLocalIdentName
->;
+const cssGeneratorLocalIdentName =
+	z.string() satisfies z.ZodType<t.CssGeneratorLocalIdentName>;
 
-const cssGeneratorEsModule = z.boolean();
-export type CssGeneratorEsModule = z.infer<typeof cssGeneratorEsModule>;
+const cssGeneratorEsModule =
+	z.boolean() satisfies z.ZodType<t.CssGeneratorEsModule>;
 
 const cssGeneratorOptions = z.strictObject({
 	exportsOnly: cssGeneratorExportsOnly.optional(),
 	esModule: cssGeneratorEsModule.optional()
-});
-export type CssGeneratorOptions = z.infer<typeof cssGeneratorOptions>;
+}) satisfies z.ZodType<t.CssGeneratorOptions>;
 
 const cssAutoGeneratorOptions = z.strictObject({
 	exportsConvention: cssGeneratorExportsConvention.optional(),
 	exportsOnly: cssGeneratorExportsOnly.optional(),
 	localIdentName: cssGeneratorLocalIdentName.optional(),
 	esModule: cssGeneratorEsModule.optional()
-});
-export type CssAutoGeneratorOptions = z.infer<typeof cssAutoGeneratorOptions>;
+}) satisfies z.ZodType<t.CssAutoGeneratorOptions>;
 
 const cssModuleGeneratorOptions = z.strictObject({
 	exportsConvention: cssGeneratorExportsConvention.optional(),
 	exportsOnly: cssGeneratorExportsOnly.optional(),
 	localIdentName: cssGeneratorLocalIdentName.optional(),
 	esModule: cssGeneratorEsModule.optional()
-});
-export type CssModuleGeneratorOptions = z.infer<
-	typeof cssModuleGeneratorOptions
->;
+}) satisfies z.ZodType<t.CssModuleGeneratorOptions>;
 
 const generatorOptionsByModuleTypeKnown = z.strictObject({
 	asset: assetGeneratorOptions.optional(),
@@ -718,29 +663,26 @@ const generatorOptionsByModuleTypeKnown = z.strictObject({
 	css: cssGeneratorOptions.optional(),
 	"css/auto": cssAutoGeneratorOptions.optional(),
 	"css/module": cssModuleGeneratorOptions.optional()
-});
+}) satisfies z.ZodType<t.GeneratorOptionsByModuleTypeKnown>;
 export type GeneratorOptionsByModuleTypeKnown = z.infer<
 	typeof generatorOptionsByModuleTypeKnown
 >;
 
-const generatorOptionsByModuleTypeUnknown = z.record(z.record(z.any()));
-export type GeneratorOptionsByModuleTypeUnknown = z.infer<
-	typeof generatorOptionsByModuleTypeUnknown
->;
+const generatorOptionsByModuleTypeUnknown = z.record(
+	z.record(z.any())
+) satisfies z.ZodType<t.GeneratorOptionsByModuleTypeUnknown>;
 
 const generatorOptionsByModuleType = generatorOptionsByModuleTypeKnown.or(
 	generatorOptionsByModuleTypeUnknown
-);
-export type GeneratorOptionsByModuleType = z.infer<
-	typeof generatorOptionsByModuleType
->;
+) satisfies z.ZodType<t.GeneratorOptionsByModuleType>;
 
 const noParseOptionSingle = z
 	.string()
 	.or(z.instanceof(RegExp))
 	.or(z.function().args(z.string()).returns(z.boolean()));
-const noParseOption = noParseOptionSingle.or(z.array(noParseOptionSingle));
-export type NoParseOption = z.infer<typeof noParseOption>;
+const noParseOption = noParseOptionSingle.or(
+	z.array(noParseOptionSingle)
+) satisfies z.ZodType<t.NoParseOption>;
 
 const moduleOptions = z.strictObject({
 	defaultRules: ruleSetRules.optional(),
@@ -748,8 +690,7 @@ const moduleOptions = z.strictObject({
 	parser: parserOptionsByModuleType.optional(),
 	generator: generatorOptionsByModuleType.optional(),
 	noParse: noParseOption.optional()
-});
-export type ModuleOptions = z.infer<typeof moduleOptions>;
+}) satisfies z.ZodType<t.ModuleOptions>;
 //#endregion
 
 //#region Target

--- a/website/docs/en/config/module.mdx
+++ b/website/docs/en/config/module.mdx
@@ -245,6 +245,12 @@ Warn or error for using non-existent exports, defaulting to the configuration of
 
 Warn or error for conflicting re-exports, defaulting to the configuration of `module.parser.javascript.exportsPresence`.
 
+#### module.parser.javascript.strictExportPresence
+
+- **Type:** `boolean`
+
+Emit errors instead of warnings when imported names don't exist in imported module.
+
 #### module.parser.javascript.worker
 
 <ApiMeta addedVersion="1.0.0-alpha.0" />
@@ -969,6 +975,16 @@ For specific generator options and the corresponding module type, you can refer 
 - **Type:** `boolean`
 
 Flag the module for side effects
+
+### Rule.enforce
+
+<PropertyType type="'pre' | 'post'" />
+
+Specifies the category of the loader.
+
+When specified as 'pre', the loader will execute before all other loaders.
+
+When specified as 'post', the loader will execute after all other loaders.
 
 ### Rule.type
 

--- a/website/docs/zh/config/module.mdx
+++ b/website/docs/zh/config/module.mdx
@@ -245,6 +245,12 @@ module.exports = {
 
 当使用了存在冲突的重导出时，是否进行警告或报错。默认会遵循 `module.parser.javascript.exportsPresence` 的配置。
 
+#### module.parser.javascript.strictExportPresence
+
+- **类型：** `boolean`
+
+当导入的名称在导入模块中不存在时，发出错误而不是警告。
+
 #### module.parser.javascript.worker
 
 <ApiMeta addedVersion="1.0.0-alpha.0" />
@@ -968,6 +974,16 @@ module.exports = {
 - **类型：** `boolean`
 
 标记模块是否存在副作用。
+
+### Rule.enforce
+
+<PropertyType type="'pre' | 'post'" />
+
+指定 loader 的类型。
+
+当指定为 'pre' 时，该 loader 会在其他所有 loader 之前执行。
+
+当指定为 'post' 时，该 loader 会在其他所有 loader 之后执行。
 
 ### Rule.type
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.module

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
