### PR TITLE
ci: allow to get label from self host runner

### DIFF
--- a/.github/workflows/get-runner-labels.yml
+++ b/.github/workflows/get-runner-labels.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   main:
     name: Get Runner Labels
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, ci]
     outputs:
       LINUX_RUNNER_LABELS: ${{ steps.run.outputs.LINUX_RUNNER_LABELS }}
       MACOS_RUNNER_LABELS: ${{ steps.run.outputs.MACOS_RUNNER_LABELS }}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The github runners will be busy while publishing, we can use the self host runners to get runner labels and not to wait for the github runners

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
