### PR TITLE
refactor: css-module should have strict buildInfo

### DIFF
--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -174,6 +174,7 @@ impl Module for CssModule {
       build_info: BuildInfo {
         hash: Some(self.compute_hash(&build_context.compiler_options)),
         cacheable: self.cacheable,
+        strict: true,
         file_dependencies: self.file_dependencies.clone(),
         context_dependencies: self.context_dependencies.clone(),
         missing_dependencies: self.missing_dependencies.clone(),

--- a/crates/rspack_plugin_extract_css/src/parser_plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/parser_plugin.rs
@@ -66,6 +66,7 @@ impl JavascriptParserPlugin for PluginCssExtractParserPlugin {
           )
           .collect::<Vec<_>>();
         self.cache.insert(data_str.clone(), deps.clone());
+        parser.build_info.strict = true;
         deps
       } else {
         vec![]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

cssExtract turns css module into normal javascript module, this module should have strict buildInfo like native css module and other asset module

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
