### PR TITLE
refactor: add JSDoc to improve config.experiments types

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1677,8 +1677,18 @@ interface ExecuteModuleContext {
     __webpack_require__: (id: string) => any;
 }
 
-// @public (undocumented)
-export type Experiments = z.infer<typeof experiments_2>;
+// @public
+export type Experiments = {
+    lazyCompilation?: boolean | LazyCompilationOptions;
+    asyncWebAssembly?: boolean;
+    outputModule?: boolean;
+    topLevelAwait?: boolean;
+    css?: boolean;
+    layers?: boolean;
+    incremental?: boolean | Incremental;
+    futureDefaults?: boolean;
+    rspackFuture?: RspackFutureOptions;
+};
 
 // @public (undocumented)
 export const experiments: Experiments_2;
@@ -1691,256 +1701,6 @@ interface Experiments_2 {
         cleanup: typeof cleanupGlobalTrace;
     };
 }
-
-// @public (undocumented)
-const experiments_2: z.ZodObject<{
-    lazyCompilation: z.ZodUnion<[z.ZodOptional<z.ZodBoolean>, z.ZodObject<{
-        backend: z.ZodOptional<z.ZodObject<{
-            client: z.ZodOptional<z.ZodString>;
-            listen: z.ZodUnion<[z.ZodOptional<z.ZodNumber>, z.ZodObject<{
-                port: z.ZodOptional<z.ZodNumber>;
-                host: z.ZodOptional<z.ZodString>;
-                backlog: z.ZodOptional<z.ZodNumber>;
-                path: z.ZodOptional<z.ZodString>;
-                exclusive: z.ZodOptional<z.ZodBoolean>;
-                readableAll: z.ZodOptional<z.ZodBoolean>;
-                writableAll: z.ZodOptional<z.ZodBoolean>;
-                ipv6Only: z.ZodOptional<z.ZodBoolean>;
-            }, "strip", z.ZodTypeAny, {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            }, {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            }>]>;
-            protocol: z.ZodOptional<z.ZodEnum<["http", "https"]>>;
-        }, "strip", z.ZodTypeAny, {
-            client?: string | undefined;
-            listen?: number | {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            } | undefined;
-            protocol?: "http" | "https" | undefined;
-        }, {
-            client?: string | undefined;
-            listen?: number | {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            } | undefined;
-            protocol?: "http" | "https" | undefined;
-        }>>;
-        imports: z.ZodOptional<z.ZodBoolean>;
-        entries: z.ZodOptional<z.ZodBoolean>;
-        test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
-    }, "strip", z.ZodTypeAny, {
-        entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-        backend?: {
-            client?: string | undefined;
-            listen?: number | {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            } | undefined;
-            protocol?: "http" | "https" | undefined;
-        } | undefined;
-        imports?: boolean | undefined;
-    }, {
-        entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-        backend?: {
-            client?: string | undefined;
-            listen?: number | {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            } | undefined;
-            protocol?: "http" | "https" | undefined;
-        } | undefined;
-        imports?: boolean | undefined;
-    }>]>;
-    asyncWebAssembly: z.ZodOptional<z.ZodBoolean>;
-    outputModule: z.ZodOptional<z.ZodBoolean>;
-    topLevelAwait: z.ZodOptional<z.ZodBoolean>;
-    css: z.ZodOptional<z.ZodBoolean>;
-    layers: z.ZodOptional<z.ZodBoolean>;
-    incremental: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodObject<{
-        make: z.ZodOptional<z.ZodBoolean>;
-        emitAssets: z.ZodOptional<z.ZodBoolean>;
-        inferAsyncModules: z.ZodOptional<z.ZodBoolean>;
-        providedExports: z.ZodOptional<z.ZodBoolean>;
-        dependenciesDiagnostics: z.ZodOptional<z.ZodBoolean>;
-        modulesHashes: z.ZodOptional<z.ZodBoolean>;
-        modulesCodegen: z.ZodOptional<z.ZodBoolean>;
-        modulesRuntimeRequirements: z.ZodOptional<z.ZodBoolean>;
-    }, "strict", z.ZodTypeAny, {
-        make?: boolean | undefined;
-        providedExports?: boolean | undefined;
-        emitAssets?: boolean | undefined;
-        inferAsyncModules?: boolean | undefined;
-        dependenciesDiagnostics?: boolean | undefined;
-        modulesHashes?: boolean | undefined;
-        modulesCodegen?: boolean | undefined;
-        modulesRuntimeRequirements?: boolean | undefined;
-    }, {
-        make?: boolean | undefined;
-        providedExports?: boolean | undefined;
-        emitAssets?: boolean | undefined;
-        inferAsyncModules?: boolean | undefined;
-        dependenciesDiagnostics?: boolean | undefined;
-        modulesHashes?: boolean | undefined;
-        modulesCodegen?: boolean | undefined;
-        modulesRuntimeRequirements?: boolean | undefined;
-    }>]>>;
-    futureDefaults: z.ZodOptional<z.ZodBoolean>;
-    rspackFuture: z.ZodOptional<z.ZodObject<{
-        bundlerInfo: z.ZodOptional<z.ZodObject<{
-            version: z.ZodOptional<z.ZodString>;
-            bundler: z.ZodOptional<z.ZodString>;
-            force: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodArray<z.ZodEnum<["version", "uniqueId"]>, "many">]>>;
-        }, "strict", z.ZodTypeAny, {
-            force?: boolean | ("version" | "uniqueId")[] | undefined;
-            version?: string | undefined;
-            bundler?: string | undefined;
-        }, {
-            force?: boolean | ("version" | "uniqueId")[] | undefined;
-            version?: string | undefined;
-            bundler?: string | undefined;
-        }>>;
-    }, "strict", z.ZodTypeAny, {
-        bundlerInfo?: {
-            force?: boolean | ("version" | "uniqueId")[] | undefined;
-            version?: string | undefined;
-            bundler?: string | undefined;
-        } | undefined;
-    }, {
-        bundlerInfo?: {
-            force?: boolean | ("version" | "uniqueId")[] | undefined;
-            version?: string | undefined;
-            bundler?: string | undefined;
-        } | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
-    css?: boolean | undefined;
-    lazyCompilation?: boolean | {
-        entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-        backend?: {
-            client?: string | undefined;
-            listen?: number | {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            } | undefined;
-            protocol?: "http" | "https" | undefined;
-        } | undefined;
-        imports?: boolean | undefined;
-    } | undefined;
-    asyncWebAssembly?: boolean | undefined;
-    outputModule?: boolean | undefined;
-    topLevelAwait?: boolean | undefined;
-    layers?: boolean | undefined;
-    incremental?: boolean | {
-        make?: boolean | undefined;
-        providedExports?: boolean | undefined;
-        emitAssets?: boolean | undefined;
-        inferAsyncModules?: boolean | undefined;
-        dependenciesDiagnostics?: boolean | undefined;
-        modulesHashes?: boolean | undefined;
-        modulesCodegen?: boolean | undefined;
-        modulesRuntimeRequirements?: boolean | undefined;
-    } | undefined;
-    futureDefaults?: boolean | undefined;
-    rspackFuture?: {
-        bundlerInfo?: {
-            force?: boolean | ("version" | "uniqueId")[] | undefined;
-            version?: string | undefined;
-            bundler?: string | undefined;
-        } | undefined;
-    } | undefined;
-}, {
-    css?: boolean | undefined;
-    lazyCompilation?: boolean | {
-        entries?: boolean | undefined;
-        test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-        backend?: {
-            client?: string | undefined;
-            listen?: number | {
-                path?: string | undefined;
-                port?: number | undefined;
-                host?: string | undefined;
-                backlog?: number | undefined;
-                exclusive?: boolean | undefined;
-                readableAll?: boolean | undefined;
-                writableAll?: boolean | undefined;
-                ipv6Only?: boolean | undefined;
-            } | undefined;
-            protocol?: "http" | "https" | undefined;
-        } | undefined;
-        imports?: boolean | undefined;
-    } | undefined;
-    asyncWebAssembly?: boolean | undefined;
-    outputModule?: boolean | undefined;
-    topLevelAwait?: boolean | undefined;
-    layers?: boolean | undefined;
-    incremental?: boolean | {
-        make?: boolean | undefined;
-        providedExports?: boolean | undefined;
-        emitAssets?: boolean | undefined;
-        inferAsyncModules?: boolean | undefined;
-        dependenciesDiagnostics?: boolean | undefined;
-        modulesHashes?: boolean | undefined;
-        modulesCodegen?: boolean | undefined;
-        modulesRuntimeRequirements?: boolean | undefined;
-    } | undefined;
-    futureDefaults?: boolean | undefined;
-    rspackFuture?: {
-        bundlerInfo?: {
-            force?: boolean | ("version" | "uniqueId")[] | undefined;
-            version?: string | undefined;
-            bundler?: string | undefined;
-        } | undefined;
-    } | undefined;
-}>;
 
 // @public (undocumented)
 export interface ExperimentsNormalized {
@@ -2367,38 +2127,17 @@ export type ImportFunctionName = string;
 // @public
 export type ImportMetaName = string;
 
-// @public (undocumented)
-export type Incremental = z.infer<typeof incremental>;
-
-// @public (undocumented)
-const incremental: z.ZodObject<{
-    make: z.ZodOptional<z.ZodBoolean>;
-    emitAssets: z.ZodOptional<z.ZodBoolean>;
-    inferAsyncModules: z.ZodOptional<z.ZodBoolean>;
-    providedExports: z.ZodOptional<z.ZodBoolean>;
-    dependenciesDiagnostics: z.ZodOptional<z.ZodBoolean>;
-    modulesHashes: z.ZodOptional<z.ZodBoolean>;
-    modulesCodegen: z.ZodOptional<z.ZodBoolean>;
-    modulesRuntimeRequirements: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    make?: boolean | undefined;
-    providedExports?: boolean | undefined;
-    emitAssets?: boolean | undefined;
-    inferAsyncModules?: boolean | undefined;
-    dependenciesDiagnostics?: boolean | undefined;
-    modulesHashes?: boolean | undefined;
-    modulesCodegen?: boolean | undefined;
-    modulesRuntimeRequirements?: boolean | undefined;
-}, {
-    make?: boolean | undefined;
-    providedExports?: boolean | undefined;
-    emitAssets?: boolean | undefined;
-    inferAsyncModules?: boolean | undefined;
-    dependenciesDiagnostics?: boolean | undefined;
-    modulesHashes?: boolean | undefined;
-    modulesCodegen?: boolean | undefined;
-    modulesRuntimeRequirements?: boolean | undefined;
-}>;
+// @public
+export type Incremental = {
+    make?: boolean;
+    emitAssets?: boolean;
+    inferAsyncModules?: boolean;
+    providedExports?: boolean;
+    dependenciesDiagnostics?: boolean;
+    modulesHashes?: boolean;
+    modulesCodegen?: boolean;
+    modulesRuntimeRequirements?: boolean;
+};
 
 // @public
 export type InfrastructureLogging = {
@@ -2960,109 +2699,17 @@ type KnownStatsProfile = {
 // @public
 export type Layer = string | null;
 
-// @public (undocumented)
-export type LazyCompilationOptions = z.infer<typeof lazyCompilationOptions>;
-
-// @public (undocumented)
-const lazyCompilationOptions: z.ZodObject<{
-    backend: z.ZodOptional<z.ZodObject<{
-        client: z.ZodOptional<z.ZodString>;
-        listen: z.ZodUnion<[z.ZodOptional<z.ZodNumber>, z.ZodObject<{
-            port: z.ZodOptional<z.ZodNumber>;
-            host: z.ZodOptional<z.ZodString>;
-            backlog: z.ZodOptional<z.ZodNumber>;
-            path: z.ZodOptional<z.ZodString>;
-            exclusive: z.ZodOptional<z.ZodBoolean>;
-            readableAll: z.ZodOptional<z.ZodBoolean>;
-            writableAll: z.ZodOptional<z.ZodBoolean>;
-            ipv6Only: z.ZodOptional<z.ZodBoolean>;
-        }, "strip", z.ZodTypeAny, {
-            path?: string | undefined;
-            port?: number | undefined;
-            host?: string | undefined;
-            backlog?: number | undefined;
-            exclusive?: boolean | undefined;
-            readableAll?: boolean | undefined;
-            writableAll?: boolean | undefined;
-            ipv6Only?: boolean | undefined;
-        }, {
-            path?: string | undefined;
-            port?: number | undefined;
-            host?: string | undefined;
-            backlog?: number | undefined;
-            exclusive?: boolean | undefined;
-            readableAll?: boolean | undefined;
-            writableAll?: boolean | undefined;
-            ipv6Only?: boolean | undefined;
-        }>]>;
-        protocol: z.ZodOptional<z.ZodEnum<["http", "https"]>>;
-    }, "strip", z.ZodTypeAny, {
-        client?: string | undefined;
-        listen?: number | {
-            path?: string | undefined;
-            port?: number | undefined;
-            host?: string | undefined;
-            backlog?: number | undefined;
-            exclusive?: boolean | undefined;
-            readableAll?: boolean | undefined;
-            writableAll?: boolean | undefined;
-            ipv6Only?: boolean | undefined;
-        } | undefined;
-        protocol?: "http" | "https" | undefined;
-    }, {
-        client?: string | undefined;
-        listen?: number | {
-            path?: string | undefined;
-            port?: number | undefined;
-            host?: string | undefined;
-            backlog?: number | undefined;
-            exclusive?: boolean | undefined;
-            readableAll?: boolean | undefined;
-            writableAll?: boolean | undefined;
-            ipv6Only?: boolean | undefined;
-        } | undefined;
-        protocol?: "http" | "https" | undefined;
-    }>>;
-    imports: z.ZodOptional<z.ZodBoolean>;
-    entries: z.ZodOptional<z.ZodBoolean>;
-    test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
-}, "strip", z.ZodTypeAny, {
-    entries?: boolean | undefined;
-    test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+// @public
+export type LazyCompilationOptions = {
     backend?: {
-        client?: string | undefined;
-        listen?: number | {
-            path?: string | undefined;
-            port?: number | undefined;
-            host?: string | undefined;
-            backlog?: number | undefined;
-            exclusive?: boolean | undefined;
-            readableAll?: boolean | undefined;
-            writableAll?: boolean | undefined;
-            ipv6Only?: boolean | undefined;
-        } | undefined;
-        protocol?: "http" | "https" | undefined;
-    } | undefined;
-    imports?: boolean | undefined;
-}, {
-    entries?: boolean | undefined;
-    test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-    backend?: {
-        client?: string | undefined;
-        listen?: number | {
-            path?: string | undefined;
-            port?: number | undefined;
-            host?: string | undefined;
-            backlog?: number | undefined;
-            exclusive?: boolean | undefined;
-            readableAll?: boolean | undefined;
-            writableAll?: boolean | undefined;
-            ipv6Only?: boolean | undefined;
-        } | undefined;
-        protocol?: "http" | "https" | undefined;
-    } | undefined;
-    imports?: boolean | undefined;
-}>;
+        client?: string;
+        listen?: number | ListenOptions;
+        protocol?: "http" | "https";
+    };
+    imports?: boolean;
+    entries?: boolean;
+    test?: RegExp | ((module: any) => boolean);
+};
 
 // @public
 export type Library = LibraryName | LibraryOptions | undefined;
@@ -3195,6 +2842,18 @@ const LimitChunkCountPlugin: {
         raw(compiler: Compiler_2): BuiltinPlugin;
         apply(compiler: Compiler_2): void;
     };
+};
+
+// @public
+type ListenOptions = {
+    port?: number;
+    host?: string;
+    backlog?: number;
+    path?: string;
+    exclusive?: boolean;
+    readableAll?: boolean;
+    writableAll?: boolean;
+    ipv6Only?: boolean;
 };
 
 // @public (undocumented)
@@ -4865,10 +4524,6 @@ declare namespace rspackExports {
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
         externalsType,
-        RspackFutureOptions,
-        LazyCompilationOptions,
-        Incremental,
-        Experiments,
         Watch,
         WatchOptions,
         DevServer,
@@ -5025,41 +4680,22 @@ declare namespace rspackExports {
         OptimizationSplitChunksNameFunction,
         OptimizationSplitChunksCacheGroup,
         OptimizationSplitChunksOptions,
-        Optimization
+        Optimization,
+        RspackFutureOptions,
+        LazyCompilationOptions,
+        Incremental,
+        Experiments
     }
 }
 
-// @public (undocumented)
-export type RspackFutureOptions = z.infer<typeof rspackFutureOptions>;
-
-// @public (undocumented)
-const rspackFutureOptions: z.ZodObject<{
-    bundlerInfo: z.ZodOptional<z.ZodObject<{
-        version: z.ZodOptional<z.ZodString>;
-        bundler: z.ZodOptional<z.ZodString>;
-        force: z.ZodOptional<z.ZodUnion<[z.ZodBoolean, z.ZodArray<z.ZodEnum<["version", "uniqueId"]>, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        force?: boolean | ("version" | "uniqueId")[] | undefined;
-        version?: string | undefined;
-        bundler?: string | undefined;
-    }, {
-        force?: boolean | ("version" | "uniqueId")[] | undefined;
-        version?: string | undefined;
-        bundler?: string | undefined;
-    }>>;
-}, "strict", z.ZodTypeAny, {
+// @public
+export type RspackFutureOptions = {
     bundlerInfo?: {
-        force?: boolean | ("version" | "uniqueId")[] | undefined;
-        version?: string | undefined;
-        bundler?: string | undefined;
-    } | undefined;
-}, {
-    bundlerInfo?: {
-        force?: boolean | ("version" | "uniqueId")[] | undefined;
-        version?: string | undefined;
-        bundler?: string | undefined;
-    } | undefined;
-}>;
+        version?: string;
+        bundler?: string;
+        force?: boolean | ("version" | "uniqueId")[];
+    };
+};
 
 // @public (undocumented)
 export type RspackOptions = z.infer<typeof rspackOptions>;
@@ -10127,7 +9763,11 @@ declare namespace t {
         OptimizationSplitChunksNameFunction,
         OptimizationSplitChunksCacheGroup,
         OptimizationSplitChunksOptions,
-        Optimization
+        Optimization,
+        RspackFutureOptions,
+        LazyCompilationOptions,
+        Incremental,
+        Experiments
     }
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2256,3 +2256,199 @@ export type Optimization = {
 	emitOnErrors?: boolean;
 };
 //#endregion
+
+//#region Experiments
+/**
+ * Options for future Rspack features.
+ */
+export type RspackFutureOptions = {
+	/**
+	 * Information about the bundler.
+	 */
+	bundlerInfo?: {
+		/**
+		 * Version of the bundler.
+		 */
+		version?: string;
+		/**
+		 * Name of the bundler.
+		 */
+		bundler?: string;
+		/**
+		 * Force specific features.
+		 */
+		force?: boolean | ("version" | "uniqueId")[];
+	};
+};
+
+/**
+ * Options for server listening.
+ */
+type ListenOptions = {
+	/**
+	 * The port to listen on.
+	 */
+	port?: number;
+	/**
+	 * The host to listen on.
+	 */
+	host?: string;
+	/**
+	 * The backlog of connections.
+	 */
+	backlog?: number;
+	/**
+	 * The path for Unix socket.
+	 */
+	path?: string;
+	/**
+	 * Whether the server is exclusive.
+	 */
+	exclusive?: boolean;
+	/**
+	 * Whether the socket is readable by all users.
+	 */
+	readableAll?: boolean;
+	/**
+	 * Whether the socket is writable by all users.
+	 */
+	writableAll?: boolean;
+	/**
+	 * Whether to use IPv6 only.
+	 */
+	ipv6Only?: boolean;
+};
+
+/**
+ * Options for lazy compilation.
+ */
+export type LazyCompilationOptions = {
+	/**
+	 * Backend configuration for lazy compilation.
+	 */
+	backend?: {
+		/**
+		 * Client script path.
+		 */
+		client?: string;
+		/**
+		 * Listening options.
+		 */
+		listen?: number | ListenOptions;
+		/**
+		 * Protocol to use.
+		 */
+		protocol?: "http" | "https";
+	};
+	/**
+	 * Enable lazy compilation for imports.
+	 */
+	imports?: boolean;
+	/**
+	 * Enable lazy compilation for entries.
+	 */
+	entries?: boolean;
+	/**
+	 * Test function or regex to determine which modules to include.
+	 */
+	test?: RegExp | ((module: any) => boolean);
+};
+
+/**
+ * Options for incremental builds.
+ */
+export type Incremental = {
+	/**
+	 * Enable incremental make.
+	 */
+	make?: boolean;
+
+	/**
+	 * Enable incremental asset emission.
+	 */
+	emitAssets?: boolean;
+
+	/**
+	 * Enable inference of async modules.
+	 */
+	inferAsyncModules?: boolean;
+
+	/**
+	 * Enable incremental provided exports.
+	 */
+	providedExports?: boolean;
+
+	/**
+	 * Enables diagnostics for dependencies.
+	 */
+	dependenciesDiagnostics?: boolean;
+
+	/**
+	 * Enable incremental module hashes.
+	 */
+	modulesHashes?: boolean;
+
+	/**
+	 * Enable incremental module code generation.
+	 */
+	modulesCodegen?: boolean;
+
+	/**
+	 * Enable incremental module runtime requirements.
+	 */
+	modulesRuntimeRequirements?: boolean;
+};
+
+/**
+ * Experimental features configuration.
+ */
+export type Experiments = {
+	/**
+	 * Enable lazy compilation.
+	 */
+	lazyCompilation?: boolean | LazyCompilationOptions;
+	/**
+	 * Enable async WebAssembly.
+	 * Support the new WebAssembly according to the [updated specification](https://github.com/WebAssembly/esm-integration), it makes a WebAssembly module an async module.
+	 */
+	asyncWebAssembly?: boolean;
+	/**
+	 * Enable output as ES module.
+	 */
+	outputModule?: boolean;
+	/**
+	 * Enable top-level await.
+	 */
+	topLevelAwait?: boolean;
+	/**
+	 * Enable CSS support.
+	 *
+	 * @description
+	 * Once enabled, Rspack will enable native CSS support, and CSS related parser and generator options.
+	 * - `module.parser["css/auto"]`
+	 * - `module.parser.css`
+	 * - `module.parser["css/module"]`
+	 * - `module.generator["css/auto"]`
+	 * - `module.generator.css`
+	 * - `module.generator["css/module"]`
+	 */
+	css?: boolean;
+	/**
+	 * Enable module layers feature.
+	 * @default false
+	 */
+	layers?: boolean;
+	/**
+	 * Enable incremental builds.
+	 */
+	incremental?: boolean | Incremental;
+	/**
+	 * Enable future default options.
+	 */
+	futureDefaults?: boolean;
+	/**
+	 * Enable future Rspack features default options.
+	 */
+	rspackFuture?: RspackFutureOptions;
+};
+//#endregion

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1204,8 +1204,7 @@ const rspackFutureOptions = z.strictObject({
 				.optional()
 		})
 		.optional()
-});
-export type RspackFutureOptions = z.infer<typeof rspackFutureOptions>;
+}) satisfies z.ZodType<t.RspackFutureOptions>;
 
 const listenOptions = z.object({
 	port: z.number().optional(),
@@ -1232,8 +1231,7 @@ const lazyCompilationOptions = z.object({
 		.instanceof(RegExp)
 		.or(z.function().args(z.custom<Module>()).returns(z.boolean()))
 		.optional()
-});
-export type LazyCompilationOptions = z.infer<typeof lazyCompilationOptions>;
+}) satisfies z.ZodType<t.LazyCompilationOptions>;
 
 const incremental = z.strictObject({
 	make: z.boolean().optional(),
@@ -1244,8 +1242,7 @@ const incremental = z.strictObject({
 	modulesHashes: z.boolean().optional(),
 	modulesCodegen: z.boolean().optional(),
 	modulesRuntimeRequirements: z.boolean().optional()
-});
-export type Incremental = z.infer<typeof incremental>;
+}) satisfies z.ZodType<t.Incremental>;
 
 const experiments = z.strictObject({
 	lazyCompilation: z.boolean().optional().or(lazyCompilationOptions),
@@ -1257,8 +1254,7 @@ const experiments = z.strictObject({
 	incremental: z.boolean().or(incremental).optional(),
 	futureDefaults: z.boolean().optional(),
 	rspackFuture: rspackFutureOptions.optional()
-});
-export type Experiments = z.infer<typeof experiments>;
+}) satisfies z.ZodType<t.Experiments>;
 //#endregion
 
 //#region Watch


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.experiments 

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
