### PR TITLE
fix(modern-module): remove extra import statement for star reexport

### DIFF
--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -333,14 +333,8 @@ head{--webpack--120:&_13;}
 `;
 
 exports[`config config/externals/reexport-star exported tests reexport star from external module 1`] = `
-import * as __WEBPACK_EXTERNAL_MODULE_external1_alias__ from "external1-alias";
-import * as __WEBPACK_EXTERNAL_MODULE_external2_alias__ from "external2-alias";
 export * from "external1-alias";
 export * from "external2-alias";
-
-;// CONCATENATED MODULE: external "external1-alias"
-
-;// CONCATENATED MODULE: external "external2-alias"
 
 ;// CONCATENATED MODULE: ./case1.js
 `;
@@ -377,6 +371,12 @@ const foo = 2
 const bar = 1
 
 export { bar, foo };
+`;
+
+exports[`config config/externals/reexport-star exported tests reexport star from external module 4`] = `
+export * from "external1-alias";
+
+;// CONCATENATED MODULE: ./case4.js
 `;
 
 exports[`config config/library/modern-module-force-concaten step  should pass: .cjs should bail out 1`] = `

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/case4.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/case4.js
@@ -1,0 +1,2 @@
+export * from 'external1'
+export * from 'external1'

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/index.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/index.js
@@ -6,4 +6,5 @@ it("reexport star from external module", function () {
 	expect(readCase("case1")).toMatchSnapshot();
 	expect(readCase("case2")).toMatchSnapshot();
 	expect(readCase("case3")).toMatchSnapshot();
+	expect(readCase("case4")).toMatchSnapshot();
 });

--- a/packages/rspack-test-tools/tests/configCases/externals/reexport-star/rspack.config.js
+++ b/packages/rspack-test-tools/tests/configCases/externals/reexport-star/rspack.config.js
@@ -5,6 +5,7 @@ module.exports = [
 			"case1": "./case1.js",
 			"case2": "./case2.js",
 			"case3": "./case3/index.js",
+			"case4": "./case4.js",
 			"index": "./index.js",
 		},
 		output: {


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Fix https://github.com/web-infra-dev/rslib/issues/429.

Previously given a module like this:

```js
export * from "external1"
```

the diff of the output after this PR will be

```diff
- import * as __WEBPACK_EXTERNAL_MODULE_external1__ from "external1";
export * from "external1"
```

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
