### PR TITLE
fix(cli): missing `exports.types` field

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },


### PR DESCRIPTION
## Summary

`@rspack/cli` has been converted to a "dual package" and the `exports.types` is required to provide typing for the `dist/index.mjs`.

https://github.com/web-infra-dev/rspack/pull/8187

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
