### PR TITLE
fix(cli): Run config function before looking for `--config-name`

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -227,6 +227,17 @@ export class RspackCLI {
 		let loadedConfig = (await loadRspackConfig(
 			options
 		)) as NonNullable<LoadedRspackConfig>;
+
+		if (typeof loadedConfig === "function") {
+			loadedConfig = loadedConfig(options.argv?.env, options.argv);
+			// if return promise we should await its result
+			if (
+				typeof (loadedConfig as unknown as Promise<unknown>).then === "function"
+			) {
+				loadedConfig = await loadedConfig;
+			}
+		}
+
 		if (options.configName) {
 			const notFoundConfigNames: string[] = [];
 
@@ -264,15 +275,6 @@ export class RspackCLI {
 			}
 		}
 
-		if (typeof loadedConfig === "function") {
-			loadedConfig = loadedConfig(options.argv?.env, options.argv);
-			// if return promise we should await its result
-			if (
-				typeof (loadedConfig as unknown as Promise<unknown>).then === "function"
-			) {
-				loadedConfig = await loadedConfig;
-			}
-		}
 		return loadedConfig;
 	}
 


### PR DESCRIPTION
## Summary

When the config is a function, we need to match `--config-name` on its return value, not the function itself.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
  - `tests/webpack-cli-test/build/config-name/config-name.test.js` seems to already have tests for this (`"should work with config as a function"`, `"should work with multiple values for --config-name when the config is a function"`), but it seems we never run those tests.
- [x] Documentation updated (or not required).
