### PR TITLE
feat(CLI): make `@rspack/cli` dual package and bundle with Rslib

### DIFF
--- a/packages/create-rspack/rslib.config.ts
+++ b/packages/create-rspack/rslib.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@rslib/core";
 
 export default defineConfig({
-	lib: [{ format: "esm" }],
+	lib: [{ format: "esm", syntax: "es2021" }],
 	output: {
 		target: "node"
 	}

--- a/packages/rspack-cli/bin/rspack
+++ b/packages/rspack-cli/bin/rspack
@@ -1,3 +1,0 @@
-#!/usr/bin/env node
-const runCLI = require("../dist/bootstrap").runCLI;
-runCLI(process.argv);

--- a/packages/rspack-cli/bin/rspack.js
+++ b/packages/rspack-cli/bin/rspack.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { RspackCLI } = require("../dist/index");
+
+async function runCLI() {
+	const cli = new RspackCLI();
+	await cli.run(process.argv);
+}
+
+runCLI();

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -11,21 +11,24 @@
   },
   "license": "MIT",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "rspack": "./bin/rspack"
+    "rspack": "./bin/rspack.js"
   },
   "files": [
     "bin",
     "dist"
   ],
   "scripts": {
-    "build": "tsc -b ./tsconfig.build.json",
-    "dev": "tsc -b -w",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "test": "cross-env jest --colors"
   },
   "dependencies": {
@@ -41,6 +44,7 @@
   },
   "devDependencies": {
     "@rspack/core": "workspace:*",
+    "@rslib/core": "0.0.12",
     "@types/interpret": "^1.1.3",
     "@types/rechoir": "^0.6.1",
     "@types/semver": "^7.5.6",

--- a/packages/rspack-cli/rslib.config.ts
+++ b/packages/rspack-cli/rslib.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "@rslib/core";
 export default defineConfig({
 	lib: [
 		{ format: "cjs", syntax: "es2021", dts: { bundle: false } },
-		{ format: "esm", syntax: "es2021", dts: { bundle: false } }
+		{ format: "esm", syntax: "es2021" }
 	],
 	source: {
 		tsconfigPath: "./tsconfig.build.json"

--- a/packages/rspack-cli/rslib.config.ts
+++ b/packages/rspack-cli/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "@rslib/core";
+
+export default defineConfig({
+	lib: [
+		{ format: "cjs", syntax: "es2021", dts: { bundle: false } },
+		{ format: "esm", syntax: "es2021", dts: { bundle: false } }
+	],
+	source: {
+		tsconfigPath: "./tsconfig.build.json"
+	},
+	output: {
+		target: "node"
+	}
+});

--- a/packages/rspack-cli/src/bootstrap.ts
+++ b/packages/rspack-cli/src/bootstrap.ts
@@ -1,6 +1,0 @@
-import { RspackCLI } from "./cli";
-
-export async function runCLI(argv: string[]) {
-	const cli = new RspackCLI();
-	await cli.run(argv);
-}

--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -12,10 +12,10 @@ import {
 	rspack
 } from "@rspack/core";
 import * as rspackCore from "@rspack/core";
+import { createColors, isColorSupported } from "colorette";
 import semver from "semver";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-
 import { BuildCommand } from "./commands/build";
 import { PreviewCommand } from "./commands/preview";
 import { ServeCommand } from "./commands/serve";
@@ -78,10 +78,7 @@ export class RspackCLI {
 		return compiler;
 	}
 	createColors(useColor?: boolean): RspackCLIColors {
-		const { createColors, isColorSupported } = require("colorette");
-
 		const shouldUseColor = useColor || isColorSupported;
-
 		return {
 			...createColors({ useColor: shouldUseColor }),
 			isColorSupported: shouldUseColor

--- a/packages/rspack-cli/src/utils/crossImport.ts
+++ b/packages/rspack-cli/src/utils/crossImport.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from "node:url";
 import isEsmFile from "./isEsmFile";
 
 /**
- * Dynamically import files. It will make sure it's not being compiled away by TS/Rollup.
+ * Dynamically import files. It will make sure it's not being compiled away by TS/Rslib.
  */
 export const dynamicImport = new Function("path", "return import(path)");
 

--- a/packages/rspack-cli/src/utils/profile.ts
+++ b/packages/rspack-cli/src/utils/profile.ts
@@ -36,6 +36,7 @@ import inspector from "node:inspector";
 import path from "node:path";
 import { URLSearchParams } from "node:url";
 import { type Compiler, type RspackOptions, rspack } from "@rspack/core";
+import { dynamicImport } from "./crossImport";
 
 type JSCPUProfileOptionsOutput = string;
 type JSCPUProfileOptions = {
@@ -209,7 +210,7 @@ class RspackProfileLoggingPlugin {
 }
 
 export async function applyProfile(profileValue: string, item: RspackOptions) {
-	const { default: exitHook } = await import("exit-hook");
+	const { default: exitHook } = await dynamicImport("exit-hook");
 	const entries = Object.entries(resolveProfile(profileValue));
 	if (entries.length <= 0) return;
 	await fs.promises.mkdir(defaultOutputDirname);

--- a/packages/rspack-cli/tests/utils/test-utils.ts
+++ b/packages/rspack-cli/tests/utils/test-utils.ts
@@ -13,7 +13,7 @@ const { node: execaNode } = execa;
 const { Writable } = require("readable-stream");
 const concat = require("concat-stream");
 
-const RSPACK_PATH = path.resolve(__dirname, "../../bin/rspack");
+const RSPACK_PATH = path.resolve(__dirname, "../../bin/rspack.js");
 const ENABLE_LOG_COMPILATION = process.env.ENABLE_PIPE || false;
 const isWindows = process.platform === "win32";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,8 +452,8 @@ importers:
         specifier: 2.0.19
         version: 2.0.19
       exit-hook:
-        specifier: ^2.2.1
-        version: 2.2.1
+        specifier: ^3.2.0
+        version: 3.2.0
       interpret:
         specifier: ^3.1.1
         version: 3.1.1
@@ -6315,9 +6315,9 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
-  exit-hook@2.2.1:
-    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
-    engines: {node: '>=6'}
+  exit-hook@3.2.0:
+    resolution: {integrity: sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
@@ -17975,7 +17975,7 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  exit-hook@2.2.1: {}
+  exit-hook@3.2.0: {}
 
   exit@0.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,8 +452,8 @@ importers:
         specifier: 2.0.19
         version: 2.0.19
       exit-hook:
-        specifier: ^3.2.0
-        version: 3.2.0
+        specifier: ^2.2.1
+        version: 2.2.1
       interpret:
         specifier: ^3.1.1
         version: 3.1.1
@@ -470,6 +470,9 @@ importers:
         specifier: 17.6.2
         version: 17.6.2
     devDependencies:
+      '@rslib/core':
+        specifier: 0.0.12
+        version: 0.0.12(@microsoft/api-extractor@7.47.10(@types/node@20.12.7))(typescript@5.6.3)
       '@rspack/core':
         specifier: workspace:*
         version: link:../rspack
@@ -6312,9 +6315,9 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
-  exit-hook@3.2.0:
-    resolution: {integrity: sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  exit-hook@2.2.1:
+    resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
+    engines: {node: '>=6'}
 
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
@@ -13848,7 +13851,7 @@ snapshots:
 
   '@rsbuild/core@1.0.14':
     dependencies:
-      '@rspack/core': 1.0.10(@swc/helpers@0.5.13)
+      '@rspack/core': 1.0.13(@swc/helpers@0.5.13)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.13
       core-js: 3.38.1
@@ -13961,7 +13964,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.0.13
       '@rspack/binding-win32-ia32-msvc': 1.0.13
       '@rspack/binding-win32-x64-msvc': 1.0.13
-    optional: true
 
   '@rspack/core@1.0.10(@swc/helpers@0.5.13)':
     dependencies:
@@ -13980,7 +13982,6 @@ snapshots:
       caniuse-lite: 1.0.30001669
     optionalDependencies:
       '@swc/helpers': 0.5.13
-    optional: true
 
   '@rspack/dev-server@1.0.5(@rspack/core@packages+rspack)(@types/express@4.17.21)(webpack-cli@5.1.4(webpack@5.94.0))(webpack@5.94.0(@swc/core@1.4.0(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0)))':
     dependencies:
@@ -17974,7 +17975,7 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  exit-hook@3.2.0: {}
+  exit-hook@2.2.1: {}
 
   exit@0.1.2: {}
 


### PR DESCRIPTION
## Summary

Use Rslib to bundle `@rspack/cli` and output both ESM/CJS bundles, this means that `@rspack/cli` is now a dual package with better ESM support.

![image](https://github.com/user-attachments/assets/c1dc6aae-f17d-4e0e-a676-a7bd853880df)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
