### PR TITLE
fix: css runtime should have hmr handler when lazy-compilation

### DIFF
--- a/crates/rspack_core/src/compiler/compilation.rs
+++ b/crates/rspack_core/src/compiler/compilation.rs
@@ -1408,6 +1408,9 @@ impl Compilation {
       let mut runtime_requirements;
 
       loop {
+        // runtime_requirements: rt_requirements of last time
+        // runtime_requirements_mut: changed rt_requirements
+        // requirements: all rt_requirements
         runtime_requirements = runtime_requirements_mut;
         runtime_requirements_mut = RuntimeGlobals::default();
         call_hook(
@@ -1415,6 +1418,8 @@ impl Compilation {
           &runtime_requirements,
           &mut runtime_requirements_mut,
         )?;
+
+        // check if we have changes to runtime_requirements
         runtime_requirements_mut =
           runtime_requirements_mut.difference(requirements.intersection(runtime_requirements_mut));
         if runtime_requirements_mut.is_empty() {
@@ -1891,6 +1896,7 @@ impl Compilation {
     let runtime_module_identifier =
       ModuleIdentifier::from(format!("{}/{}", &chunk.runtime, module.identifier()));
     module.attach(*chunk_ukey);
+
     self.chunk_graph.add_module(runtime_module_identifier);
     self
       .chunk_graph

--- a/packages/playground/cases/lazy-compilation/css-update/index.test.ts
+++ b/packages/playground/cases/lazy-compilation/css-update/index.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "@/fixtures";
+
+test("should update style", async ({ page }) => {
+	const body = await page.$("body");
+	const backgroundColor = await body!.evaluate(
+		el => window.getComputedStyle(el).backgroundColor
+	);
+	// first time enter the page, style is red
+	expect(backgroundColor, "red");
+
+	// second time enter the page, this time brings query,
+	// trigger lazy-compile
+	const url = await body!.evaluate(() => window.location.href);
+	await page.goto(`${url}?1`);
+	const updatedBody = await page.$("body");
+	const updatedBackgroundColor = await updatedBody!.evaluate(
+		el => window.getComputedStyle(el).backgroundColor
+	);
+	// first time enter the page, style is red
+	expect(updatedBackgroundColor, "blue");
+});

--- a/packages/playground/cases/lazy-compilation/css-update/rspack.config.js
+++ b/packages/playground/cases/lazy-compilation/css-update/rspack.config.js
@@ -1,0 +1,37 @@
+const rspack = require("@rspack/core");
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+	context: __dirname,
+	entry: "./src/index.js",
+	mode: "development",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [rspack.CssExtractRspackPlugin.loader, "css-loader"]
+			}
+		]
+	},
+	plugins: [new rspack.HtmlRspackPlugin(), new rspack.CssExtractRspackPlugin()],
+	experiments: {
+		css: false,
+		lazyCompilation: true
+	},
+	optimization: {
+		splitChunks: {
+			minSize: 0,
+			chunks: "all",
+			cacheGroups: {
+				styles: {
+					test: /\.css$/,
+					name: "style.css"
+				}
+			}
+		}
+	},
+	devServer: {
+		hot: true,
+		port: 5678
+	}
+};

--- a/packages/playground/cases/lazy-compilation/css-update/src/blue.css
+++ b/packages/playground/cases/lazy-compilation/css-update/src/blue.css
@@ -1,0 +1,3 @@
+body {
+	background-color: blue;
+}

--- a/packages/playground/cases/lazy-compilation/css-update/src/change.js
+++ b/packages/playground/cases/lazy-compilation/css-update/src/change.js
@@ -1,0 +1,1 @@
+import "./blue.css";

--- a/packages/playground/cases/lazy-compilation/css-update/src/index.js
+++ b/packages/playground/cases/lazy-compilation/css-update/src/index.js
@@ -1,0 +1,6 @@
+import "./red.css";
+
+if (new URL(window.location.href).search) {
+	// @ts-expect-error change.js no dts
+	import("./change.js");
+}

--- a/packages/playground/cases/lazy-compilation/css-update/src/red.css
+++ b/packages/playground/cases/lazy-compilation/css-update/src/red.css
@@ -1,0 +1,3 @@
+body {
+	background-color: red;
+}

--- a/tests/plugin-test/css-extract/cases/runtime/expected/runtime~main.js
+++ b/tests/plugin-test/css-extract/cases/runtime/expected/runtime~main.js
@@ -94,6 +94,17 @@ __webpack_require__.e = function (chunkId) {
         };
       
 })();
+// webpack/runtime/get mini-css chunk filename
+(() => {
+// This function allow to reference chunks
+        __webpack_require__.miniCssF = function (chunkId) {
+          // return url for filenames not based on template
+          
+          // return url for filenames based on template
+          return "" + chunkId + ".css";
+        };
+      
+})();
 // webpack/runtime/global
 (() => {
 __webpack_require__.g = (function () {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

The hook `runtimeRequirementInTree` is different compared to webpack, we have current `runtime_requirements` represents current runtime_requirements, `all_runtime_requirements` represents all runtime_requirements, when insert a new RuntimeModule, the module should not depend on runtimeGlobals on runtime_requirements, it should use correct runtime_requirements at codegen phase

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
