### PR TITLE
fix: temporarily use `lightingcss_rs` to fix CSS property order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,10 +2085,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightningcss"
-version = "1.0.0-alpha.58"
+name = "lightningcss-derive"
+version = "1.0.0-alpha.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec380ca49dc7f6a1cafbdd2de5e587958eac0f67ab26b1e56727fcc60a0c3d4d"
+checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "lightningcss_rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbdc3e38585310266a8e8c9e9e7c216fe710fdcee84cd154a6655f58fa77ffe2"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.5.0",
@@ -2110,18 +2122,6 @@ dependencies = [
  "serde",
  "smallvec",
  "static-self",
-]
-
-[[package]]
-name = "lightningcss-derive"
-version = "1.0.0-alpha.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12744d1279367caed41739ef094c325d53fb0ffcd4f9b84a368796f870252"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2625,9 +2625,9 @@ checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "parcel_selectors"
-version = "0.26.6"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512215cb1d3814e276ace4ec2dbc2cac16726ea3fcac20c22ae1197e16fdd72d"
+checksum = "1f4d26c18a8377a64728c04bf3b2e48ec43b0c77e687a18e03eb837d65e08a14"
 dependencies = [
  "bitflags 2.5.0",
  "cssparser",
@@ -3587,7 +3587,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "derivative",
- "lightningcss",
+ "lightningcss_rs",
  "parcel_sourcemap",
  "rspack_core",
  "rspack_error",
@@ -4103,7 +4103,7 @@ dependencies = [
 name = "rspack_plugin_lightning_css_minimizer"
 version = "0.1.0"
 dependencies = [
- "lightningcss",
+ "lightningcss_rs",
  "parcel_sourcemap",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ indexmap           = { version = "2.2.6" }
 indoc              = { version = "2.0.5" }
 itertools          = { version = "0.13.0" }
 json               = { version = "0.12.4" }
-lightningcss       = { version = "1.0.0-alpha.58" }
+lightningcss_rs    = { version = "0.1.0" }
 linked_hash_set    = { version = "0.1.4" }
 mimalloc           = { version = "0.1.43" }
 mime_guess         = { version = "2.0.4" }

--- a/crates/rspack_loader_lightningcss/Cargo.toml
+++ b/crates/rspack_loader_lightningcss/Cargo.toml
@@ -10,7 +10,7 @@ version     = "0.1.0"
 [dependencies]
 async-trait          = { workspace = true }
 derivative           = { workspace = true }
-lightningcss         = { workspace = true, features = ["sourcemap", "browserslist", "visitor", "into_owned"] }
+lightningcss_rs      = { workspace = true, features = ["sourcemap", "browserslist", "visitor", "into_owned"] }
 parcel_sourcemap     = { workspace = true }
 rspack_core          = { version = "0.1.0", path = "../rspack_core" }
 rspack_error         = { version = "0.1.0", path = "../rspack_error" }

--- a/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
+++ b/crates/rspack_plugin_lightning_css_minimizer/Cargo.toml
@@ -8,7 +8,7 @@ version     = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightningcss     = { workspace = true, features = ["sourcemap", "browserslist"] }
+lightningcss_rs  = { workspace = true, features = ["sourcemap", "browserslist"] }
 parcel_sourcemap = { workspace = true }
 rayon            = { workspace = true }
 regex            = { workspace = true }


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Lightincss have a bug about minimizing CSS may shuffle the CSS property order.

The css code: 
```css
.foo { 
   height: auto; 
   height: calc(100vh - var(--header-height, 0rem)); 
}
```
After lightningcss minify, css code would like this
```css
.foo { 
   height: calc(100vh - var(--header-height, 0rem)); 
   height: auto; 
}
```

care the lightingcss publish cycle. we publish a new crate named `lightingcss_rs`;

So we update lightingcss to lightingcss_rs for fix this issues https://github.com/web-infra-dev/rspack/issues/7921

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
