### PR TITLE
fix(ci): trigger `pkg-preview` when the needs are skipped

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,5 +398,5 @@ jobs:
       - lint
       - rust_check
       - rust_test
-    if: ${{ (success() || cancelled()) && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ !failure() && github.event_name == 'push' }}
     uses: ./.github/workflows/preview-commit.yml


### PR DESCRIPTION
## Summary

Trigger `pkg-preview` when the dependent jobs are skipped as well.

I noticed that sometimes `pkg-preview` gets skipped because the dependent jobs `rust_check` and `rust_test` are skipped.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
