### PR TITLE
refactor: add JSDoc to improve config.stats types

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -153,7 +153,7 @@ export type AssetGeneratorDataUrlOptions = {
 };
 
 // @public
-export type AssetGeneratorOptions = AssetInlineGeneratorOptions_2 & AssetResourceGeneratorOptions;
+export type AssetGeneratorOptions = AssetInlineGeneratorOptions & AssetResourceGeneratorOptions;
 
 // @public (undocumented)
 export type AssetInfo = Partial<Omit<JsAssetInfo, "extras">> & Record<string, any>;
@@ -161,50 +161,8 @@ export type AssetInfo = Partial<Omit<JsAssetInfo, "extras">> & Record<string, an
 // @public (undocumented)
 type AssetInfo_2 = KnownAssetInfo & Record<string, any>;
 
-// @public (undocumented)
-export type AssetInlineGeneratorOptions = z.infer<typeof assetInlineGeneratorOptions>;
-
-// @public (undocumented)
-const assetInlineGeneratorOptions: z.ZodObject<{
-    dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-        encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-        mimetype: z.ZodOptional<z.ZodString>;
-    }, "strict", z.ZodTypeAny, {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    }, {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-        content: z.ZodString;
-        filename: z.ZodString;
-    }, "strict", z.ZodTypeAny, {
-        filename: string;
-        content: string;
-    }, {
-        filename: string;
-        content: string;
-    }>], z.ZodUnknown>, z.ZodString>]>>;
-}, "strict", z.ZodTypeAny, {
-    dataUrl?: {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    } | ((args_0: {
-        filename: string;
-        content: string;
-    }, ...args: unknown[]) => string) | undefined;
-}, {
-    dataUrl?: {
-        mimetype?: string | undefined;
-        encoding?: false | "base64" | undefined;
-    } | ((args_0: {
-        filename: string;
-        content: string;
-    }, ...args: unknown[]) => string) | undefined;
-}>;
-
 // @public
-type AssetInlineGeneratorOptions_2 = {
+export type AssetInlineGeneratorOptions = {
     dataUrl?: AssetGeneratorDataUrl;
 };
 
@@ -1321,14 +1279,8 @@ type DependencyLocation = any;
 export interface DevServer extends webpackDevServer.Configuration {
 }
 
-// @public (undocumented)
-export type DevTool = z.infer<typeof devTool>;
-
-// @public (undocumented)
-const devTool: z.ZodUnion<[z.ZodLiteral<false>, z.ZodEnum<["eval", "cheap-source-map", "cheap-module-source-map", "source-map", "inline-cheap-source-map", "inline-cheap-module-source-map", "inline-source-map", "inline-nosources-cheap-source-map", "inline-nosources-cheap-module-source-map", "inline-nosources-source-map", "nosources-cheap-source-map", "nosources-cheap-module-source-map", "nosources-source-map", "hidden-nosources-cheap-source-map", "hidden-nosources-cheap-module-source-map", "hidden-nosources-source-map", "hidden-cheap-source-map", "hidden-cheap-module-source-map", "hidden-source-map", "eval-cheap-source-map", "eval-cheap-module-source-map", "eval-source-map", "eval-nosources-cheap-source-map", "eval-nosources-cheap-module-source-map", "eval-nosources-source-map"]>]>;
-
 // @public
-type DevTool_2 = false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map";
+export type DevTool = false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map";
 
 // @public
 export type DevtoolFallbackModuleFilenameTemplate = DevtoolModuleFilenameTemplate;
@@ -2153,244 +2105,12 @@ export type FilterItemTypes = RegExp | string | ((value: string) => boolean);
 export type FilterTypes = FilterItemTypes | FilterItemTypes[];
 
 // @public
-export type GeneratorOptionsByModuleType = GeneratorOptionsByModuleTypeKnown_2 | GeneratorOptionsByModuleTypeUnknown;
+export type GeneratorOptionsByModuleType = GeneratorOptionsByModuleTypeKnown | GeneratorOptionsByModuleTypeUnknown;
 
 // @public (undocumented)
-export type GeneratorOptionsByModuleTypeKnown = z.infer<typeof generatorOptionsByModuleTypeKnown>;
-
-// @public (undocumented)
-const generatorOptionsByModuleTypeKnown: z.ZodObject<{
-    asset: z.ZodOptional<z.ZodObject<z.objectUtil.extendShape<{
-        dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-            encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-            mimetype: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-            content: z.ZodString;
-            filename: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            filename: string;
-            content: string;
-        }, {
-            filename: string;
-            content: string;
-        }>], z.ZodUnknown>, z.ZodString>]>>;
-    }, {
-        emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-        publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    }>, "strict", z.ZodTypeAny, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    }, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    }>>;
-    "asset/inline": z.ZodOptional<z.ZodObject<{
-        dataUrl: z.ZodOptional<z.ZodUnion<[z.ZodObject<{
-            encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
-            mimetype: z.ZodOptional<z.ZodString>;
-        }, "strict", z.ZodTypeAny, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }, {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
-            content: z.ZodString;
-            filename: z.ZodString;
-        }, "strict", z.ZodTypeAny, {
-            filename: string;
-            content: string;
-        }, {
-            filename: string;
-            content: string;
-        }>], z.ZodUnknown>, z.ZodString>]>>;
-    }, "strict", z.ZodTypeAny, {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    }, {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    }>>;
-    "asset/resource": z.ZodOptional<z.ZodObject<{
-        emit: z.ZodOptional<z.ZodBoolean>;
-        filename: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>>;
-        publicPath: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<"auto">, z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodType<PathData, z.ZodTypeDef, PathData>, z.ZodOptional<z.ZodType<JsAssetInfo, z.ZodTypeDef, JsAssetInfo>>], z.ZodUnknown>, z.ZodString>]>]>>;
-    }, "strict", z.ZodTypeAny, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    }, {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    }>>;
-    css: z.ZodOptional<z.ZodObject<{
-        exportsOnly: z.ZodOptional<z.ZodBoolean>;
-        esModule: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    }, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    }>>;
-    "css/auto": z.ZodOptional<z.ZodObject<{
-        exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-        exportsOnly: z.ZodOptional<z.ZodBoolean>;
-        localIdentName: z.ZodOptional<z.ZodString>;
-        esModule: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }>>;
-    "css/module": z.ZodOptional<z.ZodObject<{
-        exportsConvention: z.ZodOptional<z.ZodEnum<["as-is", "camel-case", "camel-case-only", "dashes", "dashes-only"]>>;
-        exportsOnly: z.ZodOptional<z.ZodBoolean>;
-        localIdentName: z.ZodOptional<z.ZodString>;
-        esModule: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }, {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    css?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    "css/module"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    asset?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/inline"?: {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/resource"?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    } | undefined;
-}, {
-    css?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-    } | undefined;
-    "css/auto"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    "css/module"?: {
-        exportsOnly?: boolean | undefined;
-        esModule?: boolean | undefined;
-        exportsConvention?: "as-is" | "camel-case" | "camel-case-only" | "dashes" | "dashes-only" | undefined;
-        localIdentName?: string | undefined;
-    } | undefined;
-    asset?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/inline"?: {
-        dataUrl?: {
-            mimetype?: string | undefined;
-            encoding?: false | "base64" | undefined;
-        } | ((args_0: {
-            filename: string;
-            content: string;
-        }, ...args: unknown[]) => string) | undefined;
-    } | undefined;
-    "asset/resource"?: {
-        filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        emit?: boolean | undefined;
-    } | undefined;
-}>;
-
-// @public (undocumented)
-type GeneratorOptionsByModuleTypeKnown_2 = {
+export type GeneratorOptionsByModuleTypeKnown = {
     asset?: AssetGeneratorOptions;
-    "asset/inline"?: AssetInlineGeneratorOptions_2;
+    "asset/inline"?: AssetInlineGeneratorOptions;
     "asset/resource"?: AssetResourceGeneratorOptions;
     css?: CssGeneratorOptions;
     "css/auto"?: CssAutoGeneratorOptions;
@@ -3907,6 +3627,12 @@ declare namespace ModuleFilenameHelpers {
 export { ModuleFilenameHelpers }
 
 // @public (undocumented)
+type ModuleFilterItemTypes = RegExp | string | ((name: string, module: any, type: any) => boolean);
+
+// @public (undocumented)
+type ModuleFilterTypes = boolean | ModuleFilterItemTypes | ModuleFilterItemTypes[];
+
+// @public (undocumented)
 export type ModuleOptions = {
     defaultRules?: RuleSetRules;
     rules?: RuleSetRules;
@@ -5137,12 +4863,7 @@ declare namespace rspackExports {
         IgnoreWarningsNormalized,
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
-        AssetInlineGeneratorOptions,
-        GeneratorOptionsByModuleTypeKnown,
         externalsType,
-        DevTool,
-        StatsOptions,
-        StatsValue,
         RspackFutureOptions,
         LazyCompilationOptions,
         Incremental,
@@ -5258,6 +4979,7 @@ declare namespace rspackExports {
         AssetGeneratorDataUrlOptions,
         AssetGeneratorDataUrlFunction,
         AssetGeneratorDataUrl,
+        AssetInlineGeneratorOptions,
         AssetResourceGeneratorOptions,
         AssetGeneratorOptions,
         CssGeneratorExportsConvention,
@@ -5267,6 +4989,7 @@ declare namespace rspackExports {
         CssGeneratorOptions,
         CssAutoGeneratorOptions,
         CssModuleGeneratorOptions,
+        GeneratorOptionsByModuleTypeKnown,
         GeneratorOptionsByModuleTypeUnknown,
         GeneratorOptionsByModuleType,
         NoParseOption,
@@ -5282,11 +5005,14 @@ declare namespace rspackExports {
         FilterItemTypes,
         FilterTypes,
         InfrastructureLogging,
+        DevTool,
         NodeOptions,
         Node_2 as Node,
         Loader,
         SnapshotOptions,
         CacheOptions,
+        StatsOptions,
+        StatsValue,
         RspackPluginInstance,
         RspackPluginFunction,
         WebpackCompiler,
@@ -8558,7 +8284,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
@@ -8572,7 +8298,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
@@ -8580,7 +8306,7 @@ export const rspackOptions: z.ZodObject<{
             issuer: string;
         } | undefined;
     }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
-    externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined;
+    externalsType?: "module" | "global" | "system" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "script" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
         web?: boolean | undefined;
@@ -9157,7 +8883,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
@@ -9171,7 +8897,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "script" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
@@ -9179,7 +8905,7 @@ export const rspackOptions: z.ZodObject<{
             issuer: string;
         } | undefined;
     }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
-    externalsType?: "module" | "global" | "system" | "promise" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "module-import" | "script" | "node-commonjs" | undefined;
+    externalsType?: "module" | "global" | "system" | "commonjs" | "umd" | "amd" | "jsonp" | "import" | "var" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "script" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
         web?: boolean | undefined;
@@ -9948,245 +9674,91 @@ type StatsModuleTraceItem = {
     moduleId?: string;
 };
 
-// @public (undocumented)
-export type StatsOptions = z.infer<typeof statsOptions>;
-
-// @public (undocumented)
-const statsOptions: z.ZodObject<{
-    all: z.ZodOptional<z.ZodBoolean>;
-    preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>>;
-    assets: z.ZodOptional<z.ZodBoolean>;
-    chunks: z.ZodOptional<z.ZodBoolean>;
-    modules: z.ZodOptional<z.ZodBoolean>;
-    entrypoints: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"auto">]>>;
-    chunkGroups: z.ZodOptional<z.ZodBoolean>;
-    warnings: z.ZodOptional<z.ZodBoolean>;
-    warningsCount: z.ZodOptional<z.ZodBoolean>;
-    errors: z.ZodOptional<z.ZodBoolean>;
-    errorsCount: z.ZodOptional<z.ZodBoolean>;
-    colors: z.ZodOptional<z.ZodBoolean>;
-    hash: z.ZodOptional<z.ZodBoolean>;
-    version: z.ZodOptional<z.ZodBoolean>;
-    reasons: z.ZodOptional<z.ZodBoolean>;
-    publicPath: z.ZodOptional<z.ZodBoolean>;
-    outputPath: z.ZodOptional<z.ZodBoolean>;
-    chunkModules: z.ZodOptional<z.ZodBoolean>;
-    chunkRelations: z.ZodOptional<z.ZodBoolean>;
-    ids: z.ZodOptional<z.ZodBoolean>;
-    timings: z.ZodOptional<z.ZodBoolean>;
-    builtAt: z.ZodOptional<z.ZodBoolean>;
-    moduleAssets: z.ZodOptional<z.ZodBoolean>;
-    nestedModules: z.ZodOptional<z.ZodBoolean>;
-    source: z.ZodOptional<z.ZodBoolean>;
-    logging: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["none", "error", "warn", "info", "log", "verbose"]>, z.ZodBoolean]>>;
-    loggingDebug: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>]>]>>;
-    loggingTrace: z.ZodOptional<z.ZodBoolean>;
-    runtimeModules: z.ZodOptional<z.ZodBoolean>;
-    children: z.ZodOptional<z.ZodBoolean>;
-    usedExports: z.ZodOptional<z.ZodBoolean>;
-    providedExports: z.ZodOptional<z.ZodBoolean>;
-    optimizationBailout: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByType: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByCacheStatus: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByLayer: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByAttributes: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByPath: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByExtension: z.ZodOptional<z.ZodBoolean>;
-    modulesSpace: z.ZodOptional<z.ZodNumber>;
-    chunkModulesSpace: z.ZodOptional<z.ZodNumber>;
-    nestedModulesSpace: z.ZodOptional<z.ZodNumber>;
-    relatedAssets: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByEmitStatus: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByInfo: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByPath: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByExtension: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByChunk: z.ZodOptional<z.ZodBoolean>;
-    assetsSpace: z.ZodOptional<z.ZodNumber>;
-    orphanModules: z.ZodOptional<z.ZodBoolean>;
-    excludeModules: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny, z.ZodAny], null>, z.ZodBoolean>]>, "many">, z.ZodString]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny, z.ZodAny], null>, z.ZodBoolean>]>, z.ZodBoolean]>>;
-    excludeAssets: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny], null>, z.ZodBoolean>]>, "many">, z.ZodString]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny], null>, z.ZodBoolean>]>>;
-    modulesSort: z.ZodOptional<z.ZodString>;
-    chunkModulesSort: z.ZodOptional<z.ZodString>;
-    nestedModulesSort: z.ZodOptional<z.ZodString>;
-    chunksSort: z.ZodOptional<z.ZodString>;
-    assetsSort: z.ZodOptional<z.ZodString>;
-    performance: z.ZodOptional<z.ZodBoolean>;
-    env: z.ZodOptional<z.ZodBoolean>;
-    chunkGroupAuxiliary: z.ZodOptional<z.ZodBoolean>;
-    chunkGroupChildren: z.ZodOptional<z.ZodBoolean>;
-    chunkGroupMaxAssets: z.ZodOptional<z.ZodNumber>;
-    dependentModules: z.ZodOptional<z.ZodBoolean>;
-    chunkOrigins: z.ZodOptional<z.ZodBoolean>;
-    runtime: z.ZodOptional<z.ZodBoolean>;
-    depth: z.ZodOptional<z.ZodBoolean>;
-    reasonsSpace: z.ZodOptional<z.ZodNumber>;
-    groupReasonsByOrigin: z.ZodOptional<z.ZodBoolean>;
-    errorDetails: z.ZodOptional<z.ZodBoolean>;
-    errorStack: z.ZodOptional<z.ZodBoolean>;
-    moduleTrace: z.ZodOptional<z.ZodBoolean>;
-    cachedModules: z.ZodOptional<z.ZodBoolean>;
-    cachedAssets: z.ZodOptional<z.ZodBoolean>;
-    cached: z.ZodOptional<z.ZodBoolean>;
-    errorsSpace: z.ZodOptional<z.ZodNumber>;
-    warningsSpace: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
-    source?: boolean | undefined;
-    publicPath?: boolean | undefined;
-    all?: boolean | undefined;
-    preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
-    assets?: boolean | undefined;
-    chunks?: boolean | undefined;
-    modules?: boolean | undefined;
-    entrypoints?: boolean | "auto" | undefined;
-    chunkGroups?: boolean | undefined;
-    warnings?: boolean | undefined;
-    warningsCount?: boolean | undefined;
-    errors?: boolean | undefined;
-    errorsCount?: boolean | undefined;
-    colors?: boolean | undefined;
-    hash?: boolean | undefined;
-    version?: boolean | undefined;
-    reasons?: boolean | undefined;
-    outputPath?: boolean | undefined;
-    chunkModules?: boolean | undefined;
-    chunkRelations?: boolean | undefined;
-    ids?: boolean | undefined;
-    timings?: boolean | undefined;
-    builtAt?: boolean | undefined;
-    moduleAssets?: boolean | undefined;
-    nestedModules?: boolean | undefined;
-    logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-    loggingTrace?: boolean | undefined;
-    runtimeModules?: boolean | undefined;
-    children?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
-    optimizationBailout?: boolean | undefined;
-    groupModulesByType?: boolean | undefined;
-    groupModulesByCacheStatus?: boolean | undefined;
-    groupModulesByLayer?: boolean | undefined;
-    groupModulesByAttributes?: boolean | undefined;
-    groupModulesByPath?: boolean | undefined;
-    groupModulesByExtension?: boolean | undefined;
-    modulesSpace?: number | undefined;
-    chunkModulesSpace?: number | undefined;
-    nestedModulesSpace?: number | undefined;
-    relatedAssets?: boolean | undefined;
-    groupAssetsByEmitStatus?: boolean | undefined;
-    groupAssetsByInfo?: boolean | undefined;
-    groupAssetsByPath?: boolean | undefined;
-    groupAssetsByExtension?: boolean | undefined;
-    groupAssetsByChunk?: boolean | undefined;
-    assetsSpace?: number | undefined;
-    orphanModules?: boolean | undefined;
-    excludeModules?: string | boolean | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean))[] | undefined;
-    excludeAssets?: string | RegExp | ((args_0: string, args_1: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any) => boolean))[] | undefined;
-    modulesSort?: string | undefined;
-    chunkModulesSort?: string | undefined;
-    nestedModulesSort?: string | undefined;
-    chunksSort?: string | undefined;
-    assetsSort?: string | undefined;
-    performance?: boolean | undefined;
-    env?: boolean | undefined;
-    chunkGroupAuxiliary?: boolean | undefined;
-    chunkGroupChildren?: boolean | undefined;
-    chunkGroupMaxAssets?: number | undefined;
-    dependentModules?: boolean | undefined;
-    chunkOrigins?: boolean | undefined;
-    runtime?: boolean | undefined;
-    depth?: boolean | undefined;
-    reasonsSpace?: number | undefined;
-    groupReasonsByOrigin?: boolean | undefined;
-    errorDetails?: boolean | undefined;
-    errorStack?: boolean | undefined;
-    moduleTrace?: boolean | undefined;
-    cachedModules?: boolean | undefined;
-    cachedAssets?: boolean | undefined;
-    cached?: boolean | undefined;
-    errorsSpace?: number | undefined;
-    warningsSpace?: number | undefined;
-}, {
-    source?: boolean | undefined;
-    publicPath?: boolean | undefined;
-    all?: boolean | undefined;
-    preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
-    assets?: boolean | undefined;
-    chunks?: boolean | undefined;
-    modules?: boolean | undefined;
-    entrypoints?: boolean | "auto" | undefined;
-    chunkGroups?: boolean | undefined;
-    warnings?: boolean | undefined;
-    warningsCount?: boolean | undefined;
-    errors?: boolean | undefined;
-    errorsCount?: boolean | undefined;
-    colors?: boolean | undefined;
-    hash?: boolean | undefined;
-    version?: boolean | undefined;
-    reasons?: boolean | undefined;
-    outputPath?: boolean | undefined;
-    chunkModules?: boolean | undefined;
-    chunkRelations?: boolean | undefined;
-    ids?: boolean | undefined;
-    timings?: boolean | undefined;
-    builtAt?: boolean | undefined;
-    moduleAssets?: boolean | undefined;
-    nestedModules?: boolean | undefined;
-    logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-    loggingTrace?: boolean | undefined;
-    runtimeModules?: boolean | undefined;
-    children?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
-    optimizationBailout?: boolean | undefined;
-    groupModulesByType?: boolean | undefined;
-    groupModulesByCacheStatus?: boolean | undefined;
-    groupModulesByLayer?: boolean | undefined;
-    groupModulesByAttributes?: boolean | undefined;
-    groupModulesByPath?: boolean | undefined;
-    groupModulesByExtension?: boolean | undefined;
-    modulesSpace?: number | undefined;
-    chunkModulesSpace?: number | undefined;
-    nestedModulesSpace?: number | undefined;
-    relatedAssets?: boolean | undefined;
-    groupAssetsByEmitStatus?: boolean | undefined;
-    groupAssetsByInfo?: boolean | undefined;
-    groupAssetsByPath?: boolean | undefined;
-    groupAssetsByExtension?: boolean | undefined;
-    groupAssetsByChunk?: boolean | undefined;
-    assetsSpace?: number | undefined;
-    orphanModules?: boolean | undefined;
-    excludeModules?: string | boolean | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean))[] | undefined;
-    excludeAssets?: string | RegExp | ((args_0: string, args_1: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any) => boolean))[] | undefined;
-    modulesSort?: string | undefined;
-    chunkModulesSort?: string | undefined;
-    nestedModulesSort?: string | undefined;
-    chunksSort?: string | undefined;
-    assetsSort?: string | undefined;
-    performance?: boolean | undefined;
-    env?: boolean | undefined;
-    chunkGroupAuxiliary?: boolean | undefined;
-    chunkGroupChildren?: boolean | undefined;
-    chunkGroupMaxAssets?: number | undefined;
-    dependentModules?: boolean | undefined;
-    chunkOrigins?: boolean | undefined;
-    runtime?: boolean | undefined;
-    depth?: boolean | undefined;
-    reasonsSpace?: number | undefined;
-    groupReasonsByOrigin?: boolean | undefined;
-    errorDetails?: boolean | undefined;
-    errorStack?: boolean | undefined;
-    moduleTrace?: boolean | undefined;
-    cachedModules?: boolean | undefined;
-    cachedAssets?: boolean | undefined;
-    cached?: boolean | undefined;
-    errorsSpace?: number | undefined;
-    warningsSpace?: number | undefined;
-}>;
+// @public
+export type StatsOptions = {
+    all?: boolean;
+    preset?: boolean | StatsPresets;
+    assets?: boolean;
+    chunks?: boolean;
+    modules?: boolean;
+    entrypoints?: boolean | "auto";
+    chunkGroups?: boolean;
+    warnings?: boolean;
+    warningsCount?: boolean;
+    errors?: boolean;
+    errorsCount?: boolean;
+    colors?: boolean;
+    hash?: boolean;
+    version?: boolean;
+    reasons?: boolean;
+    publicPath?: boolean;
+    outputPath?: boolean;
+    chunkModules?: boolean;
+    chunkRelations?: boolean;
+    ids?: boolean;
+    timings?: boolean;
+    builtAt?: boolean;
+    moduleAssets?: boolean;
+    nestedModules?: boolean;
+    source?: boolean;
+    logging?: "none" | "error" | "warn" | "info" | "log" | "verbose" | boolean;
+    loggingDebug?: boolean | FilterTypes;
+    loggingTrace?: boolean;
+    runtimeModules?: boolean;
+    children?: boolean;
+    usedExports?: boolean;
+    providedExports?: boolean;
+    optimizationBailout?: boolean;
+    groupModulesByType?: boolean;
+    groupModulesByCacheStatus?: boolean;
+    groupModulesByLayer?: boolean;
+    groupModulesByAttributes?: boolean;
+    groupModulesByPath?: boolean;
+    groupModulesByExtension?: boolean;
+    modulesSpace?: number;
+    chunkModulesSpace?: number;
+    nestedModulesSpace?: number;
+    relatedAssets?: boolean;
+    groupAssetsByEmitStatus?: boolean;
+    groupAssetsByInfo?: boolean;
+    groupAssetsByPath?: boolean;
+    groupAssetsByExtension?: boolean;
+    groupAssetsByChunk?: boolean;
+    assetsSpace?: number;
+    orphanModules?: boolean;
+    excludeModules?: ModuleFilterTypes;
+    excludeAssets?: ModuleFilterTypes;
+    modulesSort?: string;
+    chunkModulesSort?: string;
+    nestedModulesSort?: string;
+    chunksSort?: string;
+    assetsSort?: string;
+    performance?: boolean;
+    env?: boolean;
+    chunkGroupAuxiliary?: boolean;
+    chunkGroupChildren?: boolean;
+    chunkGroupMaxAssets?: number;
+    dependentModules?: boolean;
+    chunkOrigins?: boolean;
+    runtime?: boolean;
+    depth?: boolean;
+    reasonsSpace?: number;
+    groupReasonsByOrigin?: boolean;
+    errorDetails?: boolean;
+    errorStack?: boolean;
+    moduleTrace?: boolean;
+    cachedModules?: boolean;
+    cachedAssets?: boolean;
+    cached?: boolean;
+    errorsSpace?: number;
+    warningsSpace?: number;
+};
 
 // @public (undocumented)
 type StatsOrBigIntStatsCallback = (err: NodeJS.ErrnoException | null, stats?: IStats | IBigIntStats) => void;
+
+// @public (undocumented)
+type StatsPresets = "normal" | "none" | "verbose" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary";
 
 // @public (undocumented)
 class StatsPrinter {
@@ -10215,242 +9787,8 @@ type StatsPrinterContext = KnownStatsPrinterContext & Record<string, any>;
 // @public (undocumented)
 type StatsProfile = KnownStatsProfile & Record<string, any>;
 
-// @public (undocumented)
-export type StatsValue = z.infer<typeof statsValue>;
-
-// @public (undocumented)
-const statsValue: z.ZodUnion<[z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>, z.ZodObject<{
-    all: z.ZodOptional<z.ZodBoolean>;
-    preset: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodEnum<["normal", "none", "verbose", "errors-only", "errors-warnings", "minimal", "detailed", "summary"]>]>>;
-    assets: z.ZodOptional<z.ZodBoolean>;
-    chunks: z.ZodOptional<z.ZodBoolean>;
-    modules: z.ZodOptional<z.ZodBoolean>;
-    entrypoints: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodLiteral<"auto">]>>;
-    chunkGroups: z.ZodOptional<z.ZodBoolean>;
-    warnings: z.ZodOptional<z.ZodBoolean>;
-    warningsCount: z.ZodOptional<z.ZodBoolean>;
-    errors: z.ZodOptional<z.ZodBoolean>;
-    errorsCount: z.ZodOptional<z.ZodBoolean>;
-    colors: z.ZodOptional<z.ZodBoolean>;
-    hash: z.ZodOptional<z.ZodBoolean>;
-    version: z.ZodOptional<z.ZodBoolean>;
-    reasons: z.ZodOptional<z.ZodBoolean>;
-    publicPath: z.ZodOptional<z.ZodBoolean>;
-    outputPath: z.ZodOptional<z.ZodBoolean>;
-    chunkModules: z.ZodOptional<z.ZodBoolean>;
-    chunkRelations: z.ZodOptional<z.ZodBoolean>;
-    ids: z.ZodOptional<z.ZodBoolean>;
-    timings: z.ZodOptional<z.ZodBoolean>;
-    builtAt: z.ZodOptional<z.ZodBoolean>;
-    moduleAssets: z.ZodOptional<z.ZodBoolean>;
-    nestedModules: z.ZodOptional<z.ZodBoolean>;
-    source: z.ZodOptional<z.ZodBoolean>;
-    logging: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["none", "error", "warn", "info", "log", "verbose"]>, z.ZodBoolean]>>;
-    loggingDebug: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodString]>, z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>]>]>]>>;
-    loggingTrace: z.ZodOptional<z.ZodBoolean>;
-    runtimeModules: z.ZodOptional<z.ZodBoolean>;
-    children: z.ZodOptional<z.ZodBoolean>;
-    usedExports: z.ZodOptional<z.ZodBoolean>;
-    providedExports: z.ZodOptional<z.ZodBoolean>;
-    optimizationBailout: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByType: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByCacheStatus: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByLayer: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByAttributes: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByPath: z.ZodOptional<z.ZodBoolean>;
-    groupModulesByExtension: z.ZodOptional<z.ZodBoolean>;
-    modulesSpace: z.ZodOptional<z.ZodNumber>;
-    chunkModulesSpace: z.ZodOptional<z.ZodNumber>;
-    nestedModulesSpace: z.ZodOptional<z.ZodNumber>;
-    relatedAssets: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByEmitStatus: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByInfo: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByPath: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByExtension: z.ZodOptional<z.ZodBoolean>;
-    groupAssetsByChunk: z.ZodOptional<z.ZodBoolean>;
-    assetsSpace: z.ZodOptional<z.ZodNumber>;
-    orphanModules: z.ZodOptional<z.ZodBoolean>;
-    excludeModules: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny, z.ZodAny], null>, z.ZodBoolean>]>, "many">, z.ZodString]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny, z.ZodAny], null>, z.ZodBoolean>]>, z.ZodBoolean]>>;
-    excludeAssets: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny], null>, z.ZodBoolean>]>, "many">, z.ZodString]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodString, z.ZodAny], null>, z.ZodBoolean>]>>;
-    modulesSort: z.ZodOptional<z.ZodString>;
-    chunkModulesSort: z.ZodOptional<z.ZodString>;
-    nestedModulesSort: z.ZodOptional<z.ZodString>;
-    chunksSort: z.ZodOptional<z.ZodString>;
-    assetsSort: z.ZodOptional<z.ZodString>;
-    performance: z.ZodOptional<z.ZodBoolean>;
-    env: z.ZodOptional<z.ZodBoolean>;
-    chunkGroupAuxiliary: z.ZodOptional<z.ZodBoolean>;
-    chunkGroupChildren: z.ZodOptional<z.ZodBoolean>;
-    chunkGroupMaxAssets: z.ZodOptional<z.ZodNumber>;
-    dependentModules: z.ZodOptional<z.ZodBoolean>;
-    chunkOrigins: z.ZodOptional<z.ZodBoolean>;
-    runtime: z.ZodOptional<z.ZodBoolean>;
-    depth: z.ZodOptional<z.ZodBoolean>;
-    reasonsSpace: z.ZodOptional<z.ZodNumber>;
-    groupReasonsByOrigin: z.ZodOptional<z.ZodBoolean>;
-    errorDetails: z.ZodOptional<z.ZodBoolean>;
-    errorStack: z.ZodOptional<z.ZodBoolean>;
-    moduleTrace: z.ZodOptional<z.ZodBoolean>;
-    cachedModules: z.ZodOptional<z.ZodBoolean>;
-    cachedAssets: z.ZodOptional<z.ZodBoolean>;
-    cached: z.ZodOptional<z.ZodBoolean>;
-    errorsSpace: z.ZodOptional<z.ZodNumber>;
-    warningsSpace: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
-    source?: boolean | undefined;
-    publicPath?: boolean | undefined;
-    all?: boolean | undefined;
-    preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
-    assets?: boolean | undefined;
-    chunks?: boolean | undefined;
-    modules?: boolean | undefined;
-    entrypoints?: boolean | "auto" | undefined;
-    chunkGroups?: boolean | undefined;
-    warnings?: boolean | undefined;
-    warningsCount?: boolean | undefined;
-    errors?: boolean | undefined;
-    errorsCount?: boolean | undefined;
-    colors?: boolean | undefined;
-    hash?: boolean | undefined;
-    version?: boolean | undefined;
-    reasons?: boolean | undefined;
-    outputPath?: boolean | undefined;
-    chunkModules?: boolean | undefined;
-    chunkRelations?: boolean | undefined;
-    ids?: boolean | undefined;
-    timings?: boolean | undefined;
-    builtAt?: boolean | undefined;
-    moduleAssets?: boolean | undefined;
-    nestedModules?: boolean | undefined;
-    logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-    loggingTrace?: boolean | undefined;
-    runtimeModules?: boolean | undefined;
-    children?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
-    optimizationBailout?: boolean | undefined;
-    groupModulesByType?: boolean | undefined;
-    groupModulesByCacheStatus?: boolean | undefined;
-    groupModulesByLayer?: boolean | undefined;
-    groupModulesByAttributes?: boolean | undefined;
-    groupModulesByPath?: boolean | undefined;
-    groupModulesByExtension?: boolean | undefined;
-    modulesSpace?: number | undefined;
-    chunkModulesSpace?: number | undefined;
-    nestedModulesSpace?: number | undefined;
-    relatedAssets?: boolean | undefined;
-    groupAssetsByEmitStatus?: boolean | undefined;
-    groupAssetsByInfo?: boolean | undefined;
-    groupAssetsByPath?: boolean | undefined;
-    groupAssetsByExtension?: boolean | undefined;
-    groupAssetsByChunk?: boolean | undefined;
-    assetsSpace?: number | undefined;
-    orphanModules?: boolean | undefined;
-    excludeModules?: string | boolean | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean))[] | undefined;
-    excludeAssets?: string | RegExp | ((args_0: string, args_1: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any) => boolean))[] | undefined;
-    modulesSort?: string | undefined;
-    chunkModulesSort?: string | undefined;
-    nestedModulesSort?: string | undefined;
-    chunksSort?: string | undefined;
-    assetsSort?: string | undefined;
-    performance?: boolean | undefined;
-    env?: boolean | undefined;
-    chunkGroupAuxiliary?: boolean | undefined;
-    chunkGroupChildren?: boolean | undefined;
-    chunkGroupMaxAssets?: number | undefined;
-    dependentModules?: boolean | undefined;
-    chunkOrigins?: boolean | undefined;
-    runtime?: boolean | undefined;
-    depth?: boolean | undefined;
-    reasonsSpace?: number | undefined;
-    groupReasonsByOrigin?: boolean | undefined;
-    errorDetails?: boolean | undefined;
-    errorStack?: boolean | undefined;
-    moduleTrace?: boolean | undefined;
-    cachedModules?: boolean | undefined;
-    cachedAssets?: boolean | undefined;
-    cached?: boolean | undefined;
-    errorsSpace?: number | undefined;
-    warningsSpace?: number | undefined;
-}, {
-    source?: boolean | undefined;
-    publicPath?: boolean | undefined;
-    all?: boolean | undefined;
-    preset?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | undefined;
-    assets?: boolean | undefined;
-    chunks?: boolean | undefined;
-    modules?: boolean | undefined;
-    entrypoints?: boolean | "auto" | undefined;
-    chunkGroups?: boolean | undefined;
-    warnings?: boolean | undefined;
-    warningsCount?: boolean | undefined;
-    errors?: boolean | undefined;
-    errorsCount?: boolean | undefined;
-    colors?: boolean | undefined;
-    hash?: boolean | undefined;
-    version?: boolean | undefined;
-    reasons?: boolean | undefined;
-    outputPath?: boolean | undefined;
-    chunkModules?: boolean | undefined;
-    chunkRelations?: boolean | undefined;
-    ids?: boolean | undefined;
-    timings?: boolean | undefined;
-    builtAt?: boolean | undefined;
-    moduleAssets?: boolean | undefined;
-    nestedModules?: boolean | undefined;
-    logging?: boolean | "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-    loggingDebug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-    loggingTrace?: boolean | undefined;
-    runtimeModules?: boolean | undefined;
-    children?: boolean | undefined;
-    usedExports?: boolean | undefined;
-    providedExports?: boolean | undefined;
-    optimizationBailout?: boolean | undefined;
-    groupModulesByType?: boolean | undefined;
-    groupModulesByCacheStatus?: boolean | undefined;
-    groupModulesByLayer?: boolean | undefined;
-    groupModulesByAttributes?: boolean | undefined;
-    groupModulesByPath?: boolean | undefined;
-    groupModulesByExtension?: boolean | undefined;
-    modulesSpace?: number | undefined;
-    chunkModulesSpace?: number | undefined;
-    nestedModulesSpace?: number | undefined;
-    relatedAssets?: boolean | undefined;
-    groupAssetsByEmitStatus?: boolean | undefined;
-    groupAssetsByInfo?: boolean | undefined;
-    groupAssetsByPath?: boolean | undefined;
-    groupAssetsByExtension?: boolean | undefined;
-    groupAssetsByChunk?: boolean | undefined;
-    assetsSpace?: number | undefined;
-    orphanModules?: boolean | undefined;
-    excludeModules?: string | boolean | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any, args_2: any) => boolean))[] | undefined;
-    excludeAssets?: string | RegExp | ((args_0: string, args_1: any) => boolean) | (string | RegExp | ((args_0: string, args_1: any) => boolean))[] | undefined;
-    modulesSort?: string | undefined;
-    chunkModulesSort?: string | undefined;
-    nestedModulesSort?: string | undefined;
-    chunksSort?: string | undefined;
-    assetsSort?: string | undefined;
-    performance?: boolean | undefined;
-    env?: boolean | undefined;
-    chunkGroupAuxiliary?: boolean | undefined;
-    chunkGroupChildren?: boolean | undefined;
-    chunkGroupMaxAssets?: number | undefined;
-    dependentModules?: boolean | undefined;
-    chunkOrigins?: boolean | undefined;
-    runtime?: boolean | undefined;
-    depth?: boolean | undefined;
-    reasonsSpace?: number | undefined;
-    groupReasonsByOrigin?: boolean | undefined;
-    errorDetails?: boolean | undefined;
-    errorStack?: boolean | undefined;
-    moduleTrace?: boolean | undefined;
-    cachedModules?: boolean | undefined;
-    cachedAssets?: boolean | undefined;
-    cached?: boolean | undefined;
-    errorsSpace?: number | undefined;
-    warningsSpace?: number | undefined;
-}>]>;
+// @public
+export type StatsValue = boolean | StatsOptions | StatsPresets;
 
 // @public (undocumented)
 type StatSync = {
@@ -10743,7 +10081,7 @@ declare namespace t {
         AssetGeneratorDataUrlOptions,
         AssetGeneratorDataUrlFunction,
         AssetGeneratorDataUrl,
-        AssetInlineGeneratorOptions_2 as AssetInlineGeneratorOptions,
+        AssetInlineGeneratorOptions,
         AssetResourceGeneratorOptions,
         AssetGeneratorOptions,
         CssGeneratorExportsConvention,
@@ -10753,7 +10091,7 @@ declare namespace t {
         CssGeneratorOptions,
         CssAutoGeneratorOptions,
         CssModuleGeneratorOptions,
-        GeneratorOptionsByModuleTypeKnown_2 as GeneratorOptionsByModuleTypeKnown,
+        GeneratorOptionsByModuleTypeKnown,
         GeneratorOptionsByModuleTypeUnknown,
         GeneratorOptionsByModuleType,
         NoParseOption,
@@ -10769,12 +10107,14 @@ declare namespace t {
         FilterItemTypes,
         FilterTypes,
         InfrastructureLogging,
-        DevTool_2 as DevTool,
+        DevTool,
         NodeOptions,
         Node_2 as Node,
         Loader,
         SnapshotOptions,
         CacheOptions,
+        StatsOptions,
+        StatsValue,
         RspackPluginInstance,
         RspackPluginFunction,
         WebpackCompiler,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1544,7 +1544,408 @@ export type SnapshotOptions = {};
  * cache: false
  */
 export type CacheOptions = boolean;
-//#endreigon
+//#endregion
+
+//#region Stats
+
+type StatsPresets =
+	| "normal"
+	| "none"
+	| "verbose"
+	| "errors-only"
+	| "errors-warnings"
+	| "minimal"
+	| "detailed"
+	| "summary";
+
+type ModuleFilterItemTypes =
+	| RegExp
+	| string
+	| ((name: string, module: any, type: any) => boolean);
+
+type ModuleFilterTypes =
+	| boolean
+	| ModuleFilterItemTypes
+	| ModuleFilterItemTypes[];
+
+/** Options for stats */
+export type StatsOptions = {
+	/**
+	 * Enables or disables the display of all stats.
+	 */
+	all?: boolean;
+	/**
+	 * Sets the preset for stats or enables/disables them.
+	 */
+	preset?: boolean | StatsPresets;
+	/**
+	 * Enables or disables the display of asset stats.
+	 * @default true
+	 */
+	assets?: boolean;
+	/**
+	 * Enables or disables the display of chunk stats.
+	 * @default true
+	 */
+	chunks?: boolean;
+	/**
+	 * Enables or disables the display of module stats.
+	 * @default true
+	 */
+	modules?: boolean;
+	/**
+	 * Enables or disables the display of entrypoint stats or sets it to 'auto'.
+	 * @default false
+	 */
+	entrypoints?: boolean | "auto";
+	/**
+	 * Enables or disables the display of chunk group stats.
+	 * @default true
+	 */
+	chunkGroups?: boolean;
+	/**
+	 * Enables or disables the display of warning stats.
+	 * @default true
+	 */
+	warnings?: boolean;
+	/**
+	 * Enables or disables the display of warning counts.
+	 * @default true
+	 */
+	warningsCount?: boolean;
+	/**
+	 * Enables or disables the display of error stats.
+	 * @default true
+	 */
+	errors?: boolean;
+	/**
+	 * Enables or disables the display of error counts.
+	 * @default true
+	 */
+	errorsCount?: boolean;
+	/**
+	 * Enables or disables the use of colors in the output.
+	 * @default false
+	 */
+	colors?: boolean;
+	/**
+	 * Enables or disables the display of the hash.
+	 * @default true
+	 */
+	hash?: boolean;
+	/**
+	 * Enables or disables the display of the version.
+	 * @default true
+	 */
+	version?: boolean;
+	/**
+	 * Enables or disables the display of reasons.
+	 * @default true
+	 */
+	reasons?: boolean;
+	/**
+	 * Enables or disables the display of the public path.
+	 * @default true
+	 */
+	publicPath?: boolean;
+	/**
+	 * Enables or disables the display of the output path.
+	 * @default true
+	 */
+	outputPath?: boolean;
+	/**
+	 * Enables or disables the display of chunk module stats.
+	 * @default true
+	 */
+	chunkModules?: boolean;
+	/**
+	 * Enables or disables the display of chunk relations.
+	 * @default false
+	 */
+	chunkRelations?: boolean;
+	/**
+	 * Enables or disables the display of module IDs.
+	 * @default false
+	 */
+	ids?: boolean;
+	/**
+	 * Enables or disables the display of build timings.
+	 * @default true
+	 */
+	timings?: boolean;
+	/**
+	 * Enables or disables the display of the build date.
+	 * @default true
+	 */
+	builtAt?: boolean;
+	/**
+	 * Enables or disables the display of module assets.
+	 * @default true
+	 */
+	moduleAssets?: boolean;
+	/**
+	 * Enables or disables the display of nested modules.
+	 * @default true
+	 */
+	nestedModules?: boolean;
+	/**
+	 * Enables or disables the display of source code.
+	 * @default false
+	 */
+	source?: boolean;
+	/**
+	 * Configures the level of logging output.
+	 * Can be set to a string value of "none", "error", "warn", "info", "log", "verbose", or a boolean value.
+	 *
+	 * @description
+	 * - `'none'`, false: Logging is disabled.
+	 * - `'error'`: Only errors are logged.
+	 * - `'warn'`: Errors and warnings are logged.
+	 * - `'info'`: Errors, warnings, and info messages are logged.
+	 * - `'log'`, true: Errors, warnings, info messages, log messages, groups, and clears are logged. Collapsed groups are initially collapsed.
+	 * - `'verbose'`: All log levels except debug and trace are logged. Collapsed groups are initially expanded.
+	 */
+	logging?: "none" | "error" | "warn" | "info" | "log" | "verbose" | boolean;
+	/**
+	 * Enables or disables debug logging, or specifies a filter for debug logging.
+	 */
+	loggingDebug?: boolean | FilterTypes;
+	/**
+	 * Enables or disables trace logging.
+	 * @default true
+	 */
+	loggingTrace?: boolean;
+	/**
+	 * Enables or disables the display of runtime modules.
+	 * @default true
+	 */
+	runtimeModules?: boolean;
+	/**
+	 * Enables or disables the display of children modules.
+	 * @default true
+	 */
+	children?: boolean;
+	/**
+	 * Enables or disables the display of used exports.
+	 * @default false
+	 */
+	usedExports?: boolean;
+	/**
+	 * Enables or disables the display of provided exports.
+	 * @default false
+	 */
+	providedExports?: boolean;
+	/**
+	 * Enables or disables optimization bailout.
+	 * @default false
+	 */
+	optimizationBailout?: boolean;
+	/**
+	 * Enables or disables grouping of modules by type.
+	 */
+	groupModulesByType?: boolean;
+	/**
+	 * Enables or disables grouping of modules by cache status.
+	 */
+	groupModulesByCacheStatus?: boolean;
+	/**
+	 * Enables or disables grouping of modules by layer.
+	 */
+	groupModulesByLayer?: boolean;
+	/**
+	 * Enables or disables grouping of modules by attributes.
+	 */
+	groupModulesByAttributes?: boolean;
+	/**
+	 * Enables or disables grouping of modules by path.
+	 */
+	groupModulesByPath?: boolean;
+	/**
+	 * Enables or disables grouping of modules by extension.
+	 */
+	groupModulesByExtension?: boolean;
+	/**
+	 * Specifies the space to use for displaying modules.
+	 * @default 15
+	 */
+	modulesSpace?: number;
+	/**
+	 * Specifies the space to use for displaying chunk modules.
+	 * @default 10
+	 */
+	chunkModulesSpace?: number;
+	/**
+	 * Specifies the space to use for displaying nested modules.
+	 * @default 10
+	 */
+	nestedModulesSpace?: number;
+	/**
+	 * Enables or disables the display of related assets.
+	 * @default false
+	 */
+	relatedAssets?: boolean;
+	/**
+	 * Enables or disables grouping of assets by emit status.
+	 */
+	groupAssetsByEmitStatus?: boolean;
+	/**
+	 * Enables or disables grouping of assets by info.
+	 */
+	groupAssetsByInfo?: boolean;
+	/**
+	 * Enables or disables grouping of assets by path.
+	 */
+	groupAssetsByPath?: boolean;
+	/**
+	 * Enables or disables grouping of assets by extension.
+	 */
+	groupAssetsByExtension?: boolean;
+	/**
+	 * Enables or disables grouping of assets by chunk.
+	 */
+	groupAssetsByChunk?: boolean;
+	/**
+	 * Specifies the space to use for displaying assets.
+	 * @default 15
+	 */
+	assetsSpace?: number;
+	/**
+	 * Enables or disables the display of orphan modules.
+	 * @default false
+	 */
+	orphanModules?: boolean;
+	/**
+	 * Specifies modules to exclude from the bundle.
+	 * @default false
+	 */
+	excludeModules?: ModuleFilterTypes;
+	/**
+	 * Exclude the matching assets information.
+	 * @default false
+	 */
+	excludeAssets?: ModuleFilterTypes;
+	/**
+	 * Specifies the sorting order for modules.
+	 * @default 'id'
+	 */
+	modulesSort?: string;
+	/**
+	 * Specifies the sorting order for chunk modules.
+	 */
+	chunkModulesSort?: string;
+	/**
+	 * Specifies the sorting order for nested modules.
+	 */
+	nestedModulesSort?: string;
+	/**
+	 * Specifies the sorting order for chunks.
+	 * @default 'id'
+	 */
+	chunksSort?: string;
+	/**
+	 * Specifies the sorting order for assets.
+	 * @default 'id'
+	 */
+	assetsSort?: string;
+	/**
+	 * Enables or disables performance optimization.
+	 * @default true
+	 */
+	performance?: boolean;
+	/**
+	 * Enables or disables environment variables.
+	 * @default false
+	 */
+	env?: boolean;
+	/**
+	 * Enables or disables auxiliary chunk grouping.
+	 * @default true
+	 */
+	chunkGroupAuxiliary?: boolean;
+	/**
+	 * Enables or disables child chunk grouping.
+	 * @default true
+	 */
+	chunkGroupChildren?: boolean;
+	/**
+	 * Specifies the maximum number of assets per chunk group.
+	 * @default 5
+	 */
+	chunkGroupMaxAssets?: number;
+	/**
+	 * Enables or disables the display of dependent modules.
+	 * @default false
+	 */
+	dependentModules?: boolean;
+	/**
+	 * Enables or disables the display of chunk origins.
+	 * @default true
+	 */
+	chunkOrigins?: boolean;
+	/**
+	 * Enables or disables the display of runtime information.
+	 */
+	runtime?: boolean;
+	/**
+	 * Enables or disables the display of depth information.
+	 * @default false
+	 */
+	depth?: boolean;
+	/**
+	 * Specifies the space to use for displaying reasons.
+	 * @default 100
+	 */
+	reasonsSpace?: number;
+	/**
+	 * Enables or disables grouping of reasons by origin.
+	 */
+	groupReasonsByOrigin?: boolean;
+	/**
+	 * Enables or disables the display of error details.
+	 * @default false
+	 */
+	errorDetails?: boolean;
+	/**
+	 * Enables or disables the display of error stack traces.
+	 * @default true
+	 */
+	errorStack?: boolean;
+	/**
+	 * Enables or disables the display of module trace information.
+	 * @default true
+	 */
+	moduleTrace?: boolean;
+	/**
+	 * Enables or disables the display of cached modules.
+	 * @default true
+	 */
+	cachedModules?: boolean;
+	/**
+	 * Enables or disables the display of cached assets.
+	 * @default true
+	 */
+	cachedAssets?: boolean;
+	/**
+	 * Enables or disables the display of cached information.
+	 */
+	cached?: boolean;
+	/**
+	 * Specifies the space to use for displaying errors.
+	 * @default 5
+	 */
+	errorsSpace?: number;
+	/**
+	 * Specifies the space to use for displaying warnings.
+	 * @default 5
+	 */
+	warningsSpace?: number;
+};
+
+/**
+ * Represents the value for stats configuration.
+ */
+export type StatsValue = boolean | StatsOptions | StatsPresets;
+//#endregion
 
 //#region Plugins
 export interface RspackPluginInstance {

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -606,9 +606,6 @@ const assetGeneratorDataUrl = assetGeneratorDataUrlOptions.or(
 const assetInlineGeneratorOptions = z.strictObject({
 	dataUrl: assetGeneratorDataUrl.optional()
 }) satisfies z.ZodType<t.AssetInlineGeneratorOptions>;
-export type AssetInlineGeneratorOptions = z.infer<
-	typeof assetInlineGeneratorOptions
->;
 
 const assetResourceGeneratorOptions = z.strictObject({
 	emit: z.boolean().optional(),
@@ -664,9 +661,6 @@ const generatorOptionsByModuleTypeKnown = z.strictObject({
 	"css/auto": cssAutoGeneratorOptions.optional(),
 	"css/module": cssModuleGeneratorOptions.optional()
 }) satisfies z.ZodType<t.GeneratorOptionsByModuleTypeKnown>;
-export type GeneratorOptionsByModuleTypeKnown = z.infer<
-	typeof generatorOptionsByModuleTypeKnown
->;
 
 const generatorOptionsByModuleTypeUnknown = z.record(
 	z.record(z.any())
@@ -922,7 +916,6 @@ const devTool = z
 			"eval-nosources-source-map"
 		])
 	) satisfies z.ZodType<t.DevTool>;
-export type DevTool = z.infer<typeof devTool>;
 //#endregion
 
 //#region Node
@@ -1065,11 +1058,12 @@ const statsOptions = z.strictObject({
 	cached: z.boolean().optional(),
 	errorsSpace: z.number().optional(),
 	warningsSpace: z.number().optional()
-});
-export type StatsOptions = z.infer<typeof statsOptions>;
+}) satisfies z.ZodType<t.StatsOptions>;
 
-const statsValue = z.boolean().or(statsPresets).or(statsOptions);
-export type StatsValue = z.infer<typeof statsValue>;
+const statsValue = z
+	.boolean()
+	.or(statsPresets)
+	.or(statsOptions) satisfies z.ZodType<t.StatsValue>;
 //#endregion
 
 //#region Plugins


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.stats

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
