### PR TITLE
feat: throw error for outdated compilation

### DIFF
--- a/crates/rspack_binding_values/src/chunk.rs
+++ b/crates/rspack_binding_values/src/chunk.rs
@@ -92,7 +92,7 @@ fn chunk(ukey: u32, compilation: &Compilation) -> &Chunk {
 
 #[napi(js_name = "__chunk_inner_is_only_initial")]
 pub fn is_only_initial(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> bool {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunk = chunk(js_chunk_ukey, compilation);
   chunk.is_only_initial(&compilation.chunk_group_by_ukey)
@@ -100,7 +100,7 @@ pub fn is_only_initial(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> bo
 
 #[napi(js_name = "__chunk_inner_can_be_initial")]
 pub fn can_be_initial(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> bool {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunk = chunk(js_chunk_ukey, compilation);
   chunk.can_be_initial(&compilation.chunk_group_by_ukey)
@@ -108,7 +108,7 @@ pub fn can_be_initial(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> boo
 
 #[napi(js_name = "__chunk_inner_has_runtime")]
 pub fn has_runtime(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> bool {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunk = chunk(js_chunk_ukey, compilation);
   chunk.has_runtime(&compilation.chunk_group_by_ukey)
@@ -116,7 +116,7 @@ pub fn has_runtime(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> bool {
 
 #[napi(js_name = "__chunk_inner_get_all_async_chunks")]
 pub fn get_all_async_chunks(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> Vec<JsChunk> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunk = chunk(js_chunk_ukey, compilation);
   chunk
@@ -128,7 +128,7 @@ pub fn get_all_async_chunks(js_chunk_ukey: u32, js_compilation: &JsCompilation) 
 
 #[napi(js_name = "__chunk_inner_get_all_initial_chunks")]
 pub fn get_all_initial_chunks(js_chunk_ukey: u32, js_compilation: &JsCompilation) -> Vec<JsChunk> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunk = chunk(js_chunk_ukey, compilation);
   chunk
@@ -143,7 +143,7 @@ pub fn get_all_referenced_chunks(
   js_chunk_ukey: u32,
   js_compilation: &JsCompilation,
 ) -> Vec<JsChunk> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunk = chunk(js_chunk_ukey, compilation);
   chunk

--- a/crates/rspack_binding_values/src/chunk_graph.rs
+++ b/crates/rspack_binding_values/src/chunk_graph.rs
@@ -12,7 +12,7 @@ pub fn get_chunk_modules(
   js_chunk_ukey: u32,
   js_compilation: &JsCompilation,
 ) -> Vec<JsModuleWrapper> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let module_graph = compilation.get_module_graph();
   let modules = compilation
@@ -33,7 +33,7 @@ pub fn get_chunk_entry_modules(
   js_chunk_ukey: u32,
   js_compilation: &JsCompilation,
 ) -> Vec<JsModuleWrapper> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let modules = compilation
     .chunk_graph
@@ -51,7 +51,7 @@ pub fn get_chunk_entry_dependent_chunks_iterable(
   js_chunk_ukey: u32,
   js_compilation: &JsCompilation,
 ) -> Vec<JsChunk> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let chunks = compilation
     .chunk_graph
@@ -76,7 +76,7 @@ pub fn get_chunk_modules_iterable_by_source_type(
   source_type: String,
   js_compilation: &JsCompilation,
 ) -> Result<Vec<JsModuleWrapper>> {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   Ok(
     compilation

--- a/crates/rspack_binding_values/src/chunk_group.rs
+++ b/crates/rspack_binding_values/src/chunk_group.rs
@@ -73,7 +73,7 @@ fn chunk_group(ukey: u32, compilation: &Compilation) -> &ChunkGroup {
 
 #[napi(js_name = "__chunk_group_inner_get_chunk_group")]
 pub fn get_chunk_group(ukey: u32, js_compilation: &JsCompilation) -> JsChunkGroup {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let cg = chunk_group(ukey, compilation);
   JsChunkGroup::from_chunk_group(cg, compilation)
@@ -81,7 +81,7 @@ pub fn get_chunk_group(ukey: u32, js_compilation: &JsCompilation) -> JsChunkGrou
 
 #[napi(js_name = "__entrypoint_inner_get_runtime_chunk")]
 pub fn get_runtime_chunk(ukey: u32, js_compilation: &JsCompilation) -> JsChunk {
-  let compilation = unsafe { js_compilation.0.as_ref() };
+  let compilation = unsafe { js_compilation.inner.as_ref() };
 
   let entrypoint = chunk_group(ukey, compilation);
   let chunk_ukey = entrypoint.get_runtime_chunk(&compilation.chunk_group_by_ukey);

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -15,6 +15,7 @@ use rspack_core::rspack_sources::BoxSource;
 use rspack_core::AssetInfo;
 use rspack_core::ChunkUkey;
 use rspack_core::Compilation;
+use rspack_core::CompilationAsset;
 use rspack_core::CompilationId;
 use rspack_core::ModuleIdentifier;
 use rspack_error::Diagnostic;
@@ -36,7 +37,36 @@ use crate::{
 use crate::{JsRspackDiagnostic, JsRspackError};
 
 #[napi]
-pub struct JsCompilation(pub(crate) NonNull<rspack_core::Compilation>);
+pub struct JsCompilation {
+  pub(crate) id: CompilationId,
+  pub(crate) inner: NonNull<Compilation>,
+}
+
+impl JsCompilation {
+  fn as_ref(&self) -> napi::Result<&'static Compilation> {
+    let compilation = unsafe { self.inner.as_ref() };
+    if compilation.id() == self.id {
+      return Ok(compilation);
+    }
+
+    Err(napi::Error::from_reason(format!(
+      "Unable to access compilation with id = {:?} now. The compilation have been removed on the Rust side.",
+      self.id
+    )))
+  }
+
+  fn as_mut(&mut self) -> napi::Result<&'static mut Compilation> {
+    let compilation = unsafe { self.inner.as_mut() };
+    if compilation.id() == self.id {
+      return Ok(compilation);
+    }
+
+    Err(napi::Error::from_reason(format!(
+      "Unable to access compilation with id = {:?} now. The compilation have been removed on the Rust side.",
+      self.id
+    )))
+  }
+}
 
 #[napi]
 impl JsCompilation {
@@ -49,7 +79,7 @@ impl JsCompilation {
     new_source_or_function: Either<JsCompatSource, JsFunction>,
     asset_info_update_or_function: Option<Either<JsAssetInfo, JsFunction>>,
   ) -> Result<()> {
-    let compilation = unsafe { self.0.as_mut() };
+    let compilation = self.as_mut()?;
 
     compilation
       .update_asset(&filename, |original_source, mut original_info| {
@@ -88,7 +118,7 @@ impl JsCompilation {
 
   #[napi(ts_return_type = "Readonly<JsAsset>[]")]
   pub fn get_assets(&self) -> Result<Vec<JsAsset>> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     let mut assets = Vec::<JsAsset>::with_capacity(compilation.assets().len());
 
@@ -104,7 +134,7 @@ impl JsCompilation {
 
   #[napi]
   pub fn get_asset(&self, name: String) -> Result<Option<JsAsset>> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     match compilation.assets().get(&name) {
       Some(asset) => Ok(Some(JsAsset {
@@ -117,7 +147,7 @@ impl JsCompilation {
 
   #[napi]
   pub fn get_asset_source(&self, name: String) -> Result<Option<JsCompatSource>> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     compilation
       .assets()
@@ -127,101 +157,113 @@ impl JsCompilation {
   }
 
   #[napi(getter, ts_return_type = "Array<JsModule>")]
-  pub fn modules(&self) -> Vec<JsModuleWrapper> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn modules(&self) -> Result<Vec<JsModuleWrapper>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .get_module_graph()
-      .modules()
-      .keys()
-      .filter_map(|module_id| {
-        compilation
-          .module_by_identifier(module_id)
-          .map(|module| JsModuleWrapper::new(module.as_ref(), Some(compilation)))
-      })
-      .collect::<Vec<_>>()
+    Ok(
+      compilation
+        .get_module_graph()
+        .modules()
+        .keys()
+        .filter_map(|module_id| {
+          compilation
+            .module_by_identifier(module_id)
+            .map(|module| JsModuleWrapper::new(module.as_ref(), Some(compilation)))
+        })
+        .collect::<Vec<_>>(),
+    )
   }
 
   #[napi(getter, ts_return_type = "Array<JsModule>")]
-  pub fn built_modules(&self) -> Vec<JsModuleWrapper> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn built_modules(&self) -> Result<Vec<JsModuleWrapper>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .built_modules
-      .iter()
-      .filter_map(|module_id| {
-        compilation
-          .module_by_identifier(module_id)
-          .map(|module| JsModuleWrapper::new(module.as_ref(), Some(compilation)))
-      })
-      .collect::<Vec<_>>()
+    Ok(
+      compilation
+        .built_modules
+        .iter()
+        .filter_map(|module_id| {
+          compilation
+            .module_by_identifier(module_id)
+            .map(|module| JsModuleWrapper::new(module.as_ref(), Some(compilation)))
+        })
+        .collect::<Vec<_>>(),
+    )
   }
 
   #[napi]
-  pub fn get_optimization_bailout(&self) -> Vec<JsStatsOptimizationBailout> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_optimization_bailout(&self) -> Result<Vec<JsStatsOptimizationBailout>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .get_module_graph()
-      .module_graph_modules()
-      .values()
-      .flat_map(|item| item.optimization_bailout.clone())
-      .map(|item| JsStatsOptimizationBailout { inner: item })
-      .collect::<Vec<_>>()
+    Ok(
+      compilation
+        .get_module_graph()
+        .module_graph_modules()
+        .values()
+        .flat_map(|item| item.optimization_bailout.clone())
+        .map(|item| JsStatsOptimizationBailout { inner: item })
+        .collect::<Vec<_>>(),
+    )
   }
 
   #[napi]
-  pub fn get_chunks(&self) -> Vec<JsChunk> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_chunks(&self) -> Result<Vec<JsChunk>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .chunk_by_ukey
-      .values()
-      .map(JsChunk::from)
-      .collect::<Vec<_>>()
+    Ok(
+      compilation
+        .chunk_by_ukey
+        .values()
+        .map(JsChunk::from)
+        .collect::<Vec<_>>(),
+    )
   }
 
   #[napi]
-  pub fn get_named_chunk_keys(&self) -> Vec<String> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_named_chunk_keys(&self) -> Result<Vec<String>> {
+    let compilation = self.as_ref()?;
 
-    compilation.named_chunks.keys().cloned().collect::<Vec<_>>()
+    Ok(compilation.named_chunks.keys().cloned().collect::<Vec<_>>())
   }
 
   #[napi]
-  pub fn get_named_chunk(&self, name: String) -> Option<JsChunk> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_named_chunk(&self, name: String) -> Result<Option<JsChunk>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .named_chunks
-      .get(&name)
-      .and_then(|c| get_chunk_from_ukey(c, &compilation.chunk_by_ukey).map(JsChunk::from))
+    Ok(
+      compilation
+        .named_chunks
+        .get(&name)
+        .and_then(|c| get_chunk_from_ukey(c, &compilation.chunk_by_ukey).map(JsChunk::from)),
+    )
   }
 
   #[napi]
-  pub fn get_named_chunk_group_keys(&self) -> Vec<String> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_named_chunk_group_keys(&self) -> Result<Vec<String>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .named_chunk_groups
-      .keys()
-      .cloned()
-      .collect::<Vec<_>>()
+    Ok(
+      compilation
+        .named_chunk_groups
+        .keys()
+        .cloned()
+        .collect::<Vec<_>>(),
+    )
   }
 
   #[napi]
-  pub fn get_named_chunk_group(&self, name: String) -> Option<JsChunkGroup> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_named_chunk_group(&self, name: String) -> Result<Option<JsChunkGroup>> {
+    let compilation = self.as_ref()?;
 
-    compilation.named_chunk_groups.get(&name).and_then(|c| {
+    Ok(compilation.named_chunk_groups.get(&name).and_then(|c| {
       get_chunk_group_from_ukey(c, &compilation.chunk_group_by_ukey)
         .map(|cg| JsChunkGroup::from_chunk_group(cg, compilation))
-    })
+    }))
   }
 
   #[napi]
-  pub fn set_asset_source(&mut self, name: String, source: JsCompatSource) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn set_asset_source(&mut self, name: String, source: JsCompatSource) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     let source: BoxSource = source.into();
     match compilation.assets_mut().entry(name) {
@@ -230,36 +272,40 @@ impl JsCompilation {
         e.insert(rspack_core::CompilationAsset::from(source));
       }
     };
+    Ok(())
   }
 
   #[napi]
-  pub fn delete_asset_source(&mut self, name: String) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn delete_asset_source(&mut self, name: String) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation
       .assets_mut()
       .entry(name)
       .and_modify(|a| a.set_source(None));
+    Ok(())
   }
 
   #[napi]
-  pub fn get_asset_filenames(&self) -> Vec<String> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_asset_filenames(&self) -> Result<Vec<String>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .assets()
-      .iter()
-      .filter(|(_, asset)| asset.get_source().is_some())
-      .map(|(filename, _)| filename)
-      .cloned()
-      .collect()
+    Ok(
+      compilation
+        .assets()
+        .iter()
+        .filter(|(_, asset)| asset.get_source().is_some())
+        .map(|(filename, _)| filename)
+        .cloned()
+        .collect(),
+    )
   }
 
   #[napi]
-  pub fn has_asset(&self, name: String) -> bool {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn has_asset(&self, name: String) -> Result<bool> {
+    let compilation = self.as_ref()?;
 
-    compilation.assets().contains_key(&name)
+    Ok(compilation.assets().contains_key(&name))
   }
 
   #[napi]
@@ -269,87 +315,105 @@ impl JsCompilation {
     source: JsCompatSource,
     asset_info: JsAssetInfo,
     module: String,
-  ) {
-    let compilation = unsafe { self.0.as_mut() };
+  ) -> Result<()> {
+    let compilation = self.as_mut()?;
 
-    self.emit_asset(filename.clone(), source, asset_info);
+    compilation.emit_asset(
+      filename.clone(),
+      CompilationAsset::new(Some(source.into()), asset_info.into()),
+    );
+
     compilation
       .module_assets
       .entry(ModuleIdentifier::from(module))
       .or_default()
       .insert(filename);
+    Ok(())
   }
 
   #[napi]
-  pub fn emit_asset(&mut self, filename: String, source: JsCompatSource, asset_info: JsAssetInfo) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn emit_asset(
+    &mut self,
+    filename: String,
+    source: JsCompatSource,
+    asset_info: JsAssetInfo,
+  ) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation.emit_asset(
       filename,
       rspack_core::CompilationAsset::new(Some(source.into()), asset_info.into()),
     );
+    Ok(())
   }
 
   #[napi]
-  pub fn delete_asset(&mut self, filename: String) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn delete_asset(&mut self, filename: String) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation.delete_asset(&filename);
+    Ok(())
   }
 
   #[napi]
-  pub fn rename_asset(&mut self, filename: String, new_name: String) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn rename_asset(&mut self, filename: String, new_name: String) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation.rename_asset(&filename, new_name);
+    Ok(())
   }
 
   #[napi(getter)]
-  pub fn entrypoints(&self) -> HashMap<String, JsChunkGroup> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn entrypoints(&self) -> Result<HashMap<String, JsChunkGroup>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .entrypoints()
-      .iter()
-      .map(|(n, _)| {
-        (
-          n.clone(),
-          JsChunkGroup::from_chunk_group(compilation.entrypoint_by_name(n), compilation),
-        )
-      })
-      .collect()
+    Ok(
+      compilation
+        .entrypoints()
+        .iter()
+        .map(|(n, _)| {
+          (
+            n.clone(),
+            JsChunkGroup::from_chunk_group(compilation.entrypoint_by_name(n), compilation),
+          )
+        })
+        .collect(),
+    )
   }
 
   #[napi(getter)]
-  pub fn chunk_groups(&self) -> Vec<JsChunkGroup> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn chunk_groups(&self) -> Result<Vec<JsChunkGroup>> {
+    let compilation = self.as_ref()?;
 
-    compilation
-      .chunk_group_by_ukey
-      .values()
-      .map(|cg| JsChunkGroup::from_chunk_group(cg, compilation))
-      .collect::<Vec<JsChunkGroup>>()
+    Ok(
+      compilation
+        .chunk_group_by_ukey
+        .values()
+        .map(|cg| JsChunkGroup::from_chunk_group(cg, compilation))
+        .collect::<Vec<JsChunkGroup>>(),
+    )
   }
 
   #[napi(getter)]
-  pub fn hash(&self) -> Option<String> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn hash(&self) -> Result<Option<String>> {
+    let compilation = self.as_ref()?;
 
-    compilation.get_hash().map(|hash| hash.to_owned())
+    Ok(compilation.get_hash().map(|hash| hash.to_owned()))
   }
 
   #[napi]
-  pub fn dependencies(&'static self) -> JsDependencies {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn dependencies(&'static self) -> Result<JsDependencies> {
+    let compilation = self.as_ref()?;
 
-    JsDependencies::new(compilation)
+    Ok(JsDependencies::new(compilation))
   }
 
   #[napi]
-  pub fn push_diagnostic(&mut self, diagnostic: JsRspackDiagnostic) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn push_diagnostic(&mut self, diagnostic: JsRspackDiagnostic) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation.push_diagnostic(diagnostic.into());
+    Ok(())
   }
 
   #[napi]
@@ -358,61 +422,71 @@ impl JsCompilation {
     start: u32,
     end: u32,
     replace_with: Vec<crate::JsRspackDiagnostic>,
-  ) {
-    let compilation = unsafe { self.0.as_mut() };
+  ) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     let diagnostics = replace_with.into_iter().map(Into::into).collect();
     compilation.splice_diagnostic(start as usize, end as usize, diagnostics);
+    Ok(())
   }
 
   #[napi(ts_args_type = r#"diagnostic: ExternalObject<'Diagnostic'>"#)]
-  pub fn push_native_diagnostic(&mut self, diagnostic: External<Diagnostic>) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn push_native_diagnostic(&mut self, diagnostic: External<Diagnostic>) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation.push_diagnostic(diagnostic.clone());
+    Ok(())
   }
 
   #[napi(ts_args_type = r#"diagnostics: ExternalObject<'Diagnostic[]'>"#)]
-  pub fn push_native_diagnostics(&mut self, mut diagnostics: External<Vec<Diagnostic>>) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn push_native_diagnostics(
+    &mut self,
+    mut diagnostics: External<Vec<Diagnostic>>,
+  ) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     while let Some(diagnostic) = diagnostics.pop() {
       compilation.push_diagnostic(diagnostic);
     }
+    Ok(())
   }
 
   #[napi]
-  pub fn get_errors(&self) -> Vec<JsRspackError> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_errors(&self) -> Result<Vec<JsRspackError>> {
+    let compilation = self.as_ref()?;
 
     let colored = compilation.options.stats.colors;
-    compilation
-      .get_errors_sorted()
-      .map(|d| {
-        JsRspackError::try_from_diagnostic(d, colored)
-          .expect("should convert diagnostic to `JsRspackError`")
-      })
-      .collect()
+    Ok(
+      compilation
+        .get_errors_sorted()
+        .map(|d| {
+          JsRspackError::try_from_diagnostic(d, colored)
+            .expect("should convert diagnostic to `JsRspackError`")
+        })
+        .collect(),
+    )
   }
 
   #[napi]
-  pub fn get_warnings(&self) -> Vec<JsRspackError> {
-    let compilation = unsafe { self.0.as_ref() };
+  pub fn get_warnings(&self) -> Result<Vec<JsRspackError>> {
+    let compilation = self.as_ref()?;
 
     let colored = compilation.options.stats.colors;
-    compilation
-      .get_warnings_sorted()
-      .map(|d| {
-        JsRspackError::try_from_diagnostic(d, colored)
-          .expect("should convert diagnostic to `JsRspackError`")
-      })
-      .collect()
+    Ok(
+      compilation
+        .get_warnings_sorted()
+        .map(|d| {
+          JsRspackError::try_from_diagnostic(d, colored)
+            .expect("should convert diagnostic to `JsRspackError`")
+        })
+        .collect(),
+    )
   }
 
   #[napi]
   pub fn get_stats(&self, reference: Reference<JsCompilation>, env: Env) -> Result<JsStats> {
     Ok(JsStats::new(reference.share_with(env, |compilation| {
-      let compilation = unsafe { compilation.0.as_ref() };
+      let compilation = compilation.as_ref()?;
 
       Ok(compilation.get_stats())
     })?))
@@ -424,7 +498,7 @@ impl JsCompilation {
     filename: LocalJsFilename,
     data: JsPathData,
   ) -> napi::Result<String> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     let chunk = data.chunk.as_ref().map(|c| c.to_chunk(compilation));
     compilation.get_asset_path(&filename.into(), data.to_path_data(chunk.as_ref()))
@@ -436,7 +510,7 @@ impl JsCompilation {
     filename: LocalJsFilename,
     data: JsPathData,
   ) -> napi::Result<PathWithInfo> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     let chunk = data.chunk.as_ref().map(|c| c.to_chunk(compilation));
     let path_and_asset_info =
@@ -446,7 +520,7 @@ impl JsCompilation {
 
   #[napi]
   pub fn get_path(&self, filename: LocalJsFilename, data: JsPathData) -> napi::Result<String> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     let chunk = data.chunk.as_ref().map(|c| c.to_chunk(compilation));
     compilation.get_path(&filename.into(), data.to_path_data(chunk.as_ref()))
@@ -458,7 +532,7 @@ impl JsCompilation {
     filename: LocalJsFilename,
     data: JsPathData,
   ) -> napi::Result<PathWithInfo> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     let chunk = data.chunk.as_ref().map(|c| c.to_chunk(compilation));
     let path_and_asset_info =
@@ -467,39 +541,43 @@ impl JsCompilation {
   }
 
   #[napi]
-  pub fn add_file_dependencies(&mut self, deps: Vec<String>) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn add_file_dependencies(&mut self, deps: Vec<String>) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation
       .file_dependencies
-      .extend(deps.into_iter().map(Into::into))
+      .extend(deps.into_iter().map(Into::into));
+    Ok(())
   }
 
   #[napi]
-  pub fn add_context_dependencies(&mut self, deps: Vec<String>) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn add_context_dependencies(&mut self, deps: Vec<String>) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation
       .context_dependencies
-      .extend(deps.into_iter().map(Into::into))
+      .extend(deps.into_iter().map(Into::into));
+    Ok(())
   }
 
   #[napi]
-  pub fn add_missing_dependencies(&mut self, deps: Vec<String>) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn add_missing_dependencies(&mut self, deps: Vec<String>) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation
       .missing_dependencies
-      .extend(deps.into_iter().map(Into::into))
+      .extend(deps.into_iter().map(Into::into));
+    Ok(())
   }
 
   #[napi]
-  pub fn add_build_dependencies(&mut self, deps: Vec<String>) {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn add_build_dependencies(&mut self, deps: Vec<String>) -> Result<()> {
+    let compilation = self.as_mut()?;
 
     compilation
       .build_dependencies
-      .extend(deps.into_iter().map(Into::into))
+      .extend(deps.into_iter().map(Into::into));
+    Ok(())
   }
 
   #[napi]
@@ -509,7 +587,7 @@ impl JsCompilation {
     module_identifiers: Vec<String>,
     f: JsFunction,
   ) -> Result<()> {
-    let compilation = unsafe { self.0.as_mut() };
+    let compilation = self.as_mut()?;
 
     callbackify(env, f, async {
       let mut modules = compilation
@@ -546,7 +624,7 @@ impl JsCompilation {
     original_module_context: Option<String>,
     callback: JsFunction,
   ) -> Result<()> {
-    let compilation = unsafe { self.0.as_ref() };
+    let compilation = self.as_ref()?;
 
     callbackify(env, callback, async {
       let module_executor = compilation
@@ -598,10 +676,10 @@ impl JsCompilation {
   }
 
   #[napi(getter)]
-  pub fn entries(&mut self) -> JsEntries {
-    let compilation = unsafe { self.0.as_mut() };
+  pub fn entries(&mut self) -> Result<JsEntries> {
+    let compilation = self.as_mut()?;
 
-    JsEntries::new(compilation)
+    Ok(JsEntries::new(compilation))
   }
 
   #[napi]
@@ -610,7 +688,7 @@ impl JsCompilation {
     chunk_ukey: u32,
     runtime_module: JsAddingRuntimeModule,
   ) -> napi::Result<()> {
-    let compilation = unsafe { self.0.as_mut() };
+    let compilation = self.as_mut()?;
 
     compilation
       .add_runtime_module(
@@ -629,14 +707,20 @@ thread_local! {
 // JsCompilationWrapper maintains a cache to ensure that the corresponding instance of the same Compilation is unique on the JS side.
 //
 // This means that when transferring a JsCompilation from Rust to JS, you must use JsCompilationWrapper instead.
-pub struct JsCompilationWrapper(NonNull<rspack_core::Compilation>);
+pub struct JsCompilationWrapper {
+  id: CompilationId,
+  inner: NonNull<Compilation>,
+}
 
 unsafe impl Send for JsCompilationWrapper {}
 
 impl JsCompilationWrapper {
   pub fn new(compilation: &Compilation) -> Self {
     #[allow(clippy::unwrap_used)]
-    Self(NonNull::new(compilation as *const Compilation as *mut Compilation).unwrap())
+    Self {
+      id: compilation.id(),
+      inner: NonNull::new(compilation as *const Compilation as *mut Compilation).unwrap(),
+    }
   }
 
   pub fn cleanup_last_compilation(compilation_id: CompilationId) {
@@ -652,17 +736,19 @@ impl ToNapiValue for JsCompilationWrapper {
   unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> Result<sys::napi_value> {
     COMPILATION_INSTANCE_REFS.with(|ref_cell| {
       let mut refs = ref_cell.borrow_mut();
-      let compilation = unsafe { val.0.as_ref() };
 
-      let compilation_id = compilation.id();
-      match refs.entry(compilation_id) {
+      match refs.entry(val.id) {
         std::collections::hash_map::Entry::Occupied(entry) => {
           let r = entry.get();
           ToNapiValue::to_napi_value(env, r)
         }
         std::collections::hash_map::Entry::Vacant(entry) => {
           let env_wrapper = Env::from_raw(env);
-          let instance = JsCompilation(val.0).into_instance(env_wrapper)?;
+          let instance = JsCompilation {
+            id: val.id,
+            inner: val.inner,
+          }
+          .into_instance(env_wrapper)?;
           let r = OneShotRef::new(env, instance)?;
           let r = entry.insert(r);
           ToNapiValue::to_napi_value(env, r)

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -512,7 +512,7 @@ impl JsCompilation {
     let compilation = unsafe { self.0.as_mut() };
 
     callbackify(env, f, async {
-      let modules = compilation
+      let mut modules = compilation
         .rebuild_module(
           IdentifierSet::from_iter(module_identifiers.into_iter().map(ModuleIdentifier::from)),
           |modules| {
@@ -524,6 +524,11 @@ impl JsCompilation {
         )
         .await
         .map_err(|e| Error::new(napi::Status::GenericFailure, format!("{e}")))?;
+
+      modules
+        .iter_mut()
+        .for_each(|module| module.attach(compilation));
+
       Ok(modules)
     })
   }

--- a/crates/rspack_binding_values/src/compilation/mod.rs
+++ b/crates/rspack_binding_values/src/compilation/mod.rs
@@ -50,8 +50,9 @@ impl JsCompilation {
     }
 
     Err(napi::Error::from_reason(format!(
-      "Unable to access compilation with id = {:?} now. The compilation have been removed on the Rust side.",
-      self.id
+      "Unable to access compilation with id = {:?} now. The compilation have been removed on the Rust side. The latest compilation id is {:?}",
+      self.id,
+      compilation.id()
     )))
   }
 
@@ -62,8 +63,9 @@ impl JsCompilation {
     }
 
     Err(napi::Error::from_reason(format!(
-      "Unable to access compilation with id = {:?} now. The compilation have been removed on the Rust side.",
-      self.id
+      "Unable to access compilation with id = {:?} now. The compilation have been removed on the Rust side. The latest compilation id is {:?}",
+      self.id,
+      compilation.id()
     )))
   }
 }

--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -386,9 +386,6 @@ impl ToNapiValue for JsModuleWrapper {
             let mut instance = unassociated_ref.from_napi_value()?;
             instance.as_mut().attach(compilation_ptr.as_ptr());
 
-            if !std::ptr::addr_eq(instance.module.as_ptr(), val.module.as_ptr()) {
-              instance.module = RefCell::new(val.module);
-            }
             let napi_value = ToNapiValue::to_napi_value(env, &unassociated_ref);
             refs.insert(module.identifier(), unassociated_ref);
             napi_value
@@ -396,11 +393,6 @@ impl ToNapiValue for JsModuleWrapper {
             match refs.entry(module.identifier()) {
               std::collections::hash_map::Entry::Occupied(entry) => {
                 let r = entry.get();
-
-                let mut instance: ClassInstance<JsModule> = r.from_napi_value()?;
-                if !std::ptr::addr_eq(instance.module.as_ptr(), val.module.as_ptr()) {
-                  instance.module = RefCell::new(val.module);
-                }
                 ToNapiValue::to_napi_value(env, r)
               }
               std::collections::hash_map::Entry::Vacant(entry) => {
@@ -411,11 +403,6 @@ impl ToNapiValue for JsModuleWrapper {
                 }
                 .into_instance(Env::from_raw(env))?;
                 let r = entry.insert(OneShotRef::new(env, instance)?);
-
-                let mut instance: ClassInstance<JsModule> = r.from_napi_value()?;
-                if !std::ptr::addr_eq(instance.module.as_ptr(), val.module.as_ptr()) {
-                  instance.module = RefCell::new(val.module);
-                }
                 ToNapiValue::to_napi_value(env, r)
               }
             }
@@ -442,11 +429,6 @@ impl ToNapiValue for JsModuleWrapper {
             }
             .into_instance(Env::from_raw(env))?;
             let r = entry.insert(OneShotRef::new(env, instance)?);
-
-            let mut instance: ClassInstance<JsModule> = r.from_napi_value()?;
-            if !std::ptr::addr_eq(instance.module.as_ptr(), val.module.as_ptr()) {
-              instance.module = RefCell::new(val.module)
-            }
             ToNapiValue::to_napi_value(env, r)
           }
         }

--- a/crates/rspack_binding_values/src/module.rs
+++ b/crates/rspack_binding_values/src/module.rs
@@ -360,6 +360,15 @@ impl JsModuleWrapper {
       refs_by_compilation_id.remove(&compilation_id)
     });
   }
+
+  pub fn attach(&mut self, compilation: *const Compilation) {
+    if self.compilation.is_none() {
+      self.compilation = Some(
+        #[allow(clippy::unwrap_used)]
+        NonNull::new(compilation as *mut Compilation).unwrap(),
+      );
+    }
+  }
 }
 
 impl ToNapiValue for JsModuleWrapper {

--- a/packages/rspack-test-tools/tests/compilerCases/access-outdated-compilation.js
+++ b/packages/rspack-test-tools/tests/compilerCases/access-outdated-compilation.js
@@ -1,0 +1,36 @@
+let lastCompilation;
+
+class MyPlugin {
+    apply(compiler) {
+        compiler.hooks.compilation.tap("Plugin", compilation => {
+            if (lastCompilation) {
+                return;
+            }
+            lastCompilation = compilation;
+        });
+    }
+}
+
+/** @type {import('../..').TCompilerCaseConfig} */
+module.exports = {
+    description: "throw error when access outdated compilation",
+    options(context) {
+        return {
+            context: context.getSource(),
+            entry: "./d",
+            plugins: [new MyPlugin()]
+        };
+    },
+    async build(_, compiler) {
+        await new Promise(resolve => {
+            compiler.run(() => {
+                compiler.run(() => {
+                    resolve();
+                });
+            });
+        });
+    },
+    async check() {
+        expect(() => lastCompilation.modules).toThrow(/Unable to access compilation/);
+    }
+};

--- a/packages/rspack-test-tools/tests/hotCases/stats/chunks/rspack.config.js
+++ b/packages/rspack-test-tools/tests/hotCases/stats/chunks/rspack.config.js
@@ -2,18 +2,16 @@
 module.exports = {
     plugins: [
         compiler => {
-            compiler.hooks.compilation.tap("PLUGIN", compilation => {
-                compiler.hooks.afterCompile.tap("PLUGIN", () => {
-                    const stats = compilation.getStats();
-                    const { chunks } = stats.toJson({
-                        all: false,
-                        chunks: true
-                    });
-                    // Ensure that HotUpdateChunk is not added to chunks
-                    expect(chunks.length).toBe(1);
-                    expect(chunks[0].runtime[0]).toBe('main');
-                    expect(chunks[0].files[0]).toBe('bundle.js');
-                })
+            compiler.hooks.afterCompile.tap("PLUGIN", compilation => {
+                const stats = compilation.getStats();
+                const { chunks } = stats.toJson({
+                    all: false,
+                    chunks: true
+                });
+                // Ensure that HotUpdateChunk is not added to chunks
+                expect(chunks.length).toBe(1);
+                expect(chunks[0].runtime[0]).toBe('main');
+                expect(chunks[0].files[0]).toBe('bundle.js');
             })
         }
     ]

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -81,6 +81,8 @@ export interface AssetEmittedInfo {
 	compilation: Compilation;
 }
 
+const COMPILATION_WEAK_MAP = new WeakMap<binding.JsCompilation, Compilation>();
+
 class Compiler {
 	#instance?: binding.Rspack;
 	#initial: boolean;
@@ -706,8 +708,14 @@ class Compiler {
 	}
 
 	#createCompilation(native: binding.JsCompilation): Compilation {
-		const compilation = new Compilation(this, native);
-		compilation.name = this.name;
+		let compilation = COMPILATION_WEAK_MAP.get(native);
+
+		if (!compilation) {
+			compilation = new Compilation(this, native);
+			compilation.name = this.name;
+			COMPILATION_WEAK_MAP.set(native, compilation);
+		}
+
 		this.#compilation = compilation;
 		return compilation;
 	}
@@ -762,9 +770,7 @@ class Compiler {
 				binding.RegisterJsTapKind.CompilerThisCompilation,
 				() => this.hooks.thisCompilation,
 				queried => (native: binding.JsCompilation) => {
-					if (this.#compilation === undefined) {
-						this.#createCompilation(native);
-					}
+					this.#createCompilation(native);
 					queried.call(this.#compilation!, this.#compilationParams!);
 				}
 			),

--- a/tests/plugin-test/css-extract/TestMemoryFS.test.js
+++ b/tests/plugin-test/css-extract/TestMemoryFS.test.js
@@ -32,6 +32,10 @@ describe("TestMemoryFS", () => {
 				return;
 			}
 
+			// CHANGE: The compilation instance of Rspack will be dropped on the Rust side after compilation.
+			// So we should obtain all the assets information after the next time the compile. 
+			const names1 = assetsNames(stats1.compilation.getAssets());
+
 			compiler.run((err2, stats2) => {
 				if (err2) {
 					done(err2);
@@ -39,9 +43,8 @@ describe("TestMemoryFS", () => {
 					return;
 				}
 
-				expect(assetsNames(stats1.compilation.getAssets())).toEqual(
-					assetsNames(stats2.compilation.getAssets())
-				);
+				const names2 = assetsNames(stats2.compilation.getAssets());
+				expect(names1).toEqual(names2);
 
 				done();
 			});


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

The Rspack compilation instance will be dropped on the Rust side after the compilation stage.

Before this PR, since the memory address of the compilation instance on the Rust side didn't change across multiple compilation cycles, when properties and methods on an outdated compilation instance on the JavaScript side were called, the data from the current Rust instance was retrieved, which was not as expected.

Now, Rspack will throw an error when an outdated JavaScript side compilation instance is accessed.

The compilation instance of Rspack will be dropped on the Rust side after compilation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
