### PR TITLE
fix: allow passing Infinity to parser.asset.dataUrlCondition.maxSize

### DIFF
--- a/crates/rspack_binding_options/src/options/raw_module/mod.rs
+++ b/crates/rspack_binding_options/src/options/raw_module/mod.rs
@@ -372,7 +372,7 @@ impl From<RawAssetParserDataUrl> for AssetParserDataUrl {
 #[derive(Debug, Clone, Default)]
 #[napi(object)]
 pub struct RawAssetParserDataUrlOptions {
-  pub max_size: Option<u32>,
+  pub max_size: Option<f64>,
 }
 
 impl From<RawAssetParserDataUrlOptions> for AssetParserDataUrlOptions {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -255,7 +255,7 @@ pub enum AssetParserDataUrl {
 
 #[derive(Debug, Clone, MergeFrom)]
 pub struct AssetParserDataUrlOptions {
-  pub max_size: Option<u32>,
+  pub max_size: Option<f64>,
 }
 
 #[derive(Debug, Clone, MergeFrom)]

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -258,7 +258,7 @@ impl AssetParserAndGenerator {
 }
 
 // Webpack's default parser.dataUrlCondition.maxSize
-const DEFAULT_MAX_SIZE: u32 = 8096;
+const DEFAULT_MAX_SIZE: f64 = 8096.0;
 
 impl ParserAndGenerator for AssetParserAndGenerator {
   fn source_types(&self) -> &[SourceType] {

--- a/crates/rspack_util/src/merge.rs
+++ b/crates/rspack_util/src/merge.rs
@@ -41,6 +41,7 @@ impl MergeFrom for Vec<String> {
 
 impl_merge_from!(i8, i16, i32, i64, i128);
 impl_merge_from!(u8, u16, u32, u64, u128);
+impl_merge_from!(f64);
 impl_merge_from!(bool);
 impl_merge_from!(String);
 impl_merge_from!(Atom);

--- a/tests/webpack-test/configCases/asset-modules/data-url/index.js
+++ b/tests/webpack-test/configCases/asset-modules/data-url/index.js
@@ -24,8 +24,9 @@ it("should generate various data-url types", () => {
 	expect(urlSvg2.href).toContain(
 		"data:image/svg+xml;p=1;q=2,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke=\"%23343a40\" stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e"
 	);
-	expect(helloWorld.href).toContain("data:text/plain,Hello%2C%20World%21");
-	expect(helloWorldBase64.href).toContain(
-		"data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="
-	);
+	// TODO: fixme
+	// expect(helloWorld.href).toContain("data:text/plain,Hello%2C%20World%21");
+	// expect(helloWorldBase64.href).toContain(
+	// 	"data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="
+	// );
 });

--- a/tests/webpack-test/configCases/asset-modules/data-url/test.filter.js
+++ b/tests/webpack-test/configCases/asset-modules/data-url/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => {return false}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
Passing Infinity to `parser.asset.dataUrlCondition.maxSize` currently has no effect, causing the [asset-modules/data-url](https://github.com/web-infra-dev/rspack/blob/84c4efa6253b8f48d735349c1fc5e25f369cdd1d/tests/webpack-test/configCases/asset-modules/data-url/webpack.config.js#L17-L21) test to fail.
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
