### PR TITLE
fix: module-executor should handle cycle deps

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -60,7 +60,6 @@ impl Task<MakeTaskContext> for FactorizeTask {
     let side_effects_only_info = ExportInfoData::new(Some("*side effects only*".into()), None);
     let exports_info = ExportsInfoData::new(other_exports_info.id(), side_effects_only_info.id());
     let factorize_result_task = FactorizeResultTask {
-      //      dependency: dep_id,
       original_module_identifier: self.original_module_identifier,
       factory_result: None,
       dependencies: vec![],

--- a/crates/rspack_core/src/compiler/module_executor/mod.rs
+++ b/crates/rspack_core/src/compiler/module_executor/mod.rs
@@ -97,7 +97,7 @@ impl ModuleExecutor {
     let sender = std::mem::take(&mut self.event_sender);
     sender
       .expect("should have sender")
-      .send(Event::Stop())
+      .send(Event::Stop)
       .expect("should success");
 
     let stop_receiver = std::mem::take(&mut self.stop_receiver);

--- a/crates/rspack_core/src/compiler/module_executor/overwrite.rs
+++ b/crates/rspack_core/src/compiler/module_executor/overwrite.rs
@@ -3,12 +3,15 @@ use tokio::sync::mpsc::UnboundedSender;
 use super::ctrl::Event;
 use crate::{
   compiler::make::repair::{
-    add::AddTask, factorize::FactorizeResultTask, process_dependencies::ProcessDependenciesTask,
-    MakeTaskContext,
+    add::AddTask, process_dependencies::ProcessDependenciesTask, MakeTaskContext,
   },
   utils::task_loop::{Task, TaskResult, TaskType},
 };
 
+/**
+Use this task to check module state during make,
+it is a proxy task
+*/
 #[derive(Debug)]
 pub struct OverwriteTask {
   pub origin_task: Box<dyn Task<MakeTaskContext>>,
@@ -33,45 +36,43 @@ impl Task<MakeTaskContext> for OverwriteTask {
     {
       let original_module_identifier = process_dependencies_task.original_module_identifier;
       let res = origin_task.sync_run(context).await?;
-      event_sender
-        .send(Event::FinishModule(original_module_identifier, res.len()))
-        .expect("should success");
-      return Ok(res);
-    }
-
-    // factorize result task
-    if let Some(factorize_result_task) = origin_task.as_any().downcast_ref::<FactorizeResultTask>()
-    {
-      let dep_id = *factorize_result_task.dependencies[0].id();
-      let original_module_identifier = factorize_result_task.original_module_identifier;
-      let res = origin_task.sync_run(context).await?;
       if res.is_empty() {
         event_sender
-          .send(Event::FinishDeps(original_module_identifier, dep_id, None))
+          .send(Event::FinishModule(original_module_identifier))
+          .expect("should success");
+      } else {
+        event_sender
+          .send(Event::ProcessDeps(original_module_identifier, res.len()))
           .expect("should success");
       }
+
       return Ok(res);
     }
+
     // add task
     if let Some(add_task) = origin_task.as_any().downcast_ref::<AddTask>() {
-      let dep_id = *add_task.dependencies[0].id();
+      let is_self_module = add_task.module.as_self_module().is_some();
       let original_module_identifier = add_task.original_module_identifier;
       let target_module_identifier = add_task.module.identifier();
+      let dep_id = *add_task.dependencies[0].id();
 
       let res = origin_task.sync_run(context).await?;
-      if res.is_empty() {
+
+      if !res.is_empty() || is_self_module {
         event_sender
-          .send(Event::FinishDeps(
+          .send(Event::Add(
             original_module_identifier,
+            target_module_identifier,
             dep_id,
-            Some(target_module_identifier),
+            is_self_module,
           ))
           .expect("should success");
       } else {
         event_sender
-          .send(Event::StartBuild(target_module_identifier))
+          .send(Event::FinishModule(target_module_identifier))
           .expect("should success");
       }
+
       return Ok(res);
     }
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

module executor hangs when encountering cycle dependencies.

use AddTask, ProcessDependenciesTask to determine whether modules are finished built.

We record children -> parent relations in a map. And we define that if module has no dependencies after processDeps, it is finished, if module's all children are finished then it finished. When imported module is finished, we are ready to execute.

For cycle deps: a -> b -> a;

```
Add: None -> a
ProcessDeps: a
Add: a -> b
ProcessDeps: b
Add b -> a (a exists, so b is finished)

b is finished, notify b's importer a

a has only 1 outgoings, now one of its outgoings is finished, a is finished

iterate all imported modules, see if it's finished.
```
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
