### PR TITLE
refactor: add JSDoc to improve config.target, devtool, node, cache types.

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -85,6 +85,9 @@ interface AdditionalData {
 type AffectedHooks = keyof Compiler["hooks"];
 
 // @public (undocumented)
+type AllowTarget = "web" | "webworker" | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | "electron-main" | `electron${number}-main` | `electron${number}.${number}-main` | "electron-renderer" | `electron${number}-renderer` | `electron${number}.${number}-renderer` | "electron-preload" | `electron${number}-preload` | `electron${number}.${number}-preload` | "nwjs" | `nwjs${number}` | `nwjs${number}.${number}` | "node-webkit" | `node-webkit${number}` | `node-webkit${number}.${number}` | "browserslist" | `browserslist:${string}`;
+
+// @public (undocumented)
 interface AmdConfig extends BaseModuleConfig {
     // (undocumented)
     moduleId?: string;
@@ -406,11 +409,8 @@ class CacheFacade {
 // @public (undocumented)
 type CacheHookMap = Map<string, SyncBailHook<[any[], StatsFactoryContext], any>[]>;
 
-// @public (undocumented)
-export type CacheOptions = z.infer<typeof cacheOptions>;
-
-// @public (undocumented)
-const cacheOptions: z.ZodBoolean;
+// @public
+export type CacheOptions = boolean;
 
 // @public (undocumented)
 type CallbackCache<T> = (err?: WebpackError_2 | null, result?: T) => void;
@@ -1328,6 +1328,9 @@ export type DevTool = z.infer<typeof devTool>;
 const devTool: z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["eval", "cheap-source-map", "cheap-module-source-map", "source-map", "inline-cheap-source-map", "inline-cheap-module-source-map", "inline-source-map", "inline-nosources-cheap-source-map", "inline-nosources-cheap-module-source-map", "inline-nosources-source-map", "nosources-cheap-source-map", "nosources-cheap-module-source-map", "nosources-source-map", "hidden-nosources-cheap-source-map", "hidden-nosources-cheap-module-source-map", "hidden-nosources-source-map", "hidden-cheap-source-map", "hidden-cheap-module-source-map", "hidden-source-map", "eval-cheap-source-map", "eval-cheap-module-source-map", "eval-source-map", "eval-nosources-cheap-source-map", "eval-nosources-cheap-module-source-map", "eval-nosources-source-map"]>]>;
 
 // @public
+type DevTool_2 = false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map";
+
+// @public
 export type DevtoolFallbackModuleFilenameTemplate = DevtoolModuleFilenameTemplate;
 
 // @public
@@ -2062,38 +2065,17 @@ export const ExternalsPlugin: {
     };
 };
 
-// @public (undocumented)
-export type ExternalsPresets = z.infer<typeof externalsPresets>;
-
-// @public (undocumented)
-const externalsPresets: z.ZodObject<{
-    node: z.ZodOptional<z.ZodBoolean>;
-    web: z.ZodOptional<z.ZodBoolean>;
-    webAsync: z.ZodOptional<z.ZodBoolean>;
-    electron: z.ZodOptional<z.ZodBoolean>;
-    electronMain: z.ZodOptional<z.ZodBoolean>;
-    electronPreload: z.ZodOptional<z.ZodBoolean>;
-    electronRenderer: z.ZodOptional<z.ZodBoolean>;
-    nwjs: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    node?: boolean | undefined;
-    web?: boolean | undefined;
-    nwjs?: boolean | undefined;
-    webAsync?: boolean | undefined;
-    electron?: boolean | undefined;
-    electronMain?: boolean | undefined;
-    electronPreload?: boolean | undefined;
-    electronRenderer?: boolean | undefined;
-}, {
-    node?: boolean | undefined;
-    web?: boolean | undefined;
-    nwjs?: boolean | undefined;
-    webAsync?: boolean | undefined;
-    electron?: boolean | undefined;
-    electronMain?: boolean | undefined;
-    electronPreload?: boolean | undefined;
-    electronRenderer?: boolean | undefined;
-}>;
+// @public
+export type ExternalsPresets = {
+    node?: boolean;
+    web?: boolean;
+    webAsync?: boolean;
+    electron?: boolean;
+    electronMain?: boolean;
+    electronPreload?: boolean;
+    electronRenderer?: boolean;
+    nwjs?: boolean;
+};
 
 // @public
 export type ExternalsType = "var" | "module" | "assign" | "this" | "window" | "self" | "global" | "commonjs" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd" | "amd-require" | "umd" | "umd2" | "jsonp" | "system" | "promise" | "import" | "module-import" | "script" | "node-commonjs";
@@ -2159,17 +2141,11 @@ interface FileSystemInfoEntry_2 {
     timestamp?: number;
 }
 
-// @public (undocumented)
-export type FilterItemTypes = z.infer<typeof filterItemTypes>;
+// @public
+export type FilterItemTypes = RegExp | string | ((value: string) => boolean);
 
-// @public (undocumented)
-const filterItemTypes: z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>;
-
-// @public (undocumented)
-export type FilterTypes = z.infer<typeof filterTypes>;
-
-// @public (undocumented)
-const filterTypes: z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>]>;
+// @public
+export type FilterTypes = FilterItemTypes | FilterItemTypes[];
 
 // @public
 export type GeneratorOptionsByModuleType = GeneratorOptionsByModuleTypeKnown_2 | GeneratorOptionsByModuleTypeUnknown;
@@ -2694,32 +2670,15 @@ const incremental: z.ZodObject<{
     moduleRuntimeRequirements?: boolean | undefined;
 }>;
 
-// @public (undocumented)
-export type InfrastructureLogging = z.infer<typeof infrastructureLogging>;
-
-// @public (undocumented)
-const infrastructureLogging: z.ZodObject<{
-    appendOnly: z.ZodOptional<z.ZodBoolean>;
-    colors: z.ZodOptional<z.ZodBoolean>;
-    console: z.ZodOptional<z.ZodType<Console, z.ZodTypeDef, Console>>;
-    debug: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>]>]>>;
-    level: z.ZodOptional<z.ZodEnum<["none", "error", "warn", "info", "log", "verbose"]>>;
-    stream: z.ZodOptional<z.ZodType<NodeJS.WritableStream, z.ZodTypeDef, NodeJS.WritableStream>>;
-}, "strict", z.ZodTypeAny, {
-    debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-    colors?: boolean | undefined;
-    appendOnly?: boolean | undefined;
-    console?: Console | undefined;
-    level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    stream?: NodeJS.WritableStream | undefined;
-}, {
-    debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-    colors?: boolean | undefined;
-    appendOnly?: boolean | undefined;
-    console?: Console | undefined;
-    level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    stream?: NodeJS.WritableStream | undefined;
-}>;
+// @public
+export type InfrastructureLogging = {
+    appendOnly?: boolean;
+    colors?: boolean;
+    console?: Console;
+    debug?: boolean | FilterTypes;
+    level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
+    stream?: NodeJS.WritableStream;
+};
 
 // @public (undocumented)
 type InputFileSystem = {
@@ -3509,10 +3468,7 @@ const LimitChunkCountPlugin: {
 };
 
 // @public (undocumented)
-export type Loader = z.infer<typeof loader>;
-
-// @public (undocumented)
-const loader: z.ZodRecord<z.ZodString, z.ZodAny>;
+export type Loader = Record<string, any>;
 
 // @public (undocumented)
 export interface LoaderContext<OptionsType = {}> {
@@ -4066,24 +4022,9 @@ export type Name = string;
 // @public (undocumented)
 export const node: Node_3;
 
-// @public (undocumented)
-type Node_2 = z.infer<typeof node_2>;
+// @public
+type Node_2 = false | NodeOptions;
 export { Node_2 as Node }
-
-// @public (undocumented)
-const node_2: z.ZodUnion<[z.ZodLiteral<false>, z.ZodObject<{
-    __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
-    __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
-    global: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"warn">]>>;
-}, "strict", z.ZodTypeAny, {
-    global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-}, {
-    global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-}>]>;
 
 // @public (undocumented)
 interface Node_3 {
@@ -4116,23 +4057,12 @@ interface NodeNextConfig extends BaseModuleConfig {
     type: "nodenext";
 }
 
-// @public (undocumented)
-export type NodeOptions = z.infer<typeof nodeOptions>;
-
-// @public (undocumented)
-const nodeOptions: z.ZodObject<{
-    __dirname: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
-    __filename: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["warn-mock", "mock", "eval-only", "node-module"]>]>>;
-    global: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"warn">]>>;
-}, "strict", z.ZodTypeAny, {
-    global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-}, {
-    global?: boolean | "warn" | undefined;
-    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module" | undefined;
-}>;
+// @public
+export type NodeOptions = {
+    __dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module";
+    __filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module";
+    global?: boolean | "warn";
+};
 
 // @public (undocumented)
 const NodeTargetPlugin: {
@@ -5199,18 +5129,8 @@ declare namespace rspackExports {
         RspackOptionsNormalized,
         AssetInlineGeneratorOptions,
         GeneratorOptionsByModuleTypeKnown,
-        Target,
         externalsType,
-        ExternalsPresets,
-        FilterItemTypes,
-        FilterTypes,
-        InfrastructureLogging,
         DevTool,
-        NodeOptions,
-        Node_2 as Node,
-        Loader,
-        SnapshotOptions,
-        CacheOptions,
         StatsOptions,
         StatsValue,
         RspackFutureOptions,
@@ -5341,12 +5261,22 @@ declare namespace rspackExports {
         GeneratorOptionsByModuleType,
         NoParseOption,
         ModuleOptions,
+        Target,
         ExternalsType,
         ExternalItemValue,
         ExternalItemObjectUnknown,
         ExternalItemFunctionData,
         ExternalItem,
         Externals,
+        ExternalsPresets,
+        FilterItemTypes,
+        FilterTypes,
+        InfrastructureLogging,
+        NodeOptions,
+        Node_2 as Node,
+        Loader,
+        SnapshotOptions,
+        CacheOptions,
         RspackPluginInstance,
         RspackPluginFunction,
         WebpackCompiler,
@@ -8560,7 +8490,7 @@ export const rspackOptions: z.ZodObject<{
         chunkLoadTimeout?: number | undefined;
         charset?: boolean | undefined;
     } | undefined;
-    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | "web" | "webworker" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | "electron-main" | `electron${number}-main` | `electron${number}.${number}-main` | "electron-renderer" | `electron${number}-renderer` | `electron${number}.${number}-renderer` | "electron-preload" | `electron${number}-preload` | `electron${number}.${number}-preload` | "nwjs" | `nwjs${number}` | `nwjs${number}.${number}` | "node-webkit" | `node-webkit${number}` | `node-webkit${number}.${number}` | "browserslist" | `browserslist:${string}` | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | "web" | "webworker" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | "electron-main" | `electron${number}-main` | `electron${number}.${number}-main` | "electron-renderer" | `electron${number}-renderer` | `electron${number}.${number}-renderer` | "electron-preload" | `electron${number}-preload` | `electron${number}.${number}-preload` | "nwjs" | `nwjs${number}` | `nwjs${number}.${number}` | "node-webkit" | `node-webkit${number}` | `node-webkit${number}.${number}` | "browserslist" | `browserslist:${string}`)[] | undefined;
+    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
     mode?: "none" | "development" | "production" | undefined;
     experiments?: {
         css?: boolean | undefined;
@@ -9158,7 +9088,7 @@ export const rspackOptions: z.ZodObject<{
         chunkLoadTimeout?: number | undefined;
         charset?: boolean | undefined;
     } | undefined;
-    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | "web" | "webworker" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | "electron-main" | `electron${number}-main` | `electron${number}.${number}-main` | "electron-renderer" | `electron${number}-renderer` | `electron${number}.${number}-renderer` | "electron-preload" | `electron${number}-preload` | `electron${number}.${number}-preload` | "nwjs" | `nwjs${number}` | `nwjs${number}.${number}` | "node-webkit" | `node-webkit${number}` | `node-webkit${number}.${number}` | "browserslist" | `browserslist:${string}` | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | "web" | "webworker" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | "electron-main" | `electron${number}-main` | `electron${number}.${number}-main` | "electron-renderer" | `electron${number}-renderer` | `electron${number}.${number}-renderer` | "electron-preload" | `electron${number}-preload` | `electron${number}.${number}-preload` | "nwjs" | `nwjs${number}` | `nwjs${number}.${number}` | "node-webkit" | `node-webkit${number}` | `node-webkit${number}.${number}` | "browserslist" | `browserslist:${string}`)[] | undefined;
+    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
     mode?: "none" | "development" | "production" | undefined;
     experiments?: {
         css?: boolean | undefined;
@@ -9816,10 +9746,7 @@ export const sharing: {
 };
 
 // @public (undocumented)
-export type SnapshotOptions = z.infer<typeof snapshotOptions>;
-
-// @public (undocumented)
-const snapshotOptions: z.ZodObject<{}, "strict", z.ZodTypeAny, {}, {}>;
+export type SnapshotOptions = {};
 
 // @public (undocumented)
 abstract class Source {
@@ -10814,12 +10741,23 @@ declare namespace t {
         GeneratorOptionsByModuleType,
         NoParseOption,
         ModuleOptions,
+        Target,
         ExternalsType,
         ExternalItemValue,
         ExternalItemObjectUnknown,
         ExternalItemFunctionData,
         ExternalItem,
         Externals,
+        ExternalsPresets,
+        FilterItemTypes,
+        FilterTypes,
+        InfrastructureLogging,
+        DevTool_2 as DevTool,
+        NodeOptions,
+        Node_2 as Node,
+        Loader,
+        SnapshotOptions,
+        CacheOptions,
         RspackPluginInstance,
         RspackPluginFunction,
         WebpackCompiler,
@@ -10835,11 +10773,8 @@ declare namespace t {
     }
 }
 
-// @public (undocumented)
-export type Target = z.infer<typeof target>;
-
-// @public (undocumented)
-const target: z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["web", "webworker", "es3", "es5", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021", "es2022"]>, z.ZodLiteral<"node">, z.ZodLiteral<"async-node">, z.ZodType<`node${number}`, z.ZodTypeDef, `node${number}`>, z.ZodType<`async-node${number}`, z.ZodTypeDef, `async-node${number}`>, z.ZodType<`node${number}.${number}`, z.ZodTypeDef, `node${number}.${number}`>, z.ZodType<`async-node${number}.${number}`, z.ZodTypeDef, `async-node${number}.${number}`>, z.ZodLiteral<"electron-main">, z.ZodType<`electron${number}-main`, z.ZodTypeDef, `electron${number}-main`>, z.ZodType<`electron${number}.${number}-main`, z.ZodTypeDef, `electron${number}.${number}-main`>, z.ZodLiteral<"electron-renderer">, z.ZodType<`electron${number}-renderer`, z.ZodTypeDef, `electron${number}-renderer`>, z.ZodType<`electron${number}.${number}-renderer`, z.ZodTypeDef, `electron${number}.${number}-renderer`>, z.ZodLiteral<"electron-preload">, z.ZodType<`electron${number}-preload`, z.ZodTypeDef, `electron${number}-preload`>, z.ZodType<`electron${number}.${number}-preload`, z.ZodTypeDef, `electron${number}.${number}-preload`>, z.ZodLiteral<"nwjs">, z.ZodType<`nwjs${number}`, z.ZodTypeDef, `nwjs${number}`>, z.ZodType<`nwjs${number}.${number}`, z.ZodTypeDef, `nwjs${number}.${number}`>, z.ZodLiteral<"node-webkit">, z.ZodType<`node-webkit${number}`, z.ZodTypeDef, `node-webkit${number}`>, z.ZodType<`node-webkit${number}.${number}`, z.ZodTypeDef, `node-webkit${number}.${number}`>, z.ZodLiteral<"browserslist">, z.ZodType<`browserslist:${string}`, z.ZodTypeDef, `browserslist:${string}`>]>, z.ZodArray<z.ZodUnion<[z.ZodEnum<["web", "webworker", "es3", "es5", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021", "es2022"]>, z.ZodLiteral<"node">, z.ZodLiteral<"async-node">, z.ZodType<`node${number}`, z.ZodTypeDef, `node${number}`>, z.ZodType<`async-node${number}`, z.ZodTypeDef, `async-node${number}`>, z.ZodType<`node${number}.${number}`, z.ZodTypeDef, `node${number}.${number}`>, z.ZodType<`async-node${number}.${number}`, z.ZodTypeDef, `async-node${number}.${number}`>, z.ZodLiteral<"electron-main">, z.ZodType<`electron${number}-main`, z.ZodTypeDef, `electron${number}-main`>, z.ZodType<`electron${number}.${number}-main`, z.ZodTypeDef, `electron${number}.${number}-main`>, z.ZodLiteral<"electron-renderer">, z.ZodType<`electron${number}-renderer`, z.ZodTypeDef, `electron${number}-renderer`>, z.ZodType<`electron${number}.${number}-renderer`, z.ZodTypeDef, `electron${number}.${number}-renderer`>, z.ZodLiteral<"electron-preload">, z.ZodType<`electron${number}-preload`, z.ZodTypeDef, `electron${number}-preload`>, z.ZodType<`electron${number}.${number}-preload`, z.ZodTypeDef, `electron${number}.${number}-preload`>, z.ZodLiteral<"nwjs">, z.ZodType<`nwjs${number}`, z.ZodTypeDef, `nwjs${number}`>, z.ZodType<`nwjs${number}.${number}`, z.ZodTypeDef, `nwjs${number}.${number}`>, z.ZodLiteral<"node-webkit">, z.ZodType<`node-webkit${number}`, z.ZodTypeDef, `node-webkit${number}`>, z.ZodType<`node-webkit${number}.${number}`, z.ZodTypeDef, `node-webkit${number}.${number}`>, z.ZodLiteral<"browserslist">, z.ZodType<`browserslist:${string}`, z.ZodTypeDef, `browserslist:${string}`>]>, "many">]>;
+// @public
+export type Target = false | AllowTarget | AllowTarget[];
 
 // @public (undocumented)
 interface Targets {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1220,6 +1220,48 @@ export type ModuleOptions = {
 
 //#endregion
 
+//#region Target
+type AllowTarget =
+	| "web"
+	| "webworker"
+	| "es3"
+	| "es5"
+	| "es2015"
+	| "es2016"
+	| "es2017"
+	| "es2018"
+	| "es2019"
+	| "es2020"
+	| "es2021"
+	| "es2022"
+	| "node"
+	| "async-node"
+	| `node${number}`
+	| `async-node${number}`
+	| `node${number}.${number}`
+	| `async-node${number}.${number}`
+	| "electron-main"
+	| `electron${number}-main`
+	| `electron${number}.${number}-main`
+	| "electron-renderer"
+	| `electron${number}-renderer`
+	| `electron${number}.${number}-renderer`
+	| "electron-preload"
+	| `electron${number}-preload`
+	| `electron${number}.${number}-preload`
+	| "nwjs"
+	| `nwjs${number}`
+	| `nwjs${number}.${number}`
+	| "node-webkit"
+	| `node-webkit${number}`
+	| `node-webkit${number}.${number}`
+	| "browserslist"
+	| `browserslist:${string}`;
+
+/** Used to configure the target environment of Rspack output and the ECMAScript version of Rspack runtime code. */
+export type Target = false | AllowTarget | AllowTarget[];
+//#endregion
+
 //#region ExternalsType
 /**
  * Specify the default type of externals.
@@ -1322,6 +1364,188 @@ export type ExternalItem =
  * */
 export type Externals = ExternalItem | ExternalItem[];
 //#endregion
+
+//#region ExternalsPresets
+/** Enable presets of externals for specific targets. */
+export type ExternalsPresets = {
+	/** Treat node.js built-in modules like `fs`, `path` or `vm` as external and load them via `require()` when used. */
+	node?: boolean;
+
+	/** Treat references to `http(s)://...` and `std:...` as external and load them via import when used. */
+	web?: boolean;
+
+	/** Treat references to `http(s)://...` and `std:...` as external and load them via async import() when used  */
+	webAsync?: boolean;
+
+	/** Treat common electron built-in modules in main and preload context like `electron`, `ipc` or `shell` as external and load them via `require()` when used. */
+	electron?: boolean;
+
+	/** Treat electron built-in modules in the main context like `app`, `ipc-main` or `shell` as external and load them via `require()` when used. */
+	electronMain?: boolean;
+
+	/** Treat electron built-in modules in the preload context like `web-frame`, `ipc-renderer` or `shell` as external and load them via require() when used. */
+	electronPreload?: boolean;
+
+	/** Treat electron built-in modules in the preload context like `web-frame`, `ipc-renderer` or `shell` as external and load them via require() when used. */
+	electronRenderer?: boolean;
+
+	/** Treat `NW.js` legacy `nw.gui` module as external and load it via `require()` when used. */
+	nwjs?: boolean;
+};
+
+//#endregion
+
+//#region InfrastructureLogging
+/**
+ * Represents a filter item type for infrastructure logging.
+ * Can be a RegExp, a string, or a function that takes a string and returns a boolean.
+ */
+export type FilterItemTypes = RegExp | string | ((value: string) => boolean);
+
+/**
+ * Represents filter types for infrastructure logging.
+ * Can be a single FilterItemTypes or an array of FilterItemTypes.
+ */
+export type FilterTypes = FilterItemTypes | FilterItemTypes[];
+
+/**
+ * Options for infrastructure level logging.
+ */
+export type InfrastructureLogging = {
+	/**
+	 * Append lines to the output instead of updating existing output, useful for status messages.
+	 */
+	appendOnly?: boolean;
+
+	/**
+	 * Enable colorful output for infrastructure level logging.
+	 */
+	colors?: boolean;
+
+	/**
+	 * Customize the console used for infrastructure level logging.
+	 */
+	console?: Console;
+
+	/**
+	 * Enable debug information of specified loggers such as plugins or loaders.
+	 */
+	debug?: boolean | FilterTypes;
+
+	/**
+	 * Enable infrastructure logging output.
+	 * @type {"none" | "error" | "warn" | "info" | "log" | "verbose"}
+	 */
+	level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
+
+	/**
+	 * Stream used for logging output.
+	 */
+	stream?: NodeJS.WritableStream;
+};
+//#endregion
+
+//#region DevTool
+/**
+ * Configuration used to control the behavior of the Source Map generation.
+ */
+export type DevTool =
+	| false
+	| "eval"
+	| "cheap-source-map"
+	| "cheap-module-source-map"
+	| "source-map"
+	| "inline-cheap-source-map"
+	| "inline-cheap-module-source-map"
+	| "inline-source-map"
+	| "inline-nosources-cheap-source-map"
+	| "inline-nosources-cheap-module-source-map"
+	| "inline-nosources-source-map"
+	| "nosources-cheap-source-map"
+	| "nosources-cheap-module-source-map"
+	| "nosources-source-map"
+	| "hidden-nosources-cheap-source-map"
+	| "hidden-nosources-cheap-module-source-map"
+	| "hidden-nosources-source-map"
+	| "hidden-cheap-source-map"
+	| "hidden-cheap-module-source-map"
+	| "hidden-source-map"
+	| "eval-cheap-source-map"
+	| "eval-cheap-module-source-map"
+	| "eval-source-map"
+	| "eval-nosources-cheap-source-map"
+	| "eval-nosources-cheap-module-source-map"
+	| "eval-nosources-source-map";
+//#endregion
+
+//#region Node
+/**
+ * Options for mocking Node.js globals and modules.
+ */
+export type NodeOptions = {
+	/**
+	 * Controls the behavior of `__dirname`.
+	 * @description
+	 * - `true`: The dirname of the input file relative to the context option.
+	 * - `false`: Regular Node.js `__dirname` behavior. The dirname of the output file when run in a Node.js environment.
+	 * - `"mock"`: The fixed value '/'.
+	 * - `"warn-mock"`: Use the fixed value of '/' but show a warning.
+	 * - `"node-module"`: Replace `__dirname` in CommonJS modules to `fileURLToPath(import.meta.url + "/..")` when `output.module` is enabled.
+	 * - `"eval-only"`: Equivalent to `false`.
+	 */
+	__dirname?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module";
+
+	/**
+	 * Controls the behavior of `__filename`.
+	 * @description
+	 * - `true`: The filename of the input file relative to the context option.
+	 * - `false`: Regular Node.js `__filename` behavior. The filename of the output file when run in a Node.js environment.
+	 * - `"mock"`: The fixed value '/index.js'.
+	 * - `"warn-mock"`: Use the fixed value of '/index.js' but show a warning.
+	 * - `"node-module"`: Replace `__filename` in CommonJS modules to `fileURLToPath(import.meta.url)` when `output.module` is enabled.
+	 * - `"eval-only"`: Equivalent to `false`.
+	 */
+	__filename?: boolean | "warn-mock" | "mock" | "eval-only" | "node-module";
+
+	/**
+	 * Controls the behavior of `global`.
+	 * @description
+	 * - `true`: Provide a polyfill.
+	 * - `false`: Don't provide a polyfill.
+	 * - `"warn"`: Provide a polyfill but show a warning.
+	 * @see {@link https://nodejs.org/api/globals.html#globals_global | Node.js documentation} for the exact behavior of this object.
+	 * @default "warn"
+	 */
+	global?: boolean | "warn";
+};
+
+/**
+ * Options for mocking Node.js globals and modules.
+ * @description Set to `false` to disable all mocking, or use `NodeOptions` to configure specific behaviors.
+ */
+export type Node = false | NodeOptions;
+
+export type Loader = Record<string, any>;
+//#endregion
+
+//#region Snapshot
+export type SnapshotOptions = {};
+//#endregion
+
+//#region Cache
+/**
+ * Options for caching snapshots and intermediate products during the build process.
+ * @description Controls whether caching is enabled or disabled.
+ * @default true in development mode, false in production mode
+ * @example
+ * // Enable caching
+ * cache: true
+ *
+ * // Disable caching
+ * cache: false
+ */
+export type CacheOptions = boolean;
+//#endreigon
 
 //#region Plugins
 export interface RspackPluginInstance {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1434,7 +1434,6 @@ export type InfrastructureLogging = {
 
 	/**
 	 * Enable infrastructure logging output.
-	 * @type {"none" | "error" | "warn" | "info" | "log" | "verbose"}
 	 */
 	level?: "none" | "error" | "warn" | "info" | "log" | "verbose";
 

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -766,8 +766,11 @@ const allowTarget = z.union([
 	)
 ]);
 
-const target = z.union([z.literal(false), allowTarget, allowTarget.array()]);
-export type Target = z.infer<typeof target>;
+const target = z.union([
+	z.literal(false),
+	allowTarget,
+	allowTarget.array()
+]) satisfies z.ZodType<t.Target>;
 //#endregion
 
 //#region ExternalsType
@@ -862,19 +865,20 @@ const externalsPresets = z.strictObject({
 	electronPreload: z.boolean().optional(),
 	electronRenderer: z.boolean().optional(),
 	nwjs: z.boolean().optional()
-});
-export type ExternalsPresets = z.infer<typeof externalsPresets>;
+}) satisfies z.ZodType<t.ExternalsPresets>;
 //#endregion
 
 //#region InfrastructureLogging
 const filterItemTypes = z
 	.instanceof(RegExp)
 	.or(z.string())
-	.or(z.function().args(z.string()).returns(z.boolean()));
-export type FilterItemTypes = z.infer<typeof filterItemTypes>;
+	.or(
+		z.function().args(z.string()).returns(z.boolean())
+	) satisfies z.ZodType<t.FilterItemTypes>;
 
-const filterTypes = filterItemTypes.array().or(filterItemTypes);
-export type FilterTypes = z.infer<typeof filterTypes>;
+const filterTypes = filterItemTypes
+	.array()
+	.or(filterItemTypes) satisfies z.ZodType<t.FilterTypes>;
 
 const infrastructureLogging = z.strictObject({
 	appendOnly: z.boolean().optional(),
@@ -883,8 +887,7 @@ const infrastructureLogging = z.strictObject({
 	debug: z.boolean().or(filterTypes).optional(),
 	level: z.enum(["none", "error", "warn", "info", "log", "verbose"]).optional(),
 	stream: z.custom<NodeJS.WritableStream>().optional()
-});
-export type InfrastructureLogging = z.infer<typeof infrastructureLogging>;
+}) satisfies z.ZodType<t.InfrastructureLogging>;
 //#endregion
 
 //#region DevTool
@@ -918,7 +921,7 @@ const devTool = z
 			"eval-nosources-cheap-module-source-map",
 			"eval-nosources-source-map"
 		])
-	);
+	) satisfies z.ZodType<t.DevTool>;
 export type DevTool = z.infer<typeof devTool>;
 //#endregion
 
@@ -933,24 +936,21 @@ const nodeOptions = z.strictObject({
 		.or(z.enum(["warn-mock", "mock", "eval-only", "node-module"]))
 		.optional(),
 	global: z.boolean().or(z.literal("warn")).optional()
-});
-export type NodeOptions = z.infer<typeof nodeOptions>;
+}) satisfies z.ZodType<t.NodeOptions>;
 
-const node = z.literal(false).or(nodeOptions);
-export type Node = z.infer<typeof node>;
+const node = z.literal(false).or(nodeOptions) satisfies z.ZodType<t.Node>;
 
-const loader = z.record(z.string(), z.any());
-export type Loader = z.infer<typeof loader>;
+const loader = z.record(z.string(), z.any()) satisfies z.ZodType<t.Loader>;
 //#endregion
 
 //#region Snapshot
-const snapshotOptions = z.strictObject({});
-export type SnapshotOptions = z.infer<typeof snapshotOptions>;
+const snapshotOptions = z.strictObject(
+	{}
+) satisfies z.ZodType<t.SnapshotOptions>;
 //#endregion
 
 //#region Cache
-const cacheOptions = z.boolean();
-export type CacheOptions = z.infer<typeof cacheOptions>;
+const cacheOptions = z.boolean() satisfies z.ZodType<t.CacheOptions>;
 //#endregion
 
 //#region Stats


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.target
- Add type & JSDoc for config.devtool
- Add type & JSDoc for config.node
- Add type & JSDoc for config.cache
- Add type & JSDoc for config.externalsPresets

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
