### PR TITLE
docs: rename shareScope to shareStrategy

### DIFF
--- a/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
@@ -66,7 +66,7 @@ module.exports = {
 
 定义当前应用共享依赖的命名空间。通过在不同的应用之间配置命名空间，可以控制模块的共享行为，包括确定哪些模块在不同的应用之间是共享的。默认的命名空间为 `"default"`。
 
-### shareScope
+### shareStrategy
 
 - 类型：`'version-first' | 'loaded-first'`
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
shareScope should be rename to shareStrategy in Chinese docs.

Ref: https://rspack.dev/zh/plugins/webpack/module-federation-plugin#sharescope-1



<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
