### PR TITLE
fix: required amd in umd external object

### DIFF
--- a/packages/rspack-test-tools/tests/configCases/externals/umd-array-externals/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-array-externals/rspack.config.js
@@ -7,7 +7,8 @@ module.exports = {
 		external: {
 			root: ["a", "b"],
 			commonjs: "a",
-			commonjs2: "a"
+			commonjs2: "a",
+			amd: "a"
 		}
 	}
 };

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/errors.js
@@ -1,0 +1,1 @@
+module.exports = [/External object must have "root", "commonjs", "commonjs2", "amd" properties when "libraryType" or "externalsType" is "umd" at "externals.lodash"/];

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/index.js
@@ -1,0 +1,5 @@
+var lodash = require("lodash");
+
+it("should works", function () {
+	expect(lodash.add(1, 1)).toBe(2);
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/lodash.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/lodash.js
@@ -1,0 +1,1 @@
+exports.add = (a, b) => a + b;

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed-no-externals-type/rspack.config.js
@@ -4,13 +4,13 @@ const { CopyRspackPlugin } = require("@rspack/core");
 module.exports = {
 	entry: "./index.js",
 	output: {
-		library: {
-			type: "commonjs",
-		}
+		libraryTarget: "umd"
 	},
 	externals: {
 		lodash: {
+			root: "./lodash.js",
 			commonjs: "./lodash.js",
+			commonjs2: "./lodash.js",
 		}
 	},
 	plugins: [

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/errors.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/errors.js
@@ -1,0 +1,1 @@
+module.exports = [/External object must have "root", "commonjs", "commonjs2", "amd" properties when "libraryType" or "externalsType" is "umd" at "externals.lodash"/];

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/index.js
@@ -1,0 +1,5 @@
+var lodash = require("lodash");
+
+it("should works", function () {
+	expect(lodash.add(1, 1)).toBe(2);
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/lodash.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/lodash.js
@@ -1,0 +1,1 @@
+exports.add = (a, b) => a + b;

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-failed/rspack.config.js
@@ -5,12 +5,15 @@ module.exports = {
 	entry: "./index.js",
 	output: {
 		library: {
-			type: "commonjs",
+			type: "umd"
 		}
 	},
+	externalsType: "umd",
 	externals: {
 		lodash: {
+			root: "./lodash.js",
 			commonjs: "./lodash.js",
+			commonjs2: "./lodash.js",
 		}
 	},
 	plugins: [

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/index.js
@@ -1,0 +1,5 @@
+var lodash = require("lodash");
+
+it("should works", function () {
+	expect(lodash.add(1, 1)).toBe(2);
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/lodash.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/lodash.js
@@ -1,0 +1,1 @@
+exports.add = (a, b) => a + b;

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation-with-external-type/rspack.config.js
@@ -4,15 +4,16 @@ const { CopyRspackPlugin } = require("@rspack/core");
 module.exports = {
 	entry: "./index.js",
 	output: {
-		library: {
-			type: "commonjs",
-		}
+		libraryTarget: "umd"
 	},
 	externals: {
 		lodash: {
+			root: "./lodash.js",
 			commonjs: "./lodash.js",
+			commonjs2: "./lodash.js",
 		}
 	},
+	externalsType: "commonjs",
 	plugins: [
 		new CopyRspackPlugin({
 			patterns: ["./lodash.js"]

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation/index.js
@@ -1,0 +1,5 @@
+var lodash = require("lodash");
+
+it("should works", function () {
+	expect(lodash.add(1, 1)).toBe(2);
+});

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation/lodash.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation/lodash.js
@@ -1,0 +1,1 @@
+exports.add = (a, b) => a + b;

--- a/packages/rspack-test-tools/tests/configCases/externals/umd-validation/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/umd-validation/rspack.config.js
@@ -5,12 +5,16 @@ module.exports = {
 	entry: "./index.js",
 	output: {
 		library: {
-			type: "commonjs",
+			type: "umd"
 		}
 	},
+	externalsType: "umd",
 	externals: {
 		lodash: {
+			root: "./lodash.js",
 			commonjs: "./lodash.js",
+			commonjs2: "./lodash.js",
+			amd: "./lodash.js"
 		}
 	},
 	plugins: [

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -84,6 +84,9 @@ interface AdditionalData {
 type AffectedHooks = keyof Compiler["hooks"];
 
 // @public (undocumented)
+type allKeys<T> = T extends any ? keyof T : never;
+
+// @public (undocumented)
 type AllowTarget = "web" | "webworker" | "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022" | "node" | "async-node" | `node${number}` | `async-node${number}` | `node${number}.${number}` | `async-node${number}.${number}` | "electron-main" | `electron${number}-main` | `electron${number}.${number}-main` | "electron-renderer" | `electron${number}-renderer` | `electron${number}.${number}-renderer` | "electron-preload" | `electron${number}-preload` | `electron${number}.${number}-preload` | "nwjs" | `nwjs${number}` | `nwjs${number}.${number}` | "node-webkit" | `node-webkit${number}` | `node-webkit${number}.${number}` | "browserslist" | `browserslist:${string}`;
 
 // @public (undocumented)
@@ -102,6 +105,12 @@ export const applyRspackOptionsBaseDefaults: (options: RspackOptionsNormalized) 
 
 // @public (undocumented)
 export const applyRspackOptionsDefaults: (options: RspackOptionsNormalized) => void;
+
+// @public (undocumented)
+type ArrayCardinality = "many" | "atleastone";
+
+// @public (undocumented)
+type arrayOutputType<T extends ZodTypeAny, Cardinality extends ArrayCardinality = "many"> = Cardinality extends "atleastone" ? [T["_output"], ...T["_output"][]] : T["_output"][];
 
 // @public
 const asRegExp: (test: string | RegExp) => RegExp;
@@ -193,6 +202,9 @@ export type Assets = Record<string, Source>;
 
 // @public
 export type AsyncChunks = boolean;
+
+// @public (undocumented)
+type AsyncParseReturnType<T> = Promise<SyncParseReturnType<T>>;
 
 // @public
 export type AuxiliaryComment = string | LibraryCustomUmdCommentObject;
@@ -297,12 +309,27 @@ export type BaseUri = string;
 type BigIntStatsCallback = (err: NodeJS.ErrnoException | null, stats?: IBigIntStats) => void;
 
 // @public (undocumented)
+const BRAND: unique symbol;
+
+// @public (undocumented)
+type BRAND<T extends string | number | symbol> = {
+    [BRAND]: {
+        [k in T]: true;
+    };
+};
+
+// @public (undocumented)
 type BufferCallback = (err: NodeJS.ErrnoException | null, data?: Buffer) => void;
 
 // @public (undocumented)
 type BufferEncodingOption = "buffer" | {
     encoding: "buffer";
 };
+
+// @public (undocumented)
+type BuiltIn = (((...args: any[]) => any) | (new (...args: any[]) => any)) | {
+    readonly [Symbol.toStringTag]: string;
+} | Date | Error | Generator | Promise<unknown> | RegExp;
 
 // @public (undocumented)
 class Cache_2 {
@@ -1257,6 +1284,9 @@ export type CssParserOptions = {
 };
 
 // @public (undocumented)
+type CustomErrorParams = Partial<util_2.Omit<ZodCustomIssue, "code">>;
+
+// @public (undocumented)
 export const DefinePlugin: {
     new (define: DefinePluginOptions): {
         name: BuiltinPluginName;
@@ -1403,6 +1433,15 @@ class DirectoryWatcher extends EventEmitter {
 }
 
 // @public (undocumented)
+type DIRTY<T> = {
+    status: "dirty";
+    value: T;
+};
+
+// @public (undocumented)
+const DIRTY: <T>(value: T) => DIRTY<T>;
+
+// @public (undocumented)
 interface Drafts {
     customMedia?: boolean;
 }
@@ -1417,6 +1456,9 @@ export class DynamicEntryPlugin extends RspackBuiltinPlugin {
     // (undocumented)
     raw(compiler: Compiler): BuiltinPlugin | undefined;
 }
+
+// @public (undocumented)
+type Effect<T> = RefinementEffect<T> | TransformEffect<T> | PreprocessEffect<T>;
 
 // @public (undocumented)
 interface Electron {
@@ -1645,6 +1687,26 @@ export class EnvironmentPlugin {
 }
 
 // @public (undocumented)
+type ErrorMapCtx = {
+    defaultError: string;
+    data: any;
+};
+
+// @public (undocumented)
+namespace errorUtil {
+    // (undocumented)
+    type ErrMessage = string | {
+        message?: string;
+    };
+    const // (undocumented)
+    errToObj: (message?: ErrMessage | undefined) => {
+        message?: string | undefined;
+    };
+    const // (undocumented)
+    toString: (message?: ErrMessage | undefined) => string | undefined;
+}
+
+// @public (undocumented)
 type ErrorWithDetails = Error & {
     details?: string;
 };
@@ -1833,12 +1895,22 @@ export type ExternalItemObjectUnknown = {
 };
 
 // @public
-export type ExternalItemValue = string | boolean | string[] | {
+export type ExternalItemObjectValue = Record<string, string | string[]>;
+
+// @public
+export type ExternalItemUmdValue = {
     root: string | string[];
     commonjs: string | string[];
     commonjs2: string | string[];
-    amd?: string | string[];
+    amd: string | string[];
 };
+
+// @public
+export type ExternalItemValue = string | boolean | string[] | ExternalItemUmdValue
+/**
+* when libraryTarget and externalsType is not 'umd'
+*/
+| ExternalItemObjectValue;
 
 // @public
 export type Externals = ExternalItem | ExternalItem[];
@@ -2220,6 +2292,9 @@ export type InfrastructureLogging = {
 };
 
 // @public (undocumented)
+type input<T extends ZodType<any, any, any>> = T["_input"];
+
+// @public (undocumented)
 type InputFileSystem = {
     readFile: ReadFile;
     readFileSync?: ReadFileSync;
@@ -2239,6 +2314,20 @@ type InputFileSystem = {
     join?: (path1: string, path2: string) => string;
     relative?: (from: string, to: string) => string;
     dirname?: (path: string) => string;
+};
+
+// @public (undocumented)
+type INVALID = {
+    status: "aborted";
+};
+
+// @public (undocumented)
+const INVALID: INVALID;
+
+// @public (undocumented)
+type IssueData = stripPath<ZodIssueOptionalMessage> & {
+    path?: (string | number)[];
+    fatal?: boolean;
 };
 
 // @public (undocumented)
@@ -3338,6 +3427,9 @@ type LStatSync = {
 };
 
 // @public (undocumented)
+type MakeReadonly<T> = T extends Map<infer K, infer V> ? ReadonlyMap<K, V> : T extends Set<infer V> ? ReadonlySet<V> : T extends [infer Head, ...infer Tail] ? readonly [Head, ...Tail] : T extends Array<infer V> ? ReadonlyArray<V> : T extends BuiltIn ? T : Readonly<T>;
+
+// @public (undocumented)
 type MapOptions = { columns?: boolean; module?: boolean };
 
 // @public
@@ -3732,6 +3824,62 @@ type ObjectEncodingOptions = {
 };
 
 // @public (undocumented)
+namespace objectUtil {
+    // (undocumented)
+    type addQuestionMarks<T extends object, _O = any> = {
+        [K in requiredKeys<T>]: T[K];
+    } & {
+        [K in optionalKeys<T>]?: T[K];
+    } & {
+        [k in keyof T]?: unknown;
+    };
+    // (undocumented)
+    type extendShape<A extends object, B extends object> = {
+        [K in keyof A as K extends keyof B ? never : K]: A[K];
+    } & {
+        [K in keyof B]: B[K];
+    };
+    // (undocumented)
+    type flatten<T> = identity<{
+        [k in keyof T]: T[k];
+    }>;
+    // (undocumented)
+    type identity<T> = T;
+    // (undocumented)
+    type MergeShapes<U, V> = {
+        [k in Exclude<keyof U, keyof V>]: U[k];
+    } & V;
+    // (undocumented)
+    type noNever<T> = identity<{
+        [k in noNeverKeys<T>]: k extends keyof T ? T[k] : never;
+    }>;
+    // (undocumented)
+    type noNeverKeys<T> = {
+        [k in keyof T]: [T[k]] extends [never] ? never : k;
+    }[keyof T];
+    // (undocumented)
+    type optionalKeys<T extends object> = {
+        [k in keyof T]: undefined extends T[k] ? k : never;
+    }[keyof T];
+    const // (undocumented)
+    mergeShapes: <U, T>(first: U, second: T) => T & U;
+    // (undocumented)
+    type requiredKeys<T extends object> = {
+        [k in keyof T]: undefined extends T[k] ? never : k;
+    }[keyof T];
+        {  };
+}
+
+// @public (undocumented)
+type OK<T> = {
+    status: "valid";
+    value: T;
+};
+
+// @public (undocumented)
+const OK: <T>(value: T) => OK<T>;
+
+// @public (undocumented)
 export type Optimization = {
     moduleIds?: "named" | "natural" | "deterministic";
     chunkIds?: "natural" | "named" | "deterministic";
@@ -3887,6 +4035,9 @@ export type Output = {
 };
 
 // @public (undocumented)
+type output<T extends ZodType<any, any, any>> = T["_output"];
+
+// @public (undocumented)
 export interface OutputFileSystem {
     // (undocumented)
     dirname?: (arg0: string) => string;
@@ -4016,6 +4167,26 @@ export interface OutputNormalized {
 }
 
 // @public (undocumented)
+interface ParseContext {
+    // (undocumented)
+    readonly common: {
+        readonly issues: ZodIssue[];
+        readonly contextualErrorMap?: ZodErrorMap;
+        readonly async: boolean;
+    };
+    // (undocumented)
+    readonly data: any;
+    // (undocumented)
+    readonly parent: ParseContext | null;
+    // (undocumented)
+    readonly parsedType: ZodParsedType;
+    // (undocumented)
+    readonly path: ParsePath;
+    // (undocumented)
+    readonly schemaErrorMap?: ZodErrorMap;
+}
+
+// @public (undocumented)
 interface ParsedIdentifier {
     	// (undocumented)
     directory: boolean;
@@ -4034,7 +4205,30 @@ interface ParsedIdentifier {
 }
 
 // @public (undocumented)
+type ParseInput = {
+    data: any;
+    path: (string | number)[];
+    parent: ParseContext;
+};
+
+// @public (undocumented)
+type ParseParams = {
+    path: (string | number)[];
+    errorMap: ZodErrorMap;
+    async: boolean;
+};
+
+// @public (undocumented)
+type ParsePath = ParsePathComponent[];
+
+// @public (undocumented)
+type ParsePathComponent = string | number;
+
+// @public (undocumented)
 type ParserConfig = TsParserConfig | EsParserConfig;
+
+// @public (undocumented)
+type ParseReturnType<T> = SyncParseReturnType<T> | AsyncParseReturnType<T>;
 
 // @public
 export type ParserOptionsByModuleType = ParserOptionsByModuleTypeKnown | ParserOptionsByModuleTypeUnknown;
@@ -4055,6 +4249,29 @@ export type ParserOptionsByModuleTypeKnown = {
 export type ParserOptionsByModuleTypeUnknown = {
     [x: string]: Record<string, any>;
 };
+
+// @public (undocumented)
+class ParseStatus {
+    // (undocumented)
+    abort(): void;
+    // (undocumented)
+    dirty(): void;
+    // (undocumented)
+    static mergeArray(status: ParseStatus, results: SyncParseReturnType<any>[]): SyncParseReturnType;
+    // (undocumented)
+    static mergeObjectAsync(status: ParseStatus, pairs: {
+        key: ParseReturnType<any>;
+        value: ParseReturnType<any>;
+    }[]): Promise<SyncParseReturnType<any>>;
+    // (undocumented)
+    static mergeObjectSync(status: ParseStatus, pairs: {
+        key: SyncParseReturnType<any>;
+        value: SyncParseReturnType<any>;
+        alwaysSet?: boolean;
+    }[]): SyncParseReturnType;
+    // (undocumented)
+    value: "aborted" | "dirty" | "valid";
+}
 
 // @public
 export type Path = string;
@@ -4108,6 +4325,15 @@ type PluginImportOptions = PluginImportConfig[] | undefined;
 
 // @public (undocumented)
 export type Plugins = Plugin_2[];
+
+// @public (undocumented)
+type PreprocessEffect<T> = {
+    type: "preprocess";
+    transform: (arg: T, ctx: RefinementCtx) => any;
+};
+
+// @public (undocumented)
+type Primitive = string | number | symbol | bigint | boolean | null | undefined;
 
 // @public (undocumented)
 type PrintedElement = {
@@ -4217,6 +4443,15 @@ export type PublicPath = "auto" | Filename;
 
 // @public (undocumented)
 type Purge = (files?: string | string[] | Set<string>) => void;
+
+// @public (undocumented)
+type RawCreateParams = {
+    errorMap?: ZodErrorMap;
+    invalid_type_error?: string;
+    required_error?: string;
+    message?: string;
+    description?: string;
+} | undefined;
 
 // @public (undocumented)
 type RawSourceMap = {
@@ -4373,6 +4608,29 @@ type RealPathSync = {
 type RecursiveArrayOrRecord<T> = {
     [index: string]: RecursiveArrayOrRecord<T>;
 } | Array<RecursiveArrayOrRecord<T>> | T;
+
+// @public (undocumented)
+type recursiveZodFormattedError<T> = T extends [any, ...any[]] ? {
+    [K in keyof T]?: ZodFormattedError<T[K]>;
+} : T extends any[] ? {
+    [k: number]: ZodFormattedError<T[number]>;
+} : T extends object ? {
+    [K in keyof T]?: ZodFormattedError<T[K]>;
+} : unknown;
+
+// @public (undocumented)
+interface RefinementCtx {
+    // (undocumented)
+    addIssue: (arg: IssueData) => void;
+    // (undocumented)
+    path: (string | number)[];
+}
+
+// @public (undocumented)
+type RefinementEffect<T> = {
+    type: "refinement";
+    refinement: (arg: T, ctx: RefinementCtx) => any;
+};
 
 // @public (undocumented)
 export type Remotes = (RemotesItem | RemotesObject)[] | RemotesObject;
@@ -4823,6 +5081,8 @@ declare namespace rspackExports {
         ModuleOptions,
         Target,
         ExternalsType,
+        ExternalItemUmdValue,
+        ExternalItemObjectValue,
         ExternalItemValue,
         ExternalItemObjectUnknown,
         ExternalItemFunctionData,
@@ -5964,22 +6224,7 @@ export const rspackOptions: z.ZodObject<{
             } | undefined;
         } | undefined;
     }>>;
-    externals: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    externals: z.ZodOptional<z.ZodUnion<[z.ZodArray<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, ZodRspackCrossChecker<t.ExternalItemUmdValue | t.ExternalItemObjectValue>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6004,22 +6249,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, ZodRspackCrossChecker<t.ExternalItemUmdValue | t.ExternalItemObjectValue>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6044,37 +6274,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>]>>>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, ZodRspackCrossChecker<t.ExternalItemUmdValue | t.ExternalItemObjectValue>]>>>]>, "many">, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodType<RegExp, z.ZodTypeDef, RegExp>]>, z.ZodRecord<z.ZodString, z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, ZodRspackCrossChecker<t.ExternalItemUmdValue | t.ExternalItemObjectValue>]>>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6099,22 +6299,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
+    }>, z.ZodFunction<z.ZodTuple<[z.ZodOptional<z.ZodType<Error, z.ZodTypeDef, Error>>, z.ZodOptional<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, ZodRspackCrossChecker<t.ExternalItemUmdValue | t.ExternalItemObjectValue>]>>, z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>], z.ZodUnknown>, z.ZodVoid>], z.ZodUnknown>, z.ZodUnknown>]>, z.ZodFunction<z.ZodTuple<[z.ZodObject<{
         context: z.ZodOptional<z.ZodString>;
         dependencyType: z.ZodOptional<z.ZodString>;
         request: z.ZodOptional<z.ZodString>;
@@ -6139,22 +6324,7 @@ export const rspackOptions: z.ZodObject<{
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, z.ZodObject<{
-        root: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        commonjs2: z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>;
-        amd: z.ZodOptional<z.ZodUnion<[z.ZodString, z.ZodArray<z.ZodString, "many">]>>;
-    }, "strict", z.ZodTypeAny, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }, {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>]>>>]>]>>;
+    }>], z.ZodUnknown>, z.ZodPromise<z.ZodUnion<[z.ZodUnion<[z.ZodUnion<[z.ZodString, z.ZodBoolean]>, z.ZodArray<z.ZodString, "many">]>, ZodRspackCrossChecker<t.ExternalItemUmdValue | t.ExternalItemObjectValue>]>>>]>]>>;
     externalsType: z.ZodOptional<z.ZodEnum<["var", "module", "assign", "this", "window", "self", "global", "commonjs", "commonjs2", "commonjs-module", "commonjs-static", "amd", "amd-require", "umd", "umd2", "jsonp", "system", "promise", "import", "module-import", "script", "node-commonjs"]>>;
     externalsPresets: z.ZodOptional<z.ZodObject<{
         node: z.ZodOptional<z.ZodBoolean>;
@@ -8405,65 +8575,35 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     loader?: Record<string, any> | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
-    externals?: string | RegExp | Record<string, string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }> | ((args_0: {
+    externals?: string | RegExp | Record<string, string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>) | (string | RegExp | Record<string, string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }> | ((args_0: {
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue>) | (string | RegExp | Record<string, string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>))[] | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue>))[] | undefined;
     externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
@@ -9040,65 +9180,35 @@ export const rspackOptions: z.ZodObject<{
     } | undefined;
     loader?: Record<string, any> | undefined;
     resolveLoader?: t.ResolveOptions | undefined;
-    externals?: string | RegExp | Record<string, string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }> | ((args_0: {
+    externals?: string | RegExp | Record<string, string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>) | (string | RegExp | Record<string, string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }> | ((args_0: {
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue>) | (string | RegExp | Record<string, string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue> | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    } | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
+    }, args_1: (args_0: Error | undefined, args_1: string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue | undefined, args_2: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined, ...args: unknown[]) => void, ...args: unknown[]) => unknown) | ((args_0: {
         request?: string | undefined;
         context?: string | undefined;
         dependencyType?: string | undefined;
         contextInfo?: {
             issuer: string;
         } | undefined;
-    }, ...args: unknown[]) => Promise<string | boolean | string[] | {
-        root: string | string[];
-        commonjs: string | string[];
-        commonjs2: string | string[];
-        amd?: string | string[] | undefined;
-    }>))[] | undefined;
+    }, ...args: unknown[]) => Promise<string | boolean | string[] | t.ExternalItemUmdValue | t.ExternalItemObjectValue>))[] | undefined;
     externalsType?: "module" | "global" | "system" | "script" | "commonjs" | "umd" | "amd" | "var" | "jsonp" | "import" | "assign" | "this" | "window" | "self" | "commonjs2" | "commonjs-module" | "commonjs-static" | "amd-require" | "umd2" | "promise" | "module-import" | "node-commonjs" | undefined;
     externalsPresets?: {
         node?: boolean | undefined;
@@ -9440,6 +9550,23 @@ enum RuntimeModuleStage {
 
 // @public (undocumented)
 type RuntimePlugins = string[];
+
+// @public (undocumented)
+type SafeParseError<Input> = {
+    success: false;
+    error: ZodError<Input>;
+    data?: never;
+};
+
+// @public (undocumented)
+type SafeParseReturnType<Input, Output> = SafeParseSuccess<Output> | SafeParseError<Input>;
+
+// @public (undocumented)
+type SafeParseSuccess<Output> = {
+    success: true;
+    data: Output;
+    error?: never;
+};
 
 // @public (undocumented)
 export type ScriptType = false | "text/javascript" | "module";
@@ -9879,6 +10006,19 @@ type StringCallback = (err: NodeJS.ErrnoException | null, data?: string) => void
 type StringOrBufferCallback = (err: NodeJS.ErrnoException | null, data?: string | Buffer) => void;
 
 // @public (undocumented)
+type StringValidation = "email" | "url" | "emoji" | "uuid" | "nanoid" | "regex" | "cuid" | "cuid2" | "ulid" | "datetime" | "date" | "time" | "duration" | "ip" | "base64" | {
+    includes: string;
+    position?: number;
+} | {
+    startsWith: string;
+} | {
+    endsWith: string;
+};
+
+// @public (undocumented)
+type stripPath<T extends object> = T extends any ? util_2.OmitKeys<T, "path"> : never;
+
+// @public (undocumented)
 export const SwcJsMinimizerRspackPlugin: {
     new (options?: SwcJsMinimizerRspackPluginOptions | undefined): {
         name: BuiltinPluginName;
@@ -9932,6 +10072,9 @@ export type SwcLoaderTransformConfig = TransformConfig;
 
 // @public (undocumented)
 export type SwcLoaderTsParserConfig = TsParserConfig;
+
+// @public (undocumented)
+type SyncParseReturnType<T = any> = OK<T> | DIRTY<T> | INVALID;
 
 // @public (undocumented)
 interface SystemjsConfig {
@@ -10061,6 +10204,8 @@ declare namespace t {
         ModuleOptions,
         Target,
         ExternalsType,
+        ExternalItemUmdValue,
+        ExternalItemObjectValue,
         ExternalItemValue,
         ExternalItemObjectUnknown,
         ExternalItemFunctionData,
@@ -10491,6 +10636,12 @@ interface TransformConfig {
     useDefineForClassFields?: boolean;
 }
 
+// @public (undocumented)
+type TransformEffect<T> = {
+    type: "transform";
+    transform: (arg: T, ctx: RefinementCtx) => any;
+};
+
 // @public
 export type TrustedTypes = {
     policyName?: string;
@@ -10505,6 +10656,14 @@ interface TsParserConfig {
     syntax: "typescript";
     tsx?: boolean;
 }
+
+// @public (undocumented)
+type typeToFlattenedError<T, U = string> = {
+    formErrors: U[];
+    fieldErrors: {
+        [P in allKeys<T>]?: U[];
+    };
+};
 
 // @public (undocumented)
 interface UmdConfig extends BaseModuleConfig {
@@ -10527,6 +10686,51 @@ export const util: {
     createHash: (algorithm: "debug" | "xxhash64" | "md4" | "native-md4" | (string & {}) | (new () => default_2)) => default_2;
     cleverMerge: <First, Second>(first: First, second: Second) => First | Second | (First & Second);
 };
+
+// @public (undocumented)
+namespace util_2 {
+    // (undocumented)
+    type AssertEqual<T, U> = (<V>() => V extends T ? 1 : 2) extends <V>() => V extends U ? 1 : 2 ? true : false;
+    // (undocumented)
+    function assertIs<T>(_arg: T): void;
+    const // (undocumented)
+    assertEqual: <A, B>(val: AssertEqual<A, B>) => AssertEqual<A, B>;
+    // (undocumented)
+    function assertNever(_x: never): never;
+    // (undocumented)
+    type Exactly<T, X> = T & Record<Exclude<keyof X, keyof T>, never>;
+    // (undocumented)
+    type flatten<T> = objectUtil.flatten<T>;
+    // (undocumented)
+    type identity<T> = objectUtil.identity<T>;
+    // (undocumented)
+    type isAny<T> = 0 extends 1 & T ? true : false;
+    // (undocumented)
+    function joinValues<T extends any[]>(array: T, separator?: string): string;
+    const // (undocumented)
+    arrayToEnum: <T extends string, U extends [T, ...T[]]>(items: U) => { [k in U[number]]: k; };
+    const // (undocumented)
+    getValidEnumValues: (obj: any) => any[];
+    const // (undocumented)
+    objectValues: (obj: any) => any[];
+    const // (undocumented)
+    objectKeys: ObjectConstructor["keys"];
+    const // (undocumented)
+    find: <T>(arr: T[], checker: (arg: T) => any) => T | undefined;
+    // (undocumented)
+    type MakePartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+    // (undocumented)
+    type noUndefined<T> = T extends undefined ? never : T;
+    // (undocumented)
+    type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+    const // (undocumented)
+    isInteger: NumberConstructor["isInteger"];
+    // (undocumented)
+    type OmitKeys<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
+    const // (undocumented)
+    jsonStringifyReplacer: (_: string, value: any) => any;
+        {  };
+}
 
 // @public (undocumented)
 export class ValidationError extends Error {
@@ -10829,6 +11033,729 @@ export type WorkerPublicPath = string;
 // @public (undocumented)
 namespace z {
         { type z_AnyZodObject as AnyZodObject, type z_AnyZodTuple as AnyZodTuple, type z_ArrayCardinality as ArrayCardinality, type z_ArrayKeys as ArrayKeys, type z_AssertArray as AssertArray, type z_AsyncParseReturnType as AsyncParseReturnType, type z_BRAND as BRAND, type z_CatchallInput as CatchallInput, type z_CatchallOutput as CatchallOutput, type z_CustomErrorParams as CustomErrorParams, z_DIRTY as DIRTY, type z_DenormalizedError as DenormalizedError, z_EMPTY_PATH as EMPTY_PATH, type z_Effect as Effect, type z_EnumLike as EnumLike, type z_EnumValues as EnumValues, type z_ErrorMapCtx as ErrorMapCtx, type z_FilterEnum as FilterEnum, z_INVALID as INVALID, type z_Indices as Indices, type z_InnerTypeOfFunction as InnerTypeOfFunction, type z_InputTypeOfTuple as InputTypeOfTuple, type z_InputTypeOfTupleWithRest as InputTypeOfTupleWithRest, type z_IpVersion as IpVersion, type z_IssueData as IssueData, type z_KeySchema as KeySchema, z_NEVER as NEVER, z_OK as OK, type z_ObjectPair as ObjectPair, type z_OuterTypeOfFunction as OuterTypeOfFunction, type z_OutputTypeOfTuple as OutputTypeOfTuple, type z_OutputTypeOfTupleWithRest as OutputTypeOfTupleWithRest, type z_ParseContext as ParseContext, type z_ParseInput as ParseInput, type z_ParseParams as ParseParams, type z_ParsePath as ParsePath, type z_ParsePathComponent as ParsePathComponent, type z_ParseResult as ParseResult, type z_ParseReturnType as ParseReturnType, z_ParseStatus as ParseStatus, type z_PassthroughType as PassthroughType, type z_PreprocessEffect as PreprocessEffect, type z_Primitive as Primitive, type z_ProcessedCreateParams as ProcessedCreateParams, type z_RawCreateParams as RawCreateParams, type z_RecordType as RecordType, type z_Refinement as Refinement, type z_RefinementCtx as RefinementCtx, type z_RefinementEffect as RefinementEffect, type z_SafeParseError as SafeParseError, type z_SafeParseReturnType as SafeParseReturnType, type z_SafeParseSuccess as SafeParseSuccess, type z_Scalars as Scalars, ZodType as Schema, type z_SomeZodObject as SomeZodObject, type z_StringValidation as StringValidation, type z_SuperRefinement as SuperRefinement, type z_SyncParseReturnType as SyncParseReturnType, type z_TransformEffect as TransformEffect, type z_TypeOf as TypeOf, type z_UnknownKeysParam as UnknownKeysParam, type z_Values as Values, type z_Writeable as Writeable, z_ZodAny as ZodAny, type z_ZodAnyDef as ZodAnyDef, z_ZodArray as ZodArray, type z_ZodArrayDef as ZodArrayDef, z_ZodBigInt as ZodBigInt, type z_ZodBigIntCheck as ZodBigIntCheck, type z_ZodBigIntDef as ZodBigIntDef, z_ZodBoolean as ZodBoolean, type z_ZodBooleanDef as ZodBooleanDef, z_ZodBranded as ZodBranded, type z_ZodBrandedDef as ZodBrandedDef, z_ZodCatch as ZodCatch, type z_ZodCatchDef as ZodCatchDef, type z_ZodCustomIssue as ZodCustomIssue, z_ZodDate as ZodDate, type z_ZodDateCheck as ZodDateCheck, type z_ZodDateDef as ZodDateDef, z_ZodDefault as ZodDefault, type z_ZodDefaultDef as ZodDefaultDef, z_ZodDiscriminatedUnion as ZodDiscriminatedUnion, type z_ZodDiscriminatedUnionDef as ZodDiscriminatedUnionDef, type z_ZodDiscriminatedUnionOption as ZodDiscriminatedUnionOption, z_ZodEffects as ZodEffects, type z_ZodEffectsDef as ZodEffectsDef, z_ZodEnum as ZodEnum, type z_ZodEnumDef as ZodEnumDef, z_ZodError as ZodError, type z_ZodErrorMap as ZodErrorMap, type z_ZodFirstPartySchemaTypes as ZodFirstPartySchemaTypes, z_ZodFirstPartyTypeKind as ZodFirstPartyTypeKind, type z_ZodFormattedError as ZodFormattedError, z_ZodFunction as ZodFunction, type z_ZodFunctionDef as ZodFunctionDef, z_ZodIntersection as ZodIntersection, type z_ZodIntersectionDef as ZodIntersectionDef, type z_ZodInvalidArgumentsIssue as ZodInvalidArgumentsIssue, type z_ZodInvalidDateIssue as ZodInvalidDateIssue, type z_ZodInvalidEnumValueIssue as ZodInvalidEnumValueIssue, type z_ZodInvalidIntersectionTypesIssue as ZodInvalidIntersectionTypesIssue, type z_ZodInvalidLiteralIssue as ZodInvalidLiteralIssue, type z_ZodInvalidReturnTypeIssue as ZodInvalidReturnTypeIssue, type z_ZodInvalidStringIssue as ZodInvalidStringIssue, type z_ZodInvalidTypeIssue as ZodInvalidTypeIssue, type z_ZodInvalidUnionDiscriminatorIssue as ZodInvalidUnionDiscriminatorIssue, type z_ZodInvalidUnionIssue as ZodInvalidUnionIssue, type z_ZodIssue as ZodIssue, type z_ZodIssueBase as ZodIssueBase, type z_ZodIssueCode as ZodIssueCode, type z_ZodIssueOptionalMessage as ZodIssueOptionalMessage, z_ZodLazy as ZodLazy, type z_ZodLazyDef as ZodLazyDef, z_ZodLiteral as ZodLiteral, type z_ZodLiteralDef as ZodLiteralDef, z_ZodMap as ZodMap, type z_ZodMapDef as ZodMapDef, z_ZodNaN as ZodNaN, type z_ZodNaNDef as ZodNaNDef, z_ZodNativeEnum as ZodNativeEnum, type z_ZodNativeEnumDef as ZodNativeEnumDef, z_ZodNever as ZodNever, type z_ZodNeverDef as ZodNeverDef, type z_ZodNonEmptyArray as ZodNonEmptyArray, type z_ZodNotFiniteIssue as ZodNotFiniteIssue, type z_ZodNotMultipleOfIssue as ZodNotMultipleOfIssue, z_ZodNull as ZodNull, type z_ZodNullDef as ZodNullDef, z_ZodNullable as ZodNullable, type z_ZodNullableDef as ZodNullableDef, type z_ZodNullableType as ZodNullableType, z_ZodNumber as ZodNumber, type z_ZodNumberCheck as ZodNumberCheck, type z_ZodNumberDef as ZodNumberDef, z_ZodObject as ZodObject, type z_ZodObjectDef as ZodObjectDef, z_ZodOptional as ZodOptional, type z_ZodOptionalDef as ZodOptionalDef, type z_ZodOptionalType as ZodOptionalType, type z_ZodParsedType as ZodParsedType, z_ZodPipeline as ZodPipeline, type z_ZodPipelineDef as ZodPipelineDef, z_ZodPromise as ZodPromise, type z_ZodPromiseDef as ZodPromiseDef, type z_ZodRawShape as ZodRawShape, z_ZodReadonly as ZodReadonly, type z_ZodReadonlyDef as ZodReadonlyDef, z_ZodRecord as ZodRecord, type z_ZodRecordDef as ZodRecordDef, ZodType as ZodSchema, z_ZodSet as ZodSet, type z_ZodSetDef as ZodSetDef, z_ZodString as ZodString, type z_ZodStringCheck as ZodStringCheck, type z_ZodStringDef as ZodStringDef, z_ZodSymbol as ZodSymbol, type z_ZodSymbolDef as ZodSymbolDef, type z_ZodTooBigIssue as ZodTooBigIssue, type z_ZodTooSmallIssue as ZodTooSmallIssue, ZodEffects as ZodTransformer, z_ZodTuple as ZodTuple, type z_ZodTupleDef as ZodTupleDef, type z_ZodTupleItems as ZodTupleItems, z_ZodType as ZodType, type z_ZodTypeAny as ZodTypeAny, type z_ZodTypeDef as ZodTypeDef, z_ZodUndefined as ZodUndefined, type z_ZodUndefinedDef as ZodUndefinedDef, z_ZodUnion as ZodUnion, type z_ZodUnionDef as ZodUnionDef, type z_ZodUnionOptions as ZodUnionOptions, z_ZodUnknown as ZodUnknown, type z_ZodUnknownDef as ZodUnknownDef, type z_ZodUnrecognizedKeysIssue as ZodUnrecognizedKeysIssue, z_ZodVoid as ZodVoid, type z_ZodVoidDef as ZodVoidDef, z_addIssueToContext as addIssueToContext, anyType as any, arrayType as array, type z_arrayOutputType as arrayOutputType, type z_baseObjectInputType as baseObjectInputType, type z_baseObjectOutputType as baseObjectOutputType, bigIntType as bigint, booleanType as boolean, z_coerce as coerce, z_custom as custom, dateType as date, z_datetimeRegex as datetimeRegex, errorMap as defaultErrorMap, type z_deoptional as deoptional, discriminatedUnionType as discriminatedUnion, effectsType as effect, enumType as enum, functionType as function, z_getErrorMap as getErrorMap, z_getParsedType as getParsedType, type TypeOf as infer, type z_inferFlattenedErrors as inferFlattenedErrors, type z_inferFormattedError as inferFormattedError, type z_input as input, instanceOfType as instanceof, intersectionType as intersection, z_isAborted as isAborted, z_isAsync as isAsync, z_isDirty as isDirty, z_isValid as isValid, z_late as late, lazyType as lazy, literalType as literal, z_makeIssue as makeIssue, mapType as map, type z_mergeTypes as mergeTypes, nanType as nan, nativeEnumType as nativeEnum, neverType as never, type z_noUnrecognized as noUnrecognized, nullType as null, nullableType as nullable, numberType as number, objectType as object, type z_objectInputType as objectInputType, type z_objectOutputType as objectOutputType, z_objectUtil as objectUtil, z_oboolean as oboolean, z_onumber as onumber, optionalType as optional, z_ostring as ostring, type z_output as output, pipelineType as pipeline, preprocessType as preprocess, promiseType as promise, z_quotelessJson as quotelessJson, recordType as record, setType as set, z_setErrorMap as setErrorMap, strictObjectType as strictObject, stringType as string, symbolType as symbol, effectsType as transformer, tupleType as tuple, type z_typeToFlattenedError as typeToFlattenedError, type z_typecast as typecast, undefinedType as undefined, unionType as union, unknownType as unknown, z_util as util, voidType as void };
+}
+
+// @public (undocumented)
+class ZodArray<T extends ZodTypeAny, Cardinality extends ArrayCardinality = "many"> extends ZodType<arrayOutputType<T, Cardinality>, ZodArrayDef<T>, Cardinality extends "atleastone" ? [T["_input"], ...T["_input"][]] : T["_input"][]> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(schema: T_1, params?: RawCreateParams) => ZodArray<T_1, "many">;
+    // (undocumented)
+    get element(): T;
+    // (undocumented)
+    length(len: number, message?: errorUtil.ErrMessage): this;
+    // (undocumented)
+    max(maxLength: number, message?: errorUtil.ErrMessage): this;
+    // (undocumented)
+    min(minLength: number, message?: errorUtil.ErrMessage): this;
+    // (undocumented)
+    nonempty(message?: errorUtil.ErrMessage): ZodArray<T, "atleastone">;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+}
+
+// @public (undocumented)
+interface ZodArrayDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    exactLength: {
+        value: number;
+        message?: string;
+    } | null;
+    // (undocumented)
+    maxLength: {
+        value: number;
+        message?: string;
+    } | null;
+    // (undocumented)
+    minLength: {
+        value: number;
+        message?: string;
+    } | null;
+    // (undocumented)
+    type: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodArray;
+}
+
+// @public (undocumented)
+class ZodBranded<T extends ZodTypeAny, B extends string | number | symbol> extends ZodType<T["_output"] & BRAND<B>, ZodBrandedDef<T>, T["_input"]> {
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<any>;
+    // (undocumented)
+    unwrap(): T;
+}
+
+// @public (undocumented)
+interface ZodBrandedDef<T extends ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    type: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodBranded;
+}
+
+// @public (undocumented)
+class ZodCatch<T extends ZodTypeAny> extends ZodType<T["_output"], ZodCatchDef<T>, unknown> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(type: T_1, params: {
+        errorMap?: ZodErrorMap | undefined;
+        invalid_type_error?: string | undefined;
+        required_error?: string | undefined;
+        message?: string | undefined;
+        description?: string | undefined;
+    } & {
+        catch: T_1["_output"] | (() => T_1["_output"]);
+    }) => ZodCatch<T_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    removeCatch(): T;
+}
+
+// @public (undocumented)
+interface ZodCatchDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    catchValue: (ctx: {
+        error: ZodError;
+        input: unknown;
+    }) => T["_input"];
+    // (undocumented)
+    innerType: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodCatch;
+}
+
+// @public (undocumented)
+type ZodCrossFieldsOptions = ZodTypeDef & {
+    patterns: Array<{
+        test: (root: RspackOptions) => boolean;
+        type: ZodType;
+        issue?: (res: ParseReturnType<any>) => Array<IssueData>;
+    }>;
+    default: ZodType;
+};
+
+// @public (undocumented)
+interface ZodCustomIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.custom;
+    // (undocumented)
+    params?: {
+        [k: string]: any;
+    };
+}
+
+// @public (undocumented)
+class ZodDefault<T extends ZodTypeAny> extends ZodType<util_2.noUndefined<T["_output"]>, ZodDefaultDef<T>, T["_input"] | undefined> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(type: T_1, params: {
+        errorMap?: ZodErrorMap | undefined;
+        invalid_type_error?: string | undefined;
+        required_error?: string | undefined;
+        message?: string | undefined;
+        description?: string | undefined;
+    } & {
+        default: T_1["_input"] | (() => util_2.noUndefined<T_1["_input"]>);
+    }) => ZodDefault<T_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    removeDefault(): T;
+}
+
+// @public (undocumented)
+interface ZodDefaultDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    defaultValue: () => util_2.noUndefined<T["_input"]>;
+    // (undocumented)
+    innerType: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodDefault;
+}
+
+// @public (undocumented)
+class ZodEffects<T extends ZodTypeAny, Output = output<T>, Input = input<T>> extends ZodType<Output, ZodEffectsDef<T>, Input> {
+    // (undocumented)
+    static create: <I extends ZodTypeAny>(schema: I, effect: Effect<I["_output"]>, params?: RawCreateParams) => ZodEffects<I, I["_output"], input<I>>;
+    // (undocumented)
+    static createWithPreprocess: <I extends ZodTypeAny>(preprocess: (arg: unknown, ctx: RefinementCtx) => unknown, schema: I, params?: RawCreateParams) => ZodEffects<I, I["_output"], unknown>;
+    // (undocumented)
+    innerType(): T;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    sourceType(): T;
+}
+
+// @public (undocumented)
+interface ZodEffectsDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    effect: Effect<any>;
+    // (undocumented)
+    schema: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodEffects;
+}
+
+// @public (undocumented)
+class ZodError<T = any> extends Error {
+    constructor(issues: ZodIssue[]);
+    // (undocumented)
+    addIssue: (sub: ZodIssue) => void;
+    // (undocumented)
+    addIssues: (subs?: ZodIssue[]) => void;
+    // (undocumented)
+    static assert(value: unknown): asserts value is ZodError;
+    // (undocumented)
+    static create: (issues: ZodIssue[]) => ZodError<any>;
+    // (undocumented)
+    get errors(): ZodIssue[];
+    // (undocumented)
+    flatten(): typeToFlattenedError<T>;
+    // (undocumented)
+    flatten<U>(mapper?: (issue: ZodIssue) => U): typeToFlattenedError<T, U>;
+    // (undocumented)
+    format(): ZodFormattedError<T>;
+    // (undocumented)
+    format<U>(mapper: (issue: ZodIssue) => U): ZodFormattedError<T, U>;
+    // (undocumented)
+    get formErrors(): typeToFlattenedError<T, string>;
+    // (undocumented)
+    get isEmpty(): boolean;
+    // (undocumented)
+    issues: ZodIssue[];
+    // (undocumented)
+    get message(): string;
+    // (undocumented)
+    toString(): string;
+}
+
+// @public (undocumented)
+type ZodErrorMap = (issue: ZodIssueOptionalMessage, _ctx: ErrorMapCtx) => {
+    message: string;
+};
+
+// @public (undocumented)
+enum ZodFirstPartyTypeKind {
+    // (undocumented)
+    ZodAny = "ZodAny",
+    // (undocumented)
+    ZodArray = "ZodArray",
+    // (undocumented)
+    ZodBigInt = "ZodBigInt",
+    // (undocumented)
+    ZodBoolean = "ZodBoolean",
+    // (undocumented)
+    ZodBranded = "ZodBranded",
+    // (undocumented)
+    ZodCatch = "ZodCatch",
+    // (undocumented)
+    ZodDate = "ZodDate",
+    // (undocumented)
+    ZodDefault = "ZodDefault",
+    // (undocumented)
+    ZodDiscriminatedUnion = "ZodDiscriminatedUnion",
+    // (undocumented)
+    ZodEffects = "ZodEffects",
+    // (undocumented)
+    ZodEnum = "ZodEnum",
+    // (undocumented)
+    ZodFunction = "ZodFunction",
+    // (undocumented)
+    ZodIntersection = "ZodIntersection",
+    // (undocumented)
+    ZodLazy = "ZodLazy",
+    // (undocumented)
+    ZodLiteral = "ZodLiteral",
+    // (undocumented)
+    ZodMap = "ZodMap",
+    // (undocumented)
+    ZodNaN = "ZodNaN",
+    // (undocumented)
+    ZodNativeEnum = "ZodNativeEnum",
+    // (undocumented)
+    ZodNever = "ZodNever",
+    // (undocumented)
+    ZodNull = "ZodNull",
+    // (undocumented)
+    ZodNullable = "ZodNullable",
+    // (undocumented)
+    ZodNumber = "ZodNumber",
+    // (undocumented)
+    ZodObject = "ZodObject",
+    // (undocumented)
+    ZodOptional = "ZodOptional",
+    // (undocumented)
+    ZodPipeline = "ZodPipeline",
+    // (undocumented)
+    ZodPromise = "ZodPromise",
+    // (undocumented)
+    ZodReadonly = "ZodReadonly",
+    // (undocumented)
+    ZodRecord = "ZodRecord",
+    // (undocumented)
+    ZodSet = "ZodSet",
+    // (undocumented)
+    ZodString = "ZodString",
+    // (undocumented)
+    ZodSymbol = "ZodSymbol",
+    // (undocumented)
+    ZodTuple = "ZodTuple",
+    // (undocumented)
+    ZodUndefined = "ZodUndefined",
+    // (undocumented)
+    ZodUnion = "ZodUnion",
+    // (undocumented)
+    ZodUnknown = "ZodUnknown",
+    // (undocumented)
+    ZodVoid = "ZodVoid"
+}
+
+// @public (undocumented)
+type ZodFormattedError<T, U = string> = {
+    _errors: U[];
+} & recursiveZodFormattedError<NonNullable<T>>;
+
+// @public (undocumented)
+class ZodIntersection<T extends ZodTypeAny, U extends ZodTypeAny> extends ZodType<T["_output"] & U["_output"], ZodIntersectionDef<T, U>, T["_input"] & U["_input"]> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny, U_1 extends ZodTypeAny>(left: T_1, right: U_1, params?: RawCreateParams) => ZodIntersection<T_1, U_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+}
+
+// @public (undocumented)
+interface ZodIntersectionDef<T extends ZodTypeAny = ZodTypeAny, U extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    left: T;
+    // (undocumented)
+    right: U;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodIntersection;
+}
+
+// @public (undocumented)
+interface ZodInvalidArgumentsIssue extends ZodIssueBase {
+    // (undocumented)
+    argumentsError: ZodError;
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_arguments;
+}
+
+// @public (undocumented)
+interface ZodInvalidDateIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_date;
+}
+
+// @public (undocumented)
+interface ZodInvalidEnumValueIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_enum_value;
+    // (undocumented)
+    options: (string | number)[];
+    // (undocumented)
+    received: string | number;
+}
+
+// @public (undocumented)
+interface ZodInvalidIntersectionTypesIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_intersection_types;
+}
+
+// @public (undocumented)
+interface ZodInvalidLiteralIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_literal;
+    // (undocumented)
+    expected: unknown;
+    // (undocumented)
+    received: unknown;
+}
+
+// @public (undocumented)
+interface ZodInvalidReturnTypeIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_return_type;
+    // (undocumented)
+    returnTypeError: ZodError;
+}
+
+// @public (undocumented)
+interface ZodInvalidStringIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_string;
+    // (undocumented)
+    validation: StringValidation;
+}
+
+// @public (undocumented)
+interface ZodInvalidTypeIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_type;
+    // (undocumented)
+    expected: ZodParsedType;
+    // (undocumented)
+    received: ZodParsedType;
+}
+
+// @public (undocumented)
+interface ZodInvalidUnionDiscriminatorIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_union_discriminator;
+    // (undocumented)
+    options: Primitive[];
+}
+
+// @public (undocumented)
+interface ZodInvalidUnionIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.invalid_union;
+    // (undocumented)
+    unionErrors: ZodError[];
+}
+
+// @public (undocumented)
+type ZodIssue = ZodIssueOptionalMessage & {
+    fatal?: boolean;
+    message: string;
+};
+
+// @public (undocumented)
+type ZodIssueBase = {
+    path: (string | number)[];
+    message?: string;
+};
+
+// @public (undocumented)
+const ZodIssueCode: {
+    invalid_type: "invalid_type";
+    invalid_literal: "invalid_literal";
+    custom: "custom";
+    invalid_union: "invalid_union";
+    invalid_union_discriminator: "invalid_union_discriminator";
+    invalid_enum_value: "invalid_enum_value";
+    unrecognized_keys: "unrecognized_keys";
+    invalid_arguments: "invalid_arguments";
+    invalid_return_type: "invalid_return_type";
+    invalid_date: "invalid_date";
+    invalid_string: "invalid_string";
+    too_small: "too_small";
+    too_big: "too_big";
+    invalid_intersection_types: "invalid_intersection_types";
+    not_multiple_of: "not_multiple_of";
+    not_finite: "not_finite";
+};
+
+// @public (undocumented)
+type ZodIssueCode = keyof typeof ZodIssueCode;
+
+// @public (undocumented)
+type ZodIssueOptionalMessage = ZodInvalidTypeIssue | ZodInvalidLiteralIssue | ZodUnrecognizedKeysIssue | ZodInvalidUnionIssue | ZodInvalidUnionDiscriminatorIssue | ZodInvalidEnumValueIssue | ZodInvalidArgumentsIssue | ZodInvalidReturnTypeIssue | ZodInvalidDateIssue | ZodInvalidStringIssue | ZodTooSmallIssue | ZodTooBigIssue | ZodInvalidIntersectionTypesIssue | ZodNotMultipleOfIssue | ZodNotFiniteIssue | ZodCustomIssue;
+
+// @public (undocumented)
+interface ZodNotFiniteIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.not_finite;
+}
+
+// @public (undocumented)
+interface ZodNotMultipleOfIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.not_multiple_of;
+    // (undocumented)
+    multipleOf: number | bigint;
+}
+
+// @public (undocumented)
+class ZodNullable<T extends ZodTypeAny> extends ZodType<T["_output"] | null, ZodNullableDef<T>, T["_input"] | null> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(type: T_1, params?: RawCreateParams) => ZodNullable<T_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    unwrap(): T;
+}
+
+// @public (undocumented)
+interface ZodNullableDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    innerType: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodNullable;
+}
+
+// @public (undocumented)
+class ZodOptional<T extends ZodTypeAny> extends ZodType<T["_output"] | undefined, ZodOptionalDef<T>, T["_input"] | undefined> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(type: T_1, params?: RawCreateParams) => ZodOptional<T_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    unwrap(): T;
+}
+
+// @public (undocumented)
+interface ZodOptionalDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    innerType: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodOptional;
+}
+
+// @public (undocumented)
+const ZodParsedType: {
+    function: "function";
+    number: "number";
+    string: "string";
+    nan: "nan";
+    integer: "integer";
+    float: "float";
+    boolean: "boolean";
+    date: "date";
+    bigint: "bigint";
+    symbol: "symbol";
+    undefined: "undefined";
+    null: "null";
+    array: "array";
+    object: "object";
+    unknown: "unknown";
+    promise: "promise";
+    void: "void";
+    never: "never";
+    map: "map";
+    set: "set";
+};
+
+// @public (undocumented)
+type ZodParsedType = keyof typeof ZodParsedType;
+
+// @public (undocumented)
+class ZodPipeline<A extends ZodTypeAny, B extends ZodTypeAny> extends ZodType<B["_output"], ZodPipelineDef<A, B>, A["_input"]> {
+    // (undocumented)
+    static create<A extends ZodTypeAny, B extends ZodTypeAny>(a: A, b: B): ZodPipeline<A, B>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<any>;
+}
+
+// @public (undocumented)
+interface ZodPipelineDef<A extends ZodTypeAny, B extends ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    in: A;
+    // (undocumented)
+    out: B;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodPipeline;
+}
+
+// @public (undocumented)
+class ZodPromise<T extends ZodTypeAny> extends ZodType<Promise<T["_output"]>, ZodPromiseDef<T>, Promise<T["_input"]>> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(schema: T_1, params?: RawCreateParams) => ZodPromise<T_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    unwrap(): T;
+}
+
+// @public (undocumented)
+interface ZodPromiseDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    type: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodPromise;
+}
+
+// @public (undocumented)
+class ZodReadonly<T extends ZodTypeAny> extends ZodType<MakeReadonly<T["_output"]>, ZodReadonlyDef<T>, MakeReadonly<T["_input"]>> {
+    // (undocumented)
+    static create: <T_1 extends ZodTypeAny>(type: T_1, params?: RawCreateParams) => ZodReadonly<T_1>;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+    // (undocumented)
+    unwrap(): T;
+}
+
+// @public (undocumented)
+interface ZodReadonlyDef<T extends ZodTypeAny = ZodTypeAny> extends ZodTypeDef {
+    // (undocumented)
+    innerType: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodReadonly;
+}
+
+// @public (undocumented)
+class ZodRspackCrossChecker<T> extends ZodType<T> {
+    constructor(params: ZodCrossFieldsOptions);
+    // (undocumented)
+    _getRootData(ctx: z.ParseContext): any;
+    // (undocumented)
+    _parse(input: z.ParseInput): z.ParseReturnType<T>;
+}
+
+// @public (undocumented)
+interface ZodTooBigIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.too_big;
+    // (undocumented)
+    exact?: boolean;
+    // (undocumented)
+    inclusive: boolean;
+    // (undocumented)
+    maximum: number | bigint;
+    // (undocumented)
+    type: "array" | "string" | "number" | "set" | "date" | "bigint";
+}
+
+// @public (undocumented)
+interface ZodTooSmallIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.too_small;
+    // (undocumented)
+    exact?: boolean;
+    // (undocumented)
+    inclusive: boolean;
+    // (undocumented)
+    minimum: number | bigint;
+    // (undocumented)
+    type: "array" | "string" | "number" | "set" | "date" | "bigint";
+}
+
+// @public (undocumented)
+abstract class ZodType<Output = any, Def extends ZodTypeDef = ZodTypeDef, Input = Output> {
+    constructor(def: Def);
+    // (undocumented)
+    and<T extends ZodTypeAny>(incoming: T): ZodIntersection<this, T>;
+    // (undocumented)
+    array(): ZodArray<this>;
+    // (undocumented)
+    brand<B extends string | number | symbol>(brand?: B): ZodBranded<this, B>;
+    // (undocumented)
+    catch(def: Output): ZodCatch<this>;
+    // (undocumented)
+    catch(def: (ctx: {
+        error: ZodError;
+        input: Input;
+    }) => Output): ZodCatch<this>;
+    // (undocumented)
+    readonly _def: Def;
+    // (undocumented)
+    default(def: util_2.noUndefined<Input>): ZodDefault<this>;
+    // (undocumented)
+    default(def: () => util_2.noUndefined<Input>): ZodDefault<this>;
+    // (undocumented)
+    describe(description: string): this;
+    // (undocumented)
+    get description(): string | undefined;
+    // (undocumented)
+    _getOrReturnCtx(input: ParseInput, ctx?: ParseContext | undefined): ParseContext;
+    // (undocumented)
+    _getType(input: ParseInput): string;
+    // (undocumented)
+    readonly _input: Input;
+    // (undocumented)
+    isNullable(): boolean;
+    // (undocumented)
+    isOptional(): boolean;
+    // (undocumented)
+    nullable(): ZodNullable<this>;
+    // (undocumented)
+    nullish(): ZodOptional<ZodNullable<this>>;
+    // (undocumented)
+    optional(): ZodOptional<this>;
+    // (undocumented)
+    or<T extends ZodTypeAny>(option: T): ZodUnion<[this, T]>;
+    // (undocumented)
+    readonly _output: Output;
+    // (undocumented)
+    parse(data: unknown, params?: Partial<ParseParams>): Output;
+    // (undocumented)
+    abstract _parse(input: ParseInput): ParseReturnType<Output>;
+    // (undocumented)
+    parseAsync(data: unknown, params?: Partial<ParseParams>): Promise<Output>;
+    // (undocumented)
+    _parseAsync(input: ParseInput): AsyncParseReturnType<Output>;
+    // (undocumented)
+    _parseSync(input: ParseInput): SyncParseReturnType<Output>;
+    // (undocumented)
+    pipe<T extends ZodTypeAny>(target: T): ZodPipeline<this, T>;
+    // (undocumented)
+    _processInputParams(input: ParseInput): {
+        status: ParseStatus;
+        ctx: ParseContext;
+    };
+    // (undocumented)
+    promise(): ZodPromise<this>;
+    // (undocumented)
+    readonly(): ZodReadonly<this>;
+    // (undocumented)
+    refine<RefinedOutput extends Output>(check: (arg: Output) => arg is RefinedOutput, message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)): ZodEffects<this, RefinedOutput, Input>;
+    // (undocumented)
+    refine(check: (arg: Output) => unknown | Promise<unknown>, message?: string | CustomErrorParams | ((arg: Output) => CustomErrorParams)): ZodEffects<this, Output, Input>;
+    // (undocumented)
+    refinement<RefinedOutput extends Output>(check: (arg: Output) => arg is RefinedOutput, refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)): ZodEffects<this, RefinedOutput, Input>;
+    // (undocumented)
+    refinement(check: (arg: Output) => boolean, refinementData: IssueData | ((arg: Output, ctx: RefinementCtx) => IssueData)): ZodEffects<this, Output, Input>;
+    // (undocumented)
+    _refinement(refinement: RefinementEffect<Output>["refinement"]): ZodEffects<this, Output, Input>;
+    // (undocumented)
+    safeParse(data: unknown, params?: Partial<ParseParams>): SafeParseReturnType<Input, Output>;
+    // (undocumented)
+    safeParseAsync(data: unknown, params?: Partial<ParseParams>): Promise<SafeParseReturnType<Input, Output>>;
+    spa: (data: unknown, params?: Partial<ParseParams> | undefined) => Promise<SafeParseReturnType<Input, Output>>;
+    // (undocumented)
+    superRefine<RefinedOutput extends Output>(refinement: (arg: Output, ctx: RefinementCtx) => arg is RefinedOutput): ZodEffects<this, RefinedOutput, Input>;
+    // (undocumented)
+    superRefine(refinement: (arg: Output, ctx: RefinementCtx) => void): ZodEffects<this, Output, Input>;
+    // (undocumented)
+    superRefine(refinement: (arg: Output, ctx: RefinementCtx) => Promise<void>): ZodEffects<this, Output, Input>;
+    // (undocumented)
+    transform<NewOut>(transform: (arg: Output, ctx: RefinementCtx) => NewOut | Promise<NewOut>): ZodEffects<this, NewOut>;
+    // (undocumented)
+    readonly _type: Output;
+}
+
+// @public (undocumented)
+type ZodTypeAny = ZodType<any, any, any>;
+
+// @public (undocumented)
+interface ZodTypeDef {
+    // (undocumented)
+    description?: string;
+    // (undocumented)
+    errorMap?: ZodErrorMap;
+}
+
+// @public (undocumented)
+class ZodUnion<T extends ZodUnionOptions> extends ZodType<T[number]["_output"], ZodUnionDef<T>, T[number]["_input"]> {
+    // (undocumented)
+    static create: <T_1 extends readonly [ZodTypeAny, ZodTypeAny, ...ZodTypeAny[]]>(types: T_1, params?: RawCreateParams) => ZodUnion<T_1>;
+    // (undocumented)
+    get options(): T;
+    // (undocumented)
+    _parse(input: ParseInput): ParseReturnType<this["_output"]>;
+}
+
+// @public (undocumented)
+interface ZodUnionDef<T extends ZodUnionOptions = Readonly<[
+ZodTypeAny,
+ZodTypeAny,
+...ZodTypeAny[]
+]>> extends ZodTypeDef {
+    // (undocumented)
+    options: T;
+    // (undocumented)
+    typeName: ZodFirstPartyTypeKind.ZodUnion;
+}
+
+// @public (undocumented)
+type ZodUnionOptions = Readonly<[ZodTypeAny, ...ZodTypeAny[]]>;
+
+// @public (undocumented)
+interface ZodUnrecognizedKeysIssue extends ZodIssueBase {
+    // (undocumented)
+    code: typeof ZodIssueCode.unrecognized_keys;
+    // (undocumented)
+    keys: string[];
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1333,7 +1333,7 @@ export type ExternalItemValue =
 			root: string | string[];
 			commonjs: string | string[];
 			commonjs2: string | string[];
-			amd?: string | string[];
+			amd: string | string[];
 	  };
 
 /**

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1319,6 +1319,22 @@ export type ExternalsType =
 //#endregion
 
 //#region Externals
+
+/**
+ * External item object when both libraryTarget and externalsType is 'umd'
+ */
+export type ExternalItemUmdValue = {
+	root: string | string[];
+	commonjs: string | string[];
+	commonjs2: string | string[];
+	amd: string | string[];
+};
+
+/**
+ * External item object when not umd
+ */
+export type ExternalItemObjectValue = Record<string, string | string[]>;
+
 /**
  * The dependency used for the external.
  */
@@ -1326,15 +1342,11 @@ export type ExternalItemValue =
 	| string
 	| boolean
 	| string[]
-	| {
-			/**
-			 * only available when libraryTarget and externalsType is 'umd'
-			 */
-			root: string | string[];
-			commonjs: string | string[];
-			commonjs2: string | string[];
-			amd: string | string[];
-	  };
+	| ExternalItemUmdValue
+	/**
+	 * when libraryTarget and externalsType is not 'umd'
+	 */
+	| ExternalItemObjectValue;
 
 /**
  * If an dependency matches exactly a property of the object, the property value is used as dependency.

--- a/packages/rspack/src/config/utils.ts
+++ b/packages/rspack/src/config/utils.ts
@@ -22,6 +22,16 @@ import {
 } from "zod";
 import type { RspackOptions } from "./types";
 
+/**
+ * The following code is modified based on
+ * https://github.com/colinhacks/zod/blob/f487d74ecd3ae703ef8932462d14d643e31658b3/src/types.ts
+ *
+ * MIT Licensed
+ * Author Colin McDonnell @colinhacks
+ * MIT License
+ * https://github.com/colinhacks/zod/blob/main/LICENSE
+ */
+
 function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
 	if (!params) return {};
 	const { errorMap, invalid_type_error, required_error, description } = params;
@@ -48,7 +58,7 @@ function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
 
 /**
  * Modified `z.union` for overriding its `_parse` to support `parent` field of context.
- * https://github.com/colinhacks/zod/blob/f487d74ecd3ae703ef8932462d14d643e31658b3/src/types.ts#L2935-L3034
+ *
  * We need to use `parent` field to get the root config object.
  */
 class RspackZodUnion<T extends ZodUnionOptions> extends z.ZodUnion<T> {

--- a/packages/rspack/src/config/utils.ts
+++ b/packages/rspack/src/config/utils.ts
@@ -1,0 +1,208 @@
+import {
+	type DIRTY,
+	INVALID,
+	type IssueData,
+	type ParseContext,
+	type ParseInput,
+	type ParseReturnType,
+	type ProcessedCreateParams,
+	type RawCreateParams,
+	type SyncParseReturnType,
+	ZodError,
+	type ZodErrorMap,
+	ZodFirstPartyTypeKind,
+	type ZodIssue,
+	ZodIssueCode,
+	ZodType,
+	type ZodTypeDef,
+	ZodUnion,
+	type ZodUnionOptions,
+	addIssueToContext,
+	z
+} from "zod";
+import type { RspackOptions } from "./types";
+
+function processCreateParams(params: RawCreateParams): ProcessedCreateParams {
+	if (!params) return {};
+	const { errorMap, invalid_type_error, required_error, description } = params;
+	if (errorMap && (invalid_type_error || required_error)) {
+		throw new Error(
+			`Can't use "invalid_type_error" or "required_error" in conjunction with custom error map.`
+		);
+	}
+	if (errorMap) return { errorMap: errorMap, description };
+	const customMap: ZodErrorMap = (iss, ctx) => {
+		const { message } = params;
+
+		if (iss.code === "invalid_enum_value") {
+			return { message: message ?? ctx.defaultError };
+		}
+		if (typeof ctx.data === "undefined") {
+			return { message: message ?? required_error ?? ctx.defaultError };
+		}
+		if (iss.code !== "invalid_type") return { message: ctx.defaultError };
+		return { message: message ?? invalid_type_error ?? ctx.defaultError };
+	};
+	return { errorMap: customMap, description };
+}
+
+/**
+ * Modified `z.union` for overriding its `_parse` to support `parent` field of context.
+ * https://github.com/colinhacks/zod/blob/f487d74ecd3ae703ef8932462d14d643e31658b3/src/types.ts#L2935-L3034
+ * We need to use `parent` field to get the root config object.
+ */
+class RspackZodUnion<T extends ZodUnionOptions> extends z.ZodUnion<T> {
+	_parse(input: ParseInput): ParseReturnType<this["_output"]> {
+		const { ctx } = this._processInputParams(input);
+		const options = this._def.options;
+
+		function handleResults(
+			results: { ctx: ParseContext; result: SyncParseReturnType<any> }[]
+		) {
+			// return first issue-free validation if it exists
+			for (const result of results) {
+				if (result.result.status === "valid") {
+					return result.result;
+				}
+			}
+
+			for (const result of results) {
+				if (result.result.status === "dirty") {
+					// add issues from dirty option
+
+					ctx.common.issues.push(...result.ctx.common.issues);
+					return result.result;
+				}
+			}
+
+			// return invalid
+			const unionErrors = results.map(
+				result => new ZodError(result.ctx.common.issues)
+			);
+
+			addIssueToContext(ctx, {
+				code: ZodIssueCode.invalid_union,
+				unionErrors
+			});
+			return INVALID;
+		}
+
+		if (ctx.common.async) {
+			return Promise.all(
+				options.map(async option => {
+					const childCtx: ParseContext = {
+						...ctx,
+						common: {
+							...ctx.common,
+							issues: []
+						},
+						parent: ctx
+					};
+					return {
+						result: await option._parseAsync({
+							data: ctx.data,
+							path: ctx.path,
+							parent: childCtx
+						}),
+						ctx: childCtx
+					};
+				})
+			).then(handleResults);
+		}
+		let dirty: undefined | { result: DIRTY<any>; ctx: ParseContext } =
+			undefined;
+		const issues: ZodIssue[][] = [];
+		for (const option of options) {
+			const childCtx: ParseContext = {
+				...ctx,
+				common: {
+					...ctx.common,
+					issues: []
+				},
+				parent: ctx
+			};
+			const result = option._parseSync({
+				data: ctx.data,
+				path: ctx.path,
+				parent: childCtx
+			});
+
+			if (result.status === "valid") {
+				return result;
+			}
+
+			if (result.status === "dirty" && !dirty) {
+				dirty = { result, ctx: childCtx };
+			}
+
+			if (childCtx.common.issues.length) {
+				issues.push(childCtx.common.issues);
+			}
+		}
+
+		if (dirty) {
+			ctx.common.issues.push(...dirty.ctx.common.issues);
+			return dirty.result;
+		}
+
+		const unionErrors = issues.map(issues => new ZodError(issues));
+		addIssueToContext(ctx, {
+			code: ZodIssueCode.invalid_union,
+			unionErrors
+		});
+
+		return INVALID;
+	}
+
+	static create = <T extends ZodUnionOptions>(
+		types: T,
+		params?: RawCreateParams
+	): ZodUnion<T> => {
+		return new RspackZodUnion({
+			options: types,
+			typeName: ZodFirstPartyTypeKind.ZodUnion,
+			...processCreateParams(params)
+		});
+	};
+}
+
+ZodUnion.create = RspackZodUnion.create;
+
+export type ZodCrossFieldsOptions = ZodTypeDef & {
+	patterns: Array<{
+		test: (root: RspackOptions) => boolean;
+		type: ZodType;
+		issue?: (res: ParseReturnType<any>) => Array<IssueData>;
+	}>;
+	default: ZodType;
+};
+
+export class ZodRspackCrossChecker<T> extends ZodType<T> {
+	constructor(private params: ZodCrossFieldsOptions) {
+		super(params);
+	}
+	_parse(input: z.ParseInput): z.ParseReturnType<T> {
+		const ctx = this._getOrReturnCtx(input);
+		const root = this._getRootData(ctx);
+
+		for (const pattern of this.params.patterns) {
+			if (pattern.test(root)) {
+				const res = pattern.type._parse(input);
+				const issues =
+					typeof pattern.issue === "function" ? pattern.issue(res) : [];
+				for (const issue of issues) {
+					addIssueToContext(ctx, issue);
+				}
+				return res;
+			}
+		}
+		return this.params.default._parse(input);
+	}
+	_getRootData(ctx: z.ParseContext) {
+		let root = ctx;
+		while (root.parent) {
+			root = root.parent;
+		}
+		return root.data;
+	}
+}

--- a/packages/rspack/src/config/zod.ts
+++ b/packages/rspack/src/config/zod.ts
@@ -804,7 +804,7 @@ const externalItemValue = z
 			root: z.string().or(z.string().array()),
 			commonjs: z.string().or(z.string().array()),
 			commonjs2: z.string().or(z.string().array()),
-			amd: z.string().or(z.string().array()).optional()
+			amd: z.string().or(z.string().array())
 		})
 	) satisfies z.ZodType<t.ExternalItemValue>;
 

--- a/scripts/test/ignore-snapshot-default-reporter.cjs
+++ b/scripts/test/ignore-snapshot-default-reporter.cjs
@@ -15,23 +15,21 @@ function getSnapshotStatus(snapshot, afterUpdate) {
 	if (snapshot.added) {
 		statuses.push(
 			SNAPSHOT_ADDED(
-				`${ARROW + jestUtil().pluralize("snapshot", snapshot.added)} written.`
+				`${ARROW + jestUtil.pluralize("snapshot", snapshot.added)} written.`
 			)
 		);
 	}
 	if (snapshot.updated) {
 		statuses.push(
 			SNAPSHOT_UPDATED(
-				`${ARROW + jestUtil().pluralize("snapshot", snapshot.updated)} updated.`
+				`${ARROW + jestUtil.pluralize("snapshot", snapshot.updated)} updated.`
 			)
 		);
 	}
 	if (snapshot.unmatched) {
 		statuses.push(
 			FAIL_COLOR(
-				`${
-					ARROW + jestUtil().pluralize("snapshot", snapshot.unmatched)
-				} failed.`
+				`${ARROW + jestUtil.pluralize("snapshot", snapshot.unmatched)} failed.`
 			)
 		);
 	}
@@ -40,7 +38,7 @@ function getSnapshotStatus(snapshot, afterUpdate) {
 			statuses.push(
 				SNAPSHOT_UPDATED(
 					`${
-						ARROW + jestUtil().pluralize("snapshot", snapshot.unchecked)
+						ARROW + jestUtil.pluralize("snapshot", snapshot.unchecked)
 					} removed.`
 				)
 			);
@@ -51,7 +49,7 @@ function getSnapshotStatus(snapshot, afterUpdate) {
 			statuses.push(
 				`${SNAPSHOT_OUTDATED(
 					`${
-						ARROW + jestUtil().pluralize("snapshot", snapshot.unchecked)
+						ARROW + jestUtil.pluralize("snapshot", snapshot.unchecked)
 					} obsolete`
 				)}.`
 			);

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -117,13 +117,8 @@ An object with `{ root, commonjs, commonjs2, amd, ... }` is only allowed for [`l
 
 ```js title="rspack.config.js"
 module.exports = {
-  //...
   externals: {
-    react: 'react',
-  },
-
-  // or
-  externals: {
+    // When `libraryTarget: 'umd'` and `externalsType: 'umd'`, the following format must be strictly followed:
     lodash: {
       root: '_', // indicates global variable
       commonjs: 'lodash',

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -112,7 +112,7 @@ module.exports = {
 ### object
 
 :::warning
-An object with `{ root, commonjs, commonjs2, amd?, ... }` is only allowed for [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) and [`externalsType: 'umd'`](#externalstype). It's not allowed for other library targets.
+An object with `{ root, commonjs, commonjs2, amd, ... }` is only allowed for [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) and [`externalsType: 'umd'`](#externalstype). It's not allowed for other library targets.
 :::
 
 ```js title="rspack.config.js"
@@ -125,10 +125,10 @@ module.exports = {
   // or
   externals: {
     lodash: {
-      root: '_', // required, indicates global variable
-      commonjs: 'lodash', // required
-      commonjs2: 'lodash', // required
-      amd: 'lodash', // optional
+      root: '_', // indicates global variable
+      commonjs: 'lodash',
+      commonjs2: 'lodash',
+      amd: 'lodash',
     },
   },
 };

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -117,14 +117,8 @@ module.exports = {
 
 ```js title="rspack.config.js"
 module.exports = {
-  //...
   externals: {
-    react: 'react',
-  },
-
-  // 或者
-
-  externals: {
+    // 在 `libraryTarget: 'umd'` 和 `externalsType: 'umd'` 时，需严格遵循以下格式：
     lodash: {
       root: '_', // 指向全局变量
       commonjs: 'lodash',

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -112,7 +112,7 @@ module.exports = {
 ### 对象
 
 :::warning
-带有 `{ root, commonjs, commonjs2, amd?, ... }` 的对象只允许用于 [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) 和 [`externalsType: 'umd'`](#externalstype)。其他库的 target 不允许这样做。
+带有 `{ root, commonjs, commonjs2, amd, ... }` 的对象只允许用于 [`libraryTarget: 'umd'`](/config/output#outputlibrarytarget) 和 [`externalsType: 'umd'`](#externalstype)。其他库的 target 不允许这样做。
 :::
 
 ```js title="rspack.config.js"
@@ -126,10 +126,10 @@ module.exports = {
 
   externals: {
     lodash: {
-      root: '_', // 必须，指向全局变量
-      commonjs: 'lodash', // 必须
-      commonjs2: 'lodash', // 必须
-      amd: 'lodash', // 可选
+      root: '_', // 指向全局变量
+      commonjs: 'lodash',
+      commonjs2: 'lodash',
+      amd: 'lodash',
     },
   },
 };


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

https://github.com/web-infra-dev/rspack/pull/8286/files#r1831012797

Cause lots of projects use object item of `externals` when not `umd` and it can actually work well. For example:

```js
module.exports = {
  output: {
     library: {
       type: "commonjs"
     }
  },
  externalsType: "commonjs",
  externals: {
    // actually same as: `react: "REACT"` or `react: "commonjs REACT"`
    react: {
      commonjs: "REACT"
    }
  }
};
```

 so if we just add a strict object validation to object item of `externals`, it will be a breaking change to these projects.

The object item of `externals` should be validate according to the values of `output.library.type/output.libraryTarget` and `externalsType`. Only if `output.library.type/output.libraryTarget` is set to `umd` and `externalsType` is not set or also set to `umd`, the object item in `externals` should be handle as an umd dependency. 

We can add a new ZodType named `ZodCrossFieldsOptions` to validate the object item in `externals`. In its `_parse` method we can get the zod context, and then get its root context through its `parent` field. Then we can do some checking cross configuration options and make sure that the object item in `externals` should only be validated when it is really handle as an umd dependency.

But there is a trick in `ZodUnion`. The `parent` field is set to `null` [here](https://github.com/colinhacks/zod/blob/f487d74ecd3ae703ef8932462d14d643e31658b3/src/types.ts#L2979). Not sure if it is a bug or not. So we need to override the `ZodUnion._parse` to pass the `parent` context to children like other `ZodType` does.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
