### PR TITLE
fix: types and docs of umd external object

### DIFF
--- a/crates/rspack_plugin_library/src/utils.rs
+++ b/crates/rspack_plugin_library/src/utils.rs
@@ -13,7 +13,10 @@ pub fn externals_dep_array(modules: &[&ExternalModule]) -> Result<String> {
         ExternalRequest::Map(map) => map.get("amd").map(|r| r.primary()),
       })
     })
-    .collect::<Result<Vec<_>>>()?;
+    .collect::<Result<Vec<_>>>()?
+    .into_iter()
+    .filter_map(|v| v)
+    .collect::<Vec<_>>();
   serde_json::to_string(&value).map_err(|e| error!(e.to_string()))
 }
 

--- a/crates/rspack_plugin_library/src/utils.rs
+++ b/crates/rspack_plugin_library/src/utils.rs
@@ -15,7 +15,7 @@ pub fn externals_dep_array(modules: &[&ExternalModule]) -> Result<String> {
     })
     .collect::<Result<Vec<_>>>()?
     .into_iter()
-    .filter_map(|v| v)
+    .flatten()
     .collect::<Vec<_>>();
   serde_json::to_string(&value).map_err(|e| error!(e.to_string()))
 }

--- a/packages/rspack-test-tools/tests/configCases/externals/item-value-object/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/item-value-object/rspack.config.js
@@ -3,14 +3,20 @@ const { CopyRspackPlugin } = require("@rspack/core");
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
 	entry: "./index.js",
+	output: {
+		library: {
+			type: "umd",
+		}
+	},
 	externals: {
 		lodash: {
 			root: "_",
 			commonjs: "./lodash.js",
+			commonjs2: "./lodash.js",
 			amd: "./lodash.js"
 		}
 	},
-	externalsType: "commonjs",
+	externalsType: "umd",
 	plugins: [
 		new CopyRspackPlugin({
 			patterns: ["./lodash.js"]

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -1850,7 +1850,12 @@ export type ExternalItemObjectUnknown = {
 };
 
 // @public
-export type ExternalItemValue = string | boolean | string[] | Record<string, string | string[]>;
+export type ExternalItemValue = string | boolean | string[] | {
+    root: string | string[];
+    commonjs: string | string[];
+    commonjs2: string | string[];
+    amd?: string | string[];
+};
 
 // @public
 export type Externals = ExternalItem | ExternalItem[];
@@ -5959,7 +5964,22 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
         } | undefined;
     }>>;
-    externals: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    externals: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
+        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
+    }, "strict", z.ZodTypeAny, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -5984,7 +6004,22 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
+        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
+    }, "strict", z.ZodTypeAny, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6009,7 +6044,37 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
+        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
+    }, "strict", z.ZodTypeAny, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>]>>>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
+        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
+    }, "strict", z.ZodTypeAny, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6034,7 +6099,22 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
+        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
+    }, "strict", z.ZodTypeAny, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6059,7 +6139,22 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>]>>>]>]>>;
+    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
+        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
+        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
+    }, "strict", z.ZodTypeAny, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }, {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>]>>>]>]>>;
     externalsType: z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>;
     externalsPresets: z.ZodOptional<z.ZodObject<{
         node: z.ZodOptional<z.ZodBoolean>;
@@ -8310,35 +8405,65 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     loader?: Record<string, any> | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
-    externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+    externals?: string | RegExp | Record<string, string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>) | (string | RegExp | Record<string, string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>))[] | undefined;
     externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
@@ -8915,35 +9040,65 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     loader?: Record<string, any> | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
-    externals?: string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+    externals?: string | RegExp | Record<string, string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>) | (string | RegExp | Record<string, string | boolean | string[] | Record<string, string | string[]>> | ((args_0: {
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>) | (string | RegExp | Record<string, string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | Record<string, string | string[]> | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | Record<string, string | string[]>>))[] | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
+        root: string | string[];
+        commonjs: string | string[];
+        commonjs2: string | string[];
+        amd?: string | string[] | undefined;
+    }>))[] | undefined;
     externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1312,7 +1312,15 @@ export type ExternalItemValue =
 	| string
 	| boolean
 	| string[]
-	| Record<string, string | string[]>;
+	| {
+			/**
+			 * only available when libraryTarget or externalsType is 'umd'
+			 */
+			root: string | string[];
+			commonjs: string | string[];
+			commonjs2: string | string[];
+			amd?: string | string[];
+	  };
 
 /**
  * If an dependency matches exactly a property of the object, the property value is used as dependency.

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1314,7 +1314,7 @@ export type ExternalItemValue =
 	| string[]
 	| {
 			/**
-			 * only available when libraryTarget or externalsType is 'umd'
+			 * only available when libraryTarget and externalsType is 'umd'
 			 */
 			root: string | string[];
 			commonjs: string | string[];

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -800,7 +800,12 @@ const externalItemValue = z
 	.or(z.boolean())
 	.or(z.string().array().min(1))
 	.or(
-		z.record(z.string().or(z.string().array()))
+		z.strictObject({
+			root: z.string().or(z.string().array()),
+			commonjs: z.string().or(z.string().array()),
+			commonjs2: z.string().or(z.string().array()),
+			amd: z.string().or(z.string().array()).optional()
+		})
 	) satisfies z.ZodType<t.ExternalItemValue>;
 
 const externalItemObjectUnknown = z.record(

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -112,7 +112,7 @@ module.exports = {
 ### object
 
 :::warning
-An object with `{ root, amd, commonjs, ... }` is only allowed for [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) and [`externalsType: 'umd'`](#externalstype). It's not allowed for other library targets.
+An object with `{ root, commonjs, commonjs2, amd?, ... }` is only allowed for [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) and [`externalsType: 'umd'`](#externalstype). It's not allowed for other library targets.
 :::
 
 ```js title="rspack.config.js"
@@ -123,20 +123,12 @@ module.exports = {
   },
 
   // or
-
   externals: {
     lodash: {
-      commonjs: 'lodash',
-      amd: 'lodash',
-      root: '_', // indicates global variable
-    },
-  },
-
-  // or
-
-  externals: {
-    subtract: {
-      root: ['math', 'subtract'],
+      root: '_', // required, indicates global variable
+      commonjs: 'lodash', // required
+      commonjs2: 'lodash', // required
+      amd: 'lodash', // optional
     },
   },
 };

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -112,7 +112,7 @@ module.exports = {
 ### 对象
 
 :::warning
-带有 `{ root, amd, commonjs, ... }` 的对象只允许用于 [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) 和 [`externalsType: 'umd'`](#externalstype)。其他库的 target 不允许这样做。
+带有 `{ root, commonjs, commonjs2, amd?, ... }` 的对象只允许用于 [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) 和 [`externalsType: 'umd'`](#externalstype)。其他库的 target 不允许这样做。
 :::
 
 ```js title="rspack.config.js"
@@ -126,17 +126,10 @@ module.exports = {
 
   externals: {
     lodash: {
-      commonjs: 'lodash',
-      amd: 'lodash',
-      root: '_', // 指向全局变量
-    },
-  },
-
-  // 或者
-
-  externals: {
-    subtract: {
-      root: ['math', 'subtract'],
+      root: '_', // 必须，指向全局变量
+      commonjs: 'lodash', // 必须
+      commonjs2: 'lodash', // 必须
+      amd: 'lodash', // 可选
     },
   },
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

relate to https://github.com/web-infra-dev/rspack/issues/8248

Cause the external object value can only be used when libraryTarget or externalTarget is `umd`, and if it will throw error when `commonjs` or `commonjs2` or `root` is not set. So we can use zod to validate the external object value. 

The `amd` field is optional because it can generate `define([])` when not set, but there is a bug here in rspack that generated `define([null])`. This pr also fix it.

Not close the issue because when libraryTarget is not `umd`, the external object value is also valid but will generate a wired code. For example, `libraryTarget: "var"` and `react: { root: "React", commonjs: "react"  }` will generate `var external_react_root_react_commonjs_react = undefined` which can not actually work. 

So we may need a better validation here to check `libraryTarget` and `externals`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
