### PR TITLE
docs: add license to website footer

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -8,7 +8,6 @@ import pluginSitemap from 'rspress-plugin-sitemap';
 import { defineConfig } from 'rspress/config';
 
 const PUBLISH_URL = 'https://rspack.dev';
-const COPYRIGHT = '© 2022-present ByteDance Inc. All Rights Reserved.';
 
 export default defineConfig({
   root: path.join(__dirname, 'docs'),
@@ -63,9 +62,6 @@ export default defineConfig({
     }),
   ],
   themeConfig: {
-    footer: {
-      message: COPYRIGHT,
-    },
     socialLinks: [
       {
         icon: 'github',

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -13,7 +13,13 @@ const CopyRight = () => {
   return (
     <footer className="bottom-0 mt-12 py-8 px-6 sm:p-8 w-full border-t border-solid border-divider-light">
       <div className="m-auto w-full text-center">
-        <div className="font-medium text-sm text-text-2">{message}</div>
+        <div className="font-medium text-sm text-text-2">
+          <p className="mb-2">
+            Rspack is free and open source software released under the MIT
+            license.
+          </p>
+          <p>© 2022-present ByteDance Inc.</p>
+        </div>
       </div>
     </footer>
   );

--- a/website/theme/pages/index.tsx
+++ b/website/theme/pages/index.tsx
@@ -1,15 +1,7 @@
-import { usePageData } from 'rspress/runtime';
 import { HomeFooter } from '../components/HomeFooter/index';
 import LandingPage from '../components/Landingpage';
 
 const CopyRight = () => {
-  const { siteData } = usePageData();
-  const { message } = siteData.themeConfig.footer || {};
-
-  if (!message) {
-    return null;
-  }
-
   return (
     <footer className="bottom-0 mt-12 py-8 px-6 sm:p-8 w-full border-t border-solid border-divider-light">
       <div className="m-auto w-full text-center">


### PR DESCRIPTION
## Summary

Add Rspack's license to the footer of Rspack website.

![image](https://github.com/user-attachments/assets/371e2c1d-28ff-4b9f-bf58-ef36220a3a27)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
