### PR TITLE
fix: use incremental in production build

### DIFF
--- a/packages/playground/cases/hooks/asset-emitted/rspack.config.js
+++ b/packages/playground/cases/hooks/asset-emitted/rspack.config.js
@@ -4,6 +4,7 @@ module.exports = {
 	entry: {
 		main: "./src/index.js"
 	},
+	mode: "development",
 	plugins: [
 		new rspack.HtmlRspackPlugin({
 			template: "./src/index.html"

--- a/packages/rspack-test-tools/tests/defaultsCases/mode/production.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/mode/production.js
@@ -8,6 +8,19 @@ module.exports = {
 		+ Received
 
 		@@ ... @@
+		-     "incremental": Object {
+		-       "buildChunkGraph": false,
+		-       "dependenciesDiagnostics": false,
+		-       "emitAssets": true,
+		-       "inferAsyncModules": false,
+		-       "make": true,
+		-       "modulesCodegen": false,
+		-       "modulesHashes": false,
+		-       "modulesRuntimeRequirements": false,
+		-       "providedExports": false,
+		-     },
+		+     "incremental": false,
+		@@ ... @@
 		-   "mode": "none",
 		+   "mode": "production",
 		@@ ... @@
@@ -51,11 +64,12 @@ module.exports = {
 		-     "usedExports": false,
 		+     "usedExports": true,
 		@@ ... @@
-		-   "performance": false,
+		+   },
 		+   "performance": Object {
 		+     "hints": "warning",
 		+     "maxAssetSize": 250000,
 		+     "maxEntrypointSize": 250000,
-		+   },
+		@@ ... @@
+		-   "performance": false,
 	`)
 };

--- a/packages/rspack-test-tools/tests/defaultsCases/mode/undefined.js
+++ b/packages/rspack-test-tools/tests/defaultsCases/mode/undefined.js
@@ -8,6 +8,19 @@ module.exports = {
 		+ Received
 
 		@@ ... @@
+		-     "incremental": Object {
+		-       "buildChunkGraph": false,
+		-       "dependenciesDiagnostics": false,
+		-       "emitAssets": true,
+		-       "inferAsyncModules": false,
+		-       "make": true,
+		-       "modulesCodegen": false,
+		-       "modulesHashes": false,
+		-       "modulesRuntimeRequirements": false,
+		-       "providedExports": false,
+		-     },
+		+     "incremental": false,
+		@@ ... @@
 		-   "mode": "none",
 		+   "mode": undefined,
 		@@ ... @@
@@ -51,11 +64,12 @@ module.exports = {
 		-     "usedExports": false,
 		+     "usedExports": true,
 		@@ ... @@
-		-   "performance": false,
+		+   },
 		+   "performance": Object {
 		+     "hints": "warning",
 		+     "maxAssetSize": 250000,
 		+     "maxEntrypointSize": 250000,
-		+   },
+		@@ ... @@
+		-   "performance": false,
 	`)
 };

--- a/packages/rspack/src/builtin-plugin/FlagDependencyUsagePlugin.ts
+++ b/packages/rspack/src/builtin-plugin/FlagDependencyUsagePlugin.ts
@@ -19,19 +19,19 @@ export class FlagDependencyUsagePlugin extends RspackBuiltinPlugin {
 		if (incremental.modulesHashes) {
 			incremental.modulesHashes = false;
 			logger.warn(
-				"`optimization.usedExports` can't be used with `incremental.modulesHashes` as export usage is a global effect. `incremental.modulesHashes` has been overrided to false."
+				"`optimization.usedExports` can't be used with `incremental.modulesHashes` as export usage is a global effect. `incremental.modulesHashes` has been overridden to false."
 			);
 		}
 		if (incremental.modulesCodegen) {
 			incremental.modulesCodegen = false;
 			logger.warn(
-				"`optimization.usedExports` can't be used with `incremental.modulesCodegen` as export usage is a global effect. `incremental.modulesCodegen` has been overrided to false."
+				"`optimization.usedExports` can't be used with `incremental.modulesCodegen` as export usage is a global effect. `incremental.modulesCodegen` has been overridden to false."
 			);
 		}
 		if (incremental.modulesRuntimeRequirements) {
 			incremental.modulesRuntimeRequirements = false;
 			logger.warn(
-				"`optimization.usedExports` can't be used with `incremental.modulesRuntimeRequirements` as export usage is a global effect. `incremental.modulesRuntimeRequirements` has been overrided to false."
+				"`optimization.usedExports` can't be used with `incremental.modulesRuntimeRequirements` as export usage is a global effect. `incremental.modulesRuntimeRequirements` has been overridden to false."
 			);
 		}
 		return createBuiltinPlugin(this.name, this.global);

--- a/packages/rspack/src/builtin-plugin/MangleExportsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/MangleExportsPlugin.ts
@@ -19,19 +19,19 @@ export class MangleExportsPlugin extends RspackBuiltinPlugin {
 		if (incremental.modulesHashes) {
 			incremental.modulesHashes = false;
 			logger.warn(
-				"`optimization.mangleExports` can't be used with `incremental.modulesHashes` as export mangling is a global effect. `incremental.modulesHashes` has been overrided to false."
+				"`optimization.mangleExports` can't be used with `incremental.modulesHashes` as export mangling is a global effect. `incremental.modulesHashes` has been overridden to false."
 			);
 		}
 		if (incremental.modulesCodegen) {
 			incremental.modulesCodegen = false;
 			logger.warn(
-				"`optimization.mangleExports` can't be used with `incremental.modulesCodegen` as export mangling is a global effect. `incremental.modulesCodegen` has been overrided to false."
+				"`optimization.mangleExports` can't be used with `incremental.modulesCodegen` as export mangling is a global effect. `incremental.modulesCodegen` has been overridden to false."
 			);
 		}
 		if (incremental.modulesRuntimeRequirements) {
 			incremental.modulesRuntimeRequirements = false;
 			logger.warn(
-				"`optimization.mangleExports` can't be used with `incremental.modulesRuntimeRequirements` as export mangling is a global effect. `incremental.modulesRuntimeRequirements` has been overrided to false."
+				"`optimization.mangleExports` can't be used with `incremental.modulesRuntimeRequirements` as export mangling is a global effect. `incremental.modulesRuntimeRequirements` has been overridden to false."
 			);
 		}
 		return createBuiltinPlugin(this.name, this.deterministic);

--- a/packages/rspack/src/builtin-plugin/MangleExportsPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/MangleExportsPlugin.ts
@@ -1,9 +1,39 @@
-import { BuiltinPluginName } from "@rspack/binding";
+import { type BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
+import type { Compiler } from "../Compiler";
+import type { Incremental } from "../config";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
-import { create } from "./base";
+export class MangleExportsPlugin extends RspackBuiltinPlugin {
+	name = BuiltinPluginName.MangleExportsPlugin;
+	affectedHooks = "compilation" as const;
 
-export const MangleExportsPlugin = create(
-	BuiltinPluginName.MangleExportsPlugin,
-	(deterministic: boolean) => deterministic,
-	"compilation"
-);
+	constructor(private deterministic: boolean) {
+		super();
+	}
+
+	raw(compiler: Compiler): BuiltinPlugin {
+		const incremental = compiler.options.experiments.incremental as Incremental;
+		const logger = compiler.getInfrastructureLogger(
+			"rspack.MangleExportsPlugin"
+		);
+		if (incremental.modulesHashes) {
+			incremental.modulesHashes = false;
+			logger.warn(
+				"`optimization.mangleExports` can't be used with `incremental.modulesHashes` as export mangling is a global effect. `incremental.modulesHashes` has been overrided to false."
+			);
+		}
+		if (incremental.modulesCodegen) {
+			incremental.modulesCodegen = false;
+			logger.warn(
+				"`optimization.mangleExports` can't be used with `incremental.modulesCodegen` as export mangling is a global effect. `incremental.modulesCodegen` has been overrided to false."
+			);
+		}
+		if (incremental.modulesRuntimeRequirements) {
+			incremental.modulesRuntimeRequirements = false;
+			logger.warn(
+				"`optimization.mangleExports` can't be used with `incremental.modulesRuntimeRequirements` as export mangling is a global effect. `incremental.modulesRuntimeRequirements` has been overrided to false."
+			);
+		}
+		return createBuiltinPlugin(this.name, this.deterministic);
+	}
+}

--- a/packages/rspack/src/builtin-plugin/ModuleConcatenationPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ModuleConcatenationPlugin.ts
@@ -1,9 +1,35 @@
-import { BuiltinPluginName } from "@rspack/binding";
+import { type BuiltinPlugin, BuiltinPluginName } from "@rspack/binding";
+import type { Compiler } from "../Compiler";
+import type { Incremental } from "../config";
+import { RspackBuiltinPlugin, createBuiltinPlugin } from "./base";
 
-import { create } from "./base";
+export class ModuleConcatenationPlugin extends RspackBuiltinPlugin {
+	name = BuiltinPluginName.ModuleConcatenationPlugin;
+	affectedHooks = "compilation" as const;
 
-export const ModuleConcatenationPlugin = create(
-	BuiltinPluginName.ModuleConcatenationPlugin,
-	() => {},
-	"compilation"
-);
+	raw(compiler: Compiler): BuiltinPlugin {
+		const incremental = compiler.options.experiments.incremental as Incremental;
+		const logger = compiler.getInfrastructureLogger(
+			"rspack.ModuleConcatenationPlugin"
+		);
+		if (incremental.modulesHashes) {
+			incremental.modulesHashes = false;
+			logger.warn(
+				"`optimization.concatenateModules` can't be used with `incremental.modulesHashes` as module concatenation is a global effect. `incremental.modulesHashes` has been overrided to false."
+			);
+		}
+		if (incremental.modulesCodegen) {
+			incremental.modulesCodegen = false;
+			logger.warn(
+				"`optimization.concatenateModules` can't be used with `incremental.modulesCodegen` as module concatenation is a global effect. `incremental.modulesCodegen` has been overrided to false."
+			);
+		}
+		if (incremental.modulesRuntimeRequirements) {
+			incremental.modulesRuntimeRequirements = false;
+			logger.warn(
+				"`optimization.concatenateModules` can't be used with `incremental.modulesRuntimeRequirements` as module concatenation is a global effect. `incremental.modulesRuntimeRequirements` has been overrided to false."
+			);
+		}
+		return createBuiltinPlugin(this.name, undefined);
+	}
+}

--- a/packages/rspack/src/builtin-plugin/ModuleConcatenationPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/ModuleConcatenationPlugin.ts
@@ -15,19 +15,19 @@ export class ModuleConcatenationPlugin extends RspackBuiltinPlugin {
 		if (incremental.modulesHashes) {
 			incremental.modulesHashes = false;
 			logger.warn(
-				"`optimization.concatenateModules` can't be used with `incremental.modulesHashes` as module concatenation is a global effect. `incremental.modulesHashes` has been overrided to false."
+				"`optimization.concatenateModules` can't be used with `incremental.modulesHashes` as module concatenation is a global effect. `incremental.modulesHashes` has been overridden to false."
 			);
 		}
 		if (incremental.modulesCodegen) {
 			incremental.modulesCodegen = false;
 			logger.warn(
-				"`optimization.concatenateModules` can't be used with `incremental.modulesCodegen` as module concatenation is a global effect. `incremental.modulesCodegen` has been overrided to false."
+				"`optimization.concatenateModules` can't be used with `incremental.modulesCodegen` as module concatenation is a global effect. `incremental.modulesCodegen` has been overridden to false."
 			);
 		}
 		if (incremental.modulesRuntimeRequirements) {
 			incremental.modulesRuntimeRequirements = false;
 			logger.warn(
-				"`optimization.concatenateModules` can't be used with `incremental.modulesRuntimeRequirements` as module concatenation is a global effect. `incremental.modulesRuntimeRequirements` has been overrided to false."
+				"`optimization.concatenateModules` can't be used with `incremental.modulesRuntimeRequirements` as module concatenation is a global effect. `incremental.modulesRuntimeRequirements` has been overridden to false."
 			);
 		}
 		return createBuiltinPlugin(this.name, undefined);

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -88,7 +88,7 @@ export const applyRspackOptionsDefaults = (
 	// but Rspack currently does not support this option
 	F(options, "cache", () => development);
 
-	applyExperimentsDefaults(options.experiments);
+	applyExperimentsDefaults(options.experiments, { development });
 
 	applySnapshotDefaults(options.snapshot, { production });
 
@@ -192,7 +192,10 @@ const applyInfrastructureLoggingDefaults = (
 	D(infrastructureLogging, "appendOnly", !tty);
 };
 
-const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
+const applyExperimentsDefaults = (
+	experiments: ExperimentsNormalized,
+	{ development }: { development: boolean }
+) => {
 	D(experiments, "futureDefaults", false);
 	// IGNORE(experiments.lazyCompilation): In webpack, lazyCompilation is undefined by default
 	D(experiments, "lazyCompilation", false);
@@ -202,17 +205,17 @@ const applyExperimentsDefaults = (experiments: ExperimentsNormalized) => {
 	D(experiments, "topLevelAwait", true);
 
 	// IGNORE(experiments.incremental): Rspack specific configuration for incremental
-	D(experiments, "incremental", {});
+	D(experiments, "incremental", development ? {} : false);
 	if (typeof experiments.incremental === "object") {
 		D(experiments.incremental, "make", true);
-		D(experiments.incremental, "emitAssets", true);
 		D(experiments.incremental, "inferAsyncModules", false);
 		D(experiments.incremental, "providedExports", false);
 		D(experiments.incremental, "dependenciesDiagnostics", false);
+		D(experiments.incremental, "buildChunkGraph", false);
 		D(experiments.incremental, "modulesHashes", false);
 		D(experiments.incremental, "modulesCodegen", false);
 		D(experiments.incremental, "modulesRuntimeRequirements", false);
-		D(experiments.incremental, "buildChunkGraph", false);
+		D(experiments.incremental, "emitAssets", true);
 	}
 	// IGNORE(experiments.rspackFuture): Rspack specific configuration
 	D(experiments, "rspackFuture", {});

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -88,7 +88,7 @@ export const applyRspackOptionsDefaults = (
 	// but Rspack currently does not support this option
 	F(options, "cache", () => development);
 
-	applyExperimentsDefaults(options.experiments, { development });
+	applyExperimentsDefaults(options.experiments, { production });
 
 	applySnapshotDefaults(options.snapshot, { production });
 
@@ -194,7 +194,7 @@ const applyInfrastructureLoggingDefaults = (
 
 const applyExperimentsDefaults = (
 	experiments: ExperimentsNormalized,
-	{ development }: { development: boolean }
+	{ production }: { production: boolean }
 ) => {
 	D(experiments, "futureDefaults", false);
 	// IGNORE(experiments.lazyCompilation): In webpack, lazyCompilation is undefined by default
@@ -205,7 +205,7 @@ const applyExperimentsDefaults = (
 	D(experiments, "topLevelAwait", true);
 
 	// IGNORE(experiments.incremental): Rspack specific configuration for incremental
-	D(experiments, "incremental", development ? {} : false);
+	D(experiments, "incremental", !production ? {} : false);
 	if (typeof experiments.incremental === "object") {
 		D(experiments.incremental, "make", true);
 		D(experiments.incremental, "inferAsyncModules", false);

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -1,5 +1,6 @@
 import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import WebpackLicense from '@components/WebpackLicense';
+import PropertyType from '@components/PropertyType';
 
 <WebpackLicense from="https://webpack.js.org/configuration/experiments/" />
 
@@ -229,8 +230,13 @@ module.exports = {
 
 <ApiMeta addedVersion="1.1.0-beta.0" />
 
-- **Type:** `undefined | boolean | Incremental`
-- **Default:** `undefined`
+<PropertyType
+  type="boolean | Incremental"
+  defaultValueList={[
+    { defaultValue: 'false', mode: 'production' },
+    { defaultValue: '{ make: true, emitAssets: true }', mode: 'development' },
+  ]}
+/>
 
 ```ts
 type Incremental = {
@@ -246,11 +252,21 @@ type Incremental = {
 };
 ```
 
-Whether to enable incremental rebuild to speed up the rebuild speed.
+Whether to enable incremental rebuild to speed up the rebuild speed. It is recommended to enable it only during development.
+
+```js
+const isDev = process.env.NODE_ENV;
+module.exports = {
+  mode: isDev ? 'development' : 'production',
+  experiments: {
+    incremental: isDev,
+  },
+};
+```
 
 `true` means enable incremental for all stages. `false` means disable incremental for all stages. Incremental can also be enabled only for specified partial stages:
 
-```ts
+```js
 module.exports = {
   experiments: {
     // enable incremental for all stages

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -1,5 +1,6 @@
 import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import WebpackLicense from '@components/WebpackLicense';
+import PropertyType from '@components/PropertyType';
 
 <WebpackLicense from="https://webpack.js.org/configuration/experiments/" />
 
@@ -227,8 +228,13 @@ module.exports = {
 
 <ApiMeta addedVersion="1.1.0-beta.0" />
 
-- **类型：** `undefined | boolean | Incremental`
-- **默认值：** `undefined`
+<PropertyType
+  type="boolean | Incremental"
+  defaultValueList={[
+    { defaultValue: 'false', mode: 'production' },
+    { defaultValue: '{ make: true, emitAssets: true }', mode: 'development' },
+  ]}
+/>
 
 ```ts
 type Incremental = {
@@ -244,11 +250,21 @@ type Incremental = {
 };
 ```
 
-是否增量地进行重构建，加快重构建的速度。
+是否增量地进行重构建，加快重构建或 HMR 的速度，建议仅在开发时启用：
+
+```js
+const isDev = process.env.NODE_ENV;
+module.exports = {
+  mode: isDev ? 'development' : 'production',
+  experiments: {
+    incremental: isDev,
+  },
+};
+```
 
 `true` 表示对全部阶段启用增量，`false` 表示对全部阶段关闭增量，也可以仅对指定的部分阶段开启增量：
 
-```ts
+```js
 module.exports = {
   experiments: {
     // 对全部阶段启用增量


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

fix https://github.com/web-infra-dev/rspack/issues/8106#issuecomment-2451220535

Before using `incremental: true` will panic in production build, caused by concatenateModules, this is expected but we should have better experience, so this PR will disable `incremental.moduleHashes/moduleCodegen/moduleRuntimeRequirements` when using with concatenateModules/usedExports/mangleExports, and log warnings.

And the docs is also updated to recommend user to only enable incremental in development mode.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
