### PR TITLE
fix: should correct cacheGroups test regex

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/split-chunks/rspack-issue-5657/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/split-chunks/rspack-issue-5657/rspack.config.js
@@ -9,10 +9,10 @@ module.exports = {
 			chunks: "all",
 			cacheGroups: {
 				lib: {
-					test: /lib/,
+					test: /[\/\\]src\/lib[\/\\]/,
 					minSize: 0,
 					maxSize: 50,
-					minChunks: 1
+					minChunks: 1,
 				}
 			}
 		}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

-->

## Summary

Rspack project folder path in my pc contains `lib`, splitChunks split my normal chunks by mistake

So make this test case filter regex more accurate

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
