### PR TITLE
chore(renovate): manually update peer dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,11 @@
 	],
 	assignees: ["@SoonIter"],
 	packageRules: [
+		// manually update peer dependencies
+		{
+			depTypeList: ["peerDependencies"],
+			enabled: false
+		},
 		{
 			matchPackagePatterns: ["*"],
 			semanticCommitType: "chore",


### PR DESCRIPTION
## Summary

Typically, we do not want to let renovate to bump peer dependencies. Peer dependencies should be bumped manually with care.

Such as https://github.com/web-infra-dev/rspack/pull/8314

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
