### PR TITLE
fix: generate correct worker expression with trusted types

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/index.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/index.js
@@ -1,0 +1,45 @@
+const fs = __non_webpack_require__("fs");
+const path = __non_webpack_require__("path");
+
+
+function createWorker() {
+	new Worker(new URL("./worker.js", import.meta.url), {
+		type: "module"
+	});
+}
+
+createWorker;
+
+it("should generate correct new Worker statement", async () => {
+	const content = fs.readFileSync(__filename, "utf-8");
+	const method = "__webpack_require__.tu";
+	expect(content).toContain(`new Worker(${method}(new URL(`)
+});
+
+
+function createWorkerWithChunkName() {
+	new Worker(/* webpackChunkName: "someChunkName" */new URL("./worker.js", import.meta.url));
+}
+
+createWorkerWithChunkName
+
+it("should generate correct new Worker statement with magic comments", async () => {
+	const content = fs.readFileSync(__filename, "utf-8");
+	const chunkName = "someChunkName";
+	expect(content).toContain(`new Worker(/* webpackChunkName: "${chunkName}" */__webpack_require__.tu(new URL(`)
+	expect(fs.existsSync(path.join(__dirname, `${chunkName}.js`))).toBeTruthy();
+});
+
+
+function createWorkerWithChunkNameInnner() {
+	new Worker(new URL(/* webpackChunkName: "someChunkName2" */ "./worker.js", import.meta.url));
+}
+
+createWorkerWithChunkNameInnner
+
+it("should generate correct new Worker statement with magic comments", async () => {
+	const content = fs.readFileSync(__filename, "utf-8");
+	const chunkName = "someChunkName2";
+	expect(content).toContain(`new Worker(__webpack_require__.tu(new URL(/* webpackChunkName: "${chunkName}" */`)
+	expect(fs.existsSync(path.join(__dirname, `${chunkName}.js`))).toBeTruthy();
+});

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/module.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/module.js
@@ -1,0 +1,3 @@
+export function upper(s) {
+	return s.toUpperCase();
+}

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/rspack.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+	output: {
+		filename: "[name].js",
+		chunkFilename: "[name].js",
+		trustedTypes: true
+	},
+	node: {
+		__dirname: false,
+		__filename: false
+	},
+	target: "web"
+};

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle: function (i, options) {
+		return ["main.js"];
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/worker.js
+++ b/packages/rspack-test-tools/tests/configCases/trusted-types/web-worker/worker.js
@@ -1,0 +1,3 @@
+onmessage = async event => {
+	postMessage(`data: ${event.data}, thanks`);
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8134

When `output.trustedTypes` is set, the `new Worker(new URL(xxx))`  should be compiled to `new Worker(__webpack_reuqire__.tu(new URL(xxx)))`, but now it is compiled to `new Worker(new URL(__webpack_require__.tu(xxx)))`

The `webpack-test/configCases/trusted-types/web-worker` case can pass because the mock environment does not have  `trustedTypes.createPolicy` so that the `__webpack_require__.tu(xxx)` will return `xxx` directly.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
