### PR TITLE
fix: correct usage of `pnpm --filter` in package scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "test:ci": "cross-env NODE_OPTIONS=--max_old_space_size=8192 pnpm run build:js && pnpm run test:unit && npm run test:plugin && pnpm test:webpack",
     "test:plugin": "pnpm --filter \"plugin-test\" test",
     "test:webpack": "pnpm --filter \"webpack-test\" test:metric",
-    "doc-coverage": "pnpm --filter '@rspack/core' doc-coverage",
-    "api-extractor:local": "pnpm --filter '@rspack/*' api-extractor --local",
-    "api-extractor:ci": "pnpm --filter '@rspack/*' api-extractor:ci"
+    "doc-coverage": "pnpm --filter \"@rspack/core\" doc-coverage",
+    "api-extractor:local": "pnpm --filter \"@rspack/*\" api-extractor --local",
+    "api-extractor:ci": "pnpm --filter \"'@rspack/*\" api-extractor:ci"
   },
   "homepage": "https://rspack.dev",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/x.mjs
+++ b/x.mjs
@@ -173,7 +173,7 @@ extractorCommand
 	.description("update api extractor snapshots")
 	.action(async () => {
 		await $`pnpm -w build:js`;
-		await $`pnpm --filter '@rspack/*' api-extractor --local`;
+		await $`pnpm --filter "@rspack/*" api-extractor --local`;
 	});
 
 extractorCommand
@@ -181,7 +181,7 @@ extractorCommand
 	.description("test api extractor snapshots")
 	.action(async () => {
 		try {
-			await $`pnpm --filter '@rspack/*' api-extractor:ci`;
+			await $`pnpm --filter "@rspack/*" api-extractor:ci`;
 		} catch (e) {
 			console.error(
 				`Api-extractor testing failed. Did you forget to update the snapshots locally?


### PR DESCRIPTION
## Summary

Using single quotes in `pnpm --filter '@rspack/*'` results in `"No projects matched the filters"`. Instead, we should use double quotes for proper functionality. (This issue may only occur on `Windows`, I don't have a `Mac` to verify)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
