### PR TITLE
fix: define lib export

### DIFF
--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -17,8 +17,8 @@
     },
     "./hot/*": "./hot/*.js",
     "./hot/*.js": "./hot/*.js",
-    "./lib/*": "./lib/*.js",
-    "./lib/*.js": "./lib/*.js",
+    "./lib/*": ".dist/lib/*.js",
+    "./lib/*.js": ".dist/lib/*.js",
     "./package.json": "./package.json",
     "./module": "./module.d.ts"
   },

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -17,6 +17,8 @@
     },
     "./hot/*": "./hot/*.js",
     "./hot/*.js": "./hot/*.js",
+    "./lib/*": "./lib/*.js",
+    "./lib/*.js": "./lib/*.js",
     "./package.json": "./package.json",
     "./module": "./module.d.ts"
   },


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

Add `/lib/*` export filed in `package.json`.

This exists in webpack and [there are hundred of projects import from there](https://github.com/search?q=%2F%28import%7Crequire%29.%2Bwebpack%5C%2Flib%5C%2F.%2B%2F+language%3ATypeScript&ref=opensearch&type=code).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
