### PR TITLE
fix: align bytes ptr address for `cacheable::from_byte`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,6 +346,8 @@ jobs:
           echo 'debug = false' >> Cargo.toml
 
       - name: Run test
+        env:
+          MIRIFLAGS: -Zmiri-tree-borrows -Zmiri-disable-isolation
         # reason for excluding https://github.com/napi-rs/napi-rs/issues/2200
         run: cargo miri test --workspace --exclude rspack_binding_options --exclude rspack_node -- --nocapture
 

--- a/crates/rspack_cacheable_test/tests/macro/cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/cacheable_dyn.rs
@@ -1,6 +1,7 @@
 use rspack_cacheable::{cacheable, cacheable_dyn, from_bytes, to_bytes};
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_cacheable_dyn_macro() {
   struct Context;
 
@@ -71,6 +72,7 @@ fn test_cacheable_dyn_macro() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_cacheable_dyn_macro_with_generics() {
   struct Context;
 

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn.rs
@@ -1,6 +1,7 @@
 use rspack_cacheable::{cacheable, from_bytes, to_bytes};
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_manual_cacheable_dyn_macro() {
   struct Context;
 

--- a/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
+++ b/crates/rspack_cacheable_test/tests/macro/manual_cacheable_dyn_with_generics.rs
@@ -1,6 +1,7 @@
 use rspack_cacheable::{cacheable, from_bytes, to_bytes};
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_manual_cacheable_dyn_macro_with_generics() {
   struct Context;
 

--- a/crates/rspack_macros_test/tests/compiletest.rs
+++ b/crates/rspack_macros_test/tests/compiletest.rs
@@ -1,4 +1,5 @@
 #[test]
+#[cfg_attr(miri, ignore)]
 fn ui() {
   let t = trybuild::TestCases::new();
   t.compile_fail("tests/ui/hook/*.rs");


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

1. cacheable::from_byte align bytes ptr address. This will fix `UnalignedPointer` error in rkyv when miri test.
2. skip `cacheable_dyn` miri test. The global register crate like `inventory` not work in miri test.

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
