### PR TITLE
build(windows): static linking VS CRT on aarch64 msvc !windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -43,10 +43,17 @@ rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup,-no_fixup_chains"]
 rustflags = ["-C", "link-args=-Wl,--warn-unresolved-symbols"]
 
 # To be able to run unit tests on Windows, support compilation to 'x86_64-pc-windows-msvc'.
+# Use Hybrid CRT to reduce the size of the binary (Coming by default with Windows 10 and later versions).
 [target.'cfg(target_os = "windows")']
-rustflags = ["-C", "link-args=/FORCE"]
+rustflags = [
+  "-C", "link-args=/FORCE", 
+  "-C", "link-args=/NODEFAULTLIB:libucrt.lib", 
+  "-C", "link-args=/DEFAULTLIB:ucrt.lib"
+]
 
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 [target.i686-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

Use Hybrid CRT (Linking `vcruntime` and `ucrtbase` statically).
See: https://github.com/web-infra-dev/rspack/pull/8451

For aarch64 msvc, it is not required to install VS CRT manually as a dependency anymore.

It's recommended to use Windows 10 or newer with rspack.

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->

<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
