### PR TITLE
fix(cli): display the error which is thrown by the plugin during the starting of `rspack serve`

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -70,8 +70,8 @@ export class RspackCLI {
 				this.getLogger().error(e.message);
 				process.exit(2);
 			} else if (e instanceof Error) {
-				if (callback) {
-					callback?.(e);
+				if (typeof callback === "function") {
+					callback(e);
 				} else {
 					this.getLogger().error(e);
 				}

--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -70,7 +70,11 @@ export class RspackCLI {
 				this.getLogger().error(e.message);
 				process.exit(2);
 			} else if (e instanceof Error) {
-				callback?.(e);
+				if (callback) {
+					callback?.(e);
+				} else {
+					this.getLogger().error(e);
+				}
 				return null;
 			}
 			throw e;

--- a/packages/rspack-cli/tests/serve/plugin-apply-error/rspack.config.js
+++ b/packages/rspack-cli/tests/serve/plugin-apply-error/rspack.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+	mode: "development",
+	devtool: false,
+	plugins: [
+		{
+			name: "test-plugin",
+			apply(compiler) {
+				throw new Error("error in plugin");
+			}
+		}
+	],
+	devServer: {}
+};

--- a/packages/rspack-cli/tests/serve/plugin-apply-error/serve-plugin-apply-error.test.ts
+++ b/packages/rspack-cli/tests/serve/plugin-apply-error/serve-plugin-apply-error.test.ts
@@ -1,0 +1,11 @@
+import { normalizeStderr, runWatch } from "../../utils/test-utils";
+
+describe("should display plugin error", () => {
+	it("display error", async () => {
+		const { stderr } = await runWatch(__dirname, ["serve"], {
+			killString: /Error: /
+		});
+
+		expect(normalizeStderr(stderr)).toContain("error in plugin");
+	});
+});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8103

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
