### PR TITLE
fix: set the correct asset_info when extracting css

### DIFF
--- a/crates/rspack_plugin_extract_css/src/plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/plugin.rs
@@ -7,11 +7,11 @@ use rspack_collections::{DatabaseItem, IdentifierMap, IdentifierSet, UkeySet};
 use rspack_core::ChunkGraph;
 use rspack_core::{
   rspack_sources::{ConcatSource, RawSource, SourceMap, SourceMapSource, WithoutOriginalOptions},
-  ApplyContext, AssetInfo, Chunk, ChunkGroupUkey, ChunkKind, ChunkUkey, Compilation,
-  CompilationContentHash, CompilationParams, CompilationRenderManifest,
-  CompilationRuntimeRequirementInTree, CompilerCompilation, CompilerOptions, Filename, Module,
-  ModuleGraph, ModuleIdentifier, ModuleType, NormalModuleFactoryParser, ParserAndGenerator,
-  ParserOptions, PathData, Plugin, PluginContext, RenderManifestEntry, RuntimeGlobals, SourceType,
+  ApplyContext, Chunk, ChunkGroupUkey, ChunkKind, ChunkUkey, Compilation, CompilationContentHash,
+  CompilationParams, CompilationRenderManifest, CompilationRuntimeRequirementInTree,
+  CompilerCompilation, CompilerOptions, Filename, Module, ModuleGraph, ModuleIdentifier,
+  ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, PathData, Plugin,
+  PluginContext, RenderManifestEntry, RuntimeGlobals, SourceType,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hash::RspackHash;
@@ -315,7 +315,7 @@ impl PluginCssExtract {
     let mut source = ConcatSource::default();
     let mut external_source = ConcatSource::default();
 
-    let (filename, _) = compilation.get_path_with_info(filename_template, path_data)?;
+    let (filename, asset_info) = compilation.get_path_with_info(filename_template, path_data)?;
 
     for module in used_modules {
       let content = Cow::Borrowed(module.content.as_str());
@@ -412,7 +412,7 @@ impl PluginCssExtract {
       RenderManifestEntry::new(
         Arc::new(external_source),
         filename,
-        AssetInfo::default(),
+        asset_info,
         false,
         false,
       ),

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-8431/index.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-8431/index.js
@@ -1,0 +1,1 @@
+import "./style.css";

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-8431/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-8431/rspack.config.js
@@ -1,0 +1,43 @@
+const { rspack } = require("@rspack/core");
+
+class Plugin {
+	apply(compiler) {
+		compiler.hooks.thisCompilation.tap("MyPlugin", compilation => {
+			compilation.hooks.processAssets.tap(
+				{
+					name: "MyPlugin",
+					stage: compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH
+				},
+				() => {
+					const css = compilation
+						.getAssets()
+						.find(asset => asset.name.endsWith(".css"));
+					expect(css.info.contenthash.length).toBeGreaterThan(0);
+				}
+			);
+		});
+	}
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	entry: "./index.js",
+	target: "web",
+	module: {
+		rules: [
+			{
+				test: /\.css$/,
+				use: [rspack.CssExtractRspackPlugin.loader, "css-loader"]
+			}
+		]
+	},
+	plugins: [
+		new rspack.CssExtractRspackPlugin({
+			filename: "[name].[contenthash].css"
+		}),
+		new Plugin()
+	],
+	experiments: {
+		css: false
+	}
+};

--- a/packages/rspack-test-tools/tests/configCases/css/rspack-issue-8431/style.css
+++ b/packages/rspack-test-tools/tests/configCases/css/rspack-issue-8431/style.css
@@ -1,0 +1,5 @@
+.example {
+	margin-left: 22px;
+	margin-top: 22px;
+	margin-bottom: 22px;
+}


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary
fix #8431
<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
The default asset_info is returned here:
https://github.com/web-infra-dev/rspack/blob/9112e35f97eeac430691e15c0305763fec56e890/crates/rspack_plugin_extract_css/src/plugin.rs#L415

Therefore, the contenthash cannot be obtained here, leading to an unexpected termination of the subsequent process:
https://github.com/web-infra-dev/rspack/blob/9112e35f97eeac430691e15c0305763fec56e890/crates/rspack_plugin_real_content_hash/src/lib.rs#L73-L75
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
