### PR TITLE
fix: should not free native compiler while compiler is running

### DIFF
--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -249,7 +249,9 @@ class Compiler {
 		new ExecuteModulePlugin().apply(this);
 
 		this.hooks.shutdown.tap("rspack:cleanup", () => {
-			this.#instance = undefined;
+			if (!this.running) {
+				this.#instance = undefined;
+			}
 		});
 	}
 


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fixed `MultiCompiler` test. Some of the cases tested scenarios where closing the compiler when it is still running. However in previous memory leak fix PR, we freed the native compiler when `compiler.close` is called. Thus, causing a segmentation fault.

To fix this issue, we need to add a compiler status check to free only if it's not running.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
