### PR TITLE
fix: should keep comments of esm export

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -39,6 +39,7 @@ pub struct ESMExportExpressionDependency {
   id: DependencyId,
   range: RealDependencyLocation,
   range_stmt: RealDependencyLocation,
+  prefix: String,
   declaration: Option<DeclarationId>,
 }
 
@@ -46,12 +47,14 @@ impl ESMExportExpressionDependency {
   pub fn new(
     range: RealDependencyLocation,
     range_stmt: RealDependencyLocation,
+    prefix: String,
     declaration: Option<DeclarationId>,
   ) -> Self {
     Self {
       range,
       range_stmt,
       declaration,
+      prefix,
       id: DependencyId::default(),
     }
   }
@@ -227,7 +230,7 @@ impl DependencyTemplate for ESMExportExpressionDependency {
       source.replace(
         self.range_stmt.start,
         self.range.start,
-        &format!("{}(", content),
+        &format!("{}({}", content, self.prefix),
         None,
       );
       source.replace_with_enforce(

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_expression_dependency.rs
@@ -174,7 +174,7 @@ impl DependencyTemplate for ESMExportExpressionDependency {
       source.replace(
         self.range_stmt.start,
         self.range.start,
-        "/* ESM default export */ ",
+        format!("/* ESM default export */ {}", self.prefix).as_str(),
         None,
       );
     } else {

--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -459,6 +459,13 @@ exports[`config config/library/modern-module-force-concaten step  should pass: .
 const d = 'd'
 `;
 
+exports[`config config/library/modern-module-force-concaten step  should pass: ESM export should concat 1`] = `
+;// CONCATENATED MODULE: ./a.js
+const a = 'a'
+
+export { a };
+`;
+
 exports[`config config/library/modern-module-force-concaten step  should pass: external module should bail out when bundling 1`] = `
 import { createRequire as __WEBPACK_EXTERNAL_createRequire } from "module";
 var __webpack_modules__ = ({
@@ -549,13 +556,6 @@ const value = foo + (bar_default())
 
 
 export { value };
-`;
-
-exports[`config config/library/modern-module-force-concaten step  should pass: ESM export should concat 1`] = `
-;// CONCATENATED MODULE: ./a.js
-const a = 'a'
-
-export { a };
 `;
 
 exports[`config config/library/modern-module-force-concaten step  should pass: unambiguous should bail out 1`] = `const c = 'c'`;

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/index.js
@@ -1,8 +1,16 @@
 import { requestEngine } from './share';
+import used from './used';
 
-it("should keep pure comment", () => {
-  const content = __non_webpack_require__("fs").readFileSync(__filename, 'utf-8');
-  const pureComment = "/* #__PURE__ */";
+used;
+
+const content = __non_webpack_require__("fs").readFileSync(__filename, 'utf-8');
+const pureComment = "/* #__PURE__ */";
+it("should keep pure comment of unused export default", () => {
   const methodName = "createRequest";
+  expect(content).toContain(`${pureComment}${methodName}`)
+});
+
+it("should keep pure comment of used export default", () => {
+  const methodName = "function __WEBPACK_DEFAULT_EXPORT__()";
   expect(content).toContain(`${pureComment}${methodName}`)
 });

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/index.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/index.js
@@ -1,0 +1,8 @@
+import { requestEngine } from './share';
+
+it("should keep pure comment", () => {
+  const content = __non_webpack_require__("fs").readFileSync(__filename, 'utf-8');
+  const pureComment = "/* #__PURE__ */";
+  const methodName = "createRequest";
+  expect(content).toContain(`${pureComment}${methodName}`)
+});

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/rspack.config.js
@@ -1,0 +1,15 @@
+/**
+ * @type {import('@rspack/core').Configuration}
+ */
+module.exports = {
+  entry: "./index.js",
+  node: {
+    __dirname: false,
+    __filename: false
+  },
+  optimization: {
+    sideEffects: false,
+    concatenateModules: false,
+    innerGraph: false
+  }
+}

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/share.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/share.js
@@ -1,10 +1,9 @@
-function createRequest(initOptions, engine) {
-  console.log('request')
+function createRequest() {
 }
 function requestEngine() {
 
 }
 
-export default /* #__PURE__ */ createRequest({}, 2);
+export default /* #__PURE__ */ createRequest();
 
 export { requestEngine };

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/share.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/share.js
@@ -1,0 +1,10 @@
+function createRequest(initOptions, engine) {
+  console.log('request')
+}
+function requestEngine() {
+
+}
+
+export default /* #__PURE__ */ createRequest({}, 2);
+
+export { requestEngine };

--- a/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/used.js
+++ b/packages/rspack-test-tools/tests/configCases/parsing/harmony-export-comment/used.js
@@ -1,0 +1,9 @@
+
+function fun2() {
+
+}
+
+export default /* #__PURE__ */ function () {
+}
+
+export { fun2 };

--- a/packages/rspack-test-tools/tests/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
+++ b/packages/rspack-test-tools/tests/treeShakingCases/pure_comments_magic_comments/__snapshots__/treeshaking.snap.txt
@@ -10,7 +10,7 @@ function res() {
 	answer;
 }
 const a = 3;
-/* unused ESM default export */ var __WEBPACK_DEFAULT_EXPORT__ = ((/* unused pure expression or super */ null && (res())));
+/* unused ESM default export */ var __WEBPACK_DEFAULT_EXPORT__ = (/*#__PURE__*/(/* unused pure expression or super */ null && (res())));
 
 
 }),


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should keep comments like `/* #__PURE__ */` of esm export

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
