### PR TITLE
test: add `rspack.default` should not exist test

### DIFF
--- a/packages/rspack-cli/tests/api/type/js-api-cjs.test.ts
+++ b/packages/rspack-cli/tests/api/type/js-api-cjs.test.ts
@@ -28,4 +28,9 @@ describe("js-api-type should be correct when requiring from @rspack/core", () =>
 		const compiler = rspackCjsNamedRequire({});
 		assert(compiler);
 	});
+
+	it("rspack.default should not exist in cjs require", async () => {
+		assert(!(rspackCjsNamedRequire as any).default);
+		assert(!(rspackCjsRequire as any).default);
+	});
 });

--- a/packages/rspack-cli/tests/api/type/js-api-esm.test.mts
+++ b/packages/rspack-cli/tests/api/type/js-api-esm.test.mts
@@ -24,4 +24,9 @@ describe("js-api-type should be correct when importing from @rspack/core", () =>
 		const compiler = rspackEsmNamedImport({});
 		assert(compiler);
 	});
+
+	it("rspack.default should not exist in esm import", async () => {
+		assert(!(rspackEsmNamedImport as any).default);
+		assert(!(rspackEsmDefaultImport as any).default);
+	});
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

enhance the test of https://github.com/web-infra-dev/rspack/pull/8169

at present, we use `module.exports = rspack` to overrides the tsup output to not to export the `rspack.default`

`rspack.default.rspack` is not expected by all of us

<img src="https://github.com/user-attachments/assets/71bfa22a-1de9-4a7c-be0e-2f3de452c2d2" width="400" />

<img src="https://github.com/user-attachments/assets/048a93f5-b966-4626-af08-63d84613e4ed"  width="400" />

<img src="https://github.com/user-attachments/assets/c5e7f56a-6554-4103-954d-fae1821ac750" width="400" />


<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
