### PR TITLE
refactor: rspack_fs use `Utf8Path` and `FileMetadata`

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -5,9 +5,7 @@ mod module_executor;
 use std::sync::Arc;
 
 use rspack_error::Result;
-use rspack_fs::{
-  AsyncNativeFileSystem, AsyncWritableFileSystem, NativeFileSystem, ReadableFileSystem,
-};
+use rspack_fs::{AsyncWritableFileSystem, NativeFileSystem, ReadableFileSystem};
 use rspack_futures::FuturesResults;
 use rspack_hook::define_hook;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
@@ -107,7 +105,7 @@ impl Compiler {
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
     let old_cache = Arc::new(OldCache::new(options.clone()));
     let module_executor = ModuleExecutor::default();
-    let output_filesystem = output_filesystem.unwrap_or_else(|| Box::new(AsyncNativeFileSystem {}));
+    let output_filesystem = output_filesystem.unwrap_or_else(|| Box::new(NativeFileSystem {}));
 
     Self {
       options: options.clone(),

--- a/crates/rspack_core/src/resolver/boxfs.rs
+++ b/crates/rspack_core/src/resolver/boxfs.rs
@@ -1,6 +1,7 @@
 use std::{io, sync::Arc};
 
-use rspack_fs::ReadableFileSystem;
+use rspack_fs::{Error, ReadableFileSystem};
+use rspack_paths::AssertUtf8;
 use rspack_resolver::{FileMetadata, FileSystem as ResolverFileSystem};
 
 #[derive(Clone)]
@@ -13,20 +14,38 @@ impl BoxFS {
 }
 impl ResolverFileSystem for BoxFS {
   fn read_to_string(&self, path: &std::path::Path) -> std::io::Result<String> {
-    self.0.read(path).and_then(|x| {
-      String::from_utf8(x).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))
-    })
+    match self.0.read(path.assert_utf8()) {
+      Ok(x) => String::from_utf8(x).map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err)),
+      Err(Error::Io(e)) => Err(e),
+    }
   }
 
   fn metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {
-    self.0.metadata(path).map(FileMetadata::from)
+    match self.0.metadata(path.assert_utf8()) {
+      Ok(meta) => Ok(FileMetadata {
+        is_dir: meta.is_directory,
+        is_file: meta.is_file,
+        is_symlink: meta.is_symlink,
+      }),
+      Err(Error::Io(e)) => Err(e),
+    }
   }
 
   fn symlink_metadata(&self, path: &std::path::Path) -> std::io::Result<FileMetadata> {
-    self.0.symlink_metadata(path).map(FileMetadata::from)
+    match self.0.symlink_metadata(path.assert_utf8()) {
+      Ok(meta) => Ok(FileMetadata {
+        is_dir: meta.is_directory,
+        is_file: meta.is_file,
+        is_symlink: meta.is_symlink,
+      }),
+      Err(Error::Io(e)) => Err(e),
+    }
   }
 
   fn canonicalize(&self, path: &std::path::Path) -> std::io::Result<std::path::PathBuf> {
-    self.0.canonicalize(path)
+    match self.0.canonicalize(path.assert_utf8()) {
+      Ok(path) => Ok(path.into()),
+      Err(Error::Io(e)) => Err(e),
+    }
   }
 }

--- a/crates/rspack_fs/Cargo.toml
+++ b/crates/rspack_fs/Cargo.toml
@@ -5,20 +5,10 @@ license     = "MIT"
 name        = "rspack_fs"
 repository  = "https://github.com/web-infra-dev/rspack"
 version     = "0.1.0"
+
 [dependencies]
-dunce = { version = "1.0.5" }
-[dependencies.rspack_error]
-path    = "../rspack_error"
-version = "0.1.0"
-
-
-[dependencies.rspack_paths]
-path    = "../rspack_paths"
-version = "0.1.0"
-
-[dependencies.futures]
-workspace = true
-
-[dependencies.tokio]
-features  = ["fs"]
-workspace = true
+dunce        = { version = "1.0.5" }
+futures      = { workspace = true }
+rspack_error = { path = "../rspack_error", version = "0.1.0" }
+rspack_paths = { path = "../rspack_paths", version = "0.1.0" }
+tokio        = { workspace = true, features = ["fs"] }

--- a/crates/rspack_fs/src/async.rs
+++ b/crates/rspack_fs/src/async.rs
@@ -3,17 +3,7 @@ use std::fmt::Debug;
 use futures::future::BoxFuture;
 use rspack_paths::Utf8Path;
 
-use crate::Result;
-
-#[derive(Debug)]
-pub struct FileStat {
-  pub is_file: bool,
-  pub is_directory: bool,
-  pub atime_ms: u64,
-  pub mtime_ms: u64,
-  pub ctime_ms: u64,
-  pub size: u64,
-}
+use crate::{FileMetadata, Result};
 
 pub trait AsyncWritableFileSystem: Debug {
   /// Creates a new, empty directory at the provided path.
@@ -47,7 +37,7 @@ pub trait AsyncWritableFileSystem: Debug {
   /// Read the entire contents of a file into a bytes vector.
   fn read_file<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<Vec<u8>>>;
 
-  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<FileStat>>;
+  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, Result<FileMetadata>>;
 }
 
 pub trait AsyncReadableFileSystem: Debug {

--- a/crates/rspack_fs/src/file_metadata.rs
+++ b/crates/rspack_fs/src/file_metadata.rs
@@ -1,0 +1,48 @@
+use std::fs::Metadata;
+
+use crate::{Error, Result};
+
+#[derive(Debug)]
+pub struct FileMetadata {
+  pub is_file: bool,
+  pub is_directory: bool,
+  pub is_symlink: bool,
+  pub atime_ms: u64,
+  pub mtime_ms: u64,
+  pub ctime_ms: u64,
+  pub size: u64,
+}
+
+impl TryFrom<Metadata> for FileMetadata {
+  type Error = Error;
+
+  fn try_from(metadata: Metadata) -> Result<Self> {
+    let mtime_ms = metadata
+      .modified()
+      .map_err(Error::from)?
+      .duration_since(std::time::UNIX_EPOCH)
+      .expect("mtime is before unix epoch")
+      .as_millis() as u64;
+    let ctime_ms = metadata
+      .created()
+      .map_err(Error::from)?
+      .duration_since(std::time::UNIX_EPOCH)
+      .expect("ctime is before unix epoch")
+      .as_millis() as u64;
+    let atime_ms = metadata
+      .accessed()
+      .map_err(Error::from)?
+      .duration_since(std::time::UNIX_EPOCH)
+      .expect("atime is before unix epoch")
+      .as_millis() as u64;
+    Ok(Self {
+      is_directory: metadata.is_dir(),
+      is_file: metadata.is_file(),
+      is_symlink: metadata.is_symlink(),
+      size: metadata.len(),
+      mtime_ms,
+      ctime_ms,
+      atime_ms,
+    })
+  }
+}

--- a/crates/rspack_fs/src/lib.rs
+++ b/crates/rspack_fs/src/lib.rs
@@ -1,10 +1,16 @@
-pub mod r#async;
-mod macros;
-mod native;
-pub use r#async::{AsyncFileSystem, AsyncReadableFileSystem, AsyncWritableFileSystem, FileStat};
-pub mod sync;
+mod r#async;
+pub use r#async::{AsyncFileSystem, AsyncReadableFileSystem, AsyncWritableFileSystem};
+
+mod sync;
 pub use sync::{FileSystem, ReadableFileSystem, WritableFileSystem};
+
+mod file_metadata;
+pub use file_metadata::FileMetadata;
+
+mod macros;
+
+mod native_fs;
+pub use native_fs::NativeFileSystem;
+
 mod error;
 pub use error::{Error, Result};
-pub use native::AsyncNativeFileSystem;
-pub use native::NativeFileSystem;

--- a/crates/rspack_fs/src/sync.rs
+++ b/crates/rspack_fs/src/sync.rs
@@ -1,13 +1,8 @@
 use std::fmt::Debug;
-use std::fs::Metadata;
-use std::io;
-use std::path::Path;
-use std::path::PathBuf;
 
-use rspack_paths::Utf8Path;
+use rspack_paths::{Utf8Path, Utf8PathBuf};
 
-// pubResolverFileSystem
-use super::Result;
+use super::{FileMetadata, Result};
 
 pub trait WritableFileSystem: Debug {
   /// Creates a new, empty directory at the provided path.
@@ -32,16 +27,16 @@ pub trait WritableFileSystem: Debug {
 
 pub trait ReadableFileSystem: Debug + Send + Sync {
   /// See [std::fs::read]
-  fn read(&self, path: &Path) -> io::Result<Vec<u8>>;
+  fn read(&self, path: &Utf8Path) -> Result<Vec<u8>>;
 
   /// See [std::fs::metadata]
-  fn metadata(&self, path: &Path) -> io::Result<Metadata>;
+  fn metadata(&self, path: &Utf8Path) -> Result<FileMetadata>;
 
   /// See [std::fs::symlink_metadata]
-  fn symlink_metadata(&self, path: &Path) -> io::Result<Metadata>;
+  fn symlink_metadata(&self, path: &Utf8Path) -> Result<FileMetadata>;
 
   /// See [std::fs::canonicalize]
-  fn canonicalize(&self, path: &Path) -> io::Result<PathBuf>;
+  fn canonicalize(&self, path: &Utf8Path) -> Result<Utf8PathBuf>;
 }
 
 /// Readable and writable file system representation.

--- a/crates/rspack_fs_node/src/async.rs
+++ b/crates/rspack_fs_node/src/async.rs
@@ -1,6 +1,6 @@
 use futures::future::BoxFuture;
 use napi::{bindgen_prelude::Either3, Either};
-use rspack_fs::r#async::{AsyncWritableFileSystem, FileStat};
+use rspack_fs::{AsyncWritableFileSystem, FileMetadata};
 use rspack_paths::Utf8Path;
 
 use crate::node::ThreadsafeNodeFS;
@@ -158,7 +158,7 @@ impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
     Box::pin(fut)
   }
 
-  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, rspack_fs::Result<FileStat>> {
+  fn stat<'a>(&'a self, file: &'a Utf8Path) -> BoxFuture<'a, rspack_fs::Result<FileMetadata>> {
     let fut = async {
       let file = file.as_str().to_string();
       let res = self.0.stat.call(file).await.map_err(|e| {
@@ -168,7 +168,7 @@ impl AsyncWritableFileSystem for AsyncNodeWritableFileSystem {
         ))
       })?;
       match res {
-        Either::A(stat) => Ok(FileStat::from(stat)),
+        Either::A(stat) => Ok(FileMetadata::from(stat)),
         Either::B(_) => Err(rspack_fs::Error::Io(std::io::Error::new(
           std::io::ErrorKind::Other,
           "output file system call stat failed",

--- a/crates/rspack_fs_node/src/node.rs
+++ b/crates/rspack_fs_node/src/node.rs
@@ -58,7 +58,7 @@ pub(crate) struct NodeFSRef {
 }
 
 use napi::Either;
-use rspack_fs::r#async::FileStat;
+use rspack_fs::FileMetadata;
 use rspack_napi::threadsafe_function::ThreadsafeFunction;
 
 #[napi(object, object_to_js = false, js_name = "ThreadsafeNodeFS")]
@@ -94,11 +94,12 @@ pub struct NodeFsStats {
   pub size: u32,
 }
 
-impl From<NodeFsStats> for FileStat {
+impl From<NodeFsStats> for FileMetadata {
   fn from(value: NodeFsStats) -> Self {
     Self {
       is_file: value.is_file,
       is_directory: value.is_directory,
+      is_symlink: false,
       atime_ms: value.atime_ms as u64,
       mtime_ms: value.mtime_ms as u64,
       ctime_ms: value.ctime_ms as u64,

--- a/crates/rspack_fs_node/src/sync.rs
+++ b/crates/rspack_fs_node/src/sync.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use napi::Env;
-use rspack_fs::{sync::WritableFileSystem, Error, Result};
+use rspack_fs::{Error, Result, WritableFileSystem};
 use rspack_paths::Utf8Path;
 
 use crate::node::{NodeFS, NodeFSRef, TryIntoNodeFSRef};

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -44,7 +44,7 @@ async fn process_resource<Context: Send>(
     {
       let resource_path_owned = resource_path.to_owned();
       // use spawn_blocking to avoid block,see https://docs.rs/tokio/latest/src/tokio/fs/read.rs.html#48
-      let result = spawn_blocking(move || fs.read(resource_path_owned.as_std_path()))
+      let result = spawn_blocking(move || fs.read(resource_path_owned.as_path()))
         .await
         .map_err(|e| error!("{e}, spawn task failed"))?;
       let result = result.map_err(|e| error!("{e}, failed to read {resource_path}"))?;


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

* update `ReadableFileSystem` trait to use `Utf8Path` and `Utf8PathBuf`
In rspack we use `Utf8Path` and `Utf8PathBuf` instead of `Path` and `PathBuf`. more info see https://github.com/web-infra-dev/rspack/pull/7570

* define `FileMetadata` to replace `Metadata` to make Async and Sync trait return same struct

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
