### PR TITLE
Remove wrong short argument for json cli.mdx

### DIFF
--- a/website/docs/en/api/cli.mdx
+++ b/website/docs/en/api/cli.mdx
@@ -35,7 +35,7 @@ By default Rspack provides some common command line arguments, you can see all o
 | -m, --mode [value]        | Specify the build mode                                 |
 | -d, --devtool [value]     | Controls whether sourcemap is generated                |
 | --analyze                 | Enables or disables build analysis                     |
-| -w, --json [filename]     | Output the stats as a JSON file                        |
+| --json [filename]     | Output the stats as a JSON file                        |
 | -w, --watch               | Listen for file changes                                |
 | -h, --help                | Show help information                                  |
 | -v, --version             | Show version number                                    |


### PR DESCRIPTION
## Summary

The documentation falsely references the argument `-w` twice.
The `--json` argument does not have a short hand

output of `npx @rspack/cli --help`
```bash
Options:
  -c, --config       config file                                        [string]
      --entry        entry file                                          [array]
  -o, --output-path  output path dir                                    [string]
  -m, --mode         mode                                               [string]
  -w, --watch        watch                            [boolean] [default: false]
      --env          env passed to config function                       [array]
      --node-env     sets process.env.NODE_ENV to be specified value    [string]
  -d, --devtool      devtool                          [boolean] [default: false]
      --configName   Name of the configuration to use.                   [array]
      --analyze      analyze                          [boolean] [default: false]
      --json         emit stats json
      --profile      capture timing information for each module
                                                      [boolean] [default: false]
  -v, --version      Show version number                               [boolean]
  -h, --help         Show help                                         [boolean]
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
