### PR TITLE
chore(deps): update typescript to v5.6

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -163,6 +163,15 @@
       "matchPackagePrefixes": [
         "@playwright/test"
       ]
+    },
+    {
+      "groupName": "typescript",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "typescript"
+      ]
     }
   ]
 }

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -144,15 +144,21 @@
     "enabled": true,
 
     /**
+     * DEFAULT VALUE: "[ "complete" ]"
+     */
+    "reportVariants": ["complete"],
+
+    /**
      * The filename for the API report files.  It will be combined with "reportFolder" or "reportTempFolder" to produce
      * a full file path.
      *
      * The file extension should be ".api.md", and the string should not contain a path separator such as "\" or "/".
+     * API Extractor will automatically append an appropriate file extension such as .api.md
      *
      * SUPPORTED TOKENS: <packageName>, <unscopedPackageName>
-     * DEFAULT VALUE: "<unscopedPackageName>.api.md"
+     * DEFAULT VALUE: "<unscopedPackageName>"
      */
-    "reportFileName": "api.md",
+    "reportFileName": "<unscopedPackageName>",
 
     /**
      * Specifies the folder where the API report file is written.  The file name portion is determined by
@@ -165,7 +171,7 @@
      * prepend a folder token such as "<projectFolder>".
      *
      * SUPPORTED TOKENS: <projectFolder>, <packageName>, <unscopedPackageName>
-     * DEFAULT VALUE: "<projectFolder>/temp/"
+     * DEFAULT VALUE: "<projectFolder>/etc/"
      */
     "reportFolder": "<projectFolder>/etc/",
 

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -40,7 +40,7 @@
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
     "@napi-rs/cli": "3.0.0-alpha.45",
-    "typescript": "5.0.2"
+    "typescript": "5.6.3"
   },
   "napi": {
     "binaryName": "rspack"

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -40,7 +40,7 @@
   "repository": "web-infra-dev/rspack",
   "devDependencies": {
     "@napi-rs/cli": "3.0.0-alpha.45",
-    "typescript": "5.6.3"
+    "typescript": "^5.6.3"
   },
   "napi": {
     "binaryName": "rspack"

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
   "devDependencies": {
     "@biomejs/biome": "1.8.0",
     "@jest/reporters": "29.7.0",
-    "@microsoft/api-extractor": "^7.43.1",
-    "@microsoft/api-extractor-model": "^7.28.14",
+    "@microsoft/api-extractor": "7.47.10",
+    "@microsoft/api-extractor-model": "7.29.8",
     "@rspack/cli": "workspace:*",
     "@taplo/cli": "^0.7.0",
     "@types/is-ci": "^3.0.4",
@@ -76,7 +76,7 @@
     "prettier-2": "npm:prettier@2.8.8",
     "rimraf": "3.0.2",
     "ts-jest": "29.1.2",
-    "typescript": "5.0.2",
+    "typescript": "5.6.3",
     "webpack": "^5.94.0",
     "webpack-cli": "5.1.4",
     "zx": "7.2.3"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "x": "zx x.mjs",
     "dev": "pnpm --filter @rspack/cli run dev",
     "clean": "pnpm --filter @rspack/cli run clean",
-    "check-dependency-version": "check-dependency-version-consistency . --ignore-dep typescript --ignore-dep @napi-rs/cli --ignore-dep chalk --ignore-package webpack-test --ignore-package webpack-examples --ignore-package plugin-test",
+    "check-dependency-version": "check-dependency-version-consistency . --ignore-dep @napi-rs/cli --ignore-dep chalk --ignore-package webpack-test --ignore-package webpack-examples --ignore-package plugin-test",
     "build:js": "pnpm --filter \"@rspack/core\" build:force && pnpm --filter \"@rspack/*\" --filter \"create-rspack\" --filter \"!@rspack/core\" build",
     "build:cli:debug": "npm run build:binding:debug && npm run build:js",
     "build:cli:release": "npm run build:binding:release && npm run build:js",
@@ -76,7 +76,7 @@
     "prettier-2": "npm:prettier@2.8.8",
     "rimraf": "3.0.2",
     "ts-jest": "29.1.2",
-    "typescript": "5.6.3",
+    "typescript": "^5.6.3",
     "webpack": "^5.94.0",
     "webpack-cli": "5.1.4",
     "zx": "7.2.3"

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@rslib/core": "0.0.12",
-    "typescript": "5.6.3"
+    "typescript": "^5.6.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@rslib/core": "0.0.12",
-    "typescript": "5.0.2"
+    "typescript": "5.6.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rspack/template-react-ts/package.json
+++ b/packages/create-rspack/template-react-ts/package.json
@@ -19,6 +19,6 @@
     "cross-env": "^7.0.3",
     "react-refresh": "^0.14.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.6.3"
   }
 }

--- a/packages/create-rspack/template-vanilla-ts/package.json
+++ b/packages/create-rspack/template-vanilla-ts/package.json
@@ -11,6 +11,6 @@
     "@rspack/cli": "workspace:*",
     "@rspack/core": "workspace:*",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.6.3"
   }
 }

--- a/packages/create-rspack/template-vue-ts/package.json
+++ b/packages/create-rspack/template-vue-ts/package.json
@@ -14,7 +14,7 @@
     "@rspack/core": "workspace:*",
     "cross-env": "^7.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3",
+    "typescript": "^5.6.3",
     "vue-loader": "^17.3.1"
   }
 }

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -28,7 +28,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-refresh": "^0.14.0",
-    "typescript": "5.0.2",
+    "typescript": "5.6.3",
     "tailwindcss": "^3.3.0",
     "vue": "^3.4.21",
     "vue-loader": "^17.3.1",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -28,7 +28,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-refresh": "^0.14.0",
-    "typescript": "5.6.3",
+    "typescript": "^5.6.3",
     "tailwindcss": "^3.3.0",
     "vue": "^3.4.21",
     "vue-loader": "^17.3.1",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -51,7 +51,7 @@
     "execa": "^5.0.0",
     "internal-ip": "6.2.0",
     "ts-node": "^10.9.2",
-    "typescript": "5.0.2"
+    "typescript": "5.6.3"
   },
   "peerDependencies": {
     "@rspack/core": "^1.0.0-alpha || ^1.x"

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -51,7 +51,7 @@
     "execa": "^5.0.0",
     "internal-ip": "6.2.0",
     "ts-node": "^10.9.2",
-    "typescript": "5.6.3"
+    "typescript": "^5.6.3"
   },
   "peerDependencies": {
     "@rspack/core": "^1.0.0-alpha || ^1.x"

--- a/packages/rspack-test-tools/etc/test-tools.api.md
+++ b/packages/rspack-test-tools/etc/test-tools.api.md
@@ -4,10 +4,6 @@
 
 ```ts
 
-/// <reference types="../jest.d.ts" />
-/// <reference types="jest" />
-/// <reference types="node" />
-
 import type { Compiler } from '@rspack/core';
 import type { Compiler as Compiler_2 } from 'webpack';
 import type { Configuration } from 'webpack';

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -114,7 +114,7 @@
     "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "terser": "5.27.2",
-    "typescript": "5.0.2",
+    "typescript": "5.6.3",
     "wast-loader": "^1.12.1"
   },
   "peerDependencies": {

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -114,7 +114,7 @@
     "source-map-loader": "^5.0.0",
     "style-loader": "^4.0.0",
     "terser": "5.27.2",
-    "typescript": "5.6.3",
+    "typescript": "^5.6.3",
     "wast-loader": "^1.12.1"
   },
   "peerDependencies": {

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -15,7 +15,7 @@ import { BuiltinPluginName } from '@rspack/binding';
 import { CacheFacade as CacheFacade_2 } from './lib/CacheFacade';
 import type { Callback } from '@rspack/lite-tapable';
 import { cleanupGlobalTrace } from '@rspack/binding';
-import { Compiler as Compiler_2 } from '../Compiler';
+import { Compiler as Compiler_2 } from '..';
 import { default as default_2 } from './util/hash';
 import type { DependenciesBlockDTO } from '@rspack/binding';
 import { RawEvalDevToolModulePluginOptions as EvalDevToolModulePluginOptions } from '@rspack/binding';
@@ -189,7 +189,7 @@ const assetInlineGeneratorOptions: z.ZodObject<{
     } | ((args_0: {
         filename: string;
         content: string;
-    }, ...args_1: unknown[]) => string) | undefined;
+    }, ...args: unknown[]) => string) | undefined;
 }, {
     dataUrl?: {
         mimetype?: string | undefined;
@@ -197,7 +197,7 @@ const assetInlineGeneratorOptions: z.ZodObject<{
     } | ((args_0: {
         filename: string;
         content: string;
-    }, ...args_1: unknown[]) => string) | undefined;
+    }, ...args: unknown[]) => string) | undefined;
 }>;
 
 // @public
@@ -1803,7 +1803,7 @@ const experiments_2: z.ZodObject<{
         test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
     }, "strip", z.ZodTypeAny, {
         entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
         backend?: {
             client?: string | undefined;
             listen?: number | {
@@ -1821,7 +1821,7 @@ const experiments_2: z.ZodObject<{
         imports?: boolean | undefined;
     }, {
         entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
         backend?: {
             client?: string | undefined;
             listen?: number | {
@@ -1900,7 +1900,7 @@ const experiments_2: z.ZodObject<{
     css?: boolean | undefined;
     lazyCompilation?: boolean | {
         entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
         backend?: {
             client?: string | undefined;
             listen?: number | {
@@ -1942,7 +1942,7 @@ const experiments_2: z.ZodObject<{
     css?: boolean | undefined;
     lazyCompilation?: boolean | {
         entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
         backend?: {
             client?: string | undefined;
             listen?: number | {
@@ -2204,8 +2204,8 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
     }>, "strict", z.ZodTypeAny, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
         dataUrl?: {
             mimetype?: string | undefined;
@@ -2213,10 +2213,10 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     }, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
         dataUrl?: {
             mimetype?: string | undefined;
@@ -2224,7 +2224,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     }>>;
     "asset/inline": z.ZodOptional<z.ZodObject<{
         dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
@@ -2253,7 +2253,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     }, {
         dataUrl?: {
             mimetype?: string | undefined;
@@ -2261,19 +2261,19 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     }>>;
     "asset/resource": z.ZodOptional<z.ZodObject<{
         emit: z.ZodOptional<z.ZodBoolean>;
         filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
         publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
     }, "strict", z.ZodTypeAny, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
     }, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
     }>>;
     css: z.ZodOptional<z.ZodObject<{
@@ -2336,8 +2336,8 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         localIdentName?: string | undefined;
     } | undefined;
     asset?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
         dataUrl?: {
             mimetype?: string | undefined;
@@ -2345,7 +2345,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     } | undefined;
     "asset/inline"?: {
         dataUrl?: {
@@ -2354,11 +2354,11 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     } | undefined;
     "asset/resource"?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
     } | undefined;
 }, {
@@ -2379,8 +2379,8 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         localIdentName?: string | undefined;
     } | undefined;
     asset?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
         dataUrl?: {
             mimetype?: string | undefined;
@@ -2388,7 +2388,7 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     } | undefined;
     "asset/inline"?: {
         dataUrl?: {
@@ -2397,11 +2397,11 @@ const generatorOptionsByModuleTypeKnown: z.ZodObject<{
         } | ((args_0: {
             filename: string;
             content: string;
-        }, ...args_1: unknown[]) => string) | undefined;
+        }, ...args: unknown[]) => string) | undefined;
     } | undefined;
     "asset/resource"?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         emit?: boolean | undefined;
     } | undefined;
 }>;
@@ -2539,15 +2539,7 @@ export type HotUpdateGlobal = string;
 export type HotUpdateMainFilename = FilenameTemplate;
 
 // @public (undocumented)
-export const HtmlRspackPlugin: {
-    new (c?: HtmlRspackPluginOptions | undefined): {
-        name: BuiltinPluginName;
-        _args: [c?: HtmlRspackPluginOptions | undefined];
-        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
-        raw(compiler: Compiler): BuiltinPlugin;
-        apply(compiler: Compiler): void;
-    };
-} & {
+export const HtmlRspackPlugin: typeof HtmlRspackPluginImpl & {
     getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     getCompilationOptions: (compilation: Compilation) => HtmlRspackPluginOptions | void;
     createHtmlTagObject: (tagName: string, attributes?: Record<string, string | boolean>, innerHTML?: string | undefined) => JsHtmlPluginTag;
@@ -2571,6 +2563,17 @@ type HtmlRspackPluginHooks = {
     afterEmit: liteTapable.AsyncSeriesWaterfallHook<[
     JsAfterEmitData & ExtraPluginHookData
     ]>;
+};
+
+// @public (undocumented)
+const HtmlRspackPluginImpl: {
+    new (c?: HtmlRspackPluginOptions | undefined): {
+        name: BuiltinPluginName;
+        _args: [c?: HtmlRspackPluginOptions | undefined];
+        affectedHooks: "done" | "make" | "compile" | "emit" | "afterEmit" | "invalid" | "thisCompilation" | "afterDone" | "compilation" | "normalModuleFactory" | "contextModuleFactory" | "initialize" | "shouldEmit" | "infrastructureLog" | "beforeRun" | "run" | "assetEmitted" | "failed" | "shutdown" | "watchRun" | "watchClose" | "environment" | "afterEnvironment" | "afterPlugins" | "afterResolvers" | "beforeCompile" | "afterCompile" | "finishMake" | "entryOption" | undefined;
+        raw(compiler: Compiler): BuiltinPlugin;
+        apply(compiler: Compiler): void;
+    };
 };
 
 // @public (undocumented)
@@ -2703,14 +2706,14 @@ const infrastructureLogging: z.ZodObject<{
     level: z.ZodOptional<z.ZodEnum<["none", "error", "warn", "info", "log", "verbose"]>>;
     stream: z.ZodOptional<z.ZodType<NodeJS.WritableStream, z.ZodTypeDef, NodeJS.WritableStream>>;
 }, "strict", z.ZodTypeAny, {
-    debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+    debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     colors?: boolean | undefined;
     appendOnly?: boolean | undefined;
     console?: Console | undefined;
     level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
     stream?: NodeJS.WritableStream | undefined;
 }, {
-    debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+    debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     colors?: boolean | undefined;
     appendOnly?: boolean | undefined;
     console?: Console | undefined;
@@ -3336,7 +3339,7 @@ const lazyCompilationOptions: z.ZodObject<{
     test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
 }, "strip", z.ZodTypeAny, {
     entries?: boolean | undefined;
-    test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+    test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
     backend?: {
         client?: string | undefined;
         listen?: number | {
@@ -3354,7 +3357,7 @@ const lazyCompilationOptions: z.ZodObject<{
     imports?: boolean | undefined;
 }, {
     entries?: boolean | undefined;
-    test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+    test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
     backend?: {
         client?: string | undefined;
         listen?: number | {
@@ -4183,13 +4186,9 @@ type NormalizedStatsOptions = KnownNormalizedStatsOptions & Omit<StatsOptions, k
 export class NormalModule {
     // (undocumented)
     static getCompilationHooks(compilation: Compilation): {
-        loader: liteTapable.SyncHook<[LoaderContext<{}>, Module], void, {
-            _UnsetAdditionalOptions: true;
-        }>;
+        loader: liteTapable.SyncHook<[LoaderContext, Module]>;
         readResourceForScheme: any;
-        readResource: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[LoaderContext<{}>], string | Buffer, {
-            _UnsetAdditionalOptions: true;
-        }>>;
+        readResource: liteTapable.HookMap<liteTapable.AsyncSeriesBailHook<[LoaderContext], string | Buffer>>;
     };
 }
 
@@ -4574,12 +4573,12 @@ const performance_2: z.ZodUnion<[z.ZodObject<{
     maxAssetSize: z.ZodOptional<z.ZodNumber>;
     maxEntrypointSize: z.ZodOptional<z.ZodNumber>;
 }, "strict", z.ZodTypeAny, {
-    assetFilter?: ((args_0: string, ...args_1: unknown[]) => boolean) | undefined;
+    assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
     hints?: false | "error" | "warning" | undefined;
     maxAssetSize?: number | undefined;
     maxEntrypointSize?: number | undefined;
 }, {
-    assetFilter?: ((args_0: string, ...args_1: unknown[]) => boolean) | undefined;
+    assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
     hints?: false | "error" | "warning" | undefined;
     maxAssetSize?: number | undefined;
     maxEntrypointSize?: number | undefined;
@@ -5482,8 +5481,8 @@ export const rspackOptions: z.ZodObject<{
         layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
     }, "strict", z.ZodTypeAny, {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -5510,8 +5509,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }, {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -5616,8 +5615,8 @@ export const rspackOptions: z.ZodObject<{
         layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
     }, "strict", z.ZodTypeAny, {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -5644,8 +5643,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }, {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -5750,8 +5749,8 @@ export const rspackOptions: z.ZodObject<{
         layer: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodNull]>>;
     }, "strict", z.ZodTypeAny, {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -5778,8 +5777,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }, {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -6004,8 +6003,8 @@ export const rspackOptions: z.ZodObject<{
         }>>;
     }, "strict", z.ZodTypeAny, {
         module?: boolean | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         environment?: {
             module?: boolean | undefined;
             arrowFunction?: boolean | undefined;
@@ -6022,7 +6021,7 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
@@ -6058,13 +6057,13 @@ export const rspackOptions: z.ZodObject<{
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         cssHeadDataCompression?: boolean | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
-        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
@@ -6099,8 +6098,8 @@ export const rspackOptions: z.ZodObject<{
         charset?: boolean | undefined;
     }, {
         module?: boolean | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         environment?: {
             module?: boolean | undefined;
             arrowFunction?: boolean | undefined;
@@ -6117,7 +6116,7 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
@@ -6153,13 +6152,13 @@ export const rspackOptions: z.ZodObject<{
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         cssHeadDataCompression?: boolean | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
-        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
@@ -6260,7 +6259,7 @@ export const rspackOptions: z.ZodObject<{
             test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
         }, "strip", z.ZodTypeAny, {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6278,7 +6277,7 @@ export const rspackOptions: z.ZodObject<{
             imports?: boolean | undefined;
         }, {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6357,7 +6356,7 @@ export const rspackOptions: z.ZodObject<{
         css?: boolean | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6399,7 +6398,7 @@ export const rspackOptions: z.ZodObject<{
         css?: boolean | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -6576,14 +6575,14 @@ export const rspackOptions: z.ZodObject<{
         level: z.ZodOptional<z.ZodEnum<["none", "error", "warn", "info", "log", "verbose"]>>;
         stream: z.ZodOptional<z.ZodType<NodeJS.WritableStream, z.ZodTypeDef, NodeJS.WritableStream>>;
     }, "strict", z.ZodTypeAny, {
-        debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         colors?: boolean | undefined;
         appendOnly?: boolean | undefined;
         console?: Console | undefined;
         level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
         stream?: NodeJS.WritableStream | undefined;
     }, {
-        debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         colors?: boolean | undefined;
         appendOnly?: boolean | undefined;
         console?: Console | undefined;
@@ -6732,7 +6731,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
@@ -6809,7 +6808,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
@@ -6903,11 +6902,11 @@ export const rspackOptions: z.ZodObject<{
             }, "strict", z.ZodTypeAny, {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -6923,11 +6922,11 @@ export const rspackOptions: z.ZodObject<{
             }, {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -6949,14 +6948,14 @@ export const rspackOptions: z.ZodObject<{
                 maxInitialSize: z.ZodOptional<z.ZodNumber>;
                 automaticNameDelimiter: z.ZodOptional<z.ZodString>;
             }, "strict", z.ZodTypeAny, {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
                 maxInitialSize?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
             }, {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -6965,8 +6964,8 @@ export const rspackOptions: z.ZodObject<{
             }>>;
             hidePathInfo: z.ZodOptional<z.ZodBoolean>;
         }, "strict", z.ZodTypeAny, {
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -6980,11 +6979,11 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -6999,7 +6998,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -7008,8 +7007,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             hidePathInfo?: boolean | undefined;
         }, {
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -7023,11 +7022,11 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -7042,7 +7041,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -7062,11 +7061,11 @@ export const rspackOptions: z.ZodObject<{
         }, "strict", z.ZodTypeAny, {
             name?: string | ((args_0: {
                 name: string;
-            }, ...args_1: unknown[]) => string) | undefined;
+            }, ...args: unknown[]) => string) | undefined;
         }, {
             name?: string | ((args_0: {
                 name: string;
-            }, ...args_1: unknown[]) => string) | undefined;
+            }, ...args: unknown[]) => string) | undefined;
         }>]>>;
         removeAvailableModules: z.ZodOptional<z.ZodBoolean>;
         removeEmptyChunks: z.ZodOptional<z.ZodBoolean>;
@@ -7081,8 +7080,8 @@ export const rspackOptions: z.ZodObject<{
         emitOnErrors: z.ZodOptional<z.ZodBoolean>;
     }, "strict", z.ZodTypeAny, {
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -7096,11 +7095,11 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -7115,7 +7114,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -7135,7 +7134,7 @@ export const rspackOptions: z.ZodObject<{
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
-            }, ...args_1: unknown[]) => string) | undefined;
+            }, ...args: unknown[]) => string) | undefined;
         } | undefined;
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
@@ -7147,8 +7146,8 @@ export const rspackOptions: z.ZodObject<{
         emitOnErrors?: boolean | undefined;
     }, {
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -7162,11 +7161,11 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -7181,7 +7180,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -7201,7 +7200,7 @@ export const rspackOptions: z.ZodObject<{
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
-            }, ...args_1: unknown[]) => string) | undefined;
+            }, ...args: unknown[]) => string) | undefined;
         } | undefined;
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
@@ -7707,8 +7706,8 @@ export const rspackOptions: z.ZodObject<{
                 filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
                 publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
             }>, "strict", z.ZodTypeAny, {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -7716,10 +7715,10 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             }, {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -7727,7 +7726,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             }>>;
             "asset/inline": z.ZodOptional<z.ZodObject<{
                 dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
@@ -7756,7 +7755,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             }, {
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -7764,19 +7763,19 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             }>>;
             "asset/resource": z.ZodOptional<z.ZodObject<{
                 emit: z.ZodOptional<z.ZodBoolean>;
                 filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
                 publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
             }, "strict", z.ZodTypeAny, {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             }, {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             }>>;
             css: z.ZodOptional<z.ZodObject<{
@@ -7839,8 +7838,8 @@ export const rspackOptions: z.ZodObject<{
                 localIdentName?: string | undefined;
             } | undefined;
             asset?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -7848,7 +7847,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
@@ -7857,11 +7856,11 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/resource"?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             } | undefined;
         }, {
@@ -7882,8 +7881,8 @@ export const rspackOptions: z.ZodObject<{
                 localIdentName?: string | undefined;
             } | undefined;
             asset?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -7891,7 +7890,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
@@ -7900,11 +7899,11 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/resource"?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             } | undefined;
         }>, z.ZodRecord<z.ZodString, z.ZodRecord<z.ZodString, z.ZodAny>>]>>;
@@ -8024,8 +8023,8 @@ export const rspackOptions: z.ZodObject<{
                 localIdentName?: string | undefined;
             } | undefined;
             asset?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -8033,7 +8032,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
@@ -8042,17 +8041,17 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/resource"?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
         rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     }, {
         parser?: {
             javascript?: {
@@ -8168,8 +8167,8 @@ export const rspackOptions: z.ZodObject<{
                 localIdentName?: string | undefined;
             } | undefined;
             asset?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -8177,7 +8176,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
@@ -8186,17 +8185,17 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/resource"?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
         rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     }>>;
     profile: z.ZodOptional<z.ZodBoolean>;
     bail: z.ZodOptional<z.ZodBoolean>;
@@ -8206,12 +8205,12 @@ export const rspackOptions: z.ZodObject<{
         maxAssetSize: z.ZodOptional<z.ZodNumber>;
         maxEntrypointSize: z.ZodOptional<z.ZodNumber>;
     }, "strict", z.ZodTypeAny, {
-        assetFilter?: ((args_0: string, ...args_1: unknown[]) => boolean) | undefined;
+        assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
         maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     }, {
-        assetFilter?: ((args_0: string, ...args_1: unknown[]) => boolean) | undefined;
+        assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
         maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
@@ -8334,8 +8333,8 @@ export const rspackOptions: z.ZodObject<{
                 localIdentName?: string | undefined;
             } | undefined;
             asset?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -8343,7 +8342,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
@@ -8352,29 +8351,29 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/resource"?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
         rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     } | undefined;
     name?: string | undefined;
     performance?: false | {
-        assetFilter?: ((args_0: string, ...args_1: unknown[]) => boolean) | undefined;
+        assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
         maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     } | undefined;
     entry?: string | string[] | Record<string, string | string[] | {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -8401,8 +8400,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }> | ((...args: unknown[]) => string | string[] | Record<string, string | string[] | {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -8429,8 +8428,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }> | Promise<string | string[] | Record<string, string | string[] | {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -8467,8 +8466,8 @@ export const rspackOptions: z.ZodObject<{
     resolve?: t.ResolveOptions | undefined;
     output?: {
         module?: boolean | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         environment?: {
             module?: boolean | undefined;
             arrowFunction?: boolean | undefined;
@@ -8485,7 +8484,7 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
@@ -8521,13 +8520,13 @@ export const rspackOptions: z.ZodObject<{
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         cssHeadDataCompression?: boolean | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
-        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
@@ -8567,7 +8566,7 @@ export const rspackOptions: z.ZodObject<{
         css?: boolean | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -8613,28 +8612,28 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args_1: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args_1: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
     externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
@@ -8647,7 +8646,7 @@ export const rspackOptions: z.ZodObject<{
         electronRenderer?: boolean | undefined;
     } | undefined;
     infrastructureLogging?: {
-        debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         colors?: boolean | undefined;
         appendOnly?: boolean | undefined;
         console?: Console | undefined;
@@ -8655,7 +8654,7 @@ export const rspackOptions: z.ZodObject<{
         stream?: NodeJS.WritableStream | undefined;
     } | undefined;
     devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
-    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args_2: unknown[]) => boolean))[] | undefined;
+    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
     watchOptions?: {
         aggregateTimeout?: number | undefined;
         followSymlinks?: boolean | undefined;
@@ -8691,7 +8690,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
@@ -8745,8 +8744,8 @@ export const rspackOptions: z.ZodObject<{
     snapshot?: {} | undefined;
     optimization?: {
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -8760,11 +8759,11 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -8779,7 +8778,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -8799,7 +8798,7 @@ export const rspackOptions: z.ZodObject<{
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
-            }, ...args_1: unknown[]) => string) | undefined;
+            }, ...args: unknown[]) => string) | undefined;
         } | undefined;
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
@@ -8932,8 +8931,8 @@ export const rspackOptions: z.ZodObject<{
                 localIdentName?: string | undefined;
             } | undefined;
             asset?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
                     mimetype?: string | undefined;
@@ -8941,7 +8940,7 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
@@ -8950,29 +8949,29 @@ export const rspackOptions: z.ZodObject<{
                 } | ((args_0: {
                     filename: string;
                     content: string;
-                }, ...args_1: unknown[]) => string) | undefined;
+                }, ...args: unknown[]) => string) | undefined;
             } | undefined;
             "asset/resource"?: {
-                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+                filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+                publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
         rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        noParse?: string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     } | undefined;
     name?: string | undefined;
     performance?: false | {
-        assetFilter?: ((args_0: string, ...args_1: unknown[]) => boolean) | undefined;
+        assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
         maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     } | undefined;
     entry?: string | string[] | Record<string, string | string[] | {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -8999,8 +8998,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }> | ((...args: unknown[]) => string | string[] | Record<string, string | string[] | {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -9027,8 +9026,8 @@ export const rspackOptions: z.ZodObject<{
         dependOn?: string | string[] | undefined;
     }> | Promise<string | string[] | Record<string, string | string[] | {
         import: string | string[];
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
         baseUri?: string | undefined;
@@ -9065,8 +9064,8 @@ export const rspackOptions: z.ZodObject<{
     resolve?: t.ResolveOptions | undefined;
     output?: {
         module?: boolean | undefined;
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
+        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         environment?: {
             module?: boolean | undefined;
             arrowFunction?: boolean | undefined;
@@ -9083,7 +9082,7 @@ export const rspackOptions: z.ZodObject<{
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
         } | undefined;
-        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
         auxiliaryComment?: string | {
             commonjs?: string | undefined;
@@ -9119,13 +9118,13 @@ export const rspackOptions: z.ZodObject<{
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
         crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
-        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         cssHeadDataCompression?: boolean | undefined;
-        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
-        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args_2: unknown[]) => string) | undefined;
+        assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
@@ -9165,7 +9164,7 @@ export const rspackOptions: z.ZodObject<{
         css?: boolean | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args_1: unknown[]) => boolean) | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
                 listen?: number | {
@@ -9211,28 +9210,28 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args_1: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args_3: unknown[]) => void, ...args_2: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args_1: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
     externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
@@ -9245,7 +9244,7 @@ export const rspackOptions: z.ZodObject<{
         electronRenderer?: boolean | undefined;
     } | undefined;
     infrastructureLogging?: {
-        debug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         colors?: boolean | undefined;
         appendOnly?: boolean | undefined;
         console?: Console | undefined;
@@ -9253,7 +9252,7 @@ export const rspackOptions: z.ZodObject<{
         stream?: NodeJS.WritableStream | undefined;
     } | undefined;
     devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
-    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args_2: unknown[]) => boolean))[] | undefined;
+    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
     watchOptions?: {
         aggregateTimeout?: number | undefined;
         followSymlinks?: boolean | undefined;
@@ -9289,7 +9288,7 @@ export const rspackOptions: z.ZodObject<{
         moduleAssets?: boolean | undefined;
         nestedModules?: boolean | undefined;
         logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+        loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         loggingTrace?: boolean | undefined;
         runtimeModules?: boolean | undefined;
         children?: boolean | undefined;
@@ -9343,8 +9342,8 @@ export const rspackOptions: z.ZodObject<{
     snapshot?: {} | undefined;
     optimization?: {
         splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
             maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
@@ -9358,11 +9357,11 @@ export const rspackOptions: z.ZodObject<{
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args_1: unknown[]) => unknown) | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
                 priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args_1: unknown[]) => unknown) | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
                 enforce?: boolean | undefined;
                 maxSize?: number | Record<string, number> | undefined;
                 reuseExistingChunk?: boolean | undefined;
@@ -9377,7 +9376,7 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             }> | undefined;
             fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args_1: unknown[]) => boolean) | undefined;
+                chunks?: RegExp | "all" | "initial" | "async" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
                 minSize?: number | undefined;
                 maxAsyncSize?: number | undefined;
@@ -9397,7 +9396,7 @@ export const rspackOptions: z.ZodObject<{
         runtimeChunk?: boolean | "single" | "multiple" | {
             name?: string | ((args_0: {
                 name: string;
-            }, ...args_1: unknown[]) => string) | undefined;
+            }, ...args: unknown[]) => string) | undefined;
         } | undefined;
         removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
@@ -10113,7 +10112,7 @@ const statsOptions: z.ZodObject<{
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
@@ -10190,7 +10189,7 @@ const statsOptions: z.ZodObject<{
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
@@ -10380,7 +10379,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
@@ -10457,7 +10456,7 @@ const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "no
     moduleAssets?: boolean | undefined;
     nestedModules?: boolean | undefined;
     logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args_1: unknown[]) => boolean))[] | undefined;
+    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     loggingTrace?: boolean | undefined;
     runtimeModules?: boolean | undefined;
     children?: boolean | undefined;
@@ -11077,7 +11076,7 @@ export type UniqueName = string;
 
 // @public (undocumented)
 export const util: {
-    createHash: (algorithm: (string & {}) | "debug" | "xxhash64" | "md4" | "native-md4" | (new () => default_2)) => default_2;
+    createHash: (algorithm: "debug" | "xxhash64" | "md4" | "native-md4" | (string & {}) | (new () => default_2)) => default_2;
     cleverMerge: <First, Second>(first: First, second: Second) => First | Second | (First & Second);
 };
 

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -62,7 +62,7 @@
     "prebundle": "^1.1.0",
     "tsc-alias": "^1.8.8",
     "tsup": "^8.3.0",
-    "typescript": "5.0.2",
+    "typescript": "5.6.3",
     "watchpack": "^2.4.0",
     "webpack-dev-server": "5.0.4",
     "webpack-sources": "3.2.3",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -62,7 +62,7 @@
     "prebundle": "^1.1.0",
     "tsc-alias": "^1.8.8",
     "tsup": "^8.3.0",
-    "typescript": "5.6.3",
+    "typescript": "^5.6.3",
     "watchpack": "^2.4.0",
     "webpack-dev-server": "5.0.4",
     "webpack-sources": "3.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,7 +83,7 @@ importers:
         specifier: 29.1.2
         version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
       webpack:
         specifier: ^5.94.0
@@ -114,7 +114,7 @@ importers:
         specifier: 3.0.0-alpha.45
         version: 3.0.0-alpha.45
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
 
   crates/rspack_fs_node:
@@ -144,7 +144,7 @@ importers:
         specifier: 0.0.12
         version: 0.0.12(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(typescript@5.6.3)
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
 
   packages/create-rspack/template-react-js:
@@ -210,10 +210,10 @@ importers:
         version: 0.14.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)
+        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.2
+        specifier: ^5.6.3
+        version: 5.6.3
 
   packages/create-rspack/template-vanilla-js:
     devDependencies:
@@ -240,10 +240,10 @@ importers:
         version: 7.0.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)
+        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.2
+        specifier: ^5.6.3
+        version: 5.6.3
 
   packages/create-rspack/template-vue-js:
     dependencies:
@@ -268,7 +268,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.4.21
-        version: 3.5.12(typescript@5.4.2)
+        version: 3.5.12(typescript@5.6.3)
     devDependencies:
       '@rspack/cli':
         specifier: workspace:*
@@ -281,13 +281,13 @@ importers:
         version: 7.0.3
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)
+        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
       typescript:
-        specifier: ^5.3.3
-        version: 5.4.2
+        specifier: ^5.6.3
+        version: 5.6.3
       vue-loader:
         specifier: ^17.3.1
-        version: 17.4.2(vue@3.5.12(typescript@5.4.2))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
+        version: 17.4.2(vue@3.5.12(typescript@5.6.3))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
 
   packages/playground:
     devDependencies:
@@ -346,7 +346,7 @@ importers:
         specifier: ^3.3.0
         version: 3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
       vue:
         specifier: ^3.4.21
@@ -422,7 +422,7 @@ importers:
         specifier: ^8.3.0
         version: 8.3.0(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(@swc/core@1.4.0(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0)
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
       watchpack:
         specifier: ^2.4.0
@@ -504,7 +504,7 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
 
   packages/rspack-test-tools:
@@ -715,7 +715,7 @@ importers:
         specifier: 5.27.2
         version: 5.27.2
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
       wast-loader:
         specifier: ^1.12.1
@@ -757,7 +757,7 @@ importers:
         specifier: ^7.6.2
         version: 7.6.3
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
       zx:
         specifier: 7.2.3
@@ -963,7 +963,7 @@ importers:
         version: 3.36.1
       css-loader:
         specifier: ^6.11.0
-        version: 6.11.0(@rspack/core@1.0.11(@swc/helpers@0.5.13))(webpack@5.94.0)
+        version: 6.11.0(@rspack/core@1.0.13(@swc/helpers@0.5.13))(webpack@5.94.0)
       date-fns:
         specifier: ^2.29.3
         version: 2.30.0
@@ -1231,7 +1231,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       typescript:
-        specifier: 5.6.3
+        specifier: ^5.6.3
         version: 5.6.3
 
 packages:
@@ -3280,8 +3280,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.0.11':
-    resolution: {integrity: sha512-Kjx36rcUWz11uQjGRzktagiYcdFBo4j9xTiUH+KAm+vkXfyki+B8HgNOifmM/nxDbwBfjXbkKOqDSJu9fcZodQ==}
+  '@rspack/binding-darwin-arm64@1.0.13':
+    resolution: {integrity: sha512-HepE4V5Rj53o+o8AMzlkdeBxZnsyXKrOJ2oumVtqRLXihVlMguYwNTSkjfmjAqq/4PJAhEeaeIFyomZg+zKC0A==}
     cpu: [arm64]
     os: [darwin]
 
@@ -3290,8 +3290,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@1.0.11':
-    resolution: {integrity: sha512-I7Rs7H972U3wGvR2nutb9YAtxlfJVgQ0xvxZbrgiOUFuzGZdKJeIhzjoLxbCPko2syMdHAKrlz0A4r2skSLiVQ==}
+  '@rspack/binding-darwin-x64@1.0.13':
+    resolution: {integrity: sha512-ucHf0q2V+K19z75BvjU6EbQggNFiz1/xJ5tSgOXUfRu5omZF1jpN/epeMGqh0MkExRwOMYKJR/pVHDw5ITcU8g==}
     cpu: [x64]
     os: [darwin]
 
@@ -3300,8 +3300,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.0.11':
-    resolution: {integrity: sha512-Rpwklue7JYB3CuoSDiN+kWnoPIkm8su/LgbRpIS/W6KTtRNHjSoqrWsBhWTdeUQintDw3N2yzax6sI5/bOiO8A==}
+  '@rspack/binding-linux-arm64-gnu@1.0.13':
+    resolution: {integrity: sha512-0fqLWDG9Z2VKxy3u6+jLVJgT2E24Xb2umP4Jtx2uNf2+aHLXifgqUdwgCElO+dj+PpOp/q8zmV5U2DXykvPU3w==}
     cpu: [arm64]
     os: [linux]
 
@@ -3310,8 +3310,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@1.0.11':
-    resolution: {integrity: sha512-FXm/Pf3lDmVKI+0llc/L08bPyJ5GIth3lJbTD0ZzGBjoUJoRFJW1ZSAAomBsl5HmjWxiky3WRV7Xc+gHMCvLwA==}
+  '@rspack/binding-linux-arm64-musl@1.0.13':
+    resolution: {integrity: sha512-eK72/jAofJRcZ23FTteUh1MfTbErWYNwVLuxnliyf1f1PwH0a7exGE6ik0/y/LdAt5PWP1r8r981EEjrpsTfRQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -3320,8 +3320,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.0.11':
-    resolution: {integrity: sha512-GDENmBO5bCQ+9NTZBiXcwd+NcdukShkH4z7Ye3gK3P1FCnDGAjwF8v0OzAI1ooRIhZqdvPvdOIkFFwfjQG2NyQ==}
+  '@rspack/binding-linux-x64-gnu@1.0.13':
+    resolution: {integrity: sha512-C9wGDim1Euc10qRk5ztPvgK4NAi6bi6Ck3+ugaRzYXPFIVegnFyXu2fv42j3Y0LRhBjnKMXZJzME5nQUPuT6Ug==}
     cpu: [x64]
     os: [linux]
 
@@ -3330,8 +3330,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@1.0.11':
-    resolution: {integrity: sha512-iI6/WhvdyHK6awfDtDQswtH/mrGWvUyqAZ12aA9hKDOdcXD4LQt/ZQU4teHY3/+0D1qS9Vj1BjeVMqQ3FIu8gw==}
+  '@rspack/binding-linux-x64-musl@1.0.13':
+    resolution: {integrity: sha512-7bQyGEoMCxXUS+RDo6qej8JjqS8kYd8CvlnfYZVUqWgCxgn19j29lKvWVibey0lnFpoJrqReOdSypbk91tSrzA==}
     cpu: [x64]
     os: [linux]
 
@@ -3340,8 +3340,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.0.11':
-    resolution: {integrity: sha512-g6q0NU3FBJGyUZ+6RFTwmGsdhhtDMweLK2q+DqR0Xp6dwHbuwmMVxrhXLDsVBK6g5h7oEuOaiMfzurQPQsu+uA==}
+  '@rspack/binding-win32-arm64-msvc@1.0.13':
+    resolution: {integrity: sha512-6QOHiCwaQeCZApWRe1y8ZNZGOj00EFdX1ypOc3R1GrfSjn+UjoKhbBtgVl2w+sPTaCZ4SvknOk9usSgcWO4gOQ==}
     cpu: [arm64]
     os: [win32]
 
@@ -3350,8 +3350,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@1.0.11':
-    resolution: {integrity: sha512-OzWQY1/IyxhpFprcIdU7obwWszMteSWnljPq2i/sHsmeoJfFy0arWtH0Di/riU5pDoyBHR70ffnDGDkfv5ckjA==}
+  '@rspack/binding-win32-ia32-msvc@1.0.13':
+    resolution: {integrity: sha512-ucm7emxYDjTsOGNwgYGz30oKcnzXLjg/Fcs0mNMmQgMEFpwBXhczfKJimCyMIlAhQCFPP4WzrXFdf03EPuw6CA==}
     cpu: [ia32]
     os: [win32]
 
@@ -3360,16 +3360,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.0.11':
-    resolution: {integrity: sha512-r4giYIe53S8f246TV5Y6y71HjjsbpXALSm4Pbmr4yhwycqUApW46EsgBqOYAPaIht1T+PkJQLjyMjHp4uHSuEA==}
+  '@rspack/binding-win32-x64-msvc@1.0.13':
+    resolution: {integrity: sha512-9G/hvr47ECjDEmBCyyQTZFilmEOIQJCQvpx6hUgDWsfUApwF9LZBW/PqBCSwhY+tIErr/AurJnBVAYub0MYpHA==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@1.0.10':
     resolution: {integrity: sha512-ILWPqLl0fS3a76OwQH6SlVIJBST39sc55yp0zwt484sb77khm0JGvJRElCdPuwgaR7JRDdqK23EvW0XIQAvY7A==}
 
-  '@rspack/binding@1.0.11':
-    resolution: {integrity: sha512-b7tD9qTjHLqCkrW2AG85ofjL8M+Tk48qtWE7UpOQsZBDxF+ONWIiZ07gp4VE8nS96VNpBgL+GSqI/K8cmaZabA==}
+  '@rspack/binding@1.0.13':
+    resolution: {integrity: sha512-mnSCZ3Qb/I3LzsYoo24AG4LgmaSOIc1CS38A9L9nv4MJj8x+1D2BaLErpaaMmhqI3lQBIcBSQkN7+WbpsCP3Uw==}
 
   '@rspack/core@1.0.10':
     resolution: {integrity: sha512-Jvj6mzf/aFN3c2E+Lu+3dSz6df2pd79/XOLN9ElA7PIjVua4lVt+dUtrTXqVgoAjaKhZJrIt2WXALYdmv4kkVA==}
@@ -3380,8 +3380,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@1.0.11':
-    resolution: {integrity: sha512-DpBPc7kDNogjXU2m+wVbdarEY366kTrZlDHxynuBY0snpB9j03vj+R/j3VfzTL84j5fqOMTb3tcu91DlVVp3UQ==}
+  '@rspack/core@1.0.13':
+    resolution: {integrity: sha512-lh8toWSWcYjlOuriQ8/h0U8riaaRQfzwU0oUNykFj1xokJMSKIQFH5WQWj2DQ386uHNv52nMbc+Jiuml1vYboA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -13881,55 +13881,55 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.0.10':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.0.11':
+  '@rspack/binding-darwin-arm64@1.0.13':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.10':
     optional: true
 
-  '@rspack/binding-darwin-x64@1.0.11':
+  '@rspack/binding-darwin-x64@1.0.13':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.0.10':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.0.11':
+  '@rspack/binding-linux-arm64-gnu@1.0.13':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.10':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@1.0.11':
+  '@rspack/binding-linux-arm64-musl@1.0.13':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.0.10':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.0.11':
+  '@rspack/binding-linux-x64-gnu@1.0.13':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.10':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.0.11':
+  '@rspack/binding-linux-x64-musl@1.0.13':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.0.10':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.0.11':
+  '@rspack/binding-win32-arm64-msvc@1.0.13':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.0.10':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.0.11':
+  '@rspack/binding-win32-ia32-msvc@1.0.13':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.0.10':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.0.11':
+  '@rspack/binding-win32-x64-msvc@1.0.13':
     optional: true
 
   '@rspack/binding@1.0.10':
@@ -13944,17 +13944,17 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.10
       '@rspack/binding-win32-x64-msvc': 1.0.10
 
-  '@rspack/binding@1.0.11':
+  '@rspack/binding@1.0.13':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.11
-      '@rspack/binding-darwin-x64': 1.0.11
-      '@rspack/binding-linux-arm64-gnu': 1.0.11
-      '@rspack/binding-linux-arm64-musl': 1.0.11
-      '@rspack/binding-linux-x64-gnu': 1.0.11
-      '@rspack/binding-linux-x64-musl': 1.0.11
-      '@rspack/binding-win32-arm64-msvc': 1.0.11
-      '@rspack/binding-win32-ia32-msvc': 1.0.11
-      '@rspack/binding-win32-x64-msvc': 1.0.11
+      '@rspack/binding-darwin-arm64': 1.0.13
+      '@rspack/binding-darwin-x64': 1.0.13
+      '@rspack/binding-linux-arm64-gnu': 1.0.13
+      '@rspack/binding-linux-arm64-musl': 1.0.13
+      '@rspack/binding-linux-x64-gnu': 1.0.13
+      '@rspack/binding-linux-x64-musl': 1.0.13
+      '@rspack/binding-win32-arm64-msvc': 1.0.13
+      '@rspack/binding-win32-ia32-msvc': 1.0.13
+      '@rspack/binding-win32-x64-msvc': 1.0.13
     optional: true
 
   '@rspack/core@1.0.10(@swc/helpers@0.5.13)':
@@ -13966,10 +13966,10 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.13
 
-  '@rspack/core@1.0.11(@swc/helpers@0.5.13)':
+  '@rspack/core@1.0.13(@swc/helpers@0.5.13)':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
-      '@rspack/binding': 1.0.11
+      '@rspack/binding': 1.0.13
       '@rspack/lite-tapable': 1.0.1
       caniuse-lite: 1.0.30001669
     optionalDependencies:
@@ -15593,12 +15593,6 @@ snapshots:
       '@vue/shared': 3.5.12
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.4.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.12
-      '@vue/shared': 3.5.12
-      vue: 3.5.12(typescript@5.4.2)
-
   '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.6.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.12
@@ -17054,7 +17048,7 @@ snapshots:
       semver: 7.6.3
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
 
-  css-loader@6.11.0(@rspack/core@1.0.11(@swc/helpers@0.5.13))(webpack@5.94.0):
+  css-loader@6.11.0(@rspack/core@1.0.13(@swc/helpers@0.5.13))(webpack@5.94.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.47)
       postcss: 8.4.47
@@ -17065,7 +17059,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      '@rspack/core': 1.0.11(@swc/helpers@0.5.13)
+      '@rspack/core': 1.0.13(@swc/helpers@0.5.13)
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4)
 
   css-loader@6.11.0(@rspack/core@packages+rspack)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
@@ -23240,26 +23234,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.0(@swc/helpers@0.5.13)
 
-  ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.7
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.4.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.0(@swc/helpers@0.5.13)
-
   ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23647,15 +23621,6 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-loader@17.4.2(vue@3.5.12(typescript@5.4.2))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
-    dependencies:
-      chalk: 4.1.2
-      hash-sum: 2.0.0
-      watchpack: 2.4.1
-      webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
-    optionalDependencies:
-      vue: 3.5.12(typescript@5.4.2)
-
   vue-loader@17.4.2(vue@3.5.12(typescript@5.6.3))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
       chalk: 4.1.2
@@ -23664,16 +23629,6 @@ snapshots:
       webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
     optionalDependencies:
       vue: 3.5.12(typescript@5.6.3)
-
-  vue@3.5.12(typescript@5.4.2):
-    dependencies:
-      '@vue/compiler-dom': 3.5.12
-      '@vue/compiler-sfc': 3.5.12
-      '@vue/runtime-dom': 3.5.12
-      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@5.4.2))
-      '@vue/shared': 3.5.12
-    optionalDependencies:
-      typescript: 5.4.2
 
   vue@3.5.12(typescript@5.6.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,11 +20,11 @@ importers:
         specifier: 29.7.0
         version: 29.7.0
       '@microsoft/api-extractor':
-        specifier: ^7.43.1
-        version: 7.43.1(@types/node@20.12.7)
+        specifier: 7.47.10
+        version: 7.47.10(@types/node@20.12.7)
       '@microsoft/api-extractor-model':
-        specifier: ^7.28.14
-        version: 7.29.3(@types/node@20.12.7)
+        specifier: 7.29.8
+        version: 7.29.8(@types/node@20.12.7)
       '@rspack/cli':
         specifier: workspace:*
         version: link:packages/rspack-cli
@@ -60,10 +60,10 @@ importers:
         version: 3.0.1
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-cli:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+        version: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-environment-node:
         specifier: 29.7.0
         version: 29.7.0
@@ -81,10 +81,10 @@ importers:
         version: 3.0.2
       ts-jest:
         specifier: 29.1.2
-        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)))(typescript@5.0.2)
+        version: 29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)))(typescript@5.6.3)
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
       webpack:
         specifier: ^5.94.0
         version: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
@@ -114,8 +114,8 @@ importers:
         specifier: 3.0.0-alpha.45
         version: 3.0.0-alpha.45
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
 
   crates/rspack_fs_node:
     devDependencies:
@@ -142,10 +142,10 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.0.12
-        version: 0.0.12(@microsoft/api-extractor@7.43.1(@types/node@20.12.7))(typescript@5.0.2)
+        version: 0.0.12(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(typescript@5.6.3)
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/create-rspack/template-react-js:
     dependencies:
@@ -249,7 +249,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.4.21
-        version: 3.5.12(typescript@5.4.2)
+        version: 3.5.12(typescript@5.6.3)
     devDependencies:
       '@rspack/cli':
         specifier: workspace:*
@@ -262,7 +262,7 @@ importers:
         version: 7.0.3
       vue-loader:
         specifier: ^17.3.1
-        version: 17.4.2(vue@3.5.12(typescript@5.4.2))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
+        version: 17.4.2(vue@3.5.12(typescript@5.6.3))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
 
   packages/create-rspack/template-vue-ts:
     dependencies:
@@ -332,7 +332,7 @@ importers:
         version: 8.4.47
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.0.2)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.6.3)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -344,16 +344,16 @@ importers:
         version: 0.14.0
       tailwindcss:
         specifier: ^3.3.0
-        version: 3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+        version: 3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
       vue:
         specifier: ^3.4.21
-        version: 3.5.12(typescript@5.0.2)
+        version: 3.5.12(typescript@5.6.3)
       vue-loader:
         specifier: ^17.3.1
-        version: 17.4.2(vue@3.5.12(typescript@5.0.2))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
+        version: 17.4.2(vue@3.5.12(typescript@5.6.3))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
       webpack-dev-server:
         specifier: 5.0.4
         version: 5.0.4(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
@@ -414,16 +414,16 @@ importers:
         version: 2.6.2
       prebundle:
         specifier: ^1.1.0
-        version: 1.1.0(typescript@5.0.2)
+        version: 1.1.0(typescript@5.6.3)
       tsc-alias:
         specifier: ^1.8.8
         version: 1.8.8
       tsup:
         specifier: ^8.3.0
-        version: 8.3.0(@microsoft/api-extractor@7.43.1(@types/node@20.12.7))(@swc/core@1.4.0(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.0.2)(yaml@2.6.0)
+        version: 8.3.0(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(@swc/core@1.4.0(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0)
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
       watchpack:
         specifier: ^2.4.0
         version: 2.4.1
@@ -502,10 +502,10 @@ importers:
         version: 6.2.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)
+        version: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
 
   packages/rspack-test-tools:
     dependencies:
@@ -680,7 +680,7 @@ importers:
         version: 8.0.1
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.0.2)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.6.3)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
       postcss-pxtorem:
         specifier: ^6.0.0
         version: 6.1.0(postcss@8.4.47)
@@ -715,8 +715,8 @@ importers:
         specifier: 5.27.2
         version: 5.27.2
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
       wast-loader:
         specifier: ^1.12.1
         version: 1.12.1
@@ -757,8 +757,8 @@ importers:
         specifier: ^7.6.2
         version: 7.6.3
       typescript:
-        specifier: 5.0.2
-        version: 5.0.2
+        specifier: 5.6.3
+        version: 5.6.3
       zx:
         specifier: 7.2.3
         version: 7.2.3
@@ -846,7 +846,7 @@ importers:
         version: 1.0.0(react-refresh@0.14.0)
       '@svgr/webpack':
         specifier: ^8.0.0
-        version: 8.1.0(typescript@5.4.2)
+        version: 8.1.0(typescript@5.6.3)
       '@swc/core':
         specifier: 1.4.0
         version: 1.4.0(@swc/helpers@0.5.13)
@@ -873,7 +873,7 @@ importers:
         version: 2.9.0(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
       postcss-loader:
         specifier: ^8.0.0
-        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.4.2)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
+        version: 8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.6.3)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -936,7 +936,7 @@ importers:
         version: link:../../packages/rspack-cli
       jest-watch-typeahead:
         specifier: ^2.2.2
-        version: 2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)))
+        version: 2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)))
 
   tests/webpack-examples:
     devDependencies:
@@ -1186,7 +1186,7 @@ importers:
         version: 7.6.3
       tailwindcss:
         specifier: ^3.3.0
-        version: 3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
+        version: 3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
     devDependencies:
       '@biomejs/biome':
         specifier: 1.8.0
@@ -1231,8 +1231,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       typescript:
-        specifier: ^5.0.4
-        version: 5.4.2
+        specifier: 5.6.3
+        version: 5.6.3
 
 packages:
 
@@ -2622,24 +2622,15 @@ packages:
     peerDependencies:
       react: '>=16'
 
-  '@microsoft/api-extractor-model@7.28.14':
-    resolution: {integrity: sha512-Bery/c8A8SsKPSvA82cTTuy/+OcxZbLRmKhPkk91/AJOQzxZsShcrmHFAGeiEqSIrv1nPZ3tKq9kfMLdCHmsqg==}
+  '@microsoft/api-extractor-model@7.29.8':
+    resolution: {integrity: sha512-t3Z/xcO6TRbMcnKGVMs4uMzv/gd5j0NhMiJIGjD4cJMeFJ1Hf8wnLSx37vxlRlL0GWlGJhnFgxvnaL6JlS+73g==}
 
-  '@microsoft/api-extractor-model@7.29.3':
-    resolution: {integrity: sha512-kEWjLr2ygL3ku9EGyjeTnL2S5IxyH9NaF1k1UoI0Nzwr4xEJBSWCVsWuF2+0lPUrRPA6mTY95fR264SJ5ETKQA==}
-
-  '@microsoft/api-extractor@7.43.1':
-    resolution: {integrity: sha512-ohg40SsvFFgzHFAtYq5wKJc8ZDyY46bphjtnSvhSSlXpPTG7GHwyyXkn48UZiUCBwr2WC7TRC1Jfwz7nreuiyQ==}
+  '@microsoft/api-extractor@7.47.10':
+    resolution: {integrity: sha512-Fx5J3E8sC5EUeqaC85NXql3hXJc7/QO3NEr/jeBgVJwacRaHdkl3pKDhkkJ6yo/GWbRCv6QnyakU0QuKg8bMig==}
     hasBin: true
-
-  '@microsoft/tsdoc-config@0.16.2':
-    resolution: {integrity: sha512-OGiIzzoBLgWWR0UdRJX98oYO+XKGf7tiK4Zk6tQ/E4IJqGCe7dvkTvgDZV5cFJUzLGDOjeAXrnZoA6QkVySuxw==}
 
   '@microsoft/tsdoc-config@0.17.0':
     resolution: {integrity: sha512-v/EYRXnCAIHxOHW+Plb6OWuUoMotxTN0GLatnpOb1xq0KuTNw/WI3pamJx/UbsoJP5k9MCw1QxvvhPcF9pH3Zg==}
-
-  '@microsoft/tsdoc@0.14.2':
-    resolution: {integrity: sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug==}
 
   '@microsoft/tsdoc@0.15.0':
     resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
@@ -3516,35 +3507,27 @@ packages:
   '@rstack-dev/doc-ui@1.5.2':
     resolution: {integrity: sha512-LPJNTRhv0eVxhsu6GR9zVK5szQwLgLmBHcOjrYkxhy6tHmDr++0ZXG9c61iAOH8A5gEbygXAmnLDsxbHD9Hosw==}
 
-  '@rushstack/node-core-library@4.1.0':
-    resolution: {integrity: sha512-qz4JFBZJCf1YN5cAXa1dP6Mki/HrsQxc/oYGAGx29dF2cwF2YMxHoly0FBhMw3IEnxo5fMj0boVfoHVBkpkx/w==}
+  '@rushstack/node-core-library@5.9.0':
+    resolution: {integrity: sha512-MMsshEWkTbXqxqFxD4gcIUWQOCeBChlGczdZbHfqmNZQFLHB3yWxDFSMHFUdu2/OB9NUk7Awn5qRL+rws4HQNg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/node-core-library@5.5.0':
-    resolution: {integrity: sha512-Cl3MYQ74Je5Y/EngMxcA3SpHjGZ/022nKbAO1aycGfQ+7eKyNCBu0oywj5B1f367GCzuHBgy+3BlVLKysHkXZw==}
+  '@rushstack/rig-package@0.5.3':
+    resolution: {integrity: sha512-olzSSjYrvCNxUFZowevC3uz8gvKr3WTpHQ7BkpjtRpA3wK+T0ybep/SRUMfr195gBzJm5gaXw0ZMgjIyHqJUow==}
+
+  '@rushstack/terminal@0.14.2':
+    resolution: {integrity: sha512-2fC1wqu1VCExKC0/L+0noVcFQEXEnoBOtCIex1TOjBzEDWcw8KzJjjj7aTP6mLxepG0XIyn9OufeFb6SFsa+sg==}
     peerDependencies:
       '@types/node': '*'
     peerDependenciesMeta:
       '@types/node':
         optional: true
 
-  '@rushstack/rig-package@0.5.2':
-    resolution: {integrity: sha512-mUDecIJeH3yYGZs2a48k+pbhM6JYwWlgjs2Ca5f2n1G2/kgdgP9D/07oglEGf6mRyXEnazhEENeYTSNDRCwdqA==}
-
-  '@rushstack/terminal@0.10.1':
-    resolution: {integrity: sha512-C6Vi/m/84IYJTkfzmXr1+W8Wi3MmBjVF/q3za91Gb3VYjKbpALHVxY6FgH625AnDe5Z0Kh4MHKWA3Z7bqgAezA==}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@rushstack/ts-command-line@4.19.2':
-    resolution: {integrity: sha512-cqmXXmBEBlzo9WtyUrHtF9e6kl0LvBY7aTSVX4jfnBfXWZQWnPq9JTFPlQZ+L/ZwjZ4HrNwQsOVvhe9oOucZkw==}
+  '@rushstack/ts-command-line@4.22.8':
+    resolution: {integrity: sha512-XbFjOoV7qZHJnSuFUHv0pKaFA4ixyCuki+xMjsMfDwfvQjs5MYG0IK5COal3tRnG7KCDe2l/G+9LrzYE/RJhgg==}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
@@ -7885,12 +7868,6 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  lodash.get@4.4.2:
-    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-
-  lodash.isequal@4.5.0:
-    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
-
   lodash.iserror@3.1.1:
     resolution: {integrity: sha512-eT/VeNns9hS7vAj1NKW/rRX6b+C3UX3/IAAqEE7aC4Oo2C0iD82NaP5IS4bSlQsammTii4qBJ8G1zd1LTL8hCw==}
 
@@ -9670,9 +9647,6 @@ packages:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
 
-  resolve@1.19.0:
-    resolution: {integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==}
-
   resolve@1.22.8:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
@@ -10800,13 +10774,13 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.0.2:
-    resolution: {integrity: sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-
   typescript@5.4.2:
     resolution: {integrity: sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10992,10 +10966,6 @@ packages:
   v8-to-istanbul@9.2.0:
     resolution: {integrity: sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==}
     engines: {node: '>=10.12.0'}
-
-  validator@13.11.0:
-    resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
-    engines: {node: '>= 0.10'}
 
   value-equal@1.0.1:
     resolution: {integrity: sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==}
@@ -11407,11 +11377,6 @@ packages:
   yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-
-  z-schema@5.0.5:
-    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
-    engines: {node: '>=8.0.0'}
-    hasBin: true
 
   zod-validation-error@3.3.1:
     resolution: {integrity: sha512-uFzCZz7FQis256dqw4AhPQgD6f3pzNca/Zh62RNELavlumQB3nDIUFbF5JQfFLcMbO1s02Q7Xg/gpcOBlEnYZA==}
@@ -12965,7 +12930,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12979,42 +12944,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.10(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 20.12.7
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.10(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -13239,31 +13169,23 @@ snapshots:
       '@types/react': 18.2.75
       react: 18.3.1
 
-  '@microsoft/api-extractor-model@7.28.14(@types/node@20.12.7)':
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.1.0(@types/node@20.12.7)
-    transitivePeerDependencies:
-      - '@types/node'
-
-  '@microsoft/api-extractor-model@7.29.3(@types/node@20.12.7)':
+  '@microsoft/api-extractor-model@7.29.8(@types/node@20.12.7)':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       '@microsoft/tsdoc-config': 0.17.0
-      '@rushstack/node-core-library': 5.5.0(@types/node@20.12.7)
+      '@rushstack/node-core-library': 5.9.0(@types/node@20.12.7)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/api-extractor@7.43.1(@types/node@20.12.7)':
+  '@microsoft/api-extractor@7.47.10(@types/node@20.12.7)':
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.14(@types/node@20.12.7)
-      '@microsoft/tsdoc': 0.14.2
-      '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 4.1.0(@types/node@20.12.7)
-      '@rushstack/rig-package': 0.5.2
-      '@rushstack/terminal': 0.10.1(@types/node@20.12.7)
-      '@rushstack/ts-command-line': 4.19.2(@types/node@20.12.7)
+      '@microsoft/api-extractor-model': 7.29.8(@types/node@20.12.7)
+      '@microsoft/tsdoc': 0.15.0
+      '@microsoft/tsdoc-config': 0.17.0
+      '@rushstack/node-core-library': 5.9.0(@types/node@20.12.7)
+      '@rushstack/rig-package': 0.5.3
+      '@rushstack/terminal': 0.14.2(@types/node@20.12.7)
+      '@rushstack/ts-command-line': 4.22.8(@types/node@20.12.7)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.8
@@ -13273,21 +13195,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@microsoft/tsdoc-config@0.16.2':
-    dependencies:
-      '@microsoft/tsdoc': 0.14.2
-      ajv: 6.12.6
-      jju: 1.4.0
-      resolve: 1.19.0
-
   '@microsoft/tsdoc-config@0.17.0':
     dependencies:
       '@microsoft/tsdoc': 0.15.0
       ajv: 8.12.0
       jju: 1.4.0
       resolve: 1.22.8
-
-  '@microsoft/tsdoc@0.14.2': {}
 
   '@microsoft/tsdoc@0.15.0': {}
 
@@ -13957,13 +13870,13 @@ snapshots:
       reduce-configs: 1.0.0
       sass-embedded: 1.79.5
 
-  '@rslib/core@0.0.12(@microsoft/api-extractor@7.43.1(@types/node@20.12.7))(typescript@5.0.2)':
+  '@rslib/core@0.0.12(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(typescript@5.6.3)':
     dependencies:
       '@rsbuild/core': 1.0.14
-      rsbuild-plugin-dts: 0.0.12(@microsoft/api-extractor@7.43.1(@types/node@20.12.7))(@rsbuild/core@1.0.14)(typescript@5.0.2)
+      rsbuild-plugin-dts: 0.0.12(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(@rsbuild/core@1.0.14)(typescript@5.6.3)
     optionalDependencies:
-      '@microsoft/api-extractor': 7.43.1(@types/node@20.12.7)
-      typescript: 5.0.2
+      '@microsoft/api-extractor': 7.47.10(@types/node@20.12.7)
+      typescript: 5.6.3
 
   '@rspack/binding-darwin-arm64@1.0.10':
     optional: true
@@ -14266,18 +14179,7 @@ snapshots:
       - react
       - react-dom
 
-  '@rushstack/node-core-library@4.1.0(@types/node@20.12.7)':
-    dependencies:
-      fs-extra: 7.0.1
-      import-lazy: 4.0.0
-      jju: 1.4.0
-      resolve: 1.22.8
-      semver: 7.5.4
-      z-schema: 5.0.5
-    optionalDependencies:
-      '@types/node': 20.12.7
-
-  '@rushstack/node-core-library@5.5.0(@types/node@20.12.7)':
+  '@rushstack/node-core-library@5.9.0(@types/node@20.12.7)':
     dependencies:
       ajv: 8.13.0
       ajv-draft-04: 1.0.0(ajv@8.13.0)
@@ -14290,21 +14192,21 @@ snapshots:
     optionalDependencies:
       '@types/node': 20.12.7
 
-  '@rushstack/rig-package@0.5.2':
+  '@rushstack/rig-package@0.5.3':
     dependencies:
       resolve: 1.22.8
       strip-json-comments: 3.1.1
 
-  '@rushstack/terminal@0.10.1(@types/node@20.12.7)':
+  '@rushstack/terminal@0.14.2(@types/node@20.12.7)':
     dependencies:
-      '@rushstack/node-core-library': 4.1.0(@types/node@20.12.7)
+      '@rushstack/node-core-library': 5.9.0(@types/node@20.12.7)
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.12.7
 
-  '@rushstack/ts-command-line@4.19.2(@types/node@20.12.7)':
+  '@rushstack/ts-command-line@4.22.8(@types/node@20.12.7)':
     dependencies:
-      '@rushstack/terminal': 0.10.1(@types/node@20.12.7)
+      '@rushstack/terminal': 0.14.2(@types/node@20.12.7)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -14372,12 +14274,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.24.4)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.24.4)
 
-  '@svgr/core@8.1.0(typescript@5.4.2)':
+  '@svgr/core@8.1.0(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.24.4
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.4)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.4.2)
+      cosmiconfig: 8.3.6(typescript@5.6.3)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -14388,35 +14290,35 @@ snapshots:
       '@babel/types': 7.23.0
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.4.2))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.6.3))':
     dependencies:
       '@babel/core': 7.24.4
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.4)
-      '@svgr/core': 8.1.0(typescript@5.4.2)
+      '@svgr/core': 8.1.0(typescript@5.6.3)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.4.2))(typescript@5.4.2)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.6.3))(typescript@5.6.3)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.4.2)
-      cosmiconfig: 8.3.6(typescript@5.4.2)
+      '@svgr/core': 8.1.0(typescript@5.6.3)
+      cosmiconfig: 8.3.6(typescript@5.6.3)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@5.4.2)':
+  '@svgr/webpack@8.1.0(typescript@5.6.3)':
     dependencies:
       '@babel/core': 7.24.4
       '@babel/plugin-transform-react-constant-elements': 7.24.7(@babel/core@7.24.4)
       '@babel/preset-env': 7.24.7(@babel/core@7.24.4)
       '@babel/preset-react': 7.24.1(@babel/core@7.24.4)
       '@babel/preset-typescript': 7.24.7(@babel/core@7.24.4)
-      '@svgr/core': 8.1.0(typescript@5.4.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.4.2))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.4.2))(typescript@5.4.2)
+      '@svgr/core': 8.1.0(typescript@5.6.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.6.3))(typescript@5.6.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -15691,17 +15593,17 @@ snapshots:
       '@vue/shared': 3.5.12
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.0.2))':
-    dependencies:
-      '@vue/compiler-ssr': 3.5.12
-      '@vue/shared': 3.5.12
-      vue: 3.5.12(typescript@5.0.2)
-
   '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.4.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.12
       '@vue/shared': 3.5.12
       vue: 3.5.12(typescript@5.4.2)
+
+  '@vue/server-renderer@3.5.12(vue@3.5.12(typescript@5.6.3))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.12
+      '@vue/shared': 3.5.12
+      vue: 3.5.12(typescript@5.6.3)
 
   '@vue/shared@3.5.12': {}
 
@@ -16956,32 +16858,23 @@ snapshots:
     optionalDependencies:
       typescript: 4.9.5
 
-  cosmiconfig@8.3.6(typescript@5.4.2):
+  cosmiconfig@8.3.6(typescript@5.6.3):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.4.2
+      typescript: 5.6.3
 
-  cosmiconfig@9.0.0(typescript@5.0.2):
+  cosmiconfig@9.0.0(typescript@5.6.3):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.0.2
-
-  cosmiconfig@9.0.0(typescript@5.4.2):
-    dependencies:
-      env-paths: 2.2.1
-      import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      parse-json: 5.2.0
-    optionalDependencies:
-      typescript: 5.4.2
+      typescript: 5.6.3
 
   create-ecdh@4.0.4:
     dependencies:
@@ -17005,28 +16898,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)):
+  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.10(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -19413,16 +19291,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)):
+  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.6.2
@@ -19432,26 +19310,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
-      exit: 0.1.2
-      import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)):
+  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)):
     dependencies:
       '@babel/core': 7.24.4
       '@jest/test-sequencer': 29.7.0
@@ -19477,38 +19336,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)):
-    dependencies:
-      '@babel/core': 7.24.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.24.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.10(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 20.12.7
-      ts-node: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)
+      ts-node: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19731,11 +19559,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.3.0
-      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
+      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -19766,24 +19594,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)):
+  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
-      '@jest/types': 29.6.3
-      import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
+      jest-cli: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -20086,10 +19902,6 @@ snapshots:
   lodash.clonedeep@4.5.0: {}
 
   lodash.debounce@4.0.8: {}
-
-  lodash.get@4.4.2: {}
-
-  lodash.isequal@4.5.0: {}
 
   lodash.iserror@3.1.1: {}
 
@@ -21267,21 +21079,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.47
 
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)):
+  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)):
     dependencies:
       lilconfig: 3.1.2
       yaml: 2.6.0
     optionalDependencies:
       postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)
-
-  postcss-load-config@4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)):
-    dependencies:
-      lilconfig: 3.1.2
-      yaml: 2.6.0
-    optionalDependencies:
-      postcss: 8.4.47
-      ts-node: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)
+      ts-node: 10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
 
   postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.47)(yaml@2.6.0):
     dependencies:
@@ -21301,21 +21105,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.0.2)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
+  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.6.3)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.0.2)
-      jiti: 1.21.0
-      postcss: 8.4.47
-      semver: 7.6.3
-    optionalDependencies:
-      '@rspack/core': link:packages/rspack
-      webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
-    transitivePeerDependencies:
-      - typescript
-
-  postcss-loader@8.1.1(@rspack/core@packages+rspack)(postcss@8.4.47)(typescript@5.4.2)(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
-    dependencies:
-      cosmiconfig: 9.0.0(typescript@5.4.2)
+      cosmiconfig: 9.0.0(typescript@5.6.3)
       jiti: 1.21.0
       postcss: 8.4.47
       semver: 7.6.3
@@ -21370,11 +21162,11 @@ snapshots:
 
   preact@10.23.2: {}
 
-  prebundle@1.1.0(typescript@5.0.2):
+  prebundle@1.1.0(typescript@5.6.3):
     dependencies:
       '@vercel/ncc': 0.38.1
       rollup: 4.24.0
-      rollup-plugin-dts: 6.1.0(rollup@4.24.0)(typescript@5.0.2)
+      rollup-plugin-dts: 6.1.0(rollup@4.24.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - typescript
 
@@ -22343,11 +22135,6 @@ snapshots:
 
   resolve.exports@2.0.2: {}
 
-  resolve@1.19.0:
-    dependencies:
-      is-core-module: 2.15.1
-      path-parse: 1.0.7
-
   resolve@1.22.8:
     dependencies:
       is-core-module: 2.15.1
@@ -22401,11 +22188,11 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rollup-plugin-dts@6.1.0(rollup@4.24.0)(typescript@5.0.2):
+  rollup-plugin-dts@6.1.0(rollup@4.24.0)(typescript@5.6.3):
     dependencies:
       magic-string: 0.30.12
       rollup: 4.24.0
-      typescript: 5.0.2
+      typescript: 5.6.3
     optionalDependencies:
       '@babel/code-frame': 7.24.7
 
@@ -22439,15 +22226,15 @@ snapshots:
 
   rrweb-cssom@0.7.1: {}
 
-  rsbuild-plugin-dts@0.0.12(@microsoft/api-extractor@7.43.1(@types/node@20.12.7))(@rsbuild/core@1.0.14)(typescript@5.0.2):
+  rsbuild-plugin-dts@0.0.12(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(@rsbuild/core@1.0.14)(typescript@5.6.3):
     dependencies:
       '@rsbuild/core': 1.0.14
       fast-glob: 3.3.2
       magic-string: 0.30.12
       picocolors: 1.1.0
     optionalDependencies:
-      '@microsoft/api-extractor': 7.43.1(@types/node@20.12.7)
-      typescript: 5.0.2
+      '@microsoft/api-extractor': 7.47.10(@types/node@20.12.7)
+      typescript: 5.6.3
 
   rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@1.0.13):
     optionalDependencies:
@@ -23194,7 +22981,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)):
+  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -23213,34 +23000,7 @@ snapshots:
       postcss: 8.4.47
       postcss-import: 15.1.0(postcss@8.4.47)
       postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
-      postcss-nested: 6.2.0(postcss@8.4.47)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.8
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
-
-  tailwindcss@3.4.14(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2)):
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.2
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.6
-      lilconfig: 2.1.0
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.0
-      postcss: 8.4.47
-      postcss-import: 15.1.0(postcss@8.4.47)
-      postcss-js: 4.0.1(postcss@8.4.47)
-      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2))
+      postcss-load-config: 4.0.2(postcss@8.4.47)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       postcss-nested: 6.2.0(postcss@8.4.47)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -23443,17 +23203,17 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2)))(typescript@5.0.2):
+  ts-jest@29.1.2(@babel/core@7.24.4)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)))(typescript@5.6.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2))
+      jest: 29.7.0(@types/node@20.12.7)(ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.6.3
-      typescript: 5.0.2
+      typescript: 5.6.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.24.4
@@ -23480,26 +23240,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.0(@swc/helpers@0.5.13)
 
-  ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.0.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.12.7
-      acorn: 8.11.3
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.0.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.4.0(@swc/helpers@0.5.13)
-
   ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.4.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -23520,6 +23260,26 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.4.0(@swc/helpers@0.5.13)
 
+  ts-node@10.9.2(@swc/core@1.4.0(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.12.7
+      acorn: 8.11.3
+      acorn-walk: 8.3.2
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.6.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.4.0(@swc/helpers@0.5.13)
+
   tsc-alias@1.8.8:
     dependencies:
       chokidar: 3.6.0
@@ -23533,7 +23293,7 @@ snapshots:
 
   tslib@2.6.2: {}
 
-  tsup@8.3.0(@microsoft/api-extractor@7.43.1(@types/node@20.12.7))(@swc/core@1.4.0(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.0.2)(yaml@2.6.0):
+  tsup@8.3.0(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(@swc/core@1.4.0(@swc/helpers@0.5.13))(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -23552,10 +23312,10 @@ snapshots:
       tinyglobby: 0.2.9
       tree-kill: 1.2.2
     optionalDependencies:
-      '@microsoft/api-extractor': 7.43.1(@types/node@20.12.7)
+      '@microsoft/api-extractor': 7.47.10(@types/node@20.12.7)
       '@swc/core': 1.4.0(@swc/helpers@0.5.13)
       postcss: 8.4.47
-      typescript: 5.0.2
+      typescript: 5.6.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -23631,9 +23391,9 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.0.2: {}
-
   typescript@5.4.2: {}
+
+  typescript@5.6.3: {}
 
   ua-parser-js@1.0.37: {}
 
@@ -23841,8 +23601,6 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  validator@13.11.0: {}
-
   value-equal@1.0.1: {}
 
   varint@6.0.0: {}
@@ -23889,15 +23647,6 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-loader@17.4.2(vue@3.5.12(typescript@5.0.2))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
-    dependencies:
-      chalk: 4.1.2
-      hash-sum: 2.0.0
-      watchpack: 2.4.1
-      webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
-    optionalDependencies:
-      vue: 3.5.12(typescript@5.0.2)
-
   vue-loader@17.4.2(vue@3.5.12(typescript@5.4.2))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
       chalk: 4.1.2
@@ -23907,15 +23656,14 @@ snapshots:
     optionalDependencies:
       vue: 3.5.12(typescript@5.4.2)
 
-  vue@3.5.12(typescript@5.0.2):
+  vue-loader@17.4.2(vue@3.5.12(typescript@5.6.3))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))):
     dependencies:
-      '@vue/compiler-dom': 3.5.12
-      '@vue/compiler-sfc': 3.5.12
-      '@vue/runtime-dom': 3.5.12
-      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@5.0.2))
-      '@vue/shared': 3.5.12
+      chalk: 4.1.2
+      hash-sum: 2.0.0
+      watchpack: 2.4.1
+      webpack: 5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
     optionalDependencies:
-      typescript: 5.0.2
+      vue: 3.5.12(typescript@5.6.3)
 
   vue@3.5.12(typescript@5.4.2):
     dependencies:
@@ -23926,6 +23674,16 @@ snapshots:
       '@vue/shared': 3.5.12
     optionalDependencies:
       typescript: 5.4.2
+
+  vue@3.5.12(typescript@5.6.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.12
+      '@vue/compiler-sfc': 3.5.12
+      '@vue/runtime-dom': 3.5.12
+      '@vue/server-renderer': 3.5.12(vue@3.5.12(typescript@5.6.3))
+      '@vue/shared': 3.5.12
+    optionalDependencies:
+      typescript: 5.6.3
 
   w-json@1.3.10: {}
 
@@ -24431,14 +24189,6 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.0.0: {}
-
-  z-schema@5.0.5:
-    dependencies:
-      lodash.get: 4.4.2
-      lodash.isequal: 4.5.0
-      validator: 13.11.0
-    optionalDependencies:
-      commander: 9.5.0
 
   zod-validation-error@3.3.1(zod@3.23.8):
     dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,7 @@
     "@pnpm/find-workspace-packages": "6.0.9",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
-    "typescript": "5.0.2",
+    "typescript": "5.6.3",
     "jest-environment-jsdom": "^29.7.0",
     "glob":"^10.3.10",
     "semver": "^7.6.2",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -15,7 +15,7 @@
     "@pnpm/find-workspace-packages": "6.0.9",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",
-    "typescript": "5.6.3",
+    "typescript": "^5.6.3",
     "jest-environment-jsdom": "^29.7.0",
     "glob":"^10.3.10",
     "semver": "^7.6.2",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "CommonJS", // DO NOT CHANGE: https://github.com/web-infra-dev/rspack/pull/4650
+    "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2021",
     "esModuleInterop": true,

--- a/website/package.json
+++ b/website/package.json
@@ -43,6 +43,6 @@
     "rspress": "1.33.1",
     "rspress-plugin-font-open-sans": "1.0.0",
     "rspress-plugin-sitemap": "^1.1.1",
-    "typescript": "^5.0.4"
+    "typescript": "5.6.3"
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -43,6 +43,6 @@
     "rspress": "1.33.1",
     "rspress-plugin-font-open-sans": "1.0.0",
     "rspress-plugin-sitemap": "^1.1.1",
-    "typescript": "5.6.3"
+    "typescript": "^5.6.3"
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
chore(deps): update ts 5.6
close https://github.com/web-infra-dev/rspack/pull/7211

after https://github.com/web-infra-dev/rspack/pull/8072, we don't rely on tsc to generate js files, so we can upgrade the version of typescript.
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

1. upgrade and unify the ts version `^5.6.3`
2. add renovate to revert https://github.com/web-infra-dev/rspack/pull/5470/files

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
