### PR TITLE
refactor: add JSDoc to improve rspack config types

### DIFF
--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -912,7 +912,7 @@ interface Config_2 {
     test?: string | string[];
 }
 
-// @public (undocumented)
+// @public
 export type Configuration = RspackOptions;
 
 // @public
@@ -4681,8 +4681,6 @@ declare namespace rspackExports {
         RspackOptionsNormalized,
         externalsType,
         rspackOptions,
-        RspackOptions,
-        Configuration,
         FilenameTemplate,
         Filename,
         Name,
@@ -4840,7 +4838,9 @@ declare namespace rspackExports {
         IgnoreWarnings,
         Profile,
         Bail,
-        Performance_2 as Performance
+        Performance_2 as Performance,
+        RspackOptions,
+        Configuration
     }
 }
 
@@ -4854,7 +4854,38 @@ export type RspackFutureOptions = {
 };
 
 // @public (undocumented)
-export type RspackOptions = z.infer<typeof rspackOptions>;
+export type RspackOptions = {
+    name?: Name;
+    dependencies?: Dependencies;
+    entry?: Entry;
+    output?: Output;
+    target?: Target;
+    mode?: Mode;
+    experiments?: Experiments;
+    externals?: Externals;
+    externalsType?: ExternalsType;
+    externalsPresets?: ExternalsPresets;
+    infrastructureLogging?: InfrastructureLogging;
+    cache?: CacheOptions;
+    context?: Context;
+    devtool?: DevTool;
+    node?: Node_2;
+    loader?: Loader;
+    ignoreWarnings?: IgnoreWarnings;
+    watchOptions?: WatchOptions;
+    watch?: Watch;
+    stats?: StatsValue;
+    snapshot?: SnapshotOptions;
+    optimization?: Optimization;
+    resolve?: ResolveOptions;
+    resolveLoader?: ResolveOptions;
+    plugins?: Plugins;
+    devServer?: DevServer;
+    module?: ModuleOptions;
+    profile?: Profile;
+    bail?: Bail;
+    performance?: Performance_2;
+};
 
 // @public (undocumented)
 export const rspackOptions: z.ZodObject<{
@@ -4944,10 +4975,6 @@ export const rspackOptions: z.ZodObject<{
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -4966,16 +4993,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }, {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -4994,6 +5021,10 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodFunction<z.ZodTuple<[], z.ZodUnknown>, z.ZodUnion<[z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
         import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
@@ -5078,10 +5109,6 @@ export const rspackOptions: z.ZodObject<{
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -5100,16 +5127,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }, {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -5128,6 +5155,10 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>, z.ZodPromise<z.ZodUnion<[z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
         import: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
         runtime: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodString]>>;
@@ -5212,10 +5243,6 @@ export const rspackOptions: z.ZodObject<{
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -5234,16 +5261,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }, {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -5262,6 +5289,10 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }>]>>, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>]>>]>>]>>;
     output: z.ZodOptional<z.ZodObject<{
         path: z.ZodOptional<z.ZodString>;
@@ -5432,33 +5463,33 @@ export const rspackOptions: z.ZodObject<{
         }, "strict", z.ZodTypeAny, {
             module?: boolean | undefined;
             const?: boolean | undefined;
-            arrowFunction?: boolean | undefined;
-            asyncFunction?: boolean | undefined;
-            bigIntLiteral?: boolean | undefined;
-            destructuring?: boolean | undefined;
             document?: boolean | undefined;
+            nodePrefixForCoreModules?: boolean | undefined;
+            globalThis?: boolean | undefined;
+            bigIntLiteral?: boolean | undefined;
+            arrowFunction?: boolean | undefined;
+            forOf?: boolean | undefined;
+            destructuring?: boolean | undefined;
             dynamicImport?: boolean | undefined;
             dynamicImportInWorker?: boolean | undefined;
-            forOf?: boolean | undefined;
-            globalThis?: boolean | undefined;
-            nodePrefixForCoreModules?: boolean | undefined;
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
+            asyncFunction?: boolean | undefined;
         }, {
             module?: boolean | undefined;
             const?: boolean | undefined;
-            arrowFunction?: boolean | undefined;
-            asyncFunction?: boolean | undefined;
-            bigIntLiteral?: boolean | undefined;
-            destructuring?: boolean | undefined;
             document?: boolean | undefined;
+            nodePrefixForCoreModules?: boolean | undefined;
+            globalThis?: boolean | undefined;
+            bigIntLiteral?: boolean | undefined;
+            arrowFunction?: boolean | undefined;
+            forOf?: boolean | undefined;
+            destructuring?: boolean | undefined;
             dynamicImport?: boolean | undefined;
             dynamicImportInWorker?: boolean | undefined;
-            forOf?: boolean | undefined;
-            globalThis?: boolean | undefined;
-            nodePrefixForCoreModules?: boolean | undefined;
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
+            asyncFunction?: boolean | undefined;
         }>>;
     }, "strict", z.ZodTypeAny, {
         module?: boolean | undefined;
@@ -5467,31 +5498,21 @@ export const rspackOptions: z.ZodObject<{
         environment?: {
             module?: boolean | undefined;
             const?: boolean | undefined;
-            arrowFunction?: boolean | undefined;
-            asyncFunction?: boolean | undefined;
-            bigIntLiteral?: boolean | undefined;
-            destructuring?: boolean | undefined;
             document?: boolean | undefined;
+            nodePrefixForCoreModules?: boolean | undefined;
+            globalThis?: boolean | undefined;
+            bigIntLiteral?: boolean | undefined;
+            arrowFunction?: boolean | undefined;
+            forOf?: boolean | undefined;
+            destructuring?: boolean | undefined;
             dynamicImport?: boolean | undefined;
             dynamicImportInWorker?: boolean | undefined;
-            forOf?: boolean | undefined;
-            globalThis?: boolean | undefined;
-            nodePrefixForCoreModules?: boolean | undefined;
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
+            asyncFunction?: boolean | undefined;
         } | undefined;
         chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
-        auxiliaryComment?: string | {
-            root?: string | undefined;
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-        } | undefined;
-        umdNamedDefine?: boolean | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: string | string[] | {
             root?: string | string[] | undefined;
             commonjs?: string | undefined;
@@ -5513,27 +5534,33 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
+        auxiliaryComment?: string | {
+            root?: string | undefined;
+            commonjs?: string | undefined;
+            amd?: string | undefined;
+            commonjs2?: string | undefined;
+        } | undefined;
+        umdNamedDefine?: boolean | undefined;
+        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        uniqueName?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
-        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
         cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        cssHeadDataCompression?: boolean | undefined;
         cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
         assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
-        libraryExport?: string | string[] | undefined;
-        libraryTarget?: string | undefined;
-        strictModuleExceptionHandling?: boolean | undefined;
         strictModuleErrorHandling?: boolean | undefined;
         globalObject?: string | undefined;
         importFunctionName?: string | undefined;
         importMetaName?: string | undefined;
         iife?: boolean | undefined;
+        wasmLoading?: string | false | undefined;
         enabledWasmLoadingTypes?: string[] | undefined;
         webassemblyModuleFilename?: string | undefined;
         chunkFormat?: string | false | undefined;
@@ -5553,8 +5580,12 @@ export const rspackOptions: z.ZodObject<{
         devtoolNamespace?: string | undefined;
         devtoolModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
         devtoolFallbackModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-        chunkLoadTimeout?: number | undefined;
         charset?: boolean | undefined;
+        chunkLoadTimeout?: number | undefined;
+        cssHeadDataCompression?: boolean | undefined;
+        libraryExport?: string | string[] | undefined;
+        libraryTarget?: string | undefined;
+        strictModuleExceptionHandling?: boolean | undefined;
     }, {
         module?: boolean | undefined;
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
@@ -5562,31 +5593,21 @@ export const rspackOptions: z.ZodObject<{
         environment?: {
             module?: boolean | undefined;
             const?: boolean | undefined;
-            arrowFunction?: boolean | undefined;
-            asyncFunction?: boolean | undefined;
-            bigIntLiteral?: boolean | undefined;
-            destructuring?: boolean | undefined;
             document?: boolean | undefined;
+            nodePrefixForCoreModules?: boolean | undefined;
+            globalThis?: boolean | undefined;
+            bigIntLiteral?: boolean | undefined;
+            arrowFunction?: boolean | undefined;
+            forOf?: boolean | undefined;
+            destructuring?: boolean | undefined;
             dynamicImport?: boolean | undefined;
             dynamicImportInWorker?: boolean | undefined;
-            forOf?: boolean | undefined;
-            globalThis?: boolean | undefined;
-            nodePrefixForCoreModules?: boolean | undefined;
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
+            asyncFunction?: boolean | undefined;
         } | undefined;
         chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
-        auxiliaryComment?: string | {
-            root?: string | undefined;
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-        } | undefined;
-        umdNamedDefine?: boolean | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: string | string[] | {
             root?: string | string[] | undefined;
             commonjs?: string | undefined;
@@ -5608,27 +5629,33 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
+        auxiliaryComment?: string | {
+            root?: string | undefined;
+            commonjs?: string | undefined;
+            amd?: string | undefined;
+            commonjs2?: string | undefined;
+        } | undefined;
+        umdNamedDefine?: boolean | undefined;
+        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        uniqueName?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
-        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
         cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        cssHeadDataCompression?: boolean | undefined;
         cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
         assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
-        libraryExport?: string | string[] | undefined;
-        libraryTarget?: string | undefined;
-        strictModuleExceptionHandling?: boolean | undefined;
         strictModuleErrorHandling?: boolean | undefined;
         globalObject?: string | undefined;
         importFunctionName?: string | undefined;
         importMetaName?: string | undefined;
         iife?: boolean | undefined;
+        wasmLoading?: string | false | undefined;
         enabledWasmLoadingTypes?: string[] | undefined;
         webassemblyModuleFilename?: string | undefined;
         chunkFormat?: string | false | undefined;
@@ -5648,8 +5675,12 @@ export const rspackOptions: z.ZodObject<{
         devtoolNamespace?: string | undefined;
         devtoolModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
         devtoolFallbackModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-        chunkLoadTimeout?: number | undefined;
         charset?: boolean | undefined;
+        chunkLoadTimeout?: number | undefined;
+        cssHeadDataCompression?: boolean | undefined;
+        libraryExport?: string | string[] | undefined;
+        libraryTarget?: string | undefined;
+        strictModuleExceptionHandling?: boolean | undefined;
     }>>;
     target: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodUnion<[z.ZodEnum<["web", "webworker", "es3", "es5", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021", "es2022"]>, z.ZodLiteral<"node">, z.ZodLiteral<"async-node">, z.ZodType<`node${number}`, z.ZodTypeDef, `node${number}`>, z.ZodType<`async-node${number}`, z.ZodTypeDef, `async-node${number}`>, z.ZodType<`node${number}.${number}`, z.ZodTypeDef, `node${number}.${number}`>, z.ZodType<`async-node${number}.${number}`, z.ZodTypeDef, `async-node${number}.${number}`>, z.ZodLiteral<"electron-main">, z.ZodType<`electron${number}-main`, z.ZodTypeDef, `electron${number}-main`>, z.ZodType<`electron${number}.${number}-main`, z.ZodTypeDef, `electron${number}.${number}-main`>, z.ZodLiteral<"electron-renderer">, z.ZodType<`electron${number}-renderer`, z.ZodTypeDef, `electron${number}-renderer`>, z.ZodType<`electron${number}.${number}-renderer`, z.ZodTypeDef, `electron${number}.${number}-renderer`>, z.ZodLiteral<"electron-preload">, z.ZodType<`electron${number}-preload`, z.ZodTypeDef, `electron${number}-preload`>, z.ZodType<`electron${number}.${number}-preload`, z.ZodTypeDef, `electron${number}.${number}-preload`>, z.ZodLiteral<"nwjs">, z.ZodType<`nwjs${number}`, z.ZodTypeDef, `nwjs${number}`>, z.ZodType<`nwjs${number}.${number}`, z.ZodTypeDef, `nwjs${number}.${number}`>, z.ZodLiteral<"node-webkit">, z.ZodType<`node-webkit${number}`, z.ZodTypeDef, `node-webkit${number}`>, z.ZodType<`node-webkit${number}.${number}`, z.ZodTypeDef, `node-webkit${number}.${number}`>, z.ZodLiteral<"browserslist">, z.ZodType<`browserslist:${string}`, z.ZodTypeDef, `browserslist:${string}`>]>, z.ZodArray<z.ZodUnion<[z.ZodEnum<["web", "webworker", "es3", "es5", "es2015", "es2016", "es2017", "es2018", "es2019", "es2020", "es2021", "es2022"]>, z.ZodLiteral<"node">, z.ZodLiteral<"async-node">, z.ZodType<`node${number}`, z.ZodTypeDef, `node${number}`>, z.ZodType<`async-node${number}`, z.ZodTypeDef, `async-node${number}`>, z.ZodType<`node${number}.${number}`, z.ZodTypeDef, `node${number}.${number}`>, z.ZodType<`async-node${number}.${number}`, z.ZodTypeDef, `async-node${number}.${number}`>, z.ZodLiteral<"electron-main">, z.ZodType<`electron${number}-main`, z.ZodTypeDef, `electron${number}-main`>, z.ZodType<`electron${number}.${number}-main`, z.ZodTypeDef, `electron${number}.${number}-main`>, z.ZodLiteral<"electron-renderer">, z.ZodType<`electron${number}-renderer`, z.ZodTypeDef, `electron${number}-renderer`>, z.ZodType<`electron${number}.${number}-renderer`, z.ZodTypeDef, `electron${number}.${number}-renderer`>, z.ZodLiteral<"electron-preload">, z.ZodType<`electron${number}-preload`, z.ZodTypeDef, `electron${number}-preload`>, z.ZodType<`electron${number}.${number}-preload`, z.ZodTypeDef, `electron${number}.${number}-preload`>, z.ZodLiteral<"nwjs">, z.ZodType<`nwjs${number}`, z.ZodTypeDef, `nwjs${number}`>, z.ZodType<`nwjs${number}.${number}`, z.ZodTypeDef, `nwjs${number}.${number}`>, z.ZodLiteral<"node-webkit">, z.ZodType<`node-webkit${number}`, z.ZodTypeDef, `node-webkit${number}`>, z.ZodType<`node-webkit${number}.${number}`, z.ZodTypeDef, `node-webkit${number}.${number}`>, z.ZodLiteral<"browserslist">, z.ZodType<`browserslist:${string}`, z.ZodTypeDef, `browserslist:${string}`>]>, "many">]>>;
     mode: z.ZodOptional<z.ZodEnum<["development", "production", "none"]>>;
@@ -5718,6 +5749,7 @@ export const rspackOptions: z.ZodObject<{
             test: z.ZodOptional<z.ZodUnion<[z.ZodType<RegExp, z.ZodTypeDef, RegExp>, z.ZodFunction<z.ZodTuple<[z.ZodType<Module, z.ZodTypeDef, Module>], z.ZodUnknown>, z.ZodBoolean>]>>;
         }, "strip", z.ZodTypeAny, {
             entries?: boolean | undefined;
+            imports?: boolean | undefined;
             test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
@@ -5733,9 +5765,9 @@ export const rspackOptions: z.ZodObject<{
                 } | undefined;
                 protocol?: "http" | "https" | undefined;
             } | undefined;
-            imports?: boolean | undefined;
         }, {
             entries?: boolean | undefined;
+            imports?: boolean | undefined;
             test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
@@ -5751,7 +5783,6 @@ export const rspackOptions: z.ZodObject<{
                 } | undefined;
                 protocol?: "http" | "https" | undefined;
             } | undefined;
-            imports?: boolean | undefined;
         }>]>;
         asyncWebAssembly: z.ZodOptional<z.ZodBoolean>;
         outputModule: z.ZodOptional<z.ZodBoolean>;
@@ -5816,8 +5847,31 @@ export const rspackOptions: z.ZodObject<{
         }>>;
     }, "strict", z.ZodTypeAny, {
         css?: boolean | undefined;
+        topLevelAwait?: boolean | undefined;
+        layers?: boolean | undefined;
+        incremental?: boolean | {
+            make?: boolean | undefined;
+            providedExports?: boolean | undefined;
+            emitAssets?: boolean | undefined;
+            inferAsyncModules?: boolean | undefined;
+            dependenciesDiagnostics?: boolean | undefined;
+            modulesHashes?: boolean | undefined;
+            modulesCodegen?: boolean | undefined;
+            modulesRuntimeRequirements?: boolean | undefined;
+        } | undefined;
+        rspackFuture?: {
+            bundlerInfo?: {
+                force?: boolean | ("version" | "uniqueId")[] | undefined;
+                version?: string | undefined;
+                bundler?: string | undefined;
+            } | undefined;
+        } | undefined;
+        asyncWebAssembly?: boolean | undefined;
+        outputModule?: boolean | undefined;
+        futureDefaults?: boolean | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
+            imports?: boolean | undefined;
             test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
@@ -5832,35 +5886,35 @@ export const rspackOptions: z.ZodObject<{
                     ipv6Only?: boolean | undefined;
                 } | undefined;
                 protocol?: "http" | "https" | undefined;
-            } | undefined;
-            imports?: boolean | undefined;
-        } | undefined;
-        asyncWebAssembly?: boolean | undefined;
-        outputModule?: boolean | undefined;
-        topLevelAwait?: boolean | undefined;
-        layers?: boolean | undefined;
-        incremental?: boolean | {
-            make?: boolean | undefined;
-            providedExports?: boolean | undefined;
-            emitAssets?: boolean | undefined;
-            inferAsyncModules?: boolean | undefined;
-            dependenciesDiagnostics?: boolean | undefined;
-            modulesHashes?: boolean | undefined;
-            modulesCodegen?: boolean | undefined;
-            modulesRuntimeRequirements?: boolean | undefined;
-        } | undefined;
-        futureDefaults?: boolean | undefined;
-        rspackFuture?: {
-            bundlerInfo?: {
-                force?: boolean | ("version" | "uniqueId")[] | undefined;
-                version?: string | undefined;
-                bundler?: string | undefined;
             } | undefined;
         } | undefined;
     }, {
         css?: boolean | undefined;
+        topLevelAwait?: boolean | undefined;
+        layers?: boolean | undefined;
+        incremental?: boolean | {
+            make?: boolean | undefined;
+            providedExports?: boolean | undefined;
+            emitAssets?: boolean | undefined;
+            inferAsyncModules?: boolean | undefined;
+            dependenciesDiagnostics?: boolean | undefined;
+            modulesHashes?: boolean | undefined;
+            modulesCodegen?: boolean | undefined;
+            modulesRuntimeRequirements?: boolean | undefined;
+        } | undefined;
+        rspackFuture?: {
+            bundlerInfo?: {
+                force?: boolean | ("version" | "uniqueId")[] | undefined;
+                version?: string | undefined;
+                bundler?: string | undefined;
+            } | undefined;
+        } | undefined;
+        asyncWebAssembly?: boolean | undefined;
+        outputModule?: boolean | undefined;
+        futureDefaults?: boolean | undefined;
         lazyCompilation?: boolean | {
             entries?: boolean | undefined;
+            imports?: boolean | undefined;
             test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
             backend?: {
                 client?: string | undefined;
@@ -5875,29 +5929,6 @@ export const rspackOptions: z.ZodObject<{
                     ipv6Only?: boolean | undefined;
                 } | undefined;
                 protocol?: "http" | "https" | undefined;
-            } | undefined;
-            imports?: boolean | undefined;
-        } | undefined;
-        asyncWebAssembly?: boolean | undefined;
-        outputModule?: boolean | undefined;
-        topLevelAwait?: boolean | undefined;
-        layers?: boolean | undefined;
-        incremental?: boolean | {
-            make?: boolean | undefined;
-            providedExports?: boolean | undefined;
-            emitAssets?: boolean | undefined;
-            inferAsyncModules?: boolean | undefined;
-            dependenciesDiagnostics?: boolean | undefined;
-            modulesHashes?: boolean | undefined;
-            modulesCodegen?: boolean | undefined;
-            modulesRuntimeRequirements?: boolean | undefined;
-        } | undefined;
-        futureDefaults?: boolean | undefined;
-        rspackFuture?: {
-            bundlerInfo?: {
-                force?: boolean | ("version" | "uniqueId")[] | undefined;
-                version?: string | undefined;
-                bundler?: string | undefined;
             } | undefined;
         } | undefined;
     }>>;
@@ -6016,20 +6047,20 @@ export const rspackOptions: z.ZodObject<{
         node?: boolean | undefined;
         web?: boolean | undefined;
         nwjs?: boolean | undefined;
-        webAsync?: boolean | undefined;
         electron?: boolean | undefined;
         electronMain?: boolean | undefined;
         electronPreload?: boolean | undefined;
         electronRenderer?: boolean | undefined;
+        webAsync?: boolean | undefined;
     }, {
         node?: boolean | undefined;
         web?: boolean | undefined;
         nwjs?: boolean | undefined;
-        webAsync?: boolean | undefined;
         electron?: boolean | undefined;
         electronMain?: boolean | undefined;
         electronPreload?: boolean | undefined;
         electronRenderer?: boolean | undefined;
+        webAsync?: boolean | undefined;
     }>>;
     infrastructureLogging: z.ZodOptional<z.ZodObject<{
         appendOnly: z.ZodOptional<z.ZodBoolean>;
@@ -6041,17 +6072,17 @@ export const rspackOptions: z.ZodObject<{
     }, "strict", z.ZodTypeAny, {
         debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         colors?: boolean | undefined;
+        stream?: NodeJS.WritableStream | undefined;
         appendOnly?: boolean | undefined;
         console?: Console | undefined;
         level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        stream?: NodeJS.WritableStream | undefined;
     }, {
         debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
         colors?: boolean | undefined;
+        stream?: NodeJS.WritableStream | undefined;
         appendOnly?: boolean | undefined;
         console?: Console | undefined;
         level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        stream?: NodeJS.WritableStream | undefined;
     }>>;
     cache: z.ZodOptional<z.ZodBoolean>;
     context: z.ZodOptional<z.ZodEffects<z.ZodString, string, string>>;
@@ -6370,12 +6401,8 @@ export const rspackOptions: z.ZodObject<{
                 priority?: number | undefined;
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
                 defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 minChunks?: number | undefined;
                 minSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
@@ -6383,6 +6410,10 @@ export const rspackOptions: z.ZodObject<{
                 maxAsyncRequests?: number | undefined;
                 maxInitialRequests?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
             }, {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
@@ -6390,12 +6421,8 @@ export const rspackOptions: z.ZodObject<{
                 priority?: number | undefined;
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
                 defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 minChunks?: number | undefined;
                 minSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
@@ -6403,6 +6430,10 @@ export const rspackOptions: z.ZodObject<{
                 maxAsyncRequests?: number | undefined;
                 maxInitialRequests?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
             }>]>>>;
             fallbackCacheGroup: z.ZodOptional<z.ZodObject<{
                 chunks: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["initial", "async", "all"]>, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodFunction<z.ZodTuple<[z.ZodType<Chunk, z.ZodTypeDef, Chunk>], z.ZodUnknown>, z.ZodBoolean>]>>;
@@ -6431,15 +6462,7 @@ export const rspackOptions: z.ZodObject<{
             name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
@@ -6447,12 +6470,8 @@ export const rspackOptions: z.ZodObject<{
                 priority?: number | undefined;
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
                 defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 minChunks?: number | undefined;
                 minSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
@@ -6460,7 +6479,12 @@ export const rspackOptions: z.ZodObject<{
                 maxAsyncRequests?: number | undefined;
                 maxInitialRequests?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
             }> | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             fallbackCacheGroup?: {
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
@@ -6470,19 +6494,18 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
+            minChunks?: number | undefined;
+            minSize?: number | Record<string, number> | undefined;
+            maxAsyncSize?: number | Record<string, number> | undefined;
+            maxInitialSize?: number | Record<string, number> | undefined;
+            maxAsyncRequests?: number | undefined;
+            maxInitialRequests?: number | undefined;
+            automaticNameDelimiter?: string | undefined;
         }, {
             name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
@@ -6490,12 +6513,8 @@ export const rspackOptions: z.ZodObject<{
                 priority?: number | undefined;
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
                 defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 minChunks?: number | undefined;
                 minSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
@@ -6503,7 +6522,12 @@ export const rspackOptions: z.ZodObject<{
                 maxAsyncRequests?: number | undefined;
                 maxInitialRequests?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
             }> | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             fallbackCacheGroup?: {
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
@@ -6513,6 +6537,13 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
+            minChunks?: number | undefined;
+            minSize?: number | Record<string, number> | undefined;
+            maxAsyncSize?: number | Record<string, number> | undefined;
+            maxInitialSize?: number | Record<string, number> | undefined;
+            maxAsyncRequests?: number | undefined;
+            maxInitialRequests?: number | undefined;
+            automaticNameDelimiter?: string | undefined;
         }>]>>;
         runtimeChunk: z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodEnum<["single", "multiple"]>, z.ZodBoolean]>, z.ZodObject<{
             name: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
@@ -6547,15 +6578,7 @@ export const rspackOptions: z.ZodObject<{
             name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
@@ -6563,12 +6586,8 @@ export const rspackOptions: z.ZodObject<{
                 priority?: number | undefined;
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
                 defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 minChunks?: number | undefined;
                 minSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
@@ -6576,7 +6595,12 @@ export const rspackOptions: z.ZodObject<{
                 maxAsyncRequests?: number | undefined;
                 maxInitialRequests?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
             }> | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             fallbackCacheGroup?: {
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
@@ -6586,10 +6610,17 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
+            minChunks?: number | undefined;
+            minSize?: number | Record<string, number> | undefined;
+            maxAsyncSize?: number | Record<string, number> | undefined;
+            maxInitialSize?: number | Record<string, number> | undefined;
+            maxAsyncRequests?: number | undefined;
+            maxInitialRequests?: number | undefined;
+            automaticNameDelimiter?: string | undefined;
         } | undefined;
         usedExports?: boolean | "global" | undefined;
         providedExports?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
+        removeAvailableModules?: boolean | undefined;
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
         chunkIds?: "named" | "natural" | "deterministic" | undefined;
         minimize?: boolean | undefined;
@@ -6600,9 +6631,9 @@ export const rspackOptions: z.ZodObject<{
                 name: string;
             }, ...args: unknown[]) => string) | undefined;
         } | undefined;
-        removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
         realContentHash?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "size" | "deterministic" | undefined;
@@ -6613,15 +6644,7 @@ export const rspackOptions: z.ZodObject<{
             name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
             chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
             usedExports?: boolean | undefined;
-            maxSize?: number | Record<string, number> | undefined;
             defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
             cacheGroups?: Record<string, false | {
                 type?: string | RegExp | undefined;
                 filename?: string | undefined;
@@ -6629,12 +6652,8 @@ export const rspackOptions: z.ZodObject<{
                 priority?: number | undefined;
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
                 defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
                 minChunks?: number | undefined;
                 minSize?: number | Record<string, number> | undefined;
                 maxAsyncSize?: number | Record<string, number> | undefined;
@@ -6642,7 +6661,12 @@ export const rspackOptions: z.ZodObject<{
                 maxAsyncRequests?: number | undefined;
                 maxInitialRequests?: number | undefined;
                 automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
             }> | undefined;
+            maxSize?: number | Record<string, number> | undefined;
             fallbackCacheGroup?: {
                 chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
                 maxSize?: number | undefined;
@@ -6652,10 +6676,17 @@ export const rspackOptions: z.ZodObject<{
                 automaticNameDelimiter?: string | undefined;
             } | undefined;
             hidePathInfo?: boolean | undefined;
+            minChunks?: number | undefined;
+            minSize?: number | Record<string, number> | undefined;
+            maxAsyncSize?: number | Record<string, number> | undefined;
+            maxInitialSize?: number | Record<string, number> | undefined;
+            maxAsyncRequests?: number | undefined;
+            maxInitialRequests?: number | undefined;
+            automaticNameDelimiter?: string | undefined;
         } | undefined;
         usedExports?: boolean | "global" | undefined;
         providedExports?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
+        removeAvailableModules?: boolean | undefined;
         moduleIds?: "named" | "natural" | "deterministic" | undefined;
         chunkIds?: "named" | "natural" | "deterministic" | undefined;
         minimize?: boolean | undefined;
@@ -6666,9 +6697,9 @@ export const rspackOptions: z.ZodObject<{
                 name: string;
             }, ...args: unknown[]) => string) | undefined;
         } | undefined;
-        removeAvailableModules?: boolean | undefined;
         removeEmptyChunks?: boolean | undefined;
         realContentHash?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
         concatenateModules?: boolean | undefined;
         innerGraph?: boolean | undefined;
         mangleExports?: boolean | "size" | "deterministic" | undefined;
@@ -7170,11 +7201,11 @@ export const rspackOptions: z.ZodObject<{
                     encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
                     mimetype: z.ZodOptional<z.ZodString>;
                 }, "strict", z.ZodTypeAny, {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 }, {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
                     content: z.ZodString;
                     filename: z.ZodString;
@@ -7194,8 +7225,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7205,8 +7236,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7217,11 +7248,11 @@ export const rspackOptions: z.ZodObject<{
                     encoding: z.ZodOptional<z.ZodUnion<[z.ZodLiteral<false>, z.ZodLiteral<"base64">]>>;
                     mimetype: z.ZodOptional<z.ZodString>;
                 }, "strict", z.ZodTypeAny, {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 }, {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 }>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
                     content: z.ZodString;
                     filename: z.ZodString;
@@ -7234,16 +7265,16 @@ export const rspackOptions: z.ZodObject<{
                 }>], z.ZodUnknown>, z.ZodString>]>>;
             }, "strict", z.ZodTypeAny, {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
                 }, ...args: unknown[]) => string) | undefined;
             }, {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7326,8 +7357,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7335,8 +7366,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7369,8 +7400,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7378,8 +7409,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7415,8 +7446,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7424,8 +7455,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7437,6 +7468,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         parser?: {
             javascript?: {
                 url?: boolean | "relative" | undefined;
@@ -7537,8 +7570,6 @@ export const rspackOptions: z.ZodObject<{
                 importDynamic?: boolean | undefined;
             } | undefined;
         } | Record<string, Record<string, any>> | undefined;
-        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     }, {
         generator?: Record<string, Record<string, any>> | {
@@ -7563,8 +7594,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7572,8 +7603,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7585,6 +7616,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         parser?: {
             javascript?: {
                 url?: boolean | "relative" | undefined;
@@ -7685,8 +7718,6 @@ export const rspackOptions: z.ZodObject<{
                 importDynamic?: boolean | undefined;
             } | undefined;
         } | Record<string, Record<string, any>> | undefined;
-        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     }>>;
     profile: z.ZodOptional<z.ZodBoolean>;
@@ -7697,14 +7728,14 @@ export const rspackOptions: z.ZodObject<{
         maxAssetSize: z.ZodOptional<z.ZodNumber>;
         maxEntrypointSize: z.ZodOptional<z.ZodNumber>;
     }, "strict", z.ZodTypeAny, {
+        maxAssetSize?: number | undefined;
         assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
-        maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     }, {
+        maxAssetSize?: number | undefined;
         assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
-        maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     }>, z.ZodLiteral<false>]>>;
 }, "strict", z.ZodTypeAny, {
@@ -7733,8 +7764,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7742,8 +7773,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -7755,6 +7786,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         parser?: {
             javascript?: {
                 url?: boolean | "relative" | undefined;
@@ -7855,15 +7888,13 @@ export const rspackOptions: z.ZodObject<{
                 importDynamic?: boolean | undefined;
             } | undefined;
         } | Record<string, Record<string, any>> | undefined;
-        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     } | undefined;
     name?: string | undefined;
     performance?: false | {
+        maxAssetSize?: number | undefined;
         assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
-        maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     } | undefined;
     entry?: string | string[] | Record<string, string | string[] | {
@@ -7872,10 +7903,6 @@ export const rspackOptions: z.ZodObject<{
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -7894,16 +7921,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }> | ((...args: unknown[]) => string | string[] | Record<string, string | string[] | {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -7922,16 +7949,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }> | Promise<string | string[] | Record<string, string | string[] | {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -7950,6 +7977,10 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }>>) | undefined;
     node?: false | {
         global?: boolean | "warn" | undefined;
@@ -7958,7 +7989,53 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     profile?: boolean | undefined;
     cache?: boolean | undefined;
-    loader?: Record<string, any> | undefined;
+    devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
+    mode?: "none" | "development" | "production" | undefined;
+    experiments?: {
+        css?: boolean | undefined;
+        topLevelAwait?: boolean | undefined;
+        layers?: boolean | undefined;
+        incremental?: boolean | {
+            make?: boolean | undefined;
+            providedExports?: boolean | undefined;
+            emitAssets?: boolean | undefined;
+            inferAsyncModules?: boolean | undefined;
+            dependenciesDiagnostics?: boolean | undefined;
+            modulesHashes?: boolean | undefined;
+            modulesCodegen?: boolean | undefined;
+            modulesRuntimeRequirements?: boolean | undefined;
+        } | undefined;
+        rspackFuture?: {
+            bundlerInfo?: {
+                force?: boolean | ("version" | "uniqueId")[] | undefined;
+                version?: string | undefined;
+                bundler?: string | undefined;
+            } | undefined;
+        } | undefined;
+        asyncWebAssembly?: boolean | undefined;
+        outputModule?: boolean | undefined;
+        futureDefaults?: boolean | undefined;
+        lazyCompilation?: boolean | {
+            entries?: boolean | undefined;
+            imports?: boolean | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            backend?: {
+                client?: string | undefined;
+                listen?: number | {
+                    path?: string | undefined;
+                    port?: number | undefined;
+                    host?: string | undefined;
+                    backlog?: number | undefined;
+                    exclusive?: boolean | undefined;
+                    readableAll?: boolean | undefined;
+                    writableAll?: boolean | undefined;
+                    ipv6Only?: boolean | undefined;
+                } | undefined;
+                protocol?: "http" | "https" | undefined;
+            } | undefined;
+        } | undefined;
+    } | undefined;
+    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
     resolve?: t.ResolveOptions | undefined;
     output?: {
         module?: boolean | undefined;
@@ -7967,31 +8044,21 @@ export const rspackOptions: z.ZodObject<{
         environment?: {
             module?: boolean | undefined;
             const?: boolean | undefined;
-            arrowFunction?: boolean | undefined;
-            asyncFunction?: boolean | undefined;
-            bigIntLiteral?: boolean | undefined;
-            destructuring?: boolean | undefined;
             document?: boolean | undefined;
+            nodePrefixForCoreModules?: boolean | undefined;
+            globalThis?: boolean | undefined;
+            bigIntLiteral?: boolean | undefined;
+            arrowFunction?: boolean | undefined;
+            forOf?: boolean | undefined;
+            destructuring?: boolean | undefined;
             dynamicImport?: boolean | undefined;
             dynamicImportInWorker?: boolean | undefined;
-            forOf?: boolean | undefined;
-            globalThis?: boolean | undefined;
-            nodePrefixForCoreModules?: boolean | undefined;
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
+            asyncFunction?: boolean | undefined;
         } | undefined;
         chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
-        auxiliaryComment?: string | {
-            root?: string | undefined;
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-        } | undefined;
-        umdNamedDefine?: boolean | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: string | string[] | {
             root?: string | string[] | undefined;
             commonjs?: string | undefined;
@@ -8013,27 +8080,33 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
+        auxiliaryComment?: string | {
+            root?: string | undefined;
+            commonjs?: string | undefined;
+            amd?: string | undefined;
+            commonjs2?: string | undefined;
+        } | undefined;
+        umdNamedDefine?: boolean | undefined;
+        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        uniqueName?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
-        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
         cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        cssHeadDataCompression?: boolean | undefined;
         cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
         assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
-        libraryExport?: string | string[] | undefined;
-        libraryTarget?: string | undefined;
-        strictModuleExceptionHandling?: boolean | undefined;
         strictModuleErrorHandling?: boolean | undefined;
         globalObject?: string | undefined;
         importFunctionName?: string | undefined;
         importMetaName?: string | undefined;
         iife?: boolean | undefined;
+        wasmLoading?: string | false | undefined;
         enabledWasmLoadingTypes?: string[] | undefined;
         webassemblyModuleFilename?: string | undefined;
         chunkFormat?: string | false | undefined;
@@ -8053,113 +8126,81 @@ export const rspackOptions: z.ZodObject<{
         devtoolNamespace?: string | undefined;
         devtoolModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
         devtoolFallbackModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-        chunkLoadTimeout?: number | undefined;
         charset?: boolean | undefined;
+        chunkLoadTimeout?: number | undefined;
+        cssHeadDataCompression?: boolean | undefined;
+        libraryExport?: string | string[] | undefined;
+        libraryTarget?: string | undefined;
+        strictModuleExceptionHandling?: boolean | undefined;
     } | undefined;
-    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
-    mode?: "none" | "development" | "production" | undefined;
-    experiments?: {
-        css?: boolean | undefined;
-        lazyCompilation?: boolean | {
-            entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            backend?: {
-                client?: string | undefined;
-                listen?: number | {
-                    path?: string | undefined;
-                    port?: number | undefined;
-                    host?: string | undefined;
-                    backlog?: number | undefined;
-                    exclusive?: boolean | undefined;
-                    readableAll?: boolean | undefined;
-                    writableAll?: boolean | undefined;
-                    ipv6Only?: boolean | undefined;
-                } | undefined;
-                protocol?: "http" | "https" | undefined;
+    optimization?: {
+        splitChunks?: false | {
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            defaultSizeTypes?: string[] | undefined;
+            cacheGroups?: Record<string, false | {
+                type?: string | RegExp | undefined;
+                filename?: string | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
+                defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
+                minChunks?: number | undefined;
+                minSize?: number | Record<string, number> | undefined;
+                maxAsyncSize?: number | Record<string, number> | undefined;
+                maxInitialSize?: number | Record<string, number> | undefined;
+                maxAsyncRequests?: number | undefined;
+                maxInitialRequests?: number | undefined;
+                automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
+            }> | undefined;
+            maxSize?: number | Record<string, number> | undefined;
+            fallbackCacheGroup?: {
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                maxSize?: number | undefined;
+                minSize?: number | undefined;
+                maxAsyncSize?: number | undefined;
+                maxInitialSize?: number | undefined;
+                automaticNameDelimiter?: string | undefined;
             } | undefined;
-            imports?: boolean | undefined;
+            hidePathInfo?: boolean | undefined;
+            minChunks?: number | undefined;
+            minSize?: number | Record<string, number> | undefined;
+            maxAsyncSize?: number | Record<string, number> | undefined;
+            maxInitialSize?: number | Record<string, number> | undefined;
+            maxAsyncRequests?: number | undefined;
+            maxInitialRequests?: number | undefined;
+            automaticNameDelimiter?: string | undefined;
         } | undefined;
-        asyncWebAssembly?: boolean | undefined;
-        outputModule?: boolean | undefined;
-        topLevelAwait?: boolean | undefined;
-        layers?: boolean | undefined;
-        incremental?: boolean | {
-            make?: boolean | undefined;
-            providedExports?: boolean | undefined;
-            emitAssets?: boolean | undefined;
-            inferAsyncModules?: boolean | undefined;
-            dependenciesDiagnostics?: boolean | undefined;
-            modulesHashes?: boolean | undefined;
-            modulesCodegen?: boolean | undefined;
-            modulesRuntimeRequirements?: boolean | undefined;
+        usedExports?: boolean | "global" | undefined;
+        providedExports?: boolean | undefined;
+        removeAvailableModules?: boolean | undefined;
+        moduleIds?: "named" | "natural" | "deterministic" | undefined;
+        chunkIds?: "named" | "natural" | "deterministic" | undefined;
+        minimize?: boolean | undefined;
+        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+        mergeDuplicateChunks?: boolean | undefined;
+        runtimeChunk?: boolean | "single" | "multiple" | {
+            name?: string | ((args_0: {
+                name: string;
+            }, ...args: unknown[]) => string) | undefined;
         } | undefined;
-        futureDefaults?: boolean | undefined;
-        rspackFuture?: {
-            bundlerInfo?: {
-                force?: boolean | ("version" | "uniqueId")[] | undefined;
-                version?: string | undefined;
-                bundler?: string | undefined;
-            } | undefined;
-        } | undefined;
+        removeEmptyChunks?: boolean | undefined;
+        realContentHash?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
+        concatenateModules?: boolean | undefined;
+        innerGraph?: boolean | undefined;
+        mangleExports?: boolean | "size" | "deterministic" | undefined;
+        nodeEnv?: string | false | undefined;
+        emitOnErrors?: boolean | undefined;
     } | undefined;
-    externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
-    externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
-    externalsPresets?: {
-        node?: boolean | undefined;
-        web?: boolean | undefined;
-        nwjs?: boolean | undefined;
-        webAsync?: boolean | undefined;
-        electron?: boolean | undefined;
-        electronMain?: boolean | undefined;
-        electronPreload?: boolean | undefined;
-        electronRenderer?: boolean | undefined;
-    } | undefined;
-    infrastructureLogging?: {
-        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-        colors?: boolean | undefined;
-        appendOnly?: boolean | undefined;
-        console?: Console | undefined;
-        level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        stream?: NodeJS.WritableStream | undefined;
-    } | undefined;
-    devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
-    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
-    watchOptions?: {
-        aggregateTimeout?: number | undefined;
-        followSymlinks?: boolean | undefined;
-        ignored?: string | RegExp | string[] | undefined;
-        poll?: number | boolean | undefined;
-        stdin?: boolean | undefined;
-    } | undefined;
-    watch?: boolean | undefined;
+    snapshot?: {} | undefined;
     stats?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
@@ -8238,77 +8279,67 @@ export const rspackOptions: z.ZodObject<{
         errorsSpace?: number | undefined;
         warningsSpace?: number | undefined;
     } | undefined;
-    snapshot?: {} | undefined;
-    optimization?: {
-        splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
-            usedExports?: boolean | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-            cacheGroups?: Record<string, false | {
-                type?: string | RegExp | undefined;
-                filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
-                usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
-                defaultSizeTypes?: string[] | undefined;
-                minChunks?: number | undefined;
-                minSize?: number | Record<string, number> | undefined;
-                maxAsyncSize?: number | Record<string, number> | undefined;
-                maxInitialSize?: number | Record<string, number> | undefined;
-                maxAsyncRequests?: number | undefined;
-                maxInitialRequests?: number | undefined;
-                automaticNameDelimiter?: string | undefined;
-            }> | undefined;
-            fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
-                maxSize?: number | undefined;
-                minSize?: number | undefined;
-                maxAsyncSize?: number | undefined;
-                maxInitialSize?: number | undefined;
-                automaticNameDelimiter?: string | undefined;
-            } | undefined;
-            hidePathInfo?: boolean | undefined;
-        } | undefined;
-        usedExports?: boolean | "global" | undefined;
-        providedExports?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
-        moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | undefined;
-        minimize?: boolean | undefined;
-        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
-        mergeDuplicateChunks?: boolean | undefined;
-        runtimeChunk?: boolean | "single" | "multiple" | {
-            name?: string | ((args_0: {
-                name: string;
-            }, ...args: unknown[]) => string) | undefined;
-        } | undefined;
-        removeAvailableModules?: boolean | undefined;
-        removeEmptyChunks?: boolean | undefined;
-        realContentHash?: boolean | undefined;
-        concatenateModules?: boolean | undefined;
-        innerGraph?: boolean | undefined;
-        mangleExports?: boolean | "size" | "deterministic" | undefined;
-        nodeEnv?: string | false | undefined;
-        emitOnErrors?: boolean | undefined;
-    } | undefined;
+    loader?: Record<string, any> | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
+    externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
+    externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
+    externalsPresets?: {
+        node?: boolean | undefined;
+        web?: boolean | undefined;
+        nwjs?: boolean | undefined;
+        electron?: boolean | undefined;
+        electronMain?: boolean | undefined;
+        electronPreload?: boolean | undefined;
+        electronRenderer?: boolean | undefined;
+        webAsync?: boolean | undefined;
+    } | undefined;
+    infrastructureLogging?: {
+        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
+        colors?: boolean | undefined;
+        stream?: NodeJS.WritableStream | undefined;
+        appendOnly?: boolean | undefined;
+        console?: Console | undefined;
+        level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
+    } | undefined;
     plugins?: (false | "" | 0 | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+    watch?: boolean | undefined;
+    watchOptions?: {
+        aggregateTimeout?: number | undefined;
+        followSymlinks?: boolean | undefined;
+        ignored?: string | RegExp | string[] | undefined;
+        poll?: number | boolean | undefined;
+        stdin?: boolean | undefined;
+    } | undefined;
     devServer?: t.DevServer | undefined;
+    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
     bail?: boolean | undefined;
 }, {
     context?: string | undefined;
@@ -8336,8 +8367,8 @@ export const rspackOptions: z.ZodObject<{
                 publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
                 emit?: boolean | undefined;
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -8345,8 +8376,8 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
             "asset/inline"?: {
                 dataUrl?: {
-                    mimetype?: string | undefined;
                     encoding?: false | "base64" | undefined;
+                    mimetype?: string | undefined;
                 } | ((args_0: {
                     filename: string;
                     content: string;
@@ -8358,6 +8389,8 @@ export const rspackOptions: z.ZodObject<{
                 emit?: boolean | undefined;
             } | undefined;
         } | undefined;
+        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
+        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         parser?: {
             javascript?: {
                 url?: boolean | "relative" | undefined;
@@ -8458,15 +8491,13 @@ export const rspackOptions: z.ZodObject<{
                 importDynamic?: boolean | undefined;
             } | undefined;
         } | Record<string, Record<string, any>> | undefined;
-        rules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
-        defaultRules?: (false | "" | 0 | "..." | t.RuleSetRule | null | undefined)[] | undefined;
         noParse?: string | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
     } | undefined;
     name?: string | undefined;
     performance?: false | {
+        maxAssetSize?: number | undefined;
         assetFilter?: ((args_0: string, ...args: unknown[]) => boolean) | undefined;
         hints?: false | "error" | "warning" | undefined;
-        maxAssetSize?: number | undefined;
         maxEntrypointSize?: number | undefined;
     } | undefined;
     entry?: string | string[] | Record<string, string | string[] | {
@@ -8475,10 +8506,6 @@ export const rspackOptions: z.ZodObject<{
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -8497,16 +8524,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }> | ((...args: unknown[]) => string | string[] | Record<string, string | string[] | {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -8525,16 +8552,16 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }> | Promise<string | string[] | Record<string, string | string[] | {
         import: string | string[];
         filename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         publicPath?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         layer?: string | null | undefined;
         runtime?: string | false | undefined;
-        baseUri?: string | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: {
             type: string;
             name?: string | string[] | {
@@ -8553,6 +8580,10 @@ export const rspackOptions: z.ZodObject<{
             umdNamedDefine?: boolean | undefined;
         } | undefined;
         dependOn?: string | string[] | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        baseUri?: string | undefined;
+        wasmLoading?: string | false | undefined;
     }>>) | undefined;
     node?: false | {
         global?: boolean | "warn" | undefined;
@@ -8561,7 +8592,53 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     profile?: boolean | undefined;
     cache?: boolean | undefined;
-    loader?: Record<string, any> | undefined;
+    devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
+    mode?: "none" | "development" | "production" | undefined;
+    experiments?: {
+        css?: boolean | undefined;
+        topLevelAwait?: boolean | undefined;
+        layers?: boolean | undefined;
+        incremental?: boolean | {
+            make?: boolean | undefined;
+            providedExports?: boolean | undefined;
+            emitAssets?: boolean | undefined;
+            inferAsyncModules?: boolean | undefined;
+            dependenciesDiagnostics?: boolean | undefined;
+            modulesHashes?: boolean | undefined;
+            modulesCodegen?: boolean | undefined;
+            modulesRuntimeRequirements?: boolean | undefined;
+        } | undefined;
+        rspackFuture?: {
+            bundlerInfo?: {
+                force?: boolean | ("version" | "uniqueId")[] | undefined;
+                version?: string | undefined;
+                bundler?: string | undefined;
+            } | undefined;
+        } | undefined;
+        asyncWebAssembly?: boolean | undefined;
+        outputModule?: boolean | undefined;
+        futureDefaults?: boolean | undefined;
+        lazyCompilation?: boolean | {
+            entries?: boolean | undefined;
+            imports?: boolean | undefined;
+            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
+            backend?: {
+                client?: string | undefined;
+                listen?: number | {
+                    path?: string | undefined;
+                    port?: number | undefined;
+                    host?: string | undefined;
+                    backlog?: number | undefined;
+                    exclusive?: boolean | undefined;
+                    readableAll?: boolean | undefined;
+                    writableAll?: boolean | undefined;
+                    ipv6Only?: boolean | undefined;
+                } | undefined;
+                protocol?: "http" | "https" | undefined;
+            } | undefined;
+        } | undefined;
+    } | undefined;
+    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
     resolve?: t.ResolveOptions | undefined;
     output?: {
         module?: boolean | undefined;
@@ -8570,31 +8647,21 @@ export const rspackOptions: z.ZodObject<{
         environment?: {
             module?: boolean | undefined;
             const?: boolean | undefined;
-            arrowFunction?: boolean | undefined;
-            asyncFunction?: boolean | undefined;
-            bigIntLiteral?: boolean | undefined;
-            destructuring?: boolean | undefined;
             document?: boolean | undefined;
+            nodePrefixForCoreModules?: boolean | undefined;
+            globalThis?: boolean | undefined;
+            bigIntLiteral?: boolean | undefined;
+            arrowFunction?: boolean | undefined;
+            forOf?: boolean | undefined;
+            destructuring?: boolean | undefined;
             dynamicImport?: boolean | undefined;
             dynamicImportInWorker?: boolean | undefined;
-            forOf?: boolean | undefined;
-            globalThis?: boolean | undefined;
-            nodePrefixForCoreModules?: boolean | undefined;
             optionalChaining?: boolean | undefined;
             templateLiteral?: boolean | undefined;
+            asyncFunction?: boolean | undefined;
         } | undefined;
         chunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         path?: string | undefined;
-        auxiliaryComment?: string | {
-            root?: string | undefined;
-            commonjs?: string | undefined;
-            amd?: string | undefined;
-            commonjs2?: string | undefined;
-        } | undefined;
-        umdNamedDefine?: boolean | undefined;
-        chunkLoading?: string | false | undefined;
-        asyncChunks?: boolean | undefined;
-        wasmLoading?: string | false | undefined;
         library?: string | string[] | {
             root?: string | string[] | undefined;
             commonjs?: string | undefined;
@@ -8616,27 +8683,33 @@ export const rspackOptions: z.ZodObject<{
             export?: string | string[] | undefined;
             umdNamedDefine?: boolean | undefined;
         } | undefined;
+        auxiliaryComment?: string | {
+            root?: string | undefined;
+            commonjs?: string | undefined;
+            amd?: string | undefined;
+            commonjs2?: string | undefined;
+        } | undefined;
+        umdNamedDefine?: boolean | undefined;
+        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
+        chunkLoading?: string | false | undefined;
+        asyncChunks?: boolean | undefined;
+        uniqueName?: string | undefined;
         pathinfo?: boolean | "verbose" | undefined;
         clean?: boolean | undefined;
-        crossOriginLoading?: false | "anonymous" | "use-credentials" | undefined;
         cssFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        cssHeadDataCompression?: boolean | undefined;
         cssChunkFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
         hotUpdateMainFilename?: string | undefined;
         hotUpdateChunkFilename?: string | undefined;
         hotUpdateGlobal?: string | undefined;
         assetModuleFilename?: string | ((args_0: PathData, args_1: JsAssetInfo | undefined, ...args: unknown[]) => string) | undefined;
-        uniqueName?: string | undefined;
         chunkLoadingGlobal?: string | undefined;
         enabledLibraryTypes?: string[] | undefined;
-        libraryExport?: string | string[] | undefined;
-        libraryTarget?: string | undefined;
-        strictModuleExceptionHandling?: boolean | undefined;
         strictModuleErrorHandling?: boolean | undefined;
         globalObject?: string | undefined;
         importFunctionName?: string | undefined;
         importMetaName?: string | undefined;
         iife?: boolean | undefined;
+        wasmLoading?: string | false | undefined;
         enabledWasmLoadingTypes?: string[] | undefined;
         webassemblyModuleFilename?: string | undefined;
         chunkFormat?: string | false | undefined;
@@ -8656,113 +8729,81 @@ export const rspackOptions: z.ZodObject<{
         devtoolNamespace?: string | undefined;
         devtoolModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
         devtoolFallbackModuleFilenameTemplate?: string | ((args_0: any) => any) | undefined;
-        chunkLoadTimeout?: number | undefined;
         charset?: boolean | undefined;
+        chunkLoadTimeout?: number | undefined;
+        cssHeadDataCompression?: boolean | undefined;
+        libraryExport?: string | string[] | undefined;
+        libraryTarget?: string | undefined;
+        strictModuleExceptionHandling?: boolean | undefined;
     } | undefined;
-    target?: false | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist" | ("es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | `electron${number}-main` | `electron${number}.${number}-main` | `electron${number}-renderer` | `electron${number}.${number}-renderer` | `electron${number}-preload` | `electron${number}.${number}-preload` | `nwjs${number}` | `nwjs${number}.${number}` | `node-webkit${number}` | `node-webkit${number}.${number}` | `browserslist:${string}` | "web" | "webworker" | "electron-main" | "electron-renderer" | "electron-preload" | "nwjs" | "node-webkit" | "browserslist")[] | undefined;
-    mode?: "none" | "development" | "production" | undefined;
-    experiments?: {
-        css?: boolean | undefined;
-        lazyCompilation?: boolean | {
-            entries?: boolean | undefined;
-            test?: RegExp | ((args_0: Module, ...args: unknown[]) => boolean) | undefined;
-            backend?: {
-                client?: string | undefined;
-                listen?: number | {
-                    path?: string | undefined;
-                    port?: number | undefined;
-                    host?: string | undefined;
-                    backlog?: number | undefined;
-                    exclusive?: boolean | undefined;
-                    readableAll?: boolean | undefined;
-                    writableAll?: boolean | undefined;
-                    ipv6Only?: boolean | undefined;
-                } | undefined;
-                protocol?: "http" | "https" | undefined;
+    optimization?: {
+        splitChunks?: false | {
+            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+            usedExports?: boolean | undefined;
+            defaultSizeTypes?: string[] | undefined;
+            cacheGroups?: Record<string, false | {
+                type?: string | RegExp | undefined;
+                filename?: string | undefined;
+                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
+                priority?: number | undefined;
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                usedExports?: boolean | undefined;
+                defaultSizeTypes?: string[] | undefined;
+                maxSize?: number | Record<string, number> | undefined;
+                minChunks?: number | undefined;
+                minSize?: number | Record<string, number> | undefined;
+                maxAsyncSize?: number | Record<string, number> | undefined;
+                maxInitialSize?: number | Record<string, number> | undefined;
+                maxAsyncRequests?: number | undefined;
+                maxInitialRequests?: number | undefined;
+                automaticNameDelimiter?: string | undefined;
+                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
+                idHint?: string | undefined;
+                reuseExistingChunk?: boolean | undefined;
+                enforce?: boolean | undefined;
+            }> | undefined;
+            maxSize?: number | Record<string, number> | undefined;
+            fallbackCacheGroup?: {
+                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
+                maxSize?: number | undefined;
+                minSize?: number | undefined;
+                maxAsyncSize?: number | undefined;
+                maxInitialSize?: number | undefined;
+                automaticNameDelimiter?: string | undefined;
             } | undefined;
-            imports?: boolean | undefined;
+            hidePathInfo?: boolean | undefined;
+            minChunks?: number | undefined;
+            minSize?: number | Record<string, number> | undefined;
+            maxAsyncSize?: number | Record<string, number> | undefined;
+            maxInitialSize?: number | Record<string, number> | undefined;
+            maxAsyncRequests?: number | undefined;
+            maxInitialRequests?: number | undefined;
+            automaticNameDelimiter?: string | undefined;
         } | undefined;
-        asyncWebAssembly?: boolean | undefined;
-        outputModule?: boolean | undefined;
-        topLevelAwait?: boolean | undefined;
-        layers?: boolean | undefined;
-        incremental?: boolean | {
-            make?: boolean | undefined;
-            providedExports?: boolean | undefined;
-            emitAssets?: boolean | undefined;
-            inferAsyncModules?: boolean | undefined;
-            dependenciesDiagnostics?: boolean | undefined;
-            modulesHashes?: boolean | undefined;
-            modulesCodegen?: boolean | undefined;
-            modulesRuntimeRequirements?: boolean | undefined;
+        usedExports?: boolean | "global" | undefined;
+        providedExports?: boolean | undefined;
+        removeAvailableModules?: boolean | undefined;
+        moduleIds?: "named" | "natural" | "deterministic" | undefined;
+        chunkIds?: "named" | "natural" | "deterministic" | undefined;
+        minimize?: boolean | undefined;
+        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+        mergeDuplicateChunks?: boolean | undefined;
+        runtimeChunk?: boolean | "single" | "multiple" | {
+            name?: string | ((args_0: {
+                name: string;
+            }, ...args: unknown[]) => string) | undefined;
         } | undefined;
-        futureDefaults?: boolean | undefined;
-        rspackFuture?: {
-            bundlerInfo?: {
-                force?: boolean | ("version" | "uniqueId")[] | undefined;
-                version?: string | undefined;
-                bundler?: string | undefined;
-            } | undefined;
-        } | undefined;
+        removeEmptyChunks?: boolean | undefined;
+        realContentHash?: boolean | undefined;
+        sideEffects?: boolean | "flag" | undefined;
+        concatenateModules?: boolean | undefined;
+        innerGraph?: boolean | undefined;
+        mangleExports?: boolean | "size" | "deterministic" | undefined;
+        nodeEnv?: string | false | undefined;
+        emitOnErrors?: boolean | undefined;
     } | undefined;
-    externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
-        request?: string | undefined;
-        context?: string | undefined;
-        dependencyType?: string | undefined;
-        contextInfo?: {
-            issuer: string;
-        } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
-    externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
-    externalsPresets?: {
-        node?: boolean | undefined;
-        web?: boolean | undefined;
-        nwjs?: boolean | undefined;
-        webAsync?: boolean | undefined;
-        electron?: boolean | undefined;
-        electronMain?: boolean | undefined;
-        electronPreload?: boolean | undefined;
-        electronRenderer?: boolean | undefined;
-    } | undefined;
-    infrastructureLogging?: {
-        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
-        colors?: boolean | undefined;
-        appendOnly?: boolean | undefined;
-        console?: Console | undefined;
-        level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
-        stream?: NodeJS.WritableStream | undefined;
-    } | undefined;
-    devtool?: false | "eval" | "cheap-source-map" | "cheap-module-source-map" | "source-map" | "inline-cheap-source-map" | "inline-cheap-module-source-map" | "inline-source-map" | "inline-nosources-cheap-source-map" | "inline-nosources-cheap-module-source-map" | "inline-nosources-source-map" | "nosources-cheap-source-map" | "nosources-cheap-module-source-map" | "nosources-source-map" | "hidden-nosources-cheap-source-map" | "hidden-nosources-cheap-module-source-map" | "hidden-nosources-source-map" | "hidden-cheap-source-map" | "hidden-cheap-module-source-map" | "hidden-source-map" | "eval-cheap-source-map" | "eval-cheap-module-source-map" | "eval-source-map" | "eval-nosources-cheap-source-map" | "eval-nosources-cheap-module-source-map" | "eval-nosources-source-map" | undefined;
-    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
-    watchOptions?: {
-        aggregateTimeout?: number | undefined;
-        followSymlinks?: boolean | undefined;
-        ignored?: string | RegExp | string[] | undefined;
-        poll?: number | boolean | undefined;
-        stdin?: boolean | undefined;
-    } | undefined;
-    watch?: boolean | undefined;
+    snapshot?: {} | undefined;
     stats?: boolean | "verbose" | "normal" | "none" | "errors-only" | "errors-warnings" | "minimal" | "detailed" | "summary" | {
         source?: boolean | undefined;
         publicPath?: boolean | undefined;
@@ -8841,77 +8882,67 @@ export const rspackOptions: z.ZodObject<{
         errorsSpace?: number | undefined;
         warningsSpace?: number | undefined;
     } | undefined;
-    snapshot?: {} | undefined;
-    optimization?: {
-        splitChunks?: false | {
-            name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-            chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
-            usedExports?: boolean | undefined;
-            maxSize?: number | Record<string, number> | undefined;
-            defaultSizeTypes?: string[] | undefined;
-            minChunks?: number | undefined;
-            minSize?: number | Record<string, number> | undefined;
-            maxAsyncSize?: number | Record<string, number> | undefined;
-            maxInitialSize?: number | Record<string, number> | undefined;
-            maxAsyncRequests?: number | undefined;
-            maxInitialRequests?: number | undefined;
-            automaticNameDelimiter?: string | undefined;
-            cacheGroups?: Record<string, false | {
-                type?: string | RegExp | undefined;
-                filename?: string | undefined;
-                name?: string | false | ((args_0: Module | undefined, ...args: unknown[]) => unknown) | undefined;
-                priority?: number | undefined;
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
-                usedExports?: boolean | undefined;
-                test?: string | RegExp | ((args_0: Module, ...args: unknown[]) => unknown) | undefined;
-                enforce?: boolean | undefined;
-                maxSize?: number | Record<string, number> | undefined;
-                reuseExistingChunk?: boolean | undefined;
-                idHint?: string | undefined;
-                defaultSizeTypes?: string[] | undefined;
-                minChunks?: number | undefined;
-                minSize?: number | Record<string, number> | undefined;
-                maxAsyncSize?: number | Record<string, number> | undefined;
-                maxInitialSize?: number | Record<string, number> | undefined;
-                maxAsyncRequests?: number | undefined;
-                maxInitialRequests?: number | undefined;
-                automaticNameDelimiter?: string | undefined;
-            }> | undefined;
-            fallbackCacheGroup?: {
-                chunks?: RegExp | "all" | "async" | "initial" | ((args_0: Chunk, ...args: unknown[]) => boolean) | undefined;
-                maxSize?: number | undefined;
-                minSize?: number | undefined;
-                maxAsyncSize?: number | undefined;
-                maxInitialSize?: number | undefined;
-                automaticNameDelimiter?: string | undefined;
-            } | undefined;
-            hidePathInfo?: boolean | undefined;
-        } | undefined;
-        usedExports?: boolean | "global" | undefined;
-        providedExports?: boolean | undefined;
-        sideEffects?: boolean | "flag" | undefined;
-        moduleIds?: "named" | "natural" | "deterministic" | undefined;
-        chunkIds?: "named" | "natural" | "deterministic" | undefined;
-        minimize?: boolean | undefined;
-        minimizer?: (false | "" | 0 | t.RspackPluginInstance | "..." | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
-        mergeDuplicateChunks?: boolean | undefined;
-        runtimeChunk?: boolean | "single" | "multiple" | {
-            name?: string | ((args_0: {
-                name: string;
-            }, ...args: unknown[]) => string) | undefined;
-        } | undefined;
-        removeAvailableModules?: boolean | undefined;
-        removeEmptyChunks?: boolean | undefined;
-        realContentHash?: boolean | undefined;
-        concatenateModules?: boolean | undefined;
-        innerGraph?: boolean | undefined;
-        mangleExports?: boolean | "size" | "deterministic" | undefined;
-        nodeEnv?: string | false | undefined;
-        emitOnErrors?: boolean | undefined;
-    } | undefined;
+    loader?: Record<string, any> | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
+    externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+        request?: string | undefined;
+        context?: string | undefined;
+        dependencyType?: string | undefined;
+        contextInfo?: {
+            issuer: string;
+        } | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
+    externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
+    externalsPresets?: {
+        node?: boolean | undefined;
+        web?: boolean | undefined;
+        nwjs?: boolean | undefined;
+        electron?: boolean | undefined;
+        electronMain?: boolean | undefined;
+        electronPreload?: boolean | undefined;
+        electronRenderer?: boolean | undefined;
+        webAsync?: boolean | undefined;
+    } | undefined;
+    infrastructureLogging?: {
+        debug?: string | boolean | RegExp | ((args_0: string, ...args: unknown[]) => boolean) | (string | RegExp | ((args_0: string, ...args: unknown[]) => boolean))[] | undefined;
+        colors?: boolean | undefined;
+        stream?: NodeJS.WritableStream | undefined;
+        appendOnly?: boolean | undefined;
+        console?: Console | undefined;
+        level?: "log" | "info" | "verbose" | "none" | "error" | "warn" | undefined;
+    } | undefined;
     plugins?: (false | "" | 0 | t.RspackPluginInstance | t.WebpackPluginInstance | t.RspackPluginFunction | t.WebpackPluginFunction | null | undefined)[] | undefined;
+    watch?: boolean | undefined;
+    watchOptions?: {
+        aggregateTimeout?: number | undefined;
+        followSymlinks?: boolean | undefined;
+        ignored?: string | RegExp | string[] | undefined;
+        poll?: number | boolean | undefined;
+        stdin?: boolean | undefined;
+    } | undefined;
     devServer?: t.DevServer | undefined;
+    ignoreWarnings?: (RegExp | ((args_0: Error, args_1: Compilation, ...args: unknown[]) => boolean))[] | undefined;
     bail?: boolean | undefined;
 }>;
 
@@ -9883,7 +9914,9 @@ declare namespace t {
         IgnoreWarnings,
         Profile,
         Bail,
-        Performance_2 as Performance
+        Performance_2 as Performance,
+        RspackOptions,
+        Configuration
     }
 }
 

--- a/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/SplitChunksPlugin.ts
@@ -11,7 +11,7 @@ import {
 import { Chunk } from "../Chunk";
 import type { Compiler } from "../Compiler";
 import { Module } from "../Module";
-import type { OptimizationSplitChunksOptions } from "../config/zod";
+import type { OptimizationSplitChunksOptions } from "../config";
 import { JsSplitChunkSizes } from "../util/SplitChunkSize";
 import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -72,7 +72,7 @@ import type {
 	SnapshotOptions,
 	StatsValue,
 	Target
-} from "./zod";
+} from "./types";
 
 export type { LoaderContext, LoaderDefinition, LoaderDefinitionFunction };
 

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -24,7 +24,7 @@ import type {
 	RuleSetLoaderWithOptions,
 	RuleSetUseItem,
 	Target
-} from "./zod";
+} from "./types";
 
 export const BUILTIN_LOADER_PREFIX = "builtin:";
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -49,7 +49,7 @@ import type {
 	RspackFutureOptions,
 	RuleSetRules,
 	SnapshotOptions
-} from "./zod";
+} from "./types";
 
 export const applyRspackOptionsDefaults = (
 	options: RspackOptionsNormalized

--- a/packages/rspack/src/config/index.ts
+++ b/packages/rspack/src/config/index.ts
@@ -2,3 +2,4 @@ export * from "./adapter";
 export * from "./defaults";
 export * from "./normalization";
 export * from "./zod";
+export type * from "./types";

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -87,7 +87,7 @@ import type {
 	WatchOptions,
 	WebassemblyModuleFilename,
 	WorkerPublicPath
-} from "./zod";
+} from "./types";
 
 export const getNormalizedRspackOptions = (
 	config: RspackOptions

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2555,3 +2555,129 @@ export type Performance =
 			maxEntrypointSize?: number;
 	  };
 //#endregion
+
+export type RspackOptions = {
+	/**
+	 * The name of the Rspack configuration.
+	 */
+	name?: Name;
+	/**
+	 * An array of dependencies required by the project.
+	 */
+	dependencies?: Dependencies;
+	/**
+	 * The entry point of the application.
+	 */
+	entry?: Entry;
+	/**
+	 * Configuration for the output of the compilation.
+	 */
+	output?: Output;
+	/**
+	 * The environment in which the code should run.
+	 */
+	target?: Target;
+	/**
+	 * The mode in which Rspack should operate.
+	 */
+	mode?: Mode;
+	/**
+	 * Options for experimental features.
+	 */
+	experiments?: Experiments;
+	/**
+	 * External libraries that should not be bundled.
+	 */
+	externals?: Externals;
+	/**
+	 * The type of externals.
+	 */
+	externalsType?: ExternalsType;
+	/**
+	 * Presets for external libraries.
+	 */
+	externalsPresets?: ExternalsPresets;
+	/**
+	 * Logging options for infrastructure.
+	 */
+	infrastructureLogging?: InfrastructureLogging;
+	/**
+	 * Options for caching.
+	 */
+	cache?: CacheOptions;
+	/**
+	 * The context in which the compilation should occur.
+	 */
+	context?: Context;
+	/**
+	 * The source map configuration.
+	 */
+	devtool?: DevTool;
+	/**
+	 * Options for Node.js environment.
+	 */
+	node?: Node;
+	/**
+	 * Configuration for loaders.
+	 */
+	loader?: Loader;
+	/**
+	 * Warnings to ignore during compilation.
+	 */
+	ignoreWarnings?: IgnoreWarnings;
+	/**
+	 * Options for watch mode.
+	 */
+	watchOptions?: WatchOptions;
+	/**
+	 * Whether to enable watch mode.
+	 */
+	watch?: Watch;
+	/**
+	 * Options for the stats output.
+	 */
+	stats?: StatsValue;
+	/**
+	 * Options for snapshotting.
+	 */
+	snapshot?: SnapshotOptions;
+	/**
+	 * Optimization options.
+	 */
+	optimization?: Optimization;
+	/**
+	 * Options for resolving modules.
+	 */
+	resolve?: ResolveOptions;
+	/**
+	 * Options for resolving loader modules.
+	 */
+	resolveLoader?: ResolveOptions;
+	/**
+	 * Plugins to use during compilation.
+	 */
+	plugins?: Plugins;
+	/**
+	 * Configuration for the development server.
+	 */
+	devServer?: DevServer;
+	/**
+	 * Options for module configuration.
+	 */
+	module?: ModuleOptions;
+	/**
+	 * Whether to capture a profile of the application.
+	 */
+	profile?: Profile;
+	/**
+	 * Whether to fail on the first error.
+	 */
+	bail?: Bail;
+	/**
+	 * Performance optimization options.
+	 */
+	performance?: Performance;
+};
+
+/** Configuration for Rspack */
+export type Configuration = RspackOptions;

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -6,8 +6,6 @@ import type { Compilation, PathData } from "../Compilation";
 import { Module } from "../Module";
 import type * as t from "./types";
 
-export type * from "./types";
-
 const filenameTemplate = z.string() satisfies z.ZodType<t.FilenameTemplate>;
 
 const filename = filenameTemplate.or(
@@ -1343,6 +1341,4 @@ export const rspackOptions = z.strictObject({
 	profile: profile.optional(),
 	bail: bail.optional(),
 	performance: performance.optional()
-});
-export type RspackOptions = z.infer<typeof rspackOptions>;
-export type Configuration = RspackOptions;
+}) satisfies z.ZodType<t.RspackOptions>;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->
Zod types system is not easy to understand by user.

We tend use raw ts provider intellisense and jsDoc for user in ide.

See https://github.com/web-infra-dev/rspack/issues/4241 more detail.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
