### PR TITLE
docs: update `webpack-assets-manifest` compatibility status

### DIFF
--- a/website/components/CommunityCompatibleTable.tsx
+++ b/website/components/CommunityCompatibleTable.tsx
@@ -301,7 +301,8 @@ export const CommunityPluginCompatibleTable: React.FC = () => {
     {
       name: 'webpack-assets-manifest',
       url: 'https://github.com/webdeveric/webpack-assets-manifest',
-      status: CompatibleStatus.Compatible,
+      status: CompatibleStatus.PartiallyCompatible,
+      description: i18n[lang]['webpack-assets-manifest-desc'],
     },
     {
       name: 'git-revision-webpack-plugin',

--- a/website/components/i18n/en.json
+++ b/website/components/i18n/en.json
@@ -26,5 +26,6 @@
   "eslint-webpack-plugin-desc": "Use [eslint-rspack-plugin](https://github.com/rspack-contrib/eslint-rspack-plugin) instead",
   "circular-dependency-plugin-desc": "Use Eslint [import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) rule instead",
   "html-webpack-tags-plugin-desc": "This plugin depends on webpack and html-webpack-plugin",
-  "needs-html-webpack-plugin": "This plugin depends on html-webpack-plugin"
+  "needs-html-webpack-plugin": "This plugin depends on html-webpack-plugin",
+  "webpack-assets-manifest-desc": "Only supports basic usage"
 }

--- a/website/components/i18n/zh.json
+++ b/website/components/i18n/zh.json
@@ -26,5 +26,6 @@
   "eslint-webpack-plugin-desc": "使用 [eslint-rspack-plugin](https://github.com/rspack-contrib/eslint-rspack-plugin) 替代",
   "circular-dependency-plugin-desc": "使用 Eslint [import/no-cycle](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md) 规则替代",
   "html-webpack-tags-plugin-desc": "该插件依赖了 webpack 和 html-webpack-plugin",
-  "needs-html-webpack-plugin": "该插件依赖了 html-webpack-plugin"
+  "needs-html-webpack-plugin": "该插件依赖了 html-webpack-plugin",
+  "webpack-assets-manifest-desc": "仅支持基础用法"
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Updated `webpack-assets-manifest` compatibility status to PartiallyCompatible since rspack only supports basic usage of `webpack-assets-manifest`.

Related issue: https://github.com/web-infra-dev/rspack/issues/8058

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
