### PR TITLE
refactor: reuse AssetConditions for banner plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3965,14 +3965,12 @@ dependencies = [
 name = "rspack_plugin_banner"
 version = "0.1.0"
 dependencies = [
- "async-recursion",
  "cow-utils",
  "futures",
  "regex",
  "rspack_core",
  "rspack_error",
  "rspack_hook",
- "rspack_regex",
  "rspack_util",
  "tracing",
 ]

--- a/crates/rspack_plugin_banner/Cargo.toml
+++ b/crates/rspack_plugin_banner/Cargo.toml
@@ -8,16 +8,14 @@ version     = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-recursion = { workspace = true }
-cow-utils       = { workspace = true }
-futures         = { workspace = true }
-regex           = { workspace = true }
-rspack_core     = { version = "0.1.0", path = "../rspack_core" }
-rspack_error    = { version = "0.1.0", path = "../rspack_error" }
-rspack_hook     = { version = "0.1.0", path = "../rspack_hook" }
-rspack_regex    = { version = "0.1.0", path = "../rspack_regex" }
-rspack_util     = { version = "0.1.0", path = "../rspack_util" }
-tracing         = { workspace = true }
+cow-utils    = { workspace = true }
+futures      = { workspace = true }
+regex        = { workspace = true }
+rspack_core  = { version = "0.1.0", path = "../rspack_core" }
+rspack_error = { version = "0.1.0", path = "../rspack_error" }
+rspack_hook  = { version = "0.1.0", path = "../rspack_hook" }
+rspack_util  = { version = "0.1.0", path = "../rspack_util" }
+tracing      = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["tracing"]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
The current rule match is async, but it seems unnecessary. We can reuse existing AssetConditions to simplify the existing code.
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
