### PR TITLE
test: replace strip-ansi with Node.js builtin util

### DIFF
--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -55,7 +55,6 @@
     "cross-env": "^7.0.3",
     "execa": "^5.0.0",
     "internal-ip": "6.2.0",
-    "strip-ansi": "6.0.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"
   },

--- a/packages/rspack-cli/tests/utils/test-utils.ts
+++ b/packages/rspack-cli/tests/utils/test-utils.ts
@@ -3,7 +3,7 @@
 "use strict";
 
 const os = require("os");
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 const path = require("path");
 const fs = require("fs");
 const execa = require("execa");

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -64,7 +64,6 @@
     "path-serializer": "0.1.2",
     "pretty-format": "29.7.0",
     "rimraf": "3.0.2",
-    "strip-ansi": "6.0.1",
     "webpack": "^5.94.0",
     "webpack-merge": "5.9.0",
     "webpack-sources": "3.2.3"

--- a/packages/rspack-test-tools/src/helper/legacy/captureStdio.js
+++ b/packages/rspack-test-tools/src/helper/legacy/captureStdio.js
@@ -1,5 +1,5 @@
 // @ts-nocheck
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 
 module.exports = (stdio, tty) => {
 	let logs = [];

--- a/packages/rspack-test-tools/src/processor/defaults.ts
+++ b/packages/rspack-test-tools/src/processor/defaults.ts
@@ -1,5 +1,5 @@
+import { stripVTControlCharacters as stripAnsi } from "node:util";
 import { diff as jestDiff } from "jest-diff";
-import stripAnsi from "strip-ansi";
 
 import type {
 	ECompilerType,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -503,9 +503,6 @@ importers:
       internal-ip:
         specifier: 6.2.0
         version: 6.2.0
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.7.40(@swc/helpers@0.5.13))(@types/node@20.12.7)(typescript@5.6.3)
@@ -575,9 +572,6 @@ importers:
       rimraf:
         specifier: 3.0.2
         version: 3.0.2
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       webpack:
         specifier: ^5.94.0
         version: 5.94.0(@swc/core@1.7.40(@swc/helpers@0.5.13))(webpack-cli@5.1.4(webpack@5.94.0))
@@ -1030,9 +1024,6 @@ importers:
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
-      strip-ansi:
-        specifier: ^6.0.0
-        version: 6.0.1
       terser:
         specifier: 5.27.2
         version: 5.27.2

--- a/tests/webpack-cli-test/api/do-install.test.js
+++ b/tests/webpack-cli-test/api/do-install.test.js
@@ -4,7 +4,7 @@
 const CLI = require("../../packages/webpack-cli/lib/webpack-cli");
 
 // eslint-disable-next-line node/no-unpublished-require
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 
 const readlineQuestionMock = jest.fn();
 

--- a/tests/webpack-cli-test/utils/test-utils.js
+++ b/tests/webpack-cli-test/utils/test-utils.js
@@ -3,7 +3,7 @@
 "use strict";
 
 const os = require("os");
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 const path = require("path");
 const fs = require("fs");
 const execa = require("execa");

--- a/tests/webpack-test/Defaults.unittest.js
+++ b/tests/webpack-test/Defaults.unittest.js
@@ -3,7 +3,7 @@ require("./helpers/warmup-webpack");
 
 const path = require("path");
 const jestDiff = require("jest-diff").diff;
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 
 /**
  * Escapes regular expression metacharacters

--- a/tests/webpack-test/helpers/captureStdio.js
+++ b/tests/webpack-test/helpers/captureStdio.js
@@ -1,4 +1,4 @@
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 
 module.exports = (stdio, tty) => {
 	let logs = [];

--- a/tests/webpack-test/helpers/diffStats.js
+++ b/tests/webpack-test/helpers/diffStats.js
@@ -1,5 +1,5 @@
 const diff = require("jest-diff").diff;
-const stripAnsi = require("strip-ansi");
+const { stripVTControlCharacters: stripAnsi } = require("node:util");
 
 const processStats = str => {
   return str.trim().split('\n').map(i => i.trim()).join('\n').replace(/\d+(\.\d+)?/g, 'XX').replace(/"/g, "");

--- a/tests/webpack-test/package.json
+++ b/tests/webpack-test/package.json
@@ -51,7 +51,6 @@
     "sass-embedded": "^1.77.8",
     "sass-loader": "^16.0.0",
     "source-map": "^0.7.4",
-    "strip-ansi": "^6.0.0",
     "terser": "5.27.2",
     "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
## Summary

Use the Node.js builtin util `stripVTControlCharacters` replace `strip-ansi`

## Related Links

https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
