### PR TITLE
perf(cli): enable Node.js compile cache

### DIFF
--- a/packages/rspack-cli/bin/rspack.js
+++ b/packages/rspack-cli/bin/rspack.js
@@ -4,7 +4,7 @@ const nodeModule = require("node:module");
 // enable on-disk code caching of all modules loaded by Node.js
 // requires Nodejs >= 22.8.0
 const { enableCompileCache } = nodeModule;
-if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+if (enableCompileCache) {
 	try {
 		enableCompileCache();
 	} catch {

--- a/packages/rspack-cli/bin/rspack.js
+++ b/packages/rspack-cli/bin/rspack.js
@@ -1,4 +1,17 @@
 #!/usr/bin/env node
+const nodeModule = require("node:module");
+
+// enable on-disk code caching of all modules loaded by Node.js
+// requires Nodejs >= 22.8.0
+const { enableCompileCache } = nodeModule;
+if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+	try {
+		enableCompileCache();
+	} catch {
+		// ignore errors
+	}
+}
+
 const { RspackCLI } = require("../dist/index");
 
 async function runCLI() {


### PR DESCRIPTION
## Summary

Enable Node.js 22 new compile cache in Rspack CLI, this makes Node.js startup faster.

- before:

<img width="876" alt="Screenshot 2024-11-04 at 15 22 05" src="https://github.com/user-attachments/assets/9bc751c5-1f1c-48dc-8731-9fd982ac89ba">

- after:

<img width="868" alt="Screenshot 2024-11-04 at 15 21 58" src="https://github.com/user-attachments/assets/ac6c083a-8755-43c9-8fe4-f69e176a2805">

## Related Links

- https://nodejs.org/id/blog/release/v22.8.0
- https://github.com/nodejs/node/pull/54501
- https://github.com/web-infra-dev/rsbuild/pull/3627

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
