### PR TITLE
fix: fix `Compiler` not getting freed after use

### DIFF
--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -247,6 +247,10 @@ class Compiler {
 
 		new JsLoaderRspackPlugin(this).apply(this);
 		new ExecuteModulePlugin().apply(this);
+
+		this.hooks.shutdown.tap("Compiler", () => {
+			this.#instance = undefined;
+		});
 	}
 
 	get recordsInputPath() {
@@ -764,74 +768,85 @@ class Compiler {
 		);
 
 		const instanceBinding: typeof binding = require("@rspack/binding");
+		const that = new WeakRef(this);
 
 		this.#registers = {
 			registerCompilerThisCompilationTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerThisCompilation,
-				() => this.hooks.thisCompilation,
+				() => that.deref()!.hooks.thisCompilation,
 				queried => (native: binding.JsCompilation) => {
-					this.#createCompilation(native);
-					queried.call(this.#compilation!, this.#compilationParams!);
+					that.deref()!.#createCompilation(native);
+					return queried.call(
+						that.deref()!.#compilation!,
+						that.deref()!.#compilationParams!
+					);
 				}
 			),
 			registerCompilerCompilationTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerCompilation,
-				() => this.hooks.compilation,
+				() => that.deref()!.hooks.compilation,
 				queried => () =>
-					queried.call(this.#compilation!, this.#compilationParams!)
+					queried.call(
+						that.deref()!.#compilation!,
+						that.deref()!.#compilationParams!
+					)
 			),
 			registerCompilerMakeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerMake,
-				() => this.hooks.make,
-				queried => async () => await queried.promise(this.#compilation!)
+				() => that.deref()!.hooks.make,
+				queried => async () =>
+					await queried.promise(that.deref()!.#compilation!)
 			),
 			registerCompilerFinishMakeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerFinishMake,
-				() => this.hooks.finishMake,
-				queried => async () => await queried.promise(this.#compilation!)
+				() => that.deref()!.hooks.finishMake,
+				queried => async () =>
+					await queried.promise(that.deref()!.#compilation!)
 			),
 			registerCompilerShouldEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerShouldEmit,
-				() => this.hooks.shouldEmit,
-				queried => () => queried.call(this.#compilation!)
+				() => that.deref()!.hooks.shouldEmit,
+				queried => () => queried.call(that.deref()!.#compilation!)
 			),
 			registerCompilerEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerEmit,
-				() => this.hooks.emit,
-				queried => async () => await queried.promise(this.#compilation!)
+				() => that.deref()!.hooks.emit,
+				queried => async () =>
+					await queried.promise(that.deref()!.#compilation!)
 			),
 			registerCompilerAfterEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerAfterEmit,
-				() => this.hooks.afterEmit,
-				queried => async () => await queried.promise(this.#compilation!)
+				() => that.deref()!.hooks.afterEmit,
+				queried => async () =>
+					await queried.promise(that.deref()!.#compilation!)
 			),
 			registerCompilerAssetEmittedTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerAssetEmitted,
-				() => this.hooks.assetEmitted,
+				() => that.deref()!.hooks.assetEmitted,
 				queried =>
 					async ({
 						filename,
 						targetPath,
 						outputPath
-					}: binding.JsAssetEmittedArgs) => {
-						return queried.promise(filename, {
-							compilation: this.#compilation!,
+					}: binding.JsAssetEmittedArgs) =>
+						queried.promise(filename, {
+							compilation: that.deref()!.#compilation!,
 							targetPath,
 							outputPath,
 							get source() {
-								return this.compilation!.getAsset(filename)?.source;
+								return that.deref()!.#compilation!.getAsset(filename)?.source!;
 							},
 							get content() {
 								return this.source?.buffer();
 							}
-						});
-					}
+						})
 			),
 			registerCompilationAdditionalTreeRuntimeRequirements:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind
 						.CompilationAdditionalTreeRuntimeRequirements,
-					() => this.#compilation!.hooks.additionalTreeRuntimeRequirements,
+					() =>
+						that.deref()!.#compilation!.hooks.additionalTreeRuntimeRequirements,
 					queried =>
 						({
 							chunk,
@@ -839,7 +854,7 @@ class Compiler {
 						}: binding.JsAdditionalTreeRuntimeRequirementsArg) => {
 							const set = __from_binding_runtime_globals(runtimeRequirements);
 							queried.call(
-								Chunk.__from_binding(chunk, this.#compilation!),
+								Chunk.__from_binding(chunk, that.deref()!.#compilation!),
 								set
 							);
 							return {
@@ -850,14 +865,17 @@ class Compiler {
 			registerCompilationRuntimeRequirementInTree:
 				this.#createHookMapRegisterTaps(
 					binding.RegisterJsTapKind.CompilationRuntimeRequirementInTree,
-					() => this.#compilation!.hooks.runtimeRequirementInTree,
+					() => that.deref()!.#compilation!.hooks.runtimeRequirementInTree,
 					queried =>
 						({
 							chunk: rawChunk,
 							runtimeRequirements
 						}: binding.JsRuntimeRequirementInTreeArg) => {
 							const set = __from_binding_runtime_globals(runtimeRequirements);
-							const chunk = Chunk.__from_binding(rawChunk, this.#compilation!);
+							const chunk = Chunk.__from_binding(
+								rawChunk,
+								that.deref()!.#compilation!
+							);
 							for (const r of set) {
 								queried.for(r).call(chunk, set);
 							}
@@ -868,13 +886,13 @@ class Compiler {
 				),
 			registerCompilationRuntimeModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationRuntimeModule,
-				() => this.#compilation!.hooks.runtimeModule,
+				() => that.deref()!.#compilation!.hooks.runtimeModule,
 				queried =>
 					({ module, chunk }: binding.JsRuntimeModuleArg) => {
 						const originSource = module.source?.source;
 						queried.call(
 							module,
-							Chunk.__from_binding(chunk, this.#compilation!)
+							Chunk.__from_binding(chunk, that.deref()!.#compilation!)
 						);
 						const newSource = module.source?.source;
 						if (newSource && newSource !== originSource) {
@@ -885,25 +903,25 @@ class Compiler {
 			),
 			registerCompilationBuildModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationBuildModule,
-				() => this.#compilation!.hooks.buildModule,
+				() => that.deref()!.#compilation!.hooks.buildModule,
 				queired => (m: binding.JsModule) =>
-					queired.call(Module.__from_binding(m, this.#compilation))
+					queired.call(Module.__from_binding(m, that.deref()!.#compilation))
 			),
 			registerCompilationStillValidModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationStillValidModule,
-				() => this.#compilation!.hooks.stillValidModule,
+				() => that.deref()!.#compilation!.hooks.stillValidModule,
 				queired => (m: binding.JsModule) =>
-					queired.call(Module.__from_binding(m, this.#compilation))
+					queired.call(Module.__from_binding(m, that.deref()!.#compilation))
 			),
 			registerCompilationSucceedModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationSucceedModule,
-				() => this.#compilation!.hooks.succeedModule,
+				() => that.deref()!.#compilation!.hooks.succeedModule,
 				queired => (m: binding.JsModule) =>
-					queired.call(Module.__from_binding(m, this.#compilation))
+					queired.call(Module.__from_binding(m, that.deref()!.#compilation))
 			),
 			registerCompilationExecuteModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationExecuteModule,
-				() => this.#compilation!.hooks.executeModule,
+				() => that.deref()!.#compilation!.hooks.executeModule,
 				queried =>
 					({
 						entry,
@@ -973,92 +991,101 @@ class Compiler {
 
 						const executeResult = __webpack_require__(entry);
 
-						this.#moduleExecutionResultsMap.set(id, executeResult);
+						that.deref()!.#moduleExecutionResultsMap.set(id, executeResult);
 					}
 			),
 			registerCompilationFinishModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationFinishModules,
-				() => this.#compilation!.hooks.finishModules,
-				queried => async () => await queried.promise(this.#compilation!.modules)
+				() => that.deref()!.#compilation!.hooks.finishModules,
+				queried => async () =>
+					await queried.promise(that.deref()!.#compilation!.modules)
 			),
 			registerCompilationOptimizeModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationOptimizeModules,
-				() => this.#compilation!.hooks.optimizeModules,
-				queried => () => queried.call(this.#compilation!.modules.values())
+				() => that.deref()!.#compilation!.hooks.optimizeModules,
+				queried => () =>
+					queried.call(that.deref()!.#compilation!.modules.values())
 			),
 			registerCompilationAfterOptimizeModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationAfterOptimizeModules,
-				() => this.#compilation!.hooks.afterOptimizeModules,
+				() => that.deref()!.#compilation!.hooks.afterOptimizeModules,
 				queried => () => {
-					queried.call(this.#compilation!.modules.values());
+					queried.call(that.deref()!.#compilation!.modules.values());
 				}
 			),
 			registerCompilationOptimizeTreeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationOptimizeTree,
-				() => this.#compilation!.hooks.optimizeTree,
+				() => that.deref()!.#compilation!.hooks.optimizeTree,
 				queried => async () =>
 					await queried.promise(
-						this.#compilation!.chunks,
-						this.#compilation!.modules
+						that.deref()!.#compilation!.chunks,
+						that.deref()!.#compilation!.modules
 					)
 			),
 			registerCompilationOptimizeChunkModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationOptimizeChunkModules,
-				() => this.#compilation!.hooks.optimizeChunkModules,
+				() => that.deref()!.#compilation!.hooks.optimizeChunkModules,
 				queried => async () =>
 					await queried.promise(
-						this.#compilation!.chunks,
-						this.#compilation!.modules
+						that.deref()!.#compilation!.chunks,
+						that.deref()!.#compilation!.modules
 					)
 			),
 			registerCompilationChunkHashTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationChunkHash,
-				() => this.#compilation!.hooks.chunkHash,
+				() => that.deref()!.#compilation!.hooks.chunkHash,
 				queried => (chunk: binding.JsChunk) => {
-					if (!this.options.output.hashFunction) {
+					if (!that.deref()!.options.output.hashFunction) {
 						throw new Error("'output.hashFunction' cannot be undefined");
 					}
-					const hash = createHash(this.options.output.hashFunction);
-					queried.call(Chunk.__from_binding(chunk, this.#compilation!), hash);
-					const digestResult = hash.digest(this.options.output.hashDigest);
+					const hash = createHash(that.deref()!.options.output.hashFunction!);
+					queried.call(
+						Chunk.__from_binding(chunk, that.deref()!.#compilation!),
+						hash
+					);
+					const digestResult = hash.digest(
+						that.deref()!.options.output.hashDigest
+					);
 					return Buffer.from(digestResult);
 				}
 			),
 			registerCompilationChunkAssetTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationChunkAsset,
-				() => this.#compilation!.hooks.chunkAsset,
+				() => that.deref()!.#compilation!.hooks.chunkAsset,
 				queried =>
 					({ chunk, filename }: binding.JsChunkAssetArgs) =>
 						queried.call(
-							Chunk.__from_binding(chunk, this.#compilation!),
+							Chunk.__from_binding(chunk, that.deref()!.#compilation!),
 							filename
 						)
 			),
 			registerCompilationProcessAssetsTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationProcessAssets,
-				() => this.#compilation!.hooks.processAssets,
-				queried => async () => await queried.promise(this.#compilation!.assets)
+				() => that.deref()!.#compilation!.hooks.processAssets,
+				queried => async () =>
+					await queried.promise(that.deref()!.#compilation!.assets)
 			),
 			registerCompilationAfterProcessAssetsTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationAfterProcessAssets,
-				() => this.#compilation!.hooks.afterProcessAssets,
-				queried => () => queried.call(this.#compilation!.assets)
+				() => that.deref()!.#compilation!.hooks.afterProcessAssets,
+				queried => () => queried.call(that.deref()!.#compilation!.assets)
 			),
 			registerCompilationSealTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationSeal,
-				() => this.#compilation!.hooks.seal,
+				() => that.deref()!.#compilation!.hooks.seal,
 				queried => () => queried.call()
 			),
 			registerCompilationAfterSealTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationAfterSeal,
-				() => this.#compilation!.hooks.afterSeal,
+				() => that.deref()!.#compilation!.hooks.afterSeal,
 				queried => async () => await queried.promise()
 			),
 			registerNormalModuleFactoryBeforeResolveTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.NormalModuleFactoryBeforeResolve,
 					() =>
-						this.#compilationParams!.normalModuleFactory.hooks.beforeResolve,
+						that.deref()!.#compilationParams!.normalModuleFactory.hooks
+							.beforeResolve,
 					queried => async (resolveData: binding.JsBeforeResolveArgs) => {
 						const normalizedResolveData: ResolveData = {
 							contextInfo: {
@@ -1078,7 +1105,8 @@ class Compiler {
 				),
 			registerNormalModuleFactoryFactorizeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryFactorize,
-				() => this.#compilationParams!.normalModuleFactory.hooks.factorize,
+				() =>
+					that.deref()!.#compilationParams!.normalModuleFactory.hooks.factorize,
 				queried => async (resolveData: binding.JsFactorizeArgs) => {
 					const normalizedResolveData: ResolveData = {
 						contextInfo: {
@@ -1098,7 +1126,8 @@ class Compiler {
 			),
 			registerNormalModuleFactoryResolveTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryResolve,
-				() => this.#compilationParams!.normalModuleFactory.hooks.resolve,
+				() =>
+					that.deref()!.#compilationParams!.normalModuleFactory.hooks.resolve,
 				queried => async (resolveData: binding.JsFactorizeArgs) => {
 					const normalizedResolveData: ResolveData = {
 						contextInfo: {
@@ -1120,7 +1149,8 @@ class Compiler {
 				this.#createHookMapRegisterTaps(
 					binding.RegisterJsTapKind.NormalModuleFactoryResolveForScheme,
 					() =>
-						this.#compilationParams!.normalModuleFactory.hooks.resolveForScheme,
+						that.deref()!.#compilationParams!.normalModuleFactory.hooks
+							.resolveForScheme,
 					queried => async (args: binding.JsResolveForSchemeArgs) => {
 						const ret = await queried
 							.for(args.scheme)
@@ -1130,7 +1160,9 @@ class Compiler {
 				),
 			registerNormalModuleFactoryAfterResolveTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryAfterResolve,
-				() => this.#compilationParams!.normalModuleFactory.hooks.afterResolve,
+				() =>
+					that.deref()!.#compilationParams!.normalModuleFactory.hooks
+						.afterResolve,
 				queried => async (arg: binding.JsAfterResolveData) => {
 					const data: ResolveData = {
 						contextInfo: {
@@ -1149,7 +1181,9 @@ class Compiler {
 			),
 			registerNormalModuleFactoryCreateModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryCreateModule,
-				() => this.#compilationParams!.normalModuleFactory.hooks.createModule,
+				() =>
+					that.deref()!.#compilationParams!.normalModuleFactory.hooks
+						.createModule,
 				queried =>
 					async (args: binding.JsNormalModuleFactoryCreateModuleArgs) => {
 						const data: NormalModuleCreateData = {
@@ -1163,7 +1197,8 @@ class Compiler {
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.ContextModuleFactoryBeforeResolve,
 					() =>
-						this.#compilationParams!.contextModuleFactory.hooks.beforeResolve,
+						that.deref()!.#compilationParams!.contextModuleFactory.hooks
+							.beforeResolve,
 					queried =>
 						async (
 							bindingData:
@@ -1185,7 +1220,8 @@ class Compiler {
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.ContextModuleFactoryAfterResolve,
 					() =>
-						this.#compilationParams!.contextModuleFactory.hooks.afterResolve,
+						that.deref()!.#compilationParams!.contextModuleFactory.hooks
+							.afterResolve,
 					queried =>
 						async (
 							bindingData:
@@ -1206,15 +1242,21 @@ class Compiler {
 			registerJavascriptModulesChunkHashTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.JavascriptModulesChunkHash,
 				() =>
-					JavascriptModulesPlugin.getCompilationHooks(this.#compilation!)
-						.chunkHash,
+					JavascriptModulesPlugin.getCompilationHooks(
+						that.deref()!.#compilation!
+					).chunkHash,
 				queried => (chunk: binding.JsChunk) => {
-					if (!this.options.output.hashFunction) {
+					if (!that.deref()!.options.output.hashFunction) {
 						throw new Error("'output.hashFunction' cannot be undefined");
 					}
-					const hash = createHash(this.options.output.hashFunction);
-					queried.call(Chunk.__from_binding(chunk, this.#compilation!), hash);
-					const digestResult = hash.digest(this.options.output.hashDigest);
+					const hash = createHash(that.deref()!.options.output.hashFunction!);
+					queried.call(
+						Chunk.__from_binding(chunk, that.deref()!.#compilation!),
+						hash
+					);
+					const digestResult = hash.digest(
+						that.deref()!.options.output.hashDigest
+					);
 					return Buffer.from(digestResult);
 				}
 			),
@@ -1222,87 +1264,91 @@ class Compiler {
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.HtmlPluginBeforeAssetTagGeneration,
 					() =>
-						HtmlRspackPlugin.getCompilationHooks(this.#compilation!)
+						HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
 							.beforeAssetTagGeneration,
-					queried => async (data: binding.JsBeforeAssetTagGenerationData) => {
-						return await queried.promise({
+					queried => async (data: binding.JsBeforeAssetTagGenerationData) =>
+						await queried.promise({
 							...data,
 							plugin: {
 								options:
-									HtmlRspackPlugin.getCompilationOptions(this.#compilation!) ||
-									{}
+									HtmlRspackPlugin.getCompilationOptions(
+										that.deref()!.#compilation!
+									) || {}
 							}
-						});
-					}
+						})
 				),
 			registerHtmlPluginAlterAssetTagsTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.HtmlPluginAlterAssetTags,
 				() =>
-					HtmlRspackPlugin.getCompilationHooks(this.#compilation!)
+					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
 						.alterAssetTags,
-				queried => async (data: binding.JsAlterAssetTagsData) => {
-					return await queried.promise(data);
-				}
+				queried => async (data: binding.JsAlterAssetTagsData) =>
+					await queried.promise(data)
 			),
 			registerHtmlPluginAlterAssetTagGroupsTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.HtmlPluginAlterAssetTagGroups,
 				() =>
-					HtmlRspackPlugin.getCompilationHooks(this.#compilation!)
+					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
 						.alterAssetTagGroups,
-				queried => async (data: binding.JsAlterAssetTagGroupsData) => {
-					return await queried.promise({
+				queried => async (data: binding.JsAlterAssetTagGroupsData) =>
+					await queried.promise({
 						...data,
 						plugin: {
 							options:
-								HtmlRspackPlugin.getCompilationOptions(this.#compilation!) || {}
+								HtmlRspackPlugin.getCompilationOptions(
+									that.deref()!.#compilation!
+								) || {}
 						}
-					});
-				}
+					})
 			),
 			registerHtmlPluginAfterTemplateExecutionTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.HtmlPluginAfterTemplateExecution,
 					() =>
-						HtmlRspackPlugin.getCompilationHooks(this.#compilation!)
+						HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
 							.afterTemplateExecution,
-					queried => async (data: binding.JsAfterTemplateExecutionData) => {
-						return await queried.promise({
+					queried => async (data: binding.JsAfterTemplateExecutionData) =>
+						await queried.promise({
 							...data,
 							plugin: {
 								options:
-									HtmlRspackPlugin.getCompilationOptions(this.#compilation!) ||
-									{}
+									HtmlRspackPlugin.getCompilationOptions(
+										that.deref()!.#compilation!
+									) || {}
 							}
-						});
-					}
+						})
 				),
 			registerHtmlPluginBeforeEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.HtmlPluginBeforeEmit,
 				() =>
-					HtmlRspackPlugin.getCompilationHooks(this.#compilation!).beforeEmit,
-				queried => async (data: binding.JsBeforeEmitData) => {
-					return await queried.promise({
+					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
+						.beforeEmit,
+				queried => async (data: binding.JsBeforeEmitData) =>
+					await queried.promise({
 						...data,
 						plugin: {
 							options:
-								HtmlRspackPlugin.getCompilationOptions(this.#compilation!) || {}
+								HtmlRspackPlugin.getCompilationOptions(
+									that.deref()!.#compilation!
+								) || {}
 						}
-					});
-				}
+					})
 			),
 			registerHtmlPluginAfterEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.HtmlPluginAfterEmit,
 				() =>
-					HtmlRspackPlugin.getCompilationHooks(this.#compilation!).afterEmit,
-				queried => async (data: binding.JsAfterEmitData) => {
-					return await queried.promise({
+					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
+						.afterEmit,
+				queried => async (data: binding.JsAfterEmitData) =>
+					await queried.promise({
 						...data,
 						plugin: {
 							options:
-								HtmlRspackPlugin.getCompilationOptions(this.#compilation!) || {}
+								HtmlRspackPlugin.getCompilationOptions(
+									that.deref()!.#compilation!
+								) || {}
 						}
-					});
-				}
+					})
 			)
 		};
 
@@ -1359,7 +1405,9 @@ class Compiler {
 		getHook: () => liteTapable.Hook<T, R, A>,
 		createTap: (queried: liteTapable.QueriedHook<T, R, A>) => any
 	): (stages: number[]) => binding.JsTap[] {
+		const that = new WeakRef(this);
 		const getTaps = (stages: number[]) => {
+			const compiler = that.deref()!;
 			const hook = getHook();
 			if (!hook.isUsed()) return [];
 			const breakpoints = [
@@ -1379,7 +1427,7 @@ class Compiler {
 					stage: liteTapable.safeStage(from + 1)
 				});
 			}
-			this.#decorateJsTaps(jsTaps);
+			compiler.#decorateJsTaps(jsTaps);
 			return jsTaps;
 		};
 		getTaps.registerKind = registerKind;
@@ -1392,7 +1440,9 @@ class Compiler {
 		getHookMap: () => liteTapable.HookMap<H>,
 		createTap: (queried: liteTapable.QueriedHookMap<H>) => any
 	): (stages: number[]) => binding.JsTap[] {
+		const that = new WeakRef(this);
 		const getTaps = (stages: number[]) => {
+			const compiler = that.deref()!;
 			const map = getHookMap();
 			if (!map.isUsed()) return [];
 			const breakpoints = [
@@ -1412,7 +1462,7 @@ class Compiler {
 					stage: liteTapable.safeStage(from + 1)
 				});
 			}
-			this.#decorateJsTaps(jsTaps);
+			compiler.#decorateJsTaps(jsTaps);
 			return jsTaps;
 		};
 		getTaps.registerKind = registerKind;

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -248,7 +248,7 @@ class Compiler {
 		new JsLoaderRspackPlugin(this).apply(this);
 		new ExecuteModulePlugin().apply(this);
 
-		this.hooks.shutdown.tap("Compiler", () => {
+		this.hooks.shutdown.tap("rspack:cleanup", () => {
 			this.#instance = undefined;
 		});
 	}

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -773,63 +773,124 @@ class Compiler {
 		this.#registers = {
 			registerCompilerThisCompilationTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerThisCompilation,
-				() => that.deref()!.hooks.thisCompilation,
-				queried => (native: binding.JsCompilation) => {
-					that.deref()!.#createCompilation(native);
-					return queried.call(
-						that.deref()!.#compilation!,
-						that.deref()!.#compilationParams!
-					);
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.thisCompilation;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function (native: binding.JsCompilation) {
+						that.deref()!.#createCompilation(native);
+						return queried.call(
+							that.deref()!.#compilation!,
+							that.deref()!.#compilationParams!
+						);
+					};
 				}
 			),
 			registerCompilerCompilationTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerCompilation,
-				() => that.deref()!.hooks.compilation,
-				queried => () =>
-					queried.call(
-						that.deref()!.#compilation!,
-						that.deref()!.#compilationParams!
-					)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.compilation;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function () {
+						return queried.call(
+							that.deref()!.#compilation!,
+							that.deref()!.#compilationParams!
+						);
+					};
+				}
 			),
 			registerCompilerMakeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerMake,
-				() => that.deref()!.hooks.make,
-				queried => async () =>
-					await queried.promise(that.deref()!.#compilation!)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.make;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(that.deref()!.#compilation!);
+					};
+				}
 			),
 			registerCompilerFinishMakeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerFinishMake,
-				() => that.deref()!.hooks.finishMake,
-				queried => async () =>
-					await queried.promise(that.deref()!.#compilation!)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.finishMake;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(that.deref()!.#compilation!);
+					};
+				}
 			),
 			registerCompilerShouldEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerShouldEmit,
-				() => that.deref()!.hooks.shouldEmit,
-				queried => () => queried.call(that.deref()!.#compilation!)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.shouldEmit;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function () {
+						return queried.call(that.deref()!.#compilation!);
+					};
+				}
 			),
 			registerCompilerEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerEmit,
-				() => that.deref()!.hooks.emit,
-				queried => async () =>
-					await queried.promise(that.deref()!.#compilation!)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.emit;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(that.deref()!.#compilation!);
+					};
+				}
 			),
 			registerCompilerAfterEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerAfterEmit,
-				() => that.deref()!.hooks.afterEmit,
-				queried => async () =>
-					await queried.promise(that.deref()!.#compilation!)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.afterEmit;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(that.deref()!.#compilation!);
+					};
+				}
 			),
 			registerCompilerAssetEmittedTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilerAssetEmitted,
-				() => that.deref()!.hooks.assetEmitted,
-				queried =>
-					async ({
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.hooks.assetEmitted;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function ({
 						filename,
 						targetPath,
 						outputPath
-					}: binding.JsAssetEmittedArgs) =>
-						queried.promise(filename, {
+					}: binding.JsAssetEmittedArgs) {
+						return queried.promise(filename, {
 							compilation: that.deref()!.#compilation!,
 							targetPath,
 							outputPath,
@@ -839,19 +900,26 @@ class Compiler {
 							get content() {
 								return this.source?.buffer();
 							}
-						})
+						});
+					};
+				}
 			),
 			registerCompilationAdditionalTreeRuntimeRequirements:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind
 						.CompilationAdditionalTreeRuntimeRequirements,
-					() =>
-						that.deref()!.#compilation!.hooks.additionalTreeRuntimeRequirements,
-					queried =>
-						({
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return that.deref()!.#compilation!.hooks
+							.additionalTreeRuntimeRequirements;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return function ({
 							chunk,
 							runtimeRequirements
-						}: binding.JsAdditionalTreeRuntimeRequirementsArg) => {
+						}: binding.JsAdditionalTreeRuntimeRequirementsArg) {
 							const set = __from_binding_runtime_globals(runtimeRequirements);
 							queried.call(
 								Chunk.__from_binding(chunk, that.deref()!.#compilation!),
@@ -860,17 +928,23 @@ class Compiler {
 							return {
 								runtimeRequirements: __to_binding_runtime_globals(set)
 							};
-						}
+						};
+					}
 				),
 			registerCompilationRuntimeRequirementInTree:
 				this.#createHookMapRegisterTaps(
 					binding.RegisterJsTapKind.CompilationRuntimeRequirementInTree,
-					() => that.deref()!.#compilation!.hooks.runtimeRequirementInTree,
-					queried =>
-						({
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return that.deref()!.#compilation!.hooks.runtimeRequirementInTree;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return function ({
 							chunk: rawChunk,
 							runtimeRequirements
-						}: binding.JsRuntimeRequirementInTreeArg) => {
+						}: binding.JsRuntimeRequirementInTreeArg) {
 							const set = __from_binding_runtime_globals(runtimeRequirements);
 							const chunk = Chunk.__from_binding(
 								rawChunk,
@@ -882,13 +956,19 @@ class Compiler {
 							return {
 								runtimeRequirements: __to_binding_runtime_globals(set)
 							};
-						}
+						};
+					}
 				),
 			registerCompilationRuntimeModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationRuntimeModule,
-				() => that.deref()!.#compilation!.hooks.runtimeModule,
-				queried =>
-					({ module, chunk }: binding.JsRuntimeModuleArg) => {
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.runtimeModule;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function ({ module, chunk }: binding.JsRuntimeModuleArg) {
 						const originSource = module.source?.source;
 						queried.call(
 							module,
@@ -899,36 +979,72 @@ class Compiler {
 							return module;
 						}
 						return;
-					}
+					};
+				}
 			),
 			registerCompilationBuildModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationBuildModule,
-				() => that.deref()!.#compilation!.hooks.buildModule,
-				queired => (m: binding.JsModule) =>
-					queired.call(Module.__from_binding(m, that.deref()!.#compilation))
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.buildModule;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function (m: binding.JsModule) {
+						return queried.call(
+							Module.__from_binding(m, that.deref()!.#compilation)
+						);
+					};
+				}
 			),
 			registerCompilationStillValidModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationStillValidModule,
-				() => that.deref()!.#compilation!.hooks.stillValidModule,
-				queired => (m: binding.JsModule) =>
-					queired.call(Module.__from_binding(m, that.deref()!.#compilation))
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.stillValidModule;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function (m: binding.JsModule) {
+						return queried.call(
+							Module.__from_binding(m, that.deref()!.#compilation)
+						);
+					};
+				}
 			),
 			registerCompilationSucceedModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationSucceedModule,
-				() => that.deref()!.#compilation!.hooks.succeedModule,
-				queired => (m: binding.JsModule) =>
-					queired.call(Module.__from_binding(m, that.deref()!.#compilation))
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.succeedModule;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function (m: binding.JsModule) {
+						return queried.call(
+							Module.__from_binding(m, that.deref()!.#compilation)
+						);
+					};
+				}
 			),
 			registerCompilationExecuteModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationExecuteModule,
-				() => that.deref()!.#compilation!.hooks.executeModule,
-				queried =>
-					({
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.executeModule;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function ({
 						entry,
 						id,
 						codegenResults,
 						runtimeModules
-					}: binding.JsExecuteModuleArg) => {
+					}: binding.JsExecuteModuleArg) {
 						const __webpack_require__: any = (id: string) => {
 							const cached = moduleCache[id];
 							if (cached !== undefined) {
@@ -992,101 +1108,223 @@ class Compiler {
 						const executeResult = __webpack_require__(entry);
 
 						that.deref()!.#moduleExecutionResultsMap.set(id, executeResult);
-					}
+					};
+				}
 			),
 			registerCompilationFinishModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationFinishModules,
-				() => that.deref()!.#compilation!.hooks.finishModules,
-				queried => async () =>
-					await queried.promise(that.deref()!.#compilation!.modules)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.finishModules;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(that.deref()!.#compilation!.modules);
+					};
+				}
 			),
 			registerCompilationOptimizeModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationOptimizeModules,
-				() => that.deref()!.#compilation!.hooks.optimizeModules,
-				queried => () =>
-					queried.call(that.deref()!.#compilation!.modules.values())
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.optimizeModules;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function () {
+						return queried.call(that.deref()!.#compilation!.modules.values());
+					};
+				}
 			),
 			registerCompilationAfterOptimizeModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationAfterOptimizeModules,
-				() => that.deref()!.#compilation!.hooks.afterOptimizeModules,
-				queried => () => {
-					queried.call(that.deref()!.#compilation!.modules.values());
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.afterOptimizeModules;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function () {
+						queried.call(that.deref()!.#compilation!.modules.values());
+					};
 				}
 			),
 			registerCompilationOptimizeTreeTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationOptimizeTree,
-				() => that.deref()!.#compilation!.hooks.optimizeTree,
-				queried => async () =>
-					await queried.promise(
-						that.deref()!.#compilation!.chunks,
-						that.deref()!.#compilation!.modules
-					)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.optimizeTree;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(
+							that.deref()!.#compilation!.chunks,
+							that.deref()!.#compilation!.modules
+						);
+					};
+				}
 			),
 			registerCompilationOptimizeChunkModulesTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationOptimizeChunkModules,
-				() => that.deref()!.#compilation!.hooks.optimizeChunkModules,
-				queried => async () =>
-					await queried.promise(
-						that.deref()!.#compilation!.chunks,
-						that.deref()!.#compilation!.modules
-					)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.optimizeChunkModules;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(
+							that.deref()!.#compilation!.chunks,
+							that.deref()!.#compilation!.modules
+						);
+					};
+				}
 			),
 			registerCompilationChunkHashTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationChunkHash,
-				() => that.deref()!.#compilation!.hooks.chunkHash,
-				queried => (chunk: binding.JsChunk) => {
-					if (!that.deref()!.options.output.hashFunction) {
-						throw new Error("'output.hashFunction' cannot be undefined");
-					}
-					const hash = createHash(that.deref()!.options.output.hashFunction!);
-					queried.call(
-						Chunk.__from_binding(chunk, that.deref()!.#compilation!),
-						hash
-					);
-					const digestResult = hash.digest(
-						that.deref()!.options.output.hashDigest
-					);
-					return Buffer.from(digestResult);
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.chunkHash;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function (chunk: binding.JsChunk) {
+						if (!that.deref()!.options.output.hashFunction) {
+							throw new Error("'output.hashFunction' cannot be undefined");
+						}
+						const hash = createHash(that.deref()!.options.output.hashFunction!);
+						queried.call(
+							Chunk.__from_binding(chunk, that.deref()!.#compilation!),
+							hash
+						);
+						const digestResult = hash.digest(
+							that.deref()!.options.output.hashDigest
+						);
+						return Buffer.from(digestResult);
+					};
 				}
 			),
 			registerCompilationChunkAssetTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationChunkAsset,
-				() => that.deref()!.#compilation!.hooks.chunkAsset,
-				queried =>
-					({ chunk, filename }: binding.JsChunkAssetArgs) =>
-						queried.call(
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.chunkAsset;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function ({ chunk, filename }: binding.JsChunkAssetArgs) {
+						return queried.call(
 							Chunk.__from_binding(chunk, that.deref()!.#compilation!),
 							filename
-						)
+						);
+					};
+				}
 			),
 			registerCompilationProcessAssetsTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationProcessAssets,
-				() => that.deref()!.#compilation!.hooks.processAssets,
-				queried => async () =>
-					await queried.promise(that.deref()!.#compilation!.assets)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.processAssets;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise(that.deref()!.#compilation!.assets);
+					};
+				}
 			),
 			registerCompilationAfterProcessAssetsTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationAfterProcessAssets,
-				() => that.deref()!.#compilation!.hooks.afterProcessAssets,
-				queried => () => queried.call(that.deref()!.#compilation!.assets)
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.afterProcessAssets;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function () {
+						return queried.call(that.deref()!.#compilation!.assets);
+					};
+				}
 			),
 			registerCompilationSealTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationSeal,
-				() => that.deref()!.#compilation!.hooks.seal,
-				queried => () => queried.call()
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.seal;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function () {
+						return queried.call();
+					};
+				}
 			),
 			registerCompilationAfterSealTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.CompilationAfterSeal,
-				() => that.deref()!.#compilation!.hooks.afterSeal,
-				queried => async () => await queried.promise()
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilation!.hooks.afterSeal;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function () {
+						return await queried.promise();
+					};
+				}
 			),
 			registerNormalModuleFactoryBeforeResolveTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.NormalModuleFactoryBeforeResolve,
-					() =>
-						that.deref()!.#compilationParams!.normalModuleFactory.hooks
-							.beforeResolve,
-					queried => async (resolveData: binding.JsBeforeResolveArgs) => {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return that.deref()!.#compilationParams!.normalModuleFactory.hooks
+							.beforeResolve;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return async function (resolveData: binding.JsBeforeResolveArgs) {
+							const normalizedResolveData: ResolveData = {
+								contextInfo: {
+									issuer: resolveData.issuer
+								},
+								request: resolveData.request,
+								context: resolveData.context,
+								fileDependencies: [],
+								missingDependencies: [],
+								contextDependencies: []
+							};
+							const ret = await queried.promise(normalizedResolveData);
+							resolveData.request = normalizedResolveData.request;
+							resolveData.context = normalizedResolveData.context;
+							return [ret, resolveData];
+						};
+					}
+				),
+			registerNormalModuleFactoryFactorizeTaps: this.#createHookRegisterTaps(
+				binding.RegisterJsTapKind.NormalModuleFactoryFactorize,
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilationParams!.normalModuleFactory.hooks
+						.factorize;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (resolveData: binding.JsFactorizeArgs) {
 						const normalizedResolveData: ResolveData = {
 							contextInfo: {
 								issuer: resolveData.issuer
@@ -1097,114 +1335,124 @@ class Compiler {
 							missingDependencies: [],
 							contextDependencies: []
 						};
-						const ret = await queried.promise(normalizedResolveData);
+						await queried.promise(normalizedResolveData);
 						resolveData.request = normalizedResolveData.request;
 						resolveData.context = normalizedResolveData.context;
-						return [ret, resolveData];
-					}
-				),
-			registerNormalModuleFactoryFactorizeTaps: this.#createHookRegisterTaps(
-				binding.RegisterJsTapKind.NormalModuleFactoryFactorize,
-				() =>
-					that.deref()!.#compilationParams!.normalModuleFactory.hooks.factorize,
-				queried => async (resolveData: binding.JsFactorizeArgs) => {
-					const normalizedResolveData: ResolveData = {
-						contextInfo: {
-							issuer: resolveData.issuer
-						},
-						request: resolveData.request,
-						context: resolveData.context,
-						fileDependencies: [],
-						missingDependencies: [],
-						contextDependencies: []
+						return resolveData;
 					};
-					await queried.promise(normalizedResolveData);
-					resolveData.request = normalizedResolveData.request;
-					resolveData.context = normalizedResolveData.context;
-					return resolveData;
 				}
 			),
 			registerNormalModuleFactoryResolveTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryResolve,
-				() =>
-					that.deref()!.#compilationParams!.normalModuleFactory.hooks.resolve,
-				queried => async (resolveData: binding.JsFactorizeArgs) => {
-					const normalizedResolveData: ResolveData = {
-						contextInfo: {
-							issuer: resolveData.issuer
-						},
-						request: resolveData.request,
-						context: resolveData.context,
-						fileDependencies: [],
-						missingDependencies: [],
-						contextDependencies: []
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilationParams!.normalModuleFactory.hooks
+						.resolve;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (resolveData: binding.JsFactorizeArgs) {
+						const normalizedResolveData: ResolveData = {
+							contextInfo: {
+								issuer: resolveData.issuer
+							},
+							request: resolveData.request,
+							context: resolveData.context,
+							fileDependencies: [],
+							missingDependencies: [],
+							contextDependencies: []
+						};
+						await queried.promise(normalizedResolveData);
+						resolveData.request = normalizedResolveData.request;
+						resolveData.context = normalizedResolveData.context;
+						return resolveData;
 					};
-					await queried.promise(normalizedResolveData);
-					resolveData.request = normalizedResolveData.request;
-					resolveData.context = normalizedResolveData.context;
-					return resolveData;
 				}
 			),
 			registerNormalModuleFactoryResolveForSchemeTaps:
 				this.#createHookMapRegisterTaps(
 					binding.RegisterJsTapKind.NormalModuleFactoryResolveForScheme,
-					() =>
-						that.deref()!.#compilationParams!.normalModuleFactory.hooks
-							.resolveForScheme,
-					queried => async (args: binding.JsResolveForSchemeArgs) => {
-						const ret = await queried
-							.for(args.scheme)
-							.promise(args.resourceData);
-						return [ret, args.resourceData];
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return that.deref()!.#compilationParams!.normalModuleFactory.hooks
+							.resolveForScheme;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return async function (args: binding.JsResolveForSchemeArgs) {
+							const ret = await queried
+								.for(args.scheme)
+								.promise(args.resourceData);
+							return [ret, args.resourceData];
+						};
 					}
 				),
 			registerNormalModuleFactoryAfterResolveTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryAfterResolve,
-				() =>
-					that.deref()!.#compilationParams!.normalModuleFactory.hooks
-						.afterResolve,
-				queried => async (arg: binding.JsAfterResolveData) => {
-					const data: ResolveData = {
-						contextInfo: {
-							issuer: arg.issuer
-						},
-						request: arg.request,
-						context: arg.context,
-						fileDependencies: arg.fileDependencies,
-						missingDependencies: arg.missingDependencies,
-						contextDependencies: arg.contextDependencies,
-						createData: arg.createData
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilationParams!.normalModuleFactory.hooks
+						.afterResolve;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (arg: binding.JsAfterResolveData) {
+						const data: ResolveData = {
+							contextInfo: {
+								issuer: arg.issuer
+							},
+							request: arg.request,
+							context: arg.context,
+							fileDependencies: arg.fileDependencies,
+							missingDependencies: arg.missingDependencies,
+							contextDependencies: arg.contextDependencies,
+							createData: arg.createData
+						};
+						const ret = await queried.promise(data);
+						return [ret, data.createData];
 					};
-					const ret = await queried.promise(data);
-					return [ret, data.createData];
 				}
 			),
 			registerNormalModuleFactoryCreateModuleTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.NormalModuleFactoryCreateModule,
-				() =>
-					that.deref()!.#compilationParams!.normalModuleFactory.hooks
-						.createModule,
-				queried =>
-					async (args: binding.JsNormalModuleFactoryCreateModuleArgs) => {
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return that.deref()!.#compilationParams!.normalModuleFactory.hooks
+						.createModule;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (
+						args: binding.JsNormalModuleFactoryCreateModuleArgs
+					) {
 						const data: NormalModuleCreateData = {
 							...args,
 							settings: {}
 						};
 						await queried.promise(data, {});
-					}
+					};
+				}
 			),
 			registerContextModuleFactoryBeforeResolveTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.ContextModuleFactoryBeforeResolve,
-					() =>
-						that.deref()!.#compilationParams!.contextModuleFactory.hooks
-							.beforeResolve,
-					queried =>
-						async (
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return that.deref()!.#compilationParams!.contextModuleFactory.hooks
+							.beforeResolve;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return async function (
 							bindingData:
 								| false
 								| binding.JsContextModuleFactoryBeforeResolveData
-						) => {
+						) {
 							const data = bindingData
 								? ContextModuleFactoryBeforeResolveData.__from_binding(
 										bindingData
@@ -1214,20 +1462,25 @@ class Compiler {
 							return result
 								? ContextModuleFactoryBeforeResolveData.__to_binding(result)
 								: false;
-						}
+						};
+					}
 				),
 			registerContextModuleFactoryAfterResolveTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.ContextModuleFactoryAfterResolve,
-					() =>
-						that.deref()!.#compilationParams!.contextModuleFactory.hooks
-							.afterResolve,
-					queried =>
-						async (
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return that.deref()!.#compilationParams!.contextModuleFactory.hooks
+							.afterResolve;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return async function (
 							bindingData:
 								| false
 								| binding.JsContextModuleFactoryAfterResolveData
-						) => {
+						) {
 							const data = bindingData
 								? ContextModuleFactoryAfterResolveData.__from_binding(
 										bindingData
@@ -1237,37 +1490,92 @@ class Compiler {
 							return result
 								? ContextModuleFactoryAfterResolveData.__to_binding(result)
 								: false;
-						}
+						};
+					}
 				),
 			registerJavascriptModulesChunkHashTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.JavascriptModulesChunkHash,
-				() =>
-					JavascriptModulesPlugin.getCompilationHooks(
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return JavascriptModulesPlugin.getCompilationHooks(
 						that.deref()!.#compilation!
-					).chunkHash,
-				queried => (chunk: binding.JsChunk) => {
-					if (!that.deref()!.options.output.hashFunction) {
-						throw new Error("'output.hashFunction' cannot be undefined");
-					}
-					const hash = createHash(that.deref()!.options.output.hashFunction!);
-					queried.call(
-						Chunk.__from_binding(chunk, that.deref()!.#compilation!),
-						hash
-					);
-					const digestResult = hash.digest(
-						that.deref()!.options.output.hashDigest
-					);
-					return Buffer.from(digestResult);
+					).chunkHash;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return function (chunk: binding.JsChunk) {
+						if (!that.deref()!.options.output.hashFunction) {
+							throw new Error("'output.hashFunction' cannot be undefined");
+						}
+						const hash = createHash(that.deref()!.options.output.hashFunction!);
+						queried.call(
+							Chunk.__from_binding(chunk, that.deref()!.#compilation!),
+							hash
+						);
+						const digestResult = hash.digest(
+							that.deref()!.options.output.hashDigest
+						);
+						return Buffer.from(digestResult);
+					};
 				}
 			),
 			registerHtmlPluginBeforeAssetTagGenerationTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.HtmlPluginBeforeAssetTagGeneration,
-					() =>
-						HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
-							.beforeAssetTagGeneration,
-					queried => async (data: binding.JsBeforeAssetTagGenerationData) =>
-						await queried.promise({
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return HtmlRspackPlugin.getCompilationHooks(
+							that.deref()!.#compilation!
+						).beforeAssetTagGeneration;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return async function (
+							data: binding.JsBeforeAssetTagGenerationData
+						) {
+							return await queried.promise({
+								...data,
+								plugin: {
+									options:
+										HtmlRspackPlugin.getCompilationOptions(
+											that.deref()!.#compilation!
+										) || {}
+								}
+							});
+						};
+					}
+				),
+			registerHtmlPluginAlterAssetTagsTaps: this.#createHookRegisterTaps(
+				binding.RegisterJsTapKind.HtmlPluginAlterAssetTags,
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return HtmlRspackPlugin.getCompilationHooks(
+						that.deref()!.#compilation!
+					).alterAssetTags;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (data: binding.JsAlterAssetTagsData) {
+						return await queried.promise(data);
+					};
+				}
+			),
+			registerHtmlPluginAlterAssetTagGroupsTaps: this.#createHookRegisterTaps(
+				binding.RegisterJsTapKind.HtmlPluginAlterAssetTagGroups,
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return HtmlRspackPlugin.getCompilationHooks(
+						that.deref()!.#compilation!
+					).alterAssetTagGroups;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (data: binding.JsAlterAssetTagGroupsData) {
+						return await queried.promise({
 							...data,
 							plugin: {
 								options:
@@ -1275,40 +1583,48 @@ class Compiler {
 										that.deref()!.#compilation!
 									) || {}
 							}
-						})
-				),
-			registerHtmlPluginAlterAssetTagsTaps: this.#createHookRegisterTaps(
-				binding.RegisterJsTapKind.HtmlPluginAlterAssetTags,
-				() =>
-					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
-						.alterAssetTags,
-				queried => async (data: binding.JsAlterAssetTagsData) =>
-					await queried.promise(data)
-			),
-			registerHtmlPluginAlterAssetTagGroupsTaps: this.#createHookRegisterTaps(
-				binding.RegisterJsTapKind.HtmlPluginAlterAssetTagGroups,
-				() =>
-					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
-						.alterAssetTagGroups,
-				queried => async (data: binding.JsAlterAssetTagGroupsData) =>
-					await queried.promise({
-						...data,
-						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									that.deref()!.#compilation!
-								) || {}
-						}
-					})
+						});
+					};
+				}
 			),
 			registerHtmlPluginAfterTemplateExecutionTaps:
 				this.#createHookRegisterTaps(
 					binding.RegisterJsTapKind.HtmlPluginAfterTemplateExecution,
-					() =>
-						HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
-							.afterTemplateExecution,
-					queried => async (data: binding.JsAfterTemplateExecutionData) =>
-						await queried.promise({
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function () {
+						return HtmlRspackPlugin.getCompilationHooks(
+							that.deref()!.#compilation!
+						).afterTemplateExecution;
+					},
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					function (queried) {
+						// biome-ignore lint/complexity/useArrowFunction: <explanation>
+						return async function (data: binding.JsAfterTemplateExecutionData) {
+							return await queried.promise({
+								...data,
+								plugin: {
+									options:
+										HtmlRspackPlugin.getCompilationOptions(
+											that.deref()!.#compilation!
+										) || {}
+								}
+							});
+						};
+					}
+				),
+			registerHtmlPluginBeforeEmitTaps: this.#createHookRegisterTaps(
+				binding.RegisterJsTapKind.HtmlPluginBeforeEmit,
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return HtmlRspackPlugin.getCompilationHooks(
+						that.deref()!.#compilation!
+					).beforeEmit;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (data: binding.JsBeforeEmitData) {
+						return await queried.promise({
 							...data,
 							plugin: {
 								options:
@@ -1316,39 +1632,33 @@ class Compiler {
 										that.deref()!.#compilation!
 									) || {}
 							}
-						})
-				),
-			registerHtmlPluginBeforeEmitTaps: this.#createHookRegisterTaps(
-				binding.RegisterJsTapKind.HtmlPluginBeforeEmit,
-				() =>
-					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
-						.beforeEmit,
-				queried => async (data: binding.JsBeforeEmitData) =>
-					await queried.promise({
-						...data,
-						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									that.deref()!.#compilation!
-								) || {}
-						}
-					})
+						});
+					};
+				}
 			),
 			registerHtmlPluginAfterEmitTaps: this.#createHookRegisterTaps(
 				binding.RegisterJsTapKind.HtmlPluginAfterEmit,
-				() =>
-					HtmlRspackPlugin.getCompilationHooks(that.deref()!.#compilation!)
-						.afterEmit,
-				queried => async (data: binding.JsAfterEmitData) =>
-					await queried.promise({
-						...data,
-						plugin: {
-							options:
-								HtmlRspackPlugin.getCompilationOptions(
-									that.deref()!.#compilation!
-								) || {}
-						}
-					})
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function () {
+					return HtmlRspackPlugin.getCompilationHooks(
+						that.deref()!.#compilation!
+					).afterEmit;
+				},
+				// biome-ignore lint/complexity/useArrowFunction: <explanation>
+				function (queried) {
+					// biome-ignore lint/complexity/useArrowFunction: <explanation>
+					return async function (data: binding.JsAfterEmitData) {
+						return await queried.promise({
+							...data,
+							plugin: {
+								options:
+									HtmlRspackPlugin.getCompilationOptions(
+										that.deref()!.#compilation!
+									) || {}
+							}
+						});
+					};
+				}
 			)
 		};
 

--- a/tests/webpack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/index.js
+++ b/tests/webpack-test/hotCases/esm-dependency-import/import-meta-webpack-hot/index.js
@@ -2,6 +2,6 @@ import {val} from "./module";
 
 it("should accept changes", (done) => {
 	expect(val).toBe(1);
-	NEXT(require("../../update")(done));
-	done();
+	// CHANGE: fix an issue when `done` is called before compiler is done, causing a segmentation fault.
+	NEXT(require("../../update")(done, true, () => done()));
 });


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

closes https://github.com/web-infra-dev/rspack/issues/3169

Fixed an issue when constantly creating compilers and the memory is not getting freed after use.

This issue was fixed with `WeakRef` and function expression which does not capture `this`, which is `Compiler` in this case. But still, I'm not able to create a MRE with both minimal Rust and JS code. So this issue might be appropriately tackled once a MRE is created.

Tests will be added in up-coming PRs. We might need to take https://github.com/napi-rs/napi-rs/tree/main/memory-testing as a reference.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or **not required**).
