### PR TITLE
refactor: rename async_run to background_run & sync_run to main_run

### DIFF
--- a/crates/rspack_core/src/compiler/make/repair/add.rs
+++ b/crates/rspack_core/src/compiler/make/repair/add.rs
@@ -21,7 +21,7 @@ impl Task<MakeTaskContext> for AddTask {
   fn get_task_type(&self) -> TaskType {
     TaskType::Sync
   }
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let module_identifier = self.module.identifier();
     let artifact = &mut context.artifact;
     let module_graph =

--- a/crates/rspack_core/src/compiler/make/repair/build.rs
+++ b/crates/rspack_core/src/compiler/make/repair/build.rs
@@ -26,7 +26,7 @@ impl Task<MakeTaskContext> for BuildTask {
   fn get_task_type(&self) -> TaskType {
     TaskType::Async
   }
-  async fn async_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
+  async fn background_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
     let Self {
       compilation_id,
       compiler_options,
@@ -102,7 +102,7 @@ impl Task<MakeTaskContext> for BuildResultTask {
   fn get_task_type(&self) -> TaskType {
     TaskType::Sync
   }
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let BuildResultTask {
       mut module,
       build_result,

--- a/crates/rspack_core/src/compiler/make/repair/factorize.rs
+++ b/crates/rspack_core/src/compiler/make/repair/factorize.rs
@@ -33,7 +33,7 @@ impl Task<MakeTaskContext> for FactorizeTask {
   fn get_task_type(&self) -> TaskType {
     TaskType::Async
   }
-  async fn async_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
+  async fn background_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
     if let Some(current_profile) = &self.current_profile {
       current_profile.mark_factory_start();
     }
@@ -204,7 +204,7 @@ impl Task<MakeTaskContext> for FactorizeResultTask {
   fn get_task_type(&self) -> TaskType {
     TaskType::Sync
   }
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let FactorizeResultTask {
       original_module_identifier,
       factory_result,

--- a/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
+++ b/crates/rspack_core/src/compiler/make/repair/process_dependencies.rs
@@ -19,7 +19,7 @@ impl Task<MakeTaskContext> for ProcessDependenciesTask {
     TaskType::Sync
   }
 
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let Self {
       original_module_identifier,
       dependencies,

--- a/crates/rspack_core/src/compiler/module_executor/ctrl.rs
+++ b/crates/rspack_core/src/compiler/module_executor/ctrl.rs
@@ -104,7 +104,7 @@ impl Task<MakeTaskContext> for CtrlTask {
     TaskType::Async
   }
 
-  async fn async_run(mut self: Box<Self>) -> TaskResult<MakeTaskContext> {
+  async fn background_run(mut self: Box<Self>) -> TaskResult<MakeTaskContext> {
     while let Some(event) = self.event_receiver.recv().await {
       tracing::info!("CtrlTask async receive {:?}", event);
       match event {
@@ -202,7 +202,7 @@ impl Task<MakeTaskContext> for FinishModuleTask {
     TaskType::Sync
   }
 
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let Self {
       mut ctrl_task,
       module_identifier,

--- a/crates/rspack_core/src/compiler/module_executor/entry.rs
+++ b/crates/rspack_core/src/compiler/module_executor/entry.rs
@@ -15,7 +15,7 @@ impl Task<MakeTaskContext> for EntryTask {
     TaskType::Sync
   }
 
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let Self { dep, layer } = *self;
     let mut module_graph =
       MakeTaskContext::get_module_graph_mut(&mut context.artifact.module_graph_partial);

--- a/crates/rspack_core/src/compiler/module_executor/execute.rs
+++ b/crates/rspack_core/src/compiler/module_executor/execute.rs
@@ -60,7 +60,7 @@ impl Task<MakeTaskContext> for ExecuteTask {
     TaskType::Sync
   }
 
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let Self {
       entry_dep_id,
       layer,

--- a/crates/rspack_core/src/compiler/module_executor/overwrite.rs
+++ b/crates/rspack_core/src/compiler/module_executor/overwrite.rs
@@ -21,7 +21,7 @@ impl Task<MakeTaskContext> for OverwriteTask {
     self.origin_task.get_task_type()
   }
 
-  async fn sync_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
+  async fn main_run(self: Box<Self>, context: &mut MakeTaskContext) -> TaskResult<MakeTaskContext> {
     let Self {
       origin_task,
       event_sender,
@@ -32,7 +32,7 @@ impl Task<MakeTaskContext> for OverwriteTask {
       .downcast_ref::<ProcessDependenciesTask>()
     {
       let original_module_identifier = process_dependencies_task.original_module_identifier;
-      let res = origin_task.sync_run(context).await?;
+      let res = origin_task.main_run(context).await?;
       event_sender
         .send(Event::FinishModule(original_module_identifier, res.len()))
         .expect("should success");
@@ -44,7 +44,7 @@ impl Task<MakeTaskContext> for OverwriteTask {
     {
       let dep_id = *factorize_result_task.dependencies[0].id();
       let original_module_identifier = factorize_result_task.original_module_identifier;
-      let res = origin_task.sync_run(context).await?;
+      let res = origin_task.main_run(context).await?;
       if res.is_empty() {
         event_sender
           .send(Event::FinishDeps(original_module_identifier, dep_id, None))
@@ -58,7 +58,7 @@ impl Task<MakeTaskContext> for OverwriteTask {
       let original_module_identifier = add_task.original_module_identifier;
       let target_module_identifier = add_task.module.identifier();
 
-      let res = origin_task.sync_run(context).await?;
+      let res = origin_task.main_run(context).await?;
       if res.is_empty() {
         event_sender
           .send(Event::FinishDeps(
@@ -76,10 +76,10 @@ impl Task<MakeTaskContext> for OverwriteTask {
     }
 
     // other task
-    origin_task.sync_run(context).await
+    origin_task.main_run(context).await
   }
 
-  async fn async_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
-    self.origin_task.async_run().await
+  async fn background_run(self: Box<Self>) -> TaskResult<MakeTaskContext> {
+    self.origin_task.background_run().await
   }
 }


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
`sync_run` is actually a async function now, so the `sync_run` name is kind of awkward, what `async_run` and `sync_run` actually means is 
* `sync_run`: can only be running in main thread(the thread drives task_loop), cause it can exclusively access mutable global state
* `async_run`: can be running in background threads
so I think run_in_main_thread and run_in_backgrund_thread is more accurate, but it's too verbose
so change `sync_run` to `main_run` and `async_run` to `background_run`

I'm open to better name cause I don't think these two names are perfect

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
