### PR TITLE
build(windows): use Hybrid CRT for smaller binary size !windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -44,9 +44,11 @@ rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
 
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
 [target.'cfg(target_os = "windows")']
-rustflags = ["-C", "link-args=/FORCE"]
+rustflags = ["-C", "link-args=/FORCE", "-C", "link-args=/NODEFAULTLIB:libucrt.lib", "-C", "link-args=/DEFAULTLIB:ucrt.lib"]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

See: 
- https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/set-up-your-development-environment?tabs=cs-vs-community%2Ccpp-vs-community%2Cvs-2022-17-1-a%2Cvs-2022-17-1-b#hybrid-cc-runtime-library-linkage
- https://github.com/axodotdev/cargo-dist/issues/496#issuecomment-1780407158

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
