### PR TITLE
fix: the attribute values of HTML tags should not be converted to lowercase

### DIFF
--- a/crates/rspack_binding_values/src/html.rs
+++ b/crates/rspack_binding_values/src/html.rs
@@ -56,7 +56,7 @@ impl From<JsHtmlPluginTag> for HtmlPluginTag {
           value.as_ref().and_then(|v| match v {
             Either::A(x) => Some(HtmlPluginAttribute {
               attr_name: key.cow_to_ascii_lowercase().into_owned(),
-              attr_value: Some(x.cow_to_ascii_lowercase().into_owned()),
+              attr_value: Some(x.to_owned()),
             }),
             Either::B(x) => {
               if *x {

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/index.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/index.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+
+it("html plugin should respect output.publicPath", () => {
+	const htmlPath = path.join(__dirname, "./index.html");
+	const htmlContent = fs.readFileSync(htmlPath, "utf-8");
+	expect(htmlContent.includes('<script defer src="foorBar.js">')).toBeTruthy();
+});

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/rspack.config.js
@@ -1,0 +1,27 @@
+const { rspack } = require("@rspack/core");
+
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Plugin", compilation => {
+			const hooks = rspack.HtmlRspackPlugin.getCompilationHooks(compilation);
+			hooks.alterAssetTags.tapPromise("Plugin", async data => {
+				for (const tag of data.assetTags.scripts) {
+					if (tag.tagName === "script") {
+						tag.attributes.defer = true;
+					}
+				}
+			});
+		});
+	}
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: {
+		foorBar: "./index.js"
+	},
+	output: {
+	    filename: "[name].js",
+	},
+	plugins: [new rspack.HtmlRspackPlugin({}), new Plugin()]
+};

--- a/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/test.config.js
+++ b/packages/rspack-test-tools/tests/configCases/builtins/html-issue-8410/test.config.js
@@ -1,0 +1,6 @@
+/** @type {import("../../../..").TConfigCaseConfig} */
+module.exports = {
+	findBundle() {
+		return ["foorBar.js"];
+	}
+};


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
fix #8410
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In fact, attr_name should not be converted to lowercase either, as this is the job of the minifier. However, it seems that swc_html_minifier currently does not support the caseSensitive configuration.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
