### PR TITLE
fix(lightningcss): align type with lightningcss

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1551,6 +1551,7 @@ export interface RawLightningCssMinimizerOptions {
   include?: number
   exclude?: number
   draft?: RawDraft
+  drafts?: RawDraft
   nonStandard?: RawNonStandard
   pseudoClasses?: RawLightningCssPseudoClasses
   unusedSymbols: Array<string>

--- a/crates/rspack_binding_options/src/options/raw_builtins/raw_lightning_css_minimizer.rs
+++ b/crates/rspack_binding_options/src/options/raw_builtins/raw_lightning_css_minimizer.rs
@@ -25,7 +25,9 @@ pub struct RawLightningCssMinimizerOptions {
   pub targets: Option<Vec<String>>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
+  // TODO: deprecate `draft` in favor of `drafts`
   pub draft: Option<RawDraft>,
+  pub drafts: Option<RawDraft>,
   pub non_standard: Option<RawNonStandard>,
   pub pseudo_classes: Option<RawLightningCssPseudoClasses>,
   pub unused_symbols: Vec<String>,
@@ -90,9 +92,14 @@ impl TryFrom<RawLightningCssMinimizerRspackPluginOptions> for PluginOptions {
           .flatten(),
         include: value.minimizer_options.include,
         exclude: value.minimizer_options.exclude,
-        draft: value.minimizer_options.draft.map(|d| Draft {
-          custom_media: d.custom_media,
-        }),
+        // We should use `drafts` if it is present, otherwise use `draft`
+        draft: value
+          .minimizer_options
+          .drafts
+          .or(value.minimizer_options.draft)
+          .map(|d| Draft {
+            custom_media: d.custom_media,
+          }),
         non_standard: value.minimizer_options.non_standard.map(|n| NonStandard {
           deep_selector_combinator: n.deep_selector_combinator,
         }),

--- a/crates/rspack_loader_lightningcss/src/config.rs
+++ b/crates/rspack_loader_lightningcss/src/config.rs
@@ -44,7 +44,9 @@ pub struct RawConfig {
   pub targets: Option<Vec<String>>,
   pub include: Option<u32>,
   pub exclude: Option<u32>,
+  // TODO: deprecate `draft` in favor of `drafts`
   pub draft: Option<Draft>,
+  pub drafts: Option<Draft>,
   pub non_standard: Option<NonStandard>,
   pub pseudo_classes: Option<PseudoClasses>,
   pub unused_symbols: Option<Vec<String>>,
@@ -64,7 +66,8 @@ impl TryFrom<RawConfig> for Config {
         .flatten(),
       include: value.include,
       exclude: value.exclude,
-      draft: value.draft,
+      // We should use `drafts` if it is present, otherwise use `draft`
+      draft: value.drafts.or(value.draft),
       non_standard: value.non_standard,
       pseudo_classes: value.pseudo_classes,
       unused_symbols: value.unused_symbols,

--- a/packages/rspack/etc/core.api.md
+++ b/packages/rspack/etc/core.api.md
@@ -3112,6 +3112,7 @@ export type LightningcssLoaderOptions = {
     include?: LightningcssFeatureOptions;
     exclude?: LightningcssFeatureOptions;
     draft?: Drafts;
+    drafts?: Drafts;
     nonStandard?: NonStandard;
     pseudoClasses?: PseudoClasses;
     unusedSymbols?: string[];
@@ -3140,6 +3141,7 @@ export type LightningCssMinimizerRspackPluginOptions = {
         include?: LightningcssFeatureOptions;
         exclude?: LightningcssFeatureOptions;
         draft?: Drafts;
+        drafts?: Drafts;
         nonStandard?: NonStandard;
         pseudoClasses?: PseudoClasses;
         unusedSymbols?: string[];

--- a/packages/rspack/src/builtin-loader/lightningcss/index.ts
+++ b/packages/rspack/src/builtin-loader/lightningcss/index.ts
@@ -254,7 +254,12 @@ export type LoaderOptions = {
 	targets?: Targets | string[] | string;
 	include?: FeatureOptions;
 	exclude?: FeatureOptions;
+	/**
+	 * @deprecated Use `drafts` instead.
+	 * This will be removed in the next major version.
+	 */
 	draft?: Drafts;
+	drafts?: Drafts;
 	nonStandard?: NonStandard;
 	pseudoClasses?: PseudoClasses;
 	unusedSymbols?: string[];

--- a/packages/rspack/src/builtin-plugin/LightningCssMinimizerRspackPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/LightningCssMinimizerRspackPlugin.ts
@@ -23,7 +23,12 @@ export type LightningCssMinimizerRspackPluginOptions = {
 		targets?: string[] | string;
 		include?: FeatureOptions;
 		exclude?: FeatureOptions;
+		/**
+		 * @deprecated Use `drafts` instead.
+		 * This will be removed in the next major version.
+		 */
 		draft?: Drafts;
+		drafts?: Drafts;
 		nonStandard?: NonStandard;
 		pseudoClasses?: PseudoClasses;
 		unusedSymbols?: string[];
@@ -35,7 +40,7 @@ export const LightningCssMinimizerRspackPlugin = create(
 	(
 		options?: LightningCssMinimizerRspackPluginOptions
 	): RawLightningCssMinimizerRspackPluginOptions => {
-		const { include, exclude, draft, nonStandard, pseudoClasses } =
+		const { include, exclude, draft, nonStandard, pseudoClasses, drafts } =
 			options?.minimizerOptions ?? {};
 		const targets = options?.minimizerOptions?.targets ?? "fully supports es6"; // last not support es module chrome version
 		return {
@@ -50,6 +55,9 @@ export const LightningCssMinimizerRspackPlugin = create(
 				exclude: exclude ? toFeatures(exclude) : undefined,
 				targets: typeof targets === "string" ? [targets] : targets,
 				draft: draft ? { customMedia: draft.customMedia ?? false } : undefined,
+				drafts: drafts
+					? { customMedia: drafts.customMedia ?? false }
+					: undefined,
 				nonStandard: nonStandard
 					? {
 							deepSelectorCombinator:

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -98,7 +98,12 @@ type LightningcssLoaderOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
+  /**
+   * @deprecated Use `drafts` instead.
+   * This will be removed in the next major version.
+   */
   draft?: Drafts;
+  drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
   unusedSymbols?: Set<String>;

--- a/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -89,7 +89,12 @@ type LightningCssMinimizerOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
+  /**
+   * @deprecated Use `drafts` instead.
+   * This will be removed in the next major version.
+   */
   draft?: Drafts;
+  drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
   unusedSymbols?: Set<String>;

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -98,7 +98,12 @@ type LightningcssLoaderOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
+  /**
+   * @deprecated Use `drafts` instead.
+   * This will be removed in the next major version.
+   */
   draft?: Drafts;
+  drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
   unusedSymbols?: Set<String>;

--- a/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/lightning-css-minimizer-rspack-plugin.mdx
@@ -89,7 +89,12 @@ type LightningCssMinimizerOptions = {
   targets?: string[] | string;
   include?: LightningcssFeatureOptions;
   exclude?: LightningcssFeatureOptions;
+  /**
+   * @deprecated Use `drafts` instead.
+   * This will be removed in the next major version.
+   */
   draft?: Drafts;
+  drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
   unusedSymbols?: string[];


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

In lightningcss, the [draft syntax options](https://lightningcss.dev/transpilation.html#draft-syntax) is drafts. 

We should align the type with lightningcss, while have not break change. So we maintain `options.draft` and `options.drafts`, then we use drafts firstly if user provide both drafts and draft options.

It's the product of another hand, [This PR](https://github.com/web-infra-dev/rspack/pull/8197) from @zackarychapple 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
