### PR TITLE
refactor: add JSDoc to improve config.ignoreWarnings, profile, bail types

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -198,11 +198,8 @@ export type AsyncChunks = boolean;
 // @public
 export type AuxiliaryComment = string | LibraryCustomUmdCommentObject;
 
-// @public (undocumented)
-export type Bail = z.infer<typeof bail>;
-
-// @public (undocumented)
-const bail: z.ZodBoolean;
+// @public
+export type Bail = boolean;
 
 // @public (undocumented)
 type BannerContent = string | BannerFunction;
@@ -2194,11 +2191,8 @@ export type IgnorePluginOptions = {
     checkResource: NonNullable<RawIgnorePluginOptions["checkResource"]>;
 };
 
-// @public (undocumented)
-export type IgnoreWarnings = z.infer<typeof ignoreWarnings>;
-
-// @public (undocumented)
-const ignoreWarnings: z.ZodArray<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Error, z.ZodTypeDef, Error>, z.ZodType<Compilation, z.ZodTypeDef, Compilation>], z.ZodUnknown>, z.ZodBoolean>]>, "many">;
+// @public
+export type IgnoreWarnings = (RegExp | ((error: Error, compilation: Compilation) => boolean))[];
 
 // @public (undocumented)
 export type IgnoreWarningsNormalized = ((warning: Error, compilation: Compilation) => boolean)[];
@@ -4121,11 +4115,8 @@ type PrintedElement = {
     content: string;
 };
 
-// @public (undocumented)
-export type Profile = z.infer<typeof profile>;
-
-// @public (undocumented)
-const profile: z.ZodBoolean;
+// @public
+export type Profile = boolean;
 
 // @public (undocumented)
 export const ProgressPlugin: {
@@ -4702,9 +4693,6 @@ declare namespace rspackExports {
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
         externalsType,
-        IgnoreWarnings,
-        Profile,
-        Bail,
         Performance_2 as Performance,
         rspackOptions,
         RspackOptions,
@@ -4862,7 +4850,10 @@ declare namespace rspackExports {
         Experiments,
         Watch,
         WatchOptions,
-        DevServer
+        DevServer,
+        IgnoreWarnings,
+        Profile,
+        Bail
     }
 }
 
@@ -9901,7 +9892,10 @@ declare namespace t {
         Experiments,
         Watch,
         WatchOptions,
-        DevServer
+        DevServer,
+        IgnoreWarnings,
+        Profile,
+        Bail
     }
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1,6 +1,6 @@
 import type { JsAssetInfo, RawFuncUseCtx } from "@rspack/binding";
 import type * as webpackDevServer from "webpack-dev-server";
-import type { PathData } from "../Compilation";
+import type { Compilation, PathData } from "../Compilation";
 import type { Compiler } from "../Compiler";
 import type { Module } from "../Module";
 import type { Chunk } from "../exports";
@@ -2503,4 +2503,29 @@ export type WatchOptions = {
  * Options for devServer, it based on `webpack-dev-server@5`
  * */
 export interface DevServer extends webpackDevServer.Configuration {}
+//#endregion
+
+//#region IgnoreWarnings
+/**
+ * An array of either regular expressions or functions that determine if a warning should be ignored.
+ */
+export type IgnoreWarnings = (
+	| RegExp
+	| ((error: Error, compilation: Compilation) => boolean)
+)[];
+//#endregion
+
+//#region Profile
+/**
+ * Capture a "profile" of the application, including statistics and hints, which can then be dissected using the Analyze tool.
+ * */
+export type Profile = boolean;
+//#endregion
+
+//#region Bail
+/**
+ * Fail out on the first error instead of tolerating it.
+ * @default false
+ * */
+export type Bail = boolean;
 //#endregion

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1290,18 +1290,15 @@ const ignoreWarnings = z
 			.args(z.instanceof(Error), z.custom<Compilation>())
 			.returns(z.boolean())
 	)
-	.array();
-export type IgnoreWarnings = z.infer<typeof ignoreWarnings>;
+	.array() satisfies z.ZodType<t.IgnoreWarnings>;
 //#endregion
 
 //#region Profile
-const profile = z.boolean();
-export type Profile = z.infer<typeof profile>;
+const profile = z.boolean() satisfies z.ZodType<t.Profile>;
 //#endregion
 
 //#region Bail
-const bail = z.boolean();
-export type Bail = z.infer<typeof bail>;
+const bail = z.boolean() satisfies z.ZodType<t.Bail>;
 //#endregion
 
 //#region Performance


### PR DESCRIPTION

<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add JSDoc for config.ignoreWarnings.
- Add JSDoc for config.profile.
- Add JSDoc for config.bail.

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
