### PR TITLE
fix: error for set user request

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -171,6 +171,7 @@ export class JsModule {
   get nameForCondition(): string | undefined
   get request(): string | undefined
   get userRequest(): string | undefined
+  set userRequest(val: string)
   get rawRequest(): string | undefined
   get factoryMeta(): JsFactoryMeta | undefined
   get type(): string

--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -209,12 +209,10 @@ impl JsModule {
   pub fn set_user_request(&mut self, val: String) -> napi::Result<()> {
     let module: &mut dyn Module = self.as_mut()?;
 
-    Ok(match module.try_as_normal_module_mut() {
-      Ok(normal_module) => {
-        *normal_module.user_request_mut() = val;
-      }
-      Err(_) => (),
-    })
+    if let Ok(normal_module) = module.try_as_normal_module_mut() {
+      *normal_module.user_request_mut() = val;
+    }
+    Ok(())
   }
 
   #[napi(getter)]

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -254,6 +254,10 @@ impl NormalModule {
     &self.user_request
   }
 
+  pub fn user_request_mut(&mut self) -> &mut String {
+    &mut self.user_request
+  }
+
   pub fn raw_request(&self) -> &str {
     &self.raw_request
   }

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3424,7 +3424,7 @@ export class Module {
     // (undocumented)
     readonly type: string;
     // (undocumented)
-    readonly userRequest?: string;
+    userRequest?: string;
 }
 
 // @public (undocumented)

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -222,7 +222,7 @@ export class Module {
 	declare readonly context?: string;
 	declare readonly resource?: string;
 	declare readonly request?: string;
-	declare readonly userRequest?: string;
+	declare userRequest?: string;
 	declare readonly rawRequest?: string;
 	declare readonly type: string;
 	declare readonly layer: null | string;
@@ -300,6 +300,16 @@ export class Module {
 				enumerable: true,
 				get(): string | undefined {
 					return module.userRequest;
+				},
+				set(val: string) {
+					// In monaco-editor-webpack-plugin, a new value is set for module.userRequest to avoid a bug in the NamedModulesPlugin.
+					// See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details
+					//
+					// However, the NamedModulesPlugin is outdated, and internally,
+					// Rspack doesn't depend on module.userRequest to generate the identifier of the module.
+					//
+					// So far, we don't really have the need to modify userRequest.
+					// For the moment, we allow the user to set userRequest, but no actual modification will be carried out.
 				}
 			},
 			rawRequest: {

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -290,14 +290,7 @@ export class Module {
 					return module.userRequest;
 				},
 				set(val: string) {
-					// In monaco-editor-webpack-plugin, a new value is set for module.userRequest to avoid a bug in the NamedModulesPlugin.
-					// See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details
-					//
-					// However, the NamedModulesPlugin is outdated, and internally,
-					// Rspack doesn't depend on module.userRequest to generate the identifier of the module.
-					//
-					// So far, we don't really have the need to modify userRequest.
-					// For the moment, we allow the user to set userRequest, but no actual modification will be carried out.
+					module.userRequest = val;
 				}
 			},
 			rawRequest: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In monaco-editor-webpack-plugin, a new value is set for module.userRequest to avoid a bug in the NamedModulesPlugin.
See https://github.com/webpack/webpack/issues/4613#issuecomment-325178346 for details

However, the NamedModulesPlugin is outdated, and internally,
Rspack doesn't depend on module.userRequest to generate the identifier of the module.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
