### PR TITLE
feat: support output.environment.nodePrefixForCoreModules

### DIFF
--- a/crates/node_binding/binding.d.ts
+++ b/crates/node_binding/binding.d.ts
@@ -1335,6 +1335,7 @@ export interface RawEntryDynamicResult {
 export interface RawEnvironment {
   const?: boolean
   arrowFunction?: boolean
+  nodePrefixForCoreModules?: boolean
 }
 
 export interface RawEvalDevToolModulePluginOptions {

--- a/crates/rspack_binding_options/src/options/raw_output.rs
+++ b/crates/rspack_binding_options/src/options/raw_output.rs
@@ -47,6 +47,7 @@ impl From<RawCrossOriginLoading> for CrossOriginLoading {
 pub struct RawEnvironment {
   pub r#const: Option<bool>,
   pub arrow_function: Option<bool>,
+  pub node_prefix_for_core_modules: Option<bool>,
 }
 
 impl From<RawEnvironment> for Environment {
@@ -54,6 +55,7 @@ impl From<RawEnvironment> for Environment {
     Self {
       r#const: value.r#const,
       arrow_function: value.arrow_function,
+      node_prefix_for_core_modules: value.node_prefix_for_core_modules,
     }
   }
 }

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -272,11 +272,19 @@ impl ExternalModule {
         )
       }
       "node-commonjs" if let Some(request) = request => {
+        let need_prefix = compilation
+          .options
+          .output
+          .environment
+          .supports_node_prefix_for_core_modules();
+
         if compilation.options.output.module {
           chunk_init_fragments.push(
             NormalInitFragment::new(
-              "import { createRequire as __WEBPACK_EXTERNAL_createRequire } from \"module\";\n"
-                .to_string(),
+              format!(
+                "import {{ createRequire as __WEBPACK_EXTERNAL_createRequire }} from \"{}\";\n",
+                if need_prefix { "node:module" } else { "module" }
+              ),
               InitFragmentStage::StageESMImports,
               0,
               InitFragmentKey::ModuleExternal("node-commonjs".to_string()),

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -461,6 +461,7 @@ pub struct LibraryCustomUmdObject {
 pub struct Environment {
   pub r#const: Option<bool>,
   pub arrow_function: Option<bool>,
+  pub node_prefix_for_core_modules: Option<bool>,
 }
 
 impl Environment {
@@ -470,5 +471,9 @@ impl Environment {
 
   pub fn supports_arrow_function(&self) -> bool {
     self.arrow_function.unwrap_or_default()
+  }
+
+  pub fn supports_node_prefix_for_core_modules(&self) -> bool {
+    self.node_prefix_for_core_modules.unwrap_or_default()
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/external_module_dependency.rs
@@ -33,9 +33,15 @@ impl DependencyTemplate for ExternalModuleDependency {
     _source: &mut TemplateReplaceSource,
     code_generatable_context: &mut TemplateContext,
   ) {
+    let need_prefix = code_generatable_context
+      .compilation
+      .options
+      .output
+      .environment
+      .supports_node_prefix_for_core_modules();
     let chunk_init_fragments = code_generatable_context.chunk_init_fragments();
     let fragment = ExternalModuleInitFragment::new(
-      self.module.clone(),
+      format!("{}{}", if need_prefix { "node:" } else { "" }, self.module),
       self.import_specifier.clone(),
       self.default_import.clone(),
       InitFragmentStage::StageConstants,

--- a/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
+++ b/packages/rspack-test-tools/tests/__snapshots__/Config.test.js.snap
@@ -514,7 +514,7 @@ export { a };
 `;
 
 exports[`config config/library/modern-module-force-concaten step  should pass: external module should bail out when bundling 1`] = `
-import { createRequire as __WEBPACK_EXTERNAL_createRequire } from "module";
+import { createRequire as __WEBPACK_EXTERNAL_createRequire } from "node:module";
 var __webpack_modules__ = ({
 "17": (function (module) {
 module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("path");

--- a/tests/webpack-test/configCases/node/prefix-in-runtime/index.js
+++ b/tests/webpack-test/configCases/node/prefix-in-runtime/index.js
@@ -1,0 +1,16 @@
+import fs from "fs";
+
+it(`should have/have not 'node:' prefix ${__filename}`,  () => {
+	const content = fs.readFileSync(__filename, "utf-8");
+
+	if (/bundle7\.js$/.test(__filename)) {
+		expect(content).toContain("require(\"fs\");");
+	} else if (/(bundle1\.mjs|bundle3\.mjs|bundle6\.mjs)$/.test(__filename)) {
+		expect(content).toContain("from \"url\"");
+		expect(content).toContain("from \"module\"");
+	} else {
+		expect(content).toContain("from \"node:url\"");
+		expect(content).toContain("from \"node:module\"");
+	}
+});
+

--- a/tests/webpack-test/configCases/node/prefix-in-runtime/test.filter.js
+++ b/tests/webpack-test/configCases/node/prefix-in-runtime/test.filter.js
@@ -1,0 +1,3 @@
+module.exports = function () {
+	return !process.version.startsWith("v10.");
+};

--- a/tests/webpack-test/configCases/node/prefix-in-runtime/webpack.config.js
+++ b/tests/webpack-test/configCases/node/prefix-in-runtime/webpack.config.js
@@ -1,0 +1,76 @@
+/** @type {import("../../../../").Configuration} */
+module.exports = [
+	{
+		target: "node",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "node14.17",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "node14.18",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "node15",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "node16",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "browserslist:node 14.18.0, node 16.0.0",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "browserslist:node 14.18.0, node 15.0.0, node 16.0.0",
+		experiments: {
+			outputModule: true
+		},
+		output: {
+			module: true,
+			chunkFormat: "module"
+		}
+	},
+	{
+		target: "node"
+	}
+];


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  We appreciate the time and effort you have invested in making these changes. Please ensure that you provide enough information to allow others to review your pull request.

  Upon submission, your pull request will be automatically assigned with reviewers.

  If you want to learn more about contributing to this project, please visit: https://github.com/web-infra-dev/rspack/blob/main/CONTRIBUTING.md.
-->

## Summary

<!-- Can you explain the reasoning behind implementing this change? What problem or issue does this pull request resolve? -->
I found this option in the [documentation](https://rspack.dev/config/output#outputenvironment), but it is not currently supported. It is intended to control whether the node: prefix is added when importing Node.js modules in the generated runtime code, enabling the code to run on other platforms such as Deno and Bun.
<!-- It would be helpful if you could provide any relevant context, such as GitHub issues or related discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
