### PR TITLE
fix(ci): correct build runner name

### DIFF
--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -37,7 +37,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-latest
+            runner: "ubuntu-latest"
           - target: x86_64-unknown-linux-musl
             runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
           - target: aarch64-unknown-linux-musl


### PR DESCRIPTION
## Summary

Related to #8253 

```bash
Error when evaluating 'runs-on' for job 'build'.
```

https://github.com/web-infra-dev/rspack/blob/a9873327db8d37e1facc5fb3d54fc62cb2f23495/.github/workflows/reusable-build.yml#L58-L60

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
