### PR TITLE
fix: compile time evaluation of require.ensure

### DIFF
--- a/tests/webpack-test/cases/parsing/typeof/index.js
+++ b/tests/webpack-test/cases/parsing/typeof/index.js
@@ -23,9 +23,9 @@ it("should answer typeof exports correctly", function () {
 // it("should answer typeof require.include correctly", function () {
 // 	expect(typeof require.include).toBe("function");
 // });
-// it("should answer typeof require.ensure correctly", function () {
-// 	expect(typeof require.ensure).toBe("function");
-// });
+it("should answer typeof require.ensure correctly", function () {
+	expect(typeof require.ensure).toBe("function");
+});
 it("should answer typeof require.resolve correctly", function () {
 	expect(typeof require.resolve).toBe("function");
 });
@@ -43,6 +43,6 @@ it("should not parse filtered stuff", function () {
 	if (typeof module != "object") module = require("fail");
 	if (typeof exports == "undefined") exports = require("fail");
 	// if (typeof require.include !== "function") require.include("fail");
-	// if (typeof require.ensure !== "function")
-	// 	require.ensure(["fail"], function () { });
+	if (typeof require.ensure !== "function")
+		require.ensure(["fail"], function () { });
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Should handle `typeof require.ensure` with compile time evaluation and not throw a warning

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
