### PR TITLE
fix: compatible static methods with html-webpack-plugin 5.6.0

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -2545,9 +2545,11 @@ export type HotUpdateMainFilename = FilenameTemplate;
 
 // @public (undocumented)
 export const HtmlRspackPlugin: typeof HtmlRspackPluginImpl & {
+    getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
     getCompilationOptions: (compilation: Compilation) => HtmlRspackPluginOptions | void;
     createHtmlTagObject: (tagName: string, attributes?: Record<string, string | boolean>, innerHTML?: string | undefined) => JsHtmlPluginTag;
+    version: number;
 };
 
 // @public (undocumented)

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -378,6 +378,9 @@ const compilationOptionsMap: WeakMap<Compilation, HtmlRspackPluginOptions> =
 	new WeakMap();
 
 const HtmlRspackPlugin = HtmlRspackPluginImpl as typeof HtmlRspackPluginImpl & {
+	/**
+	 * @deprecated Use `getCompilationHooks` instead.
+	 */
 	getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
 	getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
 	getCompilationOptions: (

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -85,8 +85,8 @@ export type HtmlRspackPluginOptions = {
 
 	/** Inject a [base](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) tag */
 	base?:
-		| string
-		| { href?: string; target?: "_self" | "_blank" | "_parent" | "_top" };
+	| string
+	| { href?: string; target?: "_self" | "_blank" | "_parent" | "_top" };
 
 	/**
 	 * Modern browsers support non blocking javascript loading ('defer') to improve the page startup performance.
@@ -378,6 +378,7 @@ const compilationOptionsMap: WeakMap<Compilation, HtmlRspackPluginOptions> =
 	new WeakMap();
 
 const HtmlRspackPlugin = HtmlRspackPluginImpl as typeof HtmlRspackPluginImpl & {
+	getHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
 	getCompilationHooks: (compilation: Compilation) => HtmlRspackPluginHooks;
 	getCompilationOptions: (
 		compilation: Compilation
@@ -387,6 +388,7 @@ const HtmlRspackPlugin = HtmlRspackPluginImpl as typeof HtmlRspackPluginImpl & {
 		attributes?: Record<string, string | boolean>,
 		innerHTML?: string | undefined
 	) => JsHtmlPluginTag;
+	version: number;
 };
 
 const voidTags = [
@@ -429,7 +431,7 @@ HtmlRspackPlugin.getCompilationOptions = (compilation: Compilation) => {
 	return compilationOptionsMap.get(compilation);
 };
 
-HtmlRspackPlugin.getCompilationHooks = (compilation: Compilation) => {
+HtmlRspackPlugin.getHooks = HtmlRspackPlugin.getCompilationHooks = (compilation: Compilation) => {
 	if (!(compilation instanceof Compilation)) {
 		throw new TypeError(
 			"The 'compilation' argument must be an instance of Compilation"
@@ -453,5 +455,7 @@ HtmlRspackPlugin.getCompilationHooks = (compilation: Compilation) => {
 	}
 	return hooks;
 };
+
+HtmlRspackPlugin.version = 5;
 
 export { HtmlRspackPlugin };

--- a/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/HtmlRspackPlugin.ts
@@ -85,8 +85,8 @@ export type HtmlRspackPluginOptions = {
 
 	/** Inject a [base](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) tag */
 	base?:
-	| string
-	| { href?: string; target?: "_self" | "_blank" | "_parent" | "_top" };
+		| string
+		| { href?: string; target?: "_self" | "_blank" | "_parent" | "_top" };
 
 	/**
 	 * Modern browsers support non blocking javascript loading ('defer') to improve the page startup performance.
@@ -431,7 +431,9 @@ HtmlRspackPlugin.getCompilationOptions = (compilation: Compilation) => {
 	return compilationOptionsMap.get(compilation);
 };
 
-HtmlRspackPlugin.getHooks = HtmlRspackPlugin.getCompilationHooks = (compilation: Compilation) => {
+HtmlRspackPlugin.getHooks = HtmlRspackPlugin.getCompilationHooks = (
+	compilation: Compilation
+) => {
 	if (!(compilation instanceof Compilation)) {
 		throw new TypeError(
 			"The 'compilation' argument must be an instance of Compilation"


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Currently, the latest published version of `html-webpack-plugin` is `5.6.0` and need to get hooks by `HtmlWebpackPlugin.getHooks`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
