### PR TITLE
chore(ci): change repo owner of rspack-ecosystem-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,7 +345,7 @@ jobs:
         continue-on-error: true
         uses: convictional/trigger-workflow-and-wait@v1.6.5
         with:
-          owner: ${{ github.repository_owner }}
+          owner: 'rspack-contrib',
           repo: "rspack-ecosystem-ci"
           workflow_file_name: "ecosystem-ci-from-commit.yml"
           github_token: ${{ secrets.RSPACK_ACCESS_TOKEN }}

--- a/.github/workflows/ecosystem-ci-trigger.yml
+++ b/.github/workflows/ecosystem-ci-trigger.yml
@@ -88,7 +88,7 @@ jobs:
             }
 
             await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
+              owner: 'rspack-contrib',
               repo: 'rspack-ecosystem-ci',
               workflow_id: 'ecosystem-ci-from-pr.yml',
               ref: 'main',

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -104,7 +104,7 @@ jobs:
           github-token: ${{ secrets.RSPACK_ACCESS_TOKEN }}
           script: |
             const result = await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
+              owner: 'rspack-contrib',
               repo: 'rspack-ecosystem-ci',
               workflow_id: 'ecosystem-ci-selected.yml',
               ref: 'main',


### PR DESCRIPTION
## Summary

The rspack-ecosystem-ci repo has been moved to https://github.com/rspack-contrib/rspack-ecosystem-ci and we need to change the repo owner to match this change.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
