### PR TITLE
refactor: add JSDoc to improve config.wath types

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4526,8 +4526,6 @@ declare namespace rspackExports {
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
         externalsType,
-        Watch,
-        WatchOptions,
         DevServer,
         IgnoreWarnings,
         Profile,
@@ -4686,7 +4684,9 @@ declare namespace rspackExports {
         RspackFutureOptions,
         LazyCompilationOptions,
         Incremental,
-        Experiments
+        Experiments,
+        Watch,
+        WatchOptions
     }
 }
 
@@ -9769,7 +9769,9 @@ declare namespace t {
         RspackFutureOptions,
         LazyCompilationOptions,
         Incremental,
-        Experiments
+        Experiments,
+        Watch,
+        WatchOptions
     }
 }
 
@@ -10039,10 +10041,7 @@ export type WasmLoading = false | WasmLoadingType;
 export type WasmLoadingType = string | "fetch-streaming" | "fetch" | "async-node";
 
 // @public (undocumented)
-export type Watch = z.infer<typeof watch>;
-
-// @public (undocumented)
-const watch: z.ZodBoolean;
+export type Watch = boolean;
 
 // @public (undocumented)
 interface Watcher {
@@ -10144,29 +10143,14 @@ export class Watching {
     watchOptions: WatchOptions;
 }
 
-// @public (undocumented)
-export type WatchOptions = z.infer<typeof watchOptions>;
-
-// @public (undocumented)
-const watchOptions: z.ZodObject<{
-    aggregateTimeout: z.ZodOptional<z.ZodNumber>;
-    followSymlinks: z.ZodOptional<z.ZodBoolean>;
-    ignored: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodArray<z.ZodString, "many">, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodString]>>;
-    poll: z.ZodOptional<z.ZodUnion<[z.ZodNumber, z.ZodBoolean]>>;
-    stdin: z.ZodOptional<z.ZodBoolean>;
-}, "strict", z.ZodTypeAny, {
-    aggregateTimeout?: number | undefined;
-    followSymlinks?: boolean | undefined;
-    ignored?: string | RegExp | string[] | undefined;
-    poll?: number | boolean | undefined;
-    stdin?: boolean | undefined;
-}, {
-    aggregateTimeout?: number | undefined;
-    followSymlinks?: boolean | undefined;
-    ignored?: string | RegExp | string[] | undefined;
-    poll?: number | boolean | undefined;
-    stdin?: boolean | undefined;
-}>;
+// @public
+export type WatchOptions = {
+    aggregateTimeout?: number;
+    followSymlinks?: boolean;
+    ignored?: string | RegExp | string[];
+    poll?: number | boolean;
+    stdin?: boolean;
+};
 
 // @public (undocumented)
 class Watchpack extends EventEmitter {

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2452,3 +2452,42 @@ export type Experiments = {
 	rspackFuture?: RspackFutureOptions;
 };
 //#endregion
+
+//#region Watch
+export type Watch = boolean;
+//#endregion
+
+//#region WatchOptions
+
+/** Options for watch mode. */
+export type WatchOptions = {
+	/**
+	 * Add a delay before rebuilding once the first file changed.
+	 * This allows webpack to aggregate any other changes made during this time period into one rebuild.
+	 * @default 5
+	 */
+	aggregateTimeout?: number;
+
+	/**
+	 * Follow symlinks while looking for files.
+	 * This is usually not needed as webpack already resolves symlinks ('resolve.symlinks' and 'resolve.alias').
+	 */
+	followSymlinks?: boolean;
+
+	/**
+	 * Ignore some files from being watched.
+	 */
+	ignored?: string | RegExp | string[];
+
+	/**
+	 * Turn on polling by passing true, or specifying a poll interval in milliseconds.
+	 * @default false
+	 */
+	poll?: number | boolean;
+
+	/**
+	 * Stop watching when stdin stream has ended.
+	 */
+	stdin?: boolean;
+};
+//#endregion

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1258,8 +1258,7 @@ const experiments = z.strictObject({
 //#endregion
 
 //#region Watch
-const watch = z.boolean();
-export type Watch = z.infer<typeof watch>;
+const watch = z.boolean() satisfies z.ZodType<t.Watch>;
 //#endregion
 
 //#region WatchOptions
@@ -1274,8 +1273,7 @@ const watchOptions = z.strictObject({
 		.optional(),
 	poll: z.number().or(z.boolean()).optional(),
 	stdin: z.boolean().optional()
-});
-export type WatchOptions = z.infer<typeof watchOptions>;
+}) satisfies z.ZodType<t.WatchOptions>;
 //#endregion
 
 //#region DevServer


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add type & JSDoc for config.watch
- Add type & JSDoc for config.watchOptions

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
