### PR TITLE
refactor: add JSDoc to improve config.performance

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -4060,27 +4060,14 @@ type PathLike = string | Buffer | URL;
 // @public (undocumented)
 type PathOrFileDescriptor = PathLike | number;
 
-// @public (undocumented)
-type Performance_2 = z.infer<typeof performance_2>;
+// @public
+type Performance_2 = false | {
+    assetFilter?: (assetFilename: string) => boolean;
+    hints?: false | "warning" | "error";
+    maxAssetSize?: number;
+    maxEntrypointSize?: number;
+};
 export { Performance_2 as Performance }
-
-// @public (undocumented)
-const performance_2: z.ZodUnion<[z.ZodObject<{
-    assetFilter: z.ZodOptional<z.ZodFunction<z.ZodTuple<[z.ZodString], z.ZodUnknown>, z.ZodBoolean>>;
-    hints: z.ZodOptional<z.ZodUnion<[z.ZodEnum<["error", "warning"]>, z.ZodLiteral<false>]>>;
-    maxAssetSize: z.ZodOptional<z.ZodNumber>;
-    maxEntrypointSize: z.ZodOptional<z.ZodNumber>;
-}, "strict", z.ZodTypeAny, {
-    assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
-    hints?: false | "error" | "warning" | undefined;
-    maxAssetSize?: number | undefined;
-    maxEntrypointSize?: number | undefined;
-}, {
-    assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
-    hints?: false | "error" | "warning" | undefined;
-    maxAssetSize?: number | undefined;
-    maxEntrypointSize?: number | undefined;
-}>, z.ZodLiteral<false>]>;
 
 // @public (undocumented)
 type PitchLoaderDefinitionFunction<OptionsType = {}, ContextAdditions = {}> = (this: LoaderContext<OptionsType> & ContextAdditions, remainingRequest: string, previousRequest: string, data: object) => string | void | Buffer | Promise<string | Buffer>;
@@ -4693,7 +4680,6 @@ declare namespace rspackExports {
         OptimizationRuntimeChunkNormalized,
         RspackOptionsNormalized,
         externalsType,
-        Performance_2 as Performance,
         rspackOptions,
         RspackOptions,
         Configuration,
@@ -4853,7 +4839,8 @@ declare namespace rspackExports {
         DevServer,
         IgnoreWarnings,
         Profile,
-        Bail
+        Bail,
+        Performance_2 as Performance
     }
 }
 
@@ -9895,7 +9882,8 @@ declare namespace t {
         DevServer,
         IgnoreWarnings,
         Profile,
-        Bail
+        Bail,
+        Performance_2 as Performance
     }
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2529,3 +2529,29 @@ export type Profile = boolean;
  * */
 export type Bail = boolean;
 //#endregion
+
+//#region Performance
+/** Options to control how Rspack notifies you of assets and entry points that exceed a specific file limit.   */
+export type Performance =
+	| false
+	| {
+			/**
+			 * Filter function to select assets that are checked.
+			 */
+			assetFilter?: (assetFilename: string) => boolean;
+			/**
+			 * Sets the format of the hints: warnings, errors or nothing at all.
+			 */
+			hints?: false | "warning" | "error";
+			/**
+			 * File size limit (in bytes) when exceeded, that webpack will provide performance hints.
+			 * @default 250000
+			 */
+			maxAssetSize?: number;
+			/**
+			 * Total size of an entry point (in bytes).
+			 * @default 250000
+			 */
+			maxEntrypointSize?: number;
+	  };
+//#endregion

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -1309,8 +1309,7 @@ const performance = z
 		maxAssetSize: z.number().optional(),
 		maxEntrypointSize: z.number().optional()
 	})
-	.or(z.literal(false));
-export type Performance = z.infer<typeof performance>;
+	.or(z.literal(false)) satisfies z.ZodType<t.Performance>;
 //#endregion
 
 export const rspackOptions = z.strictObject({


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

- Add JSDoc for config.performance

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
