### PR TITLE
perf: enable SWC `disableAllLints` by default to reduce overhead

### DIFF
--- a/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/stats.err
+++ b/packages/rspack-test-tools/tests/diagnosticsCases/config/builtin-swc-loader/stats.err
@@ -6,5 +6,5 @@ ERROR in × failed to parse builtin:swc-loader options
    ·             ▲
    ·             ╰── unknown field `parser2`, expected one of `assumptions`, `parser`, `transform`, `externalHelpers`, `target`, `loose`, `keepClassNames`, `baseUrl`, `paths`, `minify`, `experimental`, `lints`, `preserveAllComments`, `output` at line 3 column 13
  4 │       "syntax": "ecmascript"
- 5 │     }
+ 5 │     },
    ╰────

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -25,5 +25,9 @@ export type SwcLoaderOptions = Config & {
 	 */
 	rspackExperiments?: {
 		import?: PluginImportOptions;
+		/**
+		 * @deprecated use `import` instead
+		 */
+		pluginImport?: PluginImportOptions;
 	};
 };

--- a/packages/rspack/src/builtin-loader/swc/types.ts
+++ b/packages/rspack/src/builtin-loader/swc/types.ts
@@ -25,9 +25,5 @@ export type SwcLoaderOptions = Config & {
 	 */
 	rspackExperiments?: {
 		import?: PluginImportOptions;
-		/**
-		 * @deprecated use `import` instead
-		 */
-		pluginImport?: PluginImportOptions;
 	};
 };

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -253,10 +253,19 @@ type GetLoaderOptions = (
 ) => RuleSetLoaderWithOptions["options"];
 
 const getSwcLoaderOptions: GetLoaderOptions = (o, _) => {
-	if (o && typeof o === "object" && o.rspackExperiments) {
-		const expr = o.rspackExperiments;
-		if (expr.import || expr.pluginImport) {
-			expr.import = resolvePluginImport(expr.import || expr.pluginImport);
+	if (o && typeof o === "object") {
+		// enable `disableAllLints` by default to reduce performance overhead
+		o.jsc ??= {};
+		o.jsc.experimental ??= {};
+		o.jsc.experimental.disableAllLints ??= true;
+
+		// resolve `rspackExperiments.import` options
+		const { rspackExperiments } = o;
+		if (rspackExperiments) {
+			const expr = rspackExperiments;
+			if (expr.import || expr.pluginImport) {
+				expr.import = resolvePluginImport(expr.import || expr.pluginImport);
+			}
 		}
 	}
 	return o;

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -252,23 +252,24 @@ type GetLoaderOptions = (
 	options: ComposeJsUseOptions
 ) => RuleSetLoaderWithOptions["options"];
 
-const getSwcLoaderOptions: GetLoaderOptions = (o, _) => {
-	if (o && typeof o === "object") {
+const getSwcLoaderOptions: GetLoaderOptions = (options, _) => {
+	if (options && typeof options === "object") {
 		// enable `disableAllLints` by default to reduce performance overhead
-		o.jsc ??= {};
-		o.jsc.experimental ??= {};
-		o.jsc.experimental.disableAllLints ??= true;
+		options.jsc ??= {};
+		options.jsc.experimental ??= {};
+		options.jsc.experimental.disableAllLints ??= true;
 
 		// resolve `rspackExperiments.import` options
-		const { rspackExperiments } = o;
+		const { rspackExperiments } = options;
 		if (rspackExperiments) {
-			const expr = rspackExperiments;
-			if (expr.import || expr.pluginImport) {
-				expr.import = resolvePluginImport(expr.import || expr.pluginImport);
+			if (rspackExperiments.import || rspackExperiments.pluginImport) {
+				rspackExperiments.import = resolvePluginImport(
+					rspackExperiments.import || rspackExperiments.pluginImport
+				);
 			}
 		}
 	}
-	return o;
+	return options;
 };
 
 const getLightningcssLoaderOptions: GetLoaderOptions = (o, _) => {


### PR DESCRIPTION
## Summary

Enable SWC `disableAllLints` by default to reduce overhead. We prefer to use ESLint or Biome as a linter rather than run lint rules during the JavaScript transformation.

## Ref

- SWC lint rules: https://github.com/swc-project/swc/tree/b94a0e1fd2b900b05c5f18d3d993a74ff9cc6e7d/crates/swc_ecma_lints/src/rules
- https://x.com/kdy1dev/status/1840556491650240730
- https://x.com/kdy1dev/status/1841275955190616329

## Benchmark

- 10000 modules: **4% faster**

```bash
hyperfine --warmup 1 --runs 3 'SWC_LINTS=true node --run build:rspack' 'SWC_LINTS=false node --run build:rspack'
Benchmark 1: SWC_LINTS=true node --run build:rspack
  Time (mean ± σ):      2.382 s ±  0.027 s    [User: 4.496 s, System: 9.262 s]
  Range (min … max):    2.359 s …  2.412 s    3 runs

Benchmark 2: SWC_LINTS=false node --run build:rspack
  Time (mean ± σ):      2.300 s ±  0.023 s    [User: 4.232 s, System: 7.237 s]
  Range (min … max):    2.278 s …  2.323 s    3 runs

Summary
  SWC_LINTS=false node --run build:rspack ran
    1.04 ± 0.02 times faster than SWC_LINTS=true node --run build:rspack
```

- 10000 big modules: **6% faster**

```bash
hyperfine --warmup 1 --runs 3 'SWC_LINTS=true node --run build:rspack' 'SWC_LINTS=false node --run build:rspack'
Benchmark 1: SWC_LINTS=true node --run build:rspack
  Time (mean ± σ):      8.726 s ±  0.133 s    [User: 80.865 s, System: 6.063 s]
  Range (min … max):    8.593 s …  8.860 s    3 runs

Benchmark 2: SWC_LINTS=false node --run build:rspack
  Time (mean ± σ):      8.211 s ±  0.067 s    [User: 77.066 s, System: 5.413 s]
  Range (min … max):    8.135 s …  8.262 s    3 runs

Summary
  SWC_LINTS=false node --run build:rspack ran
    1.06 ± 0.02 times faster than SWC_LINTS=true node --run build:rspack
```

> From: https://github.com/hardfist/performance-compare-ng/tree/add-big/apps/10000-big

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
