### PR TITLE
fix(type): Make iterators compatible with TS 5.6 `--target ESNext`

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -412,7 +412,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 */
 	get namedChunkGroups() {
 		return createReadonlyMap<ChunkGroup>({
-			keys: (): MapIterator<string> => {
+			keys: (): ReturnType<string[]["values"]> => {
 				const names = this.#inner.getNamedChunkGroupKeys();
 				return names[Symbol.iterator]();
 			},
@@ -450,7 +450,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 	 */
 	get namedChunks() {
 		return createReadonlyMap<Chunk>({
-			keys: (): IterableIterator<string> => {
+			keys: (): ReturnType<string[]["values"]> => {
 				const names = this.#inner.getNamedChunkKeys();
 				return names[Symbol.iterator]();
 			},
@@ -1240,22 +1240,6 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
 
 export type EntryData = binding.JsEntryData;
 
-/**
- * Copied from `lib.es2015.iterable.d.ts` in TS 5.6 for compatibility
- * 1. In 5.6 and after, `IterableIterator` cannot be assigned to 'MapIterator'
- * 2. Before 5.6, Cannot find name 'MapIterator'
- * @see https://devblogs.microsoft.com/typescript/announcing-typescript-5-6/#iterator-helper-methods
- */
-interface IteratorObject<T, TReturn = unknown, TNext = unknown>
-	extends Iterator<T, TReturn, TNext> {
-	[Symbol.iterator](): IteratorObject<T, TReturn, TNext>;
-}
-type BuiltinIteratorReturn = any;
-interface MapIterator<T>
-	extends IteratorObject<T, BuiltinIteratorReturn, unknown> {
-	[Symbol.iterator](): MapIterator<T>;
-}
-
 export class Entries implements Map<string, EntryData> {
 	#data: binding.JsEntries;
 
@@ -1284,28 +1268,17 @@ export class Entries implements Map<string, EntryData> {
 		return this.#data.size;
 	}
 
-	entries(): MapIterator<[string, binding.JsEntryData]> {
-		const self = this;
-		const keys = this.keys();
-		return {
-			[Symbol.iterator]() {
-				return this;
-			},
-			next() {
-				const { done, value } = keys.next();
-				return {
-					done,
-					value: done ? (undefined as any) : [value, self.get(value)!]
-				};
-			}
-		};
+	*entries(): ReturnType<Map<string, EntryData>["entries"]> {
+		for (const key of this.keys()) {
+			yield [key, this.get(key)!];
+		}
 	}
 
-	values(): MapIterator<binding.JsEntryData> {
+	values(): ReturnType<Map<string, EntryData>["values"]> {
 		return this.#data.values()[Symbol.iterator]();
 	}
 
-	[Symbol.iterator](): MapIterator<[string, binding.JsEntryData]> {
+	[Symbol.iterator](): ReturnType<Map<string, EntryData>["entries"]> {
 		return this.entries();
 	}
 
@@ -1330,7 +1303,7 @@ export class Entries implements Map<string, EntryData> {
 		return this.#data.get(key);
 	}
 
-	keys(): MapIterator<string> {
+	keys(): ReturnType<Map<string, EntryData>["keys"]> {
 		return this.#data.keys()[Symbol.iterator]();
 	}
 }

--- a/packages/rspack/src/util/ArrayQueue.ts
+++ b/packages/rspack/src/util/ArrayQueue.ts
@@ -77,35 +77,11 @@ class ArrayQueue<T> {
 		}
 	}
 
-	[Symbol.iterator]() {
-		let i = -1;
-		let reversed = false;
-		return {
-			next: () => {
-				if (!reversed) {
-					i++;
-					if (i < this._list.length) {
-						return {
-							done: false,
-							value: this._list[i]
-						};
-					}
-					reversed = true;
-					i = this._listReversed.length;
-				}
-				i--;
-				if (i < 0) {
-					return {
-						done: true,
-						value: undefined
-					};
-				}
-				return {
-					done: false,
-					value: this._listReversed[i]
-				};
-			}
-		};
+	*[Symbol.iterator]() {
+		yield* this._list;
+		for (let i = this._listReversed.length - 1; i >= 0; i--) {
+			yield this._listReversed[i];
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Use `ReturnType<>` to avoid explicitly naming the types of builtin iterators that have changed in 5.6, and convert manually implemented iterators to generators so they are compatible with builtin iterators under `--target ESNext`.

- Fixes part of #8277.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
