### PR TITLE
fix(modern-module): concatenate entry module regardless bail reasons

### DIFF
--- a/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/modern_module_library_plugin.rs
@@ -82,13 +82,12 @@ impl ModernModuleLibraryPlugin {
           .module_graph_module_by_identifier(id)
           .expect("should have module");
         let reasons = &mgm.optimization_bailout;
-        reasons
+
+        let is_concatenation_entry_candidate = reasons
           .iter()
-          // We did want force concatenate entry point here.
-          // TODO: use constant variable to identify the reason.
-          .filter(|r| !r.contains("Module is an entry point"))
-          .collect::<Vec<_>>()
-          .is_empty()
+          .any(|r| r.contains("Module is an entry point"));
+
+        is_concatenation_entry_candidate
       })
       .collect::<HashSet<_>>();
 

--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -558,6 +558,86 @@ const value = foo + (bar_default())
 export { value };
 `;
 
+exports[`config config/library/modern-module-force-concaten step  should pass: harmony export should concat, even with bailout reason 1`] = `
+var __webpack_modules__ = ({
+"974": (function (module) {
+module.exports = 'foo'
+
+
+}),
+
+});
+/************************************************************************/
+// The module cache
+var __webpack_module_cache__ = {};
+
+// The require function
+function __webpack_require__(moduleId) {
+
+// Check if module is in cache
+var cachedModule = __webpack_module_cache__[moduleId];
+if (cachedModule !== undefined) {
+return cachedModule.exports;
+}
+// Create a new module (and put it into the cache)
+var module = (__webpack_module_cache__[moduleId] = {
+exports: {}
+});
+// Execute the module function
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+
+// Return the exports of the module
+return module.exports;
+
+}
+
+/************************************************************************/
+// webpack/runtime/compat_get_default_export
+(() => {
+// getDefaultExport function for compatibility with non-ESM modules
+__webpack_require__.n = function (module) {
+	var getter = module && module.__esModule ?
+		function () { return module['default']; } :
+		function () { return module; };
+	__webpack_require__.d(getter, { a: getter });
+	return getter;
+};
+
+
+
+
+})();
+// webpack/runtime/define_property_getters
+(() => {
+__webpack_require__.d = function(exports, definition) {
+	for(var key in definition) {
+        if(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {
+            Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+        }
+    }
+};
+})();
+// webpack/runtime/has_own_property
+(() => {
+__webpack_require__.o = function (obj, prop) {
+	return Object.prototype.hasOwnProperty.call(obj, prop);
+};
+
+})();
+/************************************************************************/
+
+// EXTERNAL MODULE: ./g/foo.js
+var foo = __webpack_require__("974");
+var foo_default = /*#__PURE__*/__webpack_require__.n(foo);
+;// CONCATENATED MODULE: ./g/index.js
+
+
+
+
+var __webpack_exports__foo = (foo_default());
+export { __webpack_exports__foo as foo };
+`;
+
 exports[`config config/library/modern-module-force-concaten step  should pass: unambiguous should bail out 1`] = `const c = 'c'`;
 
 exports[`config config/optimization/minimizer-esm-asset exported tests minimizing an asset file of esm type should success 1`] = `console.log(import.meta.url);export const a=1;`;

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/g/foo.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/g/foo.js
@@ -1,0 +1,1 @@
+module.exports = 'foo'

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/g/index.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/g/index.js
@@ -1,0 +1,3 @@
+import foo from './foo.js'
+
+export { foo }

--- a/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/library/modern-module-force-concaten/rspack.config.js
@@ -6,7 +6,8 @@ module.exports = {
 		"c": "./c.js",
 		"d": "./d.mjs",
 		"e": "./e/index.js",
-		"f": "./f/index.js"
+		"f": "./f/index.js",
+		"g": "./g/index.js"
 	},
 	externals: {
 		path: 'node-commonjs path',
@@ -39,6 +40,7 @@ module.exports = {
 					expect(assets['d.js']._value).toMatchSnapshot(".mjs should concat");
 					expect(assets['e.js']._value).toMatchSnapshot(".cjs should bail out when bundling");
 					expect(assets['f.js']._value).toMatchSnapshot("external module should bail out when bundling");
+					expect(assets['g.js']._value).toMatchSnapshot("harmony export should concat, even with bailout reason");
 				});
 			};
 			this.hooks.compilation.tap("testcase", handler);


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

If the root module is empty, it will store all bailout reasons of current config https://github.com/web-infra-dev/rspack/blob/ddd7eb9d3042a80df57fda2f1321e7d3091e0dae/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs#L982 Previously, this will make root module won't be force concatenated (see new added test case `g`)

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
