### PR TITLE
fix(lightning css): align type with lightning documentation

### DIFF
--- a/packages/rspack/src/builtin-loader/lightningcss/index.ts
+++ b/packages/rspack/src/builtin-loader/lightningcss/index.ts
@@ -254,7 +254,7 @@ export type LoaderOptions = {
 	targets?: Targets | string[] | string;
 	include?: FeatureOptions;
 	exclude?: FeatureOptions;
-	draft?: Drafts;
+	drafts?: Drafts;
 	nonStandard?: NonStandard;
 	pseudoClasses?: PseudoClasses;
 	unusedSymbols?: string[];


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
In the lightning css documentation there is a option to enable drafts. This option was incorrectly named as `draft` instead of `drafts`. Updated the typing to the proper name as per the [documentation](https://lightningcss.dev/transpilation.html#custom-media-queries).
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
