### PR TITLE
fix: rebuild should reset module.preOrderIndex

### DIFF
--- a/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
+++ b/crates/rspack_core/src/old_cache/local/code_splitting_cache.rs
@@ -6,7 +6,7 @@ use tracing::instrument;
 
 use crate::{
   build_chunk_graph::code_splitter::CodeSplitter, incremental::IncrementalPasses, ChunkByUkey,
-  ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
+  ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation, ModuleIdentifier,
 };
 
 #[derive(Debug, Default)]
@@ -19,6 +19,7 @@ pub struct CodeSplittingCache {
   named_chunk_groups: HashMap<String, ChunkGroupUkey>,
   named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
+  pub(crate) module_idx: HashMap<ModuleIdentifier, (u32, u32)>,
 }
 
 #[instrument(skip_all)]
@@ -55,6 +56,17 @@ where
       s.spawn(|_| compilation.named_chunks = cache.named_chunks.clone());
     });
 
+    let module_idx = cache.module_idx.clone();
+    let mut module_graph = compilation.get_module_graph_mut();
+    for (m, (pre, post)) in module_idx {
+      let Some(mgm) = module_graph.module_graph_module_by_identifier_mut(&m) else {
+        continue;
+      };
+
+      mgm.pre_order_index = Some(pre);
+      mgm.post_order_index = Some(post);
+    }
+
     if !has_change {
       return Ok(());
     }
@@ -71,5 +83,21 @@ where
     s.spawn(|_| cache.named_chunk_groups = compilation.named_chunk_groups.clone());
     s.spawn(|_| cache.named_chunks = compilation.named_chunks.clone());
   });
+
+  let mg = compilation.get_module_graph();
+  let mut map = HashMap::default();
+  for m in mg.modules().keys() {
+    let Some(mgm) = mg.module_graph_module_by_identifier(m) else {
+      continue;
+    };
+
+    let (Some(pre), Some(post)) = (mgm.pre_order_index, mgm.post_order_index) else {
+      continue;
+    };
+
+    map.insert(*m, (pre, post));
+  }
+  let cache = &mut compilation.code_splitting_cache;
+  cache.module_idx = map;
   Ok(())
 }

--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -36,9 +36,7 @@ fn module_ids(&self, compilation: &mut Compilation) -> Result<()> {
     |m| get_full_module_name(m, context),
     |a, b| compare_modules_by_pre_order_index_or_identifier(&module_graph, a, b),
     |module, id| {
-      let size = used_ids.len();
-      used_ids.insert(id.to_string());
-      if used_ids.len() == size {
+      if !used_ids.insert(id.to_string()) {
         conflicts += 1;
         return false;
       }

--- a/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/0/index.js
+++ b/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/0/index.js
@@ -1,0 +1,5 @@
+import v from './lib'
+
+it('should compile', async () => {
+	expect(v).toBe(1)
+})

--- a/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/0/lib.js
+++ b/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/0/lib.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/1/lib.js
+++ b/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/1/lib.js
@@ -1,0 +1,2 @@
+// change
+export default 1;

--- a/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/rspack.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/rspack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		splitChunks: false,
+	},
+};

--- a/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/test.config.js
+++ b/packages/rspack-test-tools/tests/watchCases/split-chunks-incremental/pre-order-index/test.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+	checkStats(_stepName, stats) {
+		// should keep module preOrderIndex and postOrderIndex during build
+		return [...stats.modules].filter(m => {
+			return m.moduleType !== 'runtime'
+		}).every((m) => {
+			return m.preOrderIndex !== undefined && m.postOrderIndex !== undefined
+		})
+	}
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

close #7031

mgm.preOrderIndex is set by buildChunkGraph, which is skipped during incremental rebuild.

When enable `newIncremental.buildChunkGraph`, preOrderIndex is wrong by design, I'll refactor module.preOrderIndex soon in another PR

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
